### PR TITLE
Prepare File and Load traits in artichoke-core for use in artichoke-backend

### DIFF
--- a/artichoke-core/src/file.rs
+++ b/artichoke-core/src/file.rs
@@ -13,5 +13,5 @@ pub trait File {
     /// This function can mutate interpreter state, such as defining classes and
     /// modules. This function is equivalent to the "init" methods of
     /// C-implemented Rubygems.
-    fn require(interp: Self::Artichoke) -> Result<(), ArtichokeError>;
+    fn require(interp: &Self::Artichoke) -> Result<(), ArtichokeError>;
 }

--- a/artichoke-core/src/load.rs
+++ b/artichoke-core/src/load.rs
@@ -1,5 +1,7 @@
 //! Load Ruby and Rust sources into the VM.
 
+use std::path::Path;
+
 use crate::file::File;
 use crate::ArtichokeError;
 
@@ -19,7 +21,7 @@ pub trait LoadSources {
     /// filesystem relative to `RUBY_LOAD_PATH`. If the path is absolute, the
     /// file is placed directly on the filesystem. Anscestor directories are
     /// created automatically.
-    fn def_file(&self, filename: &str, require: Self::Require) -> Result<(), ArtichokeError>;
+    fn def_file(&self, filename: Path, require: Self::Require) -> Result<(), ArtichokeError>;
 
     /// Add a Rust-backed Ruby source file to the virtual filesystem. A stub
     /// Ruby file is added to the filesystem and [`File::require`] will
@@ -29,7 +31,7 @@ pub trait LoadSources {
     /// filesystem relative to `RUBY_LOAD_PATH`. If the path is absolute, the
     /// file is placed directly on the filesystem. Anscestor directories are
     /// created automatically.
-    fn def_file_for_type<F>(&self, filename: &str) -> Result<(), ArtichokeError>
+    fn def_file_for_type<F>(&self, filename: Path) -> Result<(), ArtichokeError>
     where
         F: File;
 
@@ -39,9 +41,5 @@ pub trait LoadSources {
     /// filesystem relative to `RUBY_LOAD_PATH`. If the path is absolute, the
     /// file is placed directly on the filesystem. Anscestor directories are
     /// created automatically.
-    fn def_rb_source_file<T, F>(
-        &self,
-        filename: &str,
-        contents: &[u8],
-    ) -> Result<(), ArtichokeError>;
+    fn def_rb_source_file(&self, filename: Path, contents: &[u8]) -> Result<(), ArtichokeError>;
 }


### PR DESCRIPTION
Tweaks to the signatures of `File` and `Load` traits to make them easier to use in `artichoke-backend`.

Porting artichoke-backend to use these traits will require some surgery because removing the `AsRef<[u8]>` type parameter for file contents is a breaking change. We use `include_string` _a lot_ where we should be using `include_bytes(...).as_ref()`.

One use is the auto import stdlib generator:

https://github.com/artichoke/artichoke/blob/ede8269e156eb6a469f098fb2d033d40ce8fac48/artichoke-backend/scripts/auto_import/rust_glue.rs.erb#L22-L25

The new API is more correct and allows _all_ permissible sources to be loaded by forcing the caller to deal in bytes.