### PR TITLE
Add support for multiple Regexp backend implementations

### DIFF
--- a/artichoke-backend/src/extn/core/matchdata/begin.rs
+++ b/artichoke-backend/src/extn/core/matchdata/begin.rs
@@ -5,6 +5,7 @@ use std::mem;
 
 use crate::convert::{Convert, RustBackedValue, TryConvert};
 use crate::extn::core::matchdata::MatchData;
+use crate::extn::core::regexp::Backend;
 use crate::sys;
 use crate::types::Int;
 use crate::value::{Value, ValueLike};
@@ -51,6 +52,7 @@ pub fn method(interp: &Artichoke, args: Args, value: &Value) -> Result<Value, Er
     let data = unsafe { MatchData::try_from_ruby(interp, value) }.map_err(|_| Error::Fatal)?;
     let borrow = data.borrow();
     let regex = (*borrow.regexp.regex).as_ref().ok_or(Error::Fatal)?;
+    let Backend::Onig(regex) = regex;
     let match_against = &borrow.string[borrow.region.start..borrow.region.end];
     let captures = regex.captures(match_against).ok_or(Error::NoMatch)?;
     let index = match args {

--- a/artichoke-backend/src/extn/core/matchdata/captures.rs
+++ b/artichoke-backend/src/extn/core/matchdata/captures.rs
@@ -2,6 +2,7 @@
 
 use crate::convert::{Convert, RustBackedValue};
 use crate::extn::core::matchdata::MatchData;
+use crate::extn::core::regexp::Backend;
 use crate::value::Value;
 use crate::Artichoke;
 
@@ -15,6 +16,7 @@ pub fn method(interp: &Artichoke, value: &Value) -> Result<Value, Error> {
     let data = unsafe { MatchData::try_from_ruby(interp, value) }.map_err(|_| Error::Fatal)?;
     let borrow = data.borrow();
     let regex = (*borrow.regexp.regex).as_ref().ok_or(Error::Fatal)?;
+    let Backend::Onig(regex) = regex;
     let match_against = &borrow.string[borrow.region.start..borrow.region.end];
     let captures = regex.captures(match_against).ok_or(Error::NoMatch)?;
     let mut iter = captures.iter();

--- a/artichoke-backend/src/extn/core/matchdata/element_reference.rs
+++ b/artichoke-backend/src/extn/core/matchdata/element_reference.rs
@@ -5,6 +5,7 @@ use std::mem;
 
 use crate::convert::{Convert, RustBackedValue, TryConvert};
 use crate::extn::core::matchdata::MatchData;
+use crate::extn::core::regexp::Backend;
 use crate::sys;
 use crate::types::Int;
 use crate::value::Value;
@@ -91,6 +92,7 @@ pub fn method(interp: &Artichoke, args: Args, value: &Value) -> Result<Value, Er
     let data = unsafe { MatchData::try_from_ruby(interp, value) }.map_err(|_| Error::Fatal)?;
     let borrow = data.borrow();
     let regex = (*borrow.regexp.regex).as_ref().ok_or(Error::Fatal)?;
+    let Backend::Onig(regex) = regex;
     let match_against = &borrow.string[borrow.region.start..borrow.region.end];
     let captures = regex.captures(match_against).ok_or(Error::NoMatch)?;
     match args {

--- a/artichoke-backend/src/extn/core/matchdata/end.rs
+++ b/artichoke-backend/src/extn/core/matchdata/end.rs
@@ -5,6 +5,7 @@ use std::mem;
 
 use crate::convert::{Convert, RustBackedValue, TryConvert};
 use crate::extn::core::matchdata::MatchData;
+use crate::extn::core::regexp::Backend;
 use crate::sys;
 use crate::types::Int;
 use crate::value::{Value, ValueLike};
@@ -51,6 +52,7 @@ pub fn method(interp: &Artichoke, args: Args, value: &Value) -> Result<Value, Er
     let data = unsafe { MatchData::try_from_ruby(interp, value) }.map_err(|_| Error::Fatal)?;
     let borrow = data.borrow();
     let regex = (*borrow.regexp.regex).as_ref().ok_or(Error::Fatal)?;
+    let Backend::Onig(regex) = regex;
     let match_against = &borrow.string[borrow.region.start..borrow.region.end];
     let captures = regex.captures(match_against).ok_or(Error::NoMatch)?;
     let index = match args {

--- a/artichoke-backend/src/extn/core/matchdata/length.rs
+++ b/artichoke-backend/src/extn/core/matchdata/length.rs
@@ -4,6 +4,7 @@ use std::convert::TryFrom;
 
 use crate::convert::{Convert, RustBackedValue};
 use crate::extn::core::matchdata::MatchData;
+use crate::extn::core::regexp::Backend;
 use crate::types::Int;
 use crate::value::Value;
 use crate::Artichoke;
@@ -17,6 +18,7 @@ pub fn method(interp: &Artichoke, value: &Value) -> Result<Value, Error> {
     let data = unsafe { MatchData::try_from_ruby(interp, value) }.map_err(|_| Error::Fatal)?;
     let borrow = data.borrow();
     let regex = (*borrow.regexp.regex).as_ref().ok_or(Error::Fatal)?;
+    let Backend::Onig(regex) = regex;
     let match_against = &borrow.string[borrow.region.start..borrow.region.end];
     let captures = regex.captures(match_against);
     if let Some(captures) = captures {

--- a/artichoke-backend/src/extn/core/matchdata/named_captures.rs
+++ b/artichoke-backend/src/extn/core/matchdata/named_captures.rs
@@ -5,6 +5,7 @@ use std::convert::TryFrom;
 
 use crate::convert::{Convert, RustBackedValue};
 use crate::extn::core::matchdata::MatchData;
+use crate::extn::core::regexp::Backend;
 use crate::value::Value;
 use crate::Artichoke;
 
@@ -18,6 +19,7 @@ pub fn method(interp: &Artichoke, value: &Value) -> Result<Value, Error> {
     let data = unsafe { MatchData::try_from_ruby(interp, value) }.map_err(|_| Error::Fatal)?;
     let borrow = data.borrow();
     let regex = (*borrow.regexp.regex).as_ref().ok_or(Error::Fatal)?;
+    let Backend::Onig(regex) = regex;
     let match_against = &borrow.string[borrow.region.start..borrow.region.end];
     let captures = regex.captures(match_against).ok_or(Error::NoMatch)?;
     let mut map = HashMap::default();

--- a/artichoke-backend/src/extn/core/matchdata/names.rs
+++ b/artichoke-backend/src/extn/core/matchdata/names.rs
@@ -4,6 +4,7 @@ use std::cmp::Ordering;
 
 use crate::convert::{Convert, RustBackedValue};
 use crate::extn::core::matchdata::MatchData;
+use crate::extn::core::regexp::Backend;
 use crate::value::Value;
 use crate::Artichoke;
 
@@ -16,6 +17,7 @@ pub fn method(interp: &Artichoke, value: &Value) -> Result<Value, Error> {
     let data = unsafe { MatchData::try_from_ruby(interp, value) }.map_err(|_| Error::Fatal)?;
     let borrow = data.borrow();
     let regex = (*borrow.regexp.regex).as_ref().ok_or(Error::Fatal)?;
+    let Backend::Onig(regex) = regex;
     let mut names = vec![];
     let mut capture_names = regex.capture_names().collect::<Vec<_>>();
     capture_names.sort_by(|a, b| {

--- a/artichoke-backend/src/extn/core/matchdata/offset.rs
+++ b/artichoke-backend/src/extn/core/matchdata/offset.rs
@@ -5,6 +5,7 @@ use std::mem;
 
 use crate::convert::{Convert, RustBackedValue, TryConvert};
 use crate::extn::core::matchdata::MatchData;
+use crate::extn::core::regexp::Backend;
 use crate::sys;
 use crate::types::Int;
 use crate::value::Value;
@@ -49,6 +50,7 @@ pub fn method(interp: &Artichoke, args: Args, value: &Value) -> Result<Value, Er
     let data = unsafe { MatchData::try_from_ruby(interp, value) }.map_err(|_| Error::Fatal)?;
     let borrow = data.borrow();
     let regex = (*borrow.regexp.regex).as_ref().ok_or(Error::Fatal)?;
+    let Backend::Onig(regex) = regex;
     let match_against = &borrow.string[borrow.region.start..borrow.region.end];
     let captures = regex.captures(match_against).ok_or(Error::NoMatch)?;
     let index = match args {

--- a/artichoke-backend/src/extn/core/matchdata/to_a.rs
+++ b/artichoke-backend/src/extn/core/matchdata/to_a.rs
@@ -2,6 +2,7 @@
 
 use crate::convert::{Convert, RustBackedValue};
 use crate::extn::core::matchdata::MatchData;
+use crate::extn::core::regexp::Backend;
 use crate::value::Value;
 use crate::Artichoke;
 
@@ -15,6 +16,7 @@ pub fn method(interp: &Artichoke, value: &Value) -> Result<Value, Error> {
     let data = unsafe { MatchData::try_from_ruby(interp, value) }.map_err(|_| Error::Fatal)?;
     let borrow = data.borrow();
     let regex = (*borrow.regexp.regex).as_ref().ok_or(Error::Fatal)?;
+    let Backend::Onig(regex) = regex;
     let match_against = &borrow.string[borrow.region.start..borrow.region.end];
     let captures = regex.captures(match_against).ok_or(Error::NoMatch)?;
     let vec = captures.iter().collect::<Vec<_>>();

--- a/artichoke-backend/src/extn/core/matchdata/to_s.rs
+++ b/artichoke-backend/src/extn/core/matchdata/to_s.rs
@@ -2,6 +2,7 @@
 
 use crate::convert::{Convert, RustBackedValue};
 use crate::extn::core::matchdata::MatchData;
+use crate::extn::core::regexp::Backend;
 use crate::value::Value;
 use crate::Artichoke;
 
@@ -15,6 +16,7 @@ pub fn method(interp: &Artichoke, value: &Value) -> Result<Value, Error> {
     let data = unsafe { MatchData::try_from_ruby(interp, value) }.map_err(|_| Error::Fatal)?;
     let borrow = data.borrow();
     let regex = (*borrow.regexp.regex).as_ref().ok_or(Error::Fatal)?;
+    let Backend::Onig(regex) = regex;
     let match_against = &borrow.string[borrow.region.start..borrow.region.end];
     let captures = regex.captures(match_against).ok_or(Error::NoMatch)?;
     Ok(Value::convert(&interp, captures.at(0).unwrap_or_default()))

--- a/artichoke-backend/src/extn/core/regexp/case_compare.rs
+++ b/artichoke-backend/src/extn/core/regexp/case_compare.rs
@@ -5,7 +5,7 @@ use std::mem;
 
 use crate::convert::{Convert, RustBackedValue, TryConvert};
 use crate::extn::core::matchdata::MatchData;
-use crate::extn::core::regexp::Regexp;
+use crate::extn::core::regexp::{Backend, Regexp};
 use crate::sys;
 use crate::value::Value;
 use crate::Artichoke;
@@ -57,6 +57,7 @@ pub fn method(interp: &Artichoke, args: Args, value: &Value) -> Result<Value, Er
     };
     let borrow = data.borrow();
     let regex = (*borrow.regex).as_ref().ok_or(Error::Fatal)?;
+    let Backend::Onig(regex) = regex;
     let matchdata = if let Some(captures) = regex.captures(string.as_str()) {
         let num_regexp_globals_to_set = {
             let num_previously_set_globals = interp.borrow().num_set_regexp_capture_globals;

--- a/artichoke-backend/src/extn/core/regexp/match_.rs
+++ b/artichoke-backend/src/extn/core/regexp/match_.rs
@@ -6,7 +6,7 @@ use std::mem;
 
 use crate::convert::{Convert, RustBackedValue, TryConvert};
 use crate::extn::core::matchdata::MatchData;
-use crate::extn::core::regexp::Regexp;
+use crate::extn::core::regexp::{Backend, Regexp};
 use crate::sys;
 use crate::types::Int;
 use crate::value::Value;
@@ -99,6 +99,7 @@ pub fn method(interp: &Artichoke, args: Args, value: &Value) -> Result<Value, Er
 
     let borrow = data.borrow();
     let regex = (*borrow.regex).as_ref().ok_or(Error::Fatal)?;
+    let Backend::Onig(regex) = regex;
     let match_target = &string[byte_offset..];
     if let Some(captures) = regex.captures(match_target) {
         let num_regexp_globals_to_set = {

--- a/artichoke-backend/src/extn/core/regexp/match_operator.rs
+++ b/artichoke-backend/src/extn/core/regexp/match_operator.rs
@@ -6,7 +6,7 @@ use std::mem;
 
 use crate::convert::{Convert, RustBackedValue, TryConvert};
 use crate::extn::core::matchdata::MatchData;
-use crate::extn::core::regexp::Regexp;
+use crate::extn::core::regexp::{Backend, Regexp};
 use crate::sys;
 use crate::types::Int;
 use crate::value::Value;
@@ -50,6 +50,7 @@ pub fn method(interp: &Artichoke, args: Args, value: &Value) -> Result<Value, Er
     let data = unsafe { Regexp::try_from_ruby(interp, value) }.map_err(|_| Error::Fatal)?;
     let borrow = data.borrow();
     let regex = (*borrow.regex).as_ref().ok_or(Error::Fatal)?;
+    let Backend::Onig(regex) = regex;
     let string = if let Some(string) = args.string {
         string
     } else {

--- a/artichoke-backend/src/extn/core/regexp/match_q.rs
+++ b/artichoke-backend/src/extn/core/regexp/match_q.rs
@@ -4,7 +4,7 @@ use std::convert::TryFrom;
 use std::mem;
 
 use crate::convert::{Convert, RustBackedValue, TryConvert};
-use crate::extn::core::regexp::Regexp;
+use crate::extn::core::regexp::{Backend, Regexp};
 use crate::sys;
 use crate::types::Int;
 use crate::value::Value;
@@ -83,6 +83,7 @@ pub fn method(interp: &Artichoke, args: Args, value: &Value) -> Result<Value, Er
 
     let borrow = data.borrow();
     let regex = (*borrow.regex).as_ref().ok_or(Error::Fatal)?;
+    let Backend::Onig(regex) = regex;
     let match_target = &string[byte_offset..];
     Ok(Value::convert(interp, regex.find(match_target).is_some()))
 }

--- a/artichoke-backend/src/extn/core/regexp/named_captures.rs
+++ b/artichoke-backend/src/extn/core/regexp/named_captures.rs
@@ -3,7 +3,7 @@
 use std::convert::TryFrom;
 
 use crate::convert::{Convert, RustBackedValue};
-use crate::extn::core::regexp::Regexp;
+use crate::extn::core::regexp::{Backend, Regexp};
 use crate::types::Int;
 use crate::value::Value;
 use crate::Artichoke;
@@ -17,6 +17,7 @@ pub fn method(interp: &Artichoke, value: &Value) -> Result<Value, Error> {
     let data = unsafe { Regexp::try_from_ruby(interp, value) }.map_err(|_| Error::Fatal)?;
     let borrow = data.borrow();
     let regex = (*borrow.regex).as_ref().ok_or(Error::Fatal)?;
+    let Backend::Onig(regex) = regex;
     // Use a Vec of key-value pairs because insertion order matters for spec
     // compliance.
     let mut map = vec![];

--- a/artichoke-backend/src/extn/core/regexp/names.rs
+++ b/artichoke-backend/src/extn/core/regexp/names.rs
@@ -3,7 +3,7 @@
 use std::cmp::Ordering;
 
 use crate::convert::{Convert, RustBackedValue};
-use crate::extn::core::regexp::Regexp;
+use crate::extn::core::regexp::{Backend, Regexp};
 use crate::value::Value;
 use crate::Artichoke;
 
@@ -17,6 +17,7 @@ pub fn method(interp: &Artichoke, value: &Value) -> Result<Value, Error> {
     let borrow = data.borrow();
     let mut names = vec![];
     let regex = (*borrow.regex).as_ref().ok_or(Error::Fatal)?;
+    let Backend::Onig(regex) = regex;
     let mut capture_names = regex.capture_names().collect::<Vec<_>>();
     capture_names.sort_by(|a, b| {
         a.1.iter()

--- a/artichoke-backend/src/extn/core/string/scan.rs
+++ b/artichoke-backend/src/extn/core/string/scan.rs
@@ -5,7 +5,7 @@ use crate::convert::{Convert, RustBackedValue, TryConvert};
 use crate::extn::core::matchdata::MatchData;
 use crate::extn::core::regexp::enc::Encoding;
 use crate::extn::core::regexp::opts::Options;
-use crate::extn::core::regexp::{syntax, Regexp};
+use crate::extn::core::regexp::{syntax, Backend, Regexp};
 use crate::gc::MrbGarbageCollection;
 use crate::sys;
 use crate::value::{Value, ValueLike};
@@ -80,6 +80,7 @@ pub fn method(interp: &Artichoke, args: Args, value: Value) -> Result<Value, Err
     let mut was_match = false;
     let mut collected = vec![];
     let regex = (*regexp.regex).as_ref().ok_or(Error::Fatal)?;
+    let Backend::Onig(regex) = regex;
     let len = regex.captures_len();
 
     if len > 0 {


### PR DESCRIPTION
To prepare to implement GH-57.

Introduce a `Backend` enum which will allow the `Regexp` implementation to toggle between the `onig` and `regex` implementations.