### PR TITLE
Fixups to auto import build step

### DIFF
--- a/artichoke-backend/scripts/.rubocop.yml
+++ b/artichoke-backend/scripts/.rubocop.yml
@@ -1,0 +1,7 @@
+AllCops:
+  TargetRubyVersion: 2.5
+  DisplayCopNames: true
+Metrics:
+  Enabled: false
+Style/Documentation:
+  Enabled: false

--- a/artichoke-backend/scripts/auto_import/auto_import.rb
+++ b/artichoke-backend/scripts/auto_import/auto_import.rb
@@ -3,22 +3,23 @@
 
 require 'erb'
 
-raise 'must provide a library to import' if ARGV[0].nil?
-raise 'must provide an output directory' if ARGV[1].nil?
+raise 'must provide a library base path' if ARGV[0].nil?
+raise 'must provide a library to import' if ARGV[1].nil?
+raise 'must provide an output directory' if ARGV[2].nil?
 
-LIB = ARGV[0]
-OUT_FILE = ARGV[1]
+base = ARGV[0]
+package = ARGV[1]
+out_file = ARGV[2]
+sources = ARGV[3].to_s.split(',').map { |source| source.gsub(%r{^.*#{base}/?}, '').gsub(/\.rb$/, '') }
 auto_import_dir = File.dirname(__FILE__)
-source_file = `gem which #{LIB}`.strip # used in erb
-filename = File.basename(source_file)
 # Import the Ruby 2.6.3 sources.
-constants = `#{auto_import_dir}/get_constants_loaded.rb "#{LIB}"`.split("\n")
+constants = `#{auto_import_dir}/get_constants_loaded.rb "#{base}" "#{package}"`.split("\n")
 
 # Add Rust glue, like this example for ostruct. Make a commit here.
 template = File.read("#{auto_import_dir}/rust_glue.rs.erb")
 renderer = ERB.new(template)
 output = renderer.result(binding)
-File.write(OUT_FILE.to_s, output)
+File.write(out_file.to_s, output)
 
 # Add test for spec compliance. Make a commit here.
 # Run spec compliance tests with yarn spec.

--- a/artichoke-backend/scripts/auto_import/get_constants_loaded.rb
+++ b/artichoke-backend/scripts/auto_import/get_constants_loaded.rb
@@ -3,7 +3,10 @@
 
 # The purpose of this script is to open a fresh interpreter, pull the constants,
 # require a library and figure out what constants were added.
+base = ARGV[0]
+package = ARGV[1]
+$LOAD_PATH.unshift(base)
 old_constants = Module.constants
-require ARGV[0]
+require package
 new_constants = Module.constants - old_constants
 puts new_constants

--- a/artichoke-backend/scripts/auto_import/get_package_files.rb
+++ b/artichoke-backend/scripts/auto_import/get_package_files.rb
@@ -2,9 +2,10 @@
 
 # The purpose of this script is to open a fresh interpreter, pull the constants,
 # require a library and figure out what constants were added.
-base = ARGV[0]
-package = ARGV[1]
-require package
-lib_sources = $LOADED_FEATURES.select { |f| f.start_with?(base) }
-package_sources = lib_sources.select { |f| f =~ %r{/#{package}} }
+BASE = ARGV[0]
+PACKAGE = ARGV[1]
+$LOAD_PATH.unshift(BASE)
+require PACKAGE
+lib_sources = $LOADED_FEATURES.select { |f| f.include?(BASE) }
+package_sources = lib_sources.select { |f| f =~ /#{PACKAGE}/ }
 puts package_sources.sort

--- a/artichoke-backend/scripts/auto_import/rust_glue.rs.erb
+++ b/artichoke-backend/scripts/auto_import/rust_glue.rs.erb
@@ -9,7 +9,9 @@ pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
         .borrow_mut()
         .def_class::<<%=constant%>>("<%=constant%>", None, None);
     <% end %>
-    interp.def_rb_source_file("<%=filename%>", include_str!("<%=filename%>"))?;
+    <% sources.each do |(file, source)| %>
+      interp.def_rb_source_file("<%=file%>.rb", include_str!(concat!(env!("OUT_DIR"), "/src/generated/<%=file%>.rs")))?;
+    <% end %>
     Ok(())
 }
 <% constants.each_with_index do |constant, i| %>


### PR DESCRIPTION
Followup to GH-117. cc @johnwahba.

- Cleanup dead code in `build.rs`.
- implement commands with Ruby directly instead of redirecting through bash.
- The `-I` flag no longer exists in MRI. Sorry @johnwahba I led you astray.
- Simulate the `-I` flag by passing around the vendored base path and manipulating `$LOAD_PATH`.
- Dump stderr on command failures in `build.rs`.
- add missing rubocop config to `artichoke-backend/scripts`.
- Generated rust sources reference files through `OUT_DIR`.
- Add support for multi-source packages.