### PR TITLE
Env followup

### DIFF
--- a/artichoke-backend/src/extn/core/env/errors.rs
+++ b/artichoke-backend/src/extn/core/env/errors.rs
@@ -1,5 +1,0 @@
-#[derive(Debug, Clone)]
-pub enum EnvError {
-    InvalidSetValue,
-    InvalidSetKey,
-}


### PR DESCRIPTION
ENV object: Follow up from GH-148.

- Modify backend trait to return Result with Env Error.
- Make env module Error into an Error type.
- Handle null byte in env::var_os (fixes segfaulting test introduced in
  previous commit).
- Return Error::Fatal instead of unwrapping, e.g. HashMap backend with
  RwLock.
- Move arg validation into backend implementation.
- Move calls to raise into C API to work prevent memory leaks with
  longjmp.
- get set and to_h internal return Value instead of sys::mrb_value.

```
mruby 2.0 [2.0.1-12]
[Compiled with rustc 1.38.0-nightly 6e310f2 2019-07-07]
>>> ENV["as\0"]
Backtrace:
    (airb):1: bad environment variable name: contains null byte (ArgumentError)
    (airb):1
>>> ENV["as\0"] = "a"
Backtrace:
    (airb):2: bad environment variable name: contains null byte (ArgumentError)
    (airb):2
>>> ENV["as"] = "a\0"
Backtrace:
    (airb):3: bad environment variable value: contains null byte (ArgumentError)
    (airb):3
```