### PR TITLE
Fix segfault and borrow errors when running the entire Array spec suite

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,7 @@ jobs:
   rust:
     docker:
       - image: circleci/rust:1.38.0-buster
+    resource_class: large
     steps:
       - checkout
       - restore_cache:

--- a/artichoke-backend/src/extn/core/array/mod.rs
+++ b/artichoke-backend/src/extn/core/array/mod.rs
@@ -7,7 +7,7 @@ use crate::extn::core::exception::{
     ArgumentError, Fatal, RangeError, RubyException, RuntimeError, TypeError,
 };
 use crate::types::Int;
-use crate::value::Value;
+use crate::value::{Block, Value};
 use crate::warn::Warn;
 use crate::Artichoke;
 
@@ -53,7 +53,7 @@ impl Array {
         interp: &Artichoke,
         first: Option<Value>,
         second: Option<Value>,
-        block: Option<Value>,
+        block: Option<Block>,
         into: Value,
     ) -> Result<Value, Box<dyn RubyException>> {
         let result = if let Some(first) = first {
@@ -97,7 +97,7 @@ impl Array {
                         })?;
                         let idx = interp.convert(idx);
                         // TODO: propagate exceptions from block call.
-                        let elem = block.funcall("call", &[idx], None).map_err(|_| {
+                        let elem = block.yield_arg(interp, idx).map_err(|_| {
                             RuntimeError::new(interp, "exception during Array#initialize block")
                         })?;
                         buffer.push(elem);
@@ -124,7 +124,7 @@ impl Array {
                         })?;
                         let idx = interp.convert(idx);
                         // TODO: propagate exceptions from block call.
-                        let elem = block.funcall("call", &[idx], None).map_err(|_| {
+                        let elem = block.yield_arg(interp, idx).map_err(|_| {
                             RuntimeError::new(interp, "exception during Array#initialize block")
                         })?;
                         buffer.push(elem);

--- a/artichoke-backend/src/extn/core/array/mod.rs
+++ b/artichoke-backend/src/extn/core/array/mod.rs
@@ -97,7 +97,7 @@ impl Array {
                         })?;
                         let idx = interp.convert(idx);
                         // TODO: propagate exceptions from block call.
-                        let elem = block.yield_arg(interp, idx).map_err(|_| {
+                        let elem = block.yield_arg(interp, &idx).map_err(|_| {
                             RuntimeError::new(interp, "exception during Array#initialize block")
                         })?;
                         buffer.push(elem);
@@ -124,7 +124,7 @@ impl Array {
                         })?;
                         let idx = interp.convert(idx);
                         // TODO: propagate exceptions from block call.
-                        let elem = block.yield_arg(interp, idx).map_err(|_| {
+                        let elem = block.yield_arg(interp, &idx).map_err(|_| {
                             RuntimeError::new(interp, "exception during Array#initialize block")
                         })?;
                         buffer.push(elem);

--- a/artichoke-backend/src/extn/core/array/mruby.rs
+++ b/artichoke-backend/src/extn/core/array/mruby.rs
@@ -331,7 +331,6 @@ pub unsafe extern "C" fn ary_initialize(
     let array = Value::new(&interp, ary);
     let first = first.map(|first| Value::new(&interp, first));
     let second = second.map(|second| Value::new(&interp, second));
-    let block = interp.convert(Value::new(&interp, block));
     let result = array::trampoline::initialize(&interp, array, first, second, block);
     match result {
         Ok(value) => {

--- a/artichoke-backend/src/extn/core/array/trampoline.rs
+++ b/artichoke-backend/src/extn/core/array/trampoline.rs
@@ -4,6 +4,7 @@ use std::convert::TryFrom;
 use crate::convert::{Convert, RustBackedValue};
 use crate::extn::core::array::{backend, Array};
 use crate::extn::core::exception::{Fatal, FrozenError, IndexError, RubyException, TypeError};
+use crate::gc::MrbGarbageCollection;
 use crate::value::{Block, Value};
 use crate::Artichoke;
 
@@ -187,8 +188,17 @@ pub fn element_assignment(
             "Unable to extract Rust Array from Ruby Array receiver",
         )
     })?;
+    // TODO: properly handle self-referential sets.
+    if ary == first || ary == second || Some(ary) == third {
+        return Ok(interp.convert(None::<Value>));
+    }
     let mut borrow = array.borrow_mut();
-    borrow.element_assignment(interp, first, second, third)
+    let gc_was_enabled = interp.disable_gc();
+    let result = borrow.element_assignment(interp, first, second, third);
+    if gc_was_enabled {
+        interp.enable_gc();
+    }
+    result
 }
 
 pub fn pop(interp: &Artichoke, ary: &Value) -> Result<Value, Box<dyn RubyException>> {
@@ -205,7 +215,12 @@ pub fn pop(interp: &Artichoke, ary: &Value) -> Result<Value, Box<dyn RubyExcepti
         )
     })?;
     let mut borrow = array.borrow_mut();
-    borrow.pop(interp)
+    let gc_was_enabled = interp.disable_gc();
+    let result = borrow.pop(interp);
+    if gc_was_enabled {
+        interp.enable_gc();
+    }
+    result
 }
 
 pub fn shift(
@@ -228,9 +243,13 @@ pub fn shift(
     if let Some(count) = count {
         let popped = {
             let mut borrow = array.borrow_mut();
-            let popped = borrow.slice(interp, 0, count)?;
+            let gc_was_enabled = interp.disable_gc();
+            let result = borrow.slice(interp, 0, count)?;
             borrow.set_slice(interp, 0, count, backend::fixed::empty())?;
-            popped
+            if gc_was_enabled {
+                interp.enable_gc();
+            }
+            result
         };
         let popped = Array(popped);
         let result = unsafe { popped.try_into_ruby(interp, None) }
@@ -238,7 +257,12 @@ pub fn shift(
         Ok(result)
     } else {
         let mut borrow = array.borrow_mut();
-        borrow.pop(interp)
+        let gc_was_enabled = interp.disable_gc();
+        let result = borrow.pop(interp);
+        if gc_was_enabled {
+            interp.enable_gc();
+        }
+        result
     }
 }
 
@@ -260,7 +284,11 @@ pub fn unshift(
         )
     })?;
     let mut borrow = array.borrow_mut();
+    let gc_was_enabled = interp.disable_gc();
     borrow.set_with_drain(interp, 0, 0, value)?;
+    if gc_was_enabled {
+        interp.enable_gc();
+    }
     Ok(ary)
 }
 
@@ -283,7 +311,11 @@ pub fn concat(
             )
         })?;
         let mut borrow = array.borrow_mut();
+        let gc_was_enabled = interp.disable_gc();
         borrow.concat(interp, other)?;
+        if gc_was_enabled {
+            interp.enable_gc();
+        }
     }
     Ok(ary)
 }
@@ -303,7 +335,11 @@ pub fn push(interp: &Artichoke, ary: Value, value: Value) -> Result<Value, Box<d
     })?;
     let idx = array.borrow().len_usize();
     let mut borrow = array.borrow_mut();
+    let gc_was_enabled = interp.disable_gc();
     borrow.set(interp, idx, value)?;
+    if gc_was_enabled {
+        interp.enable_gc();
+    }
     Ok(ary)
 }
 
@@ -332,7 +368,11 @@ pub fn reverse_bang(interp: &Artichoke, ary: Value) -> Result<Value, Box<dyn Rub
         )
     })?;
     let mut borrow = array.borrow_mut();
+    let gc_was_enabled = interp.disable_gc();
     borrow.reverse_in_place(interp)?;
+    if gc_was_enabled {
+        interp.enable_gc();
+    }
     Ok(ary)
 }
 
@@ -354,28 +394,33 @@ pub fn element_set(
             "Unable to extract Rust Array from Ruby Array receiver",
         )
     })?;
-    let mut borrow = array.borrow_mut();
     let offset = if offset >= 0 {
         usize::try_from(offset)
             .map_err(|_| Fatal::new(interp, "Expected positive index to convert to usize"))?
     } else {
+        let len = array.borrow().len_usize();
         // Positive Int must be usize
         let idx = usize::try_from(-offset)
             .map_err(|_| Fatal::new(interp, "Expected positive index to convert to usize"))?;
-        if let Some(offset) = borrow.len_usize().checked_sub(idx) {
+        if let Some(offset) = len.checked_sub(idx) {
             offset
         } else {
             return Err(Box::new(IndexError::new(
                 interp,
-                format!(
-                    "index {} too small for array; minimum: {}",
-                    offset,
-                    borrow.len_usize()
-                ),
+                format!("index {} too small for array; minimum: {}", offset, len),
             )));
         }
     };
+    // TODO: properly handle self-referential sets.
+    if ary == value {
+        return Ok(interp.convert(None::<Value>));
+    }
+    let mut borrow = array.borrow_mut();
+    let gc_was_enabled = interp.disable_gc();
     borrow.set(interp, offset, value)?;
+    if gc_was_enabled {
+        interp.enable_gc();
+    }
     Ok(ary)
 }
 

--- a/artichoke-backend/src/extn/core/array/trampoline.rs
+++ b/artichoke-backend/src/extn/core/array/trampoline.rs
@@ -4,7 +4,7 @@ use std::convert::TryFrom;
 use crate::convert::{Convert, RustBackedValue};
 use crate::extn::core::array::{backend, Array};
 use crate::extn::core::exception::{Fatal, FrozenError, IndexError, RubyException, TypeError};
-use crate::value::Value;
+use crate::value::{Block, Value};
 use crate::Artichoke;
 
 #[allow(clippy::similar_names)]
@@ -409,7 +409,7 @@ pub fn initialize(
     ary: Value,
     first: Option<Value>,
     second: Option<Value>,
-    block: Option<Value>,
+    block: Option<Block>,
 ) -> Result<Value, Box<dyn RubyException>> {
     Array::initialize(interp, first, second, block, ary)
 }

--- a/artichoke-backend/src/extn/core/regexp/match_.rs
+++ b/artichoke-backend/src/extn/core/regexp/match_.rs
@@ -10,14 +10,14 @@ use crate::extn::core::matchdata::MatchData;
 use crate::extn::core::regexp::{Backend, Regexp};
 use crate::sys;
 use crate::types::Int;
-use crate::value::Value;
+use crate::value::{Block, Value};
 use crate::Artichoke;
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct Args<'a> {
     pub pattern: Option<&'a str>,
     pub pos: Option<Int>,
-    pub block: Option<Value>,
+    pub block: Option<Block>,
 }
 
 impl<'a> Args<'a> {
@@ -25,7 +25,7 @@ impl<'a> Args<'a> {
         interp: &Artichoke,
         pattern: Value,
         pos: Option<Value>,
-        block: Option<Value>,
+        block: Option<Block>,
     ) -> Result<Self, Box<dyn RubyException>> {
         let pattern = if let Ok(pattern) = pattern.clone().try_into::<Option<&str>>() {
             pattern
@@ -152,9 +152,13 @@ pub fn method(
                     sys::mrb_gv_set(mrb, sym, data.inner());
                 }
                 if let Some(block) = args.block {
-                    Ok(Value::new(interp, unsafe {
-                        sys::mrb_yield(mrb, block.inner(), data.inner())
-                    }))
+                    let result = block.yield_arg(interp, data).map_err(|_| {
+                        Fatal::new(
+                            interp,
+                            "Failed to initialize Ruby MatchData Value with Rust MatchData",
+                        )
+                    })?;
+                    Ok(result)
                 } else {
                     Ok(data)
                 }

--- a/artichoke-backend/src/extn/core/regexp/match_.rs
+++ b/artichoke-backend/src/extn/core/regexp/match_.rs
@@ -152,7 +152,7 @@ pub fn method(
                     sys::mrb_gv_set(mrb, sym, data.inner());
                 }
                 if let Some(block) = args.block {
-                    let result = block.yield_arg(interp, data).map_err(|_| {
+                    let result = block.yield_arg(interp, &data).map_err(|_| {
                         Fatal::new(
                             interp,
                             "Failed to initialize Ruby MatchData Value with Rust MatchData",

--- a/artichoke-backend/src/extn/core/regexp/mod.rs
+++ b/artichoke-backend/src/extn/core/regexp/mod.rs
@@ -4,7 +4,6 @@
 //! Each function on `Regexp` is implemented as its own module which contains
 //! the `Args` struct for invoking the function.
 
-use artichoke_core::value::Value as _;
 use onig::{self, Syntax};
 use regex;
 use std::convert::TryFrom;
@@ -279,10 +278,7 @@ impl Regexp {
             &interp,
             Value::new(&interp, pattern),
             pos.map(|pos| Value::new(&interp, pos)),
-            Value::new(&interp, block)
-                .try_into::<Option<Value>>()
-                .ok()
-                .unwrap_or_default(),
+            block,
         )
         .and_then(|args| match_::method(&interp, args, &value));
         match result {

--- a/artichoke-backend/src/extn/core/string.rs
+++ b/artichoke-backend/src/extn/core/string.rs
@@ -1,4 +1,4 @@
-use crate::convert::{Convert, TryConvert};
+use crate::convert::TryConvert;
 use crate::def::{ClassLike, Define};
 use crate::eval::Eval;
 use crate::extn::core::exception::{self, ArgumentError, Fatal};
@@ -61,12 +61,7 @@ impl RString {
         let (pattern, block) = mrb_get_args!(mrb, required = 1, &block);
         let interp = unwrap_interpreter!(mrb);
         let value = Value::new(&interp, slf);
-        let result = scan::method(
-            &interp,
-            value,
-            Value::new(&interp, pattern),
-            interp.convert(Value::new(&interp, block)),
-        );
+        let result = scan::method(&interp, value, Value::new(&interp, pattern), block);
         match result {
             Ok(result) => result.inner(),
             Err(exception) => exception::raise(interp, exception),

--- a/artichoke-backend/src/extn/core/string/scan.rs
+++ b/artichoke-backend/src/extn/core/string/scan.rs
@@ -70,7 +70,7 @@ pub fn method(
                     sys::mrb_gv_set(mrb, last_match_sym, data.inner());
                 }
                 // TODO: Propagate exceptions from yield.
-                let _ = block.yield_arg(interp, interp.convert(pattern_bytes));
+                let _ = block.yield_arg(interp, &interp.convert(pattern_bytes));
                 unsafe {
                     sys::mrb_gv_set(mrb, last_match_sym, data.inner());
                 }
@@ -178,7 +178,7 @@ pub fn method(
                         sys::mrb_gv_set(mrb, last_match_sym, data.inner());
                     }
                     // TODO: Propagate exceptions from yield.
-                    let _ = block.yield_arg(interp, interp.convert(pattern_bytes));
+                    let _ = block.yield_arg(interp, &interp.convert(pattern_bytes));
                     unsafe {
                         sys::mrb_gv_set(mrb, last_match_sym, data.inner());
                     }
@@ -311,7 +311,7 @@ pub fn method(
                                     sys::mrb_gv_set(mrb, last_match_sym, data.inner());
                                 }
                                 // TODO: Propagate exceptions from yield.
-                                let _ = block.yield_arg(interp, matched);
+                                let _ = block.yield_arg(interp, &matched);
                                 unsafe {
                                     sys::mrb_gv_set(mrb, last_match_sym, data.inner());
                                 }
@@ -337,7 +337,7 @@ pub fn method(
                                     sys::mrb_gv_set(mrb, last_match_sym, data.inner());
                                 }
                                 // TODO: Propagate exceptions from yield.
-                                let _ = block.yield_arg(interp, matched);
+                                let _ = block.yield_arg(interp, &matched);
                                 unsafe {
                                     sys::mrb_gv_set(mrb, last_match_sym, data.inner());
                                 }

--- a/artichoke-backend/src/macros.rs
+++ b/artichoke-backend/src/macros.rs
@@ -141,7 +141,7 @@ macro_rules! mrb_get_args {
             2 | 1 => {
                 let req1 = req1.assume_init();
                 let block = block.assume_init();
-                (req1, block)
+                (req1, $crate::value::Block::new(block))
             }
             _ => unreachable!("mrb_get_args should have raised"),
         }
@@ -165,7 +165,7 @@ macro_rules! mrb_get_args {
                 let req1 = req1.assume_init();
                 let opt1 = opt1.assume_init();
                 let block = block.assume_init();
-                (req1, Some(opt1), block)
+                (req1, Some(opt1), $crate::value::Block::new(block))
             }
             2 => {
                 let req1 = req1.assume_init();
@@ -175,12 +175,12 @@ macro_rules! mrb_get_args {
                     None
                 };
                 let block = block.assume_init();
-                (req1, opt1, block)
+                (req1, opt1, $crate::value::Block::new(block))
             }
             1 => {
                 let req1 = req1.assume_init();
                 let block = block.assume_init();
-                (req1, None, block)
+                (req1, None, $crate::value::Block::new(block))
             }
             _ => unreachable!("mrb_get_args should have raised"),
         }
@@ -231,7 +231,7 @@ macro_rules! mrb_get_args {
             None
         };
         let block = block.assume_init();
-        (opt1, opt2, block)
+        (opt1, opt2, $crate::value::Block::new(block))
     }};
     ($mrb:expr, required = 2, optional = 1) => {{
         let mut req1 = <std::mem::MaybeUninit<$crate::sys::mrb_value>>::uninit();

--- a/artichoke-backend/src/value.rs
+++ b/artichoke-backend/src/value.rs
@@ -405,7 +405,7 @@ impl Block {
         }
     }
 
-    pub fn yield_arg(&self, interp: &Artichoke, arg: Value) -> Result<Value, ArtichokeError> {
+    pub fn yield_arg(&self, interp: &Artichoke, arg: &Value) -> Result<Value, ArtichokeError> {
         // Ensure the borrow is out of scope by the time we eval code since
         // Rust-backed files and types may need to mutably borrow the `Artichoke` to
         // get access to the underlying `ArtichokeState`.

--- a/artichoke-backend/src/value.rs
+++ b/artichoke-backend/src/value.rs
@@ -180,7 +180,6 @@ impl ValueLike for Value {
     where
         Self::Artichoke: TryConvert<Self, T>,
     {
-        self.interp.0.borrow_mut();
         // Ensure the borrow is out of scope by the time we eval code since
         // Rust-backed files and types may need to mutably borrow the `Artichoke` to
         // get access to the underlying `ArtichokeState`.
@@ -255,7 +254,6 @@ impl ValueLike for Value {
         args: &[Self::Arg],
         block: Option<Self::Block>,
     ) -> Result<Self, ArtichokeError> {
-        self.interp.0.borrow_mut();
         // Ensure the borrow is out of scope by the time we eval code since
         // Rust-backed files and types may need to mutably borrow the `Artichoke` to
         // get access to the underlying `ArtichokeState`.
@@ -389,6 +387,54 @@ impl PartialEq for Value {
         std::ptr::eq(unsafe { sys::mrb_sys_basic_ptr(self.inner()) }, unsafe {
             sys::mrb_sys_basic_ptr(other.inner())
         })
+    }
+}
+
+#[derive(Clone, Copy)]
+pub struct Block {
+    value: sys::mrb_value,
+}
+
+impl Block {
+    /// Construct a new [`Value`] from an interpreter and [`sys::mrb_value`].
+    pub fn new(block: sys::mrb_value) -> Option<Self> {
+        if unsafe { sys::mrb_sys_value_is_nil(block) } {
+            None
+        } else {
+            Some(Self { value: block })
+        }
+    }
+
+    pub fn yield_arg(&self, interp: &Artichoke, arg: Value) -> Result<Value, ArtichokeError> {
+        // Ensure the borrow is out of scope by the time we eval code since
+        // Rust-backed files and types may need to mutably borrow the `Artichoke` to
+        // get access to the underlying `ArtichokeState`.
+        let mrb = interp.0.borrow().mrb;
+
+        let _arena = interp.create_arena_savepoint();
+
+        let value = unsafe { sys::mrb_yield(mrb, self.value, arg.inner()) };
+        let value = Value::new(interp, value);
+
+        match interp.last_error() {
+            LastError::Some(exception) => {
+                warn!("runtime error with exception backtrace: {}", exception);
+                Err(ArtichokeError::Exec(exception.to_string()))
+            }
+            LastError::UnableToExtract(err) => {
+                error!("failed to extract exception after runtime error: {}", err);
+                Err(err)
+            }
+            LastError::None if value.is_unreachable() => {
+                // Unreachable values are internal to the mruby interpreter and
+                // interacting with them via the C API is unspecified and may
+                // result in a segfault.
+                //
+                // See: https://github.com/mruby/mruby/issues/4460
+                Err(ArtichokeError::UnreachableValue)
+            }
+            LastError::None => Ok(value),
+        }
     }
 }
 


### PR DESCRIPTION
The entire suite of `Array` specs is runnable with:

```shell
./scripts/run-spec.sh core array
```

The previous `VecDeque` implementation of `Array` was able to run the specs to completion and had the following pass rate:

```
Passed 654, skipped 116, not implemented 99, failed 345 specs.
```

The class cluster implementation was not able to run the specs to completion:

- Improperly calling `block.funcall("call")` instead of using `mrb_yield` caused segfaults.
- Some methods on `Array` required a mutable borrow _and_ call back into the VM to parse arguments. These funcalls can trigger GC runs. Marking `Array`s requires a shared borrow, which panics.

The fixes are:

- Introduce a `Block` type that properly (and only) implements `yield`.
- Modify `mrb_get_args!` macro to extract block arguments into a `Block` type.
- Disable GC before acquiring mutable borrows and reenable it upon exit. This is a hack.

Real, non-hack solutions to disabling GC include hoisting arg extraction to before taking the mutable borrow or wrapping the boxed trait object in `Array` with a `RefCell`.

With this PR, the array spec suite is runnable to completion again, and the new implementation passes more specs than the old one!

```
Passed 686, skipped 116, not implemented 98, failed 314 specs.
```