### PR TITLE
Windows build fixes for artichoke_backend::fs

### DIFF
--- a/artichoke-backend/src/fs/abs.rs
+++ b/artichoke-backend/src/fs/abs.rs
@@ -377,14 +377,17 @@ mod tests {
             setup();
 
             // It's not likely this path would exist, but let's be sure.
-            let raw_path = path::Path::new(r"C:\does\not\exist", "");
+            let raw_path = path::Path::new(r"C:\does\not\exist");
             assert_eq!(
                 raw_path.metadata().unwrap_err().kind(),
                 io::ErrorKind::NotFound,
             );
 
             let path = PathAbs::new(raw_path, "").unwrap();
-            assert_eq!(path.as_os_str(), r"\\?\C:\does\not\exist");
+            assert_eq!(
+                path::Path::as_os_str(path.as_path()),
+                r"\\?\C:\does\not\exist"
+            );
         }
 
         #[test]
@@ -408,7 +411,7 @@ mod tests {
                 env::current_dir().unwrap().components().take(2), // the prefix (C:) and root (\) components
             );
 
-            let expected = PathAbs::new(current_drive_root.join("foo")).unwrap();
+            let expected = PathAbs::new(current_drive_root.join("foo"), "").unwrap();
 
             assert_eq!(actual, expected);
         }
@@ -418,8 +421,11 @@ mod tests {
             setup();
             let actual = PathAbs::new(r"C:foo", "").unwrap();
 
-            let expected =
-                PathAbs::new(path::Path::new(r"C:").canonicalize().unwrap().join("foo")).unwrap();
+            let expected = PathAbs::new(
+                path::Path::new(r"C:").canonicalize().unwrap().join("foo"),
+                "",
+            )
+            .unwrap();
 
             assert_eq!(actual, expected);
         }
@@ -429,7 +435,7 @@ mod tests {
             setup();
             let path = PathAbs::new(r"\\?\bogus\path\", "").unwrap();
 
-            assert_eq!(path.as_os_str(), r"\\?\bogus\path");
+            assert_eq!(path::Path::as_os_str(path.as_path()), r"\\?\bogus\path");
         }
     }
 

--- a/artichoke-backend/src/fs/mod.rs
+++ b/artichoke-backend/src/fs/mod.rs
@@ -146,7 +146,7 @@ pub fn osstr_to_bytes<'a>(
 ) -> Result<&'a [u8], Box<dyn RubyException>> {
     use crate::extn::core::exception::Fatal;
 
-    if let Ok(converted) = value.as_ref().to_str() {
+    if let Some(converted) = value.to_str() {
         Ok(converted.as_bytes())
     } else {
         Err(Box::new(Fatal::new(
@@ -175,8 +175,8 @@ pub fn bytes_to_osstr<'a>(
 ) -> Result<&'a OsStr, Box<dyn RubyException>> {
     use crate::extn::core::exception::Fatal;
 
-    if let Ok(converted) = str::from_utf8(value) {
-        Ok(OsStr::from(converted))
+    if let Ok(converted) = std::str::from_utf8(value) {
+        Ok(OsStr::new(converted))
     } else {
         Err(Box::new(Fatal::new(
             interp,


### PR DESCRIPTION
`PathAbs` tests and `OsStr` converters.

This PR was extracted from GH-338.