### PR TITLE
Extract artichoke core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,6 +40,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "artichoke-core"
+version = "0.1.0"
+dependencies = [
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "artichoke-frontend"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
   "artichoke-backend",
+  "artichoke-core",
   "artichoke-frontend",
   "artichoke-vfs",
   "artichoke-wasm",

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # Artichoke Ruby
 
 [![CircleCI](https://circleci.com/gh/artichoke/artichoke.svg?style=svg)](https://circleci.com/gh/artichoke/artichoke)
-[![Backend documentation](https://img.shields.io/badge/docs-artichoke--backend-blue.svg)](https://artichoke.github.io/artichoke/artichoke_backend/)
+[![Core documentation](https://img.shields.io/badge/docs-artichoke--core-blue.svg)](https://artichoke.github.io/artichoke/artichoke_core/)
 [![Virtual filesystem documentation](https://img.shields.io/badge/docs-artichoke--vfs-blue.svg)](https://artichoke.github.io/artichoke/artichoke_vfs/)
+[![mruby backend documentation](https://img.shields.io/badge/docs-artichoke--backend-blue.svg)](https://artichoke.github.io/artichoke/artichoke_backend/)
 [![mruby-sys documentation](https://img.shields.io/badge/docs-mruby--sys-blue.svg)](https://artichoke.github.io/artichoke/mruby_sys/)
 
 <p align="center">

--- a/artichoke-core/Cargo.toml
+++ b/artichoke-core/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "artichoke-core"
+version = "0.1.0"
+authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
+edition = "2018"
+
+[dependencies]
+log = "0.4"

--- a/artichoke-core/README.md
+++ b/artichoke-core/README.md
@@ -1,0 +1,14 @@
+# artichoke-core
+
+artichoke-core crate provides a set of traits that, when implemented, create a
+complete Ruby interpreter.
+
+artichoke-core is a work in progress. When fully functioning, artichoke-core
+will provide interpreter agnositc implementations of Ruby Core and Ruby Standard
+Library that pass ruby/spec if an interpreter implements all of the required
+traits.
+
+The evolution of artichoke-core can be tracked in
+[Milestone 2, ruby/spec: Core](https://github.com/artichoke/artichoke/milestone/2)
+and
+[Milestone 3, ruby/spec: Standard Library](https://github.com/artichoke/artichoke/milestone/3).

--- a/artichoke-core/src/convert.rs
+++ b/artichoke-core/src/convert.rs
@@ -1,27 +1,53 @@
+//! Convert between Rust and Ruby objects.
+
 use std::error;
 use std::fmt;
 
+/// Infallible conversion between two types.
+///
+/// See [`std::convert::From`].
 pub trait Convert {
+    /// Concrete type for the interpreter.
     type Artichoke;
+
+    /// Concrete type for source of the conversion.
     type From;
+
+    /// Concrete type for an error this conversion may produce.
+    ///
+    /// `Error` is required for infallible conversions so they can be wrapped
+    /// by a [fallible conversion](TryConvert) blanked implementation.
     type Error;
 
+    /// Performs the infallible conversion.
     fn convert(interp: Self::Artichoke, value: Self::From) -> Self;
 }
 
+/// Fallible conversions between two types.
+///
+/// See [`std::convert::TryFrom`].
 #[allow(clippy::module_name_repetitions)]
 pub trait TryConvert
 where
     Self: Sized,
 {
+    /// Concrete type for the interpreter.
     type Artichoke;
+
+    /// Concrete type for source of the conversion.
     type From;
+
+    /// Concrete type for an error this conversion may produce.
+    ///
+    /// `Error` is required for infallible conversions so they can be wrapped
+    /// by a [fallible conversion](TryConvert) blanked implementation.
     type Error;
 
+    /// Performs the fallible conversion.
     unsafe fn try_convert(interp: Self::Artichoke, value: Self::From) -> Result<Self, Self::Error>;
 }
 
-/// Provide a falible converter for types that implement an infallible
+/// Provide a fallible converter for types that implement an infallible
 /// conversion.
 impl<T> TryConvert for T
 where
@@ -36,6 +62,7 @@ where
     }
 }
 
+/// Error for a failed conversion from `From` to `To`.
 #[derive(Clone, Eq, PartialEq)]
 pub struct Error<From, To> {
     from: From,

--- a/artichoke-core/src/convert.rs
+++ b/artichoke-core/src/convert.rs
@@ -1,0 +1,77 @@
+use std::error;
+use std::fmt;
+
+pub trait Convert {
+    type Artichoke;
+    type From;
+    type Error;
+
+    fn convert(interp: Self::Artichoke, value: Self::From) -> Self;
+}
+
+#[allow(clippy::module_name_repetitions)]
+pub trait TryConvert
+where
+    Self: Sized,
+{
+    type Artichoke;
+    type From;
+    type Error;
+
+    unsafe fn try_convert(interp: Self::Artichoke, value: Self::From) -> Result<Self, Self::Error>;
+}
+
+/// Provide a falible converter for types that implement an infallible
+/// conversion.
+impl<T> TryConvert for T
+where
+    T: Convert,
+{
+    type Artichoke = <Self as Convert>::Artichoke;
+    type From = <Self as Convert>::From;
+    type Error = <Self as Convert>::Error;
+
+    unsafe fn try_convert(interp: Self::Artichoke, value: Self::From) -> Result<Self, Self::Error> {
+        Ok(Convert::convert(interp, value))
+    }
+}
+
+#[derive(Clone, Eq, PartialEq)]
+pub struct Error<From, To> {
+    from: From,
+    to: To,
+}
+
+impl<From, To> fmt::Display for Error<From, To>
+where
+    From: fmt::Display,
+    To: fmt::Display,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "failed to convert from {} to {}", self.from, self.to)
+    }
+}
+
+impl<From, To> fmt::Debug for Error<From, To>
+where
+    From: fmt::Display,
+    To: fmt::Display,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self)
+    }
+}
+
+impl<To, From> error::Error for Error<To, From>
+where
+    From: fmt::Display,
+    To: fmt::Display,
+{
+    fn description(&self) -> &str {
+        "Failed to convert types between ruby and rust"
+    }
+
+    fn cause(&self) -> Option<&dyn error::Error> {
+        None
+    }
+}

--- a/artichoke-core/src/def.rs
+++ b/artichoke-core/src/def.rs
@@ -1,0 +1,143 @@
+//! Define `Class`es, `Module`s and methods on an interpreter.
+
+use std::any::Any;
+
+use crate::ArtichokeError;
+
+/// Interpreters that implement [`DeclareClassLike`] expose methods for
+/// declaring Ruby `Class`es and `Module`s on the interpreter.
+///
+/// A [`ClassLike`] may need to be declared before it is defined with
+/// [`Define`].
+pub trait DeclareClassLike {
+    /// Concrete type used to free instances of `Class`es.
+    type Free;
+
+    /// Concrete type for a `Class` spec.
+    type ClassSpec: ClassLike;
+
+    /// Concrete type for a `Module` spec.
+    type ModuleSpec: ClassLike;
+
+    /// Concrete type for an enclosing scope
+    type Scope: EnclosingRubyScope;
+
+    /// Create a class definition bound to a Rust type `T`. Class definitions
+    /// have the same lifetime as `self`. Class defs are stored by
+    /// [`TypeId`](std::any::TypeId) of `T`.
+    ///
+    /// Class specs can also be retrieved from the state after creation with
+    /// [`DeclareClassLike::class_spec`].
+    fn def_class<T: Any>(
+        &mut self,
+        name: &str,
+        enclosing_scope: Option<Self::Scope>,
+        free: Option<Self::Free>,
+    ) -> Self::ClassSpec;
+
+    /// Retrieve a class definition from the state bound to Rust type `T`.
+    ///
+    /// This function returns `None` if type `T` has not had a class spec
+    /// registered for it using [`DeclareClassLike::def_class`].
+    fn class_spec<T: Any>(&self) -> Option<Self::ClassSpec>;
+
+    /// Create a module definition bound to a Rust type `T`. Module definitions
+    /// have the same lifetime as `self`. Module defs are stored by
+    /// [`TypeId`](std::any::TypeId) of `T`.
+    ///
+    /// Module specs can also be retrieved from the state after creation with
+    /// [`DeclareClassLike::module_spec`].
+    fn def_module<T: Any>(
+        &mut self,
+        name: &str,
+        enclosing_scope: Option<Self::Scope>,
+    ) -> Self::ModuleSpec;
+
+    /// Retrieve a module definition from the state bound to Rust type `T`.
+    ///
+    /// This function returns `None` if type `T` has not had a module spec
+    /// registered for it using [`DeclareClassLike::def_module`].
+    fn module_spec<T: Any>(&self) -> Option<Self::ModuleSpec>;
+}
+
+/// Typesafe wrapper for the [`ClassLike`] of the enclosing scope for a Ruby
+/// `Module` or `Class`.
+///
+/// In Ruby, classes and modules can be defined inside of another class or
+/// module. Some intepreters may only support resolving `ClassLike`s relative to
+/// an enclosing scope.
+pub trait EnclosingRubyScope {
+    /// Concrete type for a `Class` spec.
+    type ClassSpec: ClassLike;
+
+    /// Concrete type for a `Module` spec.
+    type ModuleSpec: ClassLike;
+
+    /// Factory for an [`EnclosingRubyScope`] that is a Ruby `Class`.
+    fn class(spec: Self::ClassSpec) -> Self;
+
+    /// Factory for an [`EnclosingRubyScope`] that is a Ruby `Module`.
+    fn module(spec: Self::ModuleSpec) -> Self;
+
+    /// Get the fully qualified name of the wrapped [`ClassLike`].
+    ///
+    /// For example, in the following Ruby code, `C` has an fqname of `A::B::C`.
+    ///
+    /// ```ruby
+    /// module A
+    ///   class B
+    ///     module C
+    ///       CONST = 1
+    ///     end
+    ///   end
+    /// end
+    /// ```
+    ///
+    /// The current implemention results in recursive calls to this function
+    /// for each enclosing scope.
+    fn fqname(&self) -> String;
+}
+
+/// `Define` trait allows a type to install classes, modules, and
+/// methods into an Artichoke interpreter.
+pub trait Define {
+    /// Concrete type for Artichoke interpreter;
+    type Artichoke;
+    /// Concrete type for result of defining `self`.
+    type Defined;
+
+    /// Define the class or module and all of its methods into the interpreter.
+    fn define(&self, interp: Self::Artichoke) -> Result<Self::Defined, ArtichokeError>;
+}
+
+/// `ClassLike` trait unifies Ruby `Class`es and `Module`s.
+pub trait ClassLike {
+    /// Concrete type for method.
+    type Method;
+    /// Concrete type for argspec.
+    ///
+    /// Argspecs define how the interpreter handles arguments for a method.
+    type ArgSpec;
+
+    /// Concrete type for an enclosing scope
+    type Scope: EnclosingRubyScope;
+
+    /// Add, but do not define, a method to this `ClassLike`.
+    fn add_method(&mut self, name: &str, method: Self::Method, args: Self::ArgSpec);
+
+    /// Add, but do not define, a method to the singleton class for this
+    /// `ClassLike`.
+    fn add_self_method(&mut self, name: &str, method: Self::Method, args: Self::ArgSpec);
+
+    fn name(&self) -> String;
+
+    /// The [`EnclosingRubyScope`] this `ClassLike` will be defined under or
+    /// `None` if this `ClassLike` is defined in
+    /// [top self](crate::top_self::TopSelf).
+    fn enclosing_scope(&self) -> Option<Self::Scope>;
+
+    /// Compute the fully qualified name of a `Class` or `Module`.
+    ///
+    /// See [`EnclosingRubyScope::fqname`].
+    fn fqname(&self) -> String;
+}

--- a/artichoke-core/src/def.rs
+++ b/artichoke-core/src/def.rs
@@ -129,6 +129,9 @@ pub trait ClassLike {
     /// `ClassLike`.
     fn add_self_method(&mut self, name: &str, method: Self::Method, args: Self::ArgSpec);
 
+    /// Name of this `Class` or `Module`.
+    ///
+    /// The local constant defined in the [`EnclosingRubyScope`].
     fn name(&self) -> String;
 
     /// The [`EnclosingRubyScope`] this `ClassLike` will be defined under or

--- a/artichoke-core/src/eval.rs
+++ b/artichoke-core/src/eval.rs
@@ -1,0 +1,60 @@
+//! Run code on an Artichoke interpreter.
+
+use crate::value::Value;
+use crate::ArtichokeError;
+
+/// Marker trait for a context used by [`Eval`].
+pub trait Context {}
+
+/// Interpreters that implement [`Eval`] expose methods for injecting code and
+/// extracting [`Value`]s from the interpereter.
+///
+/// Implementations are expected to maintain a stack of `Context` objects
+/// that maintain filename context across nested invocations of
+/// [`Eval::eval`].
+pub trait Eval {
+    /// Concrete type for eval context.
+    type Context: Context;
+
+    /// Concrete type for return values from eval.
+    type ReturnValue: Value;
+
+    /// Filename of the top eval context.
+    const TOP_FILENAME: &'static str = "(eval)";
+
+    /// Eval code on the artichoke interpreter using the current `Context`.
+    fn eval(&self, code: &[u8]) -> Result<Self::ReturnValue, ArtichokeError>;
+
+    /// Eval code on the artichoke interpreter using the current `Context`.
+    ///
+    /// Exceptions will unwind past this call.
+    fn unchecked_eval(&self, code: &[u8]) -> Self::ReturnValue;
+
+    /// Eval code on the artichoke interpreter using a custom `Context`.
+    ///
+    /// `Context` allows manipulating interpreter state before eval, for
+    /// example, setting the `__FILE__` magic constant.
+    fn eval_with_context(
+        &self,
+        code: &[u8],
+        context: Self::Context,
+    ) -> Result<Self::ReturnValue, ArtichokeError>;
+
+    /// Eval code on the artichoke interpreter using a custom `Context`.
+    ///
+    /// `Context` allows manipulating interpreter state before eval, for
+    /// example, setting the `__FILE__` magic constant.
+    ///
+    /// Exceptions will unwind past this call.
+    fn unchecked_eval_with_context(&self, code: &[u8], context: Self::Context)
+        -> Self::ReturnValue;
+
+    /// Peek at the top of the [`Context`] stack.
+    fn peek_context(&self) -> Option<&Self::Context>;
+
+    /// Push an `Context` onto the stack.
+    fn push_context(&mut self, context: Self::Context);
+
+    /// Pop an `Context` from the stack.
+    fn pop_context(&mut self);
+}

--- a/artichoke-core/src/exception.rs
+++ b/artichoke-core/src/exception.rs
@@ -1,0 +1,69 @@
+use std::fmt;
+
+use crate::ArtichokeError;
+
+/// Metadata about a Ruby exception.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Exception {
+    /// The result of calling `exception.class.name`.
+    pub class: String,
+    /// The result of calling `exception.message`.
+    pub message: String,
+    /// The result of calling `exception.backtrace`.
+    ///
+    /// Some exceptions, like `SyntaxError` which is thrown directly by the
+    /// artichoke VM, do not have backtraces, so this field is optional.
+    pub backtrace: Option<Vec<String>>,
+    /// The result of calling `exception.inspect`.
+    pub inspect: String,
+}
+
+impl Exception {
+    /// Create a new [`Exception`] from a fully qualified class name, message,
+    /// and backtrace.
+    ///
+    /// This signature may change once `inspect` parameter is no longer
+    /// required.
+    pub fn new(class: &str, message: &str, backtrace: Option<Vec<String>>, inspect: &str) -> Self {
+        Self {
+            class: class.to_owned(),
+            message: message.to_owned(),
+            backtrace,
+            inspect: inspect.to_owned(),
+        }
+    }
+}
+
+impl fmt::Display for Exception {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.inspect)?;
+        if let Some(ref backtrace) = self.backtrace {
+            for frame in backtrace {
+                write!(f, "\n{}", frame)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Represents the error state of the last group of statements on the VM.
+#[derive(Debug, PartialEq, Eq)]
+pub enum LastError {
+    /// An exception occurred.
+    Some(Exception),
+    /// No error occured.
+    None,
+    /// An error occurred while extracting `LastError`.
+    UnableToExtract(ArtichokeError),
+}
+
+/// Extract the last exception thrown on the interpreter.
+#[allow(clippy::module_name_repetitions)]
+pub trait ExceptionHandler {
+    /// Extract the last thrown exception on the artichoke interpreter if there
+    /// is one.
+    ///
+    /// If there is an error, return [`LastError::Some`], which contains the
+    /// exception class name, message, and optional backtrace.
+    fn last_error(&self) -> LastError;
+}

--- a/artichoke-core/src/exception.rs
+++ b/artichoke-core/src/exception.rs
@@ -1,3 +1,5 @@
+//! Support for Ruby `Exception`s.
+
 use std::fmt;
 
 use crate::ArtichokeError;

--- a/artichoke-core/src/file.rs
+++ b/artichoke-core/src/file.rs
@@ -1,0 +1,17 @@
+//! File-backed Rust extensions for the Artichoke VM.
+
+use crate::ArtichokeError;
+
+/// Types that implement `File` can be loaded into an interpreter and modify
+/// the VM when `require`d.
+pub trait File {
+    /// Concrete type for interpreter.
+    type Artichoke;
+
+    /// Called when the filename mapped to this type is required by the VM.
+    ///
+    /// This function can mutate interpreter state, such as defining classes and
+    /// modules. This function is equivalent to the "init" methods of
+    /// C-implemented Rubygems.
+    fn require(interp: Self::Artichoke) -> Result<(), ArtichokeError>;
+}

--- a/artichoke-core/src/lib.rs
+++ b/artichoke-core/src/lib.rs
@@ -1,5 +1,5 @@
 #![deny(clippy::all, clippy::pedantic)]
-#![deny(warnings, intra_doc_link_resolution_failure)]
+#![deny(missing_docs, warnings, intra_doc_link_resolution_failure)]
 #![doc(deny(warnings))]
 
 //! # artichoke-core
@@ -46,7 +46,12 @@ pub enum ArtichokeError {
     /// Class or module with this name is not defined in the artichoke VM.
     NotDefined(String),
     /// Arg count exceeds maximum allowed by the VM.
-    TooManyArgs { given: usize, max: usize },
+    TooManyArgs {
+        /// Number of arguments supplied.
+        given: usize,
+        /// Maximum number of arguments supported.
+        max: usize,
+    },
     /// Attempted to use an uninitialized interpreter.
     Uninitialized,
     /// Eval or funcall returned an interpreter-internal value.

--- a/artichoke-core/src/lib.rs
+++ b/artichoke-core/src/lib.rs
@@ -1,0 +1,105 @@
+#![deny(clippy::all, clippy::pedantic)]
+#![deny(warnings, intra_doc_link_resolution_failure)]
+#![doc(deny(warnings))]
+
+//! # artichoke-core
+//!
+//! artichoke-core crate provides a set of traits that, when implemented, create
+//! a complete Ruby interpreter.
+//!
+//! artichoke-core is a work in progress. When fully functioning, artichoke-core
+//! will provide interpreter agnositc implementations of Ruby Core and Ruby
+//! Standard Library that pass ruby/spec if an interpreter implements all of the
+//! required traits.
+
+use std::error;
+use std::fmt;
+use std::io;
+
+pub mod convert;
+pub mod def;
+pub mod eval;
+pub mod exception;
+pub mod file;
+pub mod load;
+pub mod state;
+pub mod top_self;
+pub mod types;
+pub mod value;
+pub mod warn;
+
+/// Errors returned by Artichoke interpreters.
+#[derive(Debug)]
+pub enum ArtichokeError {
+    /// Failed to create an argspec.
+    ArgSpec,
+    /// Failed to convert from a Rust type to a [`Value`](value::Value).
+    ConvertToRuby(convert::Error<types::Rust, types::Ruby>),
+    /// Failed to convert from a [`Value`](value::Value) to a Rust type.
+    ConvertToRust(convert::Error<types::Ruby, types::Rust>),
+    /// Exception raised during eval.
+    ///
+    /// See [`Eval`](eval::Eval).
+    Exec(exception::Exception),
+    /// Unable to initalize interpreter.
+    New,
+    /// Class or module with this name is not defined in the artichoke VM.
+    NotDefined(String),
+    /// Arg count exceeds maximum allowed by the VM.
+    TooManyArgs { given: usize, max: usize },
+    /// Attempted to use an uninitialized interpreter.
+    Uninitialized,
+    /// Eval or funcall returned an interpreter-internal value.
+    UnreachableValue,
+    /// [`io::Error`] when interacting with virtual filesystem.
+    ///
+    /// See `artichoke_vfs`.
+    Vfs(io::Error),
+}
+
+impl Eq for ArtichokeError {}
+
+impl PartialEq for ArtichokeError {
+    fn eq(&self, other: &Self) -> bool {
+        // this is a hack because io::Error does not impl PartialEq
+        format!("{}", self) == format!("{}", other)
+    }
+}
+
+impl fmt::Display for ArtichokeError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            ArtichokeError::ArgSpec => write!(f, "could not generate argspec"),
+            ArtichokeError::ConvertToRuby(inner) => write!(f, "conversion error: {}", inner),
+            ArtichokeError::ConvertToRust(inner) => write!(f, "conversion error: {}", inner),
+            ArtichokeError::Exec(backtrace) => write!(f, "{}", backtrace),
+            ArtichokeError::New => write!(f, "failed to create mrb interpreter"),
+            ArtichokeError::NotDefined(fqname) => write!(f, "{} not defined", fqname),
+            ArtichokeError::TooManyArgs { given, max } => write!(
+                f,
+                "Too many args for funcall. Gave {}, but max is {}",
+                given, max
+            ),
+            ArtichokeError::Uninitialized => write!(f, "mrb interpreter not initialized"),
+            ArtichokeError::UnreachableValue => {
+                write!(f, "extracted unreachable type from interpreter")
+            }
+            ArtichokeError::Vfs(err) => write!(f, "mrb vfs io error: {}", err),
+        }
+    }
+}
+
+impl error::Error for ArtichokeError {
+    fn description(&self) -> &str {
+        "artichoke interpreter error"
+    }
+
+    fn cause(&self) -> Option<&dyn error::Error> {
+        match self {
+            ArtichokeError::ConvertToRuby(inner) => Some(inner),
+            ArtichokeError::ConvertToRust(inner) => Some(inner),
+            ArtichokeError::Vfs(inner) => Some(inner),
+            _ => None,
+        }
+    }
+}

--- a/artichoke-core/src/load.rs
+++ b/artichoke-core/src/load.rs
@@ -1,0 +1,45 @@
+//! Load Ruby and Rust sources into the VM.
+
+use crate::file::File;
+use crate::ArtichokeError;
+
+/// Interpreters that implement [`LoadSources`] expose methods for loading Ruby
+/// and Rust sources into the VM.
+#[allow(clippy::module_name_repetitions)]
+pub trait LoadSources {
+    type Require;
+
+    /// Add a Rust-backed Ruby source file to the virtual filesystem. A stub
+    /// Ruby file is added to the filesystem and `require` will dynamically
+    /// define Ruby items when invoked via `Kernel#require`.
+    ///
+    /// If filename is a relative path, the Ruby source is added to the
+    /// filesystem relative to `RUBY_LOAD_PATH`. If the path is absolute, the
+    /// file is placed directly on the filesystem. Anscestor directories are
+    /// created automatically.
+    fn def_file(&self, filename: &str, require: Self::Require) -> Result<(), ArtichokeError>;
+
+    /// Add a Rust-backed Ruby source file to the virtual filesystem. A stub
+    /// Ruby file is added to the filesystem and [`File::require`] will
+    /// dynamically define Ruby items when invoked via `Kernel#require`.
+    ///
+    /// If filename is a relative path, the Ruby source is added to the
+    /// filesystem relative to `RUBY_LOAD_PATH`. If the path is absolute, the
+    /// file is placed directly on the filesystem. Anscestor directories are
+    /// created automatically.
+    fn def_file_for_type<F>(&self, filename: &str) -> Result<(), ArtichokeError>
+    where
+        F: File;
+
+    /// Add a pure Ruby source file to the virtual filesystem.
+    ///
+    /// If filename is a relative path, the Ruby source is added to the
+    /// filesystem relative to `RUBY_LOAD_PATH`. If the path is absolute, the
+    /// file is placed directly on the filesystem. Anscestor directories are
+    /// created automatically.
+    fn def_rb_source_file<T, F>(
+        &self,
+        filename: &str,
+        contents: &[u8],
+    ) -> Result<(), ArtichokeError>;
+}

--- a/artichoke-core/src/load.rs
+++ b/artichoke-core/src/load.rs
@@ -7,6 +7,8 @@ use crate::ArtichokeError;
 /// and Rust sources into the VM.
 #[allow(clippy::module_name_repetitions)]
 pub trait LoadSources {
+    /// Concrete type object to modify the interpreter once a source is
+    /// `require`d.
     type Require;
 
     /// Add a Rust-backed Ruby source file to the virtual filesystem. A stub

--- a/artichoke-core/src/state.rs
+++ b/artichoke-core/src/state.rs
@@ -1,0 +1,16 @@
+//! Capture stdout and stderr from an interpreter.
+
+/// Interpreters that implement [`OutputCapture`] expose methods for redirecting
+/// stdout and stderr to an internal `String` buffer and retrieving it later.
+pub trait OutputCapture {
+    /// Clear any existing output capture and capture any new IO to stdout and
+    /// stderr from the Artichoke VM.
+    ///
+    /// At a minimum, this method should capture `Kernel#puts` and
+    /// `Kernel#print`.
+    fn begin_capturing_output(&mut self);
+
+    /// Return any existing captured output or empty string if output capturing
+    /// is not enabled. Clear the existing capture buffer.
+    fn get_and_clear_captured_output(&mut self) -> String;
+}

--- a/artichoke-core/src/symbol.rs
+++ b/artichoke-core/src/symbol.rs
@@ -1,0 +1,14 @@
+//! Manipulate the VM `Symbol` cache.
+
+/// Interpreters that implement [`Symbol`] expose methods for manipulating the
+/// VM `Symbol` cache.
+pub trait Symbol {
+    /// Concrete type used to identify `Symbol`s in the VM.
+    type SymbolIdentifier;
+
+    /// Resolve a symbol from the interpreter state.
+    ///
+    /// Symbols are potentially interned. References to symbols occur vi an
+    /// indirected value of concrete type `SymbolIdentifier`.
+    fn resolve_symbol(&mut self, sym: &str) -> Self::SymbolIdentifier;
+}

--- a/artichoke-core/src/top_self.rs
+++ b/artichoke-core/src/top_self.rs
@@ -1,0 +1,21 @@
+//! Expose the global context, called
+//! [_top self_](https://www.sitepoint.com/rubys-top-self-object/), to the
+//! interpreter.
+
+use crate::value::Value;
+
+/// Return a [`Value`]-wrapped reference to "top self".
+///
+/// Top self is the root object that evaled code is executed within. Global
+/// methods, classes, and modules are defined in top self.
+#[allow(clippy::module_name_repetitions)]
+pub trait TopSelf {
+    /// Concrete [`Value`] type.
+    type Value: Value;
+
+    /// Return a [`Value`]-wrapped reference to "top self".
+    ///
+    /// Top self is the root object that evaled code is executed within. Global
+    /// methods, classes, and modules are defined in top self.
+    fn top_self(&self) -> Self::Value;
+}

--- a/artichoke-core/src/types.rs
+++ b/artichoke-core/src/types.rs
@@ -5,14 +5,29 @@ use std::fmt;
 /// Classes of Rust types.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Rust {
+    /// Rust `bool` type.
     Bool,
+    /// Rust `Vec<u8>` type.
     Bytes,
+    /// Rust float type.
+    ///
+    /// Float width is dependent on interpreter implementation and architecture.
     Float,
+    /// Rust `HashMap<K, V>` type.
     Map,
+    /// Aribtrary Rust struct type.
     Object,
+    /// Rust signed integer type.
+    ///
+    /// Int width is dependent on interpreter implementation and architecture.
     SignedInt,
+    /// Rust `String` type.
     String,
+    /// Rust unsigned integer type.
+    ///
+    /// Int width is dependent on interpreter implementation and architecture.
     UnsignedInt,
+    /// Rust `Vec<T>` type.
     Vec,
 }
 
@@ -25,25 +40,65 @@ impl fmt::Display for Rust {
 /// Classes of Ruby types.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Ruby {
+    /// Ruby `Array` type.
     Array,
+    /// Ruby `TrueClass` and `FalseClass` type.
     Bool,
+    /// Ruby `Class` type.
     Class,
+    /// FFI type for a borrowed C pointer.
     CPointer,
+    /// FFI type for an owned C pointer.
     Data,
+    /// Ruby `Exception` type.
     Exception,
+    /// Ruby `Fiber` type.
     Fiber,
+    /// Ruby `Fixnum` type.
+    ///
+    /// `Fixnum` is a type of `Integer` which represents numbers from
+    /// `[-u64::MAX, us64::MAX]`. `Fixnum`s have a special algorithm for
+    /// object IDs: `2 * self - 1`.
     Fixnum,
+    /// Ruby `Float` type.
     Float,
+    /// Ruby `Hash` type.
+    ///
+    /// Similar to a [`HashMap`](std::collections::HashMap), but with remembered
+    /// insertion order.
     Hash,
+    /// Internal type for non-heap allocated structs.
     InlineStruct,
+    /// Ruby `Module` type.
     Module,
+    /// Ruby `nil` singleton type, the only instance of `NilClass`.
     Nil,
+    /// Ruby `Object` type.
+    ///
+    /// This type represents instances of classes defined in the Artichoke VM.
     Object,
+    /// Ruby `Proc` type.
+    ///
+    /// `Proc` is a callable closure that captures lexical scope. `Proc`s can
+    /// be arbitrary arity and may or may not enforce this arity when called.
     Proc,
+    /// Ruby `Range` type.
+    ///
+    /// Similar to a Rust [iterator](std::iter).
     Range,
+    /// Internal type for the singleton class of an object.
     SingletonClass,
+    /// Ruby `String` type.
+    ///
+    /// In Artichoke, `String`s have a limited set of encodings. A `String` can
+    /// be UTF-8, [maybe UTF-8](https://docs.rs/bstr/), or binary.
     String,
+    /// Ruby `Symbol` type.
+    ///
+    /// An interned `String`. Symbols are never freed by the interpreter.
     Symbol,
+    /// Unreachable interpreter value. Receiving one of these from the
+    /// interpreter is a bug.
     Unreachable,
 }
 

--- a/artichoke-core/src/types.rs
+++ b/artichoke-core/src/types.rs
@@ -1,0 +1,54 @@
+//! Artichoke Ruby and Rust type mappings.
+
+use std::fmt;
+
+/// Classes of Rust types.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum Rust {
+    Bool,
+    Bytes,
+    Float,
+    Map,
+    Object,
+    SignedInt,
+    String,
+    UnsignedInt,
+    Vec,
+}
+
+impl fmt::Display for Rust {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+/// Classes of Ruby types.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum Ruby {
+    Array,
+    Bool,
+    Class,
+    CPointer,
+    Data,
+    Exception,
+    Fiber,
+    Fixnum,
+    Float,
+    Hash,
+    InlineStruct,
+    Module,
+    Nil,
+    Object,
+    Proc,
+    Range,
+    SingletonClass,
+    String,
+    Symbol,
+    Unreachable,
+}
+
+impl fmt::Display for Ruby {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}

--- a/artichoke-core/src/value.rs
+++ b/artichoke-core/src/value.rs
@@ -1,0 +1,62 @@
+//! Types that implement `Value` can be represented in the Artichoke VM.
+
+use crate::convert::TryConvert;
+use crate::ArtichokeError;
+
+/// A value in the Artichoke VM, equivalent to an `RValue` in MRI.
+pub trait Value {
+    /// Concrete type for Artichoke interpreter.
+    type Artichoke;
+
+    /// Concrete type for arguments passed to [`funcall`](Value::funcall).
+    type Arg;
+
+    /// Concrete type for blocks passed to [`funcall`](Value::funcall).
+    type Block;
+
+    /// Concrete type for return values of [`funcall`](Value::funcall).
+    type ReturnValue;
+
+    /// Call a method on this [`Value`] with arguments and an optional block.
+    fn funcall<T, M, A>(
+        &self,
+        func: &str,
+        args: &[Self::Arg],
+        block: Option<Self::Block>,
+    ) -> Result<T, ArtichokeError>
+    where
+        T: TryConvert;
+
+    /// Consume `self` and try to convert `self` to type `T`.
+    ///
+    /// If you do not want to consume this [`Value`], use [`Value::itself`].
+    fn try_into<T>(self) -> Result<T, ArtichokeError>
+    where
+        T: TryConvert;
+
+    /// Call `#itself` on this [`Value`] and try to convert the result to type
+    /// `T`.
+    ///
+    /// If you want to consume this [`Value`], use [`Value::try_into`].
+    fn itself<T>(&self) -> Result<T, ArtichokeError>
+    where
+        T: TryConvert;
+
+    /// Call `#freeze` on this [`Value`].
+    fn freeze(&mut self) -> Result<(), ArtichokeError>;
+
+    /// Call `#inspect` on this [`Value`].
+    ///
+    /// This function can never fail.
+    fn inspect(&self) -> String;
+
+    /// Whether `self` responds to a method.
+    ///
+    /// Equivalent to invoking `#respond_to?` on this [`Value`].
+    fn respond_to(&self, method: &str) -> Result<bool, ArtichokeError>;
+
+    /// Call `#to_s` on this [`Value`].
+    ///
+    /// This function can never fail.
+    fn to_s(&self) -> String;
+}

--- a/artichoke-core/src/warn.rs
+++ b/artichoke-core/src/warn.rs
@@ -1,0 +1,18 @@
+//! Emit warnings during VM execution.
+
+use crate::ArtichokeError;
+
+/// Interpreters that implement [`Warn`] expose methods for emitting warnings
+/// during execution.
+///
+/// Some functionality required to be compliant with ruby-spec is deprecated or
+/// invalid behavior and ruby-spec expects a warning to be emitted to `$stderr`
+/// using the
+/// [`Warning`](https://ruby-doc.org/core-2.6.3/Warning.html#method-i-warn)
+/// module from the standard library.
+pub trait Warn {
+    /// Emit a warning message using `Kernel#warn`.
+    ///
+    /// This method appends newlines to message if necessary.
+    fn warn(&self, message: &str) -> Result<(), ArtichokeError>;
+}

--- a/artichoke-wasm/src/index.html
+++ b/artichoke-wasm/src/index.html
@@ -111,6 +111,12 @@
               <div class="dropdown-menu" aria-labelledby="navbarDropdown">
                 <a
                   class="dropdown-item"
+                  href="https://artichoke.github.io/artichoke/artichoke_core/"
+                >
+                  artichoke-core
+                </a>
+                <a
+                  class="dropdown-item"
                   href="https://artichoke.github.io/artichoke/artichoke_backend/"
                 >
                   artichoke-backend


### PR DESCRIPTION
This is an experimental branch to split apart `mruby` crate into a core and several backend implementations.

I do not intend to merge this branch, but will pull learnings from it back into `master`.

Changes so far in this branch:

- `Value` is a trait.
- `class:Spec` and `module::Spec` unified under a `ClassLike` trait object.
- Simplified `Method` definition.
- Converters are generic over interpreter.
- Added `Nil` trait so interpreters can provide a `nil` `Value`.
- Removed `Mrb` prefix from all trait definitions.