### PR TITLE
Unbreak format-text.sh

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,12 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "description": "Artichoke Ruby",
-  "keywords": [
-    "programming language",
-    "scripting",
-    "ruby",
-    "rust"
-  ],
+  "keywords": ["programming language", "scripting", "ruby", "rust"],
   "homepage": "https://github.com/artichoke/artichoke#readme",
   "bugs": "https://github.com/artichoke/artichoke/issues",
   "license": "MIT",
@@ -50,9 +45,7 @@
     "prettier-eslint": "^9.0.0"
   },
   "babel": {
-    "presets": [
-      "@babel/preset-env"
-    ]
+    "presets": ["@babel/preset-env"]
   },
   "eslintConfig": {
     "env": {
@@ -62,15 +55,8 @@
       "node": true
     },
     "parser": "babel-eslint",
-    "plugins": [
-      "html",
-      "import",
-      "prettier"
-    ],
-    "extends": [
-      "airbnb",
-      "prettier"
-    ],
+    "plugins": ["html", "import", "prettier"],
+    "extends": ["airbnb", "prettier"],
     "rules": {
       "prettier/prettier": "error",
       "react/jsx-closing-bracket-location": "off",

--- a/scripts/format-text.sh
+++ b/scripts/format-text.sh
@@ -15,6 +15,16 @@ wrap() {
   fi
 }
 
+parser() {
+  if [[ $1 == "yml" ]]; then
+    echo "--parser yaml"
+  elif [[ $1 == "md" ]]; then
+    echo "--parser markdown"
+  else
+    echo "--parser $1"
+  fi
+}
+
 format() {
   # shellcheck disable=SC2046
   find . -type f \
@@ -22,7 +32,7 @@ format() {
     -and -not -path '*vendor/*/*' \
     -and -not -path '*target/*' \
     -and -not -path '*node_modules/*' -print0 |
-    xargs -0 yarn run prettier --write $(wrap "$1")
+    xargs -0 yarn run prettier $(parser "$1") --write $(wrap "$1")
 }
 
 check() {
@@ -32,7 +42,7 @@ check() {
     -and -not -path '*vendor/*/*' \
     -and -not -path '*target/*' \
     -and -not -path '*node_modules/*' -print0 |
-    xargs -0 yarn run prettier --check $(wrap "$1")
+    xargs -0 yarn run prettier $(parser "$1") --check $(wrap "$1")
 }
 
 if [[ $# -gt 1 && $1 == '--check' ]]; then


### PR DESCRIPTION
The linter was silently failing because there are no CSS sources in
artichoke. Explicitly set the parser so yarn doesn't choke on empty
lists of file inputs.