### PR TITLE
Enable compile-time selection of ENV backend

### DIFF
--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -43,5 +43,6 @@ version = "0.51.1"
 default-features = false
 
 [features]
-default = ["artichoke-array"]
+default = ["artichoke-array", "artichoke-system-environ"]
 artichoke-array = []
+artichoke-system-environ = []

--- a/artichoke-backend/src/def.rs
+++ b/artichoke-backend/src/def.rs
@@ -1,4 +1,3 @@
-use std::any::TypeId;
 use std::cell::RefCell;
 use std::ffi::{c_void, CString};
 use std::fmt;
@@ -28,8 +27,8 @@ pub unsafe extern "C" fn rust_data_free<T: 'static + RustBackedValue>(
 ) {
     if data.is_null() {
         panic!(
-            "Received null pointer in rust_data_free<{:?}>",
-            TypeId::of::<T>()
+            "Received null pointer in rust_data_free<{}>",
+            T::ruby_type_name()
         );
     }
     let data = Rc::from_raw(data as *const RefCell<T>);

--- a/artichoke-backend/src/extn/core/array/mod.rs
+++ b/artichoke-backend/src/extn/core/array/mod.rs
@@ -443,7 +443,11 @@ impl Array {
     }
 }
 
-impl RustBackedValue for Array {}
+impl RustBackedValue for Array {
+    fn ruby_type_name() -> &'static str {
+        "Array"
+    }
+}
 
 #[allow(clippy::module_name_repetitions)]
 pub trait ArrayType: Any {

--- a/artichoke-backend/src/extn/core/env/mod.rs
+++ b/artichoke-backend/src/extn/core/env/mod.rs
@@ -26,7 +26,11 @@ pub trait Env {
 
 pub struct ENV(Box<dyn Env>);
 
-impl RustBackedValue for ENV {}
+impl RustBackedValue for ENV {
+    fn ruby_type_name() -> &'static str {
+        "EnvClass"
+    }
+}
 
 pub fn initialize(
     interp: &Artichoke,

--- a/artichoke-backend/src/extn/core/matchdata/mod.rs
+++ b/artichoke-backend/src/extn/core/matchdata/mod.rs
@@ -110,7 +110,11 @@ pub struct MatchData {
     region: Region,
 }
 
-impl RustBackedValue for MatchData {}
+impl RustBackedValue for MatchData {
+    fn ruby_type_name() -> &'static str {
+        "MatchData"
+    }
+}
 
 impl MatchData {
     pub fn new(string: &str, regexp: Regexp, start: usize, end: usize) -> Self {

--- a/artichoke-backend/src/extn/core/regexp/mod.rs
+++ b/artichoke-backend/src/extn/core/regexp/mod.rs
@@ -151,7 +151,11 @@ impl Hash for Regexp {
     }
 }
 
-impl RustBackedValue for Regexp {}
+impl RustBackedValue for Regexp {
+    fn ruby_type_name() -> &'static str {
+        "Regexp"
+    }
+}
 
 impl Regexp {
     pub const IGNORECASE: Int = 1;

--- a/artichoke-backend/src/lib.rs
+++ b/artichoke-backend/src/lib.rs
@@ -143,7 +143,11 @@
 //!     }
 //! }
 //!
-//! impl RustBackedValue for Container {}
+//! impl RustBackedValue for Container {
+//!     fn ruby_type_name() -> &'static str {
+//!         "Container"
+//!     }
+//! }
 //!
 //! impl File for Container {
 //!   fn require(interp: Artichoke) -> Result<(), ArtichokeError> {

--- a/artichoke-backend/tests/leak_mrb_tt_data_rc.rs
+++ b/artichoke-backend/tests/leak_mrb_tt_data_rc.rs
@@ -39,7 +39,11 @@ struct Container {
     inner: String,
 }
 
-impl RustBackedValue for Container {}
+impl RustBackedValue for Container {
+    fn ruby_type_name() -> &'static str {
+        "Container"
+    }
+}
 
 impl Container {
     unsafe extern "C" fn initialize(

--- a/artichoke-backend/tests/manual.rs
+++ b/artichoke-backend/tests/manual.rs
@@ -20,7 +20,11 @@ struct Container {
     inner: i64,
 }
 
-impl RustBackedValue for Container {}
+impl RustBackedValue for Container {
+    fn ruby_type_name() -> &'static str {
+        "Container"
+    }
+}
 
 impl Container {
     unsafe extern "C" fn initialize(

--- a/artichoke-backend/tests/obj_new_borrow_mut.rs
+++ b/artichoke-backend/tests/obj_new_borrow_mut.rs
@@ -20,7 +20,11 @@ use artichoke_backend::sys;
 
 struct Obj;
 
-impl RustBackedValue for Obj {}
+impl RustBackedValue for Obj {
+    fn ruby_type_name() -> &'static str {
+        "Obj"
+    }
+}
 
 unsafe extern "C" fn initialize(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
     let interp = unwrap_interpreter!(mrb);

--- a/artichoke-backend/vendor/mruby/mrbgems/mruby-method/src/method.c
+++ b/artichoke-backend/vendor/mruby/mrbgems/mruby-method/src/method.c
@@ -276,7 +276,7 @@ method_parameters(mrb_state *mrb, mrb_value self)
 
   if (mrb_nil_p(proc)) {
     mrb_value rest = mrb_symbol_value(mrb_intern_lit(mrb, "rest"));
-    mrb_value arest = mrb_ary_new_from_values(mrb, 1, &rest);
+    mrb_value arest = ARY_NEW_FROM_VALUES(mrb, 1, &rest);
     return ARY_NEW_FROM_VALUES(mrb, 1, &arest);
   }
 

--- a/artichoke-backend/vendor/mruby/src/class.c
+++ b/artichoke-backend/vendor/mruby/src/class.c
@@ -545,7 +545,9 @@ mrb_get_argv(mrb_state *mrb)
   mrb_value *array_argv;
   if (argc < 0) {
     mrb_int argc = ARRAY_LEN(mrb, mrb->c->stack[1]);
-    array_argv = RARRAY_PTR(mrb_ary_new_capa(mrb, argc));
+    mrb_value argv_mrb = mrb_ary_new_capa(mrb, argc);
+    mrb_gc_protect(mrb, argv_mrb);
+    array_argv = RARRAY_PTR(argv_mrb);
     int udx;
     for (udx = 0; udx < argc; udx++) {
       array_argv[udx] = ARY_REF(mrb, mrb->c->stack[1], udx);

--- a/artichoke-backend/vendor/mruby/src/state.c
+++ b/artichoke-backend/vendor/mruby/src/state.c
@@ -40,7 +40,9 @@ mrb_open_core(mrb_allocf f, void *ud)
   *mrb->c = mrb_context_zero;
   mrb->root_c = mrb->c;
 
+  mrb->gc.disabled = 1;
   mrb_init_core(mrb);
+  mrb->gc.disabled = 0;
 
   return mrb;
 }


### PR DESCRIPTION
This commit introduces the `artichoke-system-environ` feature. This feature
is enabled by default. When `artichoke-system-environ` is enabled, `ENV` will
delegate to the system environment via `std::env`.

When this feature is disabled, `ENV `will fallback to a `HashMap<Vec<u8>, Vec<u8>>`.
Using an in-memory backend is desirable in Wasm environments where (modulo an
emscripten shim) there is no environ. This also helps Artichoke tell a better
sandboxing story.

This commit also makes use of a technique introduced in the
`Kernel#Integer` patch which exposes functionality through an `Artichoke`
module that the Core delegates to. `Artichoke::Environ#[]`,
`Artichoke::Environ#[]=`, and `Artichoke::Environ#to_h` provide the same
glue that originally came from `EnvClass`.

`Artichoke::Environ` provides the same interface but as self methods
that memoize an `Environ` instance. This allows the Artichoke runtime to
inject a different concrete `ENV` backend per interpreter.

Shout out to @cdeler and @tkbky for laying the foundational work to make
this PR possible.