### PR TITLE
Use cc crate to build mruby-sys static library

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
           # https://github.com/mruby/mruby/blob/master/doc/guides/compile.md#prerequisites
           name: Install mruby Build Dependencies
           command: |
-            sudo apt-get install -y binutils bison gperf ruby-full
+            sudo apt-get install -y bison gperf ruby-full
             bison --version
             gperf --version
             ruby --version

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,6 +81,28 @@ cargo fmt -- --check
 cargo clippy --all-targets --all-features
 ```
 
+### C Toolchain
+
+#### `cc` Crate
+
+Artichoke and some of its dependencies use the Rust
+[`cc` crate](https://crates.io/crates/cc) to build. `cc` uses a
+[platform-dependent C compiler](https://github.com/alexcrichton/cc-rs#compile-time-requirements)
+to compile C sources. On Unix, `cc` crate uses the `cc` binary.
+
+#### mruby Backend
+
+To build the Artichoke mruby backend, you will need a C compiler toolchain. By
+default, mruby requires the following to compile:
+
+- ar
+- gcc
+- bison
+- gperf
+
+You can override the requirement for gcc by setting the `CC` and `LD`
+environment variables.
+
 ### Node.js
 
 Artichoke uses Yarn and Node.js for linting and orchestration.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -297,6 +297,7 @@ dependencies = [
  "bindgen 0.51.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs_extra 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/mruby-sys/Cargo.toml
+++ b/mruby-sys/Cargo.toml
@@ -18,6 +18,7 @@ doctest = false
 [build-dependencies]
 cc = "1.0"
 fs_extra = "1.1.0"
+walkdir = "2"
 
 [build-dependencies.bindgen]
 version = "0.51.0"

--- a/mruby-sys/bootstrap.gembox
+++ b/mruby-sys/bootstrap.gembox
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# The "bootstrap" gembox contains the gems necessary to build mrbgems that
+# mruby-sys has as dependencies.
+#
+# Some mrbgems include Ruby sources which are compiled into C sources with the
+# mrbc compiler.
+#
+# This gembox can become empty and the default build nulled out once the
+# Artichoke runtime is complete.
+MRuby::GemBox.new do |conf|
+  conf.gem core: 'mruby-compiler'
+  conf.gem core: 'mruby-bin-mrbc'
+end

--- a/mruby-sys/build_config.rb
+++ b/mruby-sys/build_config.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# mruby requires a "default" build. This default build bootstraps the
+# compilation of the "sys" build.
+#
+# The "bootstrap" build compiles the mrbc bytecode compiler which is required
+# by some gems in the "sys" build.
+#
+# This build can be nulled out once the Artichoke runtime is complete.
+MRuby::Build.new do |conf|
+  # Gets set by the VS command prompts.
+  if ENV['VisualStudioVersion'] || ENV['VSINSTALLDIR']
+    toolchain :visualcpp
+  else
+    toolchain :gcc
+  end
+
+  conf.bins = ['mrbc']
+  conf.gembox File.join(File.dirname(File.absolute_path(__FILE__)), 'bootstrap')
+end
+
+# This cross-build generates C sources so `build.rs` can compile them into a
+# static lib.
+MRuby::CrossBuild.new('sys') do |conf|
+  conf.cc.command = 'true'
+  conf.cxx.command = 'true'
+  conf.objc.command = 'true'
+  conf.asm.command = 'true'
+  conf.linker.command = 'true'
+  conf.archiver.command = 'true'
+
+  # C compiler settings
+  # https://github.com/mruby/mruby/blob/master/doc/guides/mrbconf.md#other-configuration
+  conf.cc.defines += %w[MRB_DISABLE_STDIO MRB_UTF8_STRING]
+
+  conf.bins = []
+
+  # gemset for mruby-sys
+  conf.gembox File.join(File.dirname(File.absolute_path(__FILE__)), 'sys')
+end


### PR DESCRIPTION
Modify mruby-sys build to use the `cc` crate to compile one static library called `libmrubysys.a`.

Compiling with `cc` crate makes it easier to compile a wasm32-unknown-unknown build. We still can't do that because of `onig`.

To accomplish this, the `host` build now compiles the bare minimum of mruby to bootstrap the `sys` build. Until GH-32 is complete, mruby-sys depends on gems with Ruby sources. These Ruby sources get translated to bytecode embedded in C sources using the `mrbc` binary. The `host` build produces this binary.

The `sys` build only generates C sources using `minirake` by replacing compiler commands with `true`. `build.rs` the collects all of the headers and sources and compiles them with `cc` crate.

Adds docs for GH-137. `cc` is required to build. By default, that is expected to be `gcc`.
Fixes GH-145.