### PR TITLE
Improve usage of MaybeUninit

### DIFF
--- a/artichoke-backend/src/eval.rs
+++ b/artichoke-backend/src/eval.rs
@@ -177,7 +177,7 @@ impl Eval for Artichoke {
         let value = unsafe {
             let data =
                 sys::mrb_sys_cptr_value(mrb, Box::into_raw(Box::new(protect)) as *mut c_void);
-            let mut state = <mem::MaybeUninit<sys::mrb_bool>>::uninit();
+            let mut state = mem::MaybeUninit::<sys::mrb_bool>::uninit();
 
             let value = sys::mrb_protect(mrb, Some(Protect::run), data, state.as_mut_ptr());
             if state.assume_init() != 0 {
@@ -240,7 +240,7 @@ impl Eval for Artichoke {
         let value = unsafe {
             let data =
                 sys::mrb_sys_cptr_value(mrb, Box::into_raw(Box::new(protect)) as *mut c_void);
-            let mut state = <mem::MaybeUninit<sys::mrb_bool>>::uninit();
+            let mut state = mem::MaybeUninit::<sys::mrb_bool>::uninit();
 
             // We call `mrb_protect` even though we are doing an unchecked eval
             // because we need to provide a landing pad to deallocate the

--- a/artichoke-backend/src/extn/core/array/args.rs
+++ b/artichoke-backend/src/extn/core/array/args.rs
@@ -250,8 +250,8 @@ unsafe fn is_range(
     range: &Value,
     length: Int,
 ) -> Result<Option<(Int, usize)>, Box<dyn RubyException>> {
-    let mut start = <mem::MaybeUninit<sys::mrb_int>>::uninit();
-    let mut len = <mem::MaybeUninit<sys::mrb_int>>::uninit();
+    let mut start = mem::MaybeUninit::<sys::mrb_int>::uninit();
+    let mut len = mem::MaybeUninit::<sys::mrb_int>::uninit();
     let mrb = interp.0.borrow().mrb;
     // `mrb_range_beg_len` can raise.
     // TODO: Wrap this in a call to `mrb_protect`.

--- a/artichoke-backend/src/extn/core/matchdata/element_reference.rs
+++ b/artichoke-backend/src/extn/core/matchdata/element_reference.rs
@@ -100,8 +100,8 @@ impl<'a> Args<'a> {
         first: &Value,
         length: Int,
     ) -> Result<Option<Self>, Box<dyn RubyException>> {
-        let mut start = <mem::MaybeUninit<sys::mrb_int>>::uninit();
-        let mut len = <mem::MaybeUninit<sys::mrb_int>>::uninit();
+        let mut start = mem::MaybeUninit::<sys::mrb_int>::uninit();
+        let mut len = mem::MaybeUninit::<sys::mrb_int>::uninit();
         let mrb = interp.0.borrow().mrb;
         // `mrb_range_beg_len` can raise.
         // TODO: Wrap this in a call to `mrb_protect`.

--- a/artichoke-backend/src/macros.rs
+++ b/artichoke-backend/src/macros.rs
@@ -59,7 +59,7 @@ macro_rules! mrb_get_args {
         ()
     }};
     ($mrb:expr, required = 1) => {{
-        let mut req1 = <std::mem::MaybeUninit<$crate::sys::mrb_value>>::uninit();
+        let mut req1 = std::mem::MaybeUninit::<$crate::sys::mrb_value>::uninit();
         let argc = $crate::sys::mrb_get_args(
             $mrb,
             $crate::macros::argspec::REQ1.as_ptr() as *const i8,
@@ -71,7 +71,7 @@ macro_rules! mrb_get_args {
         }
     }};
     ($mrb:expr, optional = 1) => {{
-        let mut opt1 = <std::mem::MaybeUninit<$crate::sys::mrb_value>>::uninit();
+        let mut opt1 = std::mem::MaybeUninit::<$crate::sys::mrb_value>::uninit();
         let argc = $crate::sys::mrb_get_args(
             $mrb,
             $crate::macros::argspec::OPT1.as_ptr() as *const i8,
@@ -87,8 +87,8 @@ macro_rules! mrb_get_args {
         }
     }};
     ($mrb:expr, required = 1, optional = 1) => {{
-        let mut req1 = <std::mem::MaybeUninit<$crate::sys::mrb_value>>::uninit();
-        let mut opt1 = <std::mem::MaybeUninit<$crate::sys::mrb_value>>::uninit();
+        let mut req1 = std::mem::MaybeUninit::<$crate::sys::mrb_value>::uninit();
+        let mut opt1 = std::mem::MaybeUninit::<$crate::sys::mrb_value>::uninit();
         let argc = $crate::sys::mrb_get_args(
             $mrb,
             $crate::macros::argspec::REQ1_OPT1.as_ptr() as *const i8,
@@ -109,9 +109,9 @@ macro_rules! mrb_get_args {
         }
     }};
     ($mrb:expr, required = 1, optional = 2) => {{
-        let mut req1 = <std::mem::MaybeUninit<$crate::sys::mrb_value>>::uninit();
-        let mut opt1 = <std::mem::MaybeUninit<$crate::sys::mrb_value>>::uninit();
-        let mut opt2 = <std::mem::MaybeUninit<$crate::sys::mrb_value>>::uninit();
+        let mut req1 = std::mem::MaybeUninit::<$crate::sys::mrb_value>::uninit();
+        let mut opt1 = std::mem::MaybeUninit::<$crate::sys::mrb_value>::uninit();
+        let mut opt2 = std::mem::MaybeUninit::<$crate::sys::mrb_value>::uninit();
         let argc = $crate::sys::mrb_get_args(
             $mrb,
             $crate::macros::argspec::REQ1_OPT2.as_ptr() as *const i8,
@@ -139,8 +139,8 @@ macro_rules! mrb_get_args {
         }
     }};
     ($mrb:expr, required = 1, &block) => {{
-        let mut req1 = <std::mem::MaybeUninit<$crate::sys::mrb_value>>::uninit();
-        let mut block = <std::mem::MaybeUninit<$crate::sys::mrb_value>>::uninit();
+        let mut req1 = std::mem::MaybeUninit::<$crate::sys::mrb_value>::uninit();
+        let mut block = std::mem::MaybeUninit::<$crate::sys::mrb_value>::uninit();
         let argc = $crate::sys::mrb_get_args(
             $mrb,
             $crate::macros::argspec::REQ1_REQBLOCK.as_ptr() as *const i8,
@@ -157,10 +157,10 @@ macro_rules! mrb_get_args {
         }
     }};
     ($mrb:expr, required = 1, optional = 1, &block) => {{
-        let mut req1 = <std::mem::MaybeUninit<$crate::sys::mrb_value>>::uninit();
-        let mut opt1 = <std::mem::MaybeUninit<$crate::sys::mrb_value>>::uninit();
-        let mut has_opt1 = <std::mem::MaybeUninit<$crate::sys::mrb_bool>>::uninit();
-        let mut block = <std::mem::MaybeUninit<$crate::sys::mrb_value>>::uninit();
+        let mut req1 = std::mem::MaybeUninit::<$crate::sys::mrb_value>::uninit();
+        let mut opt1 = std::mem::MaybeUninit::<$crate::sys::mrb_value>::uninit();
+        let mut has_opt1 = std::mem::MaybeUninit::<$crate::sys::mrb_bool>::uninit();
+        let mut block = std::mem::MaybeUninit::<$crate::sys::mrb_value>::uninit();
         let argc = $crate::sys::mrb_get_args(
             $mrb,
             $crate::macros::argspec::REQ1_REQBLOCK_OPT1.as_ptr() as *const i8,
@@ -196,8 +196,8 @@ macro_rules! mrb_get_args {
         }
     }};
     ($mrb:expr, required = 2) => {{
-        let mut req1 = <std::mem::MaybeUninit<$crate::sys::mrb_value>>::uninit();
-        let mut req2 = <std::mem::MaybeUninit<$crate::sys::mrb_value>>::uninit();
+        let mut req1 = std::mem::MaybeUninit::<$crate::sys::mrb_value>::uninit();
+        let mut req2 = std::mem::MaybeUninit::<$crate::sys::mrb_value>::uninit();
         let argc = $crate::sys::mrb_get_args(
             $mrb,
             $crate::macros::argspec::REQ2.as_ptr() as *const i8,
@@ -214,11 +214,11 @@ macro_rules! mrb_get_args {
         }
     }};
     ($mrb:expr, optional = 2, &block) => {{
-        let mut opt1 = <std::mem::MaybeUninit<$crate::sys::mrb_value>>::uninit();
-        let mut has_opt1 = <std::mem::MaybeUninit<$crate::sys::mrb_bool>>::uninit();
-        let mut opt2 = <std::mem::MaybeUninit<$crate::sys::mrb_value>>::uninit();
-        let mut has_opt2 = <std::mem::MaybeUninit<$crate::sys::mrb_bool>>::uninit();
-        let mut block = <std::mem::MaybeUninit<$crate::sys::mrb_value>>::uninit();
+        let mut opt1 = std::mem::MaybeUninit::<$crate::sys::mrb_value>::uninit();
+        let mut has_opt1 = std::mem::MaybeUninit::<$crate::sys::mrb_bool>::uninit();
+        let mut opt2 = std::mem::MaybeUninit::<$crate::sys::mrb_value>::uninit();
+        let mut has_opt2 = std::mem::MaybeUninit::<$crate::sys::mrb_bool>::uninit();
+        let mut block = std::mem::MaybeUninit::<$crate::sys::mrb_value>::uninit();
         $crate::sys::mrb_get_args(
             $mrb,
             $crate::macros::argspec::OPT2_OPTBLOCK.as_ptr() as *const i8,
@@ -244,9 +244,9 @@ macro_rules! mrb_get_args {
         (opt1, opt2, $crate::value::Block::new(block))
     }};
     ($mrb:expr, required = 2, optional = 1) => {{
-        let mut req1 = <std::mem::MaybeUninit<$crate::sys::mrb_value>>::uninit();
-        let mut req2 = <std::mem::MaybeUninit<$crate::sys::mrb_value>>::uninit();
-        let mut opt1 = <std::mem::MaybeUninit<$crate::sys::mrb_value>>::uninit();
+        let mut req1 = std::mem::MaybeUninit::<$crate::sys::mrb_value>::uninit();
+        let mut req2 = std::mem::MaybeUninit::<$crate::sys::mrb_value>::uninit();
+        let mut opt1 = std::mem::MaybeUninit::<$crate::sys::mrb_value>::uninit();
         let argc = $crate::sys::mrb_get_args(
             $mrb,
             $crate::macros::argspec::REQ2_OPT1.as_ptr() as *const i8,
@@ -270,8 +270,8 @@ macro_rules! mrb_get_args {
         }
     }};
     ($mrb:expr, *args) => {{
-        let mut args = <std::mem::MaybeUninit<*const $crate::sys::mrb_value>>::uninit();
-        let mut count = <std::mem::MaybeUninit<usize>>::uninit();
+        let mut args = std::mem::MaybeUninit::<*const $crate::sys::mrb_value>::uninit();
+        let mut count = std::mem::MaybeUninit::<usize>::uninit();
         let _argc = $crate::sys::mrb_get_args(
             $mrb,
             $crate::macros::argspec::REST.as_ptr() as *const i8,

--- a/artichoke-backend/src/sys/ffi_tests.rs
+++ b/artichoke-backend/src/sys/ffi_tests.rs
@@ -621,7 +621,7 @@ fn protect() {
 
         let mrb = mrb_open();
 
-        let mut state = <mem::MaybeUninit<mrb_bool>>::uninit();
+        let mut state = mem::MaybeUninit::<mrb_bool>::uninit();
         let nil = mrb_sys_nil_value();
 
         // `mrb_protect` calls the passed function with `data` as an argument.
@@ -673,8 +673,8 @@ pub fn args() {
     unsafe {
         extern "C" fn add(mrb: *mut mrb_state, _slf: mrb_value) -> mrb_value {
             unsafe {
-                let mut a = <mem::MaybeUninit<mrb_value>>::uninit();
-                let mut b = <mem::MaybeUninit<mrb_value>>::uninit();
+                let mut a = mem::MaybeUninit::<mrb_value>::uninit();
+                let mut b = mem::MaybeUninit::<mrb_value>::uninit();
 
                 let argspec = CString::new("oo").unwrap();
                 mrb_get_args(mrb, argspec.as_ptr(), a.as_mut_ptr(), b.as_mut_ptr());
@@ -731,8 +731,8 @@ pub fn str_args() {
     unsafe {
         extern "C" fn add(mrb: *mut mrb_state, _slf: mrb_value) -> mrb_value {
             unsafe {
-                let mut a = <mem::MaybeUninit<*const c_char>>::uninit();
-                let mut b = <mem::MaybeUninit<*const c_char>>::uninit();
+                let mut a = mem::MaybeUninit::<*const c_char>::uninit();
+                let mut b = mem::MaybeUninit::<*const c_char>::uninit();
 
                 let argspec = CString::new("zz").unwrap();
                 mrb_get_args(mrb, argspec.as_ptr(), a.as_mut_ptr(), b.as_mut_ptr());

--- a/artichoke-backend/src/value.rs
+++ b/artichoke-backend/src/value.rs
@@ -221,7 +221,7 @@ impl ValueLike for Value {
         let value = unsafe {
             let data =
                 sys::mrb_sys_cptr_value(mrb, Box::into_raw(Box::new(protect)) as *mut c_void);
-            let mut state = <mem::MaybeUninit<sys::mrb_bool>>::uninit();
+            let mut state = mem::MaybeUninit::<sys::mrb_bool>::uninit();
 
             let value = sys::mrb_protect(mrb, Some(Protect::run), data, state.as_mut_ptr());
             if state.assume_init() != 0 {
@@ -295,7 +295,7 @@ impl ValueLike for Value {
         let value = unsafe {
             let data =
                 sys::mrb_sys_cptr_value(mrb, Box::into_raw(Box::new(protect)) as *mut c_void);
-            let mut state = <mem::MaybeUninit<sys::mrb_bool>>::uninit();
+            let mut state = mem::MaybeUninit::<sys::mrb_bool>::uninit();
 
             let value = sys::mrb_protect(mrb, Some(Protect::run), data, state.as_mut_ptr());
             if state.assume_init() != 0 {

--- a/artichoke-backend/tests/leak/mod.rs
+++ b/artichoke-backend/tests/leak/mod.rs
@@ -46,7 +46,8 @@ impl Detector {
 }
 
 fn resident_memsize() -> i64 {
-    let mut out: libc::rusage = unsafe { mem::zeroed() };
-    assert!(unsafe { libc::getrusage(libc::RUSAGE_SELF, &mut out) } == 0);
+    let mut out = mem::MaybeUninit::<libc::rusage>::uninit();
+    assert!(unsafe { libc::getrusage(libc::RUSAGE_SELF, out.as_mut_ptr()) } == 0);
+    let out = unsafe { out.assume_init() };
     out.ru_maxrss
 }


### PR DESCRIPTION
- Use the docs recommended syntax for initializing.
- Replace mem::zeroed usage in leak module with MaybeUninit.