### PR TITLE
Unify ValueLike::funcall and ValueLike::funcall_with_block

### DIFF
--- a/artichoke-backend/src/convert/object.rs
+++ b/artichoke-backend/src/convert/object.rs
@@ -201,16 +201,14 @@ mod tests {
         };
 
         let value = unsafe { obj.try_into_ruby(&interp, None) }.expect("convert");
-        let class = value.funcall::<Value, _, _>("class", &[]).expect("funcall");
+        let class = value.funcall::<Value>("class", &[], None).expect("funcall");
         assert_eq!(class.to_s(), "Container");
         let data = unsafe { Container::try_from_ruby(&interp, &value) }.expect("convert");
         assert_eq!(Rc::strong_count(&data), 2);
         assert_eq!(&data.borrow().inner, "contained string contents");
         drop(data);
-        let inner = value
-            .funcall::<String, _, _>("value", &[])
-            .expect("funcall");
-        assert_eq!(&inner, "contained string contents");
+        let inner = value.funcall::<&str>("value", &[], None).expect("funcall");
+        assert_eq!(inner, "contained string contents");
     }
 
     #[test]
@@ -234,13 +232,13 @@ mod tests {
         spec.borrow().define(&interp).expect("class install");
 
         let value = interp.convert("string");
-        let class = value.funcall::<Value, _, _>("class", &[]).expect("funcall");
+        let class = value.funcall::<Value>("class", &[], None).expect("funcall");
         assert_eq!(class.to_s(), "String");
         let data = unsafe { Container::try_from_ruby(&interp, &value) };
         assert!(data.is_err());
         let value =
             unsafe { Box::new(Other::default()).try_into_ruby(&interp, None) }.expect("convert");
-        let class = value.funcall::<Value, _, _>("class", &[]).expect("funcall");
+        let class = value.funcall::<Value>("class", &[], None).expect("funcall");
         assert_eq!(class.to_s(), "Other");
         let data = unsafe { Container::try_from_ruby(&interp, &value) };
         assert!(data.is_err());

--- a/artichoke-backend/src/exception.rs
+++ b/artichoke-backend/src/exception.rs
@@ -95,21 +95,21 @@ impl ExceptionHandler for Artichoke {
         // ```
         let exception = Value::new(self, unsafe { sys::mrb_sys_obj_value(exc as *mut c_void) });
         let class = exception
-            .funcall::<Value, _, _>("class", &[])
-            .and_then(|exception| exception.funcall::<String, _, _>("name", &[]));
+            .funcall::<Value>("class", &[], None)
+            .and_then(|exception| exception.funcall::<String>("name", &[], None));
         let class = match class {
             Ok(class) => class,
             Err(err) => return LastError::UnableToExtract(err),
         };
-        let message = match exception.funcall::<String, _, _>("message", &[]) {
+        let message = match exception.funcall::<String>("message", &[], None) {
             Ok(message) => message,
             Err(err) => return LastError::UnableToExtract(err),
         };
-        let backtrace = match exception.funcall::<Option<Vec<String>>, _, _>("backtrace", &[]) {
+        let backtrace = match exception.funcall::<Option<Vec<String>>>("backtrace", &[], None) {
             Ok(backtrace) => backtrace,
             Err(err) => return LastError::UnableToExtract(err),
         };
-        let inspect = match exception.funcall::<String, _, _>("inspect", &[]) {
+        let inspect = match exception.funcall::<String>("inspect", &[], None) {
             Ok(inspect) => inspect,
             Err(err) => return LastError::UnableToExtract(err),
         };
@@ -183,7 +183,7 @@ fail
             "#,
         );
         let kernel = interp.eval(r#"Kernel"#).unwrap();
-        let _ = kernel.funcall::<Value, _, _>("raise", &[]);
-        let _ = kernel.funcall::<Value, _, _>("raise", &[]);
+        let _ = kernel.funcall::<Value>("raise", &[], None);
+        let _ = kernel.funcall::<Value>("raise", &[], None);
     }
 }

--- a/artichoke-backend/src/extn/core/kernel/mod.rs
+++ b/artichoke-backend/src/extn/core/kernel/mod.rs
@@ -60,9 +60,12 @@ impl Warning {
         if !sys::mrb_sys_value_is_nil(stderr) {
             let args = args::Rest::extract(&interp);
             let stderr = Value::new(&interp, stderr);
-            // TODO: introduce a `unchecked_funcall` to propagate errors.
-            let _ = stderr
-                .funcall::<Value, _, _>("print", args.map(|args| args.rest).unwrap_or_default());
+            // TODO: introduce a `unchecked_funcall` to propagate errors, GH-249.
+            let _ = stderr.funcall::<Value>(
+                "print",
+                args.map(|args| args.rest).unwrap_or_default().as_ref(),
+                None,
+            );
         }
         sys::mrb_sys_nil_value()
     }

--- a/artichoke-backend/src/extn/core/matchdata/begin.rs
+++ b/artichoke-backend/src/extn/core/matchdata/begin.rs
@@ -40,7 +40,7 @@ impl Args {
             Ok(Args::Index(index))
         } else if let Ok(name) = interp.try_convert(Value::new(interp, first)) {
             Ok(Args::Name(name))
-        } else if let Ok(index) = Value::new(interp, first).funcall::<Int, _, _>("to_int", &[]) {
+        } else if let Ok(index) = Value::new(interp, first).funcall::<Int>("to_int", &[], None) {
             Ok(Args::Index(index))
         } else {
             Err(Error::IndexType)

--- a/artichoke-backend/src/extn/core/matchdata/end.rs
+++ b/artichoke-backend/src/extn/core/matchdata/end.rs
@@ -40,7 +40,7 @@ impl Args {
             Ok(Args::Index(index))
         } else if let Ok(name) = interp.try_convert(Value::new(interp, first)) {
             Ok(Args::Name(name))
-        } else if let Ok(index) = Value::new(interp, first).funcall::<Int, _, _>("to_int", &[]) {
+        } else if let Ok(index) = Value::new(interp, first).funcall::<Int>("to_int", &[], None) {
             Ok(Args::Index(index))
         } else {
             Err(Error::IndexType)

--- a/artichoke-backend/src/extn/core/regexp/union.rs
+++ b/artichoke-backend/src/extn/core/regexp/union.rs
@@ -55,8 +55,8 @@ pub fn method(interp: &Artichoke, args: Args, slf: sys::mrb_value) -> Result<Val
             {
                 if let Ok(regexp) = unsafe { Regexp::try_from_ruby(&interp, &pattern) } {
                     patterns.push(regexp.borrow().pattern.clone());
-                } else if let Ok(pattern) = pattern.funcall::<String, _, _>("to_str", &[]) {
-                    patterns.push(syntax::escape(pattern.as_str()));
+                } else if let Ok(pattern) = pattern.funcall::<&str>("to_str", &[], None) {
+                    patterns.push(syntax::escape(pattern));
                 } else {
                     return Err(Error::NoImplicitConversionToString);
                 }
@@ -66,8 +66,8 @@ pub fn method(interp: &Artichoke, args: Args, slf: sys::mrb_value) -> Result<Val
             let pattern = arg;
             if let Ok(regexp) = unsafe { Regexp::try_from_ruby(&interp, &pattern) } {
                 regexp.borrow().pattern.clone()
-            } else if let Ok(pattern) = pattern.funcall::<String, _, _>("to_str", &[]) {
-                syntax::escape(pattern.as_str())
+            } else if let Ok(pattern) = pattern.funcall::<&str>("to_str", &[], None) {
+                syntax::escape(pattern)
             } else {
                 return Err(Error::NoImplicitConversionToString);
             }
@@ -77,8 +77,8 @@ pub fn method(interp: &Artichoke, args: Args, slf: sys::mrb_value) -> Result<Val
         for pattern in args.rest {
             if let Ok(regexp) = unsafe { Regexp::try_from_ruby(&interp, &pattern) } {
                 patterns.push(regexp.borrow().pattern.clone());
-            } else if let Ok(pattern) = pattern.funcall::<String, _, _>("to_str", &[]) {
-                patterns.push(syntax::escape(pattern.as_str()));
+            } else if let Ok(pattern) = pattern.funcall::<&str>("to_str", &[], None) {
+                patterns.push(syntax::escape(pattern));
             } else {
                 return Err(Error::NoImplicitConversionToString);
             }

--- a/artichoke-backend/src/extn/core/string.rs
+++ b/artichoke-backend/src/extn/core/string.rs
@@ -154,39 +154,21 @@ mod tests {
 
         let s = interp.convert("abababa");
         let result = s
-            .funcall::<Vec<String>, _, _>("scan", &[interp.eval("/./").expect("eval")])
+            .funcall::<Vec<&str>>("scan", &[interp.eval("/./").expect("eval")], None)
             .expect("funcall");
-        assert_eq!(
-            result,
-            vec!["a", "b", "a", "b", "a", "b", "a"]
-                .into_iter()
-                .map(str::to_owned)
-                .collect::<Vec<_>>()
-        );
+        assert_eq!(result, vec!["a", "b", "a", "b", "a", "b", "a"]);
         let result = s
-            .funcall::<Vec<String>, _, _>("scan", &[interp.eval("/../").expect("eval")])
+            .funcall::<Vec<&str>>("scan", &[interp.eval("/../").expect("eval")], None)
             .expect("funcall");
-        assert_eq!(
-            result,
-            vec!["ab", "ab", "ab"]
-                .into_iter()
-                .map(str::to_owned)
-                .collect::<Vec<_>>()
-        );
+        assert_eq!(result, vec!["ab", "ab", "ab"]);
         let result = s
-            .funcall::<Vec<String>, _, _>("scan", &[interp.eval("'aba'").expect("eval")])
+            .funcall::<Vec<&str>>("scan", &[interp.eval("'aba'").expect("eval")], None)
             .expect("funcall");
-        assert_eq!(
-            result,
-            vec!["aba", "aba"]
-                .into_iter()
-                .map(str::to_owned)
-                .collect::<Vec<_>>()
-        );
+        assert_eq!(result, vec!["aba", "aba"]);
         let result = s
-            .funcall::<Vec<String>, _, _>("scan", &[interp.eval("'no no no'").expect("eval")])
+            .funcall::<Vec<&str>>("scan", &[interp.eval("'no no no'").expect("eval")], None)
             .expect("funcall");
-        assert_eq!(result, <Vec<String>>::new());
+        assert_eq!(result, <Vec<&str>>::new());
     }
 
     #[test]
@@ -195,9 +177,9 @@ mod tests {
         string::init(&interp).expect("string init");
 
         let s = interp.eval("-'abababa'").expect("eval");
-        let result = s.funcall::<bool, _, _>("frozen?", &[]).expect("funcall");
-        assert!(result);
-        let result = s.funcall::<String, _, _>("itself", &[]).expect("funcall");
-        assert_eq!(result, "abababa");
+        let result = s.funcall::<bool>("frozen?", &[], None);
+        assert_eq!(result, Ok(true));
+        let result = s.funcall::<&str>("itself", &[], None);
+        assert_eq!(result, Ok("abababa"));
     }
 }

--- a/artichoke-backend/src/extn/core/string/scan.rs
+++ b/artichoke-backend/src/extn/core/string/scan.rs
@@ -39,8 +39,8 @@ impl Args {
         let regexp = if let Ok(regexp) = Regexp::try_from_ruby(interp, &Value::new(interp, pattern))
         {
             Some(regexp.borrow().clone())
-        } else if let Some(ref pattern) = Value::new(interp, pattern)
-            .funcall::<Option<String>, _, _>("to_str", &[])
+        } else if let Some(pattern) = Value::new(interp, pattern)
+            .funcall::<Option<&str>>("to_str", &[], None)
             .map_err(|_| Error::WrongType)?
         {
             Regexp::new(

--- a/artichoke-backend/src/warn.rs
+++ b/artichoke-backend/src/warn.rs
@@ -32,7 +32,7 @@ impl Warn for Artichoke {
             let kernel = (*mrb).kernel_module;
             Value::new(self, sys::mrb_sys_module_value(kernel))
         };
-        kernel.funcall::<Value, _, _>("warn", &[self.convert(message)])?;
+        kernel.funcall::<Value>("warn", &[self.convert(message)], None)?;
         Ok(())
     }
 }

--- a/artichoke-backend/tests/leak_funcall.rs
+++ b/artichoke-backend/tests/leak_funcall.rs
@@ -31,7 +31,7 @@ fn funcall_arena() {
         let expected = format!(r#""{}""#, "a".repeat(1024 * 1024));
         // we have to call a function that calls into the Ruby VM, so we can't
         // just use `to_s`.
-        let inspect = s.funcall::<String, _, _>("inspect", &[]);
+        let inspect = s.funcall::<String>("inspect", &[], None);
         assert_eq!(inspect, Ok(expected));
         interp.incremental_gc();
     });

--- a/spec-runner/src/mspec.rs
+++ b/spec-runner/src/mspec.rs
@@ -59,7 +59,7 @@ impl Runner {
         let specs = self.interp.convert(self.specs);
         self.interp
             .top_self()
-            .funcall::<bool, _, _>("run_specs", &[specs])
+            .funcall::<bool>("run_specs", &[specs], None)
     }
 }
 


### PR DESCRIPTION
Unify funcall and funcall_with_block into ValueLike::funcall that takes
an optional block.

This commit is made possible by and is a follow up to GH-248. This
commit is a prerequisite to implementing Value in artichoke-backend with
the Value trait in artichoke-core.

Simplify the signature of funcall to remove AsRef generics. The method is
now always an &str and the args always a &[Value].

This commit updates every funcall callsite in Artichoke. Update converted
return type to use &str converters to avoid allocations where possible.