### PR TITLE
Remove dependency on mrblib

### DIFF
--- a/artichoke-backend/src/extn/core/kernel/kernel.rb
+++ b/artichoke-backend/src/extn/core/kernel/kernel.rb
@@ -116,6 +116,14 @@ module Kernel
     !(self =~ other) # rubocop:disable Style/InverseMethods
   end
 
+  def singleton_method(name)
+    m = method(name)
+    sc = (class << self; self; end)
+    raise NameError, "undefined method '#{name}' for class '#{sc}'" if m.owner != sc
+
+    m
+  end
+
   # Throws an object, uncaught throws will bubble up through other catch blocks.
   #
   # @param [Symbol] tag  tag being thrown

--- a/artichoke-backend/src/extn/core/method/method.rb
+++ b/artichoke-backend/src/extn/core/method/method.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class Method
+  def <<(other)
+    ->(*args, &block) { call(other.call(*args, &block)) }
+  end
+
+  def >>(other)
+    ->(*args, &block) { other.call(call(*args, &block)) }
+  end
+
+  def to_proc
+    m = self
+    ->(*args, &b) { m.call(*args, &b) }
+  end
+end

--- a/artichoke-backend/src/extn/core/method/mod.rs
+++ b/artichoke-backend/src/extn/core/method/mod.rs
@@ -1,0 +1,13 @@
+use crate::eval::Eval;
+use crate::{Artichoke, ArtichokeError};
+
+pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
+    interp
+        .0
+        .borrow_mut()
+        .def_class::<Method>("Method", None, None);
+    interp.eval(&include_bytes!("method.rb")[..])?;
+    Ok(())
+}
+
+pub struct Method;

--- a/artichoke-backend/src/extn/core/mod.rs
+++ b/artichoke-backend/src/extn/core/mod.rs
@@ -14,6 +14,7 @@ pub mod hash;
 pub mod integer;
 pub mod kernel;
 pub mod matchdata;
+pub mod method;
 pub mod module;
 pub mod numeric;
 pub mod object;
@@ -44,6 +45,7 @@ pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
     float::init(interp)?;
     kernel::init(interp)?;
     matchdata::init(interp)?;
+    method::init(interp)?;
     module::init(interp)?;
     object::init(interp)?;
     proc::init(interp)?;

--- a/artichoke-backend/src/extn/core/module/module.rb
+++ b/artichoke-backend/src/extn/core/module/module.rb
@@ -1,6 +1,48 @@
 # frozen_string_literal: true
 
 class Module
+  def <(other)
+    if equal?(other)
+      false
+    else
+      self <= other
+    end
+  end
+
+  def <=(other)
+    raise TypeError, 'compared with non class/module' unless other.is_a?(Module)
+
+    return true if ancestors.include?(other)
+    return false if other.ancestors.include?(self)
+
+    nil
+  end
+
+  def >(other)
+    if equal?(other)
+      false
+    else
+      self >= other
+    end
+  end
+
+  def >=(other)
+    raise TypeError, 'compared with non class/module' unless other.is_a?(Module)
+
+    other < self
+  end
+
+  def <=>(other)
+    return 0 if equal?(other)
+    return nil unless other.is_a?(Module)
+
+    cmp = self < other
+    return -1 if cmp
+    return 1 unless cmp.nil?
+
+    nil
+  end
+
   def attr_accessor(*names)
     attr_reader(*names)
     attr_writer(*names)
@@ -21,8 +63,20 @@ class Module
     end
     self
   end
+
+  alias attr attr_reader
 end
 
 def self.autoload(const, path); end
 
 def self.autoload?(const); end
+
+def self.include(*modules)
+  self.class.include(*modules)
+end
+
+def self.private(*methods); end
+
+def self.protected(*methods); end
+
+def self.public(*methods); end

--- a/artichoke-backend/src/extn/core/proc/mod.rs
+++ b/artichoke-backend/src/extn/core/proc/mod.rs
@@ -3,7 +3,7 @@ use crate::{Artichoke, ArtichokeError};
 
 pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
     interp.0.borrow_mut().def_class::<Proc>("Proc", None, None);
-    interp.eval(include_str!("proc.rb"))?;
+    interp.eval(&include_bytes!("proc.rb")[..])?;
     Ok(())
 }
 

--- a/artichoke-backend/src/extn/core/string.rb
+++ b/artichoke-backend/src/extn/core/string.rb
@@ -81,6 +81,14 @@ class String
     nil
   end
 
+  def %(other)
+    if other.is_a?(Array)
+      sprintf(self, *other) # rubocop:disable Style/FormatString
+    else
+      sprintf(self, other) # rubocop:disable Style/FormatString
+    end
+  end
+
   def +@
     return dup if frozen?
 


### PR DESCRIPTION
Extract the Ruby sources from the remaining mrbgems. These are the last
dependencies on mrblib and mrbc from the mruby build. This unblocks work
on GH-303.

Fixes GH-196.

This PR was extracted from GH-338.