### PR TITLE
Impl. Integer#size in Rust

### DIFF
--- a/artichoke-backend/src/extn/core/integer/mod.rs
+++ b/artichoke-backend/src/extn/core/integer/mod.rs
@@ -25,6 +25,10 @@ pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
         .add_method("chr", Integer::chr, sys::mrb_args_opt(1));
 
     integer
+        .borrow_mut()
+        .add_method("size", Integer::size, sys::mrb_args_none());
+
+    integer
         .borrow()
         .define(interp)
         .map_err(|_| ArtichokeError::New)?;
@@ -106,6 +110,20 @@ impl Integer {
                     vec![argc],
                 )
             }
+        }
+    }
+
+    pub unsafe extern "C" fn size(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
+        let interp = unwrap_interpreter!(mrb);
+        let nil = Value::convert(&interp, None::<Value>);
+        if let Ok(_value) = Int::try_convert(&interp, Value::new(&interp, slf)) {
+            if let Ok(size) = Int::try_from(mem::size_of::<Int>()) {
+                Value::convert(&interp, size).inner()
+            } else {
+                nil.inner()
+            }
+        } else {
+            nil.inner()
         }
     }
 }

--- a/artichoke-backend/src/extn/core/integer/mod.rs
+++ b/artichoke-backend/src/extn/core/integer/mod.rs
@@ -5,7 +5,7 @@ use std::mem;
 use crate::convert::{Convert, TryConvert};
 use crate::def::{ClassLike, Define};
 use crate::eval::Eval;
-use crate::extn::core::error::{ArgumentError, RangeError, RubyException};
+use crate::extn::core::error::{ArgumentError, RangeError, RubyException, RuntimeError};
 use crate::sys;
 use crate::types::Int;
 use crate::value::Value;
@@ -115,15 +115,15 @@ impl Integer {
 
     pub unsafe extern "C" fn size(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
         let interp = unwrap_interpreter!(mrb);
-        let nil = Value::convert(&interp, None::<Value>);
-        if let Ok(_value) = Int::try_convert(&interp, Value::new(&interp, slf)) {
+        let result = Int::try_convert(&interp, Value::new(&interp, slf));
+        if result.is_ok() {
             if let Ok(size) = Int::try_from(mem::size_of::<Int>()) {
                 Value::convert(&interp, size).inner()
             } else {
-                nil.inner()
+                RuntimeError::raise(interp, "fatal Integer#size error")
             }
         } else {
-            nil.inner()
+            RuntimeError::raise(interp, "fatal Integer#size error")
         }
     }
 }


### PR DESCRIPTION
This PR implements `Integer#size` in Rust.

Fixes #179 

Ran the tests (integer/size_spec.rb), only passed for the fixnum's not the bignum's.