### PR TITLE
Add RUBY_* global constants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,6 +35,7 @@ version = "0.1.0"
 dependencies = [
  "artichoke-core 0.1.0",
  "artichoke-vfs 0.5.0-alpha",
+ "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs_extra 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -45,6 +46,8 @@ dependencies = [
  "quickcheck_macros 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "target-lexicon 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -79,6 +82,11 @@ dependencies = [
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "autocfg"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "backtrace"
@@ -195,6 +203,17 @@ dependencies = [
 name = "cfg-if"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "chrono"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "clang-sys"
@@ -371,6 +390,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -444,6 +468,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -732,6 +773,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "same-file"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -756,6 +802,21 @@ dependencies = [
 name = "semver-parser"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "serde"
+version = "1.0.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "serde_json"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ryu 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "shellexpand"
@@ -822,6 +883,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "target-lexicon"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -843,6 +914,16 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "time"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -951,6 +1032,7 @@ dependencies = [
 "checksum arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0d382e583f07208808f6b1249e60848879ba3543f57c32277bf52d69c2f0f0ee"
 "checksum arrayvec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "b8d73f9beda665eaa98ab9e4f7442bd4e7de6652587de55b2525e52e29c1b0ba"
 "checksum atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90"
+"checksum autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "b671c8fb71b457dd4ae18c4ba1e59aa81793daacc361d82fcd410cef0d491875"
 "checksum backtrace 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)" = "1371048253fa3bac6704bfd6bbfc922ee9bdcee8881330d40f308b81cc5adc55"
 "checksum backtrace-sys 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "82a830b4ef2d1124a711c71d263c5abdc710ef8e907bd508c88be475cebc422b"
 "checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
@@ -963,6 +1045,7 @@ dependencies = [
 "checksum cc 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)" = "8dae9c4b8fedcae85592ba623c4fd08cfdab3e3b72d6df780c6ead964a69bfff"
 "checksum cexpr 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a7fa24eb00d5ffab90eaeaf1092ac85c04c64aaf358ea6f84505b8116d24c6af"
 "checksum cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
+"checksum chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e8493056968583b0193c1bb04d6f7684586f3726992d6c573261941a895dbd68"
 "checksum clang-sys 0.28.1 (registry+https://github.com/rust-lang/crates.io-index)" = "81de550971c976f176130da4b2978d3b524eaa0fd9ac31f3ceb5ae1231fb4853"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
@@ -983,6 +1066,7 @@ dependencies = [
 "checksum getrandom 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "fc344b02d3868feb131e8b5fe2b9b0a1cc42942679af493061fc13b853243872"
 "checksum glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 "checksum humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ca7e5f2e110db35f93b837c81797f3714500b81d517bf20c431b16d3ca4f114"
+"checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)" = "34fcd2c08d2f832f376f4173a231990fa5aef4e99fb569867318a227ef4c06ba"
 "checksum libloading 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f2b111a074963af1d37a139918ac6d49ad1d0d5e47f72fd55388619691a7d753"
@@ -992,6 +1076,8 @@ dependencies = [
 "checksum nix 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6c722bee1037d430d0f8e687bbdbf222f27cc6e4e68d5caf630857bb2b6dbdce"
 "checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
 "checksum nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
+"checksum num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "b85e541ef8255f6cf42bbfe4ef361305c6c135d10919ecc26126c4e5ae94bc09"
+"checksum num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"
 "checksum num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bcef43580c035376c0705c42792c294b66974abbfd2789b511784023f71f3273"
 "checksum onig 5.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e4e723fc996fff1aeab8f62205f3e8528bf498bdd5eadb2784d2d31f30077947"
 "checksum onig_sys 69.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0a8d4efbf5f59cece01f539305191485b651acb3785b9d5eef05749f0496514e"
@@ -1025,10 +1111,13 @@ dependencies = [
 "checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum rustyline 5.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f8ee0838a6594169a1c5f4bb9af0fe692cc99691941710a8cc6576395ede804e"
+"checksum ryu 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c92464b447c0ee8c4fb3824ecc8383b81717b9f1e74ba2e72540aef7b9f82997"
 "checksum same-file 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "585e8ddcedc187886a30fa705c47985c3fa88d06624095856b36ca0b82ff4421"
 "checksum scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+"checksum serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)" = "fec2851eb56d010dc9a21b89ca53ee75e6528bab60c11e89d38390904982da9f"
+"checksum serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)" = "051c49229f282f7c6f3813f8286cc1e3323e8051823fce42c7ea80fe13521704"
 "checksum shellexpand 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de7a5b5a9142fd278a10e0209b021a1b85849352e6951f4f914735c976737564"
 "checksum shlex 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
@@ -1036,9 +1125,11 @@ dependencies = [
 "checksum syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)" = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 "checksum synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "02353edf96d6e4dc81aea2d8490a7e9db177bf8acb0e951c24940bf866cb313f"
+"checksum target-lexicon 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7975cb2c6f37d77b190bc5004a2bb015971464756fde9514651a525ada2a741a"
 "checksum termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "96d6098003bde162e4277c70665bd87c326f5a0c3f3fbfb285787fa482d54e6e"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
+"checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
 "checksum unicode-segmentation 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1967f4cdfc355b37fd76d2a954fb2ed3871034eb4f26d60537d88795cfc332a9"
 "checksum unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7007dbd421b92cc6e28410fe7362e2e0a2503394908f417b68ec8d1c364c4e20"
 "checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,7 +63,6 @@ version = "0.1.0"
 dependencies = [
  "artichoke-backend 0.1.0",
  "artichoke-core 0.1.0",
- "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustyline 5.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -29,5 +29,8 @@ quickcheck = "0.9"
 quickcheck_macros = "0.8"
 
 [build-dependencies]
+chrono = "0.4"
 fs_extra = "1.1.0"
 rayon = "1.1"
+rustc_version = "0.2.3"
+target-lexicon = "0.8.1"

--- a/artichoke-backend/build.rs
+++ b/artichoke-backend/build.rs
@@ -311,7 +311,7 @@ fn main() {
     let mut commit = metadata.commit_hash.unwrap();
     commit.truncate(7);
     println!(
-        "cargo:rustc-env=ARTICHOKE_COMPILER_VERSION=rustc {} [{}] on {}",
+        "cargo:rustc-env=ARTICHOKE_COMPILER_VERSION=Rust {} (rev {}) on {}",
         metadata.semver, commit, metadata.host
     );
 }

--- a/artichoke-backend/build.rs
+++ b/artichoke-backend/build.rs
@@ -2,12 +2,15 @@
 #![deny(warnings, intra_doc_link_resolution_failure)]
 #![doc(deny(warnings))]
 
+use chrono::{DateTime, Datelike, NaiveDateTime, Utc};
 use fs_extra::dir;
 use rayon::prelude::*;
 use std::env;
 use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
+use std::str::FromStr;
+use target_lexicon::Triple;
 
 /// Path helpers
 struct Build;
@@ -222,4 +225,93 @@ fn main() {
         });
         Build::generate_rust_glue(package, sources);
     });
+
+    // Release information
+
+    // birth date taken from git log of first commit.
+    let initial_commit = Command::new("git")
+        .arg("rev-list")
+        .arg("--max-parents=0")
+        .arg("HEAD")
+        .output()
+        .unwrap();
+    if !initial_commit.status.success() {
+        panic!(
+            "Command executed with failing error: {}",
+            String::from_utf8(initial_commit.stderr).unwrap()
+        );
+    }
+    let initial_commit = String::from_utf8(initial_commit.stdout).unwrap();
+    let birth_date = Command::new("git")
+        .arg("show")
+        .arg("--no-patch")
+        .arg("--format=%cD")
+        .arg(initial_commit.trim())
+        .output()
+        .unwrap();
+    if !birth_date.status.success() {
+        panic!(
+            "Command executed with failing error: {}",
+            String::from_utf8(birth_date.stderr).unwrap()
+        );
+    }
+    let birth_date = String::from_utf8(birth_date.stdout).unwrap();
+    let birth_date =
+        <DateTime<Utc>>::from(DateTime::parse_from_rfc2822(birth_date.trim()).expect("birth"));
+    let build_date: DateTime<Utc> = Utc::now();
+    println!(
+        "cargo:rustc-env=RUBY_RELEASE_DATE={}",
+        NaiveDateTime::from_timestamp(build_date.timestamp(), 0).date()
+    );
+    println!("cargo:rustc-env=RUBY_RELEASE_YEAR={}", build_date.year());
+    println!("cargo:rustc-env=RUBY_RELEASE_MONTH={}", build_date.month());
+    println!("cargo:rustc-env=RUBY_RELEASE_DAY={}", build_date.day());
+
+    let revision_count = Command::new("git")
+        .arg("rev-list")
+        .arg("--count")
+        .arg("HEAD")
+        .output()
+        .unwrap();
+    if !revision_count.status.success() {
+        panic!(
+            "Command executed with failing error: {}",
+            String::from_utf8(revision_count.stderr).unwrap()
+        );
+    }
+    let revision_count = String::from_utf8(revision_count.stdout).unwrap();
+    println!("cargo:rustc-env=RUBY_REVISION={}", revision_count);
+
+    let target_platform = Triple::from_str(env::var("TARGET").unwrap().as_str()).unwrap();
+    let ruby_platform = format!(
+        "{}-{}",
+        target_platform.architecture, target_platform.operating_system
+    );
+    println!("cargo:rustc-env=RUBY_PLATFORM={}", ruby_platform);
+
+    println!(
+        "cargo:rustc-env=RUBY_COPYRIGHT=Copyright (c) {} Ryan Lopopolo <rjl@hyperbo.la>",
+        if birth_date.year() == build_date.year() {
+            format!("{}", birth_date.year())
+        } else {
+            format!("{}-{}", birth_date.year(), build_date.year())
+        }
+    );
+
+    println!(
+        "cargo:rustc-env=RUBY_DESCRIPTION=artichoke {} ({} revision {}) [{}]",
+        env::var("CARGO_PKG_VERSION").unwrap(),
+        NaiveDateTime::from_timestamp(build_date.timestamp(), 0).date(),
+        revision_count.trim(),
+        ruby_platform
+    );
+
+    // compiler info
+    let metadata = rustc_version::version_meta().unwrap();
+    let mut commit = metadata.commit_hash.unwrap();
+    commit.truncate(7);
+    println!(
+        "cargo:rustc-env=ARTICHOKE_COMPILER_VERSION=rustc {} [{}] on {}",
+        metadata.semver, commit, metadata.host
+    );
 }

--- a/artichoke-backend/src/extn/mod.rs
+++ b/artichoke-backend/src/extn/mod.rs
@@ -1,35 +1,62 @@
 use crate::convert::Convert;
 use crate::sys;
+use crate::types::Int;
 use crate::{Artichoke, ArtichokeError};
 
 pub mod core;
 pub mod stdlib;
 
-pub const RUBY_PLATFORM: &str = "x86_64-unknown-artichoke";
+pub const RUBY_COPYRIGHT: &str = env!("RUBY_COPYRIGHT");
+pub const RUBY_DESCRIPTION: &str = env!("RUBY_DESCRIPTION");
+pub const RUBY_ENGINE: &str = "artichoke";
+pub const RUBY_ENGINE_VERSION: &str = env!("CARGO_PKG_VERSION");
+pub const RUBY_PATCHLEVEL: &str = "0";
+pub const RUBY_PLATFORM: &str = env!("RUBY_PLATFORM");
+pub const RUBY_RELEASE_DATE: &str = env!("RUBY_RELEASE_DATE");
+pub const RUBY_REVISION: &str = env!("RUBY_REVISION");
+pub const RUBY_VERSION: &str = "2.6.3";
+
+pub const ARTICHOKE_COMPILER_VERSION: &str = env!("ARTICHOKE_COMPILER_VERSION");
+
 pub const INPUT_RECORD_SEPARATOR: &str = "\n";
 
+macro_rules! global_const {
+    ($interp:expr, $constant:ident) => {
+        let mrb = $interp.0.borrow().mrb;
+        unsafe {
+            sys::mrb_define_global_const(
+                mrb,
+                concat!(stringify!($constant), "\0").as_ptr() as *const i8,
+                $interp.convert($constant).inner(),
+            );
+        }
+    };
+    ($interp:expr, $constant:ident as Int) => {
+        let mrb = $interp.0.borrow().mrb;
+        let constant = $constant.parse::<Int>().map_err(|_| ArtichokeError::New)?;
+        unsafe {
+            sys::mrb_define_global_const(
+                mrb,
+                concat!(stringify!($constant), "\0").as_ptr() as *const i8,
+                $interp.convert(constant).inner(),
+            );
+        }
+    };
+}
+
 pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
-    let mrb = interp.0.borrow().mrb;
-    unsafe {
-        let ruby_platform = interp.convert(RUBY_PLATFORM);
-        sys::mrb_define_global_const(
-            mrb,
-            b"RUBY_PLATFORM\0".as_ptr() as *const i8,
-            ruby_platform.inner(),
-        );
-        let ruby_description = interp.convert(sys::mruby_sys_version(true));
-        sys::mrb_define_global_const(
-            mrb,
-            b"RUBY_DESCRIPTION\0".as_ptr() as *const i8,
-            ruby_description.inner(),
-        );
-        let input_record_separator = interp.convert(INPUT_RECORD_SEPARATOR);
-        sys::mrb_gv_set(
-            mrb,
-            interp.0.borrow_mut().sym_intern("$/"),
-            input_record_separator.inner(),
-        );
-    }
+    global_const!(interp, RUBY_COPYRIGHT);
+    global_const!(interp, RUBY_DESCRIPTION);
+    global_const!(interp, RUBY_ENGINE);
+    global_const!(interp, RUBY_ENGINE_VERSION);
+    global_const!(interp, RUBY_PATCHLEVEL as Int);
+    global_const!(interp, RUBY_PLATFORM);
+    global_const!(interp, RUBY_RELEASE_DATE);
+    global_const!(interp, RUBY_REVISION as Int);
+    global_const!(interp, RUBY_VERSION);
+
+    global_const!(interp, ARTICHOKE_COMPILER_VERSION);
+
     core::init(interp)?;
     stdlib::init(interp)?;
     Ok(())

--- a/artichoke-backend/src/extn/mod.rs
+++ b/artichoke-backend/src/extn/mod.rs
@@ -21,7 +21,7 @@ pub const ARTICHOKE_COMPILER_VERSION: &str = env!("ARTICHOKE_COMPILER_VERSION");
 pub const INPUT_RECORD_SEPARATOR: &str = "\n";
 
 macro_rules! global_const {
-    ($interp:expr, $constant:ident) => {
+    ($interp:expr, $constant:ident) => {{
         let mrb = $interp.0.borrow().mrb;
         unsafe {
             sys::mrb_define_global_const(
@@ -30,8 +30,8 @@ macro_rules! global_const {
                 $interp.convert($constant).inner(),
             );
         }
-    };
-    ($interp:expr, $constant:ident as Int) => {
+    }};
+    ($interp:expr, $constant:ident as Int) => {{
         let mrb = $interp.0.borrow().mrb;
         let constant = $constant.parse::<Int>().map_err(|_| ArtichokeError::New)?;
         unsafe {
@@ -41,7 +41,7 @@ macro_rules! global_const {
                 $interp.convert(constant).inner(),
             );
         }
-    };
+    }};
 }
 
 pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {

--- a/artichoke-frontend/Cargo.toml
+++ b/artichoke-frontend/Cargo.toml
@@ -4,9 +4,6 @@ version = "0.1.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2018"
 
-[dependencies]
-rustc_version = "0.2.3"
-
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 rustyline = "5.0.2"
 


### PR DESCRIPTION
Add the following constants to the VM when initializing `extn`:

```ruby
RUBY_COPYRIGHT
RUBY_DESCRIPTION
RUBY_ENGINE
RUBY_ENGINE_VERSION
RUBY_PATCHLEVEL
RUBY_PLATFORM
RUBY_RELEASE_DATE
RUBY_REVISION
RUBY_VERSION
```

Also add these Artichoke-specific constants:

```ruby
ARTICHOKE_COMPILER_VERSION
```

These constants are generated at compile time in `build.rs`.

TODO: include backend type in `RUBY_ENGINE_VERSION`.