### PR TITLE
Don't define existing Modules if they already exist on the mruby VM

### DIFF
--- a/artichoke-backend/src/module.rs
+++ b/artichoke-backend/src/module.rs
@@ -134,7 +134,9 @@ impl PartialEq for Spec {
 impl Define for Spec {
     fn define(&self, interp: &Artichoke) -> Result<*mut sys::RClass, ArtichokeError> {
         let mrb = interp.borrow().mrb;
-        let rclass = if let Some(ref scope) = self.enclosing_scope {
+        let rclass = if let Some(rclass) = self.rclass(interp) {
+            rclass
+        } else if let Some(ref scope) = self.enclosing_scope {
             let scope = scope
                 .rclass(interp)
                 .ok_or_else(|| ArtichokeError::NotDefined(scope.fqname()))?;


### PR DESCRIPTION
Make the same change as a4ffbe38, but for module.rs.

Following Matz's recommendation in https://github.com/mruby/mruby/issues/4660