### PR TITLE
Improve focus of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,120 +10,47 @@
 [![mruby-sys documentation](https://img.shields.io/badge/docs-mruby--sys-blue.svg)](https://artichoke.github.io/artichoke/mruby_sys/)
 
 <p align="center">
-  <img width="200" height="200" src="https://artichoke.run/logo.svg">
+  <a href="https://artichoke.run">
+    <img width="200" height="200" src="https://artichoke.run/logo.svg">
+  </a>
 </p>
 
 Artichoke is a platform for building
 [MRI-compatible](https://github.com/ruby/spec) Ruby implementations. Artichoke
 provides a Ruby runtime implemented in Rust that can be loaded into many VM
-backends.
-
-## Architecture
-
-A Ruby implementation based on Artichoke consists of three components: Artichoke
-core, a VM backend, and the Artichoke frontend.
-
-### Core
-
-[Artichoke core](https://artichoke.github.io/artichoke/artichoke_core/) exposes
-a set of traits that define:
-
-- Capabilities of a VM backend.
-- Capabilities of a
-  [Ruby `Value`](https://artichoke.github.io/artichoke/artichoke_core/value/trait.Value.html).
-- Interoperability between the VM backend and the Rust-implemented core.
-
-Capabilities a Ruby implementation must provide include
-[evaluating code](https://artichoke.github.io/artichoke/artichoke_core/eval/trait.Eval.html),
-[declaring classes and modules](https://artichoke.github.io/artichoke/artichoke_core/def/trait.DeclareClassLike.html),
-and
-[exposing _top self_](https://artichoke.github.io/artichoke/artichoke_core/top_self/trait.TopSelf.html).
-
-#### Runtime
-
-Artichoke core provides an implementation-agnostic Ruby runtime which any
-implementation can load. The runtime in Artichoke core will pass 100% of the
-[Core](https://github.com/artichoke/artichoke/labels/A-ruby-core) and
-[Standard Library](https://github.com/artichoke/artichoke/labels/A-ruby-stdlib)
-Ruby specs. The runtime will be implemented in a hybrid of Rust and Ruby. The
-[`Regexp` implementation](/artichoke-backend/src/extn/core/regexp) is a
-representative example of the approach.
-
-#### Embedding
-
-Artichoke core will support embedding with:
-
-- Multiple
-  [filesystem backends](https://github.com/artichoke/artichoke/labels/A-filesystem),
-  including an in-memory
-  [virtual filesystem](https://artichoke.github.io/artichoke/artichoke_vfs/).
-- [Optional standard-library](https://github.com/artichoke/artichoke/labels/A-optional-stdlib).
-- [Optional multi-threading](https://github.com/artichoke/artichoke/labels/A-parallelism).
-- Capturable IO.
-
-#### Experimentation
-
-A Rust-implemented Ruby runtime offers an opportunity to experiment with:
-
-- [Improving performance](https://github.com/artichoke/artichoke/labels/A-performance)
-  of MRI Core and Standard Library.
-- Implementing the runtime with
-  [state-of-the-art dependencies](https://github.com/artichoke/artichoke/labels/A-deps).
-- Distributing
-  [single-binary builds](https://github.com/artichoke/artichoke/labels/A-single-binary).
-
-### VM Backend
-
-Artichoke core does not provide a parser or a VM for executing Ruby. VM backends
-provide these functions.
-
-Artichoke currently includes an
-[mruby backend](https://github.com/artichoke/artichoke/labels/B-mruby). There
-are plans to add an
-[MRI backend](https://github.com/artichoke/artichoke/labels/B-MRI) and a pure
-Rust backend.
-
-VM backends are responsible for passing 100% of the
-[Language](https://github.com/artichoke/artichoke/labels/A-ruby-language) Ruby
-specs.
-
-#### Experimentation
-
-VM backends offer an opportunity to experiment with:
-
-- [Dynamic codegen](https://github.com/artichoke/artichoke/labels/A-codegen).
-- [Compilation](https://github.com/artichoke/artichoke/labels/A-compiler).
-- [Parallelism and eliminating the GIL](https://github.com/artichoke/artichoke/labels/A-parallelism).
-- [Memory management and garbage collection techniques](https://github.com/artichoke/artichoke/labels/A-memory-management).
-
-### Frontend
-
-Artichoke will include `ruby` and `irb`
-[binary frontends](https://github.com/artichoke/artichoke/labels/A-frontend)
-with dynamically selectable VM backends.
-
-Artichoke will produce a
-[WebAssembly frontend](https://github.com/artichoke/artichoke/labels/A-cross-build).
-
-Artichoke will include implementation-agnostic
-[C APIs](https://github.com/artichoke/artichoke/labels/A-C-API) targeting:
-
-- [MRI API](https://github.com/artichoke/artichoke/labels/CAPI-MRI) from Ruby.
-- [`MRB_API`](https://github.com/artichoke/artichoke/labels/CAPI-mruby) from
-  mruby.
+backends. Rubies implemented with Artichoke will be source and C API compatible
+with MRI Ruby 2.6.3.
 
 ## Try Artichoke
 
-You can [try Artichoke in your browser](https://artichoke.run). The Artichoke
-Playground runs a [WebAssembly](https://webassembly.org/) build of Artichoke.
+You can [try Artichoke in your browser](https://artichoke.run). The
+[Artichoke Playground](https://github.com/artichoke/playground) runs a
+[WebAssembly](https://webassembly.org/) build of Artichoke.
 
-If you would prefer to run a local build,
+If you would prefer to run a local build, you can
 [set up a Rust toolchain](/CONTRIBUTING.md#rust-toolchain) and launch an
 interactive Artichoke shell with:
 
 ```shell
 cargo run -p artichoke-frontend --bin airb
 ```
+
+## Design and Goals
+
+Artichoke is
+[designed to enable experimentation](/doc/artichoke-design-and-goals.md). The
+top goals of the project are:
+
+- [Support WebAssembly as a build target](https://github.com/artichoke/artichoke/labels/O-wasm-unknown).
+- Support embedding and executing Ruby in untrusted environments.
+- [Distribute Ruby applications as single-binary artifacts](https://github.com/artichoke/artichoke/labels/A-single-binary).
+- [Implement Ruby with state-of-the-art dependencies](https://github.com/artichoke/artichoke/labels/A-deps).
+- Experiment with VMs to support
+  [dynamic codegen](https://github.com/artichoke/artichoke/labels/A-codegen),
+  [ahead of time compilation](https://github.com/artichoke/artichoke/labels/A-compiler),
+  [parallelism and eliminating the GIL](https://github.com/artichoke/artichoke/labels/A-parallelism),
+  and novel
+  [memory management and garbage collection techniques](https://github.com/artichoke/artichoke/labels/A-memory-management).
 
 ## Contributing
 

--- a/doc/artichoke-design-and-goals.md
+++ b/doc/artichoke-design-and-goals.md
@@ -1,0 +1,112 @@
+# Design and Goals
+
+Artichoke is a platform for building Ruby implementations. You can build a
+[ruby/spec](https://github.com/ruby/spec)-compliant Ruby by combining Artichoke
+core, a VM and parser backend, and the Artichoke frontend.
+
+Artichoke is designed to enable experimentation. The top goals of the project
+are:
+
+- [Support WebAssembly as a build target](https://github.com/artichoke/artichoke/labels/O-wasm-unknown).
+- Support embedding and executing Ruby in untrusted environments.
+- [Distribute Ruby applications as single-binary artifacts](https://github.com/artichoke/artichoke/labels/A-single-binary).
+- [Implement Ruby with state-of-the-art dependencies](https://github.com/artichoke/artichoke/labels/A-deps).
+- Experiment with VMs to support
+  [dynamic codegen](https://github.com/artichoke/artichoke/labels/A-codegen),
+  [ahead of time compilation](https://github.com/artichoke/artichoke/labels/A-compiler),
+  [parallelism and eliminating the GIL](https://github.com/artichoke/artichoke/labels/A-parallelism),
+  and novel
+  [memory management and garbage collection techniques](https://github.com/artichoke/artichoke/labels/A-memory-management).
+
+## Core
+
+The traits in
+[Artichoke core](https://artichoke.github.io/artichoke/artichoke_core/) define:
+
+- Capabilities of a VM backend.
+- Capabilities of a
+  [Ruby `Value`](https://artichoke.github.io/artichoke/artichoke_core/value/trait.Value.html).
+- Interoperability between the VM backend and the Rust-implemented core.
+
+Example capabilities a Ruby implementation must provide include
+[evaluating code](https://artichoke.github.io/artichoke/artichoke_core/eval/trait.Eval.html),
+[declaring classes and modules](https://artichoke.github.io/artichoke/artichoke_core/def/trait.DeclareClassLike.html),
+and
+[exposing _top self_](https://artichoke.github.io/artichoke/artichoke_core/top_self/trait.TopSelf.html).
+
+### Runtime
+
+Artichoke core provides an implementation-agnostic Ruby runtime. The runtime in
+Artichoke core will pass 100% of the
+[Core](https://github.com/artichoke/artichoke/labels/A-ruby-core) and
+[Standard Library](https://github.com/artichoke/artichoke/labels/A-ruby-stdlib)
+Ruby specs. The runtime will be implemented in a hybrid of Rust and Ruby. The
+[`Regexp` implementation](/artichoke-backend/src/extn/core/regexp) is a
+representative example of the approach.
+
+### Embedding
+
+Artichoke core will support embedding with:
+
+- Multiple
+  [filesystem backends](https://github.com/artichoke/artichoke/labels/A-filesystem),
+  including an in-memory
+  [virtual filesystem](https://artichoke.github.io/artichoke/artichoke_vfs/).
+- Multiple [`ENV` backends](/artichoke-backend/src/extn/core/env), including an
+  in-memory `HashMap` backend.
+- Optional C dependencies via multiple implementations of Core classes, e.g.
+  [`Regexp`](/artichoke-backend/src/extn/core/regexp).
+- [Optional standard-library](https://github.com/artichoke/artichoke/labels/A-optional-stdlib).
+- [Optional multi-threading](https://github.com/artichoke/artichoke/labels/A-parallelism).
+- Capturable IO.
+
+### Experimentation
+
+A Rust-implemented Ruby runtime offers an opportunity to experiment with:
+
+- [Improving performance](https://github.com/artichoke/artichoke/labels/A-performance)
+  of MRI Core and Standard Library.
+- Implementing the runtime with
+  [state-of-the-art dependencies](https://github.com/artichoke/artichoke/labels/A-deps).
+- Distributing
+  [single-binary builds](https://github.com/artichoke/artichoke/labels/A-single-binary).
+
+## VM Backend
+
+Artichoke core does not provide a parser or a VM for executing Ruby. VM backends
+provide these functions.
+
+Artichoke currently includes an
+[mruby backend](https://github.com/artichoke/artichoke/labels/B-mruby). There
+are plans to add an
+[MRI backend](https://github.com/artichoke/artichoke/labels/B-MRI) and a pure
+Rust backend.
+
+VM backends are responsible for passing 100% of the
+[Language](https://github.com/artichoke/artichoke/labels/A-ruby-language) Ruby
+specs.
+
+### Experimentation
+
+VM backends offer an opportunity to experiment with:
+
+- [Dynamic codegen](https://github.com/artichoke/artichoke/labels/A-codegen).
+- [Compilation](https://github.com/artichoke/artichoke/labels/A-compiler).
+- [Parallelism and eliminating the GIL](https://github.com/artichoke/artichoke/labels/A-parallelism).
+- [Memory management and garbage collection techniques](https://github.com/artichoke/artichoke/labels/A-memory-management).
+
+## Frontend
+
+Artichoke will include `ruby` and `irb`
+[binary frontends](https://github.com/artichoke/artichoke/labels/A-frontend)
+with dynamically selectable VM backends.
+
+Artichoke will produce a
+[WebAssembly frontend](https://github.com/artichoke/artichoke/labels/A-cross-build).
+
+Artichoke will include implementation-agnostic
+[C APIs](https://github.com/artichoke/artichoke/labels/A-C-API) targeting:
+
+- [MRI API](https://github.com/artichoke/artichoke/labels/CAPI-MRI) from Ruby.
+- [`MRB_API`](https://github.com/artichoke/artichoke/labels/CAPI-mruby) from
+  mruby.


### PR DESCRIPTION
- Pull call to action and playround above the fold.
- Move detailed description of design and goals to `doc/`.
- Link to design and goals from README.
- Include top-5 project goals in README.
- Inclue top-5 project goals in design and goals doc.

cc @tummychow