### PR TITLE
Implement Artichoke as a wrapper around Rc

### DIFF
--- a/artichoke-backend/scripts/auto_import/rust_glue.rs.erb
+++ b/artichoke-backend/scripts/auto_import/rust_glue.rs.erb
@@ -6,10 +6,12 @@ pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
     <% constants.each do |(constant, klass)| %>
     <% if klass == "Class" %>
     interp
+        .0
         .borrow_mut()
         .def_class::<<%= constant %>>("<%= constant %>", None, None);
     <% elsif klass == "Module" %>
     interp
+        .0
         .borrow_mut()
         .def_module::<<%= constant %>>("<%= constant %>", None);
     <% else %>

--- a/artichoke-backend/src/convert/array.rs
+++ b/artichoke-backend/src/convert/array.rs
@@ -24,7 +24,7 @@ impl Convert<Vec<Value>> for Value {
     type To = Ruby;
 
     fn convert(interp: &Artichoke, value: Vec<Self>) -> Self {
-        let mrb = interp.borrow().mrb;
+        let mrb = interp.0.borrow().mrb;
         let array =
             unsafe { sys::mrb_ary_new_capa(mrb, Int::try_from(value.len()).unwrap_or_default()) };
 
@@ -43,7 +43,7 @@ impl Convert<Vec<Option<Value>>> for Value {
     type To = Ruby;
 
     fn convert(interp: &Artichoke, value: Vec<Option<Self>>) -> Self {
-        let mrb = interp.borrow().mrb;
+        let mrb = interp.0.borrow().mrb;
         let array =
             unsafe { sys::mrb_ary_new_capa(mrb, Int::try_from(value.len()).unwrap_or_default()) };
 
@@ -71,7 +71,7 @@ impl TryConvert<Value> for Vec<Value> {
         interp: &Artichoke,
         value: Value,
     ) -> Result<Self, Error<Self::From, Self::To>> {
-        let mrb = interp.borrow().mrb;
+        let mrb = interp.0.borrow().mrb;
         match value.ruby_type() {
             Ruby::Array => {
                 let array = value.inner();
@@ -103,7 +103,7 @@ impl TryConvert<Value> for Vec<Option<Value>> {
         interp: &Artichoke,
         value: Value,
     ) -> Result<Self, Error<Self::From, Self::To>> {
-        let mrb = interp.borrow().mrb;
+        let mrb = interp.0.borrow().mrb;
         match value.ruby_type() {
             Ruby::Array => {
                 let array = value.inner();

--- a/artichoke-backend/src/convert/bytes.rs
+++ b/artichoke-backend/src/convert/bytes.rs
@@ -20,7 +20,7 @@ impl Convert<&[u8]> for Value {
     type To = Ruby;
 
     fn convert(interp: &Artichoke, value: &[u8]) -> Self {
-        let mrb = interp.borrow().mrb;
+        let mrb = interp.0.borrow().mrb;
         // mruby strings contain raw bytes, so we can convert from a &[u8] to a
         // `char *` and `size_t`.
         let raw = value.as_ptr() as *const i8;
@@ -37,7 +37,7 @@ impl TryConvert<Value> for Vec<u8> {
         interp: &Artichoke,
         value: Value,
     ) -> Result<Self, Error<Self::From, Self::To>> {
-        let mrb = interp.borrow().mrb;
+        let mrb = interp.0.borrow().mrb;
         match value.ruby_type() {
             Ruby::String => {
                 let bytes = value.inner();
@@ -98,7 +98,7 @@ mod tests {
         let interp = crate::interpreter().expect("init");
         let value = Value::convert(&interp, v.clone());
         let inner = value.inner();
-        let len = unsafe { sys::mrb_string_value_len(interp.borrow().mrb, inner) };
+        let len = unsafe { sys::mrb_string_value_len(interp.0.borrow().mrb, inner) };
         let len = usize::try_from(len).expect("usize");
         v.len() == len
     }

--- a/artichoke-backend/src/convert/float.rs
+++ b/artichoke-backend/src/convert/float.rs
@@ -11,7 +11,7 @@ impl Convert<Float> for Value {
     type To = Ruby;
 
     fn convert(interp: &Artichoke, value: Float) -> Self {
-        let mrb = interp.borrow().mrb;
+        let mrb = interp.0.borrow().mrb;
         Self::new(interp, unsafe { sys::mrb_sys_float_value(mrb, value) })
     }
 }

--- a/artichoke-backend/src/convert/hash.rs
+++ b/artichoke-backend/src/convert/hash.rs
@@ -18,7 +18,7 @@ impl Convert<Vec<(Value, Value)>> for Value {
     type To = Ruby;
 
     fn convert(interp: &Artichoke, value: Vec<(Self, Self)>) -> Self {
-        let mrb = interp.borrow().mrb;
+        let mrb = interp.0.borrow().mrb;
         let hash =
             unsafe { sys::mrb_hash_new_capa(mrb, Int::try_from(value.len()).unwrap_or_default()) };
         for (key, val) in value {
@@ -87,7 +87,7 @@ impl TryConvert<Value> for Vec<(Value, Value)> {
         interp: &Artichoke,
         value: Value,
     ) -> Result<Self, Error<Self::From, Self::To>> {
-        let mrb = interp.borrow().mrb;
+        let mrb = interp.0.borrow().mrb;
         match value.ruby_type() {
             Ruby::Hash => {
                 let hash = value.inner();

--- a/artichoke-backend/src/convert/object.rs
+++ b/artichoke-backend/src/convert/object.rs
@@ -41,8 +41,9 @@ where
         interp: &Artichoke,
         slf: Option<sys::mrb_value>,
     ) -> Result<Value, ArtichokeError> {
-        let mrb = interp.borrow().mrb;
+        let mrb = interp.0.borrow().mrb;
         let spec = interp
+            .0
             .borrow()
             .class_spec::<Self>()
             .ok_or(ArtichokeError::ConvertToRuby(Error {
@@ -97,7 +98,7 @@ where
         interp: &Artichoke,
         slf: &Value,
     ) -> Result<Rc<RefCell<Self>>, ArtichokeError> {
-        let mrb = interp.borrow().mrb;
+        let mrb = interp.0.borrow().mrb;
         // Make sure we have a Data otherwise extraction will fail.
         if slf.ruby_type() != Ruby::Data {
             return Err(ArtichokeError::ConvertToRust(Error {
@@ -106,6 +107,7 @@ where
             }));
         }
         let spec = interp
+            .0
             .borrow()
             .class_spec::<Self>()
             .ok_or_else(|| ArtichokeError::NotDefined("class".to_owned()))?;
@@ -188,7 +190,7 @@ mod tests {
     #[test]
     fn convert_obj_roundtrip() {
         let interp = crate::interpreter().expect("init");
-        let spec = interp.borrow_mut().def_class::<Container>(
+        let spec = interp.0.borrow_mut().def_class::<Container>(
             "Container",
             None,
             Some(rust_data_free::<Container>),
@@ -217,7 +219,7 @@ mod tests {
     #[test]
     fn convert_obj_not_data() {
         let interp = crate::interpreter().expect("init");
-        let spec = interp.borrow_mut().def_class::<Container>(
+        let spec = interp.0.borrow_mut().def_class::<Container>(
             "Container",
             None,
             Some(rust_data_free::<Container>),
@@ -226,7 +228,7 @@ mod tests {
         spec.borrow_mut()
             .add_method("value", Container::value, sys::mrb_args_none());
         spec.borrow().define(&interp).expect("class install");
-        let spec = interp.borrow_mut().def_class::<Box<Other>>(
+        let spec = interp.0.borrow_mut().def_class::<Box<Other>>(
             "Other",
             None,
             Some(rust_data_free::<Container>),

--- a/artichoke-backend/src/convert/string.rs
+++ b/artichoke-backend/src/convert/string.rs
@@ -81,8 +81,8 @@ mod tests {
     fn convert_to_string(s: String) -> bool {
         let interp = crate::interpreter().expect("init");
         let value = Value::convert(&interp, s.clone());
-        let ptr = unsafe { sys::mrb_string_value_ptr(interp.borrow().mrb, value.inner()) };
-        let len = unsafe { sys::mrb_string_value_len(interp.borrow().mrb, value.inner()) };
+        let ptr = unsafe { sys::mrb_string_value_ptr(interp.0.borrow().mrb, value.inner()) };
+        let len = unsafe { sys::mrb_string_value_len(interp.0.borrow().mrb, value.inner()) };
         let string =
             unsafe { std::slice::from_raw_parts(ptr as *const u8, len.try_into().unwrap()) };
         s.as_bytes() == string

--- a/artichoke-backend/src/def.rs
+++ b/artichoke-backend/src/def.rs
@@ -89,7 +89,7 @@ impl EnclosingRubyScope {
     /// struct Inner;
     ///
     /// let interp = artichoke_backend::interpreter().expect("init");
-    /// let mut api = interp.borrow_mut();
+    /// let mut api = interp.0.borrow_mut();
     /// if let Some(scope) = api.class_spec::<Fixnum>().map(EnclosingRubyScope::class) {
     ///     api.def_class::<Inner>("Inner", Some(scope), None);
     /// }
@@ -123,7 +123,7 @@ impl EnclosingRubyScope {
     /// struct Inner;
     ///
     /// let interp = artichoke_backend::interpreter().expect("init");
-    /// let mut api = interp.borrow_mut();
+    /// let mut api = interp.0.borrow_mut();
     /// if let Some(scope) = api.module_spec::<Kernel>().map(EnclosingRubyScope::module) {
     ///     api.def_class::<Inner>("Inner", Some(scope), None);
     /// }
@@ -270,7 +270,7 @@ mod tests {
         // Setup: define module and class hierarchy
         let interp = crate::interpreter().expect("init");
         {
-            let mut api = interp.borrow_mut();
+            let mut api = interp.0.borrow_mut();
             let root = api.def_module::<Root>("A", None);
             let mod_under_root = api.def_module::<ModuleUnderRoot>(
                 "B",
@@ -294,26 +294,28 @@ mod tests {
             );
         }
 
-        let spec = interp.borrow().module_spec::<Root>().unwrap();
+        let spec = interp.0.borrow().module_spec::<Root>().unwrap();
         spec.borrow().define(&interp).expect("def module");
-        let spec = interp.borrow().module_spec::<ModuleUnderRoot>().unwrap();
+        let spec = interp.0.borrow().module_spec::<ModuleUnderRoot>().unwrap();
         spec.borrow().define(&interp).expect("def module");
-        let spec = interp.borrow().class_spec::<ClassUnderRoot>().unwrap();
+        let spec = interp.0.borrow().class_spec::<ClassUnderRoot>().unwrap();
         spec.borrow().define(&interp).expect("def class");
-        let spec = interp.borrow().class_spec::<ClassUnderModule>().unwrap();
+        let spec = interp.0.borrow().class_spec::<ClassUnderModule>().unwrap();
         spec.borrow().define(&interp).expect("def class");
-        let spec = interp.borrow().module_spec::<ModuleUnderClass>().unwrap();
+        let spec = interp.0.borrow().module_spec::<ModuleUnderClass>().unwrap();
         spec.borrow().define(&interp).expect("def module");
-        let spec = interp.borrow().class_spec::<ClassUnderClass>().unwrap();
+        let spec = interp.0.borrow().class_spec::<ClassUnderClass>().unwrap();
         spec.borrow().define(&interp).expect("def class");
 
         let spec = interp
+            .0
             .borrow()
             .module_spec::<Root>()
             .expect("Root not defined");
         assert_eq!(&spec.borrow().fqname(), "A");
         assert_eq!(&format!("{}", spec.borrow()), "artichoke module spec -- A");
         let spec = interp
+            .0
             .borrow()
             .module_spec::<ModuleUnderRoot>()
             .expect("ModuleUnderRoot not defined");
@@ -323,6 +325,7 @@ mod tests {
             "artichoke module spec -- A::B"
         );
         let spec = interp
+            .0
             .borrow()
             .class_spec::<ClassUnderRoot>()
             .expect("ClassUnderRoot not defined");
@@ -332,6 +335,7 @@ mod tests {
             "artichoke class spec -- A::C"
         );
         let spec = interp
+            .0
             .borrow()
             .class_spec::<ClassUnderModule>()
             .expect("ClassUnderModule not defined");
@@ -341,6 +345,7 @@ mod tests {
             "artichoke class spec -- A::B::D"
         );
         let spec = interp
+            .0
             .borrow()
             .module_spec::<ModuleUnderClass>()
             .expect("ModuleUnderClass not defined");
@@ -350,6 +355,7 @@ mod tests {
             "artichoke module spec -- A::C::E"
         );
         let spec = interp
+            .0
             .borrow()
             .class_spec::<ClassUnderClass>()
             .expect("ClassUnderClass not defined");
@@ -383,7 +389,7 @@ mod tests {
             }
             let interp = crate::interpreter().expect("init");
             let (cls, module) = {
-                let mut api = interp.borrow_mut();
+                let mut api = interp.0.borrow_mut();
                 let cls = api.def_class::<Class>("DefineMethodTestClass", None, None);
                 let module = api.def_module::<Module>("DefineMethodTestModule", None);
                 cls.borrow_mut()

--- a/artichoke-backend/src/eval.rs
+++ b/artichoke-backend/src/eval.rs
@@ -18,7 +18,7 @@ struct Protect {
 impl Protect {
     fn new(interp: &Artichoke, code: &[u8]) -> Self {
         Self {
-            ctx: interp.borrow().ctx,
+            ctx: interp.0.borrow().ctx,
             code: code.to_vec(),
         }
     }
@@ -144,14 +144,14 @@ impl Eval for Artichoke {
         // Rust-backed files and types may need to mutably borrow the `Artichoke` to
         // get access to the underlying `ArtichokeState`.
         let (mrb, ctx) = {
-            let borrow = self.borrow();
+            let borrow = self.0.borrow();
             (borrow.mrb, borrow.ctx)
         };
 
         // Grab the persistent `Context` from the context on the `State` or
         // the root context if the stack is empty.
         let context = {
-            let api = self.borrow();
+            let api = self.0.borrow();
             if let Some(context) = api.context_stack.last() {
                 context.clone()
             } else {
@@ -214,14 +214,14 @@ impl Eval for Artichoke {
         // Rust-backed files and types may need to mutably borrow the `Artichoke` to
         // get access to the underlying `ArtichokeState`.
         let (mrb, ctx) = {
-            let borrow = self.borrow();
+            let borrow = self.0.borrow();
             (borrow.mrb, borrow.ctx)
         };
 
         // Grab the persistent `Context` from the context on the `State` or
         // the root context if the stack is empty.
         let context = {
-            let api = self.borrow();
+            let api = self.0.borrow();
             if let Some(context) = api.context_stack.last() {
                 context.clone()
             } else {
@@ -279,17 +279,17 @@ impl Eval for Artichoke {
     }
 
     fn peek_context(&self) -> Option<Context> {
-        let api = self.borrow();
+        let api = self.0.borrow();
         api.context_stack.last().cloned()
     }
 
     fn push_context(&self, context: Context) {
-        let mut api = self.borrow_mut();
+        let mut api = self.0.borrow_mut();
         api.context_stack.push(context);
     }
 
     fn pop_context(&self) {
-        let mut api = self.borrow_mut();
+        let mut api = self.0.borrow_mut();
         api.context_stack.pop();
     }
 }
@@ -319,14 +319,14 @@ mod tests {
         let context = Context::new("context.rb");
         interp.push_context(context);
         interp.eval("15").expect("eval");
-        assert_eq!(interp.borrow().context_stack.len(), 1);
+        assert_eq!(interp.0.borrow().context_stack.len(), 1);
     }
 
     #[test]
     fn root_context_is_not_pushed_after_eval() {
         let interp = crate::interpreter().expect("init");
         interp.eval("15").expect("eval");
-        assert_eq!(interp.borrow().context_stack.len(), 0);
+        assert_eq!(interp.0.borrow().context_stack.len(), 0);
     }
 
     #[test]
@@ -352,7 +352,7 @@ mod tests {
         impl File for NestedEval {
             fn require(interp: Artichoke) -> Result<(), ArtichokeError> {
                 let spec = {
-                    let mut api = interp.borrow_mut();
+                    let mut api = interp.0.borrow_mut();
                     let spec = api.def_module::<Self>("NestedEval", None);
                     spec.borrow_mut().add_self_method(
                         "file",

--- a/artichoke-backend/src/exception.rs
+++ b/artichoke-backend/src/exception.rs
@@ -67,7 +67,7 @@ pub trait ExceptionHandler {
 impl ExceptionHandler for Artichoke {
     fn last_error(&self) -> LastError {
         let _arena = self.create_arena_savepoint();
-        let mrb = { self.borrow().mrb };
+        let mrb = { self.0.borrow().mrb };
         let exc = unsafe {
             let exc = (*mrb).exc;
             // Clear the current exception from the mruby interpreter so

--- a/artichoke-backend/src/extn/core/array/mod.rs
+++ b/artichoke-backend/src/extn/core/array/mod.rs
@@ -3,7 +3,10 @@ use crate::Artichoke;
 use crate::ArtichokeError;
 
 pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
-    interp.borrow_mut().def_class::<Array>("Array", None, None);
+    interp
+        .0
+        .borrow_mut()
+        .def_class::<Array>("Array", None, None);
     interp.eval(include_str!("array.rb"))?;
     Ok(())
 }

--- a/artichoke-backend/src/extn/core/comparable/mod.rs
+++ b/artichoke-backend/src/extn/core/comparable/mod.rs
@@ -5,11 +5,12 @@ use crate::eval::Eval;
 use crate::{Artichoke, ArtichokeError};
 
 pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
-    if interp.borrow().module_spec::<Comparable>().is_some() {
+    if interp.0.borrow().module_spec::<Comparable>().is_some() {
         return Ok(());
     }
 
     let comparable = interp
+        .0
         .borrow_mut()
         .def_module::<Comparable>("Comparable", None);
     comparable.borrow().define(interp)?;

--- a/artichoke-backend/src/extn/core/enumerable/mod.rs
+++ b/artichoke-backend/src/extn/core/enumerable/mod.rs
@@ -3,11 +3,12 @@ use crate::eval::Eval;
 use crate::{Artichoke, ArtichokeError};
 
 pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
-    if interp.borrow().module_spec::<Enumerable>().is_some() {
+    if interp.0.borrow().module_spec::<Enumerable>().is_some() {
         return Ok(());
     }
 
     let enumerable = interp
+        .0
         .borrow_mut()
         .def_module::<Enumerable>("Enumerable", None);
     enumerable.borrow().define(interp)?;

--- a/artichoke-backend/src/extn/core/env/env_object.rs
+++ b/artichoke-backend/src/extn/core/env/env_object.rs
@@ -32,7 +32,7 @@ impl<T: EnvBackend> Env<T> {
     unsafe fn extract_two_string_args(interp: &Artichoke) -> (String, Option<String>) {
         let mut key = <mem::MaybeUninit<sys::mrb_value>>::uninit();
         let mut value = <mem::MaybeUninit<sys::mrb_value>>::uninit();
-        let mrb = interp.borrow().mrb;
+        let mrb = interp.0.borrow().mrb;
 
         sys::mrb_get_args(
             mrb,
@@ -65,7 +65,7 @@ impl<T: EnvBackend> Env<T> {
 
     unsafe fn extract_string_arg(interp: &Artichoke) -> Result<String, Error> {
         let mut other = <mem::MaybeUninit<sys::mrb_value>>::uninit();
-        let mrb = interp.borrow().mrb;
+        let mrb = interp.0.borrow().mrb;
         sys::mrb_get_args(
             mrb,
             Self::STRING_SINGLE_ARG_SPEC.as_ptr() as *const i8,

--- a/artichoke-backend/src/extn/core/env/mod.rs
+++ b/artichoke-backend/src/extn/core/env/mod.rs
@@ -21,11 +21,12 @@ fn init_internal_with_backend<T: EnvBackend>(interp: &Artichoke) -> Result<(), A
 where
     T: 'static,
 {
-    if interp.borrow().class_spec::<Env<T>>().is_some() {
+    if interp.0.borrow().class_spec::<Env<T>>().is_some() {
         return Ok(());
     }
 
     let env = interp
+        .0
         .borrow_mut()
         .def_class::<Env<T>>("EnvClass", None, None);
 

--- a/artichoke-backend/src/extn/core/hash/mod.rs
+++ b/artichoke-backend/src/extn/core/hash/mod.rs
@@ -3,7 +3,7 @@ use crate::Artichoke;
 use crate::ArtichokeError;
 
 pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
-    interp.borrow_mut().def_class::<Hash>("Hash", None, None);
+    interp.0.borrow_mut().def_class::<Hash>("Hash", None, None);
     interp.eval(include_str!("hash.rb"))?;
     Ok(())
 }

--- a/artichoke-backend/src/extn/core/integer/mod.rs
+++ b/artichoke-backend/src/extn/core/integer/mod.rs
@@ -12,11 +12,12 @@ use crate::value::Value;
 use crate::{Artichoke, ArtichokeError};
 
 pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
-    if interp.borrow().class_spec::<Integer>().is_some() {
+    if interp.0.borrow().class_spec::<Integer>().is_some() {
         return Ok(());
     }
 
     let integer = interp
+        .0
         .borrow_mut()
         .def_class::<Integer>("Integer", None, None);
 

--- a/artichoke-backend/src/extn/core/kernel/args.rs
+++ b/artichoke-backend/src/extn/core/kernel/args.rs
@@ -23,7 +23,7 @@ impl Rest {
             .write_all(b"\0")
             .map_err(|_| ArtichokeError::ArgSpec)?;
         sys::mrb_get_args(
-            interp.borrow().mrb,
+            interp.0.borrow().mrb,
             argspec.as_ptr() as *const i8,
             args.as_mut_ptr(),
             count.as_mut_ptr(),

--- a/artichoke-backend/src/extn/core/matchdata/begin.rs
+++ b/artichoke-backend/src/extn/core/matchdata/begin.rs
@@ -31,7 +31,7 @@ impl Args {
     pub unsafe fn extract(interp: &Artichoke) -> Result<Self, Error> {
         let mut first = <mem::MaybeUninit<sys::mrb_value>>::uninit();
         sys::mrb_get_args(
-            interp.borrow().mrb,
+            interp.0.borrow().mrb,
             Self::ARGSPEC.as_ptr() as *const i8,
             first.as_mut_ptr(),
         );

--- a/artichoke-backend/src/extn/core/matchdata/element_reference.rs
+++ b/artichoke-backend/src/extn/core/matchdata/element_reference.rs
@@ -36,7 +36,7 @@ impl Args {
         let mut second = <mem::MaybeUninit<sys::mrb_value>>::uninit();
         let mut has_second = <mem::MaybeUninit<sys::mrb_bool>>::uninit();
         sys::mrb_get_args(
-            interp.borrow().mrb,
+            interp.0.borrow().mrb,
             Self::ARGSPEC.as_ptr() as *const i8,
             first.as_mut_ptr(),
             second.as_mut_ptr(),
@@ -70,7 +70,7 @@ impl Args {
         let mut start = <mem::MaybeUninit<sys::mrb_int>>::uninit();
         let mut len = <mem::MaybeUninit<sys::mrb_int>>::uninit();
         let check_range = sys::mrb_range_beg_len(
-            interp.borrow().mrb,
+            interp.0.borrow().mrb,
             first,
             start.as_mut_ptr(),
             len.as_mut_ptr(),

--- a/artichoke-backend/src/extn/core/matchdata/end.rs
+++ b/artichoke-backend/src/extn/core/matchdata/end.rs
@@ -31,7 +31,7 @@ impl Args {
     pub unsafe fn extract(interp: &Artichoke) -> Result<Self, Error> {
         let mut first = <mem::MaybeUninit<sys::mrb_value>>::uninit();
         sys::mrb_get_args(
-            interp.borrow().mrb,
+            interp.0.borrow().mrb,
             Self::ARGSPEC.as_ptr() as *const i8,
             first.as_mut_ptr(),
         );

--- a/artichoke-backend/src/extn/core/matchdata/mod.rs
+++ b/artichoke-backend/src/extn/core/matchdata/mod.rs
@@ -37,7 +37,7 @@ pub mod to_a;
 pub mod to_s;
 
 pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
-    let match_data = interp.borrow_mut().def_class::<MatchData>(
+    let match_data = interp.0.borrow_mut().def_class::<MatchData>(
         "MatchData",
         None,
         Some(rust_data_free::<MatchData>),

--- a/artichoke-backend/src/extn/core/matchdata/offset.rs
+++ b/artichoke-backend/src/extn/core/matchdata/offset.rs
@@ -31,7 +31,7 @@ impl Args {
     pub unsafe fn extract(interp: &Artichoke) -> Result<Self, Error> {
         let mut first = <mem::MaybeUninit<sys::mrb_value>>::uninit();
         sys::mrb_get_args(
-            interp.borrow().mrb,
+            interp.0.borrow().mrb,
             Self::ARGSPEC.as_ptr() as *const i8,
             first.as_mut_ptr(),
         );

--- a/artichoke-backend/src/extn/core/module.rs
+++ b/artichoke-backend/src/extn/core/module.rs
@@ -4,6 +4,7 @@ use crate::ArtichokeError;
 
 pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
     interp
+        .0
         .borrow_mut()
         .def_class::<Module>("Module", None, None);
     interp.eval(include_str!("module.rb"))?;

--- a/artichoke-backend/src/extn/core/numeric/mod.rs
+++ b/artichoke-backend/src/extn/core/numeric/mod.rs
@@ -4,6 +4,7 @@ use crate::ArtichokeError;
 
 pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
     interp
+        .0
         .borrow_mut()
         .def_class::<Numeric>("Numeric", None, None);
     interp.eval(include_str!("numeric.rb"))?;

--- a/artichoke-backend/src/extn/core/proc/mod.rs
+++ b/artichoke-backend/src/extn/core/proc/mod.rs
@@ -3,7 +3,7 @@ use crate::Artichoke;
 use crate::ArtichokeError;
 
 pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
-    interp.borrow_mut().def_class::<Proc>("Proc", None, None);
+    interp.0.borrow_mut().def_class::<Proc>("Proc", None, None);
     interp.eval(include_str!("proc.rb"))?;
     Ok(())
 }

--- a/artichoke-backend/src/extn/core/range/mod.rs
+++ b/artichoke-backend/src/extn/core/range/mod.rs
@@ -3,7 +3,10 @@ use crate::Artichoke;
 use crate::ArtichokeError;
 
 pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
-    interp.borrow_mut().def_class::<Range>("Range", None, None);
+    interp
+        .0
+        .borrow_mut()
+        .def_class::<Range>("Range", None, None);
     interp.eval(include_str!("range.rb"))?;
     Ok(())
 }

--- a/artichoke-backend/src/extn/core/regexp/eql.rs
+++ b/artichoke-backend/src/extn/core/regexp/eql.rs
@@ -28,7 +28,7 @@ impl Args {
     pub unsafe fn extract(interp: &Artichoke) -> Self {
         let mut other = <mem::MaybeUninit<sys::mrb_value>>::uninit();
         sys::mrb_get_args(
-            interp.borrow().mrb,
+            interp.0.borrow().mrb,
             Self::ARGSPEC.as_ptr() as *const i8,
             other.as_mut_ptr(),
         );

--- a/artichoke-backend/src/extn/core/regexp/escape.rs
+++ b/artichoke-backend/src/extn/core/regexp/escape.rs
@@ -27,7 +27,7 @@ impl Args {
     pub unsafe fn extract(interp: &Artichoke) -> Result<Self, Error> {
         let mut string = <mem::MaybeUninit<sys::mrb_value>>::uninit();
         sys::mrb_get_args(
-            interp.borrow().mrb,
+            interp.0.borrow().mrb,
             Self::ARGSPEC.as_ptr() as *const i8,
             string.as_mut_ptr(),
         );

--- a/artichoke-backend/src/extn/core/regexp/initialize.rs
+++ b/artichoke-backend/src/extn/core/regexp/initialize.rs
@@ -38,7 +38,7 @@ impl Args {
         let mut enc = <mem::MaybeUninit<sys::mrb_value>>::uninit();
         let mut has_enc = <mem::MaybeUninit<sys::mrb_bool>>::uninit();
         sys::mrb_get_args(
-            interp.borrow().mrb,
+            interp.0.borrow().mrb,
             Self::ARGSPEC.as_ptr() as *const i8,
             pattern.as_mut_ptr(),
             opts.as_mut_ptr(),

--- a/artichoke-backend/src/extn/core/regexp/match_operator.rs
+++ b/artichoke-backend/src/extn/core/regexp/match_operator.rs
@@ -29,7 +29,7 @@ impl Args {
     pub unsafe fn extract(interp: &Artichoke) -> Result<Self, Error> {
         let mut string = <mem::MaybeUninit<sys::mrb_value>>::uninit();
         sys::mrb_get_args(
-            interp.borrow().mrb,
+            interp.0.borrow().mrb,
             Self::ARGSPEC.as_ptr() as *const i8,
             string.as_mut_ptr(),
         );
@@ -46,13 +46,13 @@ impl Args {
 //
 // See: https://ruby-doc.org/core-2.6.3/Regexp.html#method-i-3D-7E
 pub fn method(interp: &Artichoke, args: Args, value: &Value) -> Result<Value, Error> {
-    let mrb = interp.borrow().mrb;
+    let mrb = interp.0.borrow().mrb;
     let string = if let Some(string) = args.string {
         string
     } else {
         unsafe {
             let nil = Value::convert(interp, None::<Value>);
-            sys::mrb_gv_set(mrb, interp.borrow_mut().sym_intern("$~"), nil.inner());
+            sys::mrb_gv_set(mrb, interp.0.borrow_mut().sym_intern("$~"), nil.inner());
             return Ok(nil);
         }
     };
@@ -63,14 +63,15 @@ pub fn method(interp: &Artichoke, args: Args, value: &Value) -> Result<Value, Er
         Backend::Onig(regex) => {
             if let Some(captures) = regex.captures(string.as_str()) {
                 let num_regexp_globals_to_set = {
-                    let num_previously_set_globals = interp.borrow().num_set_regexp_capture_globals;
+                    let num_previously_set_globals =
+                        interp.0.borrow().num_set_regexp_capture_globals;
                     cmp::max(num_previously_set_globals, captures.len())
                 };
                 for group in 0..num_regexp_globals_to_set {
                     let sym = if group == 0 {
-                        interp.borrow_mut().sym_intern("$&")
+                        interp.0.borrow_mut().sym_intern("$&")
                     } else {
-                        interp.borrow_mut().sym_intern(&format!("${}", group))
+                        interp.0.borrow_mut().sym_intern(&format!("${}", group))
                     };
 
                     let value = Value::convert(&interp, captures.at(group));
@@ -78,7 +79,7 @@ pub fn method(interp: &Artichoke, args: Args, value: &Value) -> Result<Value, Er
                         sys::mrb_gv_set(mrb, sym, value.inner());
                     }
                 }
-                interp.borrow_mut().num_set_regexp_capture_globals = captures.len();
+                interp.0.borrow_mut().num_set_regexp_capture_globals = captures.len();
 
                 let matchdata = MatchData::new(string.as_str(), borrow.clone(), 0, string.len());
                 let matchdata =
@@ -87,13 +88,13 @@ pub fn method(interp: &Artichoke, args: Args, value: &Value) -> Result<Value, Er
                     let pre_match = &string[..match_pos.0];
                     let post_match = &string[match_pos.1..];
                     unsafe {
-                        let pre_match_sym = interp.borrow_mut().sym_intern("$`");
+                        let pre_match_sym = interp.0.borrow_mut().sym_intern("$`");
                         sys::mrb_gv_set(
                             mrb,
                             pre_match_sym,
                             Value::convert(interp, pre_match).inner(),
                         );
-                        let post_match_sym = interp.borrow_mut().sym_intern("$'");
+                        let post_match_sym = interp.0.borrow_mut().sym_intern("$'");
                         sys::mrb_gv_set(
                             mrb,
                             post_match_sym,
@@ -109,19 +110,19 @@ pub fn method(interp: &Artichoke, args: Args, value: &Value) -> Result<Value, Er
                 }
             } else {
                 unsafe {
-                    let last_match_sym = interp.borrow_mut().sym_intern("$~");
+                    let last_match_sym = interp.0.borrow_mut().sym_intern("$~");
                     sys::mrb_gv_set(
                         mrb,
                         last_match_sym,
                         Value::convert(interp, None::<Value>).inner(),
                     );
-                    let pre_match_sym = interp.borrow_mut().sym_intern("$`");
+                    let pre_match_sym = interp.0.borrow_mut().sym_intern("$`");
                     sys::mrb_gv_set(
                         mrb,
                         pre_match_sym,
                         Value::convert(interp, None::<Value>).inner(),
                     );
-                    let post_match_sym = interp.borrow_mut().sym_intern("$'");
+                    let post_match_sym = interp.0.borrow_mut().sym_intern("$'");
                     sys::mrb_gv_set(
                         mrb,
                         post_match_sym,
@@ -137,7 +138,11 @@ pub fn method(interp: &Artichoke, args: Args, value: &Value) -> Result<Value, Er
         Backend::Rust(_) => unimplemented!("Rust-backed Regexp"),
     };
     unsafe {
-        sys::mrb_gv_set(mrb, interp.borrow_mut().sym_intern("$~"), matchdata.inner());
+        sys::mrb_gv_set(
+            mrb,
+            interp.0.borrow_mut().sym_intern("$~"),
+            matchdata.inner(),
+        );
     }
     Ok(pos)
 }

--- a/artichoke-backend/src/extn/core/regexp/match_q.rs
+++ b/artichoke-backend/src/extn/core/regexp/match_q.rs
@@ -31,7 +31,7 @@ impl Args {
         let mut pos = <mem::MaybeUninit<sys::mrb_value>>::uninit();
         let mut has_pos = <mem::MaybeUninit<sys::mrb_bool>>::uninit();
         sys::mrb_get_args(
-            interp.borrow().mrb,
+            interp.0.borrow().mrb,
             Self::ARGSPEC.as_ptr() as *const i8,
             string.as_mut_ptr(),
             pos.as_mut_ptr(),

--- a/artichoke-backend/src/extn/core/regexp/mod.rs
+++ b/artichoke-backend/src/extn/core/regexp/mod.rs
@@ -45,6 +45,7 @@ pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
     interp.eval(include_str!("regexp.rb"))?;
     let regexp =
         interp
+            .0
             .borrow_mut()
             .def_class::<Regexp>("Regexp", None, Some(rust_data_free::<Regexp>));
     regexp.borrow_mut().mrb_value_is_rust_backed(true);

--- a/artichoke-backend/src/extn/core/regexp/union.rs
+++ b/artichoke-backend/src/extn/core/regexp/union.rs
@@ -27,7 +27,7 @@ impl Args {
         let mut args = <mem::MaybeUninit<*const sys::mrb_value>>::uninit();
         let mut count = <mem::MaybeUninit<usize>>::uninit();
         sys::mrb_get_args(
-            interp.borrow().mrb,
+            interp.0.borrow().mrb,
             Self::ARGSPEC.as_ptr() as *const i8,
             args.as_mut_ptr(),
             count.as_mut_ptr(),
@@ -42,7 +42,7 @@ impl Args {
 }
 
 pub fn method(interp: &Artichoke, args: Args, slf: sys::mrb_value) -> Result<Value, Error> {
-    let mrb = interp.borrow().mrb;
+    let mrb = interp.0.borrow().mrb;
     let pattern = if args.rest.is_empty() {
         "(?!)".to_owned()
     } else if args.rest.len() == 1 {

--- a/artichoke-backend/src/extn/core/string.rs
+++ b/artichoke-backend/src/extn/core/string.rs
@@ -11,10 +11,11 @@ use crate::{Artichoke, ArtichokeError};
 mod scan;
 
 pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
-    if interp.borrow().class_spec::<RString>().is_some() {
+    if interp.0.borrow().class_spec::<RString>().is_some() {
         return Ok(());
     }
     let string = interp
+        .0
         .borrow_mut()
         .def_class::<RString>("String", None, None);
     interp.eval(include_str!("string.rb"))?;

--- a/artichoke-backend/src/extn/core/symbol/mod.rs
+++ b/artichoke-backend/src/extn/core/symbol/mod.rs
@@ -4,6 +4,7 @@ use crate::ArtichokeError;
 
 pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
     interp
+        .0
         .borrow_mut()
         .def_class::<Symbol>("Symbol", None, None);
     interp.eval(include_str!("symbol.rb"))?;

--- a/artichoke-backend/src/extn/core/thread.rs
+++ b/artichoke-backend/src/extn/core/thread.rs
@@ -4,9 +4,13 @@ use crate::{Artichoke, ArtichokeError};
 
 pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
     interp
+        .0
         .borrow_mut()
         .def_class::<Thread>("Thread", None, None);
-    interp.borrow_mut().def_class::<Mutex>("Mutex", None, None);
+    interp
+        .0
+        .borrow_mut()
+        .def_class::<Mutex>("Mutex", None, None);
     interp.def_rb_source_file("thread.rb", include_str!("thread.rb"))?;
     // Thread is loaded by default, so eval it on interpreter initialization
     // https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/UnneededRequireStatement

--- a/artichoke-backend/src/extn/mod.rs
+++ b/artichoke-backend/src/extn/mod.rs
@@ -10,7 +10,7 @@ pub const RUBY_PLATFORM: &str = "x86_64-unknown-artichoke";
 pub const INPUT_RECORD_SEPARATOR: &str = "\n";
 
 pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
-    let mrb = interp.borrow().mrb;
+    let mrb = interp.0.borrow().mrb;
     unsafe {
         let ruby_platform = Value::convert(interp, RUBY_PLATFORM);
         sys::mrb_define_global_const(
@@ -27,7 +27,7 @@ pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
         let input_record_separator = Value::convert(interp, INPUT_RECORD_SEPARATOR);
         sys::mrb_gv_set(
             mrb,
-            interp.borrow_mut().sym_intern("$/"),
+            interp.0.borrow_mut().sym_intern("$/"),
             input_record_separator.inner(),
         );
     }

--- a/artichoke-backend/src/extn/stdlib/delegate.rs
+++ b/artichoke-backend/src/extn/stdlib/delegate.rs
@@ -4,9 +4,11 @@ use crate::ArtichokeError;
 
 pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
     interp
+        .0
         .borrow_mut()
         .def_class::<Delegator>("Delegator", None, None);
     interp
+        .0
         .borrow_mut()
         .def_class::<SimpleDelegator>("SimpleDelegator", None, None);
     interp.def_rb_source_file("delegate.rb", include_str!("delegate.rb"))?;

--- a/artichoke-backend/src/extn/stdlib/forwardable.rs
+++ b/artichoke-backend/src/extn/stdlib/forwardable.rs
@@ -4,6 +4,7 @@ use crate::ArtichokeError;
 
 pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
     interp
+        .0
         .borrow_mut()
         .def_module::<Forwardable>("Forwardable", None);
     interp.def_rb_source_file("forwardable.rb", include_str!("forwardable.rb"))?;

--- a/artichoke-backend/src/extn/stdlib/monitor.rs
+++ b/artichoke-backend/src/extn/stdlib/monitor.rs
@@ -4,6 +4,7 @@ use crate::ArtichokeError;
 
 pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
     interp
+        .0
         .borrow_mut()
         .def_class::<Monitor>("Monitor", None, None);
     interp.def_rb_source_file("monitor.rb", include_str!("monitor.rb"))?;

--- a/artichoke-backend/src/extn/stdlib/ostruct.rs
+++ b/artichoke-backend/src/extn/stdlib/ostruct.rs
@@ -4,6 +4,7 @@ use crate::ArtichokeError;
 
 pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
     interp
+        .0
         .borrow_mut()
         .def_class::<OpenStruct>("OpenStruct", None, None);
     interp.def_rb_source_file("ostruct.rb", include_str!("ostruct.rb"))?;

--- a/artichoke-backend/src/extn/stdlib/set.rs
+++ b/artichoke-backend/src/extn/stdlib/set.rs
@@ -3,8 +3,9 @@ use crate::Artichoke;
 use crate::ArtichokeError;
 
 pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
-    interp.borrow_mut().def_class::<Set>("Set", None, None);
+    interp.0.borrow_mut().def_class::<Set>("Set", None, None);
     interp
+        .0
         .borrow_mut()
         .def_class::<SortedSet>("SortedSet", None, None);
     interp.def_rb_source_file("set.rb", include_str!("set.rb"))?;

--- a/artichoke-backend/src/extn/stdlib/strscan.rs
+++ b/artichoke-backend/src/extn/stdlib/strscan.rs
@@ -4,6 +4,7 @@ use crate::ArtichokeError;
 
 pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
     interp
+        .0
         .borrow_mut()
         .def_module::<StringScanner>("StringScanner", None);
     interp.def_rb_source_file("strscan.rb", include_str!("strscan.rb"))?;

--- a/artichoke-backend/src/ffi.rs
+++ b/artichoke-backend/src/ffi.rs
@@ -45,7 +45,7 @@ pub unsafe fn from_user_data(mrb: *mut sys::mrb_state) -> Result<Artichoke, Arti
         "Extracted Artichoke from user data pointer on {}",
         mrb.debug()
     );
-    Ok(api)
+    Ok(Artichoke(api))
 }
 
 #[cfg(test)]
@@ -63,7 +63,7 @@ mod tests {
     #[test]
     fn from_user_data_null_user_data() {
         let interp = crate::interpreter().expect("init");
-        let mrb = interp.borrow().mrb;
+        let mrb = interp.0.borrow().mrb;
         unsafe {
             // fake null user data
             (*mrb).ud = std::ptr::null_mut();
@@ -75,7 +75,7 @@ mod tests {
     #[test]
     fn from_user_data() {
         let interp = crate::interpreter().expect("init");
-        let mrb = interp.borrow().mrb;
+        let mrb = interp.0.borrow().mrb;
         let res = unsafe { super::from_user_data(mrb) };
         assert!(res.is_ok());
     }
@@ -83,12 +83,12 @@ mod tests {
     #[test]
     fn from_user_data_rc_refcount() {
         let interp = crate::interpreter().expect("init");
-        assert_eq!(Rc::strong_count(&interp), 1);
-        let mrb = interp.borrow().mrb;
+        assert_eq!(Rc::strong_count(&interp.0), 1);
+        let mrb = interp.0.borrow().mrb;
         let res = unsafe { super::from_user_data(mrb) };
-        assert_eq!(Rc::strong_count(&interp), 2);
+        assert_eq!(Rc::strong_count(&interp.0), 2);
         assert!(res.is_ok());
         drop(res);
-        assert_eq!(Rc::strong_count(&interp), 1);
+        assert_eq!(Rc::strong_count(&interp.0), 1);
     }
 }

--- a/artichoke-backend/src/gc.rs
+++ b/artichoke-backend/src/gc.rs
@@ -1,5 +1,3 @@
-use std::rc::Rc;
-
 use crate::sys;
 use crate::Artichoke;
 
@@ -32,7 +30,7 @@ impl ArenaIndex {
 
 impl Drop for ArenaIndex {
     fn drop(&mut self) {
-        unsafe { sys::mrb_sys_gc_arena_restore(self.interp.borrow().mrb, self.index) };
+        unsafe { sys::mrb_sys_gc_arena_restore(self.interp.0.borrow().mrb, self.index) };
     }
 }
 
@@ -84,29 +82,29 @@ pub trait MrbGarbageCollection {
 impl MrbGarbageCollection for Artichoke {
     fn create_arena_savepoint(&self) -> ArenaIndex {
         ArenaIndex {
-            index: unsafe { sys::mrb_sys_gc_arena_save(self.borrow().mrb) },
-            interp: Rc::clone(self),
+            index: unsafe { sys::mrb_sys_gc_arena_save(self.0.borrow().mrb) },
+            interp: self.clone(),
         }
     }
 
     fn live_object_count(&self) -> i32 {
-        unsafe { sys::mrb_sys_gc_live_objects(self.borrow().mrb) }
+        unsafe { sys::mrb_sys_gc_live_objects(self.0.borrow().mrb) }
     }
 
     fn incremental_gc(&self) {
-        unsafe { sys::mrb_incremental_gc(self.borrow().mrb) };
+        unsafe { sys::mrb_incremental_gc(self.0.borrow().mrb) };
     }
 
     fn full_gc(&self) {
-        unsafe { sys::mrb_full_gc(self.borrow().mrb) };
+        unsafe { sys::mrb_full_gc(self.0.borrow().mrb) };
     }
 
     fn enable_gc(&self) -> bool {
-        unsafe { sys::mrb_sys_gc_enable(self.borrow().mrb) }
+        unsafe { sys::mrb_sys_gc_enable(self.0.borrow().mrb) }
     }
 
     fn disable_gc(&self) -> bool {
-        unsafe { sys::mrb_sys_gc_disable(self.borrow().mrb) }
+        unsafe { sys::mrb_sys_gc_disable(self.0.borrow().mrb) }
     }
 }
 

--- a/artichoke-backend/src/interpreter.rs
+++ b/artichoke-backend/src/interpreter.rs
@@ -39,7 +39,7 @@ pub fn interpreter() -> Result<Artichoke, ArtichokeError> {
     // operation `Rc::strong_count` will still be 1. This dance is required to
     // avoid leaking Artichoke objects, which will let the `Drop` impl close the mrb
     // context and interpreter.
-    let interp = unsafe { Rc::from_raw(ptr) };
+    let interp = Artichoke(unsafe { Rc::from_raw(ptr) });
 
     // Initialize Artichoke Core and Standard Library runtime
     extn::init(&interp)?;

--- a/artichoke-backend/src/lib.rs
+++ b/artichoke-backend/src/lib.rs
@@ -117,7 +117,7 @@
 //! impl Container {
 //!     unsafe extern "C" fn initialize(mrb: *mut sys::mrb_state, mut slf: sys::mrb_value) -> sys::mrb_value {
 //!         let interp = unwrap_interpreter!(mrb);
-//!         let api = interp.borrow();
+//!         let api = interp.0.borrow();
 //!         let int = mem::uninitialized::<sys::mrb_int>();
 //!         let mut argspec = vec![];
 //!         argspec.write_all(format!("{}\0", sys::specifiers::INTEGER).as_bytes()).unwrap();
@@ -144,7 +144,7 @@
 //!
 //! impl File for Container {
 //!   fn require(interp: Artichoke) -> Result<(), ArtichokeError> {
-//!         let spec = interp.borrow_mut().def_class::<Self>("Container", None, Some(rust_data_free::<Self>));
+//!         let spec = interp.0.borrow_mut().def_class::<Self>("Container", None, Some(rust_data_free::<Self>));
 //!         spec.borrow_mut().add_method("initialize", Self::initialize, sys::mrb_args_req(1));
 //!         spec.borrow_mut().add_method("value", Self::value, sys::mrb_args_none());
 //!         spec.borrow_mut().mrb_value_is_rust_backed(true);
@@ -254,7 +254,8 @@ pub use mruby_sys as sys;
 ///
 /// Functionality is added to the interpreter via traits, for example,
 /// [garbage collection](gc::MrbGarbageCollection) or [eval](eval::Eval).
-pub type Artichoke = Rc<RefCell<state::State>>;
+#[derive(Debug, Clone)]
+pub struct Artichoke(pub Rc<RefCell<state::State>>); // TODO: this should not be pub
 
 /// Errors returned by artichoke-backend crate.
 #[derive(Debug)]

--- a/artichoke-backend/src/load.rs
+++ b/artichoke-backend/src/load.rs
@@ -70,7 +70,7 @@ impl LoadSources for Artichoke {
     where
         T: AsRef<str>,
     {
-        let api = self.borrow();
+        let api = self.0.borrow();
         let path = self.normalize_source_path(filename.as_ref());
         if let Some(parent) = path.parent() {
             api.vfs.create_dir_all(parent)?;
@@ -102,7 +102,7 @@ impl LoadSources for Artichoke {
         T: AsRef<str>,
         F: AsRef<[u8]>,
     {
-        let api = self.borrow();
+        let api = self.0.borrow();
         let path = self.normalize_source_path(filename.as_ref());
         if let Some(parent) = path.parent() {
             api.vfs.create_dir_all(parent)?;

--- a/artichoke-backend/src/method.rs
+++ b/artichoke-backend/src/method.rs
@@ -56,7 +56,7 @@ impl Spec {
         interp: &Artichoke,
         into: *mut sys::RClass,
     ) -> Result<(), ArtichokeError> {
-        let mrb = interp.borrow().mrb;
+        let mrb = interp.0.borrow().mrb;
         match self.method_type {
             Type::Class => {
                 sys::mrb_define_class_method(

--- a/artichoke-backend/src/module.rs
+++ b/artichoke-backend/src/module.rs
@@ -62,14 +62,14 @@ impl ClassLike for Spec {
     }
 
     fn rclass(&self, interp: &Artichoke) -> Option<*mut sys::RClass> {
-        let mrb = interp.borrow().mrb;
+        let mrb = interp.0.borrow().mrb;
         if let Some(ref scope) = self.enclosing_scope {
             if let Some(scope) = scope.rclass(interp) {
                 let defined = unsafe {
                     sys::mrb_const_defined_at(
                         mrb,
                         sys::mrb_sys_obj_value(scope as *mut c_void),
-                        interp.borrow_mut().sym_intern(self.name.as_str()),
+                        interp.0.borrow_mut().sym_intern(self.name.as_str()),
                     )
                 };
                 if defined == 0 {
@@ -90,7 +90,7 @@ impl ClassLike for Spec {
                 sys::mrb_const_defined_at(
                     mrb,
                     sys::mrb_sys_obj_value((*mrb).object_class as *mut c_void),
-                    interp.borrow_mut().sym_intern(self.name.as_str()),
+                    interp.0.borrow_mut().sym_intern(self.name.as_str()),
                 )
             };
             if defined == 0 {
@@ -133,7 +133,7 @@ impl PartialEq for Spec {
 
 impl Define for Spec {
     fn define(&self, interp: &Artichoke) -> Result<*mut sys::RClass, ArtichokeError> {
-        let mrb = interp.borrow().mrb;
+        let mrb = interp.0.borrow().mrb;
         let rclass = if let Some(rclass) = self.rclass(interp) {
             rclass
         } else if let Some(ref scope) = self.enclosing_scope {

--- a/artichoke-backend/src/state.rs
+++ b/artichoke-backend/src/state.rs
@@ -112,7 +112,7 @@ impl State {
     /// fn main() {
     ///     let interp = artichoke_backend::interpreter().expect("init");
     ///     let spec = {
-    ///         let mut api = interp.borrow_mut();
+    ///         let mut api = interp.0.borrow_mut();
     ///         let spec = api.def_class::<()>("Container", None, None);
     ///         spec.borrow_mut().add_method("value", value, sys::mrb_args_none());
     ///         spec.borrow_mut().add_self_method("value", value, sys::mrb_args_none());
@@ -181,7 +181,7 @@ impl State {
     /// fn main() {
     ///     let interp = artichoke_backend::interpreter().expect("init");
     ///     let spec = {
-    ///         let mut api = interp.borrow_mut();
+    ///         let mut api = interp.0.borrow_mut();
     ///         let spec = api.def_module::<()>("Container", None);
     ///         spec.borrow_mut().add_method("value", value, sys::mrb_args_none());
     ///         spec.borrow_mut().add_self_method("value", value, sys::mrb_args_none());

--- a/artichoke-backend/src/top_self.rs
+++ b/artichoke-backend/src/top_self.rs
@@ -17,6 +17,6 @@ pub trait TopSelf {
 
 impl TopSelf for Artichoke {
     fn top_self(&self) -> Value {
-        Value::new(self, unsafe { sys::mrb_top_self(self.borrow().mrb) })
+        Value::new(self, unsafe { sys::mrb_top_self(self.0.borrow().mrb) })
     }
 }

--- a/artichoke-backend/src/warn.rs
+++ b/artichoke-backend/src/warn.rs
@@ -23,9 +23,9 @@ pub trait Warn {
 impl Warn for Artichoke {
     fn warn(&self, message: &str) -> Result<(), ArtichokeError> {
         warn!("rb warning: {}", message);
-        let mrb = self.borrow().mrb;
+        let mrb = self.0.borrow().mrb;
         let kernel = unsafe {
-            let stderr = sys::mrb_gv_get(mrb, self.borrow_mut().sym_intern("$stderr"));
+            let stderr = sys::mrb_gv_get(mrb, self.0.borrow_mut().sym_intern("$stderr"));
             if sys::mrb_sys_value_is_nil(stderr) {
                 return Ok(());
             }

--- a/artichoke-backend/tests/leak_mrb_tt_data_rc.rs
+++ b/artichoke-backend/tests/leak_mrb_tt_data_rc.rs
@@ -61,7 +61,7 @@ impl Container {
                 argspec
                     .write_all(b"\0")
                     .map_err(|_| ArtichokeError::ArgSpec)?;
-                sys::mrb_get_args(interp.borrow().mrb, argspec.as_ptr() as *const i8, &inner);
+                sys::mrb_get_args(interp.0.borrow().mrb, argspec.as_ptr() as *const i8, &inner);
                 let inner = Value::new(interp, inner.assume_init());
                 let inner =
                     String::try_convert(&interp, inner).map_err(ArtichokeError::ConvertToRust)?;
@@ -82,7 +82,7 @@ impl Container {
 impl File for Container {
     fn require(interp: Artichoke) -> Result<(), ArtichokeError> {
         let spec = {
-            let mut api = interp.borrow_mut();
+            let mut api = interp.0.borrow_mut();
             let spec = api.def_class::<Self>("Container", None, Some(rust_data_free::<Self>));
             spec.borrow_mut()
                 .add_method("initialize", Self::initialize, sys::mrb_args_req(1));

--- a/artichoke-backend/tests/leak_unbounded_arena_growth.rs
+++ b/artichoke-backend/tests/leak_unbounded_arena_growth.rs
@@ -23,7 +23,6 @@
 use artichoke_backend::eval::Eval;
 use artichoke_backend::gc::MrbGarbageCollection;
 use artichoke_backend::ArtichokeError;
-use std::rc::Rc;
 
 mod leak;
 
@@ -49,7 +48,7 @@ end
         "n".repeat(1024 * 1024)
     );
     leak::Detector::new("current exception", ITERATIONS, LEAK_TOLERANCE).check_leaks(|_| {
-        let interp = Rc::clone(&interp);
+        let interp = interp.clone();
         let code = "bad_code";
         let arena = interp.create_arena_savepoint();
         let result = interp.eval(code).map(|_| ());
@@ -67,7 +66,7 @@ end
     let expected = "a".repeat(1024 * 1024);
     leak::Detector::new("to_s", ITERATIONS, LEAK_TOLERANCE).check_leaks_with_finalizer(
         |_| {
-            let interp = Rc::clone(&interp);
+            let interp = interp.clone();
             let arena = interp.create_arena_savepoint();
             let result = interp.eval("'a' * 1024 * 1024").expect("eval");
             arena.restore();
@@ -75,7 +74,7 @@ end
             drop(result);
             interp.incremental_gc();
         },
-        || Rc::clone(&interp).full_gc(),
+        || interp.clone().full_gc(),
     );
 
     // Value::to_s_debug
@@ -83,7 +82,7 @@ end
     let expected = format!(r#"String<"{}">"#, "a".repeat(1024 * 1024));
     leak::Detector::new("to_s_debug", ITERATIONS, 3 * LEAK_TOLERANCE).check_leaks_with_finalizer(
         |_| {
-            let interp = Rc::clone(&interp);
+            let interp = interp.clone();
             let arena = interp.create_arena_savepoint();
             let result = interp.eval("'a' * 1024 * 1024").expect("eval");
             arena.restore();
@@ -91,6 +90,6 @@ end
             drop(result);
             interp.incremental_gc();
         },
-        || Rc::clone(&interp).full_gc(),
+        || interp.clone().full_gc(),
     );
 }

--- a/artichoke-backend/tests/manual.rs
+++ b/artichoke-backend/tests/manual.rs
@@ -42,7 +42,7 @@ impl Container {
                 argspec
                     .write_all(b"\0")
                     .map_err(|_| ArtichokeError::ArgSpec)?;
-                sys::mrb_get_args(interp.borrow().mrb, argspec.as_ptr() as *const i8, &inner);
+                sys::mrb_get_args(interp.0.borrow().mrb, argspec.as_ptr() as *const i8, &inner);
                 let inner = Value::new(interp, inner.assume_init());
                 let inner =
                     i64::try_convert(&interp, inner).map_err(ArtichokeError::ConvertToRust)?;
@@ -74,7 +74,7 @@ impl Container {
 impl File for Container {
     fn require(interp: Artichoke) -> Result<(), ArtichokeError> {
         let spec = {
-            let mut api = interp.borrow_mut();
+            let mut api = interp.0.borrow_mut();
             let spec =
                 api.def_class::<Box<Self>>("Container", None, Some(rust_data_free::<Box<Self>>));
             spec.borrow_mut()

--- a/artichoke-backend/tests/obj_new_borrow_mut.rs
+++ b/artichoke-backend/tests/obj_new_borrow_mut.rs
@@ -24,14 +24,14 @@ impl RustBackedValue for Obj {}
 
 unsafe extern "C" fn initialize(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
     let interp = unwrap_interpreter!(mrb);
-    interp.borrow_mut();
+    interp.0.borrow_mut();
     slf
 }
 
 #[test]
 fn obj_new_borrow_mut() {
     let interp = artichoke_backend::interpreter().expect("init");
-    let class = interp.borrow_mut().def_class::<Obj>("Obj", None, None);
+    let class = interp.0.borrow_mut().def_class::<Obj>("Obj", None, None);
     class
         .borrow_mut()
         .add_method("initialize", initialize, sys::mrb_args_none());

--- a/artichoke-backend/tests/segfault_rc_transmute.rs
+++ b/artichoke-backend/tests/segfault_rc_transmute.rs
@@ -41,9 +41,9 @@ fn segfault_rc_transmute() {
     // Increase the strong count on the Rc to 255.
     let mut interps = vec![];
     for _ in 0..254 {
-        interps.push(Rc::clone(&interp));
+        interps.push(Rc::clone(&interp.0));
     }
-    println!("strong count = {}", Rc::strong_count(&interp));
+    println!("strong count = {}", Rc::strong_count(&interp.0));
 
     // create an object to collect on the artichoke heap.
     let bytes = std::iter::repeat(255_u8)
@@ -51,7 +51,7 @@ fn segfault_rc_transmute() {
         .collect::<Vec<_>>();
     let _val = unsafe {
         sys::mrb_str_new(
-            interp.borrow().mrb,
+            interp.0.borrow().mrb,
             bytes.as_ptr() as *const i8,
             bytes.len(),
         )
@@ -62,9 +62,9 @@ fn segfault_rc_transmute() {
     println!("full gc succeeded");
 
     // temporarily increase strong count to 256 and drop the reference
-    let temp = Rc::clone(&interp);
+    let temp = Rc::clone(&interp.0);
     drop(temp);
-    println!("strong count = {}", Rc::strong_count(&interp));
+    println!("strong count = {}", Rc::strong_count(&interp.0));
 
     println!("attempting full gc");
     interp.full_gc();
@@ -72,8 +72,8 @@ fn segfault_rc_transmute() {
     println!("full gc succeeded");
 
     // Increase the strong count to 256, which is beyond u8::MAX
-    interps.push(Rc::clone(&interp));
-    println!("strong count = {}", Rc::strong_count(&interp));
+    interps.push(Rc::clone(&interp.0));
+    println!("strong count = {}", Rc::strong_count(&interp.0));
 
     println!("attempting full gc");
     interp.full_gc();

--- a/artichoke-frontend/src/bin/string_scan_bench.rs
+++ b/artichoke-frontend/src/bin/string_scan_bench.rs
@@ -18,7 +18,7 @@ fn main() {
             process::exit(1);
         }
     };
-    let mrb = interp.borrow().mrb;
+    let mrb = interp.0.borrow().mrb;
 
     // program is either supplied as a file via command line argument or piped
     // in via stdin.
@@ -46,7 +46,7 @@ fn main() {
         include_bytes!("../../ruby/fixtures/learnxinyminutes.txt").as_ref(),
     );
     data.protect();
-    unsafe { sys::mrb_gv_set(mrb, interp.borrow_mut().sym_intern("$data"), data.inner()) }
+    unsafe { sys::mrb_gv_set(mrb, interp.0.borrow_mut().sym_intern("$data"), data.inner()) }
     let ctx = Context::new("(main)");
     if let Err(err) = interp.eval_with_context(program, ctx) {
         eprintln!("{}", err);

--- a/artichoke-frontend/src/parser.rs
+++ b/artichoke-frontend/src/parser.rs
@@ -64,8 +64,8 @@ pub struct Parser {
 impl Parser {
     /// Create a new parser from an interpreter instance.
     pub fn new(interp: &Artichoke) -> Option<Self> {
-        let mrb = interp.borrow().mrb;
-        let context = interp.borrow().ctx;
+        let mrb = interp.0.borrow().mrb;
+        let context = interp.0.borrow().ctx;
         let parser = unsafe { sys::mrb_parser_new(mrb) };
         if parser.is_null() {
             None

--- a/artichoke-frontend/src/repl.rs
+++ b/artichoke-frontend/src/repl.rs
@@ -89,7 +89,7 @@ pub fn run(
     let parser = Parser::new(&interp).ok_or(Error::ReplInit)?;
     interp.push_context(Context::new(REPL_FILENAME));
     unsafe {
-        let api = interp.borrow();
+        let api = interp.0.borrow();
         (*api.ctx).lineno = 1;
     }
 
@@ -129,7 +129,7 @@ pub fn run(
                 for line in buf.lines() {
                     rl.add_history_entry(line);
                     unsafe {
-                        let api = interp.borrow();
+                        let api = interp.0.borrow();
                         (*api.ctx).lineno += 1;
                     }
                 }


### PR DESCRIPTION
Moving the interpreter traits to artichoke-core means the interpreter
traits will be foreign. Rc is also a foreign type. Rust orphaning rules
will prevent us from implementing artichoke-core traits in
artichoke-backend.

There is a lot that is suboptimal here. Migrating APIs into artichoke-core
should clean this up a bit.