### PR TITLE
Fix mruby-sys build flakiness when compiling mruby-compiler mrbgem

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,9 +56,8 @@ jobs:
           # https://github.com/mruby/mruby/blob/master/doc/guides/compile.md#prerequisites
           name: Install mruby Build Dependencies
           command: |
-            sudo apt-get install -y bison gperf
+            sudo apt-get install -y bison
             bison --version
-            gperf --version
       - run:
           # needed for cc crate in build.rs
           name: Install mruby-sys Build Dependencies

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,7 +97,6 @@ default, mruby requires the following to compile:
 
 - clang
 - bison
-- gperf
 - ar
 
 You can override the requirement for clang by setting the `CC` and `LD`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,12 +95,12 @@ to compile C sources. On Unix, `cc` crate uses the `cc` binary.
 To build the Artichoke mruby backend, you will need a C compiler toolchain. By
 default, mruby requires the following to compile:
 
-- ar
-- gcc
+- clang
 - bison
 - gperf
+- ar
 
-You can override the requirement for gcc by setting the `CC` and `LD`
+You can override the requirement for clang by setting the `CC` and `LD`
 environment variables.
 
 ### Node.js

--- a/mruby-sys/build_config.rb
+++ b/mruby-sys/build_config.rb
@@ -14,6 +14,7 @@ MRuby::Build.new do |conf|
   else
     toolchain :clang
   end
+  conf.gperf.command = 'true'
 
   conf.bins = ['mrbc']
   conf.gembox File.join(File.dirname(File.absolute_path(__FILE__)), 'bootstrap')
@@ -26,6 +27,7 @@ MRuby::CrossBuild.new('sys') do |conf|
   conf.cxx.command = 'true'
   conf.objc.command = 'true'
   conf.asm.command = 'true'
+  conf.gperf.command = 'true'
   conf.linker.command = 'true'
   conf.archiver.command = 'true'
 

--- a/mruby-sys/build_config.rb
+++ b/mruby-sys/build_config.rb
@@ -12,7 +12,7 @@ MRuby::Build.new do |conf|
   if ENV['VisualStudioVersion'] || ENV['VSINSTALLDIR']
     toolchain :visualcpp
   else
-    toolchain :gcc
+    toolchain :clang
   end
 
   conf.bins = ['mrbc']

--- a/mruby-sys/build_config.rb
+++ b/mruby-sys/build_config.rb
@@ -15,6 +15,7 @@ MRuby::Build.new do |conf|
     toolchain :clang
   end
   conf.gperf.command = 'true'
+  conf.gperf.compile_options = ''
 
   conf.bins = ['mrbc']
   conf.gembox File.join(File.dirname(File.absolute_path(__FILE__)), 'bootstrap')
@@ -28,6 +29,7 @@ MRuby::CrossBuild.new('sys') do |conf|
   conf.objc.command = 'true'
   conf.asm.command = 'true'
   conf.gperf.command = 'true'
+  conf.gperf.compile_options = ''
   conf.linker.command = 'true'
   conf.archiver.command = 'true'
 


### PR DESCRIPTION
I think the build flakiness started when we switched back to gcc for the bootstrap
build. Maybe something to do with the buster upgrade?

Either way, cc crate already requires clang so it makes sense to unify things.