### PR TITLE
Free Strings from Rust heap after evaling Ruby

### DIFF
--- a/artichoke-wasm/src/index.html
+++ b/artichoke-wasm/src/index.html
@@ -194,7 +194,10 @@
       const eval_ruby = source => {
         const code = write_string(artichoke, source);
         const output = _artichoke_eval(artichoke, code);
-        return read_string(artichoke, output);
+        const result = read_string(artichoke, output);
+        _artichoke_string_free(artichoke, code);
+        _artichoke_string_free(artichoke, output);
+        return result;
       };
       const playground_run = () => {
         const editor = ace.edit("editor");


### PR DESCRIPTION
All Strings consumed by the interpreter need to be owned by Rust. The Wasm
frontend returns 'pointers' to Strings in a 'heap' (HashMap) and exposes
an API for finding the length of the String behind a pointer and reading
and writing characters from and into the String.

JS copies code into the heap and copies results out of the heap. Once this
eval and result extract is done, the Rust copies of the Strings are no longer
required. Currently, these Strings leak. This PR explicitly frees the Strings
from the heap which will let them be reclaimed by Rust.