### PR TITLE
Remove warning silencers and fixup warnings in array and exception modules

### DIFF
--- a/artichoke-backend/src/exception.rs
+++ b/artichoke-backend/src/exception.rs
@@ -1,4 +1,3 @@
-#![allow(warnings)]
 use std::ffi::c_void;
 use std::fmt;
 

--- a/artichoke-backend/src/extn/core/array/backend/aggregate.rs
+++ b/artichoke-backend/src/extn/core/array/backend/aggregate.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use std::cell::RefCell;
 
 use crate::convert::Convert;

--- a/artichoke-backend/src/extn/core/array/backend/buffer.rs
+++ b/artichoke-backend/src/extn/core/array/backend/buffer.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use std::cell::RefCell;
 use std::iter;
 

--- a/artichoke-backend/src/extn/core/array/backend/fixed/empty.rs
+++ b/artichoke-backend/src/extn/core/array/backend/fixed/empty.rs
@@ -1,5 +1,3 @@
-use std::borrow::Cow;
-
 use crate::convert::Convert;
 use crate::extn::core::array::{backend, ArrayType};
 use crate::extn::core::exception::RubyException;

--- a/artichoke-backend/src/extn/core/array/backend/fixed/hole.rs
+++ b/artichoke-backend/src/extn/core/array/backend/fixed/hole.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use std::num::NonZeroUsize;
 
 use crate::convert::Convert;

--- a/artichoke-backend/src/extn/core/array/backend/fixed/one.rs
+++ b/artichoke-backend/src/extn/core/array/backend/fixed/one.rs
@@ -1,5 +1,3 @@
-use std::borrow::Cow;
-
 use crate::convert::Convert;
 use crate::extn::core::array::{backend, ArrayType};
 use crate::extn::core::exception::RubyException;

--- a/artichoke-backend/src/extn/core/array/backend/fixed/two.rs
+++ b/artichoke-backend/src/extn/core/array/backend/fixed/two.rs
@@ -1,5 +1,3 @@
-use std::borrow::Cow;
-
 use crate::convert::Convert;
 use crate::extn::core::array::{backend, ArrayType};
 use crate::extn::core::exception::RubyException;

--- a/artichoke-backend/src/extn/core/array/backend/repeated/value.rs
+++ b/artichoke-backend/src/extn/core/array/backend/repeated/value.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use std::cmp;
 use std::num::NonZeroUsize;
 

--- a/artichoke-backend/src/extn/core/array/mod.rs
+++ b/artichoke-backend/src/extn/core/array/mod.rs
@@ -1,8 +1,5 @@
-#![allow(warnings)]
-
 use artichoke_core::value::Value as _;
 use downcast::Any;
-use std::borrow::Cow;
 use std::convert::TryFrom;
 
 use crate::convert::{Convert, RustBackedValue};


### PR DESCRIPTION
I sometimes add an `!#[allow(warnings)]` pragma when iterating on code and it looks like I forgot to remove these.