### PR TITLE
Enable CircleCI to lint Ruby scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,6 +136,8 @@ jobs:
           target: ./artichoke-frontend/ruby
       - rubocop:
           target: ./spec-runner/src
+      - rubocop:
+          target: ./scripts
   js:
     docker:
       - image: circleci/node:lts

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -46,7 +46,7 @@ lint_ruby_sources artichoke-frontend/ruby
 ## spec-runner
 lint_ruby_sources spec-runner/src
 ## scripts
-lint_ruby_sources scripts/
+lint_ruby_sources scripts
 
 # C sources
 


### PR DESCRIPTION
Followup to GH-85. cc @johnwahba 