### PR TITLE
Make String#scan implementation pass ruby/spec

### DIFF
--- a/artichoke-backend/src/extn/core/string/scan.rs
+++ b/artichoke-backend/src/extn/core/string/scan.rs
@@ -1,45 +1,105 @@
-use std::cmp;
 use std::str;
 
 use crate::convert::{Convert, RustBackedValue};
 use crate::extn::core::exception::{Fatal, RubyException, TypeError};
 use crate::extn::core::matchdata::MatchData;
+use crate::extn::core::regexp::enc::Encoding;
+use crate::extn::core::regexp::opts::Options;
 use crate::extn::core::regexp::{Backend, Regexp};
 use crate::sys;
+use crate::types::Ruby;
 use crate::value::{Value, ValueLike};
 use crate::Artichoke;
 
-fn literal_scan(string: &[u8], pattern: &[u8]) -> usize {
+fn literal_scan_count(string: &[u8], pattern: &[u8]) -> (usize, usize) {
     if pattern.is_empty() {
-        string.len() + 1
+        (string.len() + 1, string.len())
     } else if pattern.len() > string.len() {
-        0
+        (0, 0)
     } else if pattern == string {
-        1
+        (1, 0)
     } else {
         match pattern.len() {
             0 => unreachable!("handled above"),
             1 => {
+                let mut matches = 0;
+                let mut last_pos = 0;
                 let byte0 = pattern[0];
-                memchr::memchr_iter(byte0, string).count()
+                for pos in memchr::memchr_iter(byte0, string) {
+                    matches += 1;
+                    last_pos = pos;
+                }
+                (matches, last_pos)
             }
             _ => {
-                let mut count = 0;
+                let mut matches = 0;
+                let mut last_pos = 0;
                 let byte0 = pattern[0];
                 let rest = &pattern[1..];
                 let strlen = string.len();
                 let patlen = pattern.len();
-                for pos in memchr::memchr_iter(byte0, string) {
-                    if strlen - pos > patlen && &string[pos + 1..pos + patlen] == rest {
-                        count += 1;
+                let mut start = 0;
+                while let Some(pos) = memchr::memchr(byte0, &string[start..]) {
+                    last_pos = pos;
+                    let idx = start + pos;
+                    start = idx + 1;
+                    if idx + patlen <= strlen {
+                        if &string[idx + 1..idx + patlen] == rest {
+                            matches += 1;
+                            start = idx + patlen;
+                        }
+                    } else {
+                        break;
                     }
                 }
-                count
+                (matches, last_pos)
             }
         }
     }
 }
 
+fn literal_scan_with_pos(string: &[u8], pattern: &[u8]) -> Vec<usize> {
+    if pattern.is_empty() {
+        (0..=string.len()).collect::<Vec<_>>()
+    } else if pattern.len() > string.len() {
+        Vec::with_capacity(0)
+    } else if pattern == string {
+        let mut matches = Vec::with_capacity(1);
+        matches.push(0);
+        matches
+    } else {
+        match pattern.len() {
+            0 => unreachable!("handled above"),
+            1 => {
+                let byte0 = pattern[0];
+                memchr::memchr_iter(byte0, string).collect::<Vec<_>>()
+            }
+            _ => {
+                let mut matches = vec![];
+                let byte0 = pattern[0];
+                let rest = &pattern[1..];
+                let strlen = string.len();
+                let patlen = pattern.len();
+                let mut start = 0;
+                while let Some(pos) = memchr::memchr(byte0, &string[start..]) {
+                    let idx = start + pos;
+                    start = idx + 1;
+                    if idx + patlen <= strlen {
+                        if &string[idx + 1..idx + patlen] == rest {
+                            matches.push(idx);
+                            start = idx + patlen;
+                        }
+                    } else {
+                        break;
+                    }
+                }
+                matches
+            }
+        }
+    }
+}
+
+#[allow(clippy::cognitive_complexity)]
 pub fn method(
     interp: &Artichoke,
     value: Value,
@@ -52,20 +112,103 @@ pub fn method(
             "Unable to convert Ruby String Receiver to Rust byte slice",
         )
     })?;
-    if let Ok(pattern_bytes) = pattern.clone().try_into::<&[u8]>() {
-        let matches = literal_scan(string, pattern_bytes);
+    if let Ruby::Symbol = pattern.ruby_type() {
+        Err(Box::new(TypeError::new(
+            interp,
+            format!(
+                "wrong argument type {} (expected Regexp)",
+                pattern.pretty_name()
+            ),
+        )))
+    } else if let Ok(pattern_bytes) = pattern.clone().try_into::<&[u8]>() {
         if let Some(ref block) = block {
+            let matches = literal_scan_with_pos(string, pattern_bytes);
+            // TODO: Regexp and MatchData should operate on byte slices.
+            let s = str::from_utf8(string).map_err(|_| {
+                Fatal::new(
+                    interp,
+                    "String#scan does not support literal scans with block over UTF-8 invalid data",
+                )
+            })?;
+            let pattern_str = str::from_utf8(pattern_bytes).map_err(|_| {
+                Fatal::new(
+                    interp,
+                    "String#scan does not support literal scans with block over UTF-8 invalid data",
+                )
+            })?;
+            let regex = Regexp::new(
+                pattern_str.to_owned(),
+                pattern_str.to_owned(),
+                Options::default(),
+                Options::default(),
+                Encoding::default(),
+            )
+            .ok_or_else(|| Fatal::new(interp, "Could not convert UTF-8 literal to Rust Regex"))?;
             let mrb = interp.0.borrow().mrb;
-            for _ in 0..matches {
+            let last_match_sym = interp.0.borrow_mut().sym_intern("$~");
+            let mut matchdata = MatchData::new(s, regex, 0, string.len());
+            let patlen = pattern_bytes.len();
+            for pos in &matches {
+                matchdata.set_region(*pos, pos + patlen);
+                let data = unsafe { matchdata.clone().try_into_ruby(interp, None) }
+                    .map_err(|_| Fatal::new(interp, "Failed to convert MatchData to Ruby Value"))?;
                 unsafe {
+                    sys::mrb_gv_set(mrb, last_match_sym, data.inner());
                     sys::mrb_yield(mrb, block.inner(), interp.convert(pattern_bytes).inner());
+                    sys::mrb_gv_set(mrb, last_match_sym, data.inner());
+                }
+            }
+            if matches.is_empty() {
+                unsafe {
+                    sys::mrb_gv_set(mrb, last_match_sym, sys::mrb_sys_nil_value());
                 }
             }
             Ok(value)
         } else {
+            let (matches, last_pos) = literal_scan_count(string, pattern_bytes);
             let mut result = Vec::with_capacity(matches);
             for _ in 0..matches {
                 result.push(interp.convert(pattern_bytes));
+            }
+            if matches > 0 {
+                // TODO: Regexp and MatchData should operate on byte slices.
+                let s = str::from_utf8(string).map_err(|_| {
+                    Fatal::new(
+                    interp,
+                    "String#scan does not support literal scans with block over UTF-8 invalid data",
+                )
+                })?;
+                let pattern_str = str::from_utf8(pattern_bytes).map_err(|_| {
+                    Fatal::new(
+                    interp,
+                    "String#scan does not support literal scans with block over UTF-8 invalid data",
+                )
+                })?;
+                let regex = Regexp::new(
+                    pattern_str.to_owned(),
+                    pattern_str.to_owned(),
+                    Options::default(),
+                    Options::default(),
+                    Encoding::default(),
+                )
+                .ok_or_else(|| {
+                    Fatal::new(interp, "Could not convert UTF-8 literal to Rust Regex")
+                })?;
+                let mrb = interp.0.borrow().mrb;
+                let last_match_sym = interp.0.borrow_mut().sym_intern("$~");
+                let mut matchdata = MatchData::new(s, regex, 0, string.len());
+                matchdata.set_region(last_pos, last_pos + pattern_bytes.len());
+                let data = unsafe { matchdata.clone().try_into_ruby(interp, None) }
+                    .map_err(|_| Fatal::new(interp, "Failed to convert MatchData to Ruby Value"))?;
+                unsafe {
+                    sys::mrb_gv_set(mrb, last_match_sym, data.inner());
+                }
+            } else {
+                let mrb = interp.0.borrow().mrb;
+                let last_match_sym = interp.0.borrow_mut().sym_intern("$~");
+                unsafe {
+                    sys::mrb_gv_set(mrb, last_match_sym, sys::mrb_sys_nil_value());
+                }
             }
             Ok(interp.convert(result))
         }
@@ -73,19 +216,100 @@ pub fn method(
         let pattern_type_name = pattern.pretty_name();
         let pattern_bytes = pattern.funcall::<&[u8]>("to_str", &[], None);
         if let Ok(pattern_bytes) = pattern_bytes {
-            let matches = literal_scan(string, pattern_bytes);
             if let Some(ref block) = block {
+                let matches = literal_scan_with_pos(string, pattern_bytes);
+                // TODO: Regexp and MatchData should operate on byte slices.
+                let s = str::from_utf8(string).map_err(|_| {
+                    Fatal::new(
+                    interp,
+                    "String#scan does not support literal scans with block over UTF-8 invalid data",
+                )
+                })?;
+                let pattern_str = str::from_utf8(pattern_bytes).map_err(|_| {
+                    Fatal::new(
+                    interp,
+                    "String#scan does not support literal scans with block over UTF-8 invalid data",
+                )
+                })?;
+                let regex = Regexp::new(
+                    pattern_str.to_owned(),
+                    pattern_str.to_owned(),
+                    Options::default(),
+                    Options::default(),
+                    Encoding::default(),
+                )
+                .ok_or_else(|| {
+                    Fatal::new(interp, "Could not convert UTF-8 literal to Rust Regex")
+                })?;
                 let mrb = interp.0.borrow().mrb;
-                for _ in 0..matches {
+                let last_match_sym = interp.0.borrow_mut().sym_intern("$~");
+                let mut matchdata = MatchData::new(s, regex, 0, string.len());
+                let patlen = pattern_bytes.len();
+                for pos in &matches {
+                    matchdata.set_region(*pos, pos + patlen);
+                    let data =
+                        unsafe { matchdata.clone().try_into_ruby(interp, None) }.map_err(|_| {
+                            Fatal::new(interp, "Failed to convert MatchData to Ruby Value")
+                        })?;
                     unsafe {
+                        sys::mrb_gv_set(mrb, last_match_sym, data.inner());
                         sys::mrb_yield(mrb, block.inner(), interp.convert(pattern_bytes).inner());
+                        sys::mrb_gv_set(mrb, last_match_sym, data.inner());
+                    }
+                }
+                if matches.is_empty() {
+                    unsafe {
+                        sys::mrb_gv_set(mrb, last_match_sym, sys::mrb_sys_nil_value());
                     }
                 }
                 Ok(value)
             } else {
+                let (matches, last_pos) = literal_scan_count(string, pattern_bytes);
                 let mut result = Vec::with_capacity(matches);
                 for _ in 0..matches {
                     result.push(interp.convert(pattern_bytes));
+                }
+                if matches > 0 {
+                    // TODO: Regexp and MatchData should operate on byte slices.
+                    let s = str::from_utf8(string).map_err(|_| {
+                        Fatal::new(
+                    interp,
+                    "String#scan does not support literal scans with block over UTF-8 invalid data",
+                )
+                    })?;
+                    let pattern_str = str::from_utf8(pattern_bytes).map_err(|_| {
+                        Fatal::new(
+                    interp,
+                    "String#scan does not support literal scans with block over UTF-8 invalid data",
+                )
+                    })?;
+                    let regex = Regexp::new(
+                        pattern_str.to_owned(),
+                        pattern_str.to_owned(),
+                        Options::default(),
+                        Options::default(),
+                        Encoding::default(),
+                    )
+                    .ok_or_else(|| {
+                        Fatal::new(interp, "Could not convert UTF-8 literal to Rust Regex")
+                    })?;
+                    let mrb = interp.0.borrow().mrb;
+                    let last_match_sym = interp.0.borrow_mut().sym_intern("$~");
+                    let mut matchdata = MatchData::new(s, regex, 0, string.len());
+                    matchdata.set_region(last_pos, last_pos + pattern_bytes.len());
+                    let data =
+                        unsafe { matchdata.clone().try_into_ruby(interp, None) }.map_err(|_| {
+                            Fatal::new(interp, "Failed to convert MatchData to Ruby Value")
+                        })?;
+                    unsafe {
+                        sys::mrb_gv_set(mrb, last_match_sym, data.inner());
+                    }
+                } else {
+                    let mrb = interp.0.borrow().mrb;
+                    let last_match_sym = interp.0.borrow_mut().sym_intern("$~");
+                    unsafe {
+                        sys::mrb_gv_set(mrb, last_match_sym, sys::mrb_sys_nil_value());
+                    }
                 }
                 Ok(interp.convert(result))
             }
@@ -101,13 +325,7 @@ pub fn method(
             let mrb = interp.0.borrow().mrb;
             let last_match_sym = interp.0.borrow_mut().sym_intern("$~");
             let mut matchdata = MatchData::new(s, borrow.clone(), 0, string.len());
-            let data = unsafe { matchdata.clone().try_into_ruby(interp, None) }
-                .map_err(|_| Fatal::new(interp, "Failed to convert MatchData to Ruby Value"))?;
-            unsafe {
-                sys::mrb_gv_set(mrb, last_match_sym, data.inner());
-            }
 
-            let mut was_match = false;
             let mut collected = vec![];
             let regex = (*borrow.regex)
                 .as_ref()
@@ -115,70 +333,93 @@ pub fn method(
             match regex {
                 Backend::Onig(regex) => {
                     let len = regex.captures_len();
+                    let mut any_match = false;
 
                     if len > 0 {
+                        // zero old globals
+                        let previously_set_globals =
+                            interp.0.borrow().num_set_regexp_capture_globals;
+                        for group in 1..=previously_set_globals {
+                            let sym = interp.0.borrow_mut().sym_intern(&format!("${}", group));
+                            unsafe {
+                                sys::mrb_gv_set(mrb, sym, sys::mrb_sys_nil_value());
+                            }
+                        }
+                        interp.0.borrow_mut().num_set_regexp_capture_globals = len;
                         for captures in regex.captures_iter(s) {
-                            was_match = true;
+                            any_match = true;
+                            let fullmatch = interp.0.borrow_mut().sym_intern("$&");
+                            let fullcapture = captures.at(0);
+                            unsafe {
+                                sys::mrb_gv_set(
+                                    mrb,
+                                    fullmatch,
+                                    interp.convert(fullcapture).inner(),
+                                );
+                            }
                             let mut groups = vec![];
-                            let num_regexp_globals_to_set = {
-                                let num_previously_set_globals =
-                                    interp.0.borrow().num_set_regexp_capture_globals;
-                                cmp::max(num_previously_set_globals, captures.len())
-                            };
-                            for group in 0..num_regexp_globals_to_set {
-                                let sym = if group == 0 {
-                                    interp.0.borrow_mut().sym_intern("$&")
-                                } else {
-                                    interp.0.borrow_mut().sym_intern(&format!("${}", group))
-                                };
-
+                            for group in 1..=len {
+                                let sym = interp.0.borrow_mut().sym_intern(&format!("${}", group));
                                 let capture = captures.at(group);
-                                if group > 0 {
-                                    groups.push(captures.at(group));
-                                }
+                                groups.push(captures.at(group));
                                 unsafe {
                                     sys::mrb_gv_set(mrb, sym, interp.convert(capture).inner());
                                 }
                             }
-                            interp.0.borrow_mut().num_set_regexp_capture_globals = captures.len();
 
                             let matched = interp.convert(groups);
                             if let Some(pos) = captures.pos(0) {
                                 matchdata.set_region(pos.0, pos.1);
                             }
+                            let data = unsafe { matchdata.clone().try_into_ruby(interp, None) }
+                                .map_err(|_| {
+                                    Fatal::new(interp, "Failed to convert MatchData to Ruby Value")
+                                })?;
                             if let Some(ref block) = block {
                                 unsafe {
+                                    sys::mrb_gv_set(mrb, last_match_sym, data.inner());
                                     sys::mrb_yield(mrb, block.inner(), matched.inner());
                                     sys::mrb_gv_set(mrb, last_match_sym, data.inner());
                                 }
                             } else {
                                 collected.push(matched);
+                                unsafe {
+                                    sys::mrb_gv_set(mrb, last_match_sym, data.inner());
+                                }
                             }
                         }
                     } else {
                         for pos in regex.find_iter(s) {
-                            was_match = true;
+                            any_match = true;
                             let scanned = &s[pos.0..pos.1];
                             let matched = interp.convert(scanned);
                             matchdata.set_region(pos.0, pos.1);
+                            let data = unsafe { matchdata.clone().try_into_ruby(interp, None) }
+                                .map_err(|_| {
+                                    Fatal::new(interp, "Failed to convert MatchData to Ruby Value")
+                                })?;
                             if let Some(ref block) = block {
                                 unsafe {
+                                    sys::mrb_gv_set(mrb, last_match_sym, data.inner());
                                     sys::mrb_yield(mrb, block.inner(), matched.inner());
                                     sys::mrb_gv_set(mrb, last_match_sym, data.inner());
                                 }
                             } else {
                                 collected.push(matched);
+                                unsafe {
+                                    sys::mrb_gv_set(mrb, last_match_sym, data.inner());
+                                }
                             }
+                        }
+                    }
+                    if !any_match {
+                        unsafe {
+                            sys::mrb_gv_set(mrb, last_match_sym, sys::mrb_sys_nil_value());
                         }
                     }
                 }
                 Backend::Rust(_) => unimplemented!("Rust-backed Regexp"),
             };
-            if !was_match {
-                unsafe {
-                    sys::mrb_gv_set(mrb, last_match_sym, sys::mrb_sys_nil_value());
-                }
-            }
             let result = if block.is_some() {
                 value
             } else {

--- a/scripts/spec-compliance.sh
+++ b/scripts/spec-compliance.sh
@@ -146,6 +146,7 @@ register_spec core array unshift
 register_spec core comparable
 register_spec core matchdata
 register_spec core regexp
+register_spec core string scan
 
 register_spec library monitor
 register_spec library stringscanner


### PR DESCRIPTION
- proper handling of `Regexp` globals
- proper setting of `MatchData` with a clone per block iteration.
- Optimizations for deferring `MatchData` creation for `String` patterns.