### PR TITLE
Vendor and fork path_abs::PathAbs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,7 +35,6 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "mruby-sys 2.0.1-12",
  "onig 4.3.2 (git+https://github.com/artichoke/rust-onig?branch=wasm)",
- "path_abs 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck_macros 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -338,17 +337,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "path_abs"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
- "std_prelude 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "stfu8 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -621,21 +609,6 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "serde"
-version = "1.0.98"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "serde_derive"
-version = "1.0.98"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.42 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "shellexpand"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -652,20 +625,6 @@ dependencies = [
  "artichoke-backend 0.1.0",
  "fs_extra 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-embed 4.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "std_prelude"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "stfu8"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -860,7 +819,6 @@ dependencies = [
 "checksum nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
 "checksum onig 4.3.2 (git+https://github.com/artichoke/rust-onig?branch=wasm)" = "<none>"
 "checksum onig_sys 69.1.0 (git+https://github.com/artichoke/rust-onig?branch=wasm)" = "<none>"
-"checksum path_abs 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "35022afdd8880d98720e5d13c497fa5a3f7ce64ea0278f4774829e8245eed51a"
 "checksum peeking_take_while 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 "checksum pkg-config 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c1d2cfa5a714db3b5f24f0915e74fcdf91d09d496ba61329705dda7774d2af"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
@@ -893,12 +851,8 @@ dependencies = [
 "checksum scoped_threadpool 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1d51f5df5af43ab3f1360b429fa5e0152ac5ce8c0bd6485cae490332e96846a8"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
-"checksum serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)" = "7fe5626ac617da2f2d9c48af5515a21d5a480dbd151e01bb1c355e26a3e68113"
-"checksum serde_derive 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)" = "01e69e1b8a631f245467ee275b8c757b818653c6d704cdbcaeb56b56767b529c"
 "checksum shellexpand 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de7a5b5a9142fd278a10e0209b021a1b85849352e6951f4f914735c976737564"
 "checksum shlex 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
-"checksum std_prelude 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)" = "8207e78455ffdf55661170876f88daf85356e4edd54e0a3dbc79586ca1e50cbe"
-"checksum stfu8 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4bf70433e3300a3c395d06606a700cdf4205f4f14dbae2c6833127c6bb22db77"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 "checksum syn 0.15.42 (registry+https://github.com/rust-lang/crates.io-index)" = "eadc09306ca51a40555dd6fc2b415538e9e18bc9f870e47b1a524a79fe2dcf5e"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2018"
 
 [dependencies]
 log = "0.4.6"
-path_abs = "0.4.1"
 
 [dependencies.artichoke-vfs]
 path = "../artichoke-vfs"

--- a/artichoke-backend/README.md
+++ b/artichoke-backend/README.md
@@ -198,3 +198,11 @@ CactusRef contains Ruby sources derived from Ruby @
 [2.6.3](https://github.com/ruby/ruby/tree/v2_6_3) which is copyright Yukihiro
 Matsumoto \<matz@netlab.jp\> under the
 [2-clause BSDL License](https://github.com/ruby/ruby/blob/v2_6_3/COPYING).
+
+artichoke-backend contains a fork of path_abs @
+[8370838](https://github.com/vitiral/path_abs/tree/8370838b6110786c2ba7cf7fd984a4783f37701c)
+which is copyright (c) 2018 Garrett Berg, vitiral@gmail.com. path_abs is dual
+licensed with the
+[MIT License](https://github.com/vitiral/path_abs/blob/8370838b6110786c2ba7cf7fd984a4783f37701c/LICENSE-MIT)
+and
+[Apache 2.0 License](https://github.com/vitiral/path_abs/blob/8370838b6110786c2ba7cf7fd984a4783f37701c/LICENSE-APACHE).

--- a/artichoke-backend/README.md
+++ b/artichoke-backend/README.md
@@ -194,9 +194,9 @@ The infallible converters are safe Rust functions. The fallibile converters are
 artichoke-backend is licensed with the [MIT License](/LICENSE) (c) Ryan
 Lopopolo.
 
-CactusRef contains Ruby sources derived from Ruby @
+Some portions of artichoke-backend are derived from Ruby @
 [2.6.3](https://github.com/ruby/ruby/tree/v2_6_3) which is copyright Yukihiro
-Matsumoto \<matz@netlab.jp\> under the
+Matsumoto \<matz@netlab.jp\>. Ruby is licensed with the
 [2-clause BSDL License](https://github.com/ruby/ruby/blob/v2_6_3/COPYING).
 
 artichoke-backend contains a fork of path_abs @

--- a/artichoke-backend/src/extn/core/kernel/require.rs
+++ b/artichoke-backend/src/extn/core/kernel/require.rs
@@ -82,7 +82,6 @@ impl Args {
 
 pub mod method {
     use log::trace;
-    use path_abs::PathAbs;
     use std::path::{Path, PathBuf};
     use std::rc::Rc;
 
@@ -125,11 +124,6 @@ pub mod method {
             vec![path.join(args.file.as_str())]
         };
         for path in files {
-            // canonicalize path (remove '.' and '..' components).
-            let path = match PathAbs::new(path) {
-                Ok(path) => path,
-                Err(_) => continue,
-            };
             let is_file = {
                 let api = interp.borrow();
                 api.vfs.is_file(path.as_path())

--- a/artichoke-backend/src/fs/abs.rs
+++ b/artichoke-backend/src/fs/abs.rs
@@ -1,0 +1,443 @@
+/* Copyright (c) 2018 Garrett Berg, vitiral@gmail.com
+ *
+ * Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+ * http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+ * http://opensource.org/licenses/MIT>, at your option. This file may not be
+ * copied, modified, or distributed except according to those terms.
+ */
+
+//! The absolute path type.
+
+use std::borrow::Borrow;
+use std::error;
+use std::ffi;
+use std::fmt;
+use std::io;
+use std::path::{Component, Path, PathBuf, PrefixComponent};
+use std::sync::Arc;
+
+pub type Result<T> = ::std::result::Result<T, Error>;
+
+pub struct Error {
+    io_err: io::Error,
+    action: String,
+    path: Arc<PathBuf>,
+}
+
+impl Error {
+    /// Create a new error when the path and action are known.
+    pub fn new(io_err: io::Error, action: &str, path: Arc<PathBuf>) -> Self {
+        Self {
+            io_err,
+            action: action.into(),
+            path,
+        }
+    }
+}
+
+impl fmt::Debug for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Error<{}>", self)
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{} when {} {}",
+            self.io_err,
+            self.action,
+            self.path.display()
+        )
+    }
+}
+
+impl Error {
+    /// Returns the path associated with this error.
+    pub fn path(&self) -> &Path {
+        self.path.as_ref()
+    }
+
+    /// Returns the `std::io::Error` associated with this errors.
+    pub fn io_error(&self) -> &io::Error {
+        &self.io_err
+    }
+
+    /// Returns the action being performed when this error occured.
+    pub fn action(&self) -> &str {
+        &self.action
+    }
+}
+
+impl error::Error for Error {
+    fn description(&self) -> &str {
+        self.io_err.description()
+    }
+
+    fn cause(&self) -> Option<&dyn error::Error> {
+        Some(&self.io_err)
+    }
+}
+
+impl From<Error> for io::Error {
+    fn from(err: Error) -> Self {
+        Self::new(err.io_err.kind(), err)
+    }
+}
+
+/// Converts any [`PrefixComponent`] into verbatim ("extended-length") form.
+fn make_verbatim_prefix(prefix: &PrefixComponent<'_>) -> Result<PathBuf> {
+    let path_prefix = Path::new(prefix.as_os_str());
+
+    if prefix.kind().is_verbatim() {
+        // This prefix already uses the extended-length
+        // syntax, so we can use it as-is.
+        Ok(path_prefix.to_path_buf())
+    } else {
+        // This prefix needs canonicalization.
+        let res = path_prefix
+            .canonicalize()
+            .map_err(|e| Error::new(e, "canonicalizing", path_prefix.to_path_buf().into()))?;
+        Ok(res)
+    }
+}
+
+/// Pops the last component from path, returning an error for a root path.
+fn pop_or_error(path: &mut PathBuf) -> ::std::result::Result<(), io::Error> {
+    if path.pop() {
+        Ok(())
+    } else {
+        Err(io::Error::new(io::ErrorKind::NotFound, ".. consumed root"))
+    }
+}
+
+/// An absolute (not _necessarily_ [canonicalized][1]) path that may or may not
+/// exist.
+///
+/// [1]: https://doc.rust-lang.org/std/path/struct.Path.html?search=#method.canonicalize
+#[derive(Clone, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[allow(clippy::module_name_repetitions)]
+pub struct PathAbs(Arc<PathBuf>);
+
+impl PathAbs {
+    /// Construct an absolute path from an arbitrary (absolute or relative) one.
+    ///
+    /// This is different from [`canonicalize`](Path::canonicalize) in that it
+    /// _preserves_ symlinks and the destination may or may not exist.
+    ///
+    /// This function will:
+    /// - Resolve relative paths against the current working directory.
+    /// - Strip any `.` components (`/a/./c` -> `/a/c`)
+    /// - Resolve `..` _semantically_ (not using the file system). So,
+    ///   `a/b/c/../d => a/b/d` will _always_ be true regardless of symlinks. If
+    ///   you want symlinks correctly resolved, use `canonicalize()` instead.
+    pub fn new<P: AsRef<Path>, D: AsRef<Path>>(path: P, cwd: D) -> Result<Self> {
+        let path = Arc::new(path.as_ref().to_path_buf());
+        let mut res = PathBuf::new();
+
+        for each in path.components() {
+            match each {
+                Component::Prefix(p) => {
+                    // We don't care what's already in res, we can entirely
+                    // replace it..
+                    res = make_verbatim_prefix(&p)?;
+                }
+
+                Component::RootDir => {
+                    if cfg!(windows) {
+                        // In an ideal world, we would say
+                        //
+                        //  res = std::fs::canonicalize(each)?;
+                        //
+                        // ...to get a properly canonicalized path.
+                        // Unfortunately, Windows cannot canonicalize `\` if
+                        // the current directory happens to use extended-length
+                        // syntax (like `\\?\C:\Windows`), so we'll have to do
+                        // it manually: initialize `res` with the current
+                        // working directory (whatever it is), and truncate it
+                        // to its prefix by pushing `\`.
+                        if res.as_os_str().is_empty() {
+                            // res has not been initialized, let's initialize it
+                            // to the supplied current working directory.
+                            res = cwd.as_ref().to_path_buf();
+                        }
+                        res.push(each);
+                    } else {
+                        // On other platforms, a root path component is always
+                        // absolute so we can replace whatever's in res.
+                        res = Path::new(&each).to_path_buf();
+                    }
+                }
+
+                // This does nothing and can be ignored.
+                Component::CurDir => (),
+
+                Component::ParentDir => {
+                    // A parent component is always relative to some existing
+                    // path.
+                    if res.as_os_str().is_empty() {
+                        // res has not been initialized, let's initialize it to
+                        // the supplied current working directory.
+                        res = cwd.as_ref().to_path_buf();
+                    }
+                    pop_or_error(&mut res)
+                        .map_err(|e| Error::new(e, "resolving absolute", path.clone()))?;
+                }
+
+                Component::Normal(c) => {
+                    // A normal component is always relative to some existing
+                    // path.
+                    if res.as_os_str().is_empty() {
+                        // res has not been initialized, let's initialize it to
+                        // the supplied current working directory.
+                        res = cwd.as_ref().to_path_buf();
+                    }
+                    res.push(c);
+                }
+            }
+        }
+
+        Ok(Self(Arc::new(res)))
+    }
+
+    /// Create a PathAbs unchecked.
+    ///
+    /// This is mostly used for constructing during tests, or if the path was previously validated.
+    /// This is effectively the same as a `Arc<PathBuf>`.
+    ///
+    /// > Note: This is memory safe, so is not marked `unsafe`. However, it could cause
+    /// > panics in some methods if the path was not properly validated.
+    pub fn new_unchecked<P: Into<Arc<PathBuf>>>(path: P) -> Self {
+        Self(path.into())
+    }
+
+    /// Return a reference to a basic `std::path::Path`
+    pub fn as_path(&self) -> &Path {
+        self.as_ref()
+    }
+}
+
+impl fmt::Debug for PathAbs {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl AsRef<ffi::OsStr> for PathAbs {
+    fn as_ref(&self) -> &std::ffi::OsStr {
+        self.0.as_ref().as_ref()
+    }
+}
+
+impl AsRef<Path> for PathAbs {
+    fn as_ref(&self) -> &Path {
+        self.0.as_ref()
+    }
+}
+
+impl AsRef<PathBuf> for PathAbs {
+    fn as_ref(&self) -> &PathBuf {
+        self.0.as_ref()
+    }
+}
+
+impl Borrow<Path> for PathAbs {
+    fn borrow(&self) -> &Path {
+        self.as_ref()
+    }
+}
+
+impl Borrow<PathBuf> for PathAbs {
+    fn borrow(&self) -> &PathBuf {
+        self.as_ref()
+    }
+}
+
+impl<'a> Borrow<Path> for &'a PathAbs {
+    fn borrow(&self) -> &Path {
+        self.as_ref()
+    }
+}
+
+impl<'a> Borrow<PathBuf> for &'a PathAbs {
+    fn borrow(&self) -> &PathBuf {
+        self.as_ref()
+    }
+}
+
+impl From<PathAbs> for Arc<PathBuf> {
+    fn from(path: PathAbs) -> Self {
+        path.0
+    }
+}
+
+impl From<PathAbs> for PathBuf {
+    fn from(path: PathAbs) -> Self {
+        match Arc::try_unwrap(path.0) {
+            Ok(p) => p,
+            Err(inner) => inner.as_ref().clone(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::env;
+    use std::io;
+    use std::path;
+
+    use super::PathAbs;
+
+    fn setup() {
+        #[cfg(windows)]
+        std::env::set_current_dir(r"C:\").expect("Could not change to a regular directory");
+
+        // For cfg(unix), we're always in a regular directory, so we don't need
+        // to do anything special.
+    }
+
+    #[test]
+    fn absolute_path_is_idempotent() {
+        setup();
+        // The current_dir() result is always absolute,
+        // so absolutizing it should not change it.
+
+        let actual = PathAbs::new(env::current_dir().unwrap(), "").unwrap();
+        let expected = env::current_dir().unwrap().canonicalize().unwrap();
+
+        assert_eq!(actual.as_path(), expected.as_path());
+    }
+
+    #[test]
+    fn absolute_path_removes_currentdir_component() {
+        setup();
+        let actual = PathAbs::new("foo/./bar", "").unwrap();
+        let expected = PathAbs::new("foo/bar", "").unwrap();
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn absolute_path_removes_empty_component() {
+        setup();
+        let actual = PathAbs::new("foo//bar", "").unwrap();
+        let expected = PathAbs::new("foo/bar", "").unwrap();
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn absolute_path_interprets_relative_to_current_directory() {
+        setup();
+        let actual = PathAbs::new("foo", env::current_dir().unwrap()).unwrap();
+        let expected = PathAbs::new(env::current_dir().unwrap().join("foo"), "").unwrap();
+
+        assert_eq!(actual, expected);
+    }
+
+    #[cfg(unix)]
+    mod unix {
+        use super::*;
+
+        #[test]
+        fn absolute_path_need_not_exist() {
+            setup();
+
+            // It's not likely this path would exist, but let's be sure.
+            let raw_path = path::Path::new("/does/not/exist");
+            assert_eq!(
+                raw_path.metadata().unwrap_err().kind(),
+                io::ErrorKind::NotFound,
+            );
+
+            let path = PathAbs::new(raw_path, "").unwrap();
+
+            assert_eq!(path::Path::as_os_str(path.as_path()), "/does/not/exist");
+        }
+
+        #[test]
+        fn absolute_path_cannot_go_above_root() {
+            setup();
+            let err = PathAbs::new("/foo/../..", "").unwrap_err();
+
+            assert_eq!(err.io_error().kind(), io::ErrorKind::NotFound);
+            assert_eq!(err.io_error().to_string(), ".. consumed root");
+            assert_eq!(err.action(), "resolving absolute");
+            assert_eq!(err.path(), path::Path::new("/foo/../.."));
+        }
+    }
+
+    #[cfg(windows)]
+    mod windows {
+        use super::*;
+
+        #[test]
+        fn absolute_path_need_not_exist() {
+            setup();
+
+            // It's not likely this path would exist, but let's be sure.
+            let raw_path = path::Path::new(r"C:\does\not\exist", "");
+            assert_eq!(
+                raw_path.metadata().unwrap_err().kind(),
+                io::ErrorKind::NotFound,
+            );
+
+            let path = PathAbs::new(raw_path, "").unwrap();
+            assert_eq!(path.as_os_str(), r"\\?\C:\does\not\exist");
+        }
+
+        #[test]
+        fn absolute_path_cannot_go_above_root() {
+            setup();
+            let err = PathAbs::new(r"C:\foo\..\..", "").unwrap_err();
+
+            assert_eq!(err.io_error().kind(), io::ErrorKind::NotFound);
+            assert_eq!(err.io_error().to_string(), ".. consumed root");
+            assert_eq!(err.action(), "resolving absolute");
+            assert_eq!(err.path(), path::Path::new(r"C:\foo\..\.."));
+        }
+
+        #[test]
+        fn absolute_supports_root_only_relative_path() {
+            setup();
+            let actual = PathAbs::new(r"\foo", "").unwrap();
+
+            let mut current_drive_root = path::PathBuf::new();
+            current_drive_root.extend(
+                env::current_dir().unwrap().components().take(2), // the prefix (C:) and root (\) components
+            );
+
+            let expected = PathAbs::new(current_drive_root.join("foo")).unwrap();
+
+            assert_eq!(actual, expected);
+        }
+
+        #[test]
+        fn absolute_supports_prefix_only_relative_path() {
+            setup();
+            let actual = PathAbs::new(r"C:foo", "").unwrap();
+
+            let expected =
+                PathAbs::new(path::Path::new(r"C:").canonicalize().unwrap().join("foo")).unwrap();
+
+            assert_eq!(actual, expected);
+        }
+
+        #[test]
+        fn absolute_accepts_bogus_prefix() {
+            setup();
+            let path = PathAbs::new(r"\\?\bogus\path\", "").unwrap();
+
+            assert_eq!(path.as_os_str(), r"\\?\bogus\path");
+        }
+    }
+
+    #[test]
+    fn test_root_parent() {
+        let actual = PathAbs::new("/a/../..", "").expect_err("Can go outside of `/`?");
+        assert_eq!(actual.io_error().kind(), io::ErrorKind::NotFound);
+        assert_eq!(actual.action(), "resolving absolute");
+        assert_eq!(actual.path(), path::Path::new(r"/a/../.."));
+    }
+}

--- a/artichoke-vfs/README.md
+++ b/artichoke-vfs/README.md
@@ -15,7 +15,7 @@ the file system into particular states.
 
 ## License
 
-artichoke-vfs is a fork of `filesystem` crate at
+artichoke-vfs is a fork of filesystem at
 [v0.4.4](https://github.com/iredelmeier/filesystem-rs/tree/v0.4.4) copyright
-Isobel Redelmeier under the
+Isobel Redelmeier. filesystem is licensed with the
 [MIT License](https://github.com/iredelmeier/filesystem-rs/blob/v0.4.4/LICENSE).

--- a/mruby-sys/README.md
+++ b/mruby-sys/README.md
@@ -23,16 +23,16 @@ things with C unions that are more convenient to do in C.
 
 mruby-sys is licensed under the [MIT License](../LICENSE).
 
-Some portions of mruby-sys are derived from
-[mrusty @ 1.0.0](https://github.com/anima-engine/mrusty/tree/v1.0.0) which is
-Copyright (C) 2016 Dragoș Tiselice under the
+mruby-sys vendors and links against [mruby](https://github.com/mruby/mruby)
+which is Copyright (c) 2019 mruby developers. mruby is licensed with the
+[MIT License](https://github.com/mruby/mruby/blob/master/LICENSE).
+
+Some portions of mruby-sys are derived from mrusty @
+[1.0.0](https://github.com/anima-engine/mrusty/tree/v1.0.0) which is Copyright
+(C) 2016 Dragoș Tiselice. mrusty is licensed with the
 [Mozilla Public License 2.0](https://github.com/anima-engine/mrusty/blob/v1.0.0/LICENSE).
 
-Some portions of mruby-sys are derived from
-[go-mruby @ cd6a04a](https://github.com/mitchellh/go-mruby/tree/cd6a04a) which
-is Copyright (c) 2017 Mitchell Hashimoto under the
+Some portions of mruby-sys are derived from go-mruby @
+[cd6a04a](https://github.com/mitchellh/go-mruby/tree/cd6a04a) which is Copyright
+(c) 2017 Mitchell Hashimoto. go-mruby is licensed with the
 [MIT License](https://github.com/mitchellh/go-mruby/blob/cd6a04a/LICENSE).
-
-mruby-sys links against [mruby](https://github.com/mruby/mruby) which is
-Copyright (c) 2019 mruby developers under the
-[MIT License](https://github.com/mruby/mruby/blob/master/LICENSE).


### PR DESCRIPTION
path_abs does not compile under wasm32-unknown-unknown because it
includes conditional compilation on OS vendor targeting unix and
windows. Artichoke does not make use of this functionality.

path_abs canonicalizes relative paths using env::current_dir. Artichoke
uses a virtual filesystem so this behavior is never what we want.

This commit removes the dependency on path_abs and replaces it with a
vendored copy of the PathAbs implementation. This fork modifies the
public API of PathAbs::new to take the "canonicalized" current working
directory to use for absolutizing relative paths.

Tests from upstream are included.

This commit forks path_abs from commit https://github.com/vitiral/path_abs/tree/8370838b6110786c2ba7cf7fd984a4783f37701c.