### PR TITLE
Rollout to playground

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,6 +66,11 @@ jobs:
             sudo apt-get install -y clang
             clang --version
       - run:
+          name: Build workspace without default features
+          command: |
+            cargo build -p artichoke-backend --no-default-features
+            touch artichoke-backend/build.rs
+      - run:
           name: Build Workspace
           command: |
             cargo build

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -41,3 +41,7 @@ walkdir = "2"
 [build-dependencies.bindgen]
 version = "0.51.1"
 default-features = false
+
+[features]
+default = ["artichoke-array"]
+artichoke-array = []

--- a/artichoke-backend/build.rs
+++ b/artichoke-backend/build.rs
@@ -222,9 +222,11 @@ mod libmruby {
 
         if let Architecture::Wasm32 = target.architecture {
             build.include(wasm_include_dir());
-            if let OperatingSystem::Unknown = target.operating_system {
-                build.define("MRB_DISABLE_DIRECT_THREADING", None);
+            if let OperatingSystem::Emscripten = target.operating_system {
+                build.define("MRB_API", Some(r#"__attribute__((used))"#));
+            } else if let OperatingSystem::Unknown = target.operating_system {
                 build.define("MRB_API", Some(r#"__attribute__((visibility("default")))"#));
+                build.define("MRB_DISABLE_DIRECT_THREADING", None);
             }
         }
 
@@ -262,7 +264,6 @@ mod libmruby {
         if let Architecture::Wasm32 = target.architecture {
             bindgen = bindgen
                 .clang_arg(format!("-I{}", wasm_include_dir().to_str().unwrap()))
-                .clang_arg("-DMRB_DISABLE_DIRECT_THREADING")
                 .clang_arg(r#"-DMRB_API=__attribute__((visibility("default")))"#);
         }
         bindgen

--- a/artichoke-backend/build.rs
+++ b/artichoke-backend/build.rs
@@ -208,8 +208,11 @@ mod libmruby {
             .define("MRB_DISABLE_STDIO", None)
             .define("MRB_UTF8_STRING", None)
             .define(mrb_int, None)
-            .define("ARTICHOKE", None)
             .define("DISABLE_GEMS", None);
+
+        if env::var("CARGO_FEATURE_ARTICHOKE_ARRAY").is_ok() {
+            build.define("ARTICHOKE", None);
+        }
 
         for gem in gems() {
             let mut dir = "include";
@@ -246,7 +249,6 @@ mod libmruby {
             .clang_arg("-DMRB_DISABLE_STDIO")
             .clang_arg("-DMRB_UTF8_STRING")
             .clang_arg(format!("-D{}", mrb_int))
-            .clang_arg("-DARTICHOKE")
             .whitelist_function("^mrb.*")
             .whitelist_type("^mrb.*")
             .whitelist_var("^mrb.*")
@@ -266,6 +268,10 @@ mod libmruby {
                 .clang_arg(format!("-I{}", wasm_include_dir().to_str().unwrap()))
                 .clang_arg(r#"-DMRB_API=__attribute__((visibility("default")))"#);
         }
+        if env::var("CARGO_FEATURE_ARTICHOKE_ARRAY").is_ok() {
+            bindgen = bindgen.clang_arg("-DARTICHOKE");
+        }
+
         bindgen
             .generate()
             .unwrap()

--- a/artichoke-backend/mruby-sys/include/mruby-sys.h
+++ b/artichoke-backend/mruby-sys/include/mruby-sys.h
@@ -37,3 +37,6 @@
 #ifdef ARTICHOKE
 #include <mruby-sys/artichoke.h>
 #endif
+
+// Expose mrbgems subsystem initializer
+MRB_API void mrb_init_mrbgems(mrb_state *mrb);

--- a/artichoke-backend/mruby-sys/include/mruby-sys/artichoke.h
+++ b/artichoke-backend/mruby-sys/include/mruby-sys/artichoke.h
@@ -1,13 +1,6 @@
-#include <mruby.h>
-#include <mruby/array.h>
 #include <mruby/boxing_no.h>
-#include <mruby/class.h>
 #include <mruby/common.h>
-#include <mruby/data.h>
-#include <mruby/error.h>
-#include <mruby/proc.h>
 #include <mruby/value.h>
-#include <mruby/variable.h>
 
 // Array overrides
 MRB_API mrb_value artichoke_assoc_new(mrb_state *mrb, mrb_value car,

--- a/artichoke-backend/mruby-sys/include/mruby-sys/artichoke.h
+++ b/artichoke-backend/mruby-sys/include/mruby-sys/artichoke.h
@@ -3,46 +3,26 @@
 #include <mruby/value.h>
 
 // Array overrides
-MRB_API mrb_value artichoke_assoc_new(mrb_state *mrb, mrb_value car,
-                                      mrb_value cdr);
-MRB_API mrb_value artichoke_value_to_ary(mrb_state *mrb, mrb_value value);
-MRB_API mrb_value artichoke_ary_new(mrb_state *mrb);
-MRB_API mrb_value artichoke_ary_new_capa(mrb_state *, mrb_int);
-MRB_API mrb_value artichoke_ary_new_from_values(mrb_state *mrb, mrb_int size,
-                                                const mrb_value *vals);
-MRB_API mrb_value artichoke_ary_splat(mrb_state *mrb, mrb_value value);
-MRB_API mrb_value artichoke_ary_clone(mrb_state *mrb, mrb_value value);
-MRB_API mrb_value artichoke_ary_clear(mrb_state *mrb, mrb_value self);
-MRB_API mrb_value artichoke_ary_entry(mrb_value ary, mrb_int offset);
-MRB_API mrb_value artichoke_ary_ref(mrb_state *mrb, mrb_value ary, mrb_int n);
-MRB_API mrb_value artichoke_ary_entry(mrb_value ary, mrb_int offset);
-MRB_API mrb_value artichoke_ary_ref(mrb_state *mrb, mrb_value ary, mrb_int n);
-MRB_API mrb_value artichoke_ary_join(mrb_state *mrb, mrb_value ary,
-                                     mrb_value sep);
-MRB_API mrb_value artichoke_ary_pop(mrb_state *mrb, mrb_value ary);
-MRB_API mrb_value artichoke_ary_resize(mrb_state *mrb, mrb_value ary,
-                                       mrb_int new_len);
-MRB_API mrb_value artichoke_ary_shift(mrb_state *mrb, mrb_value self);
-MRB_API mrb_value artichoke_ary_splice(mrb_state *mrb, mrb_value self,
-                                       mrb_int head, mrb_int len,
-                                       mrb_value rpl);
-MRB_API mrb_value artichoke_ary_shift(mrb_state *mrb, mrb_value self);
-MRB_API mrb_value artichoke_ary_unshift(mrb_state *mrb, mrb_value self,
-                                        mrb_value item);
-MRB_API mrb_int artichoke_ary_len(mrb_state *mrb, mrb_value self);
-MRB_API void artichoke_ary_concat(mrb_state *mrb, mrb_value self,
-                                  mrb_value other);
-MRB_API void artichoke_ary_push(mrb_state *mrb, mrb_value array,
-                                mrb_value value);
-MRB_API void artichoke_ary_replace(mrb_state *mrb, mrb_value self,
-                                   mrb_value other);
-MRB_API void artichoke_ary_set(mrb_state *mrb, mrb_value ary, mrb_int n,
-                               mrb_value val);
-MRB_API mrb_bool artichoke_ary_check(mrb_state *mrb, mrb_value ary);
+mrb_value artichoke_value_to_ary(mrb_state *mrb, mrb_value value);
+mrb_value artichoke_ary_new(mrb_state *mrb);
+mrb_value artichoke_ary_new_capa(mrb_state *, mrb_int);
+mrb_value artichoke_ary_new_from_values(mrb_state *mrb, mrb_int size,
+                                        const mrb_value *vals);
+mrb_value artichoke_ary_splat(mrb_state *mrb, mrb_value value);
+mrb_value artichoke_ary_clone(mrb_state *mrb, mrb_value value);
+mrb_value artichoke_ary_ref(mrb_state *mrb, mrb_value ary, mrb_int n);
+mrb_value artichoke_ary_pop(mrb_state *mrb, mrb_value ary);
+mrb_value artichoke_ary_shift(mrb_state *mrb, mrb_value self);
+mrb_value artichoke_ary_unshift(mrb_state *mrb, mrb_value self, mrb_value item);
+mrb_int artichoke_ary_len(mrb_state *mrb, mrb_value self);
+void artichoke_ary_concat(mrb_state *mrb, mrb_value self, mrb_value other);
+void artichoke_ary_push(mrb_state *mrb, mrb_value array, mrb_value value);
+void artichoke_ary_set(mrb_state *mrb, mrb_value ary, mrb_int n, mrb_value val);
+mrb_bool artichoke_ary_check(mrb_state *mrb, mrb_value ary);
 
 // GC
-MRB_API void artichoke_gc_mark_ary(mrb_state *mrb, mrb_value ary);
-MRB_API size_t artichoke_gc_mark_ary_size(mrb_state *mrb, mrb_value ary);
+void artichoke_gc_mark_ary(mrb_state *mrb, mrb_value ary);
+size_t artichoke_gc_mark_ary_size(mrb_state *mrb, mrb_value ary);
 
 // Expose mrbgems subsystem initializer
 MRB_API void mrb_init_mrbgems(mrb_state *mrb);

--- a/artichoke-backend/mruby-sys/include/mruby-sys/artichoke.h
+++ b/artichoke-backend/mruby-sys/include/mruby-sys/artichoke.h
@@ -23,6 +23,3 @@ mrb_bool artichoke_ary_check(mrb_state *mrb, mrb_value ary);
 // GC
 void artichoke_gc_mark_ary(mrb_state *mrb, mrb_value ary);
 size_t artichoke_gc_mark_ary_size(mrb_state *mrb, mrb_value ary);
-
-// Expose mrbgems subsystem initializer
-MRB_API void mrb_init_mrbgems(mrb_state *mrb);

--- a/artichoke-backend/mruby-sys/include/mruby-sys/ext.h
+++ b/artichoke-backend/mruby-sys/include/mruby-sys/ext.h
@@ -22,8 +22,6 @@
  * initializers).
  */
 
-#include <mruby.h>
-#include <mruby/array.h>
 #include <mruby/boxing_no.h>
 #include <mruby/class.h>
 #include <mruby/common.h>

--- a/artichoke-backend/mruby-sys/src/mruby-sys/ext.c
+++ b/artichoke-backend/mruby-sys/src/mruby-sys/ext.c
@@ -14,11 +14,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-#include <mruby-sys/ext.h>
 #include <mruby.h>
 #include <mruby/array.h>
 #include <mruby/range.h>
 #include <mruby/string.h>
+
+#include <mruby-sys/ext.h>
 
 // Check whether `mrb_value` is nil, false, or true
 

--- a/artichoke-backend/mruby-sys/src/mruby-sys/ext.c
+++ b/artichoke-backend/mruby-sys/src/mruby-sys/ext.c
@@ -15,6 +15,8 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 #include <mruby-sys/ext.h>
+#include <mruby.h>
+#include <mruby/array.h>
 #include <mruby/range.h>
 #include <mruby/string.h>
 

--- a/artichoke-backend/src/convert/array.rs
+++ b/artichoke-backend/src/convert/array.rs
@@ -2,7 +2,8 @@ use std::collections::HashMap;
 use std::convert::TryFrom;
 
 use crate::convert::float::Float;
-use crate::convert::{Convert, RustBackedValue, TryConvert};
+use crate::convert::{Convert, TryConvert};
+#[cfg(feature = "artichoke-array")]
 use crate::extn::core::array::{backend, Array};
 use crate::sys;
 use crate::types::{Int, Ruby, Rust};
@@ -11,16 +12,52 @@ use crate::{Artichoke, ArtichokeError};
 
 // bail out implementation for mixed-type collections
 impl Convert<&[Value], Value> for Artichoke {
+    #[cfg(feature = "artichoke-array")]
     fn convert(&self, value: &[Value]) -> Value {
+        use crate::convert::RustBackedValue;
         let ary = Array::new(Box::new(backend::buffer::Buffer::from(value)));
         unsafe { ary.try_into_ruby(self, None) }.expect("Array into Value")
+    }
+
+    #[cfg(not(feature = "artichoke-array"))]
+    fn convert(&self, value: &[Value]) -> Value {
+        let mrb = self.0.borrow().mrb;
+        let capa = Int::try_from(value.len()).unwrap_or_default();
+        let array = unsafe { sys::mrb_ary_new_capa(mrb, capa) };
+
+        for (idx, item) in value.iter().enumerate() {
+            let idx = Int::try_from(idx).unwrap_or_default();
+            let item = item.inner();
+            unsafe {
+                sys::mrb_ary_set(mrb, array, idx, item);
+            }
+        }
+        Value::new(self, array)
     }
 }
 
 impl Convert<Vec<Value>, Value> for Artichoke {
+    #[cfg(feature = "artichoke-array")]
     fn convert(&self, value: Vec<Value>) -> Value {
+        use crate::convert::RustBackedValue;
         let ary = Array::new(Box::new(backend::buffer::Buffer::from(value)));
         unsafe { ary.try_into_ruby(self, None) }.expect("Array into Value")
+    }
+
+    #[cfg(not(feature = "artichoke-array"))]
+    fn convert(&self, value: Vec<Value>) -> Value {
+        let mrb = self.0.borrow().mrb;
+        let capa = Int::try_from(value.len()).unwrap_or_default();
+        let array = unsafe { sys::mrb_ary_new_capa(mrb, capa) };
+
+        for (idx, item) in value.iter().enumerate() {
+            let idx = Int::try_from(idx).unwrap_or_default();
+            let item = item.inner();
+            unsafe {
+                sys::mrb_ary_set(mrb, array, idx, item);
+            }
+        }
+        Value::new(self, array)
     }
 }
 
@@ -42,7 +79,9 @@ impl TryConvert<Value, Vec<Value>> for Artichoke {
                 }
                 Ok(elems)
             }
+            #[cfg(feature = "artichoke-array")]
             Ruby::Data => {
+                use crate::convert::RustBackedValue;
                 let array = unsafe { Array::try_from_ruby(self, &value)? };
                 let borrow = array.borrow();
                 Ok(borrow.as_vec(self))

--- a/artichoke-backend/src/convert/hash.rs
+++ b/artichoke-backend/src/convert/hash.rs
@@ -4,6 +4,7 @@ use std::hash::BuildHasher;
 
 use crate::convert::float::Float;
 use crate::convert::{Convert, TryConvert};
+#[cfg(feature = "artichoke-array")]
 use crate::extn::core::array;
 use crate::sys;
 use crate::types::{Int, Ruby, Rust};
@@ -44,7 +45,10 @@ impl TryConvert<Value, Vec<(Value, Value)>> for Artichoke {
                 for idx in 0..size {
                     // Doing a `hash[key]` access is guaranteed to succeed since
                     // we're iterating over the keys in the hash.
+                    #[cfg(feature = "artichoke-array")]
                     let key = unsafe { array::mruby::artichoke_ary_ref(mrb, keys, idx) };
+                    #[cfg(not(feature = "artichoke-array"))]
+                    let key = unsafe { sys::mrb_ary_ref(mrb, keys, idx) };
                     let value = unsafe { sys::mrb_hash_get(mrb, hash, key) };
                     pairs.push((Value::new(self, key), Value::new(self, value)));
                 }

--- a/artichoke-backend/src/extn/core/array/mruby.rs
+++ b/artichoke-backend/src/extn/core/array/mruby.rs
@@ -10,6 +10,7 @@ use crate::sys;
 use crate::value::Value;
 use crate::{Artichoke, ArtichokeError};
 
+#[cfg(feature = "artichoke-array")]
 pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
     let array = interp.0.borrow_mut().def_class::<array::Array>(
         "Array",
@@ -54,6 +55,12 @@ pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
         .add_method("size", ary_len, sys::mrb_args_none());
     array.borrow().define(interp)?;
 
+    interp.eval(&include_bytes!("array.rb")[..])?;
+    Ok(())
+}
+
+#[cfg(not(feature = "artichoke-array"))]
+pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
     interp.eval(&include_bytes!("array.rb")[..])?;
     Ok(())
 }

--- a/artichoke-backend/src/extn/core/artichoke/mod.rs
+++ b/artichoke-backend/src/extn/core/artichoke/mod.rs
@@ -1,10 +1,12 @@
+use crate::def::Define;
 use crate::{Artichoke, ArtichokeError};
 
 pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
-    interp
+    let artichoke = interp
         .0
         .borrow_mut()
         .def_module::<RArtichoke>("Artichoke", None);
+    artichoke.borrow().define(interp)?;
     Ok(())
 }
 

--- a/artichoke-backend/src/extn/core/env/mruby.rs
+++ b/artichoke-backend/src/extn/core/env/mruby.rs
@@ -31,9 +31,7 @@ pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
     env.borrow_mut()
         .add_method("to_h", artichoke_env_to_h, sys::mrb_args_none());
 
-    env.borrow()
-        .define(interp)
-        .map_err(|_| ArtichokeError::New)?;
+    env.borrow().define(interp)?;
 
     interp.eval("ENV = EnvClass.new")?;
 

--- a/artichoke-backend/src/extn/core/exception/mod.rs
+++ b/artichoke-backend/src/extn/core/exception/mod.rs
@@ -160,10 +160,7 @@ macro_rules! ruby_exception_impl {
                 if let Some(superclass) = superclass {
                     class.borrow_mut().with_super_class(superclass);
                 }
-                class
-                    .borrow()
-                    .define(interp)
-                    .map_err(|_| ArtichokeError::New)?;
+                class.borrow().define(interp)?;
                 Ok(class)
             }
 

--- a/artichoke-backend/src/extn/core/integer/mod.rs
+++ b/artichoke-backend/src/extn/core/integer/mod.rs
@@ -29,10 +29,7 @@ pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
         .borrow_mut()
         .add_method("size", Integer::size, sys::mrb_args_none());
 
-    integer
-        .borrow()
-        .define(interp)
-        .map_err(|_| ArtichokeError::New)?;
+    integer.borrow().define(interp)?;
 
     interp.eval(include_str!("integer.rb"))?;
 

--- a/artichoke-backend/src/extn/core/kernel/mod.rs
+++ b/artichoke-backend/src/extn/core/kernel/mod.rs
@@ -18,10 +18,7 @@ pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
     warning
         .borrow_mut()
         .add_self_method("warn", Warning::warn, sys::mrb_args_req(1));
-    warning
-        .borrow()
-        .define(interp)
-        .map_err(|_| ArtichokeError::New)?;
+    warning.borrow().define(interp)?;
     let kernel = interp.0.borrow_mut().def_module::<Kernel>("Kernel", None);
     kernel
         .borrow_mut()
@@ -37,7 +34,7 @@ pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
             .borrow_mut()
             .module_spec::<RArtichoke>()
             .map(EnclosingRubyScope::module)
-            .unwrap();
+            .ok_or(ArtichokeError::New)?;
         let spec = interp
             .0
             .borrow_mut()
@@ -51,10 +48,7 @@ pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
         );
         spec
     };
-    artichoke_kernel
-        .borrow()
-        .define(interp)
-        .map_err(|_| ArtichokeError::New)?;
+    artichoke_kernel.borrow().define(interp)?;
     kernel
         .borrow_mut()
         .add_self_method("load", Kernel::load, sys::mrb_args_rest());
@@ -67,10 +61,7 @@ pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
     kernel
         .borrow_mut()
         .add_method("warn", Kernel::warn, sys::mrb_args_rest());
-    kernel
-        .borrow()
-        .define(interp)
-        .map_err(|_| ArtichokeError::New)?;
+    kernel.borrow().define(interp)?;
     interp.eval(include_str!("kernel.rb"))?;
     trace!("Patched Kernel#require onto interpreter");
     Ok(())

--- a/artichoke-backend/src/extn/core/mod.rs
+++ b/artichoke-backend/src/extn/core/mod.rs
@@ -1,6 +1,7 @@
 use crate::eval::Eval;
 use crate::{Artichoke, ArtichokeError};
 
+#[cfg(feature = "artichoke-array")]
 pub mod array;
 pub mod artichoke;
 pub mod comparable;
@@ -28,6 +29,7 @@ pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
     interp.eval(include_str!("object.rb"))?;
     enumerable::init(interp)?;
     // `Array` depends on: `Enumerable`
+    #[cfg(feature = "artichoke-array")]
     array::mruby::init(interp)?;
     module::init(interp)?;
     // Some `Exception`s depend on: `attr_accessor` (defined in `Module`)

--- a/artichoke-backend/src/extn/core/mod.rs
+++ b/artichoke-backend/src/extn/core/mod.rs
@@ -1,7 +1,6 @@
 use crate::eval::Eval;
 use crate::{Artichoke, ArtichokeError};
 
-#[cfg(feature = "artichoke-array")]
 pub mod array;
 pub mod artichoke;
 pub mod comparable;
@@ -29,7 +28,6 @@ pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
     interp.eval(include_str!("object.rb"))?;
     enumerable::init(interp)?;
     // `Array` depends on: `Enumerable`
-    #[cfg(feature = "artichoke-array")]
     array::mruby::init(interp)?;
     module::init(interp)?;
     // Some `Exception`s depend on: `attr_accessor` (defined in `Module`)

--- a/artichoke-backend/src/extn/core/string.rs
+++ b/artichoke-backend/src/extn/core/string.rs
@@ -23,10 +23,7 @@ pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
     string
         .borrow_mut()
         .add_method("scan", RString::scan, sys::mrb_args_req(1));
-    string
-        .borrow()
-        .define(interp)
-        .map_err(|_| ArtichokeError::New)?;
+    string.borrow().define(interp)?;
     trace!("Patched String onto interpreter");
     Ok(())
 }


### PR DESCRIPTION
An assortment of changes that will make it easier to bump the playground to the latest master.

- Add a `artichoke-array` feature, enabled by default, that controls whether `artichoke-backend` builds without `RArray`.
- Changes to headers in `mruby-sys` C extension for clarity.
- Set `EMSCRIPTEN_KEEPALIVE` macro in `artichoke-backend` build script for wasm32-unknown-emscripten target.
- Define `Artichoke` module explicitly in Rust rather than implicitly through `array.rb`.
- Stop swallowing errors during init by squashing into `ArtichokeError::New`.