### PR TITLE
Enable Regexp in Wasm build

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ MRI in the following ways:
   [Deterministic garbage collection](https://github.com/artichoke/artichoke/milestone/5).
 - ✅ Single binary distribution (all Ruby sources from core and stdlib are
   embedded in `artichoke` executable).
-- ❌ [WebAssembly build target](https://github.com/artichoke/artichoke/milestone/6).
+- ❌
+  [WebAssembly build target](https://github.com/artichoke/artichoke/milestone/6).
 - ❌ [mruby](https://github.com/mruby/mruby)-compatible
   [C API (all 311 `MRB_API` functions)](https://github.com/artichoke/artichoke/milestone/7).
 - ❌

--- a/artichoke-backend/src/extn/core/mod.rs
+++ b/artichoke-backend/src/extn/core/mod.rs
@@ -7,10 +7,8 @@ pub mod env;
 pub mod error;
 pub mod hash;
 pub mod kernel;
-#[cfg(not(target_arch = "wasm32"))]
 pub mod matchdata;
 pub mod module;
-#[cfg(not(target_arch = "wasm32"))]
 pub mod regexp;
 pub mod string;
 pub mod thread;
@@ -22,10 +20,8 @@ pub fn patch(interp: &Artichoke) -> Result<(), ArtichokeError> {
     error::patch(interp)?;
     hash::patch(interp)?;
     kernel::patch(interp)?;
-    #[cfg(not(target_arch = "wasm32"))]
     matchdata::init(interp)?;
     module::patch(interp)?;
-    #[cfg(not(target_arch = "wasm32"))]
     regexp::init(interp)?;
     string::patch(interp)?;
     thread::init(interp)?;

--- a/artichoke-backend/src/extn/core/regexp/opts.rs
+++ b/artichoke-backend/src/extn/core/regexp/opts.rs
@@ -34,7 +34,10 @@ impl Options {
         bits
     }
 
-    pub fn modifier_string(self) -> &'static str {
+    // This function should return a &'static str but linking fails under the
+    // wasm32-unknown-emscripten build if this function does not return an owned
+    // String.
+    pub fn modifier_string(self) -> String {
         match (self.multiline, self.ignore_case, self.extended) {
             (true, true, true) => "mix",
             (true, true, false) => "mi",
@@ -45,9 +48,13 @@ impl Options {
             (false, false, true) => "x",
             (false, false, false) => "",
         }
+        .to_owned()
     }
 
-    fn onig_string(self) -> &'static str {
+    // This function should return a &'static str but linking fails under the
+    // wasm32-unknown-emscripten build if this function does not return an owned
+    // String.
+    fn onig_string(self) -> String {
         match (self.multiline, self.ignore_case, self.extended) {
             (true, true, true) => "mix",
             (true, true, false) => "mi-x",
@@ -58,6 +65,7 @@ impl Options {
             (false, false, true) => "x-mi",
             (false, false, false) => "-mix",
         }
+        .to_owned()
     }
 }
 
@@ -104,14 +112,14 @@ pub fn parse_pattern(pattern: &str, mut opts: Options) -> (String, Options) {
     match chars.next() {
         None => {
             pat_buf.push_str("(?");
-            pat_buf.push_str(opts.onig_string());
+            pat_buf.push_str(opts.onig_string().as_str());
             pat_buf.push(':');
             pat_buf.push(')');
             return (pat_buf, opts);
         }
         Some(token) if token != '(' => {
             pat_buf.push_str("(?");
-            pat_buf.push_str(opts.onig_string());
+            pat_buf.push_str(opts.onig_string().as_str());
             pat_buf.push(':');
             pat_buf.push_str(pattern);
             pat_buf.push(')');
@@ -123,7 +131,7 @@ pub fn parse_pattern(pattern: &str, mut opts: Options) -> (String, Options) {
     match chars.next() {
         None => {
             pat_buf.push_str("(?");
-            pat_buf.push_str(opts.onig_string());
+            pat_buf.push_str(opts.onig_string().as_str());
             pat_buf.push(':');
             pat_buf.push_str(pattern);
             pat_buf.push(')');
@@ -131,7 +139,7 @@ pub fn parse_pattern(pattern: &str, mut opts: Options) -> (String, Options) {
         }
         Some(token) if token != '?' => {
             pat_buf.push_str("(?");
-            pat_buf.push_str(opts.onig_string());
+            pat_buf.push_str(opts.onig_string().as_str());
             pat_buf.push(':');
             pat_buf.push_str(pattern);
             pat_buf.push(')');
@@ -156,7 +164,7 @@ pub fn parse_pattern(pattern: &str, mut opts: Options) -> (String, Options) {
             ':' => break,
             _ => {
                 pat_buf.push_str("(?");
-                pat_buf.push_str(opts.onig_string());
+                pat_buf.push_str(opts.onig_string().as_str());
                 pat_buf.push(':');
                 pat_buf.push_str(pattern);
                 pat_buf.push(')');

--- a/artichoke-backend/src/extn/core/string.rs
+++ b/artichoke-backend/src/extn/core/string.rs
@@ -3,15 +3,11 @@ use log::trace;
 use crate::convert::TryConvert;
 use crate::def::{ClassLike, Define};
 use crate::eval::Eval;
-#[cfg(target_arch = "wasm32")]
-use crate::extn::core::error::{ArgumentError, RubyException};
-#[cfg(not(target_arch = "wasm32"))]
 use crate::extn::core::error::{ArgumentError, RubyException, RuntimeError, TypeError};
 use crate::sys;
 use crate::value::Value;
 use crate::{Artichoke, ArtichokeError};
 
-#[cfg(not(target_arch = "wasm32"))]
 mod scan;
 
 pub fn patch(interp: &Artichoke) -> Result<(), ArtichokeError> {
@@ -25,7 +21,6 @@ pub fn patch(interp: &Artichoke) -> Result<(), ArtichokeError> {
     string
         .borrow_mut()
         .add_method("ord", RString::ord, sys::mrb_args_none());
-    #[cfg(not(target_arch = "wasm32"))]
     string
         .borrow_mut()
         .add_method("scan", RString::scan, sys::mrb_args_req(1));
@@ -61,7 +56,6 @@ impl RString {
         }
     }
 
-    #[cfg(not(target_arch = "wasm32"))]
     unsafe extern "C" fn scan(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
         let interp = unwrap_interpreter!(mrb);
         let value = Value::new(&interp, slf);

--- a/artichoke-backend/src/extn/stdlib/json.rb
+++ b/artichoke-backend/src/extn/stdlib/json.rb
@@ -56,9 +56,5 @@ require 'json/common'
 module JSON
   require 'json/version'
 
-  begin
-    require 'json/ext'
-  rescue LoadError
-    require 'json/pure'
-  end
+  require 'json/pure'
 end

--- a/artichoke-wasm/src/index.html
+++ b/artichoke-wasm/src/index.html
@@ -162,7 +162,7 @@
         <div id="editor" class="h-100 col-8"></div>
         <pre
           id="output"
-          class="h-100 w-100 ml-1 border text-wrap overflow-auto"
+          class="h-100 w-100 ml-1 border overflow-auto"
         ></pre>
       </div>
       <div class="d-flex">

--- a/artichoke-wasm/src/index.html
+++ b/artichoke-wasm/src/index.html
@@ -160,10 +160,7 @@
       </div>
       <div class="d-flex h-100 flex-grow">
         <div id="editor" class="h-100 col-8"></div>
-        <pre
-          id="output"
-          class="h-100 w-100 ml-1 border overflow-auto"
-        ></pre>
+        <pre id="output" class="h-100 w-100 ml-1 border overflow-auto"></pre>
       </div>
       <div class="d-flex">
         <p>

--- a/artichoke-wasm/src/main.rs
+++ b/artichoke-wasm/src/main.rs
@@ -119,7 +119,6 @@ pub fn artichoke_eval(state: u32, ptr: u32) -> u32 {
     -s WASM=1
     -s ASSERTIONS=1
     -s ENVIRONMENT='web'
-    -s TOTAL_MEMORY=5242880
     -s EXPORTED_FUNCTIONS=["_artichoke_web_repl_init","_artichoke_string_new","_artichoke_string_free","_artichoke_string_getlen","_artichoke_string_getch","_artichoke_string_putch","_artichoke_eval"]
     -s EXTRA_EXPORTED_RUNTIME_METHODS=["ccall","cwrap"]
 "#)]

--- a/artichoke-wasm/src/main.rs
+++ b/artichoke-wasm/src/main.rs
@@ -117,7 +117,6 @@ pub fn artichoke_eval(state: u32, ptr: u32) -> u32 {
 
 #[cfg(link_args = r#"
     -s WASM=1
-    -s LINKABLE=1
     -s ASSERTIONS=1
     -s ENVIRONMENT='web'
     -s TOTAL_MEMORY=5242880

--- a/artichoke-wasm/src/playground.js
+++ b/artichoke-wasm/src/playground.js
@@ -6,32 +6,35 @@ import "artichoke-wasm/artichoke_wasm.wasm";
 import "artichoke-wasm/deps/artichoke-wasm";
 
 const sample = `
-# The following calls to Kernel#require include real implementations of Ruby
-# Standard Library packages.
-#
-# https://ruby-doc.org/stdlib-2.5.1/libdoc/forwardable/rdoc/Forwardable.html
-# https://ruby-doc.org/stdlib-2.6.3/libdoc/set/rdoc/Set.html
+# frozen_string_literal: true
+
 require 'forwardable'
-require 'set'
+require 'json'
 
-class Registry
+class Properties
   extend Forwardable
-  def_delegators :@records, :add, :to_a
+  def_delegators :@properties, :[], :[]=, :to_json
 
-  def initialize
-    @records = Set.new
+  def initialize(name)
+    @name = name
+    @properties = {}
+  end
+
+  def inspect
+    @name
   end
 end
 
-registry = Registry.new
+artichoke = Properties.new('Artichoke Ruby')
+artichoke[:language] = 'Ruby'
+artichoke[:implementation] = 'Artichoke'
+artichoke[:target] = 'wasm'
+artichoke[:emoji] = '💎'
 
-10.times do |record|
-  registry.add("Artichoke")
-  registry.add("💎")
-end
+serialized = JSON.pretty_generate(artichoke)
+puts serialized if serialized =~ /💎/
 
-puts registry.to_a
-registry.to_a
+artichoke
 `;
 
 ace.edit("editor", {

--- a/scripts/format-text.sh
+++ b/scripts/format-text.sh
@@ -34,7 +34,7 @@ check() {
     -and -not -path '*target*' \
     -and -not -path '*node_modules*' \
     -and -not -path '*spec/ruby*' -print0 |
-    xargs -0 yarn run prettier --write --check $(wrap "$1")
+    xargs -0 yarn run prettier --check $(wrap "$1")
 }
 
 if [[ $# -gt 1 && $1 == '--check' ]]; then


### PR DESCRIPTION
Works around a link failure under emscripten.

Updates the prepopulated example to use JSON and Regexp.

Fixes GH-48.