### PR TITLE
Remove Kernel::NOT_SET and Kernel#not_set?

### DIFF
--- a/artichoke-backend/src/extn/core/kernel/kernel.rb
+++ b/artichoke-backend/src/extn/core/kernel/kernel.rb
@@ -40,12 +40,6 @@ module Kernel
     e.value
   end
 
-  NOT_SET = Object.new
-
-  def not_set?
-    self == NOT_SET
-  end
-
   # Throws an object, uncaught throws will bubble up through other catch blocks.
   #
   # @param [Symbol] tag  tag being thrown


### PR DESCRIPTION
This API and constant were added in artichoke/ferrocarril#85 to load Sinatra and
work around mruby not supporting expressions as default parameters in method argument
lists.

This patch belongs in nemesis instead of artichoke core.