### PR TITLE
Rename generated webpack outputs so they do not conflict with rustdoc

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,7 +7,7 @@ const OptimizeCSSAssetsPlugin = require("optimize-css-assets-webpack-plugin");
 
 const plugins = [
   new MiniCssExtractPlugin({
-    filename: "[name].css",
+    filename: "[hash].css",
     chunkFilename: "[id].css"
   }),
   new HtmlWebPackPlugin({
@@ -43,6 +43,7 @@ module.exports = (env, argv) => {
     },
     entry: path.resolve(__dirname, "artichoke-wasm/src/playground.js"),
     output: {
+      filename: "[hash].bundle.js",
       path: path.resolve(__dirname, `target/webpack/${target}`)
     },
     module: {


### PR DESCRIPTION
By default, webpack outputs to `main.js` which conflicts with the JS generated by rustdoc.

The CircleCI build blindly copies generated webpack sources into the doc root.

This PR changes the webpack config to use generated hashes for JS and CSS filenames.