### PR TITLE
Improve log ergonomics in artichoke-backend

### DIFF
--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2018"
 
 [dependencies]
-log = "0.4.6"
+log = "0.4"
 regex = "1"
 
 [dependencies.artichoke-core]

--- a/artichoke-backend/src/convert/object.rs
+++ b/artichoke-backend/src/convert/object.rs
@@ -1,4 +1,3 @@
-use log::warn;
 use std::cell::RefCell;
 use std::convert::TryInto;
 use std::ffi::c_void;

--- a/artichoke-backend/src/eval.rs
+++ b/artichoke-backend/src/eval.rs
@@ -1,4 +1,3 @@
-use log::{error, trace, warn};
 use std::ffi::{c_void, CString};
 use std::mem;
 

--- a/artichoke-backend/src/exception.rs
+++ b/artichoke-backend/src/exception.rs
@@ -1,4 +1,3 @@
-use log::{debug, trace};
 use std::ffi::c_void;
 use std::fmt;
 

--- a/artichoke-backend/src/extn/core/comparable/mod.rs
+++ b/artichoke-backend/src/extn/core/comparable/mod.rs
@@ -1,5 +1,3 @@
-use log::trace;
-
 use crate::def::Define;
 use crate::eval::Eval;
 use crate::{Artichoke, ArtichokeError};

--- a/artichoke-backend/src/extn/core/env/mod.rs
+++ b/artichoke-backend/src/extn/core/env/mod.rs
@@ -1,4 +1,3 @@
-use log::trace;
 use std::error;
 use std::fmt;
 

--- a/artichoke-backend/src/extn/core/error.rs
+++ b/artichoke-backend/src/extn/core/error.rs
@@ -1,4 +1,3 @@
-use log::warn;
 use std::ffi::CString;
 use std::rc::Rc;
 

--- a/artichoke-backend/src/extn/core/integer/mod.rs
+++ b/artichoke-backend/src/extn/core/integer/mod.rs
@@ -1,4 +1,3 @@
-use log::trace;
 use std::convert::TryFrom;
 use std::mem;
 

--- a/artichoke-backend/src/extn/core/kernel/mod.rs
+++ b/artichoke-backend/src/extn/core/kernel/mod.rs
@@ -1,5 +1,3 @@
-use log::trace;
-
 use crate::convert::Convert;
 use crate::def::{ClassLike, Define};
 use crate::eval::{Context, Eval};

--- a/artichoke-backend/src/extn/core/kernel/require.rs
+++ b/artichoke-backend/src/extn/core/kernel/require.rs
@@ -80,7 +80,7 @@ impl Args {
 }
 
 pub mod method {
-    use log::trace;
+
     use std::path::{Path, PathBuf};
 
     use crate::eval::Eval;

--- a/artichoke-backend/src/extn/core/string.rs
+++ b/artichoke-backend/src/extn/core/string.rs
@@ -1,5 +1,3 @@
-use log::trace;
-
 use crate::convert::TryConvert;
 use crate::def::{ClassLike, Define};
 use crate::eval::Eval;

--- a/artichoke-backend/src/ffi.rs
+++ b/artichoke-backend/src/ffi.rs
@@ -2,7 +2,6 @@
 //!
 //! These functions are unsafe. Use them carefully.
 
-use log::{error, trace};
 use std::cell::RefCell;
 use std::mem;
 use std::rc::Rc;

--- a/artichoke-backend/src/interpreter.rs
+++ b/artichoke-backend/src/interpreter.rs
@@ -1,4 +1,3 @@
-use log::{debug, error};
 use std::cell::RefCell;
 use std::ffi::c_void;
 use std::rc::Rc;

--- a/artichoke-backend/src/lib.rs
+++ b/artichoke-backend/src/lib.rs
@@ -206,6 +206,9 @@
 //! The infallible converters are safe Rust functions. The fallibile converters are
 //! `unsafe` Rust functions.
 
+#[macro_use]
+extern crate log;
+
 use std::cell::RefCell;
 use std::rc::Rc;
 

--- a/artichoke-backend/src/load.rs
+++ b/artichoke-backend/src/load.rs
@@ -1,4 +1,3 @@
-use log::trace;
 use std::path::PathBuf;
 
 use crate::file::File;

--- a/artichoke-backend/src/value.rs
+++ b/artichoke-backend/src/value.rs
@@ -1,4 +1,3 @@
-use log::{error, trace, warn};
 use std::convert::TryFrom;
 use std::ffi::c_void;
 use std::fmt;

--- a/artichoke-backend/src/warn.rs
+++ b/artichoke-backend/src/warn.rs
@@ -1,5 +1,3 @@
-use log::warn;
-
 use crate::convert::Convert;
 use crate::sys;
 use crate::value::{Value, ValueLike};


### PR DESCRIPTION
- Relax log dep to `0.4`.
- Import macros globally with `macro_use` + `extern crate log`.
- Remove explicit macro imports.

This makes it easier to log in `artichoke-backend`.