### PR TITLE
Limit total memory in Wasm build to 5MiB

### DIFF
--- a/artichoke-wasm/src/main.rs
+++ b/artichoke-wasm/src/main.rs
@@ -120,6 +120,7 @@ pub fn artichoke_eval(state: u32, ptr: u32) -> u32 {
     -s LINKABLE=1
     -s ASSERTIONS=1
     -s ENVIRONMENT='web'
+    -s TOTAL_MEMORY=5242880
     -s EXPORTED_FUNCTIONS=["_artichoke_web_repl_init","_artichoke_string_new","_artichoke_string_free","_artichoke_string_getlen","_artichoke_string_getch","_artichoke_string_putch","_artichoke_eval"]
     -s EXTRA_EXPORTED_RUNTIME_METHODS=["ccall","cwrap"]
 "#)]


### PR DESCRIPTION
Fix a crash in Mobile Safari caused by an out of memory error.