### PR TITLE
Fix wasm32 i64 converter compiler error

### DIFF
--- a/artichoke-backend/src/convert/fixnum.rs
+++ b/artichoke-backend/src/convert/fixnum.rs
@@ -88,7 +88,9 @@ impl TryConvert<i64, Value> for Artichoke {
             from: Rust::UnsignedInt,
             to: Ruby::Fixnum,
         })?;
-        Ok(Self::new(self, unsafe { sys::mrb_sys_fixnum_value(value) }))
+        Ok(Value::new(self, unsafe {
+            sys::mrb_sys_fixnum_value(value)
+        }))
     }
 }
 


### PR DESCRIPTION
This converter is not compiled as part of the artichoke build pipeline
and it got missed in GH-242.