### PR TITLE
Add artichoke and ruby binaries to artichoke-frontend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,6 +68,7 @@ version = "0.1.0"
 dependencies = [
  "artichoke-backend 0.1.0",
  "artichoke-core 0.1.0",
+ "bstr 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustyline 5.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,6 +69,7 @@ dependencies = [
  "artichoke-backend 0.1.0",
  "artichoke-core 0.1.0",
  "rustyline 5.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "structopt 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -407,6 +408,14 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "heck"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-segmentation 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "humantime"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -545,6 +554,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "ppv-lite86"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "proc-macro-error"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -891,6 +910,27 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "structopt"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "structopt-derive 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "structopt-derive"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro-error 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "syn"
 version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1129,6 +1169,7 @@ dependencies = [
 "checksum fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 "checksum getrandom 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "473a1265acc8ff1e808cd0a1af8cee3c2ee5200916058a2ca113c29f2d903571"
 "checksum glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+"checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum humantime 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
@@ -1148,6 +1189,7 @@ dependencies = [
 "checksum peeking_take_while 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 "checksum pkg-config 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)" = "72d5370d90f49f70bd033c3d75e87fc529fbfff9d6f7cccef07d6170079d91ea"
 "checksum ppv-lite86 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e3cbf9f658cdb5000fcf6f362b8ea2ba154b9f146a61c7a20d647034c6b6561b"
+"checksum proc-macro-error 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "aeccfe4d5d8ea175d5f0e4a2ad0637e0f4121d63bd99d356fb1f39ab2e7c6097"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum proc-macro2 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "90cf5f418035b98e655e9cdb225047638296b862b42411c4e45bb88d700f7fc0"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
@@ -1189,6 +1231,8 @@ dependencies = [
 "checksum shellexpand 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de7a5b5a9142fd278a10e0209b021a1b85849352e6951f4f914735c976737564"
 "checksum shlex 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+"checksum structopt 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6d4f66a4c0ddf7aee4677995697366de0749b0139057342eccbb609b12d0affc"
+"checksum structopt-derive 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8fe0c13e476b4e21ff7f5c4ace3818b6d7bdc16897c31c73862471bc1663acae"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 "checksum syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)" = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
 "checksum syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "66850e97125af79138385e9b88339cbcd037e3f28ceab8c5ad98e64f0f1f80bf"

--- a/artichoke-frontend/Cargo.toml
+++ b/artichoke-frontend/Cargo.toml
@@ -4,8 +4,9 @@ version = "0.1.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2018"
 
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-rustyline = "5.0.2"
+[dependencies]
+rustyline = "5.0.3"
+structopt = "0.3"
 
 [dependencies.artichoke-backend]
 path = "../artichoke-backend"

--- a/artichoke-frontend/Cargo.toml
+++ b/artichoke-frontend/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2018"
 
 [dependencies]
+bstr = "0.2"
 rustyline = "5.0.3"
 structopt = "0.3"
 

--- a/artichoke-frontend/src/bin/airb.rs
+++ b/artichoke-frontend/src/bin/airb.rs
@@ -1,10 +1,9 @@
 #![deny(warnings, intra_doc_link_resolution_failure)]
 #![deny(clippy::all, clippy::pedantic)]
 
-#[cfg(not(target_arch = "wasm32"))]
-fn main() -> Result<(), artichoke_frontend::repl::Error> {
-    artichoke_frontend::repl::run(std::io::stdout(), std::io::stderr(), None)
-}
+use artichoke_frontend::repl;
+use std::io;
 
-#[cfg(target_arch = "wasm32")]
-fn main() {}
+fn main() -> Result<(), artichoke_frontend::repl::Error> {
+    repl::run(io::stdout(), io::stderr(), None)
+}

--- a/artichoke-frontend/src/bin/artichoke.rs
+++ b/artichoke-frontend/src/bin/artichoke.rs
@@ -1,0 +1,135 @@
+use artichoke_backend::eval::{Context, Eval};
+use artichoke_backend::fs;
+use artichoke_core::ArtichokeError;
+use bstr::BStr;
+use std::fs::File;
+use std::io::{self, Read};
+use std::path::PathBuf;
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+#[structopt(name = "artichoke", about = "Artichoke is a Ruby made with Rust.")]
+struct Opt {
+    #[structopt(long)]
+    /// print the copyright
+    copyright: bool,
+
+    #[structopt(short = "e")]
+    /// one line of script. Several -e's allowed. Omit [programfile]
+    command: Option<Vec<String>>,
+
+    #[structopt(parse(from_os_str))]
+    programfile: Option<PathBuf>,
+}
+
+enum Error {
+    Artichoke(ArtichokeError),
+    Fail(String),
+}
+
+impl From<ArtichokeError> for Error {
+    fn from(err: ArtichokeError) -> Self {
+        Self::Artichoke(err)
+    }
+}
+
+impl From<String> for Error {
+    fn from(err: String) -> Self {
+        Self::Fail(err)
+    }
+}
+
+impl From<&'static str> for Error {
+    fn from(err: &'static str) -> Self {
+        Self::Fail(err.to_owned())
+    }
+}
+
+fn try_main() -> Result<(), Error> {
+    let opt = Opt::from_args();
+    if opt.copyright {
+        let interp = artichoke_backend::interpreter()?;
+        interp.eval("puts RUBY_COPYRIGHT")?;
+    } else if let Some(commands) = opt.command {
+        let interp = artichoke_backend::interpreter()?;
+        interp.push_context(Context::new(b"-e".as_ref()));
+        for command in commands {
+            interp.eval(command)?;
+        }
+    } else if let Some(programfile) = opt.programfile {
+        let interp = artichoke_backend::interpreter()?;
+        let mut file = File::open(programfile.as_path()).map_err(|_| {
+            if let Ok(file) = fs::osstr_to_bytes(&interp, programfile.as_os_str()) {
+                let file = format!("{:?}", <&BStr>::from(file));
+                format!(
+                    "No such file or directory -- {} (LoadError)",
+                    &file[1..file.len() - 1]
+                )
+            } else {
+                format!("No such file or directory -- {:?} (LoadError)", programfile)
+            }
+        })?;
+        let mut program = Vec::new();
+        let result = file.read_to_end(&mut program);
+        match result {
+            Ok(_) => interp.eval(program.as_slice())?,
+            Err(err) => {
+                let reason = match err.kind() {
+                    io::ErrorKind::NotFound => {
+                        if let Ok(file) = fs::osstr_to_bytes(&interp, programfile.as_os_str()) {
+                            let file = format!("{:?}", <&BStr>::from(file));
+                            format!(
+                                "No such file or directory -- {} (LoadError)",
+                                &file[1..file.len() - 1]
+                            )
+                        } else {
+                            format!("No such file or directory -- {:?} (LoadError)", programfile)
+                        }
+                    }
+                    io::ErrorKind::PermissionDenied => {
+                        if let Ok(file) = fs::osstr_to_bytes(&interp, programfile.as_os_str()) {
+                            let file = format!("{:?}", <&BStr>::from(file));
+                            format!(
+                                "Permission denied -- {} (LoadError)",
+                                &file[1..file.len() - 1]
+                            )
+                        } else {
+                            format!("Permission denied -- {:?} (LoadError)", programfile)
+                        }
+                    }
+                    _ => {
+                        if let Ok(file) = fs::osstr_to_bytes(&interp, programfile.as_os_str()) {
+                            let file = format!("{:?}", <&BStr>::from(file));
+                            format!(
+                                "Could not read file -- {} (LoadError)",
+                                &file[1..file.len() - 1]
+                            )
+                        } else {
+                            format!("Could not read file -- {:?} (LoadError)", programfile)
+                        }
+                    }
+                };
+                return Err(Error::Fail(reason));
+            }
+        };
+    } else {
+        let mut program = Vec::new();
+        let result = io::stdin().read_to_end(&mut program);
+        if result.is_ok() {
+            let interp = artichoke_backend::interpreter()?;
+            interp.eval(program.as_slice())?;
+        } else {
+            return Err(Error::from("Could not read program from STDIN"));
+        }
+    }
+
+    Ok(())
+}
+
+fn main() {
+    match try_main() {
+        Ok(_) => {}
+        Err(Error::Artichoke(err)) => eprintln!("{}", err),
+        Err(Error::Fail(err)) => eprintln!("{}", err),
+    }
+}

--- a/artichoke-frontend/src/bin/ruby.rs
+++ b/artichoke-frontend/src/bin/ruby.rs
@@ -1,0 +1,1 @@
+artichoke.rs

--- a/artichoke-frontend/src/repl.rs
+++ b/artichoke-frontend/src/repl.rs
@@ -1,5 +1,3 @@
-#![cfg(not(target_arch = "wasm32"))]
-
 //! A REPL (read–eval–print–loop) for an artichoke interpreter exposed by
 //! the [`artichoke-backend`](artichoke_backend) crate.
 //!


### PR DESCRIPTION
These binaries are identical (ruby.rs is a symlink to artichoke.rs).
Currently supported flags:

--copyright for printing RUBY_COPYRIGHT
-e for inline eval (including multiple -e flags)
programfile for loading programs from the host filesystem
reading program input from STDIN

These binaries are useful for benchmarking Artichoke using the shell
in the absence of a Time Core implementation.

This commit makes progress on GH-17.