### PR TITLE
Regex crate regexp backend

### DIFF
--- a/artichoke-backend/src/extn/core/regexp/backend/mod.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/mod.rs
@@ -1,0 +1,1 @@
+pub mod regex;

--- a/artichoke-backend/src/extn/core/regexp/backend/regex/case_compare.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/regex/case_compare.rs
@@ -1,0 +1,122 @@
+//! [`Regexp#===`](https://ruby-doc.org/core-2.6.3/Regexp.html#method-i-3D-3D-3D)
+
+use std::cmp;
+use std::mem;
+
+use crate::convert::{Convert, RustBackedValue, TryConvert};
+use crate::extn::core::matchdata::MatchData;
+use crate::extn::core::regexp::Regexp;
+use crate::sys;
+use crate::value::Value;
+use crate::Artichoke;
+
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub enum Error {
+    Fatal,
+    NoImplicitConversionToString,
+}
+
+#[derive(Debug, Clone)]
+pub struct Args {
+    pub string: Option<String>,
+}
+
+impl Args {
+    const ARGSPEC: &'static [u8] = b"o\0";
+
+    pub unsafe fn extract(interp: &Artichoke) -> Result<Self, Error> {
+        let mut string = <mem::MaybeUninit<sys::mrb_value>>::uninit();
+        sys::mrb_get_args(
+            interp.borrow().mrb,
+            Self::ARGSPEC.as_ptr() as *const i8,
+            string.as_mut_ptr(),
+        );
+        let string = string.assume_init();
+        if let Ok(string) = <Option<String>>::try_convert(interp, Value::new(interp, string)) {
+            Ok(Self { string })
+        } else {
+            Err(Error::NoImplicitConversionToString)
+        }
+    }
+}
+
+pub fn method(interp: &Artichoke, args: Args, value: &Value) -> Result<Value, Error> {
+    let mrb = interp.borrow().mrb;
+    let data = unsafe { Regexp::try_from_ruby(interp, value) }.map_err(|_| Error::Fatal)?;
+    let string = if let Some(string) = args.string {
+        string
+    } else {
+        unsafe {
+            sys::mrb_gv_set(
+                mrb,
+                interp.borrow_mut().sym_intern("$~"),
+                sys::mrb_sys_nil_value(),
+            );
+            return Ok(Value::convert(interp, false));
+        }
+    };
+    let borrow = data.borrow();
+    let regex = (*borrow.regex).as_ref().ok_or(Error::Fatal)?;
+    let matchdata = if let Some(captures) = regex.captures(string.as_str()) {
+        let num_regexp_globals_to_set = {
+            let num_previously_set_globals = interp.borrow().num_set_regexp_capture_globals;
+            cmp::max(num_previously_set_globals, captures.len())
+        };
+        for group in 0..num_regexp_globals_to_set {
+            let sym = if group == 0 {
+                interp.borrow_mut().sym_intern("$&")
+            } else {
+                interp.borrow_mut().sym_intern(&format!("${}", group))
+            };
+
+            let value = Value::convert(&interp, captures.get(group).map(|m| m.as_str()));
+            unsafe {
+                sys::mrb_gv_set(mrb, sym, value.inner());
+            }
+        }
+        interp.borrow_mut().num_set_regexp_capture_globals = captures.len();
+
+        if let Some(match_) = captures.get(0) {
+            let pre_match = &string[..match_.start()];
+            let post_match = &string[match_.end()..];
+            unsafe {
+                let pre_match_sym = interp.borrow_mut().sym_intern("$`");
+                sys::mrb_gv_set(
+                    mrb,
+                    pre_match_sym,
+                    Value::convert(interp, pre_match).inner(),
+                );
+                let post_match_sym = interp.borrow_mut().sym_intern("$'");
+                sys::mrb_gv_set(
+                    mrb,
+                    post_match_sym,
+                    Value::convert(interp, post_match).inner(),
+                );
+            }
+        }
+        let matchdata = MatchData::new(string.as_str(), borrow.clone(), 0, string.len());
+        unsafe { matchdata.try_into_ruby(&interp, None) }.map_err(|_| Error::Fatal)?
+    } else {
+        unsafe {
+            let pre_match_sym = interp.borrow_mut().sym_intern("$`");
+            sys::mrb_gv_set(
+                mrb,
+                pre_match_sym,
+                Value::convert(interp, None::<Value>).inner(),
+            );
+            let post_match_sym = interp.borrow_mut().sym_intern("$'");
+            sys::mrb_gv_set(
+                mrb,
+                post_match_sym,
+                Value::convert(interp, None::<Value>).inner(),
+            );
+        }
+        Value::convert(interp, None::<Value>)
+    };
+    unsafe {
+        sys::mrb_gv_set(mrb, interp.borrow_mut().sym_intern("$~"), matchdata.inner());
+    }
+    Ok(Value::convert(&interp, !unsafe {
+        sys::mrb_sys_value_is_nil(matchdata.inner())
+    }))
+}

--- a/artichoke-backend/src/extn/core/regexp/backend/regex/casefold.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/regex/casefold.rs
@@ -1,0 +1,17 @@
+//! [`Regexp#casefold?`](https://ruby-doc.org/core-2.6.3/Regexp.html#method-i-casefold-3F)
+
+use crate::convert::{Convert, RustBackedValue};
+use crate::extn::core::regexp::Regexp;
+use crate::value::Value;
+use crate::Artichoke;
+
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub enum Error {
+    Fatal,
+}
+
+pub fn method(interp: &Artichoke, value: &Value) -> Result<Value, Error> {
+    let data = unsafe { Regexp::try_from_ruby(interp, value) }.map_err(|_| Error::Fatal)?;
+    let borrow = data.borrow();
+    Ok(Value::convert(interp, borrow.literal_options.ignore_case))
+}

--- a/artichoke-backend/src/extn/core/regexp/backend/regex/enc.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/regex/enc.rs
@@ -1,0 +1,98 @@
+//! Parse encoding parameter to `Regexp#initialize` and `Regexp::compile`.
+
+use std::hash::{Hash, Hasher};
+
+use crate::extn::core::regexp::Regexp;
+use crate::types::Int;
+use crate::value::Value;
+
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub enum Error {
+    InvalidEncoding,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum Encoding {
+    Fixed,
+    No,
+    None,
+}
+
+impl Encoding {
+    pub fn flags(self) -> Int {
+        match self {
+            Encoding::Fixed => Regexp::FIXEDENCODING,
+            Encoding::No => Regexp::NOENCODING,
+            Encoding::None => 0,
+        }
+    }
+
+    pub fn string(self) -> &'static str {
+        match self {
+            Encoding::Fixed | Encoding::None => "",
+            Encoding::No => "n",
+        }
+    }
+}
+
+impl Default for Encoding {
+    fn default() -> Self {
+        Encoding::None
+    }
+}
+
+impl Hash for Encoding {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.string().hash(state);
+    }
+}
+
+impl PartialEq for Encoding {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Encoding::No, Encoding::None)
+            | (Encoding::None, Encoding::No)
+            | (Encoding::No, Encoding::No)
+            | (Encoding::None, Encoding::None)
+            | (Encoding::Fixed, Encoding::Fixed) => true,
+            _ => false,
+        }
+    }
+}
+
+impl Eq for Encoding {}
+
+pub fn parse(value: &Value) -> Result<Encoding, Error> {
+    if let Ok(encoding) = value.itself::<Int>() {
+        // Only deal with Encoding opts
+        let encoding = encoding & !Regexp::ALL_REGEXP_OPTS;
+        if encoding == Regexp::FIXEDENCODING {
+            Ok(Encoding::Fixed)
+        } else if encoding == Regexp::NOENCODING {
+            Ok(Encoding::No)
+        } else if encoding == 0 {
+            Ok(Encoding::default())
+        } else {
+            Err(Error::InvalidEncoding)
+        }
+    } else if let Ok(encoding) = value.itself::<String>() {
+        if encoding.contains('u') && encoding.contains('n') {
+            return Err(Error::InvalidEncoding);
+        }
+        let mut enc = vec![];
+        for flag in encoding.chars() {
+            match flag {
+                'u' | 's' | 'e' => enc.push(Encoding::Fixed),
+                'n' => enc.push(Encoding::No),
+                'i' | 'm' | 'x' | 'o' => continue,
+                _ => return Err(Error::InvalidEncoding),
+            }
+        }
+        if enc.len() > 1 {
+            return Err(Error::InvalidEncoding);
+        }
+        Ok(enc.pop().unwrap_or_default())
+    } else {
+        Ok(Encoding::default())
+    }
+}

--- a/artichoke-backend/src/extn/core/regexp/backend/regex/eql.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/regex/eql.rs
@@ -1,0 +1,58 @@
+//! [`Regexp#eql?`](https://ruby-doc.org/core-2.6.3/Regexp.html#method-i-eql-3F)
+//! and
+//! [`Regexp#==`](https://ruby-doc.org/core-2.6.3/Regexp.html#method-i-3D-3D)
+
+use std::cell::RefCell;
+use std::mem;
+use std::rc::Rc;
+
+use crate::convert::{Convert, RustBackedValue};
+use crate::extn::core::regexp::Regexp;
+use crate::sys;
+use crate::value::Value;
+use crate::Artichoke;
+
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub enum Error {
+    Fatal,
+}
+
+#[derive(Debug)]
+pub struct Args {
+    pub other: Option<Rc<RefCell<Regexp>>>,
+}
+
+impl Args {
+    const ARGSPEC: &'static [u8] = b"o\0";
+
+    pub unsafe fn extract(interp: &Artichoke) -> Self {
+        let mut other = <mem::MaybeUninit<sys::mrb_value>>::uninit();
+        sys::mrb_get_args(
+            interp.borrow().mrb,
+            Self::ARGSPEC.as_ptr() as *const i8,
+            other.as_mut_ptr(),
+        );
+        let other = other.assume_init();
+        if let Ok(other) = Regexp::try_from_ruby(interp, &Value::new(interp, other)) {
+            Self { other: Some(other) }
+        } else {
+            Self { other: None }
+        }
+    }
+}
+
+#[allow(clippy::if_same_then_else)]
+pub fn method(interp: &Artichoke, args: Args, value: &Value) -> Result<Value, Error> {
+    let data = unsafe { Regexp::try_from_ruby(interp, value) }.map_err(|_| Error::Fatal)?;
+    let slf = data.borrow();
+    if let Some(other) = args.other {
+        let borrow = other.borrow();
+        if slf.pattern == borrow.pattern {
+            Ok(Value::convert(interp, slf.encoding == borrow.encoding))
+        } else {
+            Ok(Value::convert(interp, false))
+        }
+    } else {
+        Ok(Value::convert(interp, false))
+    }
+}

--- a/artichoke-backend/src/extn/core/regexp/backend/regex/escape.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/regex/escape.rs
@@ -1,0 +1,48 @@
+//! [`Regexp::escape`](https://ruby-doc.org/core-2.6.3/Regexp.html#method-c-escape)
+//! and
+//! [`Regexp::quote`](https://ruby-doc.org/core-2.6.3/Regexp.html#method-c-quote)
+
+use std::mem;
+
+use crate::convert::{Convert, TryConvert};
+use crate::extn::core::regexp::syntax;
+use crate::sys;
+use crate::value::Value;
+use crate::Artichoke;
+
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub enum Error {
+    Fatal,
+    NoImplicitConversionToString,
+}
+
+#[derive(Debug, Clone)]
+pub struct Args {
+    pub pattern: String,
+}
+
+impl Args {
+    const ARGSPEC: &'static [u8] = b"o\0";
+
+    pub unsafe fn extract(interp: &Artichoke) -> Result<Self, Error> {
+        let mut string = <mem::MaybeUninit<sys::mrb_value>>::uninit();
+        sys::mrb_get_args(
+            interp.borrow().mrb,
+            Self::ARGSPEC.as_ptr() as *const i8,
+            string.as_mut_ptr(),
+        );
+        let string = string.assume_init();
+        if let Ok(pattern) = String::try_convert(interp, Value::new(interp, string)) {
+            Ok(Self { pattern })
+        } else {
+            Err(Error::NoImplicitConversionToString)
+        }
+    }
+}
+
+pub fn method(interp: &Artichoke, args: &Args) -> Result<Value, Error> {
+    Ok(Value::convert(
+        interp,
+        syntax::escape(args.pattern.as_str()),
+    ))
+}

--- a/artichoke-backend/src/extn/core/regexp/backend/regex/fixed_encoding.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/regex/fixed_encoding.rs
@@ -1,0 +1,24 @@
+//! [`Regexp#fixed_encoding?`](https://ruby-doc.org/core-2.6.3/Regexp.html#method-i-fixed_encoding-3F)
+
+use crate::convert::{Convert, RustBackedValue};
+use crate::extn::core::regexp::enc::Encoding;
+use crate::extn::core::regexp::Regexp;
+use crate::value::Value;
+use crate::Artichoke;
+
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub enum Error {
+    Fatal,
+}
+
+pub fn method(interp: &Artichoke, value: &Value) -> Result<Value, Error> {
+    let data = unsafe { Regexp::try_from_ruby(interp, value) }.map_err(|_| Error::Fatal)?;
+    let borrow = data.borrow();
+    match borrow.encoding {
+        Encoding::No if borrow.literal_options.flags() & Regexp::NOENCODING == 0 => {
+            Ok(Value::convert(interp, false))
+        }
+        Encoding::Fixed | Encoding::No => Ok(Value::convert(interp, true)),
+        Encoding::None => Ok(Value::convert(interp, false)),
+    }
+}

--- a/artichoke-backend/src/extn/core/regexp/backend/regex/hash.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/regex/hash.rs
@@ -1,0 +1,25 @@
+//! [`Regexp#hash`](https://ruby-doc.org/core-2.6.3/Regexp.html#method-i-hash)
+
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+
+use crate::convert::{Convert, RustBackedValue};
+use crate::extn::core::regexp::Regexp;
+use crate::types::Int;
+use crate::value::Value;
+use crate::Artichoke;
+
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub enum Error {
+    Fatal,
+}
+
+pub fn method(interp: &Artichoke, value: &Value) -> Result<Value, Error> {
+    let data = unsafe { Regexp::try_from_ruby(interp, value) }.map_err(|_| Error::Fatal)?;
+    let borrow = data.borrow();
+    let mut s = DefaultHasher::new();
+    borrow.hash(&mut s);
+    let hash = s.finish();
+    #[allow(clippy::cast_possible_wrap)]
+    Ok(Value::convert(interp, hash as Int))
+}

--- a/artichoke-backend/src/extn/core/regexp/backend/regex/initialize.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/regex/initialize.rs
@@ -1,0 +1,123 @@
+//! [`Regexp::new`](https://ruby-doc.org/core-2.6.3/Regexp.html#method-c-new)
+//! and
+//! [`Regexp::compile`](https://ruby-doc.org/core-2.6.3/Regexp.html#method-c-compile)
+
+use std::mem;
+
+use crate::convert::RustBackedValue;
+use crate::extn::core::regexp::enc::{self, Encoding};
+use crate::extn::core::regexp::opts::{self, Options};
+use crate::extn::core::regexp::Regexp;
+use crate::sys;
+use crate::value::Value;
+use crate::warn::Warn;
+use crate::Artichoke;
+
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub enum Error {
+    Fatal,
+    NoImplicitConversionToString,
+    Syntax,
+    Unicode,
+}
+
+#[derive(Debug)]
+pub struct Args {
+    pub pattern: Value,
+    pub options: Option<Options>,
+    pub encoding: Option<Encoding>,
+}
+
+impl Args {
+    const ARGSPEC: &'static [u8] = b"o|o?o?\0";
+
+    pub unsafe fn extract(interp: &Artichoke) -> Result<Self, Error> {
+        let mut pattern = <mem::MaybeUninit<sys::mrb_value>>::uninit();
+        let mut opts = <mem::MaybeUninit<sys::mrb_value>>::uninit();
+        let mut has_opts = <mem::MaybeUninit<sys::mrb_bool>>::uninit();
+        let mut enc = <mem::MaybeUninit<sys::mrb_value>>::uninit();
+        let mut has_enc = <mem::MaybeUninit<sys::mrb_bool>>::uninit();
+        sys::mrb_get_args(
+            interp.borrow().mrb,
+            Self::ARGSPEC.as_ptr() as *const i8,
+            pattern.as_mut_ptr(),
+            opts.as_mut_ptr(),
+            has_opts.as_mut_ptr(),
+            enc.as_mut_ptr(),
+            has_enc.as_mut_ptr(),
+        );
+        let pattern = pattern.assume_init();
+        let has_opts = has_opts.assume_init() != 0;
+        let has_enc = has_enc.assume_init() != 0;
+        let pattern = Value::new(&interp, pattern);
+        let options = if has_opts {
+            Some(opts::parse(&Value::new(interp, opts.assume_init())))
+        } else {
+            None
+        };
+        let encoding = if has_enc {
+            let encoding = Value::new(interp, enc.assume_init());
+            match enc::parse(&encoding) {
+                Ok(encoding) => Some(encoding),
+                Err(enc::Error::InvalidEncoding) => {
+                    let warning = format!("encoding option is ignored -- {}", encoding.to_s());
+                    interp.warn(warning.as_str()).map_err(|_| Error::Fatal)?;
+                    None
+                }
+            }
+        } else if has_opts {
+            let encoding = Value::new(interp, opts.assume_init());
+            match enc::parse(&encoding) {
+                Ok(encoding) => Some(encoding),
+                Err(enc::Error::InvalidEncoding) => {
+                    let warning = format!("encoding option is ignored -- {}", encoding.to_s());
+                    interp.warn(warning.as_str()).map_err(|_| Error::Fatal)?;
+                    None
+                }
+            }
+        } else {
+            None
+        };
+
+        Ok(Self {
+            pattern,
+            options,
+            encoding,
+        })
+    }
+}
+
+pub fn method(interp: &Artichoke, args: Args, slf: sys::mrb_value) -> Result<Value, Error> {
+    let mut literal_options = args.options.unwrap_or_default();
+    let literal_pattern =
+        if let Ok(regexp) = unsafe { Regexp::try_from_ruby(interp, &args.pattern) } {
+            interp
+                .warn("flags ignored when initializing from Regexp")
+                .map_err(|_| Error::Fatal)?;
+            let borrow = regexp.borrow();
+            literal_options = borrow.options;
+            borrow.literal_pattern.clone()
+        } else {
+            let bytes = args
+                .pattern
+                .try_into::<Vec<u8>>()
+                .map_err(|_| Error::NoImplicitConversionToString)?;
+            String::from_utf8(bytes).map_err(|_| Error::Unicode)?
+        };
+    let (pattern, options) = opts::parse_pattern(literal_pattern.as_str(), literal_options);
+    if let Some(data) = Regexp::new(
+        literal_pattern,
+        pattern,
+        literal_options,
+        options,
+        args.encoding.unwrap_or_default(),
+    ) {
+        unsafe {
+            data.try_into_ruby(interp, Some(slf))
+                .map_err(|_| Error::Fatal)
+        }
+    } else {
+        // Regexp is invalid.
+        Err(Error::Syntax)
+    }
+}

--- a/artichoke-backend/src/extn/core/regexp/backend/regex/inspect.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/regex/inspect.rs
@@ -1,0 +1,23 @@
+//! [`Regexp#inspect`](https://ruby-doc.org/core-2.6.3/Regexp.html#method-i-inspect)
+
+use crate::convert::{Convert, RustBackedValue};
+use crate::extn::core::regexp::Regexp;
+use crate::value::Value;
+use crate::Artichoke;
+
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub enum Error {
+    Fatal,
+}
+
+pub fn method(interp: &Artichoke, value: &Value) -> Result<Value, Error> {
+    let data = unsafe { Regexp::try_from_ruby(interp, value) }.map_err(|_| Error::Fatal)?;
+    let borrow = data.borrow();
+    let s = format!(
+        "/{}/{}{}",
+        borrow.literal_pattern.as_str().replace("/", r"\/"),
+        borrow.literal_options.modifier_string(),
+        borrow.encoding.string()
+    );
+    Ok(Value::convert(interp, s))
+}

--- a/artichoke-backend/src/extn/core/regexp/backend/regex/match_.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/regex/match_.rs
@@ -1,0 +1,176 @@
+//! [`Regexp#match`](https://ruby-doc.org/core-2.6.3/Regexp.html#method-i-match)
+
+use std::cmp;
+use std::convert::TryFrom;
+use std::mem;
+
+use crate::convert::{Convert, RustBackedValue, TryConvert};
+use crate::extn::core::matchdata::MatchData;
+use crate::extn::core::regexp::Regexp;
+use crate::sys;
+use crate::types::Int;
+use crate::value::Value;
+use crate::Artichoke;
+
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub enum Error {
+    Fatal,
+    PosType,
+    StringType,
+}
+
+#[derive(Debug)]
+pub struct Args {
+    pub string: Option<String>,
+    pub pos: Option<Int>,
+    pub block: Option<Value>,
+}
+
+impl Args {
+    const ARGSPEC: &'static [u8] = b"o&|o?\0";
+
+    pub unsafe fn extract(interp: &Artichoke) -> Result<Self, Error> {
+        let mut string = <mem::MaybeUninit<sys::mrb_value>>::uninit();
+        let mut pos = <mem::MaybeUninit<sys::mrb_value>>::uninit();
+        let mut has_pos = <mem::MaybeUninit<sys::mrb_bool>>::uninit();
+        let mut block = <mem::MaybeUninit<sys::mrb_value>>::uninit();
+        sys::mrb_get_args(
+            interp.borrow().mrb,
+            Self::ARGSPEC.as_ptr() as *const i8,
+            string.as_mut_ptr(),
+            block.as_mut_ptr(),
+            pos.as_mut_ptr(),
+            has_pos.as_mut_ptr(),
+        );
+        let string = string.assume_init();
+        let block = block.assume_init();
+        let has_pos = has_pos.assume_init() != 0;
+        let string = if let Ok(string) =
+            <Option<String>>::try_convert(&interp, Value::new(interp, string))
+        {
+            string
+        } else {
+            return Err(Error::StringType);
+        };
+        let pos = if has_pos {
+            let pos = Int::try_convert(&interp, Value::new(&interp, pos.assume_init()))
+                .map_err(|_| Error::PosType)?;
+            Some(pos)
+        } else {
+            None
+        };
+        let block = if sys::mrb_sys_value_is_nil(block) {
+            None
+        } else {
+            Some(Value::new(interp, block))
+        };
+        Ok(Self { string, pos, block })
+    }
+}
+
+pub fn method(interp: &Artichoke, args: Args, value: &Value) -> Result<Value, Error> {
+    let mrb = interp.borrow().mrb;
+    let data = unsafe { Regexp::try_from_ruby(interp, value) }.map_err(|_| Error::Fatal)?;
+    let string = if let Some(string) = args.string {
+        string
+    } else {
+        unsafe {
+            let matchdata = Value::convert(interp, None::<Value>);
+            sys::mrb_gv_set(mrb, interp.borrow_mut().sym_intern("$~"), matchdata.inner());
+            return Ok(matchdata);
+        }
+    };
+    let pos = args.pos.unwrap_or_default();
+    let pos = if pos < 0 {
+        let strlen = Int::try_from(string.chars().count()).unwrap_or_default();
+        let pos = strlen + pos;
+        if pos < 0 {
+            return Ok(Value::convert(interp, None::<Value>));
+        }
+        usize::try_from(pos).map_err(|_| Error::Fatal)?
+    } else {
+        usize::try_from(pos).map_err(|_| Error::Fatal)?
+    };
+    // onig will panic if pos is beyond the end of string
+    if pos > string.chars().count() {
+        return Ok(Value::convert(interp, None::<Value>));
+    }
+    let byte_offset = string.chars().take(pos).collect::<String>().len();
+
+    let borrow = data.borrow();
+    let regex = (*borrow.regex).as_ref().ok_or(Error::Fatal)?;
+    let match_target = &string[byte_offset..];
+    if let Some(captures) = regex.captures(match_target) {
+        let num_regexp_globals_to_set = {
+            let num_previously_set_globals = interp.borrow().num_set_regexp_capture_globals;
+            cmp::max(num_previously_set_globals, captures.len())
+        };
+        for group in 0..num_regexp_globals_to_set {
+            let sym = if group == 0 {
+                interp.borrow_mut().sym_intern("$&")
+            } else {
+                interp.borrow_mut().sym_intern(&format!("${}", group))
+            };
+
+            let value = Value::convert(&interp, captures.get(group).map(|m| m.as_str()));
+            unsafe {
+                sys::mrb_gv_set(mrb, sym, value.inner());
+            }
+        }
+        interp.borrow_mut().num_set_regexp_capture_globals = captures.len();
+
+        let mut matchdata = MatchData::new(string.as_str(), borrow.clone(), 0, string.len());
+        if let Some(match_) = captures.get(0) {
+            let pre_match = &string[..match_.start()];
+            let post_match = &string[match_.end()..];
+            unsafe {
+                let pre_match_sym = interp.borrow_mut().sym_intern("$`");
+                sys::mrb_gv_set(
+                    mrb,
+                    pre_match_sym,
+                    Value::convert(interp, pre_match).inner(),
+                );
+                let post_match_sym = interp.borrow_mut().sym_intern("$'");
+                sys::mrb_gv_set(
+                    mrb,
+                    post_match_sym,
+                    Value::convert(interp, post_match).inner(),
+                );
+            }
+            matchdata.set_region(byte_offset + match_.start(), byte_offset + match_.end());
+        }
+        let data = unsafe { matchdata.try_into_ruby(interp, None) }.map_err(|_| Error::Fatal)?;
+        unsafe {
+            sys::mrb_gv_set(mrb, interp.borrow_mut().sym_intern("$~"), data.inner());
+        }
+        if let Some(block) = args.block {
+            Ok(Value::new(interp, unsafe {
+                sys::mrb_yield(mrb, block.inner(), data.inner())
+            }))
+        } else {
+            Ok(data)
+        }
+    } else {
+        unsafe {
+            let last_match_sym = interp.borrow_mut().sym_intern("$~");
+            sys::mrb_gv_set(
+                mrb,
+                last_match_sym,
+                Value::convert(interp, None::<Value>).inner(),
+            );
+            let pre_match_sym = interp.borrow_mut().sym_intern("$`");
+            sys::mrb_gv_set(
+                mrb,
+                pre_match_sym,
+                Value::convert(interp, None::<Value>).inner(),
+            );
+            let post_match_sym = interp.borrow_mut().sym_intern("$'");
+            sys::mrb_gv_set(
+                mrb,
+                post_match_sym,
+                Value::convert(interp, None::<Value>).inner(),
+            );
+        }
+        Ok(Value::convert(interp, None::<Value>))
+    }
+}

--- a/artichoke-backend/src/extn/core/regexp/backend/regex/match_operator.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/regex/match_operator.rs
@@ -1,0 +1,138 @@
+//! [`Regexp#=~`](https://ruby-doc.org/core-2.6.3/Regexp.html#method-i-3D-7E)
+
+use std::cmp;
+use std::convert::TryFrom;
+use std::mem;
+
+use crate::convert::{Convert, RustBackedValue, TryConvert};
+use crate::extn::core::matchdata::MatchData;
+use crate::extn::core::regexp::Regexp;
+use crate::sys;
+use crate::types::Int;
+use crate::value::Value;
+use crate::Artichoke;
+
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub enum Error {
+    Fatal,
+    NoImplicitConversionToString,
+}
+
+#[derive(Debug, Clone)]
+pub struct Args {
+    pub string: Option<String>,
+}
+
+impl Args {
+    const ARGSPEC: &'static [u8] = b"o\0";
+
+    pub unsafe fn extract(interp: &Artichoke) -> Result<Self, Error> {
+        let mut string = <mem::MaybeUninit<sys::mrb_value>>::uninit();
+        sys::mrb_get_args(
+            interp.borrow().mrb,
+            Self::ARGSPEC.as_ptr() as *const i8,
+            string.as_mut_ptr(),
+        );
+        let string = string.assume_init();
+        if let Ok(string) = <Option<String>>::try_convert(interp, Value::new(interp, string)) {
+            Ok(Self { string })
+        } else {
+            Err(Error::NoImplicitConversionToString)
+        }
+    }
+}
+
+// TODO: extract named captures and assign to local variables, see GH-156.
+//
+// See: https://ruby-doc.org/core-2.6.3/Regexp.html#method-i-3D-7E
+pub fn method(interp: &Artichoke, args: Args, value: &Value) -> Result<Value, Error> {
+    let mrb = interp.borrow().mrb;
+    let data = unsafe { Regexp::try_from_ruby(interp, value) }.map_err(|_| Error::Fatal)?;
+    let borrow = data.borrow();
+    let regex = (*borrow.regex).as_ref().ok_or(Error::Fatal)?;
+    let string = if let Some(string) = args.string {
+        string
+    } else {
+        unsafe {
+            let nil = Value::convert(interp, None::<Value>);
+            sys::mrb_gv_set(mrb, interp.borrow_mut().sym_intern("$~"), nil.inner());
+            return Ok(nil);
+        }
+    };
+    let (matchdata, pos) = if let Some(captures) = regex.captures(string.as_str()) {
+        let num_regexp_globals_to_set = {
+            let num_previously_set_globals = interp.borrow().num_set_regexp_capture_globals;
+            cmp::max(num_previously_set_globals, captures.len())
+        };
+        for group in 0..num_regexp_globals_to_set {
+            let sym = if group == 0 {
+                interp.borrow_mut().sym_intern("$&")
+            } else {
+                interp.borrow_mut().sym_intern(&format!("${}", group))
+            };
+
+            let value = Value::convert(&interp, captures.get(group).map(|m| m.as_str()));
+            unsafe {
+                sys::mrb_gv_set(mrb, sym, value.inner());
+            }
+        }
+        interp.borrow_mut().num_set_regexp_capture_globals = captures.len();
+
+        let matchdata = MatchData::new(string.as_str(), borrow.clone(), 0, string.len());
+        let matchdata =
+            unsafe { matchdata.try_into_ruby(&interp, None) }.map_err(|_| Error::Fatal)?;
+        if let Some(match_) = captures.get(0) {
+            let pre_match = &string[..match_.start()];
+            let post_match = &string[match_.end()..];
+            unsafe {
+                let pre_match_sym = interp.borrow_mut().sym_intern("$`");
+                sys::mrb_gv_set(
+                    mrb,
+                    pre_match_sym,
+                    Value::convert(interp, pre_match).inner(),
+                );
+                let post_match_sym = interp.borrow_mut().sym_intern("$'");
+                sys::mrb_gv_set(
+                    mrb,
+                    post_match_sym,
+                    Value::convert(interp, post_match).inner(),
+                );
+            }
+            (
+                matchdata,
+                Value::convert(interp, Int::try_from(match_.start()).ok()),
+            )
+        } else {
+            (matchdata, Value::convert(interp, None::<Value>))
+        }
+    } else {
+        unsafe {
+            let last_match_sym = interp.borrow_mut().sym_intern("$~");
+            sys::mrb_gv_set(
+                mrb,
+                last_match_sym,
+                Value::convert(interp, None::<Value>).inner(),
+            );
+            let pre_match_sym = interp.borrow_mut().sym_intern("$`");
+            sys::mrb_gv_set(
+                mrb,
+                pre_match_sym,
+                Value::convert(interp, None::<Value>).inner(),
+            );
+            let post_match_sym = interp.borrow_mut().sym_intern("$'");
+            sys::mrb_gv_set(
+                mrb,
+                post_match_sym,
+                Value::convert(interp, None::<Value>).inner(),
+            );
+        }
+        (
+            Value::convert(interp, None::<Value>),
+            Value::convert(interp, None::<Value>),
+        )
+    };
+    unsafe {
+        sys::mrb_gv_set(mrb, interp.borrow_mut().sym_intern("$~"), matchdata.inner());
+    }
+    Ok(pos)
+}

--- a/artichoke-backend/src/extn/core/regexp/backend/regex/match_q.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/regex/match_q.rs
@@ -1,0 +1,88 @@
+//! [`Regexp#match?`](https://ruby-doc.org/core-2.6.3/Regexp.html#method-i-match-3F)
+
+use std::convert::TryFrom;
+use std::mem;
+
+use crate::convert::{Convert, RustBackedValue, TryConvert};
+use crate::extn::core::regexp::Regexp;
+use crate::sys;
+use crate::types::Int;
+use crate::value::Value;
+use crate::Artichoke;
+
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub enum Error {
+    Fatal,
+    PosType,
+    StringType,
+}
+
+#[derive(Debug)]
+pub struct Args {
+    pub string: Option<String>,
+    pub pos: Option<Int>,
+}
+
+impl Args {
+    const ARGSPEC: &'static [u8] = b"o|o?\0";
+
+    pub unsafe fn extract(interp: &Artichoke) -> Result<Self, Error> {
+        let mut string = <mem::MaybeUninit<sys::mrb_value>>::uninit();
+        let mut pos = <mem::MaybeUninit<sys::mrb_value>>::uninit();
+        let mut has_pos = <mem::MaybeUninit<sys::mrb_bool>>::uninit();
+        sys::mrb_get_args(
+            interp.borrow().mrb,
+            Self::ARGSPEC.as_ptr() as *const i8,
+            string.as_mut_ptr(),
+            pos.as_mut_ptr(),
+            has_pos.as_mut_ptr(),
+        );
+        let string = string.assume_init();
+        let has_pos = has_pos.assume_init() != 0;
+        let string = if let Ok(string) =
+            <Option<String>>::try_convert(&interp, Value::new(interp, string))
+        {
+            string
+        } else {
+            return Err(Error::StringType);
+        };
+        let pos = if has_pos {
+            let pos = Int::try_convert(&interp, Value::new(&interp, pos.assume_init()))
+                .map_err(|_| Error::PosType)?;
+            Some(pos)
+        } else {
+            None
+        };
+        Ok(Self { string, pos })
+    }
+}
+
+pub fn method(interp: &Artichoke, args: Args, value: &Value) -> Result<Value, Error> {
+    let data = unsafe { Regexp::try_from_ruby(interp, value) }.map_err(|_| Error::Fatal)?;
+    let string = if let Some(string) = args.string {
+        string
+    } else {
+        return Ok(Value::convert(interp, false));
+    };
+    let pos = args.pos.unwrap_or_default();
+    let pos = if pos < 0 {
+        let strlen = Int::try_from(string.chars().count()).unwrap_or_default();
+        let pos = strlen + pos;
+        if pos < 0 {
+            return Ok(Value::convert(interp, false));
+        }
+        usize::try_from(pos).map_err(|_| Error::Fatal)?
+    } else {
+        usize::try_from(pos).map_err(|_| Error::Fatal)?
+    };
+    // onig will panic if pos is beyond the end of string
+    if pos > string.chars().count() {
+        return Ok(Value::convert(interp, false));
+    }
+    let byte_offset = string.chars().take(pos).collect::<String>().len();
+
+    let borrow = data.borrow();
+    let regex = (*borrow.regex).as_ref().ok_or(Error::Fatal)?;
+    let match_target = &string[byte_offset..];
+    Ok(Value::convert(interp, regex.is_match(match_target)))
+}

--- a/artichoke-backend/src/extn/core/regexp/backend/regex/named_captures.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/regex/named_captures.rs
@@ -1,0 +1,48 @@
+//! [`Regexp#named_captures`](https://ruby-doc.org/core-2.6.3/Regexp.html#method-i-named_captures)
+
+use std::collections::HashMap;
+use std::convert::TryFrom;
+
+use crate::convert::{Convert, RustBackedValue};
+use crate::extn::core::regexp::Regexp;
+use crate::types::Int;
+use crate::value::Value;
+use crate::Artichoke;
+
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub enum Error {
+    Fatal,
+}
+
+pub fn method(interp: &Artichoke, value: &Value) -> Result<Value, Error> {
+    let data = unsafe { Regexp::try_from_ruby(interp, value) }.map_err(|_| Error::Fatal)?;
+    let borrow = data.borrow();
+    let regex = (*borrow.regex).as_ref().ok_or(Error::Fatal)?;
+    // Use a Vec of key-value pairs because insertion order matters for spec
+    // compliance.
+    let mut map = HashMap::new();
+    let mut captures = vec![];
+    for (idx, name) in regex.capture_names().enumerate() {
+        if let Some(name) = name {
+            if !map.contains_key(name) {
+                captures.push(name);
+                map.insert(name.to_owned(), vec![]);
+            }
+            if let Some(indexes) = map.get_mut(name) {
+                let idx = Int::try_from(idx).map_err(|_| Error::Fatal)?;
+                indexes.push(idx);
+            }
+        }
+    }
+    let pairs = captures
+        .into_iter()
+        .filter_map(|name| {
+            if let Some(indexes) = map.remove(name) {
+                Some((name.to_owned(), indexes))
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<_>>();
+    Ok(Value::convert(interp, pairs))
+}

--- a/artichoke-backend/src/extn/core/regexp/backend/regex/names.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/regex/names.rs
@@ -1,0 +1,27 @@
+//! [`Regexp#names`](https://ruby-doc.org/core-2.6.3/Regexp.html#method-i-names)
+
+use crate::convert::{Convert, RustBackedValue};
+use crate::extn::core::regexp::Regexp;
+use crate::value::Value;
+use crate::Artichoke;
+
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub enum Error {
+    Fatal,
+}
+
+pub fn method(interp: &Artichoke, value: &Value) -> Result<Value, Error> {
+    let data = unsafe { Regexp::try_from_ruby(interp, value) }.map_err(|_| Error::Fatal)?;
+    let borrow = data.borrow();
+    let mut names = vec![];
+    let regex = (*borrow.regex).as_ref().ok_or(Error::Fatal)?;
+    let capture_names = regex.capture_names().collect::<Vec<_>>();
+    for name in capture_names {
+        if let Some(name) = name {
+            if !names.contains(&name) {
+                names.push(name);
+            }
+        }
+    }
+    Ok(Value::convert(&interp, names))
+}

--- a/artichoke-backend/src/extn/core/regexp/backend/regex/options.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/regex/options.rs
@@ -1,0 +1,18 @@
+//! [`Regexp#options`](https://ruby-doc.org/core-2.6.3/Regexp.html#method-i-options)
+
+use crate::convert::{Convert, RustBackedValue};
+use crate::extn::core::regexp::Regexp;
+use crate::value::Value;
+use crate::Artichoke;
+
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub enum Error {
+    Fatal,
+}
+
+pub fn method(interp: &Artichoke, value: &Value) -> Result<Value, Error> {
+    let data = unsafe { Regexp::try_from_ruby(interp, value) }.map_err(|_| Error::Fatal)?;
+    let borrow = data.borrow();
+    let opts = borrow.literal_options.flags() | borrow.encoding.flags();
+    Ok(Value::convert(interp, opts))
+}

--- a/artichoke-backend/src/extn/core/regexp/backend/regex/opts.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/regex/opts.rs
@@ -1,0 +1,198 @@
+//! Parse options parameter to `Regexp#initialize` and `Regexp::compile`.
+
+use crate::extn::core::regexp::Regexp;
+use crate::types::Int;
+use crate::value::Value;
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
+pub struct Options {
+    pub multiline: bool,
+    pub ignore_case: bool,
+    pub extended: bool,
+}
+
+impl Options {
+    pub fn ignore_case() -> Self {
+        let mut opts = Self::default();
+        opts.ignore_case = true;
+        opts
+    }
+
+    pub fn flags(self) -> Int {
+        let mut bits = 0;
+        if self.multiline {
+            bits |= Regexp::MULTILINE;
+        }
+        if self.ignore_case {
+            bits |= Regexp::IGNORECASE;
+        }
+        if self.extended {
+            bits |= Regexp::EXTENDED;
+        }
+        bits
+    }
+
+    // This function should return a &'static str but linking fails under the
+    // wasm32-unknown-emscripten build if this function does not return an owned
+    // String.
+    pub fn modifier_string(self) -> String {
+        match (self.multiline, self.ignore_case, self.extended) {
+            (true, true, true) => "mix",
+            (true, true, false) => "mi",
+            (true, false, true) => "mx",
+            (true, false, false) => "m",
+            (false, true, true) => "ix",
+            (false, true, false) => "i",
+            (false, false, true) => "x",
+            (false, false, false) => "",
+        }
+        .to_owned()
+    }
+
+    // This function should return a &'static str but linking fails under the
+    // wasm32-unknown-emscripten build if this function does not return an owned
+    // String.
+    fn onig_string(self) -> String {
+        match (self.multiline, self.ignore_case, self.extended) {
+            (true, true, true) => "mix",
+            (true, true, false) => "mi-x",
+            (true, false, true) => "mx-i",
+            (true, false, false) => "m-ix",
+            (false, true, true) => "ix-m",
+            (false, true, false) => "i-mx",
+            (false, false, true) => "x-mi",
+            (false, false, false) => "-mix",
+        }
+        .to_owned()
+    }
+}
+
+pub fn parse(value: &Value) -> Options {
+    // If options is an Integer, it should be one or more of the constants
+    // Regexp::EXTENDED, Regexp::IGNORECASE, and Regexp::MULTILINE, logically
+    // or-ed together. Otherwise, if options is not nil or false, the regexp
+    // will be case insensitive.
+    if let Ok(options) = value.itself::<Int>() {
+        // Only deal with Regexp opts
+        let options = options & Regexp::ALL_REGEXP_OPTS;
+        Options {
+            multiline: options & Regexp::MULTILINE > 0,
+            ignore_case: options & Regexp::IGNORECASE > 0,
+            extended: options & Regexp::EXTENDED > 0,
+        }
+    } else if let Ok(options) = value.itself::<Option<bool>>() {
+        match options {
+            Some(false) | None => Options::default(),
+            _ => Options::ignore_case(),
+        }
+    } else if let Ok(options) = value.itself::<Option<String>>() {
+        if let Some(options) = options {
+            Options {
+                multiline: options.contains('m'),
+                ignore_case: options.contains('i'),
+                extended: options.contains('x'),
+            }
+        } else {
+            Options::default()
+        }
+    } else {
+        Options::ignore_case()
+    }
+}
+
+// TODO: Add tests for this parse_pattern, see GH-157.
+pub fn parse_pattern(pattern: &str, mut opts: Options) -> (String, Options) {
+    let orig_opts = opts;
+    let mut chars = pattern.chars();
+    let mut enabled = true;
+    let mut pat_buf = String::new();
+    let mut pointer = 0;
+    match chars.next() {
+        None => {
+            pat_buf.push_str("(?");
+            pat_buf.push_str(opts.onig_string().as_str());
+            pat_buf.push(':');
+            pat_buf.push(')');
+            return (pat_buf, opts);
+        }
+        Some(token) if token != '(' => {
+            pat_buf.push_str("(?");
+            pat_buf.push_str(opts.onig_string().as_str());
+            pat_buf.push(':');
+            pat_buf.push_str(pattern);
+            pat_buf.push(')');
+            return (pat_buf, opts);
+        }
+        _ => (),
+    };
+    pointer += 1;
+    match chars.next() {
+        None => {
+            pat_buf.push_str("(?");
+            pat_buf.push_str(opts.onig_string().as_str());
+            pat_buf.push(':');
+            pat_buf.push_str(pattern);
+            pat_buf.push(')');
+            return (pat_buf, opts);
+        }
+        Some(token) if token != '?' => {
+            pat_buf.push_str("(?");
+            pat_buf.push_str(opts.onig_string().as_str());
+            pat_buf.push(':');
+            pat_buf.push_str(pattern);
+            pat_buf.push(')');
+            return (pat_buf, opts);
+        }
+        _ => (),
+    };
+    pointer += 1;
+    for token in chars {
+        pointer += 1;
+        match token {
+            '-' => enabled = false,
+            'i' => {
+                opts.ignore_case = enabled;
+            }
+            'm' => {
+                opts.multiline = enabled;
+            }
+            'x' => {
+                opts.extended = enabled;
+            }
+            ':' => break,
+            _ => {
+                pat_buf.push_str("(?");
+                pat_buf.push_str(opts.onig_string().as_str());
+                pat_buf.push(':');
+                pat_buf.push_str(pattern);
+                pat_buf.push(')');
+                return (pat_buf, opts);
+            }
+        }
+    }
+    let mut chars = pattern[pointer..].chars();
+    let mut token = chars.next();
+    let mut nest = 1;
+    while token.is_some() {
+        match token {
+            Some(token) if token == '(' => nest += 1,
+            Some(token) if token == ')' => {
+                nest -= 1;
+                if nest == 0 && chars.next().is_some() {
+                    return (
+                        format!("(?{}:{})", orig_opts.onig_string(), pattern),
+                        orig_opts,
+                    );
+                }
+                break;
+            }
+            _ => (),
+        }
+        token = chars.next();
+    }
+
+    (
+        format!("(?{}:{}", opts.onig_string(), &pattern[pointer..]),
+        opts,
+    )
+}

--- a/artichoke-backend/src/extn/core/regexp/backend/regex/source.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/regex/source.rs
@@ -1,0 +1,18 @@
+//! [`Regexp#source`](https://ruby-doc.org/core-2.6.3/Regexp.html#method-i-source)
+
+use crate::convert::{Convert, RustBackedValue};
+use crate::extn::core::regexp::Regexp;
+use crate::value::Value;
+use crate::Artichoke;
+
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub enum Error {
+    Fatal,
+}
+
+pub fn method(interp: &Artichoke, value: &Value) -> Result<Value, Error> {
+    let data = unsafe { Regexp::try_from_ruby(interp, value) }.map_err(|_| Error::Fatal)?;
+    let borrow = data.borrow();
+    let s = borrow.literal_pattern.to_string();
+    Ok(Value::convert(interp, s))
+}

--- a/artichoke-backend/src/extn/core/regexp/backend/regex/syntax.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/regex/syntax.rs
@@ -1,0 +1,79 @@
+// This module is forked from Rust regex crate @ 172898a.
+//
+// https://github.com/rust-lang/regex/blob/172898a4fda4fd6a2d1be9fc7b8a0ea971c84ca6/regex-syntax/src/lib.rs
+//
+// MIT Licence
+// Copyright (c) 2014 The Rust Project Developers
+
+//! Helpers for parsing Regexp patterns.
+
+/// Escapes all regular expression meta characters in `text`.
+///
+/// The string returned may be safely used as a literal in a regular
+/// expression.
+pub fn escape(text: &str) -> String {
+    let mut quoted = String::with_capacity(text.len());
+    escape_into(text, &mut quoted);
+    quoted
+}
+
+/// Escapes all meta characters in `text` and writes the result into `buf`.
+///
+/// This will append escape characters into the given buffer. The characters
+/// that are appended are safe to use as a literal in a regular expression.
+pub fn escape_into(text: &str, buf: &mut String) {
+    for c in text.chars() {
+        if is_meta_character(c) {
+            buf.push('\\');
+            buf.push(c);
+        } else if let Some(escape) = is_non_supported_non_printable_character(c) {
+            buf.push_str(escape.as_str());
+        } else if is_non_printable_character(c) {
+            for c in c.escape_default() {
+                buf.push(c);
+            }
+        } else if c == ' ' {
+            buf.push('\\');
+            buf.push(' ');
+        } else {
+            buf.push(c);
+        }
+    }
+}
+
+/// Returns true if the given character has significance in a regex.
+///
+/// These are the only characters that are allowed to be escaped, with one
+/// exception: an ASCII space character may be escaped when extended mode (with
+/// the `x` flag) is enabld. In particular, `is_meta_character(' ')` returns
+/// `false`.
+///
+/// Note that the set of characters for which this function returns `true` or
+/// `false` is fixed and won't change in a semver compatible release.
+pub fn is_meta_character(c: char) -> bool {
+    match c {
+        '\\' | '/' | '.' | '+' | '*' | '?' | '(' | ')' | '|' | '[' | ']' | '{' | '}' | '^'
+        | '$' | '#' | '&' | '-' | '~' => true,
+        _ => false,
+    }
+}
+
+/// Returns true if the given character is non-printable and needs to be quoted.
+pub fn is_non_printable_character(c: char) -> bool {
+    let form_feed = 0x0C as char; // "\f"
+    match c {
+        '\n' | '\r' | '\t' => true,
+        c if c == form_feed => true,
+        _ => false,
+    }
+}
+
+/// Returns true if the given character is non-printable and Rust does not support
+/// the escape sequence.
+pub fn is_non_supported_non_printable_character(c: char) -> Option<String> {
+    let form_feed = 0x0C as char; // "\f"
+    match c {
+        c if c == form_feed => Some("\\f".to_owned()),
+        _ => None,
+    }
+}

--- a/artichoke-backend/src/extn/core/regexp/backend/regex/to_s.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/regex/to_s.rs
@@ -1,0 +1,18 @@
+//! [`Regexp#to_s`](https://ruby-doc.org/core-2.6.3/Regexp.html#method-i-to_s)
+
+use crate::convert::{Convert, RustBackedValue};
+use crate::extn::core::regexp::Regexp;
+use crate::value::Value;
+use crate::Artichoke;
+
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub enum Error {
+    Fatal,
+}
+
+pub fn method(interp: &Artichoke, value: &Value) -> Result<Value, Error> {
+    let data = unsafe { Regexp::try_from_ruby(interp, value) }.map_err(|_| Error::Fatal)?;
+    let borrow = data.borrow();
+    let s = borrow.pattern.to_string();
+    Ok(Value::convert(interp, s))
+}

--- a/artichoke-backend/src/extn/core/regexp/backend/regex/union.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/regex/union.rs
@@ -1,0 +1,98 @@
+//! [`Regexp::union`](https://ruby-doc.org/core-2.6.3/Regexp.html#method-c-union)
+
+use std::mem;
+
+use crate::convert::{Convert, RustBackedValue};
+use crate::extn::core::regexp::{syntax, Regexp};
+use crate::sys;
+use crate::types::Ruby;
+use crate::value::{Value, ValueLike};
+use crate::Artichoke;
+
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub enum Error {
+    Fatal,
+    NoImplicitConversionToString,
+}
+
+#[derive(Debug)]
+pub struct Args {
+    pub rest: Vec<Value>,
+}
+
+impl Args {
+    const ARGSPEC: &'static [u8] = b"*\0";
+
+    pub unsafe fn extract(interp: &Artichoke) -> Self {
+        let mut args = <mem::MaybeUninit<*const sys::mrb_value>>::uninit();
+        let mut count = <mem::MaybeUninit<usize>>::uninit();
+        sys::mrb_get_args(
+            interp.borrow().mrb,
+            Self::ARGSPEC.as_ptr() as *const i8,
+            args.as_mut_ptr(),
+            count.as_mut_ptr(),
+        );
+        let args = std::slice::from_raw_parts(args.assume_init(), count.assume_init());
+        let args = args
+            .iter()
+            .map(|value| Value::new(&interp, *value))
+            .collect::<Vec<_>>();
+        Self { rest: args }
+    }
+}
+
+pub fn method(interp: &Artichoke, args: Args, slf: sys::mrb_value) -> Result<Value, Error> {
+    let mrb = interp.borrow().mrb;
+    let pattern = if args.rest.is_empty() {
+        "(?!)".to_owned()
+    } else if args.rest.len() == 1 {
+        let arg = args.rest.into_iter().nth(0).unwrap();
+        if arg.ruby_type() == Ruby::Array {
+            let mut patterns = vec![];
+            for pattern in arg
+                .itself::<Vec<Value>>()
+                .map_err(|_| Error::NoImplicitConversionToString)?
+            {
+                if let Ok(regexp) = unsafe { Regexp::try_from_ruby(&interp, &pattern) } {
+                    patterns.push(regexp.borrow().pattern.clone());
+                } else if let Ok(pattern) = pattern.funcall::<String, _, _>("to_str", &[]) {
+                    patterns.push(syntax::escape(pattern.as_str()));
+                } else {
+                    return Err(Error::NoImplicitConversionToString);
+                }
+            }
+            patterns.join("|")
+        } else {
+            let pattern = arg;
+            if let Ok(regexp) = unsafe { Regexp::try_from_ruby(&interp, &pattern) } {
+                regexp.borrow().pattern.clone()
+            } else if let Ok(pattern) = pattern.funcall::<String, _, _>("to_str", &[]) {
+                syntax::escape(pattern.as_str())
+            } else {
+                return Err(Error::NoImplicitConversionToString);
+            }
+        }
+    } else {
+        let mut patterns = vec![];
+        for pattern in args.rest {
+            if let Ok(regexp) = unsafe { Regexp::try_from_ruby(&interp, &pattern) } {
+                patterns.push(regexp.borrow().pattern.clone());
+            } else if let Ok(pattern) = pattern.funcall::<String, _, _>("to_str", &[]) {
+                patterns.push(syntax::escape(pattern.as_str()));
+            } else {
+                return Err(Error::NoImplicitConversionToString);
+            }
+        }
+        patterns.join("|")
+    };
+
+    let value = unsafe {
+        sys::mrb_obj_new(
+            mrb,
+            sys::mrb_sys_class_ptr(slf),
+            1,
+            [Value::convert(interp, pattern).inner()].as_ptr() as *const sys::mrb_value,
+        )
+    };
+    Ok(Value::new(interp, value))
+}

--- a/artichoke-backend/src/extn/core/regexp/mod.rs
+++ b/artichoke-backend/src/extn/core/regexp/mod.rs
@@ -19,6 +19,10 @@ use crate::types::Int;
 use crate::value::Value;
 use crate::{Artichoke, ArtichokeError};
 
+// This module is where multiple Regexp implementations will live. Disabled
+// until work is done to convert this frontend to a newtype wrapper around a
+// trait object.
+#[cfg(feature = "regexp-boxed-trait-object")]
 pub mod backend;
 
 pub mod enc;


### PR DESCRIPTION
This is a WIP PR that adds the Rust Regex crate as an alternate backend to Artichoke's `Regexp`.

This PR is a code dump of a proof of concept I wrote earlier in the summer. It is disabled and hidden behind an undeclared crate feature. The patterns in Artichoke have changed significantly since this code was written, notably argument extraction, error propagation and exception handling, and the introduction of boxed trait objects.

The following work needs to be done to get this merged:

- Rip out enum based dispatch between onig and regex types.
- Introduce a `RegexpType` trait that provides the core functionality to support the Ruby API. This API should prefer to return Rust native types instead of boxed `Value`s.
- Alter the `Regexp` struct to be a newtype wrapper around `Box<dyn RegexpType>`. A newtype wrapper is a tuple-like struct with a single field.
- Move the mruby glue and module init function to an `mruby` module in the `regexp` module. The `mruby` module should contain the VM initializer (safe) and unsafe entrypoints that trampoline to safe rust functions.
- The safe rust entrypoints live in a `trampoline` module and return `Result<Value, Box<dyn RubyException>>`. These trampolines extract the `Regexp` from the receiver `Value` and delegate to the `Regexp` implementation methods.

The `Array` and `ENV` implementations are the templates to refer to when implementing the design.