### PR TITLE
Alter ArrayType to take &mut self for mutating methods

### DIFF
--- a/artichoke-backend/src/extn/core/array/backend/aggregate.rs
+++ b/artichoke-backend/src/extn/core/array/backend/aggregate.rs
@@ -181,7 +181,7 @@ impl ArrayType for Aggregate {
                     }
                 }
                 if drained < drain {
-                    while let Some((chunk, part)) = iter.next() {
+                    for (chunk, part) in iter {
                         replace_end = chunk;
                         let mut realloc = None;
                         drained += part.set_slice(
@@ -252,7 +252,7 @@ impl ArrayType for Aggregate {
                     }
                 }
                 if drained < drain {
-                    while let Some((chunk, part)) = iter.next() {
+                    for (chunk, part) in iter {
                         replace_end = chunk;
                         let mut realloc = None;
                         drained += part.set_slice(

--- a/artichoke-backend/src/extn/core/array/backend/aggregate.rs
+++ b/artichoke-backend/src/extn/core/array/backend/aggregate.rs
@@ -1,5 +1,3 @@
-use std::cell::RefCell;
-
 use crate::convert::Convert;
 use crate::extn::core::array::{backend, ArrayType};
 use crate::extn::core::exception::{RangeError, RubyException};
@@ -7,7 +5,7 @@ use crate::value::Value;
 use crate::Artichoke;
 
 #[derive(Default)]
-pub struct Aggregate(RefCell<Vec<Box<dyn ArrayType>>>);
+pub struct Aggregate(Vec<Box<dyn ArrayType>>);
 
 impl Aggregate {
     pub fn new() -> Self {
@@ -15,28 +13,21 @@ impl Aggregate {
     }
 
     pub fn with_parts(parts: Vec<Box<dyn ArrayType>>) -> Self {
-        Self(RefCell::new(
-            parts.into_iter().filter(|part| !part.is_empty()).collect(),
-        ))
+        Self(parts.into_iter().filter(|part| !part.is_empty()).collect())
     }
 
     pub fn into_parts(self) -> Vec<Box<dyn ArrayType>> {
-        self.0.replace(Vec::with_capacity(0))
+        self.0
     }
 
     pub fn parts(&self) -> Vec<Box<dyn ArrayType>> {
-        let borrow = self.0.borrow();
-        let mut parts = Vec::with_capacity(borrow.len());
-        for part in borrow.iter() {
-            parts.push(part.box_clone())
-        }
-        parts
+        self.0.iter().map(|part| part.box_clone()).collect()
     }
 }
 
 impl Clone for Aggregate {
     fn clone(&self) -> Self {
-        Self::with_parts(self.parts())
+        Self(self.parts())
     }
 }
 
@@ -46,16 +37,14 @@ impl ArrayType for Aggregate {
     }
 
     fn gc_mark(&self, interp: &Artichoke) {
-        let borrow = self.0.borrow();
-        for part in borrow.iter() {
+        for part in &self.0 {
             part.gc_mark(interp);
         }
     }
 
     fn real_children(&self) -> usize {
         let mut real_children = 0_usize;
-        let borrow = self.0.borrow();
-        for part in borrow.iter() {
+        for part in &self.0 {
             real_children =
                 if let Some(real_children) = real_children.checked_add(part.real_children()) {
                     real_children
@@ -68,8 +57,7 @@ impl ArrayType for Aggregate {
 
     fn len(&self) -> usize {
         let mut len = 0_usize;
-        let borrow = self.0.borrow();
-        for part in borrow.iter() {
+        for part in &self.0 {
             len = if let Some(len) = len.checked_add(part.len()) {
                 len
             } else {
@@ -85,7 +73,7 @@ impl ArrayType for Aggregate {
 
     fn get(&self, interp: &Artichoke, index: usize) -> Result<Value, Box<dyn RubyException>> {
         let mut base = 0;
-        for part in self.0.borrow().iter() {
+        for part in &self.0 {
             let idx = index - base;
             if idx < part.len() {
                 return part.get(interp, idx);
@@ -104,8 +92,7 @@ impl ArrayType for Aggregate {
         len: usize,
     ) -> Result<Box<dyn ArrayType>, Box<dyn RubyException>> {
         let mut base = 0;
-        let borrow = self.0.borrow();
-        let mut iter = borrow.iter();
+        let mut iter = self.0.iter();
         while let Some(part) = iter.next() {
             let idx = start - base;
             if idx < part.len() {
@@ -133,7 +120,7 @@ impl ArrayType for Aggregate {
     }
 
     fn set(
-        &self,
+        &mut self,
         interp: &Artichoke,
         index: usize,
         elem: Value,
@@ -141,9 +128,8 @@ impl ArrayType for Aggregate {
     ) -> Result<(), Box<dyn RubyException>> {
         let _ = realloc;
         let mut base = 0;
-        let mut borrow = self.0.borrow_mut();
-        for partidx in 0..borrow.len() {
-            let part = &borrow[partidx];
+        for partidx in 0..self.0.len() {
+            let part = &mut self.0[partidx];
             let idx = index - base;
             if idx < part.len() {
                 let mut realloc = None;
@@ -152,7 +138,7 @@ impl ArrayType for Aggregate {
                     let reallocated_parts = reallocated_parts
                         .into_iter()
                         .filter(|part| !part.is_empty());
-                    borrow.splice(partidx..=partidx, reallocated_parts);
+                    self.0.splice(partidx..=partidx, reallocated_parts);
                 }
                 return Ok(());
             }
@@ -161,14 +147,14 @@ impl ArrayType for Aggregate {
                 .ok_or_else(|| RangeError::new(interp, "array too big"))?;
         }
         if index > base {
-            borrow.push(backend::fixed::hole(index - base));
+            self.0.push(backend::fixed::hole(index - base));
         }
-        borrow.push(backend::fixed::one(elem));
+        self.0.push(backend::fixed::one(elem));
         Ok(())
     }
 
     fn set_with_drain(
-        &self,
+        &mut self,
         interp: &Artichoke,
         start: usize,
         drain: usize,
@@ -177,9 +163,8 @@ impl ArrayType for Aggregate {
     ) -> Result<usize, Box<dyn RubyException>> {
         let _ = realloc;
         let mut base = 0;
-        let mut borrow = self.0.borrow_mut();
-        for partidx in 0..borrow.len() {
-            let part = &borrow[partidx];
+        for partidx in 0..self.0.len() {
+            let part = &mut self.0[partidx];
             let idx = start - base;
             if idx < part.len() {
                 let replace_part_begin_idx = partidx;
@@ -197,8 +182,8 @@ impl ArrayType for Aggregate {
                     }
                 }
                 if drained < drain {
-                    for partidx in replace_part_begin_idx + 1..borrow.len() {
-                        let part = &borrow[partidx];
+                    for partidx in replace_part_begin_idx + 1..self.0.len() {
+                        let part = &mut self.0[partidx];
                         replace_part_end_idx = partidx;
                         let mut realloc = None;
                         drained += part.set_slice(
@@ -224,7 +209,7 @@ impl ArrayType for Aggregate {
                     let reallocated_parts = reallocated_parts
                         .into_iter()
                         .filter(|part| !part.is_empty());
-                    borrow.splice(
+                    self.0.splice(
                         replace_part_begin_idx..=replace_part_end_idx,
                         reallocated_parts,
                     );
@@ -236,14 +221,14 @@ impl ArrayType for Aggregate {
                 .ok_or_else(|| RangeError::new(interp, "array too big"))?;
         }
         if start > base {
-            borrow.push(backend::fixed::hole(start - base));
+            self.0.push(backend::fixed::hole(start - base));
         }
-        borrow.push(backend::fixed::one(with));
+        self.0.push(backend::fixed::one(with));
         Ok(0)
     }
 
     fn set_slice(
-        &self,
+        &mut self,
         interp: &Artichoke,
         start: usize,
         drain: usize,
@@ -252,9 +237,8 @@ impl ArrayType for Aggregate {
     ) -> Result<usize, Box<dyn RubyException>> {
         let _ = realloc;
         let mut base = 0;
-        let mut borrow = self.0.borrow_mut();
-        for partidx in 0..borrow.len() {
-            let part = &borrow[partidx];
+        for partidx in 0..self.0.len() {
+            let part = &mut self.0[partidx];
             let idx = start - base;
             if idx < part.len() {
                 let replace_part_begin_idx = partidx;
@@ -272,8 +256,8 @@ impl ArrayType for Aggregate {
                     }
                 }
                 if drained < drain {
-                    for partidx in replace_part_begin_idx + 1..borrow.len() {
-                        let part = &borrow[partidx];
+                    for partidx in replace_part_begin_idx + 1..self.0.len() {
+                        let part = &mut self.0[partidx];
                         replace_part_end_idx = partidx;
                         let mut realloc = None;
                         drained += part.set_slice(
@@ -299,7 +283,7 @@ impl ArrayType for Aggregate {
                     let reallocated_parts = reallocated_parts
                         .into_iter()
                         .filter(|part| !part.is_empty());
-                    borrow.splice(
+                    self.0.splice(
                         replace_part_begin_idx..=replace_part_end_idx,
                         reallocated_parts,
                     );
@@ -311,14 +295,14 @@ impl ArrayType for Aggregate {
                 .ok_or_else(|| RangeError::new(interp, "array too big"))?;
         }
         if start > base {
-            borrow.push(backend::fixed::hole(start - base));
+            self.0.push(backend::fixed::hole(start - base));
         }
-        borrow.push(with);
+        self.0.push(with);
         Ok(0)
     }
 
     fn concat(
-        &self,
+        &mut self,
         interp: &Artichoke,
         other: Box<dyn ArrayType>,
         realloc: &mut Option<Vec<Box<dyn ArrayType>>>,
@@ -326,29 +310,26 @@ impl ArrayType for Aggregate {
         let _ = interp;
         let _ = realloc;
         if let Ok(other) = other.downcast_ref::<Self>() {
-            let mut borrow = self.0.borrow_mut();
-            borrow.extend(other.parts());
+            self.0.extend(other.parts());
         } else {
-            let mut borrow = self.0.borrow_mut();
-            borrow.push(other);
+            self.0.push(other);
         }
         Ok(())
     }
 
     fn pop(
-        &self,
+        &mut self,
         interp: &Artichoke,
         realloc: &mut Option<Vec<Box<dyn ArrayType>>>,
     ) -> Result<Value, Box<dyn RubyException>> {
         let _ = realloc;
-        let mut borrow = self.0.borrow_mut();
-        if let Some(first) = borrow.last() {
+        if let Some(first) = self.0.last_mut() {
             let mut realloc = None;
             let popped = first.pop(interp, &mut realloc)?;
             if let Some(realloc) = realloc {
                 let reallocated_parts = realloc.into_iter().filter(|part| !part.is_empty());
-                borrow.pop();
-                borrow.extend(reallocated_parts);
+                self.0.pop();
+                self.0.extend(reallocated_parts);
             }
             Ok(popped)
         } else {
@@ -357,10 +338,9 @@ impl ArrayType for Aggregate {
     }
 
     fn reverse(&self, interp: &Artichoke) -> Result<Box<dyn ArrayType>, Box<dyn RubyException>> {
-        let borrow = self.0.borrow();
-        let mut parts = Vec::with_capacity(borrow.len());
-        for idx in (0..borrow.len()).rev() {
-            parts.push(borrow[idx].reverse(interp)?);
+        let mut parts = Vec::with_capacity(self.0.len());
+        for idx in (0..self.0.len()).rev() {
+            parts.push(self.0[idx].reverse(interp)?);
         }
         Ok(Box::new(Self::with_parts(parts)))
     }

--- a/artichoke-backend/src/extn/core/array/backend/aggregate.rs
+++ b/artichoke-backend/src/extn/core/array/backend/aggregate.rs
@@ -128,8 +128,7 @@ impl ArrayType for Aggregate {
     ) -> Result<(), Box<dyn RubyException>> {
         let _ = realloc;
         let mut base = 0;
-        for partidx in 0..self.0.len() {
-            let part = &mut self.0[partidx];
+        for (chunk, part) in self.0.iter_mut().enumerate() {
             let idx = index - base;
             if idx < part.len() {
                 let mut realloc = None;
@@ -138,7 +137,7 @@ impl ArrayType for Aggregate {
                     let reallocated_parts = reallocated_parts
                         .into_iter()
                         .filter(|part| !part.is_empty());
-                    self.0.splice(partidx..=partidx, reallocated_parts);
+                    self.0.splice(chunk..=chunk, reallocated_parts);
                 }
                 return Ok(());
             }
@@ -163,12 +162,12 @@ impl ArrayType for Aggregate {
     ) -> Result<usize, Box<dyn RubyException>> {
         let _ = realloc;
         let mut base = 0;
-        for partidx in 0..self.0.len() {
-            let part = &mut self.0[partidx];
+        let mut iter = self.0.iter_mut().enumerate();
+        while let Some((chunk, part)) = iter.next() {
             let idx = start - base;
             if idx < part.len() {
-                let replace_part_begin_idx = partidx;
-                let mut replace_part_end_idx = partidx;
+                let replace_start = chunk;
+                let mut replace_end = chunk;
                 let mut reallocated_parts = None::<Vec<Box<dyn ArrayType>>>;
                 let mut drained = 0;
                 let mut realloc = None;
@@ -182,9 +181,8 @@ impl ArrayType for Aggregate {
                     }
                 }
                 if drained < drain {
-                    for partidx in replace_part_begin_idx + 1..self.0.len() {
-                        let part = &mut self.0[partidx];
-                        replace_part_end_idx = partidx;
+                    while let Some((chunk, part)) = iter.next() {
+                        replace_end = chunk;
                         let mut realloc = None;
                         drained += part.set_slice(
                             interp,
@@ -209,10 +207,8 @@ impl ArrayType for Aggregate {
                     let reallocated_parts = reallocated_parts
                         .into_iter()
                         .filter(|part| !part.is_empty());
-                    self.0.splice(
-                        replace_part_begin_idx..=replace_part_end_idx,
-                        reallocated_parts,
-                    );
+                    self.0
+                        .splice(replace_start..=replace_end, reallocated_parts);
                 }
                 return Ok(drained);
             }
@@ -237,12 +233,12 @@ impl ArrayType for Aggregate {
     ) -> Result<usize, Box<dyn RubyException>> {
         let _ = realloc;
         let mut base = 0;
-        for partidx in 0..self.0.len() {
-            let part = &mut self.0[partidx];
+        let mut iter = self.0.iter_mut().enumerate();
+        while let Some((chunk, part)) = iter.next() {
             let idx = start - base;
             if idx < part.len() {
-                let replace_part_begin_idx = partidx;
-                let mut replace_part_end_idx = partidx;
+                let replace_start = chunk;
+                let mut replace_end = chunk;
                 let mut reallocated_parts = None::<Vec<Box<dyn ArrayType>>>;
                 let mut drained = 0;
                 let mut realloc = None;
@@ -256,9 +252,8 @@ impl ArrayType for Aggregate {
                     }
                 }
                 if drained < drain {
-                    for partidx in replace_part_begin_idx + 1..self.0.len() {
-                        let part = &mut self.0[partidx];
-                        replace_part_end_idx = partidx;
+                    while let Some((chunk, part)) = iter.next() {
+                        replace_end = chunk;
                         let mut realloc = None;
                         drained += part.set_slice(
                             interp,
@@ -283,10 +278,8 @@ impl ArrayType for Aggregate {
                     let reallocated_parts = reallocated_parts
                         .into_iter()
                         .filter(|part| !part.is_empty());
-                    self.0.splice(
-                        replace_part_begin_idx..=replace_part_end_idx,
-                        reallocated_parts,
-                    );
+                    self.0
+                        .splice(replace_start..=replace_end, reallocated_parts);
                 }
                 return Ok(drained);
             }

--- a/artichoke-backend/src/extn/core/array/backend/fixed/empty.rs
+++ b/artichoke-backend/src/extn/core/array/backend/fixed/empty.rs
@@ -52,7 +52,7 @@ impl ArrayType for Empty {
     }
 
     fn set(
-        &self,
+        &mut self,
         interp: &Artichoke,
         index: usize,
         elem: Value,
@@ -70,7 +70,7 @@ impl ArrayType for Empty {
     }
 
     fn set_with_drain(
-        &self,
+        &mut self,
         interp: &Artichoke,
         start: usize,
         drain: usize,
@@ -90,7 +90,7 @@ impl ArrayType for Empty {
     }
 
     fn set_slice(
-        &self,
+        &mut self,
         interp: &Artichoke,
         start: usize,
         drain: usize,
@@ -109,18 +109,20 @@ impl ArrayType for Empty {
     }
 
     fn concat(
-        &self,
+        &mut self,
         interp: &Artichoke,
         other: Box<dyn ArrayType>,
         realloc: &mut Option<Vec<Box<dyn ArrayType>>>,
     ) -> Result<(), Box<dyn RubyException>> {
         let _ = interp;
-        *realloc = Some(vec![other]);
+        if !other.is_empty() {
+            *realloc = Some(vec![other]);
+        }
         Ok(())
     }
 
     fn pop(
-        &self,
+        &mut self,
         interp: &Artichoke,
         realloc: &mut Option<Vec<Box<dyn ArrayType>>>,
     ) -> Result<Value, Box<dyn RubyException>> {

--- a/artichoke-backend/src/extn/core/array/backend/fixed/two.rs
+++ b/artichoke-backend/src/extn/core/array/backend/fixed/two.rs
@@ -65,34 +65,35 @@ impl ArrayType for Two {
     }
 
     fn set(
-        &self,
+        &mut self,
         interp: &Artichoke,
         index: usize,
         elem: Value,
         realloc: &mut Option<Vec<Box<dyn ArrayType>>>,
     ) -> Result<(), Box<dyn RubyException>> {
         let _ = interp;
-        let alloc = if index == 0 {
-            vec![backend::fixed::two(elem, self.1.clone())]
+        if index == 0 {
+            self.0 = elem;
         } else if index == 1 {
-            vec![backend::fixed::two(self.0.clone(), elem)]
+            self.1 = elem;
         } else if index == 2 {
             let buffer = vec![self.0.clone(), self.1.clone(), elem];
             let buffer: Box<dyn ArrayType> = Box::new(backend::buffer::Buffer::from(buffer));
-            vec![buffer]
+            let alloc = vec![buffer];
+            *realloc = Some(alloc);
         } else {
-            vec![
+            let alloc = vec![
                 self.box_clone(),
                 backend::fixed::hole(index - 2),
                 backend::fixed::one(elem),
-            ]
-        };
-        *realloc = Some(alloc);
+            ];
+            *realloc = Some(alloc);
+        }
         Ok(())
     }
 
     fn set_with_drain(
-        &self,
+        &mut self,
         interp: &Artichoke,
         start: usize,
         drain: usize,
@@ -100,44 +101,48 @@ impl ArrayType for Two {
         realloc: &mut Option<Vec<Box<dyn ArrayType>>>,
     ) -> Result<usize, Box<dyn RubyException>> {
         let _ = interp;
-        let (alloc, drained) = if start == 0 && drain == 0 {
+        let drained = if start == 0 && drain == 0 {
             let buffer = vec![with, self.0.clone(), self.1.clone()];
             let buffer: Box<dyn ArrayType> = Box::new(backend::buffer::Buffer::from(buffer));
             let alloc = vec![buffer];
-            (alloc, 0)
+            *realloc = Some(alloc);
+            0
         } else if start == 0 && drain == 1 {
-            let alloc = vec![backend::fixed::two(with, self.1.clone())];
-            (alloc, 1)
+            self.0 = with;
+            1
         } else if start == 0 {
             let alloc = vec![backend::fixed::one(with)];
-            (alloc, 2)
+            *realloc = Some(alloc);
+            2
         } else if start == 1 && drain == 0 {
             let buffer = vec![self.0.clone(), with, self.1.clone()];
             let buffer: Box<dyn ArrayType> = Box::new(backend::buffer::Buffer::from(buffer));
             let alloc = vec![buffer];
-            (alloc, 0)
+            *realloc = Some(alloc);
+            0
         } else if start == 1 {
-            let alloc = vec![backend::fixed::two(self.0.clone(), with)];
-            (alloc, 1)
+            self.1 = with;
+            1
         } else if start == 2 {
             let buffer = vec![with, self.0.clone(), self.1.clone()];
             let buffer: Box<dyn ArrayType> = Box::new(backend::buffer::Buffer::from(buffer));
             let alloc = vec![buffer];
-            (alloc, 0)
+            *realloc = Some(alloc);
+            0
         } else {
             let alloc = vec![
                 self.box_clone(),
                 backend::fixed::hole(start - 2),
                 backend::fixed::one(with),
             ];
-            (alloc, 0)
+            *realloc = Some(alloc);
+            0
         };
-        *realloc = Some(alloc);
         Ok(drained)
     }
 
     fn set_slice(
-        &self,
+        &mut self,
         interp: &Artichoke,
         start: usize,
         drain: usize,
@@ -176,7 +181,7 @@ impl ArrayType for Two {
     }
 
     fn concat(
-        &self,
+        &mut self,
         interp: &Artichoke,
         other: Box<dyn ArrayType>,
         realloc: &mut Option<Vec<Box<dyn ArrayType>>>,
@@ -199,7 +204,7 @@ impl ArrayType for Two {
     }
 
     fn pop(
-        &self,
+        &mut self,
         interp: &Artichoke,
         realloc: &mut Option<Vec<Box<dyn ArrayType>>>,
     ) -> Result<Value, Box<dyn RubyException>> {

--- a/artichoke-backend/src/extn/core/array/backend/repeated/value.rs
+++ b/artichoke-backend/src/extn/core/array/backend/repeated/value.rs
@@ -67,7 +67,7 @@ impl ArrayType for Value {
     }
 
     fn set(
-        &self,
+        &mut self,
         interp: &Artichoke,
         index: usize,
         elem: value::Value,
@@ -106,7 +106,7 @@ impl ArrayType for Value {
     }
 
     fn set_with_drain(
-        &self,
+        &mut self,
         interp: &Artichoke,
         start: usize,
         drain: usize,
@@ -143,7 +143,7 @@ impl ArrayType for Value {
     }
 
     fn set_slice(
-        &self,
+        &mut self,
         interp: &Artichoke,
         start: usize,
         drain: usize,
@@ -180,7 +180,7 @@ impl ArrayType for Value {
     }
 
     fn concat(
-        &self,
+        &mut self,
         interp: &Artichoke,
         other: Box<dyn ArrayType>,
         realloc: &mut Option<Vec<Box<dyn ArrayType>>>,
@@ -191,15 +191,16 @@ impl ArrayType for Value {
     }
 
     fn pop(
-        &self,
+        &mut self,
         interp: &Artichoke,
         realloc: &mut Option<Vec<Box<dyn ArrayType>>>,
     ) -> Result<value::Value, Box<dyn RubyException>> {
         let _ = interp;
-        *realloc = Some(vec![backend::repeated::value(
-            self.0.clone(),
-            self.1.get() - 1,
-        )]);
+        if let Some(len) = NonZeroUsize::new(self.1.get() - 1) {
+            self.1 = len;
+        } else {
+            *realloc = Some(vec![backend::fixed::empty()]);
+        }
         Ok(self.0.clone())
     }
 

--- a/artichoke-backend/src/extn/core/array/mod.rs
+++ b/artichoke-backend/src/extn/core/array/mod.rs
@@ -467,7 +467,7 @@ pub trait ArrayType: Any {
     ) -> Result<Box<dyn ArrayType>, Box<dyn RubyException>>;
 
     fn set(
-        &self,
+        &mut self,
         interp: &Artichoke,
         index: usize,
         elem: Value,
@@ -475,7 +475,7 @@ pub trait ArrayType: Any {
     ) -> Result<(), Box<dyn RubyException>>;
 
     fn set_with_drain(
-        &self,
+        &mut self,
         interp: &Artichoke,
         start: usize,
         drain: usize,
@@ -484,7 +484,7 @@ pub trait ArrayType: Any {
     ) -> Result<usize, Box<dyn RubyException>>;
 
     fn set_slice(
-        &self,
+        &mut self,
         interp: &Artichoke,
         start: usize,
         drain: usize,
@@ -493,18 +493,20 @@ pub trait ArrayType: Any {
     ) -> Result<usize, Box<dyn RubyException>>;
 
     fn concat(
-        &self,
+        &mut self,
         interp: &Artichoke,
         other: Box<dyn ArrayType>,
         realloc: &mut Option<Vec<Box<dyn ArrayType>>>,
     ) -> Result<(), Box<dyn RubyException>>;
 
     fn pop(
-        &self,
+        &mut self,
         interp: &Artichoke,
         realloc: &mut Option<Vec<Box<dyn ArrayType>>>,
     ) -> Result<Value, Box<dyn RubyException>>;
 
+    // TODO: Change the semantics of this function to do an in place reverse
+    // like `Array#reverse!` and implement Array#reverse` in Ruby.
     fn reverse(&self, interp: &Artichoke) -> Result<Box<dyn ArrayType>, Box<dyn RubyException>>;
 }
 


### PR DESCRIPTION
This API change allows us to drop interior mutability via RefCell from
all concrete ArrayType implementations. This cuts down on allocations
by allowing ArrayTypes to not realloc by mutating themselves directly,
e.g. Hole::pop.

This is a followup to GH-333.