### PR TITLE
Prepare for adding ENV to spec-compliance.sh

### DIFF
--- a/artichoke-backend/src/extn/core/error.rs
+++ b/artichoke-backend/src/extn/core/error.rs
@@ -1,3 +1,43 @@
+//! # Ruby Exception Hierarchy
+//!
+//! The built-in subclasses of
+//! [`Exception`](https://ruby-doc.org/core-2.6.3/Exception.html) are:
+//!
+//! - NoMemoryError
+//! - ScriptError
+//!   - LoadError
+//!   - NotImplementedError
+//!   - SyntaxError
+//! - SecurityError
+//! - SignalException
+//!   - Interrupt
+//! - StandardError -- default for `rescue`
+//!   - ArgumentError
+//!     - UncaughtThrowError
+//!   - EncodingError
+//!   - FiberError
+//!   - IOError
+//!     - EOFError
+//!   - IndexError
+//!     - KeyError
+//!     - StopIteration
+//!   - LocalJumpError
+//!   - NameError
+//!     - NoMethodError
+//!   - RangeError
+//!     - FloatDomainError
+//!   - RegexpError
+//!   - RuntimeError -- default for `raise`
+//!     - FrozenError
+//!   - SystemCallError
+//!     - Errno::*
+//!   - ThreadError
+//!   - TypeError
+//!   - ZeroDivisionError
+//! - SystemExit
+//! - SystemStackError
+//! - fatal -- impossible to rescue
+
 use std::ffi::CString;
 use std::rc::Rc;
 

--- a/artichoke-backend/src/extn/core/error.rs
+++ b/artichoke-backend/src/extn/core/error.rs
@@ -3,40 +3,40 @@
 //! The built-in subclasses of
 //! [`Exception`](https://ruby-doc.org/core-2.6.3/Exception.html) are:
 //!
-//! - NoMemoryError
-//! - ScriptError
-//!   - LoadError
-//!   - NotImplementedError
-//!   - SyntaxError
-//! - SecurityError
-//! - SignalException
-//!   - Interrupt
-//! - StandardError -- default for `rescue`
-//!   - ArgumentError
-//!     - UncaughtThrowError
-//!   - EncodingError
-//!   - FiberError
-//!   - IOError
-//!     - EOFError
-//!   - IndexError
-//!     - KeyError
-//!     - StopIteration
-//!   - LocalJumpError
-//!   - NameError
-//!     - NoMethodError
-//!   - RangeError
-//!     - FloatDomainError
-//!   - RegexpError
-//!   - RuntimeError -- default for `raise`
-//!     - FrozenError
-//!   - SystemCallError
-//!     - Errno::*
-//!   - ThreadError
-//!   - TypeError
-//!   - ZeroDivisionError
-//! - SystemExit
-//! - SystemStackError
-//! - fatal -- impossible to rescue
+//! - `NoMemoryError`
+//! - `ScriptError`
+//!   - `LoadError`
+//!   - `NotImplementedError`
+//!   - `SyntaxError`
+//! - `SecurityError`
+//! - `SignalException`
+//!   - `Interrupt`
+//! - `StandardError` -- default for `rescue`
+//!   - `ArgumentError`
+//!     - `UncaughtThrowError`
+//!   - `EncodingError`
+//!   - `FiberError`
+//!   - `IOError`
+//!     - `EOFError`
+//!   - `IndexError`
+//!     - `KeyError`
+//!     - `StopIteration`
+//!   - `LocalJumpError`
+//!   - `NameError`
+//!     - `NoMethodError`
+//!   - `RangeError`
+//!     - `FloatDomainError`
+//!   - `RegexpError`
+//!   - `RuntimeError` -- default for `raise`
+//!     - `FrozenError`
+//!   - `SystemCallError`
+//!     - `Errno::*`
+//!   - `ThreadError`
+//!   - `TypeError`
+//!   - `ZeroDivisionError`
+//! - `SystemExit`
+//! - `SystemStackError`
+//! - `fatal` -- impossible to rescue
 
 use std::ffi::CString;
 use std::rc::Rc;

--- a/artichoke-backend/src/extn/core/string.rb
+++ b/artichoke-backend/src/extn/core/string.rb
@@ -12,6 +12,7 @@ class Encoding
   US_ASCII = new('US-ASCII')
   ASCII = US_ASCII
   EUC_JP = new('EUC-JP')
+  IBM437 = new('IBM437')
   ISO_8859_1 = new('ISO-8859-1')
   Shift_JIS = new('Shift_JIS')
   SHIFT_JIS = Shift_JIS

--- a/scripts/spec-compliance.sh
+++ b/scripts/spec-compliance.sh
@@ -10,13 +10,13 @@ spec_runner="$(pwd)/target/debug/spec-runner"
 
 run_core_spec() {
   pushd "spec-runner/vendor/spec/core" >/dev/null
-  $spec_runner "$1"/**/*.rb
+  $spec_runner ../**/shared/**/*.rb "$1"/**/*.rb
   popd >/dev/null
 }
 
 run_library_spec() {
   pushd "spec-runner/vendor/spec/library" >/dev/null
-  $spec_runner "$1"/**/*.rb
+  $spec_runner ../**/shared/**/*.rb "$1"/**/*.rb
   popd >/dev/null
 }
 


### PR DESCRIPTION
Prep to make GH-268 easier.

- Include all shared setups when running specs, not just the ones in the target class.
- Add `Encoding` stub to get `ENV` specs to load.
- Add docs for Ruby `Exception` hierarchy.

The `Exception` docs will come in handy because `ENV` requires an implementation of `Errno::EINVAL`.