### PR TITLE
Code quality improvements

### DIFF
--- a/artichoke-backend/src/extn/core/array/mod.rs
+++ b/artichoke-backend/src/extn/core/array/mod.rs
@@ -1,6 +1,7 @@
 use artichoke_core::value::Value as _;
 use downcast::Any;
 use std::convert::TryFrom;
+use std::mem;
 
 use crate::convert::{Convert, RustBackedValue};
 use crate::extn::core::exception::{
@@ -265,7 +266,7 @@ impl Array {
         if let Some(mut realloc) = realloc {
             match realloc.len() {
                 0 => self.clear(),
-                1 => self.0 = realloc.remove(0),
+                1 => mem::swap(&mut self.0, &mut realloc[0]),
                 _ => {
                     let aggregate: Box<dyn ArrayType> =
                         Box::new(backend::aggregate::Aggregate::with_parts(realloc));
@@ -300,7 +301,7 @@ impl Array {
         if let Some(mut realloc) = realloc {
             match realloc.len() {
                 0 => self.clear(),
-                1 => self.0 = realloc.remove(0),
+                1 => mem::swap(&mut self.0, &mut realloc[0]),
                 _ => {
                     let aggregate: Box<dyn ArrayType> =
                         Box::new(backend::aggregate::Aggregate::with_parts(realloc));
@@ -324,7 +325,7 @@ impl Array {
         if let Some(mut realloc) = realloc {
             match realloc.len() {
                 0 => self.clear(),
-                1 => self.0 = realloc.remove(0),
+                1 => mem::swap(&mut self.0, &mut realloc[0]),
                 _ => {
                     let aggregate: Box<dyn ArrayType> =
                         Box::new(backend::aggregate::Aggregate::with_parts(realloc));
@@ -347,7 +348,7 @@ impl Array {
         if let Some(mut realloc) = realloc {
             match realloc.len() {
                 0 => self.clear(),
-                1 => self.0 = realloc.remove(0),
+                1 => mem::swap(&mut self.0, &mut realloc[0]),
                 _ => {
                     let aggregate: Box<dyn ArrayType> =
                         Box::new(backend::aggregate::Aggregate::with_parts(realloc));
@@ -401,7 +402,7 @@ impl Array {
         if let Some(mut realloc) = realloc {
             match realloc.len() {
                 0 => self.clear(),
-                1 => self.0 = realloc.remove(0),
+                1 => mem::swap(&mut self.0, &mut realloc[0]),
                 _ => {
                     let aggregate: Box<dyn ArrayType> =
                         Box::new(backend::aggregate::Aggregate::with_parts(realloc));
@@ -428,7 +429,7 @@ impl Array {
         if let Some(mut realloc) = realloc {
             match realloc.len() {
                 0 => self.clear(),
-                1 => self.0 = realloc.remove(0),
+                1 => mem::swap(&mut self.0, &mut realloc[0]),
                 _ => {
                     let aggregate: Box<dyn ArrayType> =
                         Box::new(backend::aggregate::Aggregate::with_parts(realloc));

--- a/artichoke-backend/src/extn/core/array/mod.rs
+++ b/artichoke-backend/src/extn/core/array/mod.rs
@@ -159,18 +159,6 @@ impl Array {
         Ok(result)
     }
 
-    pub fn initialize_copy(
-        &self,
-        interp: &Artichoke,
-        into: Value,
-    ) -> Result<Value, Box<dyn RubyException>> {
-        let result = self.0.box_clone();
-        let result = Self(result);
-        let result = unsafe { result.try_into_ruby(interp, Some(into.inner())) }
-            .map_err(|_| Fatal::new(interp, "Unable to initialize Ruby Array from Rust Array"))?;
-        Ok(result)
-    }
-
     fn element_reference(
         &self,
         interp: &Artichoke,

--- a/artichoke-backend/src/extn/core/array/mruby.rs
+++ b/artichoke-backend/src/extn/core/array/mruby.rs
@@ -172,7 +172,7 @@ pub unsafe extern "C" fn artichoke_ary_pop(
 ) -> sys::mrb_value {
     let interp = unwrap_interpreter!(mrb);
     let array = Value::new(&interp, ary);
-    let result = array::trampoline::pop(&interp, &array);
+    let result = array::trampoline::pop(&interp, array);
     match result {
         Ok(value) => {
             let basic = sys::mrb_sys_basic_ptr(ary);
@@ -214,7 +214,7 @@ pub unsafe extern "C" fn artichoke_ary_ref(
     let interp = unwrap_interpreter!(mrb);
     let ary = Value::new(&interp, ary);
     let offset = isize::try_from(offset).unwrap_or_default();
-    let result = array::trampoline::ary_ref(&interp, &ary, offset);
+    let result = array::trampoline::ary_ref(&interp, ary, offset);
     match result {
         Ok(value) => interp.convert(value).inner(),
         Err(exception) => exception::raise(interp, exception),
@@ -392,7 +392,7 @@ pub unsafe extern "C" fn artichoke_ary_shift(
 ) -> sys::mrb_value {
     let interp = unwrap_interpreter!(mrb);
     let array = Value::new(&interp, ary);
-    let result = array::trampoline::shift(&interp, &array, Some(1));
+    let result = array::trampoline::shift(&interp, array, Some(1));
     match result {
         Ok(value) => {
             let basic = sys::mrb_sys_basic_ptr(ary);

--- a/artichoke-backend/src/extn/core/array/mruby.rs
+++ b/artichoke-backend/src/extn/core/array/mruby.rs
@@ -2,6 +2,7 @@ use std::convert::TryFrom;
 use std::slice;
 
 use crate::convert::{Convert, RustBackedValue};
+#[cfg(feature = "artichoke-array")]
 use crate::def::{rust_data_free, ClassLike, Define};
 use crate::eval::Eval;
 use crate::extn::core::array;

--- a/artichoke-backend/src/extn/core/array/mruby.rs
+++ b/artichoke-backend/src/extn/core/array/mruby.rs
@@ -114,6 +114,7 @@ pub unsafe extern "C" fn artichoke_ary_new_from_values(
         .map(|val| Value::new(&interp, *val))
         .collect::<Vec<_>>();
     let result = array::trampoline::from_values(&interp, values.as_slice());
+    drop(values);
     match result {
         Ok(value) => {
             let basic = sys::mrb_sys_basic_ptr(value.inner());

--- a/artichoke-backend/src/extn/core/array/trampoline.rs
+++ b/artichoke-backend/src/extn/core/array/trampoline.rs
@@ -118,9 +118,9 @@ pub fn to_ary(interp: &Artichoke, value: Value) -> Result<Value, Box<dyn RubyExc
     }
 }
 
-pub fn ary_ref<'a>(
-    interp: &'a Artichoke,
-    ary: &Value,
+pub fn ary_ref(
+    interp: &Artichoke,
+    ary: Value,
     offset: isize,
 ) -> Result<Option<Value>, Box<dyn RubyException>> {
     let ary = unsafe { Array::try_from_ruby(interp, &ary) }.map_err(|_| {
@@ -201,14 +201,14 @@ pub fn element_assignment(
     result
 }
 
-pub fn pop(interp: &Artichoke, ary: &Value) -> Result<Value, Box<dyn RubyException>> {
+pub fn pop(interp: &Artichoke, ary: Value) -> Result<Value, Box<dyn RubyException>> {
     if ary.is_frozen() {
         return Err(Box::new(FrozenError::new(
             interp,
             "can't modify frozen Array",
         )));
     }
-    let array = unsafe { Array::try_from_ruby(interp, ary) }.map_err(|_| {
+    let array = unsafe { Array::try_from_ruby(interp, &ary) }.map_err(|_| {
         Fatal::new(
             interp,
             "Unable to extract Rust Array from Ruby Array receiver",
@@ -225,7 +225,7 @@ pub fn pop(interp: &Artichoke, ary: &Value) -> Result<Value, Box<dyn RubyExcepti
 
 pub fn shift(
     interp: &Artichoke,
-    ary: &Value,
+    ary: Value,
     count: Option<usize>,
 ) -> Result<Value, Box<dyn RubyException>> {
     if ary.is_frozen() {
@@ -234,7 +234,7 @@ pub fn shift(
             "can't modify frozen Array",
         )));
     }
-    let array = unsafe { Array::try_from_ruby(interp, ary) }.map_err(|_| {
+    let array = unsafe { Array::try_from_ruby(interp, &ary) }.map_err(|_| {
         Fatal::new(
             interp,
             "Unable to extract Rust Array from Ruby Array receiver",


### PR DESCRIPTION
While investigating the segfaults in GH-327, I encountered several bits of suboptimal code.

This PR is several small refactorings to improve code quality.

- Refactor `RustBackedValue::try_from_ruby` for readability, remove duplicated conditionals, and panic when encountering null pointers.
- Panic in `rust_data_free::<T>` when encountering a null pointer.
- Use `Vec::from` or `Iterator::collect` where possible in `Buffer`.
- Downcast to `Buffer` for some mutable operations in `Buffer` to minimize allocations and method calls.
- Use an in place swap to handle single-part reallocs in `Array`.
- Delete unused and semantically confusing function `Array::initialize_copy`.
- Clean up the last remaining Array mruby trampoline functions that passed arguments by reference.