### PR TITLE
Fix missing rename from h to groups

### DIFF
--- a/artichoke-backend/src/extn/core/enumerable/enumerable.rb
+++ b/artichoke-backend/src/extn/core/enumerable/enumerable.rb
@@ -215,7 +215,7 @@ module Enumerable
     groups = {}
     each do |val|
       group = block.call(val)
-      values = h.fetch(group, [])
+      values = groups.fetch(group, [])
       values << val
       groups[group] = values
     end


### PR DESCRIPTION
Thanks @isbear for pointing this out.

This made it through because we're not yet running the enumerable tests.