### PR TITLE
Fixes to auto_import script to handle windows paths

### DIFF
--- a/artichoke-backend/scripts/auto_import/auto_import.rb
+++ b/artichoke-backend/scripts/auto_import/auto_import.rb
@@ -10,7 +10,7 @@ raise 'must provide an output directory' if ARGV[2].nil?
 base = ARGV[0]
 package = ARGV[1]
 out_file = ARGV[2]
-sources = ARGV[3].to_s.split(',').map { |source| source.gsub(%r{^.*#{base}/?}, '').gsub(/\.rb$/, '') }
+sources = ARGV[3].to_s.split(',').map { |source| source.gsub(%r{^.*#{Regexp.escape(base)}[/\\]?}, '').gsub(/\.rb$/, '') }
 auto_import_dir = File.dirname(__FILE__)
 # Import the Ruby 2.6.3 sources.
 constants = `ruby --disable-did_you_mean --disable-gems #{auto_import_dir}/get_constants_loaded.rb "#{base}" "#{package}"`.split("\n").map { |const| const.split(',') }

--- a/artichoke-backend/scripts/auto_import/get_package_files.rb
+++ b/artichoke-backend/scripts/auto_import/get_package_files.rb
@@ -4,8 +4,13 @@
 # require a library and figure out what constants were added.
 BASE = ARGV[0]
 PACKAGE = ARGV[1]
+
 $LOAD_PATH.unshift(BASE)
+
 require PACKAGE
+
 lib_sources = $LOADED_FEATURES.select { |f| f.include?(BASE) }
+lib_sources += $LOADED_FEATURES.map { |f| f.gsub('/', '\\') }.select { |f| f.include?(BASE) }
 package_sources = lib_sources.select { |f| f =~ /#{PACKAGE}/ }
-puts package_sources.sort
+
+puts package_sources.sort.uniq

--- a/artichoke-backend/scripts/auto_import/rust_glue.rs.erb
+++ b/artichoke-backend/scripts/auto_import/rust_glue.rs.erb
@@ -19,8 +19,8 @@ pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
     <% end %>
     <% sources.each do |(file, source)| %>
     interp.def_rb_source_file(
-        "<%= file %>.rb",
-        include_str!(concat!(env!("OUT_DIR"), "/src/generated/<%= file %>.rb"))
+        "<%= file.gsub('\\', '/') %>.rb",
+        include_str!(concat!(env!("OUT_DIR"), "/src/generated/<%= file.gsub('\\', '/') %>.rb"))
     )?;
     <% end %>
     Ok(())


### PR DESCRIPTION
There are some crimes being committed by all parties converting back and forth between forward and backward slashes on windows.

This PR was extracted from GH-338.