### PR TITLE
Purge mrbgems

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,7 +42,7 @@ dependencies = [
  "fs_extra 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "mruby-sys 2.0.1-14",
+ "mruby-sys 2.0.1-15",
  "onig 5.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck_macros 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -328,7 +328,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "mruby-sys"
-version = "2.0.1-14"
+version = "2.0.1-15"
 dependencies = [
  "bindgen 0.51.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/mruby-sys/Cargo.toml
+++ b/mruby-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mruby-sys"
-version = "2.0.1-14"
+version = "2.0.1-15"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2018"
 links = "mruby"

--- a/mruby-sys/build.rs
+++ b/mruby-sys/build.rs
@@ -31,11 +31,7 @@ impl Build {
             "mruby-metaprog",     // APIs on Kernel and Module for accessing classes and variables
             "mruby-pack",         // Array#pack and String#unpack
             "mruby-sprintf",      // Kernel#sprintf, Kernel#format, String#%
-            "mruby-math",         // Math module from core
-            "mruby-time",         // Time class from core
-            "mruby-struct",       // Struct class from core
             "mruby-proc-ext",     // required by mruby-method, see GH-32
-            "mruby-random",       // Kernel#rand
             "mruby-object-ext",   // Pending removal, see GH-32
             "mruby-kernel-ext",   // Pending removal, see GH-32
             "mruby-class-ext",    // Pending removal, see GH-32

--- a/mruby-sys/build.rs
+++ b/mruby-sys/build.rs
@@ -25,20 +25,20 @@ impl Build {
     fn gems() -> Vec<&'static str> {
         vec![
             "mruby-compiler",     // Ruby parser and bytecode generation
-            "mruby-eval",         // eval, instance_eval, and friends
-            "mruby-method",       // `Method`, `UnboundMethod`, and method APIs on Kernel and Module
             "mruby-error",        // `mrb_raise`, `mrb_protect`
+            "mruby-eval",         // eval, instance_eval, and friends
             "mruby-metaprog",     // APIs on Kernel and Module for accessing classes and variables
-            "mruby-pack",         // Array#pack and String#unpack
-            "mruby-sprintf",      // Kernel#sprintf, Kernel#format, String#%
-            "mruby-proc-ext",     // required by mruby-method, see GH-32
-            "mruby-object-ext",   // Pending removal, see GH-32
-            "mruby-kernel-ext",   // Pending removal, see GH-32
-            "mruby-class-ext",    // Pending removal, see GH-32
-            "mruby-fiber",        // Fiber class from core, required by mruby-enumerator
+            "mruby-method",       // `Method`, `UnboundMethod`, and method APIs on Kernel and Module
+            "mruby-toplevel-ext", // expose API for top self
             "mruby-enumerator",   // Enumerator class from core
             "mruby-enum-lazy",    // Enumerable#lazy
-            "mruby-toplevel-ext", // expose API for top self
+            "mruby-fiber",        // Fiber class from core, required by mruby-enumerator
+            "mruby-pack",         // Array#pack and String#unpack
+            "mruby-sprintf",      // Kernel#sprintf, Kernel#format, String#%
+            "mruby-class-ext",    // Pending removal, see GH-32
+            "mruby-kernel-ext",   // Pending removal, see GH-32
+            "mruby-object-ext",   // Pending removal, see GH-32
+            "mruby-proc-ext",     // required by mruby-method, see GH-32
         ]
     }
 

--- a/mruby-sys/build.rs
+++ b/mruby-sys/build.rs
@@ -24,25 +24,25 @@ impl Build {
 
     fn gems() -> Vec<&'static str> {
         vec![
-            "mruby-compiler",
-            "mruby-eval",
-            "mruby-method",
-            "mruby-error",
-            "mruby-metaprog",
-            "mruby-pack",
-            "mruby-sprintf",
-            "mruby-math",
-            "mruby-time",
-            "mruby-struct",
-            "mruby-proc-ext",
-            "mruby-random",
-            "mruby-object-ext",
-            "mruby-kernel-ext",
-            "mruby-class-ext",
-            "mruby-fiber",
-            "mruby-enumerator",
-            "mruby-enum-lazy",
-            "mruby-toplevel-ext",
+            "mruby-compiler",     // Ruby parser and bytecode generation
+            "mruby-eval",         // eval, instance_eval, and friends
+            "mruby-method",       // `Method`, `UnboundMethod`, and method APIs on Kernel and Module
+            "mruby-error",        // `mrb_raise`, `mrb_protect`
+            "mruby-metaprog",     // APIs on Kernel and Module for accessing classes and variables
+            "mruby-pack",         // Array#pack and String#unpack
+            "mruby-sprintf",      // Kernel#sprintf, Kernel#format, String#%
+            "mruby-math",         // Math module from core
+            "mruby-time",         // Time class from core
+            "mruby-struct",       // Struct class from core
+            "mruby-proc-ext",     // required by mruby-method, see GH-32
+            "mruby-random",       // Kernel#rand
+            "mruby-object-ext",   // Pending removal, see GH-32
+            "mruby-kernel-ext",   // Pending removal, see GH-32
+            "mruby-class-ext",    // Pending removal, see GH-32
+            "mruby-fiber",        // Fiber class from core, required by mruby-enumerator
+            "mruby-enumerator",   // Enumerator class from core
+            "mruby-enum-lazy",    // Enumerable#lazy
+            "mruby-toplevel-ext", // expose API for top self
         ]
     }
 


### PR DESCRIPTION
@tkbky and @lopopolo had a discussion in GH-217 about whether some mrbgems could be removed from the build.

The set of gems in the build was chosen for [artichoke/ferrocarril](https://github.com/artichoke/ferrocarril) which targets running Sinatra.

Our goals in Artichoke are to pass the specs we have implemented. Incompleteness in the Ruby core implementation is acceptable.

This PR removes the following gems for the build and gives their tracking tickets:

- mruby-math => GH-222
- mruby-time => GH-33
- mruby-struct => GH-223
- mruby-random => GH-34