### PR TITLE
Implement more methods on Symbol in Ruby

### DIFF
--- a/artichoke-backend/src/extn/core/integer/mod.rs
+++ b/artichoke-backend/src/extn/core/integer/mod.rs
@@ -47,7 +47,6 @@ impl Integer {
         let interp = unwrap_interpreter!(mrb);
         let mut encoding = <mem::MaybeUninit<sys::mrb_value>>::uninit();
         let argc = sys::mrb_get_args(mrb, b"|o\0".as_ptr() as *const i8, encoding.as_mut_ptr());
-        println!("argc {:?}", argc);
         match argc {
             0 => {
                 // When no encoding is supplied, MRI assumes the encoding is

--- a/artichoke-backend/src/extn/core/symbol/symbol.rb
+++ b/artichoke-backend/src/extn/core/symbol/symbol.rb
@@ -56,10 +56,28 @@ class Symbol
     to_s.length
   end
 
+  def match(*args)
+    to_s.match(*args)
+  end
+
+  def match?(*args)
+    to_s.match?(*args)
+  end
+
+  def succ
+    to_s.succ.intern
+  end
+
+  def swapcase
+    to_s.swapcase.intern
+  end
+
   def upcase
     to_s.upcase.intern
   end
 
-  alias size length
   alias intern to_sym
+  alias next succ
+  alias size length
+  alias slice []
 end

--- a/artichoke-backend/src/extn/core/symbol/symbol.rb
+++ b/artichoke-backend/src/extn/core/symbol/symbol.rb
@@ -76,6 +76,10 @@ class Symbol
     ->(obj, *args, &block) { obj.__send__(self, *args, &block) }
   end
 
+  def to_sym
+    self
+  end
+
   def upcase
     to_s.upcase.intern
   end

--- a/artichoke-backend/src/extn/core/symbol/symbol.rb
+++ b/artichoke-backend/src/extn/core/symbol/symbol.rb
@@ -18,15 +18,7 @@ class Symbol
   end
 
   def capitalize
-    (to_s.capitalize! || self).to_sym
-  end
-
-  def downcase
-    (to_s.downcase! || self).to_sym
-  end
-
-  def upcase
-    (to_s.upcase! || self).to_sym
+    to_s.capitalize.intern
   end
 
   def casecmp(other)
@@ -45,6 +37,14 @@ class Symbol
     return nil if c.nil?
 
     c.zero?
+  end
+
+  def downcase
+    to_s.downcase.intern
+  end
+
+  def upcase
+    to_s.upcase.intern
   end
 
   def empty?

--- a/artichoke-backend/src/extn/core/symbol/symbol.rb
+++ b/artichoke-backend/src/extn/core/symbol/symbol.rb
@@ -32,9 +32,11 @@ class Symbol
   def casecmp(other)
     return nil unless other.is_a?(Symbol)
 
-    lhs = to_s
-    lhs.upcase!
-    rhs = other.to_s.upcase
+    # Case-insensitive version of Symbol#<=>. Currently, case-insensitivity only
+    # works on characters A-Z/a-z, not all of Unicode. This is different from
+    # Symbol#casecmp?.
+    lhs = to_s.tr('a-z', 'A-Z')
+    rhs = other.to_s.tr('a-z', 'A-Z')
     lhs <=> rhs
   end
 

--- a/artichoke-backend/src/extn/core/symbol/symbol.rb
+++ b/artichoke-backend/src/extn/core/symbol/symbol.rb
@@ -48,12 +48,16 @@ class Symbol
     self == :''
   end
 
-  def upcase
-    to_s.upcase.intern
+  def encoding
+    raise NotImplementedError, 'Artichoke does not have Encoding support'
   end
 
   def length
     to_s.length
+  end
+
+  def upcase
+    to_s.upcase.intern
   end
 
   alias size length

--- a/artichoke-backend/src/extn/core/symbol/symbol.rb
+++ b/artichoke-backend/src/extn/core/symbol/symbol.rb
@@ -9,6 +9,10 @@ class Symbol
     to_s <=> other.to_s
   end
 
+  def =~(other)
+    to_s =~ other
+  end
+
   def capitalize
     (to_s.capitalize! || self).to_sym
   end

--- a/artichoke-backend/src/extn/core/symbol/symbol.rb
+++ b/artichoke-backend/src/extn/core/symbol/symbol.rb
@@ -72,6 +72,10 @@ class Symbol
     to_s.swapcase.intern
   end
 
+  def to_proc
+    ->(obj, *args, &block) { obj.__send__(self, *args, &block) }
+  end
+
   def upcase
     to_s.upcase.intern
   end

--- a/artichoke-backend/src/extn/core/symbol/symbol.rb
+++ b/artichoke-backend/src/extn/core/symbol/symbol.rb
@@ -32,11 +32,12 @@ class Symbol
     lhs <=> rhs
   end
 
-  def casecmp?(sym)
-    c = casecmp(sym)
-    return nil if c.nil?
-
-    c.zero?
+  def casecmp?(other)
+    # Returns true if `self` and `other` are equal after Unicode case folding,
+    # false if they are not equal.
+    #
+    # Delegate to String#casecmp? which is also Unicode case folding-aware.
+    to_s.casecmp?(other.to_s)
   end
 
   def downcase

--- a/artichoke-backend/src/extn/core/symbol/symbol.rb
+++ b/artichoke-backend/src/extn/core/symbol/symbol.rb
@@ -3,6 +3,12 @@
 class Symbol
   include Comparable
 
+  def <=>(other)
+    return nil unless other.is_a?(Symbol)
+
+    to_s <=> other.to_s
+  end
+
   def capitalize
     (to_s.capitalize! || self).to_sym
   end

--- a/artichoke-backend/src/extn/core/symbol/symbol.rb
+++ b/artichoke-backend/src/extn/core/symbol/symbol.rb
@@ -13,6 +13,10 @@ class Symbol
     to_s =~ other
   end
 
+  def [](*args)
+    to_s[*args]
+  end
+
   def capitalize
     (to_s.capitalize! || self).to_sym
   end

--- a/artichoke-backend/src/extn/core/symbol/symbol.rb
+++ b/artichoke-backend/src/extn/core/symbol/symbol.rb
@@ -44,12 +44,12 @@ class Symbol
     to_s.downcase.intern
   end
 
-  def upcase
-    to_s.upcase.intern
+  def empty?
+    self == :''
   end
 
-  def empty?
-    to_s.empty?
+  def upcase
+    to_s.upcase.intern
   end
 
   def length


### PR DESCRIPTION
Followup to GH-218.

Implement the complete `Symbol` API in Ruby. The only remaining pieces implemented in C are:

- `Symbol::all_symbols`
- `Symbol#id2name`
- `Symbol#to_s`
- `Symbol#inspect`

This PR cleans up some of the Unicode handling in `casecmp` and delegates to `String` wherever possible.

cc @tkbky 