### PR TITLE
Improvements to project onboarding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,6 +46,7 @@ dependencies = [
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "onig 5.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -207,6 +208,10 @@ dependencies = [
 name = "cc"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "jobserver 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "cexpr"
@@ -435,6 +440,16 @@ dependencies = [
 name = "itoa"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "jobserver"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "getrandom 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "lazy_static"
@@ -1186,6 +1201,7 @@ dependencies = [
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum humantime 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
+"checksum jobserver 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "f2b1d42ef453b30b7387e113da1c83ab1605d90c5b4e0eb8e96d016ed3b8c160"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)" = "34fcd2c08d2f832f376f4173a231990fa5aef4e99fb569867318a227ef4c06ba"
 "checksum libloading 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f2b111a074963af1d37a139918ac6d49ad1d0d5e47f72fd55388619691a7d753"

--- a/README.md
+++ b/README.md
@@ -34,13 +34,17 @@ You can [try Artichoke in your browser](https://artichoke.run). The
 [Artichoke Playground](https://github.com/artichoke/playground) runs a
 [WebAssembly](https://webassembly.org/) build of Artichoke.
 
-If you would prefer to run a local build, you can
-[set up a Rust toolchain](/CONTRIBUTING.md#rust-toolchain) and launch an
-interactive Artichoke shell with:
+You can launch an interactive `irb`-style shell locally. The following command
+launches the Artichoke `irb` shell using `cargo`. `cargo` is the Rust equivalent
+to Ruby `bundler` that also manages building Rust code.
 
 ```sh
-cargo run -p artichoke-frontend --bin airb
+cargo run --bin airb
 ```
+
+To build Artichoke, you'll need Rust, clang, and Ruby.
+[`CONTRIBUTING.md`](/CONTRIBUTING.md) has more detail on
+[how to set up the compiler toolchain](/CONTRIBUTING.md#setup).
 
 ## Design and Goals
 

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -27,9 +27,10 @@ quickcheck = "0.9"
 quickcheck_macros = "0.8"
 
 [build-dependencies]
-cc = "1.0"
+cc = { version = "1.0", features = ["parallel"] }
 chrono = "0.4"
 fs_extra = "1.1.0"
+num_cpus = "1"
 rayon = "1.2"
 rustc_version = "0.2.3"
 target-lexicon = "0.8.1"

--- a/artichoke-backend/build.rs
+++ b/artichoke-backend/build.rs
@@ -134,7 +134,7 @@ mod libmruby {
         );
         if !Command::new(mruby_minirake())
             .arg("--jobs")
-            .arg("4")
+            .arg(num_cpus::get().to_string())
             .env("MRUBY_BUILD_DIR", mruby_build_dir())
             .env("MRUBY_CONFIG", build_config())
             .current_dir(mruby_source_dir())


### PR DESCRIPTION
I just got a new machine so it was an opportunity to set up a fresh clone with no prior deps installed.

Issues I ran into:

- Missing `bundler`
- `artichoke-backend` takes forever to build even on my 8 core machine with lots of time at low CPU utilization.

To address these:

- Added a new quickstart guide to the `README` to describe high level build deps.
- Add `parallel` feature to `cc` crate. We already include `rayon` so this pulled in no new deps.
- Added `num_cpus` crate to specify `--jobs` arg when building host build for mruby.

The build is still slow, but these build changes shaved 10 seconds off.

Fixes GH-319.