### PR TITLE
Implement artichoke-backend Value with artichoke-core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,6 +59,7 @@ name = "artichoke-frontend"
 version = "0.1.0"
 dependencies = [
  "artichoke-backend 0.1.0",
+ "artichoke-core 0.1.0",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustyline 5.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -771,6 +772,7 @@ name = "spec-runner"
 version = "0.1.0"
 dependencies = [
  "artichoke-backend 0.1.0",
+ "artichoke-core 0.1.0",
  "fs_extra 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-embed 5.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/artichoke-backend/src/class.rs
+++ b/artichoke-backend/src/class.rs
@@ -209,6 +209,7 @@ mod tests {
     use crate::def::{ClassLike, Define, EnclosingRubyScope};
     use crate::eval::Eval;
     use crate::module;
+    use crate::value::ValueLike;
 
     #[test]
     fn super_class() {

--- a/artichoke-backend/src/convert/array.rs
+++ b/artichoke-backend/src/convert/array.rs
@@ -5,7 +5,7 @@ use crate::convert::float::Float;
 use crate::convert::{Convert, TryConvert};
 use crate::sys;
 use crate::types::{Int, Ruby, Rust};
-use crate::value::Value;
+use crate::value::{Value, ValueLike};
 use crate::{Artichoke, ArtichokeError};
 
 // bail out implementation for mixed-type collections
@@ -73,7 +73,7 @@ macro_rules! ruby_to_array {
                 let elems: Vec<Value> = self.try_convert(value)?;
                 let mut vec = <Vec<$elem>>::with_capacity(elems.len());
                 for elem in elems.into_iter() {
-                    let elem: $elem = self.try_convert(elem)?;
+                    let elem = elem.try_into::<$elem>()?;
                     vec.push(elem);
                 }
                 Ok(vec)

--- a/artichoke-backend/src/convert/boolean.rs
+++ b/artichoke-backend/src/convert/boolean.rs
@@ -47,6 +47,7 @@ mod tests {
     use crate::eval::Eval;
     use crate::sys;
     use crate::types::{Ruby, Rust};
+    use crate::value::ValueLike;
     use crate::ArtichokeError;
 
     #[test]

--- a/artichoke-backend/src/convert/bytes.rs
+++ b/artichoke-backend/src/convert/bytes.rs
@@ -70,6 +70,7 @@ mod tests {
     use crate::eval::Eval;
     use crate::sys;
     use crate::types::{Ruby, Rust};
+    use crate::value::ValueLike;
     use crate::ArtichokeError;
 
     #[test]

--- a/artichoke-backend/src/convert/fixnum.rs
+++ b/artichoke-backend/src/convert/fixnum.rs
@@ -132,7 +132,7 @@ mod tests {
     use crate::eval::Eval;
     use crate::sys;
     use crate::types::{Int, Ruby, Rust};
-    use crate::value::Value;
+    use crate::value::{Value, ValueLike};
     use crate::ArtichokeError;
 
     #[test]

--- a/artichoke-backend/src/convert/float.rs
+++ b/artichoke-backend/src/convert/float.rs
@@ -37,6 +37,7 @@ mod tests {
     use crate::eval::Eval;
     use crate::sys;
     use crate::types::{Ruby, Rust};
+    use crate::value::ValueLike;
     use crate::ArtichokeError;
 
     #[test]

--- a/artichoke-backend/src/convert/hash.rs
+++ b/artichoke-backend/src/convert/hash.rs
@@ -6,7 +6,7 @@ use crate::convert::float::Float;
 use crate::convert::{Convert, TryConvert};
 use crate::sys;
 use crate::types::{Int, Ruby, Rust};
-use crate::value::Value;
+use crate::value::{Value, ValueLike};
 use crate::{Artichoke, ArtichokeError};
 
 // TODO: implement `PartialEq`, `Eq`, and `Hash` on `Value`, see GH-159.

--- a/artichoke-backend/src/convert/hash.rs
+++ b/artichoke-backend/src/convert/hash.rs
@@ -539,7 +539,7 @@ mod tests {
 
     use crate::convert::Convert;
     use crate::types::Int;
-    use crate::value::Value;
+    use crate::value::{Value, ValueLike};
 
     #[test]
     fn roundtrip_kv() {

--- a/artichoke-backend/src/convert/nilable.rs
+++ b/artichoke-backend/src/convert/nilable.rs
@@ -7,7 +7,7 @@ use crate::convert::float::Float;
 use crate::convert::{Convert, TryConvert};
 use crate::sys;
 use crate::types::{Int, Ruby};
-use crate::value::Value;
+use crate::value::{Value, ValueLike};
 use crate::{Artichoke, ArtichokeError};
 
 // bail out implementation for mixed-type collections
@@ -51,8 +51,7 @@ macro_rules! ruby_to_option {
         impl<'a> TryConvert<Value, Option<$elem>> for Artichoke {
             fn try_convert(&self, value: Value) -> Result<Option<$elem>, ArtichokeError> {
                 if let Some(value) = self.convert(value) {
-                    let result: Result<$elem, _> = self.try_convert(value);
-                    result.map(Some)
+                    value.try_into::<$elem>().map(Some)
                 } else {
                     Ok(None)
                 }

--- a/artichoke-backend/src/convert/string.rs
+++ b/artichoke-backend/src/convert/string.rs
@@ -67,12 +67,13 @@ impl<'a> TryConvert<Value, &'a str> for Artichoke {
 // the tests for String to exercise both code paths.
 mod tests {
     use quickcheck_macros::quickcheck;
-    use std::convert::TryInto;
+    use std::convert::TryFrom;
 
     use crate::convert::Convert;
     use crate::eval::Eval;
     use crate::sys;
     use crate::types::{Ruby, Rust};
+    use crate::value::ValueLike;
     use crate::ArtichokeError;
 
     #[test]
@@ -96,7 +97,7 @@ mod tests {
         let ptr = unsafe { sys::mrb_string_value_ptr(interp.0.borrow().mrb, value.inner()) };
         let len = unsafe { sys::mrb_string_value_len(interp.0.borrow().mrb, value.inner()) };
         let string =
-            unsafe { std::slice::from_raw_parts(ptr as *const u8, len.try_into().unwrap()) };
+            unsafe { std::slice::from_raw_parts(ptr as *const u8, usize::try_from(len).unwrap()) };
         s.as_bytes() == string
     }
 

--- a/artichoke-backend/src/convert/string.rs
+++ b/artichoke-backend/src/convert/string.rs
@@ -4,7 +4,7 @@ use std::str;
 use crate::convert::{Convert, TryConvert};
 use crate::sys;
 use crate::types::{Ruby, Rust};
-use crate::value::Value;
+use crate::value::{Value, ValueLike};
 use crate::{Artichoke, ArtichokeError};
 
 impl Convert<String, Value> for Artichoke {

--- a/artichoke-backend/src/def.rs
+++ b/artichoke-backend/src/def.rs
@@ -370,6 +370,7 @@ mod tests {
         use crate::def::{ClassLike, Define};
         use crate::eval::Eval;
         use crate::sys;
+        use crate::value::ValueLike;
 
         #[test]
         fn define_method() {

--- a/artichoke-backend/src/eval.rs
+++ b/artichoke-backend/src/eval.rs
@@ -304,7 +304,7 @@ mod tests {
     use crate::file::File;
     use crate::load::LoadSources;
     use crate::sys;
-    use crate::value::Value;
+    use crate::value::{Value, ValueLike};
     use crate::{Artichoke, ArtichokeError};
 
     #[test]

--- a/artichoke-backend/src/extn/core/env/env_object.rs
+++ b/artichoke-backend/src/extn/core/env/env_object.rs
@@ -179,7 +179,7 @@ impl<T: EnvBackend> RustBackedValue for Env<T> where T: 'static {}
 mod tests {
     use crate::eval::Eval;
     use crate::extn::core::env;
-    use crate::value::Value;
+    use crate::value::{Value, ValueLike};
     use crate::ArtichokeError;
 
     #[test]

--- a/artichoke-backend/src/extn/core/env/env_object.rs
+++ b/artichoke-backend/src/extn/core/env/env_object.rs
@@ -5,7 +5,7 @@ use std::mem;
 use crate::extn::core::env::backends::EnvBackend;
 use crate::extn::core::env::Error;
 use crate::sys;
-use crate::value::Value;
+use crate::value::{Value, ValueLike};
 use crate::Artichoke;
 
 pub trait RubyEnvNativeApi {
@@ -46,7 +46,7 @@ impl<T: EnvBackend> Env<T> {
         let key_v = Value::new(interp, key);
         let value_v = Value::new(interp, value);
 
-        if sys::mrb_sys_value_is_nil(value_v.inner()) {
+        if value_v.is_nil() {
             (key_v.to_s(), None)
         } else {
             (key_v.to_s(), Some(value_v.to_s()))

--- a/artichoke-backend/src/extn/core/integer/mod.rs
+++ b/artichoke-backend/src/extn/core/integer/mod.rs
@@ -8,7 +8,7 @@ use crate::eval::Eval;
 use crate::extn::core::error::{ArgumentError, RangeError, RubyException, RuntimeError};
 use crate::sys;
 use crate::types::Int;
-use crate::value::Value;
+use crate::value::{Value, ValueLike};
 use crate::{Artichoke, ArtichokeError};
 
 pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {

--- a/artichoke-backend/src/extn/core/kernel/mod.rs
+++ b/artichoke-backend/src/extn/core/kernel/mod.rs
@@ -198,6 +198,7 @@ mod tests {
     use crate::eval::Eval;
     use crate::file::File;
     use crate::load::LoadSources;
+    use crate::value::ValueLike;
     use crate::{Artichoke, ArtichokeError};
 
     // Integration test for `Kernel::require`:

--- a/artichoke-backend/src/extn/core/matchdata/string.rs
+++ b/artichoke-backend/src/extn/core/matchdata/string.rs
@@ -2,7 +2,7 @@
 
 use crate::convert::{Convert, RustBackedValue};
 use crate::extn::core::matchdata::MatchData;
-use crate::value::Value;
+use crate::value::{Value, ValueLike};
 use crate::Artichoke;
 
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
@@ -12,10 +12,9 @@ pub enum Error {
 
 pub fn method(interp: &Artichoke, value: &Value) -> Result<Value, Error> {
     if let Ok(data) = unsafe { MatchData::try_from_ruby(interp, value) } {
-        interp
-            .convert(data.borrow().string.as_str())
-            .freeze()
-            .map_err(|_| Error::Fatal)
+        let mut result = interp.convert(data.borrow().string.as_str());
+        result.freeze().map_err(|_| Error::Fatal)?;
+        Ok(result)
     } else {
         Err(Error::Fatal)
     }

--- a/artichoke-backend/src/extn/core/regexp/enc.rs
+++ b/artichoke-backend/src/extn/core/regexp/enc.rs
@@ -4,7 +4,7 @@ use std::hash::{Hash, Hasher};
 
 use crate::extn::core::regexp::Regexp;
 use crate::types::Int;
-use crate::value::Value;
+use crate::value::{Value, ValueLike};
 
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
 pub enum Error {
@@ -75,7 +75,7 @@ pub fn parse(value: &Value) -> Result<Encoding, Error> {
         } else {
             Err(Error::InvalidEncoding)
         }
-    } else if let Ok(encoding) = value.itself::<String>() {
+    } else if let Ok(encoding) = value.itself::<&str>() {
         if encoding.contains('u') && encoding.contains('n') {
             return Err(Error::InvalidEncoding);
         }

--- a/artichoke-backend/src/extn/core/regexp/initialize.rs
+++ b/artichoke-backend/src/extn/core/regexp/initialize.rs
@@ -9,7 +9,7 @@ use crate::extn::core::regexp::enc::{self, Encoding};
 use crate::extn::core::regexp::opts::{self, Options};
 use crate::extn::core::regexp::Regexp;
 use crate::sys;
-use crate::value::Value;
+use crate::value::{Value, ValueLike};
 use crate::warn::Warn;
 use crate::Artichoke;
 

--- a/artichoke-backend/src/extn/core/regexp/opts.rs
+++ b/artichoke-backend/src/extn/core/regexp/opts.rs
@@ -4,7 +4,7 @@ use onig::RegexOptions;
 
 use crate::extn::core::regexp::Regexp;
 use crate::types::Int;
-use crate::value::Value;
+use crate::value::{Value, ValueLike};
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
 pub struct Options {
@@ -87,7 +87,7 @@ pub fn parse(value: &Value) -> Options {
             Some(false) | None => Options::default(),
             _ => Options::ignore_case(),
         }
-    } else if let Ok(options) = value.itself::<Option<String>>() {
+    } else if let Ok(options) = value.itself::<Option<&str>>() {
         if let Some(options) = options {
             Options {
                 multiline: options.contains('m'),

--- a/artichoke-backend/src/extn/core/string.rs
+++ b/artichoke-backend/src/extn/core/string.rs
@@ -5,7 +5,7 @@ use crate::def::{ClassLike, Define};
 use crate::eval::Eval;
 use crate::extn::core::error::{ArgumentError, RubyException, RuntimeError, TypeError};
 use crate::sys;
-use crate::value::Value;
+use crate::value::{Value, ValueLike};
 use crate::{Artichoke, ArtichokeError};
 
 mod scan;

--- a/artichoke-backend/src/extn/core/thread.rs
+++ b/artichoke-backend/src/extn/core/thread.rs
@@ -26,6 +26,7 @@ mod tests {
     #![allow(clippy::shadow_unrelated)]
 
     use crate::eval::Eval;
+    use crate::value::ValueLike;
     use crate::ArtichokeError;
 
     #[test]

--- a/artichoke-backend/src/extn/stdlib/forwardable.rs
+++ b/artichoke-backend/src/extn/stdlib/forwardable.rs
@@ -19,6 +19,7 @@ pub struct Forwardable;
 #[cfg(test)]
 mod tests {
     use crate::eval::Eval;
+    use crate::value::ValueLike;
 
     #[test]
     #[allow(clippy::shadow_unrelated)]

--- a/artichoke-backend/src/extn/stdlib/monitor.rs
+++ b/artichoke-backend/src/extn/stdlib/monitor.rs
@@ -18,6 +18,7 @@ pub struct Monitor;
 #[cfg(test)]
 mod tests {
     use crate::eval::Eval;
+    use crate::value::ValueLike;
 
     #[test]
     fn mon_initialize() {

--- a/artichoke-backend/src/gc.rs
+++ b/artichoke-backend/src/gc.rs
@@ -112,6 +112,7 @@ impl MrbGarbageCollection for Artichoke {
 mod tests {
     use crate::eval::Eval;
     use crate::gc::MrbGarbageCollection;
+    use crate::value::ValueLike;
 
     #[test]
     fn arena_restore_on_explicit_restore() {

--- a/artichoke-backend/src/lib.rs
+++ b/artichoke-backend/src/lib.rs
@@ -20,6 +20,7 @@
 //!
 //! ```rust
 //! use artichoke_backend::eval::Eval;
+//! use artichoke_core::value::Value as ValueLike;
 //!
 //! let interp = artichoke_backend::interpreter().unwrap();
 //! let result = interp.eval("10 * 10").unwrap();
@@ -56,6 +57,7 @@
 //! ```rust
 //! use artichoke_backend::eval::Eval;
 //! use artichoke_backend::load::LoadSources;
+//! use artichoke_core::value::Value as ValueLike;
 //!
 //! let mut interp = artichoke_backend::interpreter().unwrap();
 //! let code = "
@@ -66,8 +68,8 @@
 //! interp.def_rb_source_file("source.rb", code).unwrap();
 //! interp.eval("require 'source'").unwrap();
 //! let result = interp.eval("source_location").unwrap();
-//! let result = result.try_into::<String>().unwrap();
-//! assert_eq!(&result, "/src/lib/source.rb");
+//! let result = result.try_into::<&str>().unwrap();
+//! assert_eq!(result, "/src/lib/source.rb");
 //! ```
 //!
 //! ## Embed Rust Objects in `mrb_value`
@@ -109,6 +111,7 @@
 //! use artichoke_backend::sys;
 //! use artichoke_backend::value::Value;
 //! use artichoke_backend::{Artichoke, ArtichokeError};
+//! use artichoke_core::value::Value as ValueLike;
 //! use std::io::Write;
 //! use std::mem;
 //!

--- a/artichoke-backend/src/value.rs
+++ b/artichoke-backend/src/value.rs
@@ -169,7 +169,7 @@ impl ValueLike for Value {
 
         let _arena = self.interp.create_arena_savepoint();
 
-        let args = args.as_ref().iter().map(Value::inner).collect::<Vec<_>>();
+        let args = args.as_ref().iter().map(Self::inner).collect::<Vec<_>>();
         if args.len() > MRB_FUNCALL_ARGC_MAX {
             warn!(
                 "Too many args supplied to funcall: given {}, max {}.",
@@ -207,7 +207,7 @@ impl ValueLike for Value {
             }
             value
         };
-        let value = Value::new(&self.interp, value);
+        let value = Self::new(&self.interp, value);
 
         match self.interp.last_error() {
             LastError::Some(exception) => {
@@ -262,7 +262,7 @@ impl ValueLike for Value {
     }
 
     fn respond_to(&self, method: &str) -> Result<bool, ArtichokeError> {
-        let method: Value = self.interp.convert(method);
+        let method = self.interp.convert(method);
         self.funcall::<bool>("respond_to?", &[method], None)
     }
 

--- a/artichoke-backend/tests/leak_funcall.rs
+++ b/artichoke-backend/tests/leak_funcall.rs
@@ -15,7 +15,8 @@
 
 use artichoke_backend::convert::Convert;
 use artichoke_backend::gc::MrbGarbageCollection;
-use artichoke_backend::value::{Value, ValueLike};
+use artichoke_backend::value::Value;
+use artichoke_core::value::Value as ValueLike;
 
 mod leak;
 

--- a/artichoke-backend/tests/leak_mrb_tt_data_rc.rs
+++ b/artichoke-backend/tests/leak_mrb_tt_data_rc.rs
@@ -26,6 +26,7 @@ use artichoke_backend::load::LoadSources;
 use artichoke_backend::sys;
 use artichoke_backend::value::Value;
 use artichoke_backend::{Artichoke, ArtichokeError};
+use artichoke_core::value::Value as ValueLike;
 use std::mem;
 
 mod leak;

--- a/artichoke-backend/tests/leak_unbounded_arena_growth.rs
+++ b/artichoke-backend/tests/leak_unbounded_arena_growth.rs
@@ -23,6 +23,7 @@
 use artichoke_backend::eval::Eval;
 use artichoke_backend::gc::MrbGarbageCollection;
 use artichoke_backend::ArtichokeError;
+use artichoke_core::value::Value as ValueLike;
 
 mod leak;
 

--- a/artichoke-backend/tests/leak_unbounded_arena_growth.rs
+++ b/artichoke-backend/tests/leak_unbounded_arena_growth.rs
@@ -1,6 +1,7 @@
-#![cfg(not(target_os = "macos"))]
 #![deny(clippy::all, clippy::pedantic)]
 #![deny(warnings, intra_doc_link_resolution_failure)]
+// Tests are compiled but not executed on macOS
+#![cfg_attr(target_os = "macos", allow(dead_code))]
 
 //! This integration test checks for memory leaks that stem from improper
 //! handling of `mrb_state`.
@@ -30,7 +31,7 @@ mod leak;
 const ITERATIONS: usize = 100;
 const LEAK_TOLERANCE: i64 = 1024 * 1024 * 15;
 
-#[test]
+#[cfg_attr(not(target_os = "macos"), test)]
 fn unbounded_arena_growth() {
     // ArtichokeApi::current_exception
     let interp = artichoke_backend::interpreter().expect("init");

--- a/artichoke-backend/tests/manual.rs
+++ b/artichoke-backend/tests/manual.rs
@@ -12,6 +12,7 @@ use artichoke_backend::load::LoadSources;
 use artichoke_backend::sys;
 use artichoke_backend::value::Value;
 use artichoke_backend::{Artichoke, ArtichokeError};
+use artichoke_core::value::Value as ValueLike;
 use std::mem;
 
 #[derive(Clone, Debug, Default)]

--- a/artichoke-core/src/value.rs
+++ b/artichoke-core/src/value.rs
@@ -18,7 +18,7 @@ where
     type Block;
 
     /// Call a method on this [`Value`] with arguments and an optional block.
-    fn funcall<T, M, A>(
+    fn funcall<T>(
         &self,
         func: &str,
         args: &[Self::Arg],
@@ -45,15 +45,18 @@ where
     /// Call `#freeze` on this [`Value`].
     fn freeze(&mut self) -> Result<(), ArtichokeError>;
 
-    /// Call `#inspect` on this [`Value`].
-    ///
-    /// This function can never fail.
-    fn inspect(&self) -> String;
+    /// Whether `self` is `nil`
+    fn is_nil(&self) -> bool;
 
     /// Whether `self` responds to a method.
     ///
     /// Equivalent to invoking `#respond_to?` on this [`Value`].
     fn respond_to(&self, method: &str) -> Result<bool, ArtichokeError>;
+
+    /// Call `#inspect` on this [`Value`].
+    ///
+    /// This function can never fail.
+    fn inspect(&self) -> String;
 
     /// Call `#to_s` on this [`Value`].
     ///

--- a/artichoke-frontend/Cargo.toml
+++ b/artichoke-frontend/Cargo.toml
@@ -12,3 +12,6 @@ rustyline = "5.0.2"
 
 [dependencies.artichoke-backend]
 path = "../artichoke-backend"
+
+[dependencies.artichoke-core]
+path = "../artichoke-core"

--- a/artichoke-frontend/src/repl.rs
+++ b/artichoke-frontend/src/repl.rs
@@ -11,6 +11,7 @@ use artichoke_backend::eval::{Context, Eval};
 use artichoke_backend::gc::MrbGarbageCollection;
 use artichoke_backend::sys;
 use artichoke_backend::ArtichokeError;
+use artichoke_core::value::Value;
 use rustyline::error::ReadlineError;
 use rustyline::Editor;
 use std::io::{self, Write};

--- a/spec-runner/Cargo.toml
+++ b/spec-runner/Cargo.toml
@@ -9,6 +9,9 @@ edition = "2018"
 [dependencies.artichoke-backend]
 path = "../artichoke-backend"
 
+[dependencies.artichoke-core]
+path = "../artichoke-core"
+
 [dependencies.rust-embed]
 version = "5.1.0"
 features = ["interpolate-folder-path"]

--- a/spec-runner/src/mspec.rs
+++ b/spec-runner/src/mspec.rs
@@ -4,8 +4,8 @@ use artichoke_backend::convert::Convert;
 use artichoke_backend::eval::Eval;
 use artichoke_backend::load::LoadSources;
 use artichoke_backend::top_self::TopSelf;
-use artichoke_backend::value::ValueLike;
 use artichoke_backend::{Artichoke, ArtichokeError};
+use artichoke_core::value::Value;
 
 pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
     interp.def_rb_source_file("mspec.rb", include_str!("mspec.rb"))?;


### PR DESCRIPTION
Followup to GH-250 and GH-248.

- Simplify type signature of artichoke-core Value::funcall.
- Add artichoke-core Value::is_nil.
- Use Value::try_into more places in converter implementations.
- Re-export (crate internal) artichoke-core Value as artichoke-backend
  value::ValueLike for compatibility.
- Refer to Value trait in artichoke-core in artichoke-frontend and
  spec-runner.
- Use slice converters in more places.
- Mark artichoke-backend Value::inner `#[inline]`.