### PR TITLE
Add scaffolding to support Regexp backed by Rust regex crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,6 +37,7 @@ dependencies = [
  "onig 4.3.2 (git+https://github.com/artichoke/rust-onig?branch=wasm)",
  "quickcheck 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck_macros 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 
 [dependencies]
 log = "0.4.6"
+regex = "1"
 
 [dependencies.artichoke-vfs]
 path = "../artichoke-vfs"

--- a/artichoke-backend/src/extn/core/matchdata/begin.rs
+++ b/artichoke-backend/src/extn/core/matchdata/begin.rs
@@ -51,33 +51,37 @@ impl Args {
 pub fn method(interp: &Artichoke, args: Args, value: &Value) -> Result<Value, Error> {
     let data = unsafe { MatchData::try_from_ruby(interp, value) }.map_err(|_| Error::Fatal)?;
     let borrow = data.borrow();
-    let regex = (*borrow.regexp.regex).as_ref().ok_or(Error::Fatal)?;
-    let Backend::Onig(regex) = regex;
     let match_against = &borrow.string[borrow.region.start..borrow.region.end];
-    let captures = regex.captures(match_against).ok_or(Error::NoMatch)?;
-    let index = match args {
-        Args::Index(index) => {
-            if index < 0 {
-                // Positive Int must be usize
-                let index = usize::try_from(-index).map_err(|_| Error::Fatal)?;
-                captures.len().checked_sub(index).ok_or(Error::Fatal)?
-            } else {
-                // Positive Int must be usize
-                usize::try_from(index).map_err(|_| Error::Fatal)?
-            }
+    let regex = (*borrow.regexp.regex).as_ref().ok_or(Error::Fatal)?;
+    let begin = match regex {
+        Backend::Onig(regex) => {
+            let captures = regex.captures(match_against).ok_or(Error::NoMatch)?;
+            let index = match args {
+                Args::Index(index) => {
+                    if index < 0 {
+                        // Positive Int must be usize
+                        let index = usize::try_from(-index).map_err(|_| Error::Fatal)?;
+                        captures.len().checked_sub(index).ok_or(Error::Fatal)?
+                    } else {
+                        // Positive Int must be usize
+                        usize::try_from(index).map_err(|_| Error::Fatal)?
+                    }
+                }
+                Args::Name(name) => {
+                    let index = regex
+                        .capture_names()
+                        .find(|capture| capture.0 == name)
+                        .ok_or(Error::NoGroup)?
+                        .1
+                        .last()
+                        .ok_or(Error::NoMatch)?;
+                    usize::try_from(*index).map_err(|_| Error::Fatal)?
+                }
+            };
+            captures.pos(index).ok_or(Error::NoMatch)?.0
         }
-        Args::Name(name) => {
-            let index = regex
-                .capture_names()
-                .find(|capture| capture.0 == name)
-                .ok_or(Error::NoGroup)?
-                .1
-                .last()
-                .ok_or(Error::NoMatch)?;
-            usize::try_from(*index).map_err(|_| Error::Fatal)?
-        }
+        Backend::Rust(_) => unimplemented!("Rust-backed Regexp"),
     };
-    let begin = captures.pos(index).ok_or(Error::NoMatch)?.0;
     let begin = match_against[0..begin].chars().count();
     let begin = begin + borrow.region.start;
     let begin = Int::try_from(begin).map_err(|_| Error::Fatal)?;

--- a/artichoke-backend/src/extn/core/matchdata/captures.rs
+++ b/artichoke-backend/src/extn/core/matchdata/captures.rs
@@ -15,13 +15,17 @@ pub enum Error {
 pub fn method(interp: &Artichoke, value: &Value) -> Result<Value, Error> {
     let data = unsafe { MatchData::try_from_ruby(interp, value) }.map_err(|_| Error::Fatal)?;
     let borrow = data.borrow();
-    let regex = (*borrow.regexp.regex).as_ref().ok_or(Error::Fatal)?;
-    let Backend::Onig(regex) = regex;
     let match_against = &borrow.string[borrow.region.start..borrow.region.end];
-    let captures = regex.captures(match_against).ok_or(Error::NoMatch)?;
-    let mut iter = captures.iter();
-    // skip 0 (full match) capture group
-    iter.next();
-    let vec = iter.collect::<Vec<_>>();
-    Ok(Value::convert(&interp, vec))
+    let regex = (*borrow.regexp.regex).as_ref().ok_or(Error::Fatal)?;
+    match regex {
+        Backend::Onig(regex) => {
+            let captures = regex.captures(match_against).ok_or(Error::NoMatch)?;
+            let mut iter = captures.iter();
+            // skip 0 (full match) capture group
+            iter.next();
+            let vec = iter.collect::<Vec<_>>();
+            Ok(Value::convert(&interp, vec))
+        }
+        Backend::Rust(_) => unimplemented!("Rust-backed Regexp"),
+    }
 }

--- a/artichoke-backend/src/extn/core/matchdata/element_reference.rs
+++ b/artichoke-backend/src/extn/core/matchdata/element_reference.rs
@@ -91,60 +91,64 @@ impl Args {
 pub fn method(interp: &Artichoke, args: Args, value: &Value) -> Result<Value, Error> {
     let data = unsafe { MatchData::try_from_ruby(interp, value) }.map_err(|_| Error::Fatal)?;
     let borrow = data.borrow();
-    let regex = (*borrow.regexp.regex).as_ref().ok_or(Error::Fatal)?;
-    let Backend::Onig(regex) = regex;
     let match_against = &borrow.string[borrow.region.start..borrow.region.end];
-    let captures = regex.captures(match_against).ok_or(Error::NoMatch)?;
-    match args {
-        Args::Index(index) => {
-            if index < 0 {
-                // Positive Int must be usize
-                let index = usize::try_from(-index).map_err(|_| Error::Fatal)?;
-                match captures.len().checked_sub(index) {
-                    Some(0) | None => Ok(Value::convert(interp, None::<Value>)),
-                    Some(index) => Ok(Value::convert(interp, captures.at(index))),
-                }
-            } else {
-                // Positive Int must be usize
-                let index = usize::try_from(index).map_err(|_| Error::Fatal)?;
-                Ok(Value::convert(interp, captures.at(index)))
-            }
-        }
-        Args::Name(name) => {
-            let index = regex
-                .capture_names()
-                .find_map(|capture| {
-                    if capture.0 == name {
-                        Some(capture.1)
+    let regex = (*borrow.regexp.regex).as_ref().ok_or(Error::Fatal)?;
+    match regex {
+        Backend::Onig(regex) => {
+            let captures = regex.captures(match_against).ok_or(Error::NoMatch)?;
+            match args {
+                Args::Index(index) => {
+                    if index < 0 {
+                        // Positive Int must be usize
+                        let index = usize::try_from(-index).map_err(|_| Error::Fatal)?;
+                        match captures.len().checked_sub(index) {
+                            Some(0) | None => Ok(Value::convert(interp, None::<Value>)),
+                            Some(index) => Ok(Value::convert(interp, captures.at(index))),
+                        }
                     } else {
-                        None
+                        // Positive Int must be usize
+                        let index = usize::try_from(index).map_err(|_| Error::Fatal)?;
+                        Ok(Value::convert(interp, captures.at(index)))
                     }
-                })
-                .ok_or_else(|| Error::NoGroup(name))?;
-            let group = index
-                .iter()
-                .filter_map(|index| {
-                    usize::try_from(*index)
-                        .ok()
-                        .and_then(|index| captures.at(index))
-                })
-                .last();
-            Ok(Value::convert(interp, group))
-        }
-        Args::StartLen(start, len) => {
-            let start = if start < 0 {
-                // Positive i64 must be usize
-                let start = usize::try_from(-start).map_err(|_| Error::Fatal)?;
-                captures.len().checked_sub(start).ok_or(Error::Fatal)?
-            } else {
-                // Positive i64 must be usize
-                usize::try_from(start).map_err(|_| Error::Fatal)?
-            };
-            let mut matches = vec![];
-            for index in start..(start + len) {
-                matches.push(captures.at(index));
+                }
+                Args::Name(name) => {
+                    let index = regex
+                        .capture_names()
+                        .find_map(|capture| {
+                            if capture.0 == name {
+                                Some(capture.1)
+                            } else {
+                                None
+                            }
+                        })
+                        .ok_or_else(|| Error::NoGroup(name))?;
+                    let group = index
+                        .iter()
+                        .filter_map(|index| {
+                            usize::try_from(*index)
+                                .ok()
+                                .and_then(|index| captures.at(index))
+                        })
+                        .last();
+                    Ok(Value::convert(interp, group))
+                }
+                Args::StartLen(start, len) => {
+                    let start = if start < 0 {
+                        // Positive i64 must be usize
+                        let start = usize::try_from(-start).map_err(|_| Error::Fatal)?;
+                        captures.len().checked_sub(start).ok_or(Error::Fatal)?
+                    } else {
+                        // Positive i64 must be usize
+                        usize::try_from(start).map_err(|_| Error::Fatal)?
+                    };
+                    let mut matches = vec![];
+                    for index in start..(start + len) {
+                        matches.push(captures.at(index));
+                    }
+                    Ok(Value::convert(interp, matches))
+                }
             }
-            Ok(Value::convert(interp, matches))
         }
+        Backend::Rust(_) => unimplemented!("Rust-backed Regexp"),
     }
 }

--- a/artichoke-backend/src/extn/core/matchdata/end.rs
+++ b/artichoke-backend/src/extn/core/matchdata/end.rs
@@ -51,33 +51,37 @@ impl Args {
 pub fn method(interp: &Artichoke, args: Args, value: &Value) -> Result<Value, Error> {
     let data = unsafe { MatchData::try_from_ruby(interp, value) }.map_err(|_| Error::Fatal)?;
     let borrow = data.borrow();
-    let regex = (*borrow.regexp.regex).as_ref().ok_or(Error::Fatal)?;
-    let Backend::Onig(regex) = regex;
     let match_against = &borrow.string[borrow.region.start..borrow.region.end];
-    let captures = regex.captures(match_against).ok_or(Error::NoMatch)?;
-    let index = match args {
-        Args::Index(index) => {
-            if index < 0 {
-                // Positive i64 must be usize
-                let index = usize::try_from(-index).map_err(|_| Error::Fatal)?;
-                captures.len().checked_sub(index).ok_or(Error::Fatal)?
-            } else {
-                // Positive i64 must be usize
-                usize::try_from(index).map_err(|_| Error::Fatal)?
-            }
+    let regex = (*borrow.regexp.regex).as_ref().ok_or(Error::Fatal)?;
+    let end = match regex {
+        Backend::Onig(regex) => {
+            let captures = regex.captures(match_against).ok_or(Error::NoMatch)?;
+            let index = match args {
+                Args::Index(index) => {
+                    if index < 0 {
+                        // Positive i64 must be usize
+                        let index = usize::try_from(-index).map_err(|_| Error::Fatal)?;
+                        captures.len().checked_sub(index).ok_or(Error::Fatal)?
+                    } else {
+                        // Positive i64 must be usize
+                        usize::try_from(index).map_err(|_| Error::Fatal)?
+                    }
+                }
+                Args::Name(name) => {
+                    let index = regex
+                        .capture_names()
+                        .find(|capture| capture.0 == name)
+                        .ok_or(Error::NoGroup)?
+                        .1
+                        .last()
+                        .ok_or(Error::NoMatch)?;
+                    usize::try_from(*index).map_err(|_| Error::Fatal)?
+                }
+            };
+            captures.pos(index).ok_or(Error::NoMatch)?.1
         }
-        Args::Name(name) => {
-            let index = regex
-                .capture_names()
-                .find(|capture| capture.0 == name)
-                .ok_or(Error::NoGroup)?
-                .1
-                .last()
-                .ok_or(Error::NoMatch)?;
-            usize::try_from(*index).map_err(|_| Error::Fatal)?
-        }
+        Backend::Rust(_) => unimplemented!("Rust-backed Regexp"),
     };
-    let end = captures.pos(index).ok_or(Error::NoMatch)?.1;
     let end = match_against[0..end].chars().count();
     let end = end + borrow.region.start;
     let end = Int::try_from(end).map_err(|_| Error::Fatal)?;

--- a/artichoke-backend/src/extn/core/matchdata/length.rs
+++ b/artichoke-backend/src/extn/core/matchdata/length.rs
@@ -17,14 +17,18 @@ pub enum Error {
 pub fn method(interp: &Artichoke, value: &Value) -> Result<Value, Error> {
     let data = unsafe { MatchData::try_from_ruby(interp, value) }.map_err(|_| Error::Fatal)?;
     let borrow = data.borrow();
-    let regex = (*borrow.regexp.regex).as_ref().ok_or(Error::Fatal)?;
-    let Backend::Onig(regex) = regex;
     let match_against = &borrow.string[borrow.region.start..borrow.region.end];
-    let captures = regex.captures(match_against);
-    if let Some(captures) = captures {
-        let len = Int::try_from(captures.len()).map_err(|_| Error::Fatal)?;
-        Ok(Value::convert(interp, len))
-    } else {
-        Ok(Value::convert(interp, 0))
+    let regex = (*borrow.regexp.regex).as_ref().ok_or(Error::Fatal)?;
+    match regex {
+        Backend::Onig(regex) => {
+            let captures = regex.captures(match_against);
+            if let Some(captures) = captures {
+                let len = Int::try_from(captures.len()).map_err(|_| Error::Fatal)?;
+                Ok(Value::convert(interp, len))
+            } else {
+                Ok(Value::convert(interp, 0))
+            }
+        }
+        Backend::Rust(_) => unimplemented!("Rust-backed Regexp"),
     }
 }

--- a/artichoke-backend/src/extn/core/matchdata/mod.rs
+++ b/artichoke-backend/src/extn/core/matchdata/mod.rs
@@ -157,8 +157,10 @@ impl MatchData {
         let num_captures = match Self::try_from_ruby(&interp, &Value::new(&interp, slf)) {
             Ok(data) => {
                 if let Some(regex) = (*data.borrow().regexp.regex).as_ref() {
-                    let Backend::Onig(regex) = regex;
-                    regex.captures_len()
+                    match regex {
+                        Backend::Onig(regex) => regex.captures_len(),
+                        Backend::Rust(_) => unimplemented!("Rust-backed Regexp"),
+                    }
                 } else {
                     0
                 }

--- a/artichoke-backend/src/extn/core/matchdata/to_a.rs
+++ b/artichoke-backend/src/extn/core/matchdata/to_a.rs
@@ -15,10 +15,14 @@ pub enum Error {
 pub fn method(interp: &Artichoke, value: &Value) -> Result<Value, Error> {
     let data = unsafe { MatchData::try_from_ruby(interp, value) }.map_err(|_| Error::Fatal)?;
     let borrow = data.borrow();
-    let regex = (*borrow.regexp.regex).as_ref().ok_or(Error::Fatal)?;
-    let Backend::Onig(regex) = regex;
     let match_against = &borrow.string[borrow.region.start..borrow.region.end];
-    let captures = regex.captures(match_against).ok_or(Error::NoMatch)?;
-    let vec = captures.iter().collect::<Vec<_>>();
-    Ok(Value::convert(&interp, vec))
+    let regex = (*borrow.regexp.regex).as_ref().ok_or(Error::Fatal)?;
+    match regex {
+        Backend::Onig(regex) => {
+            let captures = regex.captures(match_against).ok_or(Error::NoMatch)?;
+            let vec = captures.iter().collect::<Vec<_>>();
+            Ok(Value::convert(&interp, vec))
+        }
+        Backend::Rust(_) => unimplemented!("Rust-backed Regexp"),
+    }
 }

--- a/artichoke-backend/src/extn/core/matchdata/to_s.rs
+++ b/artichoke-backend/src/extn/core/matchdata/to_s.rs
@@ -15,9 +15,13 @@ pub enum Error {
 pub fn method(interp: &Artichoke, value: &Value) -> Result<Value, Error> {
     let data = unsafe { MatchData::try_from_ruby(interp, value) }.map_err(|_| Error::Fatal)?;
     let borrow = data.borrow();
-    let regex = (*borrow.regexp.regex).as_ref().ok_or(Error::Fatal)?;
-    let Backend::Onig(regex) = regex;
     let match_against = &borrow.string[borrow.region.start..borrow.region.end];
-    let captures = regex.captures(match_against).ok_or(Error::NoMatch)?;
-    Ok(Value::convert(&interp, captures.at(0).unwrap_or_default()))
+    let regex = (*borrow.regexp.regex).as_ref().ok_or(Error::Fatal)?;
+    match regex {
+        Backend::Onig(regex) => {
+            let captures = regex.captures(match_against).ok_or(Error::NoMatch)?;
+            Ok(Value::convert(&interp, captures.at(0).unwrap_or_default()))
+        }
+        Backend::Rust(_) => unimplemented!("Rust-backed Regexp"),
+    }
 }

--- a/artichoke-backend/src/extn/core/regexp/case_compare.rs
+++ b/artichoke-backend/src/extn/core/regexp/case_compare.rs
@@ -57,62 +57,66 @@ pub fn method(interp: &Artichoke, args: Args, value: &Value) -> Result<Value, Er
     };
     let borrow = data.borrow();
     let regex = (*borrow.regex).as_ref().ok_or(Error::Fatal)?;
-    let Backend::Onig(regex) = regex;
-    let matchdata = if let Some(captures) = regex.captures(string.as_str()) {
-        let num_regexp_globals_to_set = {
-            let num_previously_set_globals = interp.borrow().num_set_regexp_capture_globals;
-            cmp::max(num_previously_set_globals, captures.len())
-        };
-        for group in 0..num_regexp_globals_to_set {
-            let sym = if group == 0 {
-                interp.borrow_mut().sym_intern("$&")
+    let matchdata = match regex {
+        Backend::Onig(regex) => {
+            if let Some(captures) = regex.captures(string.as_str()) {
+                let num_regexp_globals_to_set = {
+                    let num_previously_set_globals = interp.borrow().num_set_regexp_capture_globals;
+                    cmp::max(num_previously_set_globals, captures.len())
+                };
+                for group in 0..num_regexp_globals_to_set {
+                    let sym = if group == 0 {
+                        interp.borrow_mut().sym_intern("$&")
+                    } else {
+                        interp.borrow_mut().sym_intern(&format!("${}", group))
+                    };
+
+                    let value = Value::convert(&interp, captures.at(group));
+                    unsafe {
+                        sys::mrb_gv_set(mrb, sym, value.inner());
+                    }
+                }
+                interp.borrow_mut().num_set_regexp_capture_globals = captures.len();
+
+                if let Some(match_pos) = captures.pos(0) {
+                    let pre_match = &string[..match_pos.0];
+                    let post_match = &string[match_pos.1..];
+                    unsafe {
+                        let pre_match_sym = interp.borrow_mut().sym_intern("$`");
+                        sys::mrb_gv_set(
+                            mrb,
+                            pre_match_sym,
+                            Value::convert(interp, pre_match).inner(),
+                        );
+                        let post_match_sym = interp.borrow_mut().sym_intern("$'");
+                        sys::mrb_gv_set(
+                            mrb,
+                            post_match_sym,
+                            Value::convert(interp, post_match).inner(),
+                        );
+                    }
+                }
+                let matchdata = MatchData::new(string.as_str(), borrow.clone(), 0, string.len());
+                unsafe { matchdata.try_into_ruby(&interp, None) }.map_err(|_| Error::Fatal)?
             } else {
-                interp.borrow_mut().sym_intern(&format!("${}", group))
-            };
-
-            let value = Value::convert(&interp, captures.at(group));
-            unsafe {
-                sys::mrb_gv_set(mrb, sym, value.inner());
+                unsafe {
+                    let pre_match_sym = interp.borrow_mut().sym_intern("$`");
+                    sys::mrb_gv_set(
+                        mrb,
+                        pre_match_sym,
+                        Value::convert(interp, None::<Value>).inner(),
+                    );
+                    let post_match_sym = interp.borrow_mut().sym_intern("$'");
+                    sys::mrb_gv_set(
+                        mrb,
+                        post_match_sym,
+                        Value::convert(interp, None::<Value>).inner(),
+                    );
+                }
+                Value::convert(interp, None::<Value>)
             }
         }
-        interp.borrow_mut().num_set_regexp_capture_globals = captures.len();
-
-        if let Some(match_pos) = captures.pos(0) {
-            let pre_match = &string[..match_pos.0];
-            let post_match = &string[match_pos.1..];
-            unsafe {
-                let pre_match_sym = interp.borrow_mut().sym_intern("$`");
-                sys::mrb_gv_set(
-                    mrb,
-                    pre_match_sym,
-                    Value::convert(interp, pre_match).inner(),
-                );
-                let post_match_sym = interp.borrow_mut().sym_intern("$'");
-                sys::mrb_gv_set(
-                    mrb,
-                    post_match_sym,
-                    Value::convert(interp, post_match).inner(),
-                );
-            }
-        }
-        let matchdata = MatchData::new(string.as_str(), borrow.clone(), 0, string.len());
-        unsafe { matchdata.try_into_ruby(&interp, None) }.map_err(|_| Error::Fatal)?
-    } else {
-        unsafe {
-            let pre_match_sym = interp.borrow_mut().sym_intern("$`");
-            sys::mrb_gv_set(
-                mrb,
-                pre_match_sym,
-                Value::convert(interp, None::<Value>).inner(),
-            );
-            let post_match_sym = interp.borrow_mut().sym_intern("$'");
-            sys::mrb_gv_set(
-                mrb,
-                post_match_sym,
-                Value::convert(interp, None::<Value>).inner(),
-            );
-        }
-        Value::convert(interp, None::<Value>)
+        Backend::Rust(_) => unimplemented!("Rust-backed Regexp"),
     };
     unsafe {
         sys::mrb_gv_set(mrb, interp.borrow_mut().sym_intern("$~"), matchdata.inner());

--- a/artichoke-backend/src/extn/core/regexp/match_.rs
+++ b/artichoke-backend/src/extn/core/regexp/match_.rs
@@ -97,81 +97,87 @@ pub fn method(interp: &Artichoke, args: Args, value: &Value) -> Result<Value, Er
     }
     let byte_offset = string.chars().take(pos).collect::<String>().len();
 
+    let match_target = &string[byte_offset..];
     let borrow = data.borrow();
     let regex = (*borrow.regex).as_ref().ok_or(Error::Fatal)?;
-    let Backend::Onig(regex) = regex;
-    let match_target = &string[byte_offset..];
-    if let Some(captures) = regex.captures(match_target) {
-        let num_regexp_globals_to_set = {
-            let num_previously_set_globals = interp.borrow().num_set_regexp_capture_globals;
-            cmp::max(num_previously_set_globals, captures.len())
-        };
-        for group in 0..num_regexp_globals_to_set {
-            let sym = if group == 0 {
-                interp.borrow_mut().sym_intern("$&")
+    match regex {
+        Backend::Onig(regex) => {
+            if let Some(captures) = regex.captures(match_target) {
+                let num_regexp_globals_to_set = {
+                    let num_previously_set_globals = interp.borrow().num_set_regexp_capture_globals;
+                    cmp::max(num_previously_set_globals, captures.len())
+                };
+                for group in 0..num_regexp_globals_to_set {
+                    let sym = if group == 0 {
+                        interp.borrow_mut().sym_intern("$&")
+                    } else {
+                        interp.borrow_mut().sym_intern(&format!("${}", group))
+                    };
+
+                    let value = Value::convert(&interp, captures.at(group));
+                    unsafe {
+                        sys::mrb_gv_set(mrb, sym, value.inner());
+                    }
+                }
+                interp.borrow_mut().num_set_regexp_capture_globals = captures.len();
+
+                let mut matchdata =
+                    MatchData::new(string.as_str(), borrow.clone(), 0, string.len());
+                if let Some(match_pos) = captures.pos(0) {
+                    let pre_match = &match_target[..match_pos.0];
+                    let post_match = &match_target[match_pos.1..];
+                    unsafe {
+                        let pre_match_sym = interp.borrow_mut().sym_intern("$`");
+                        sys::mrb_gv_set(
+                            mrb,
+                            pre_match_sym,
+                            Value::convert(interp, pre_match).inner(),
+                        );
+                        let post_match_sym = interp.borrow_mut().sym_intern("$'");
+                        sys::mrb_gv_set(
+                            mrb,
+                            post_match_sym,
+                            Value::convert(interp, post_match).inner(),
+                        );
+                    }
+                    matchdata.set_region(byte_offset + match_pos.0, byte_offset + match_pos.1);
+                }
+                let data =
+                    unsafe { matchdata.try_into_ruby(interp, None) }.map_err(|_| Error::Fatal)?;
+                unsafe {
+                    sys::mrb_gv_set(mrb, interp.borrow_mut().sym_intern("$~"), data.inner());
+                }
+                if let Some(block) = args.block {
+                    Ok(Value::new(interp, unsafe {
+                        sys::mrb_yield(mrb, block.inner(), data.inner())
+                    }))
+                } else {
+                    Ok(data)
+                }
             } else {
-                interp.borrow_mut().sym_intern(&format!("${}", group))
-            };
-
-            let value = Value::convert(&interp, captures.at(group));
-            unsafe {
-                sys::mrb_gv_set(mrb, sym, value.inner());
+                unsafe {
+                    let last_match_sym = interp.borrow_mut().sym_intern("$~");
+                    sys::mrb_gv_set(
+                        mrb,
+                        last_match_sym,
+                        Value::convert(interp, None::<Value>).inner(),
+                    );
+                    let pre_match_sym = interp.borrow_mut().sym_intern("$`");
+                    sys::mrb_gv_set(
+                        mrb,
+                        pre_match_sym,
+                        Value::convert(interp, None::<Value>).inner(),
+                    );
+                    let post_match_sym = interp.borrow_mut().sym_intern("$'");
+                    sys::mrb_gv_set(
+                        mrb,
+                        post_match_sym,
+                        Value::convert(interp, None::<Value>).inner(),
+                    );
+                }
+                Ok(Value::convert(interp, None::<Value>))
             }
         }
-        interp.borrow_mut().num_set_regexp_capture_globals = captures.len();
-
-        let mut matchdata = MatchData::new(string.as_str(), borrow.clone(), 0, string.len());
-        if let Some(match_pos) = captures.pos(0) {
-            let pre_match = &match_target[..match_pos.0];
-            let post_match = &match_target[match_pos.1..];
-            unsafe {
-                let pre_match_sym = interp.borrow_mut().sym_intern("$`");
-                sys::mrb_gv_set(
-                    mrb,
-                    pre_match_sym,
-                    Value::convert(interp, pre_match).inner(),
-                );
-                let post_match_sym = interp.borrow_mut().sym_intern("$'");
-                sys::mrb_gv_set(
-                    mrb,
-                    post_match_sym,
-                    Value::convert(interp, post_match).inner(),
-                );
-            }
-            matchdata.set_region(byte_offset + match_pos.0, byte_offset + match_pos.1);
-        }
-        let data = unsafe { matchdata.try_into_ruby(interp, None) }.map_err(|_| Error::Fatal)?;
-        unsafe {
-            sys::mrb_gv_set(mrb, interp.borrow_mut().sym_intern("$~"), data.inner());
-        }
-        if let Some(block) = args.block {
-            Ok(Value::new(interp, unsafe {
-                sys::mrb_yield(mrb, block.inner(), data.inner())
-            }))
-        } else {
-            Ok(data)
-        }
-    } else {
-        unsafe {
-            let last_match_sym = interp.borrow_mut().sym_intern("$~");
-            sys::mrb_gv_set(
-                mrb,
-                last_match_sym,
-                Value::convert(interp, None::<Value>).inner(),
-            );
-            let pre_match_sym = interp.borrow_mut().sym_intern("$`");
-            sys::mrb_gv_set(
-                mrb,
-                pre_match_sym,
-                Value::convert(interp, None::<Value>).inner(),
-            );
-            let post_match_sym = interp.borrow_mut().sym_intern("$'");
-            sys::mrb_gv_set(
-                mrb,
-                post_match_sym,
-                Value::convert(interp, None::<Value>).inner(),
-            );
-        }
-        Ok(Value::convert(interp, None::<Value>))
+        Backend::Rust(_) => unimplemented!("Rust-backed Regexp"),
     }
 }

--- a/artichoke-backend/src/extn/core/regexp/match_operator.rs
+++ b/artichoke-backend/src/extn/core/regexp/match_operator.rs
@@ -47,10 +47,6 @@ impl Args {
 // See: https://ruby-doc.org/core-2.6.3/Regexp.html#method-i-3D-7E
 pub fn method(interp: &Artichoke, args: Args, value: &Value) -> Result<Value, Error> {
     let mrb = interp.borrow().mrb;
-    let data = unsafe { Regexp::try_from_ruby(interp, value) }.map_err(|_| Error::Fatal)?;
-    let borrow = data.borrow();
-    let regex = (*borrow.regex).as_ref().ok_or(Error::Fatal)?;
-    let Backend::Onig(regex) = regex;
     let string = if let Some(string) = args.string {
         string
     } else {
@@ -60,77 +56,85 @@ pub fn method(interp: &Artichoke, args: Args, value: &Value) -> Result<Value, Er
             return Ok(nil);
         }
     };
-    let (matchdata, pos) = if let Some(captures) = regex.captures(string.as_str()) {
-        let num_regexp_globals_to_set = {
-            let num_previously_set_globals = interp.borrow().num_set_regexp_capture_globals;
-            cmp::max(num_previously_set_globals, captures.len())
-        };
-        for group in 0..num_regexp_globals_to_set {
-            let sym = if group == 0 {
-                interp.borrow_mut().sym_intern("$&")
+    let data = unsafe { Regexp::try_from_ruby(interp, value) }.map_err(|_| Error::Fatal)?;
+    let borrow = data.borrow();
+    let regex = (*borrow.regex).as_ref().ok_or(Error::Fatal)?;
+    let (matchdata, pos) = match regex {
+        Backend::Onig(regex) => {
+            if let Some(captures) = regex.captures(string.as_str()) {
+                let num_regexp_globals_to_set = {
+                    let num_previously_set_globals = interp.borrow().num_set_regexp_capture_globals;
+                    cmp::max(num_previously_set_globals, captures.len())
+                };
+                for group in 0..num_regexp_globals_to_set {
+                    let sym = if group == 0 {
+                        interp.borrow_mut().sym_intern("$&")
+                    } else {
+                        interp.borrow_mut().sym_intern(&format!("${}", group))
+                    };
+
+                    let value = Value::convert(&interp, captures.at(group));
+                    unsafe {
+                        sys::mrb_gv_set(mrb, sym, value.inner());
+                    }
+                }
+                interp.borrow_mut().num_set_regexp_capture_globals = captures.len();
+
+                let matchdata = MatchData::new(string.as_str(), borrow.clone(), 0, string.len());
+                let matchdata =
+                    unsafe { matchdata.try_into_ruby(&interp, None) }.map_err(|_| Error::Fatal)?;
+                if let Some(match_pos) = captures.pos(0) {
+                    let pre_match = &string[..match_pos.0];
+                    let post_match = &string[match_pos.1..];
+                    unsafe {
+                        let pre_match_sym = interp.borrow_mut().sym_intern("$`");
+                        sys::mrb_gv_set(
+                            mrb,
+                            pre_match_sym,
+                            Value::convert(interp, pre_match).inner(),
+                        );
+                        let post_match_sym = interp.borrow_mut().sym_intern("$'");
+                        sys::mrb_gv_set(
+                            mrb,
+                            post_match_sym,
+                            Value::convert(interp, post_match).inner(),
+                        );
+                    }
+                    (
+                        matchdata,
+                        Value::convert(interp, Int::try_from(match_pos.0).ok()),
+                    )
+                } else {
+                    (matchdata, Value::convert(interp, None::<Value>))
+                }
             } else {
-                interp.borrow_mut().sym_intern(&format!("${}", group))
-            };
-
-            let value = Value::convert(&interp, captures.at(group));
-            unsafe {
-                sys::mrb_gv_set(mrb, sym, value.inner());
+                unsafe {
+                    let last_match_sym = interp.borrow_mut().sym_intern("$~");
+                    sys::mrb_gv_set(
+                        mrb,
+                        last_match_sym,
+                        Value::convert(interp, None::<Value>).inner(),
+                    );
+                    let pre_match_sym = interp.borrow_mut().sym_intern("$`");
+                    sys::mrb_gv_set(
+                        mrb,
+                        pre_match_sym,
+                        Value::convert(interp, None::<Value>).inner(),
+                    );
+                    let post_match_sym = interp.borrow_mut().sym_intern("$'");
+                    sys::mrb_gv_set(
+                        mrb,
+                        post_match_sym,
+                        Value::convert(interp, None::<Value>).inner(),
+                    );
+                }
+                (
+                    Value::convert(interp, None::<Value>),
+                    Value::convert(interp, None::<Value>),
+                )
             }
         }
-        interp.borrow_mut().num_set_regexp_capture_globals = captures.len();
-
-        let matchdata = MatchData::new(string.as_str(), borrow.clone(), 0, string.len());
-        let matchdata =
-            unsafe { matchdata.try_into_ruby(&interp, None) }.map_err(|_| Error::Fatal)?;
-        if let Some(match_pos) = captures.pos(0) {
-            let pre_match = &string[..match_pos.0];
-            let post_match = &string[match_pos.1..];
-            unsafe {
-                let pre_match_sym = interp.borrow_mut().sym_intern("$`");
-                sys::mrb_gv_set(
-                    mrb,
-                    pre_match_sym,
-                    Value::convert(interp, pre_match).inner(),
-                );
-                let post_match_sym = interp.borrow_mut().sym_intern("$'");
-                sys::mrb_gv_set(
-                    mrb,
-                    post_match_sym,
-                    Value::convert(interp, post_match).inner(),
-                );
-            }
-            (
-                matchdata,
-                Value::convert(interp, Int::try_from(match_pos.0).ok()),
-            )
-        } else {
-            (matchdata, Value::convert(interp, None::<Value>))
-        }
-    } else {
-        unsafe {
-            let last_match_sym = interp.borrow_mut().sym_intern("$~");
-            sys::mrb_gv_set(
-                mrb,
-                last_match_sym,
-                Value::convert(interp, None::<Value>).inner(),
-            );
-            let pre_match_sym = interp.borrow_mut().sym_intern("$`");
-            sys::mrb_gv_set(
-                mrb,
-                pre_match_sym,
-                Value::convert(interp, None::<Value>).inner(),
-            );
-            let post_match_sym = interp.borrow_mut().sym_intern("$'");
-            sys::mrb_gv_set(
-                mrb,
-                post_match_sym,
-                Value::convert(interp, None::<Value>).inner(),
-            );
-        }
-        (
-            Value::convert(interp, None::<Value>),
-            Value::convert(interp, None::<Value>),
-        )
+        Backend::Rust(_) => unimplemented!("Rust-backed Regexp"),
     };
     unsafe {
         sys::mrb_gv_set(mrb, interp.borrow_mut().sym_intern("$~"), matchdata.inner());

--- a/artichoke-backend/src/extn/core/regexp/match_q.rs
+++ b/artichoke-backend/src/extn/core/regexp/match_q.rs
@@ -81,9 +81,11 @@ pub fn method(interp: &Artichoke, args: Args, value: &Value) -> Result<Value, Er
     }
     let byte_offset = string.chars().take(pos).collect::<String>().len();
 
+    let match_target = &string[byte_offset..];
     let borrow = data.borrow();
     let regex = (*borrow.regex).as_ref().ok_or(Error::Fatal)?;
-    let Backend::Onig(regex) = regex;
-    let match_target = &string[byte_offset..];
-    Ok(Value::convert(interp, regex.find(match_target).is_some()))
+    match regex {
+        Backend::Onig(regex) => Ok(Value::convert(interp, regex.find(match_target).is_some())),
+        Backend::Rust(_) => unimplemented!("Rust-backed Regexp"),
+    }
 }

--- a/artichoke-backend/src/extn/core/regexp/mod.rs
+++ b/artichoke-backend/src/extn/core/regexp/mod.rs
@@ -5,6 +5,7 @@
 //! the `Args` struct for invoking the function.
 
 use onig::{self, Syntax};
+use regex;
 use std::hash::{Hash, Hasher};
 use std::mem;
 use std::rc::Rc;
@@ -129,6 +130,7 @@ pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
 #[derive(Debug)]
 pub enum Backend {
     Onig(onig::Regex),
+    Rust(regex::Regex),
 }
 
 #[derive(Debug, Clone, Default)]

--- a/artichoke-backend/src/extn/core/regexp/names.rs
+++ b/artichoke-backend/src/extn/core/regexp/names.rs
@@ -17,18 +17,22 @@ pub fn method(interp: &Artichoke, value: &Value) -> Result<Value, Error> {
     let borrow = data.borrow();
     let mut names = vec![];
     let regex = (*borrow.regex).as_ref().ok_or(Error::Fatal)?;
-    let Backend::Onig(regex) = regex;
-    let mut capture_names = regex.capture_names().collect::<Vec<_>>();
-    capture_names.sort_by(|a, b| {
-        a.1.iter()
-            .fold(u32::max_value(), |a, &b| a.min(b))
-            .partial_cmp(b.1.iter().fold(&u32::max_value(), |a, b| a.min(b)))
-            .unwrap_or(Ordering::Equal)
-    });
-    for (name, _) in capture_names {
-        if !names.contains(&name) {
-            names.push(name);
+    match regex {
+        Backend::Onig(regex) => {
+            let mut capture_names = regex.capture_names().collect::<Vec<_>>();
+            capture_names.sort_by(|a, b| {
+                a.1.iter()
+                    .fold(u32::max_value(), |a, &b| a.min(b))
+                    .partial_cmp(b.1.iter().fold(&u32::max_value(), |a, b| a.min(b)))
+                    .unwrap_or(Ordering::Equal)
+            });
+            for (name, _) in capture_names {
+                if !names.contains(&name) {
+                    names.push(name);
+                }
+            }
         }
+        Backend::Rust(_) => unimplemented!("Rust-backed Regexp"),
     }
     Ok(Value::convert(&interp, names))
 }


### PR DESCRIPTION
This PR adds a new entry to the `regexp::Backend` enum which uses the Rust regex crate.

regex crate is a regex engine implemented with an FSM. For some cases, it is _much_ faster than oniguruma, but it does not support all features that Ruby `Regexp`s must have, like lookahead and backreferences.

Artichoke now supports choosing between multiple Regexp backends. Right now, the regex crate backend is a set of unimplemented stubs, but this lays the groundwork for implementing support for both engines.

This PR is in support of GH-57.