### PR TITLE
Sets the circleci rust toolchain build image to 1.37.0-buster

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ commands:
 jobs:
   rust:
     docker:
-      - image: circleci/rust:buster
+      - image: circleci/rust:1.37.0-buster
     steps:
       - checkout
       - restore_cache:


### PR DESCRIPTION
Should close #182