### PR TITLE
Rename patch functions to init in artichoke-backend extn

### DIFF
--- a/artichoke-backend/src/extn/core/array.rs
+++ b/artichoke-backend/src/extn/core/array.rs
@@ -2,7 +2,7 @@ use crate::eval::Eval;
 use crate::Artichoke;
 use crate::ArtichokeError;
 
-pub fn patch(interp: &Artichoke) -> Result<(), ArtichokeError> {
+pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
     interp.borrow_mut().def_class::<Array>("Array", None, None);
     interp.eval(include_str!("array.rb"))?;
     Ok(())

--- a/artichoke-backend/src/extn/core/env/env_object.rs
+++ b/artichoke-backend/src/extn/core/env/env_object.rs
@@ -185,14 +185,14 @@ mod tests {
     #[test]
     fn test_env_initialized() {
         let interp = crate::interpreter().expect("init");
-        env::patch(&interp).expect("env init");
+        env::init(&interp).expect("env init");
     }
 
     #[test]
     fn test_env_get_unexisting_variable() {
         // given
         let interp = crate::interpreter().expect("init");
-        env::patch(&interp).expect("env init");
+        env::init(&interp).expect("env init");
 
         // when
         let non_existing_env_variable = (&interp)
@@ -208,7 +208,7 @@ mod tests {
     fn test_env_get_with_incorrect_number_of_args() {
         // given
         let interp = crate::interpreter().expect("init");
-        env::patch(&interp).expect("env init");
+        env::init(&interp).expect("env init");
 
         // when
         let env_get_no_args = (&interp).eval(r"ENV[]");
@@ -223,7 +223,7 @@ mod tests {
     fn test_env_set() {
         // given
         let interp = crate::interpreter().expect("init");
-        env::patch(&interp).expect("env init");
+        env::init(&interp).expect("env init");
 
         // when
         let env_set_random_var =
@@ -239,7 +239,7 @@ mod tests {
     fn test_two_set() {
         // given
         let interp = crate::interpreter().expect("init");
-        env::patch(&interp).expect("env init");
+        env::init(&interp).expect("env init");
 
         // when
         let _env_set_1 = (&interp).eval(r"ENV['f38e2156-0633-4b06-80e7-9d5fa4b5a553'] = 'val1'");
@@ -257,7 +257,7 @@ mod tests {
     fn test_set_get() {
         // given
         let interp = crate::interpreter().expect("init");
-        env::patch(&interp).expect("env init");
+        env::init(&interp).expect("env init");
         let var_name = "81fdf184-01b4-4248-82db-3b3e8482abf6";
         let var_value = "val";
         let set_var_cmd = format!(r"ENV['{0}'] = '{1}'", var_name, var_value);
@@ -276,7 +276,7 @@ mod tests {
     fn test_set_nil() {
         // given
         let interp = crate::interpreter().expect("init");
-        env::patch(&interp).expect("env init");
+        env::init(&interp).expect("env init");
         let var_name = "9a557fda-73a6-4de8-8999-ddeda18703f2";
         let var_value = "val";
         let set_var_cmd = format!(r"ENV['{0}'] = '{1}'", var_name, var_value);
@@ -299,7 +299,7 @@ mod tests {
     fn test_get_name_with_null_byte() {
         // given
         let interp = crate::interpreter().expect("init");
-        env::patch(&interp).expect("env init");
+        env::init(&interp).expect("env init");
 
         // when
         let result = interp.eval(r#"ENV["bar\0"]"#);
@@ -320,7 +320,7 @@ mod tests {
     fn test_set_name_with_null_byte() {
         // given
         let interp = crate::interpreter().expect("init");
-        env::patch(&interp).expect("env init");
+        env::init(&interp).expect("env init");
 
         // when
         let result = interp.eval(r#"ENV["bar\0"] = "foo""#);
@@ -341,7 +341,7 @@ mod tests {
     fn test_set_value_with_null_byte() {
         // given
         let interp = crate::interpreter().expect("init");
-        env::patch(&interp).expect("env init");
+        env::init(&interp).expect("env init");
 
         // when
         let result = interp.eval(r#"ENV['bar'] = "foo\0""#);
@@ -362,7 +362,7 @@ mod tests {
     fn test_set_value_with_equal() {
         // given
         let interp = crate::interpreter().expect("init");
-        env::patch(&interp).expect("env init");
+        env::init(&interp).expect("env init");
 
         // when
         let result = interp.eval(r#"ENV['bar='] = "foo""#);

--- a/artichoke-backend/src/extn/core/env/mod.rs
+++ b/artichoke-backend/src/extn/core/env/mod.rs
@@ -13,11 +13,11 @@ mod env_object;
 use backends::{EnvBackend, EnvStdBackend};
 use env_object::{Env, RubyEnvNativeApi};
 
-pub fn patch(interp: &Artichoke) -> Result<(), ArtichokeError> {
-    patch_internal_with_backend::<EnvStdBackend>(interp)
+pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
+    init_internal_with_backend::<EnvStdBackend>(interp)
 }
 
-fn patch_internal_with_backend<T: EnvBackend>(interp: &Artichoke) -> Result<(), ArtichokeError>
+fn init_internal_with_backend<T: EnvBackend>(interp: &Artichoke) -> Result<(), ArtichokeError>
 where
     T: 'static,
 {

--- a/artichoke-backend/src/extn/core/error.rs
+++ b/artichoke-backend/src/extn/core/error.rs
@@ -8,7 +8,7 @@ use crate::sys;
 use crate::value::Value;
 use crate::{Artichoke, ArtichokeError};
 
-pub fn patch(interp: &Artichoke) -> Result<(), ArtichokeError> {
+pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
     let exception = interp
         .borrow_mut()
         .def_class::<Exception>("Exception", None, None);

--- a/artichoke-backend/src/extn/core/hash.rs
+++ b/artichoke-backend/src/extn/core/hash.rs
@@ -2,7 +2,7 @@ use crate::eval::Eval;
 use crate::Artichoke;
 use crate::ArtichokeError;
 
-pub fn patch(interp: &Artichoke) -> Result<(), ArtichokeError> {
+pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
     interp.borrow_mut().def_class::<Hash>("Hash", None, None);
     interp.eval(include_str!("hash.rb"))?;
     Ok(())

--- a/artichoke-backend/src/extn/core/kernel/mod.rs
+++ b/artichoke-backend/src/extn/core/kernel/mod.rs
@@ -13,7 +13,7 @@ use crate::{Artichoke, ArtichokeError};
 mod args;
 pub mod require;
 
-pub fn patch(interp: &Artichoke) -> Result<(), ArtichokeError> {
+pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
     let warning = interp.borrow_mut().def_module::<Warning>("Warning", None);
     warning
         .borrow_mut()

--- a/artichoke-backend/src/extn/core/mod.rs
+++ b/artichoke-backend/src/extn/core/mod.rs
@@ -13,17 +13,17 @@ pub mod regexp;
 pub mod string;
 pub mod thread;
 
-pub fn patch(interp: &Artichoke) -> Result<(), ArtichokeError> {
+pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
     interp.eval(include_str!("object.rb"))?;
-    array::patch(interp)?;
-    env::patch(interp)?;
-    error::patch(interp)?;
-    hash::patch(interp)?;
-    kernel::patch(interp)?;
+    array::init(interp)?;
+    env::init(interp)?;
+    error::init(interp)?;
+    hash::init(interp)?;
+    kernel::init(interp)?;
     matchdata::init(interp)?;
-    module::patch(interp)?;
+    module::init(interp)?;
     regexp::init(interp)?;
-    string::patch(interp)?;
+    string::init(interp)?;
     thread::init(interp)?;
     Ok(())
 }

--- a/artichoke-backend/src/extn/core/module.rs
+++ b/artichoke-backend/src/extn/core/module.rs
@@ -2,7 +2,7 @@ use crate::eval::Eval;
 use crate::Artichoke;
 use crate::ArtichokeError;
 
-pub fn patch(interp: &Artichoke) -> Result<(), ArtichokeError> {
+pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
     interp
         .borrow_mut()
         .def_class::<Module>("Module", None, None);

--- a/artichoke-backend/src/extn/core/string.rs
+++ b/artichoke-backend/src/extn/core/string.rs
@@ -10,7 +10,7 @@ use crate::{Artichoke, ArtichokeError};
 
 mod scan;
 
-pub fn patch(interp: &Artichoke) -> Result<(), ArtichokeError> {
+pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
     if interp.borrow().class_spec::<RString>().is_some() {
         return Ok(());
     }
@@ -84,7 +84,7 @@ mod tests {
     #[test]
     fn string_equal_squiggle() {
         let interp = crate::interpreter().expect("init");
-        string::patch(&interp).expect("string init");
+        string::init(&interp).expect("string init");
 
         let value = interp.eval(r#""cat o' 9 tails" =~ /\d/"#).unwrap();
         assert_eq!(value.try_into::<Option<i64>>(), Ok(Some(7)));
@@ -95,7 +95,7 @@ mod tests {
     #[test]
     fn string_idx() {
         let interp = crate::interpreter().expect("init");
-        string::patch(&interp).expect("string init");
+        string::init(&interp).expect("string init");
 
         assert_eq!(
             &interp
@@ -150,7 +150,7 @@ mod tests {
     #[test]
     fn string_scan() {
         let interp = crate::interpreter().expect("init");
-        string::patch(&interp).expect("string init");
+        string::init(&interp).expect("string init");
 
         let s = Value::convert(&interp, "abababa");
         let result = s
@@ -192,7 +192,7 @@ mod tests {
     #[test]
     fn string_unary_minus() {
         let interp = crate::interpreter().expect("init");
-        string::patch(&interp).expect("string init");
+        string::init(&interp).expect("string init");
 
         let s = interp.eval("-'abababa'").expect("eval");
         let result = s.funcall::<bool, _, _>("frozen?", &[]).expect("funcall");

--- a/artichoke-backend/src/extn/mod.rs
+++ b/artichoke-backend/src/extn/mod.rs
@@ -9,7 +9,7 @@ pub mod stdlib;
 pub const RUBY_PLATFORM: &str = "x86_64-unknown-artichoke";
 pub const INPUT_RECORD_SEPARATOR: &str = "\n";
 
-pub fn patch(interp: &Artichoke) -> Result<(), ArtichokeError> {
+pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
     let mrb = interp.borrow().mrb;
     unsafe {
         let ruby_platform = Value::convert(interp, RUBY_PLATFORM);
@@ -31,7 +31,7 @@ pub fn patch(interp: &Artichoke) -> Result<(), ArtichokeError> {
             input_record_separator.inner(),
         );
     }
-    core::patch(interp)?;
-    stdlib::patch(interp)?;
+    core::init(interp)?;
+    stdlib::init(interp)?;
     Ok(())
 }

--- a/artichoke-backend/src/extn/stdlib/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/mod.rs
@@ -9,8 +9,8 @@ pub mod set;
 pub mod strscan;
 mod stubs;
 
-pub fn patch(interp: &Artichoke) -> Result<(), ArtichokeError> {
-    stubs::patch(interp)?;
+pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
+    stubs::init(interp)?;
     delegate::init(interp)?;
     forwardable::init(interp)?;
     json::init(interp)?;

--- a/artichoke-backend/src/extn/stdlib/stubs.rs
+++ b/artichoke-backend/src/extn/stdlib/stubs.rs
@@ -2,7 +2,7 @@ use crate::load::LoadSources;
 use crate::Artichoke;
 use crate::ArtichokeError;
 
-pub fn patch(interp: &Artichoke) -> Result<(), ArtichokeError> {
+pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
     interp.def_rb_source_file("erb.rb", "class ERB; def initialize(*args); end; end")?;
     interp.def_rb_source_file("time.rb", "")?;
     interp.def_rb_source_file("fileutils.rb", "")?;

--- a/artichoke-backend/src/interpreter.rs
+++ b/artichoke-backend/src/interpreter.rs
@@ -41,8 +41,8 @@ pub fn interpreter() -> Result<Artichoke, ArtichokeError> {
     // context and interpreter.
     let interp = unsafe { Rc::from_raw(ptr) };
 
-    // Patch mruby builtins with Rust extensions
-    extn::patch(&interp)?;
+    // Initialize Artichoke Core and Standard Library runtime
+    extn::init(&interp)?;
 
     debug!("Allocated {}", mrb.debug());
 


### PR DESCRIPTION
`patch` is an artifact of basing extn initially on mruby. The goal is to
be able to initialize extn from scratch, so we won't be patching from a
base, but rather initializing from nothing.