### PR TITLE
[WIP] build under wasm32-unknown-unknown target

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+node_modules
+target

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -803,6 +803,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm"
+version = "0.1.0"
+dependencies = [
+ "artichoke-backend 0.1.0",
+]
+
+[[package]]
 name = "which"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,7 +43,7 @@ dependencies = [
  "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "mruby-sys 2.0.1-14",
- "onig 5.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "onig 5.0.0 (git+https://github.com/artichoke/rust-onig?rev=bb6482017f6e8a5b7e75a10d5151cee0191bd6b8)",
  "quickcheck 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck_macros 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -370,18 +370,18 @@ dependencies = [
 [[package]]
 name = "onig"
 version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/artichoke/rust-onig?rev=bb6482017f6e8a5b7e75a10d5151cee0191bd6b8#bb6482017f6e8a5b7e75a10d5151cee0191bd6b8"
 dependencies = [
  "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
- "onig_sys 69.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "onig_sys 69.2.0 (git+https://github.com/artichoke/rust-onig?rev=bb6482017f6e8a5b7e75a10d5151cee0191bd6b8)",
 ]
 
 [[package]]
 name = "onig_sys"
 version = "69.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/artichoke/rust-onig?rev=bb6482017f6e8a5b7e75a10d5151cee0191bd6b8#bb6482017f6e8a5b7e75a10d5151cee0191bd6b8"
 dependencies = [
  "bindgen 0.50.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -947,8 +947,8 @@ dependencies = [
 "checksum nix 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4dbdc256eaac2e3bd236d93ad999d3479ef775c863dbda3068c4006a92eec51b"
 "checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
 "checksum nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
-"checksum onig 5.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e4e723fc996fff1aeab8f62205f3e8528bf498bdd5eadb2784d2d31f30077947"
-"checksum onig_sys 69.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0a8d4efbf5f59cece01f539305191485b651acb3785b9d5eef05749f0496514e"
+"checksum onig 5.0.0 (git+https://github.com/artichoke/rust-onig?rev=bb6482017f6e8a5b7e75a10d5151cee0191bd6b8)" = "<none>"
+"checksum onig_sys 69.2.0 (git+https://github.com/artichoke/rust-onig?rev=bb6482017f6e8a5b7e75a10d5151cee0191bd6b8)" = "<none>"
 "checksum peeking_take_while 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 "checksum pkg-config 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c1d2cfa5a714db3b5f24f0915e74fcdf91d09d496ba61329705dda7774d2af"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,6 +162,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "byteorder"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -807,7 +812,56 @@ name = "wasm"
 version = "0.1.0"
 dependencies = [
  "artichoke-backend 0.1.0",
+ "wasm-bindgen 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "wasm-bindgen-macro 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bumpalo 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-shared 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-macro-support 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-backend 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-shared 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "which"
@@ -867,6 +921,7 @@ dependencies = [
 "checksum bindgen 0.51.0 (registry+https://github.com/rust-lang/crates.io-index)" = "18270cdd7065ec045a6bb4bdcd5144d14a78b3aedb3bc5111e688773ac8b9ad0"
 "checksum bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3d155346769a6855b86399e9bc3814ab343cd3d62c7e985113d46a0ec3c281fd"
 "checksum blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "5d6d530bdd2d52966a6d03b7a964add7ae1a288d25214066fd4b600f0f796400"
+"checksum bumpalo 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2cd43d82f27d68911e6ee11ee791fb248f138f5d69424dc02e098d4f152b0b05"
 "checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
 "checksum cc 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)" = "ce400c638d48ee0e9ab75aef7997609ec57367ccfe1463f21bf53c3eca67bf46"
 "checksum cexpr 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a7fa24eb00d5ffab90eaeaf1092ac85c04c64aaf358ea6f84505b8116d24c6af"
@@ -947,6 +1002,11 @@ dependencies = [
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)" = "9658c94fa8b940eab2250bd5a457f9c48b748420d71293b165c8cdbe2f55f71e"
+"checksum wasm-bindgen 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)" = "4de97fa1806bb1a99904216f6ac5e0c050dc4f8c676dc98775047c38e5c01b55"
+"checksum wasm-bindgen-backend 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)" = "5d82c170ef9f5b2c63ad4460dfcee93f3ec04a9a36a4cc20bc973c39e59ab8e3"
+"checksum wasm-bindgen-macro 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)" = "f07d50f74bf7a738304f6b8157f4a581e1512cd9e9cdb5baad8c31bbe8ffd81d"
+"checksum wasm-bindgen-macro-support 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)" = "95cf8fe77e45ba5f91bc8f3da0c3aa5d464b3d8ed85d84f4d4c7cc106436b1d7"
+"checksum wasm-bindgen-shared 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)" = "d9c2d4d4756b2e46d3a5422e06277d02e4d3e1d62d138b76a4c681e925743623"
 "checksum which 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b57acb10231b9493c8472b20cb57317d0679a49e0bdbee44b3b803a6473af164"
 "checksum winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "f10e386af2b13e47c89e7236a7a14a086791a2b88ebad6df9bf42040195cf770"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
   "artichoke-vfs",
   "mruby-sys",
   "spec-runner",
+  "wasm",
 ]
 
 [profile.release]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM artichoke-ci-base:latest
+
+COPY --chown=artichoke:artichoke . /app
+
+RUN cd /app && cargo build --target wasm32-unknown-unknown

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -15,9 +15,8 @@ path = "../artichoke-vfs"
 path = "../mruby-sys"
 
 [dependencies.onig]
-version = "5"
-# git = "https://github.com/artichoke/rust-onig"
-# branch = "wasm"
+git = "https://github.com/artichoke/rust-onig"
+rev = "bb6482017f6e8a5b7e75a10d5151cee0191bd6b8"
 
 [dev-dependencies]
 env_logger = "0.6.1"

--- a/artichoke-backend/src/eval.rs
+++ b/artichoke-backend/src/eval.rs
@@ -1,3 +1,4 @@
+#![allow(warnings)]
 use log::{error, trace, warn};
 use std::ffi::{c_void, CString};
 use std::mem;
@@ -168,22 +169,22 @@ impl Eval for Artichoke {
         }
         drop(context);
 
-        let args = Rc::new(Protect::new(self, code.as_ref()));
+        let args = Box::new(Protect::new(self, code.as_ref()));
         drop(code);
         trace!("Evaling code on {}", mrb.debug());
-        let value = unsafe {
-            let data = sys::mrb_sys_cptr_value(mrb, Rc::into_raw(Rc::clone(&args)) as *mut c_void);
-            let mut state = <mem::MaybeUninit<sys::mrb_bool>>::uninit();
+        // let value = unsafe {
+        //     let data = sys::mrb_sys_cptr_value(mrb, Box::into_raw(args) as *mut c_void);
+        //     let mut state = <mem::MaybeUninit<sys::mrb_bool>>::uninit();
 
-            let value =
-                sys::mrb_protect(mrb, Some(Protect::run_protected), data, state.as_mut_ptr());
-            drop(args);
-            if state.assume_init() != 0 {
-                (*mrb).exc = sys::mrb_sys_obj_ptr(value);
-            }
-            value
-        };
-        let value = Value::new(self, value);
+        //     let value =
+        //         sys::mrb_protect(mrb, Some(Protect::run_protected), data, state.as_mut_ptr());
+        //     drop(args);
+        //     if state.assume_init() != 0 {
+        //         (*mrb).exc = sys::mrb_sys_obj_ptr(value);
+        //     }
+        //     value
+        // };
+        let value = Value::new(self, unsafe { sys::mrb_sys_nil_value() });
 
         match self.last_error() {
             LastError::Some(exception) => {
@@ -238,24 +239,25 @@ impl Eval for Artichoke {
         }
         drop(context);
 
-        let args = Rc::new(Protect::new(self, code.as_ref()));
+        let args = Box::new(Protect::new(self, code.as_ref()));
         drop(code);
         trace!("Evaling code on {}", mrb.debug());
-        let value = unsafe {
-            let data = sys::mrb_sys_cptr_value(mrb, Rc::into_raw(Rc::clone(&args)) as *mut c_void);
-            let mut state = <mem::MaybeUninit<sys::mrb_bool>>::uninit();
+        // let value = unsafe {
+        //     let data = sys::mrb_sys_cptr_value(mrb, Box::into_raw(args) as *mut c_void);
+        //     let mut state = <mem::MaybeUninit<sys::mrb_bool>>::uninit();
 
-            let value =
-                sys::mrb_protect(mrb, Some(Protect::run_protected), data, state.as_mut_ptr());
-            drop(args);
-            if state.assume_init() != 0 {
-                (*mrb).exc = sys::mrb_sys_obj_ptr(value);
-                sys::mrb_sys_raise_current_exception(mrb);
-                unreachable!("mrb_raise will unwind the stack with longjmp");
-            }
-            value
-        };
-        Value::new(self, value)
+        //     let value =
+        //         sys::mrb_protect(mrb, Some(Protect::run_protected), data, state.as_mut_ptr());
+        //     drop(args);
+        //     if state.assume_init() != 0 {
+        //         (*mrb).exc = sys::mrb_sys_obj_ptr(value);
+        //         sys::mrb_sys_raise_current_exception(mrb);
+        //         unreachable!("mrb_raise will unwind the stack with longjmp");
+        //     }
+        //     value
+        // };
+        // Value::new(self, value)
+        Value::new(self, unsafe { sys::mrb_sys_nil_value() })
     }
 
     fn eval_with_context<T>(&self, code: T, context: Context) -> Result<Value, ArtichokeError>

--- a/mruby-sys/Cargo.toml
+++ b/mruby-sys/Cargo.toml
@@ -12,6 +12,7 @@ links = "mruby"
 # not possible to annotate these doctests with `ignore` because you can only add
 # attributes to fenced code blocks.
 doctest = false
+crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -4,9 +4,11 @@ version = "0.1.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2018"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]
 crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+wasm-bindgen = "0.2"
 
 [dependencies.artichoke-backend]
 path = "../artichoke-backend"

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "wasm"
+version = "0.1.0"
+authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies.artichoke-backend]
+path = "../artichoke-backend"

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -1,0 +1,25 @@
+use artichoke_backend::eval::Eval;
+use artichoke_backend::types::Int;
+
+#[no_mangle]
+pub fn artichoke_wasm_eval() -> Int {
+    let interp = if let Ok(interp) = artichoke_backend::interpreter() {
+        interp
+    } else {
+        return -1;
+    };
+    let value = if let Ok(value) = interp.eval("10 * 10") {
+        value
+    } else {
+        return -2;
+    };
+    value.try_into::<Int>().unwrap_or(-3)
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        assert_eq!(2 + 2, 4);
+    }
+}

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -1,18 +1,15 @@
 use artichoke_backend::eval::Eval;
 use artichoke_backend::types::Int;
+use wasm_bindgen::prelude::*;
 
-#[no_mangle]
+#[wasm_bindgen]
 pub fn artichoke_wasm_eval() -> Int {
     let interp = if let Ok(interp) = artichoke_backend::interpreter() {
         interp
     } else {
         return -1;
     };
-    let value = if let Ok(value) = interp.eval("10 * 10") {
-        value
-    } else {
-        return -2;
-    };
+    let value = interp.unchecked_eval("10 * 10");
     value.try_into::<Int>().unwrap_or(-3)
 }
 


### PR DESCRIPTION
This branch makes much progress to build artichoke under the wasm32-unknown-unknown target.

This branch includes a new `wasm` crate which exports a funtion that initializes an interpreter and evals a single `Integer` expression and returns the result. This code can be built with:

```console
$ cargo build --target wasm32-unknown-unknown -p wasm
```

The build currently fails at the linker stage:

```
  = note: rust-lld: error: function signature mismatch: mrb_protect
          >>> defined as (i32, i32, i32, i64, i32, i32, i32) -> void in /home/artichoke/target/wasm32-unknown-unknown/debug/deps/artichoke_backend.1ja1zfqnm5ty63ed.rcgu.o
          >>> defined as (i32, i32, i32, i32, i32) -> void in /home/artichoke/target/wasm32-unknown-unknown/debug/deps/libmruby_sys.rlib(exception.o)

          rust-lld: error: function signature mismatch: mrb_gc_protect
          >>> defined as (i32, i64, i32, i32) -> void in /home/artichoke/target/wasm32-unknown-unknown/debug/deps/artichoke_backend.7pvpltx2v0gmmy3.rcgu.o
          >>> defined as (i32, i32) -> void in /home/artichoke/target/wasm32-unknown-unknown/debug/deps/libmruby_sys.rlib(exception.o)
```

In order to get to this point, this branch makes the following changes:

- Update [rust-onig fork](https://github.com/artichoke/rust-onig) to the latest 5.0.0 master.
- Update the oniguruma dependency to a [fork](https://github.com/artichoke/oniguruma/tree/disable-direct-threading) that contains these changes:
  - Introduce a check for a macro that, when defined, disables direct threading in the regex engine. Direct threading is only enabled in snapshot clang. See GH-149. Defining this macro enables building oniguruma for wasm32-unknown-unknown on clang-8.
  - Explicitly `#include <stdint.h>` in two sources. This header defines the `uintptr_t ` type which is part of C99, but optional. The emscripten wasm headers we vendor do not automatically define this type and require an explicit include.
- Vendor emscipten latest-upstream headers in onig_sys in rust-onig.
- Include these headers for wasm targets.
- Alter onig_sys `build.rs` to handle `CARGO_CFG_TARGET_FAMILY` being unset.
- Define `ONIG_EXTERN` in wasm builds to set export visibility.
- Define `MRB_DISABLE_DIRECT_THREADING` for wasm builds of mruby-sys.
- Update rust-onig dep in artichoke-backend to new fork branch.
- Update `Regexp` implementation in artichoke-backend to compile with API changes in onig 5.0.

To build for wasm, I've been using this docker container: https://github.com/artichoke/artichoke-ci

cc @singpolyma-shopify