### PR TITLE
Update to onig 5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "argon2rs"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -35,7 +43,7 @@ dependencies = [
  "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "mruby-sys 2.0.1-12",
- "onig 4.3.2 (git+https://github.com/artichoke/rust-onig?branch=wasm)",
+ "onig 5.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck_macros 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -96,6 +104,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cexpr 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clang-sys 0.28.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "peeking_take_while 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "shlex 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "which 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -162,6 +192,20 @@ dependencies = [
  "glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
  "libloading 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "clap"
+version = "2.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -320,20 +364,21 @@ dependencies = [
 
 [[package]]
 name = "onig"
-version = "4.3.2"
-source = "git+https://github.com/artichoke/rust-onig?branch=wasm#d1346f4475bbe76bfed6fc8fc136761990a29bd5"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
- "onig_sys 69.1.0 (git+https://github.com/artichoke/rust-onig?branch=wasm)",
+ "onig_sys 69.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "onig_sys"
-version = "69.1.0"
-source = "git+https://github.com/artichoke/rust-onig?branch=wasm#d1346f4475bbe76bfed6fc8fc136761990a29bd5"
+version = "69.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "bindgen 0.50.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -630,6 +675,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "syn"
 version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -677,6 +727,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "thread_local"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -717,6 +775,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "utf8parse"
 version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "vec_map"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -786,12 +849,14 @@ dependencies = [
 
 [metadata]
 "checksum aho-corasick 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "36b7aa1ccb7d7ea3f437cf025a2ab1c47cc6c1bc9fc84918ff449def12f5e282"
+"checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum argon2rs 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3f67b0b6a86dae6e67ff4ca2b6201396074996379fba2b92ff649126f37cb392"
 "checksum arrayvec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "b8d73f9beda665eaa98ab9e4f7442bd4e7de6652587de55b2525e52e29c1b0ba"
 "checksum atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90"
 "checksum autocfg 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "22130e92352b948e7e82a49cdb0aa94f2211761117f29e052dd397c1ac33542b"
 "checksum backtrace 0.3.33 (registry+https://github.com/rust-lang/crates.io-index)" = "88fb679bc9af8fa639198790a77f52d345fe13656c08b43afa9424c206b731c6"
 "checksum backtrace-sys 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "82a830b4ef2d1124a711c71d263c5abdc710ef8e907bd508c88be475cebc422b"
+"checksum bindgen 0.50.0 (registry+https://github.com/rust-lang/crates.io-index)" = "65a913de3fa2fa95f2c593bb7e33b1be1ce1ce8a83f34b6bb02e6f01400b96cc"
 "checksum bindgen 0.51.0 (registry+https://github.com/rust-lang/crates.io-index)" = "18270cdd7065ec045a6bb4bdcd5144d14a78b3aedb3bc5111e688773ac8b9ad0"
 "checksum bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3d155346769a6855b86399e9bc3814ab343cd3d62c7e985113d46a0ec3c281fd"
 "checksum blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "5d6d530bdd2d52966a6d03b7a964add7ae1a288d25214066fd4b600f0f796400"
@@ -800,6 +865,7 @@ dependencies = [
 "checksum cexpr 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a7fa24eb00d5ffab90eaeaf1092ac85c04c64aaf358ea6f84505b8116d24c6af"
 "checksum cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
 "checksum clang-sys 0.28.1 (registry+https://github.com/rust-lang/crates.io-index)" = "81de550971c976f176130da4b2978d3b524eaa0fd9ac31f3ceb5ae1231fb4853"
+"checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum constant_time_eq 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8ff012e225ce166d4422e0e78419d901719760f62ae2b7969ca6b564d1b54a9e"
 "checksum dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3fd78930633bd1c6e35c4b42b1df7b0cbc6bc191146e512bb3bedf243fcc3901"
@@ -819,8 +885,8 @@ dependencies = [
 "checksum nix 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4dbdc256eaac2e3bd236d93ad999d3479ef775c863dbda3068c4006a92eec51b"
 "checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
 "checksum nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
-"checksum onig 4.3.2 (git+https://github.com/artichoke/rust-onig?branch=wasm)" = "<none>"
-"checksum onig_sys 69.1.0 (git+https://github.com/artichoke/rust-onig?branch=wasm)" = "<none>"
+"checksum onig 5.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e4e723fc996fff1aeab8f62205f3e8528bf498bdd5eadb2784d2d31f30077947"
+"checksum onig_sys 69.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0a8d4efbf5f59cece01f539305191485b651acb3785b9d5eef05749f0496514e"
 "checksum peeking_take_while 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 "checksum pkg-config 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c1d2cfa5a714db3b5f24f0915e74fcdf91d09d496ba61329705dda7774d2af"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
@@ -855,11 +921,13 @@ dependencies = [
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum shellexpand 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de7a5b5a9142fd278a10e0209b021a1b85849352e6951f4f914735c976737564"
 "checksum shlex 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
+"checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 "checksum syn 0.15.42 (registry+https://github.com/rust-lang/crates.io-index)" = "eadc09306ca51a40555dd6fc2b415538e9e18bc9f870e47b1a524a79fe2dcf5e"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 "checksum synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "02353edf96d6e4dc81aea2d8490a7e9db177bf8acb0e951c24940bf866cb313f"
 "checksum termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "96d6098003bde162e4277c70665bd87c326f5a0c3f3fbfb285787fa482d54e6e"
+"checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum ucd-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "fa9b3b49edd3468c0e6565d85783f51af95212b6fa3986a5500954f00b460874"
 "checksum unicode-segmentation 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1967f4cdfc355b37fd76d2a954fb2ed3871034eb4f26d60537d88795cfc332a9"
@@ -868,6 +936,7 @@ dependencies = [
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum utf8-ranges 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9d50aa7650df78abf942826607c62468ce18d9019673d4a2ebe1865dbb96ffde"
 "checksum utf8parse 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8772a4ccbb4e89959023bc5b7cb8623a795caa7092d99f3aa9501b9484d4557d"
+"checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)" = "9658c94fa8b940eab2250bd5a457f9c48b748420d71293b165c8cdbe2f55f71e"

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -15,8 +15,9 @@ path = "../artichoke-vfs"
 path = "../mruby-sys"
 
 [dependencies.onig]
-git = "https://github.com/artichoke/rust-onig"
-branch = "wasm"
+version = "5"
+# git = "https://github.com/artichoke/rust-onig"
+# branch = "wasm"
 
 [dev-dependencies]
 env_logger = "0.6.1"

--- a/artichoke-backend/src/extn/core/matchdata/begin.rs
+++ b/artichoke-backend/src/extn/core/matchdata/begin.rs
@@ -68,13 +68,17 @@ pub fn method(interp: &Artichoke, args: Args, value: &Value) -> Result<Value, Er
                     }
                 }
                 Args::Name(name) => {
-                    let index = regex
-                        .capture_names()
-                        .find(|capture| capture.0 == name)
-                        .ok_or(Error::NoGroup)?
-                        .1
-                        .last()
-                        .ok_or(Error::NoMatch)?;
+                    let mut indexes = None;
+                    regex.foreach_name(|group, group_indexes| {
+                        if name == group {
+                            indexes = Some(group_indexes.to_vec());
+                            false
+                        } else {
+                            true
+                        }
+                    });
+                    let indexes = indexes.ok_or(Error::NoGroup)?;
+                    let index = indexes.last().ok_or(Error::NoMatch)?;
                     usize::try_from(*index).map_err(|_| Error::Fatal)?
                 }
             };

--- a/artichoke-backend/src/extn/core/matchdata/element_reference.rs
+++ b/artichoke-backend/src/extn/core/matchdata/element_reference.rs
@@ -112,17 +112,17 @@ pub fn method(interp: &Artichoke, args: Args, value: &Value) -> Result<Value, Er
                     }
                 }
                 Args::Name(name) => {
-                    let index = regex
-                        .capture_names()
-                        .find_map(|capture| {
-                            if capture.0 == name {
-                                Some(capture.1)
-                            } else {
-                                None
-                            }
-                        })
-                        .ok_or_else(|| Error::NoGroup(name))?;
-                    let group = index
+                    let mut indexes = None;
+                    regex.foreach_name(|group, group_indexes| {
+                        if name == group {
+                            indexes = Some(group_indexes.to_vec());
+                            false
+                        } else {
+                            true
+                        }
+                    });
+                    let indexes = indexes.ok_or_else(|| Error::NoGroup(name))?;
+                    let group = indexes
                         .iter()
                         .filter_map(|index| {
                             usize::try_from(*index)

--- a/artichoke-backend/src/extn/core/matchdata/end.rs
+++ b/artichoke-backend/src/extn/core/matchdata/end.rs
@@ -68,13 +68,17 @@ pub fn method(interp: &Artichoke, args: Args, value: &Value) -> Result<Value, Er
                     }
                 }
                 Args::Name(name) => {
-                    let index = regex
-                        .capture_names()
-                        .find(|capture| capture.0 == name)
-                        .ok_or(Error::NoGroup)?
-                        .1
-                        .last()
-                        .ok_or(Error::NoMatch)?;
+                    let mut indexes = None;
+                    regex.foreach_name(|group, group_indexes| {
+                        if name == group {
+                            indexes = Some(group_indexes.to_vec());
+                            false
+                        } else {
+                            true
+                        }
+                    });
+                    let indexes = indexes.ok_or(Error::NoGroup)?;
+                    let index = indexes.last().ok_or(Error::NoMatch)?;
                     usize::try_from(*index).map_err(|_| Error::Fatal)?
                 }
             };

--- a/artichoke-backend/src/extn/core/matchdata/names.rs
+++ b/artichoke-backend/src/extn/core/matchdata/names.rs
@@ -20,7 +20,11 @@ pub fn method(interp: &Artichoke, value: &Value) -> Result<Value, Error> {
     let regex = (*borrow.regexp.regex).as_ref().ok_or(Error::Fatal)?;
     match regex {
         Backend::Onig(regex) => {
-            let mut capture_names = regex.capture_names().collect::<Vec<_>>();
+            let mut capture_names = vec![];
+            regex.foreach_name(|group, group_indexes| {
+                capture_names.push((group.to_owned(), group_indexes.to_vec()));
+                true
+            });
             capture_names.sort_by(|a, b| {
                 a.1.iter()
                     .fold(u32::max_value(), |a, &b| a.min(b))

--- a/artichoke-backend/src/extn/core/regexp/named_captures.rs
+++ b/artichoke-backend/src/extn/core/regexp/named_captures.rs
@@ -22,14 +22,15 @@ pub fn method(interp: &Artichoke, value: &Value) -> Result<Value, Error> {
     let regex = (*borrow.regex).as_ref().ok_or(Error::Fatal)?;
     match regex {
         Backend::Onig(regex) => {
-            for (name, index) in regex.capture_names() {
+            regex.foreach_name(|group, group_indexes| {
                 let mut indexes = vec![];
-                for idx in index {
-                    let idx = Int::try_from(*idx).map_err(|_| Error::Fatal)?;
+                for idx in group_indexes {
+                    let idx = Int::try_from(*idx).unwrap_or_default();
                     indexes.push(idx);
                 }
-                map.push((name, Value::convert(interp, indexes)));
-            }
+                map.push((group.to_owned(), Value::convert(interp, indexes)));
+                true
+            });
         }
         Backend::Rust(_) => unimplemented!("Rust-backed Regexp"),
     }

--- a/artichoke-backend/src/extn/core/regexp/names.rs
+++ b/artichoke-backend/src/extn/core/regexp/names.rs
@@ -19,7 +19,11 @@ pub fn method(interp: &Artichoke, value: &Value) -> Result<Value, Error> {
     let regex = (*borrow.regex).as_ref().ok_or(Error::Fatal)?;
     match regex {
         Backend::Onig(regex) => {
-            let mut capture_names = regex.capture_names().collect::<Vec<_>>();
+            let mut capture_names = vec![];
+            regex.foreach_name(|group, group_indexes| {
+                capture_names.push((group.to_owned(), group_indexes.to_vec()));
+                true
+            });
             capture_names.sort_by(|a, b| {
                 a.1.iter()
                     .fold(u32::max_value(), |a, &b| a.min(b))


### PR DESCRIPTION
onig 5.0 uses bindgen to generate bindings for oniguruma and is easier
to hack on. To upstream the changes in GH-172 that add
wasm32-unknown-unknown support to Artichoke, we need to build with onig
5.0.

In addition to updating the dependency, this commit updates the `Regexp`
and `MatchData` implementations to work with the new APIs exposed by
onig.

The only change is the removal of `Regex::capture_names` and the
addition of the `Regex::foreach_name` function that replaces it. This
changes the API from an iterator to a callback with a break parameter.
This change appears to be a result of upstream changes in oniguruma.

This commit does not include any of the wasm support present in our
fork: https://github.com/artichoke/rust-onig/tree/wasm3. This means that
once this commit is merged, artichoke will no longer build under
wasm32-unknown-emscripten. This is safe because the playground is pinned
to a specific version of artichoke-backend.