### PR TITLE
Support non-ascii strings in Wasm frontend

### DIFF
--- a/artichoke-wasm/src/index.html
+++ b/artichoke-wasm/src/index.html
@@ -176,18 +176,19 @@
     <script type="text/javascript">
       const read_string = (state, ptr) => {
         const len = _artichoke_string_getlen(state, ptr);
-        const chars = [];
+        const bytes = [];
         for (let idx = 0; idx < len; idx++) {
-          let char = _artichoke_string_getch(state, ptr, idx);
-          chars.push(String.fromCharCode(char));
+          let byte = _artichoke_string_getch(state, ptr, idx);
+          bytes.push(byte);
         }
-        return chars.join("");
+        return new TextDecoder().decode(new Uint8Array(bytes));
       };
       const write_string = (state, s) => {
         const ptr = _artichoke_string_new(state);
-        for (let idx = 0; idx < s.length; idx++) {
-          let char = s.charCodeAt(idx);
-          _artichoke_string_putch(state, ptr, char);
+        const bytes = new TextEncoder().encode(s);;
+        for (let idx = 0; idx < bytes.length; idx++) {
+          let byte = bytes[idx];
+          _artichoke_string_putch(state, ptr, byte);
         }
         return ptr;
       };

--- a/artichoke-wasm/src/index.html
+++ b/artichoke-wasm/src/index.html
@@ -174,47 +174,15 @@
       </div>
     </div>
     <script type="text/javascript">
-      const read_string = (state, ptr) => {
-        const len = _artichoke_string_getlen(state, ptr);
-        const bytes = [];
-        for (let idx = 0; idx < len; idx++) {
-          let byte = _artichoke_string_getch(state, ptr, idx);
-          bytes.push(byte);
-        }
-        return new TextDecoder().decode(new Uint8Array(bytes));
-      };
-      const write_string = (state, s) => {
-        const ptr = _artichoke_string_new(state);
-        const bytes = new TextEncoder().encode(s);;
-        for (let idx = 0; idx < bytes.length; idx++) {
-          let byte = bytes[idx];
-          _artichoke_string_putch(state, ptr, byte);
-        }
-        return ptr;
-      };
-      const eval_ruby = source => {
-        const code = write_string(artichoke, source);
-        const output = _artichoke_eval(artichoke, code);
-        const result = read_string(artichoke, output);
-        _artichoke_string_free(artichoke, code);
-        _artichoke_string_free(artichoke, output);
-        return result;
-      };
-      const playground_run = () => {
-        const editor = ace.edit("editor");
-        const source = editor.getValue();
-        const output = eval_ruby(source);
-        document.getElementById("output").innerText = output;
-      };
       var Module = {
-        onRuntimeInitialized: function() {
+        onRuntimeInitialized: () => {
           window.artichoke = _artichoke_web_repl_init();
           document.getElementById(
             "artichoke-build-info"
-          ).innerText = read_string(artichoke, 0);
+          ).innerText = _artichoke_build_info();
           document
             .getElementById("run")
-            .addEventListener("click", playground_run);
+            .addEventListener("click", _artichoke_playground_eval);
         }
       };
     </script>

--- a/artichoke-wasm/src/playground.js
+++ b/artichoke-wasm/src/playground.js
@@ -43,3 +43,42 @@ ace.edit("editor", {
 });
 
 ace.edit("editor").setValue(sample.trim(), -1);
+
+const read_string = (state, ptr) => {
+  const len = window._artichoke_string_getlen(state, ptr);
+  const bytes = [];
+  for (let idx = 0; idx < len; idx++) {
+    let byte = window._artichoke_string_getch(state, ptr, idx);
+    bytes.push(byte);
+  }
+  return new TextDecoder().decode(new Uint8Array(bytes));
+};
+
+const write_string = (state, s) => {
+  const ptr = window._artichoke_string_new(state);
+  const bytes = new TextEncoder().encode(s);
+  for (let idx = 0; idx < bytes.length; idx++) {
+    let byte = bytes[idx];
+    window._artichoke_string_putch(state, ptr, byte);
+  }
+  return ptr;
+};
+
+const eval_ruby = source => {
+  const code = write_string(artichoke, source);
+  const output = window._artichoke_eval(artichoke, code);
+  const result = read_string(artichoke, output);
+  window._artichoke_string_free(artichoke, code);
+  window._artichoke_string_free(artichoke, output);
+  return result;
+};
+
+const playground_run = () => {
+  const editor = ace.edit("editor");
+  const source = editor.getValue();
+  const output = eval_ruby(source);
+  document.getElementById("output").innerText = output;
+};
+
+window._artichoke_build_info = () => read_string(window.artichoke, 0);
+window._artichoke_playground_eval = playground_run;

--- a/artichoke-wasm/src/playground.js
+++ b/artichoke-wasm/src/playground.js
@@ -6,9 +6,12 @@ import "artichoke-wasm/artichoke_wasm.wasm";
 import "artichoke-wasm/deps/artichoke-wasm.js";
 
 const sample = `
+# The following calls to Kernel#require include real implementations of Ruby
+# Standard Library packages.
+#
 # https://ruby-doc.org/stdlib-2.5.1/libdoc/forwardable/rdoc/Forwardable.html
-require 'forwardable'
 # https://ruby-doc.org/stdlib-2.6.3/libdoc/set/rdoc/Set.html
+require 'forwardable'
 require 'set'
 
 class Registry
@@ -22,10 +25,9 @@ end
 
 registry = Registry.new
 
-3.times do
-  10.times do |record|
-    registry.add(record)
-  end
+10.times do |record|
+  registry.add("Artichoke")
+  registry.add("💎")
 end
 
 puts registry.to_a

--- a/artichoke-wasm/src/string.rs
+++ b/artichoke-wasm/src/string.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 #[derive(Debug, Clone, Default)]
 pub struct Heap {
-    memory: HashMap<u32, String>,
+    memory: HashMap<u32, Vec<u8>>,
     next_free: u32,
 }
 
@@ -10,7 +10,7 @@ impl Heap {
     pub fn allocate(&mut self, s: String) -> u32 {
         let ptr = self.next_free;
         self.next_free += 1;
-        self.memory.insert(ptr, s);
+        self.memory.insert(ptr, s.into_bytes());
         ptr
     }
 
@@ -18,16 +18,13 @@ impl Heap {
         self.memory.remove(&ptr);
     }
 
-    pub fn string(&self, ptr: u32) -> &str {
-        self.memory
-            .get(&ptr)
-            .map(|s| s.as_ref())
-            .unwrap_or_default()
+    pub fn string(&self, ptr: u32) -> &[u8] {
+        self.memory.get(&ptr).map(Vec::as_slice).unwrap_or_default()
     }
 
     pub fn string_getlen(&self, ptr: u32) -> u32 {
         if let Some(s) = self.memory.get(&ptr) {
-            s.as_bytes().len() as u32
+            s.len() as u32
         } else {
             0
         }
@@ -35,7 +32,7 @@ impl Heap {
 
     pub fn string_getch(&self, ptr: u32, idx: u32) -> u8 {
         if let Some(s) = self.memory.get(&ptr) {
-            s.as_bytes()[idx as usize]
+            s[idx as usize]
         } else {
             0
         }
@@ -43,7 +40,7 @@ impl Heap {
 
     pub fn string_putch(&mut self, ptr: u32, ch: u8) {
         if let Some(s) = self.memory.get_mut(&ptr) {
-            s.push(ch as char);
+            s.push(ch);
         }
     }
 }


### PR DESCRIPTION
Properly encode/decode between Rust UTF-8 String and JavaScript UCS-2 String.
Modify String heap to be backed by a `Vec<u8>`.
Move playground runtime out of `index.html` into `playground.js`.