### PR TITLE
Implement Array#shuffle and Array#shuffle! in Rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,6 +48,7 @@ dependencies = [
  "onig 5.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck_macros 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -12,8 +12,8 @@ log = "0.4"
 memchr = "2"
 once_cell = "1"
 onig = "5"
-regex = "1"
 rand = "0.7"
+regex = "1"
 
 [dependencies.artichoke-core]
 path = "../artichoke-core"

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -13,6 +13,7 @@ memchr = "2"
 once_cell = "1"
 onig = "5"
 regex = "1"
+rand = "0.7"
 
 [dependencies.artichoke-core]
 path = "../artichoke-core"
@@ -44,6 +45,3 @@ default-features = false
 default = ["artichoke-array", "artichoke-system-environ"]
 artichoke-array = []
 artichoke-system-environ = []
-
-[dependencies.rand]
-version = "0.7.2"

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -44,3 +44,6 @@ default-features = false
 default = ["artichoke-array", "artichoke-system-environ"]
 artichoke-array = []
 artichoke-system-environ = []
+
+[dependencies.rand]
+version = "0.7.2"

--- a/artichoke-backend/src/extn/core/array/array.rb
+++ b/artichoke-backend/src/extn/core/array/array.rb
@@ -1236,6 +1236,7 @@ class Array
   end
 
   def shuffle(_rng = (not_set = true)) # rubocop:disable Lint/UselessAssignment
+    raise NotImplementedError, 'TODO implement in Rust' unless not_set
     dup.shuffle!
   end
 

--- a/artichoke-backend/src/extn/core/array/array.rb
+++ b/artichoke-backend/src/extn/core/array/array.rb
@@ -1236,11 +1236,7 @@ class Array
   end
 
   def shuffle(_rng = (not_set = true)) # rubocop:disable Lint/UselessAssignment
-    raise NotImplementedError, 'TODO implement in Rust'
-  end
-
-  def shuffle!(_rng = (not_set = true)) # rubocop:disable Lint/UselessAssignment
-    raise NotImplementedError, 'TODO implement in Rust'
+    dup.shuffle!
   end
 
   def slice!(*args)

--- a/artichoke-backend/src/extn/core/array/array.rb
+++ b/artichoke-backend/src/extn/core/array/array.rb
@@ -1235,8 +1235,9 @@ class Array
     result
   end
 
-  def shuffle(_rng = (not_set = true)) # rubocop:disable Lint/UselessAssignment
+  def shuffle(_rng = (not_set = true))
     raise NotImplementedError, 'TODO implement in Rust' unless not_set
+
     dup.shuffle!
   end
 

--- a/artichoke-backend/src/extn/core/array/backend/aggregate.rs
+++ b/artichoke-backend/src/extn/core/array/backend/aggregate.rs
@@ -342,8 +342,15 @@ impl ArrayType for Aggregate {
 
     fn shuffle(&mut self, interp: &Artichoke) -> Result<(), Box<dyn RubyException>> {
         let _ = interp;
+
+        let mut buffer = Vec::with_capacity(self.0.len());
+        for idx in 0..self.0.len() {
+            buffer.push(self.0.get(idx).unwrap());
+        }
+    
         let mut rng = rand::thread_rng();
-        self.0.shuffle(&mut rng);
+        buffer.shuffle(&mut rng);
+        
         Ok(())
     }
 }

--- a/artichoke-backend/src/extn/core/array/backend/aggregate.rs
+++ b/artichoke-backend/src/extn/core/array/backend/aggregate.rs
@@ -340,10 +340,13 @@ impl ArrayType for Aggregate {
         Ok(Box::new(Self::with_parts(parts)))
     }
 
-    fn shuffle_bang(&mut self, interp: &Artichoke) -> Result<Box<dyn ArrayType>, Box<dyn RubyException>> {
+    fn shuffle_bang(
+        &mut self,
+        interp: &Artichoke,
+    ) -> Result<Box<dyn ArrayType>, Box<dyn RubyException>> {
         let _ = interp;
         let mut rng = rand::thread_rng();
-        self.0.shuffle(&mut rng); 
+        self.0.shuffle(&mut rng);
         Ok(self.box_clone())
     }
 }

--- a/artichoke-backend/src/extn/core/array/backend/aggregate.rs
+++ b/artichoke-backend/src/extn/core/array/backend/aggregate.rs
@@ -340,13 +340,13 @@ impl ArrayType for Aggregate {
         Ok(Box::new(Self::with_parts(parts)))
     }
 
-    fn shuffle_bang(
+    fn shuffle(
         &mut self,
         interp: &Artichoke,
-    ) -> Result<Box<dyn ArrayType>, Box<dyn RubyException>> {
+    ) -> Result<(), Box<dyn RubyException>> {
         let _ = interp;
         let mut rng = rand::thread_rng();
         self.0.shuffle(&mut rng);
-        Ok(self.box_clone())
+        Ok(())
     }
 }

--- a/artichoke-backend/src/extn/core/array/backend/aggregate.rs
+++ b/artichoke-backend/src/extn/core/array/backend/aggregate.rs
@@ -347,10 +347,10 @@ impl ArrayType for Aggregate {
         for idx in 0..self.0.len() {
             buffer.push(self.0.get(idx).unwrap());
         }
-    
+
         let mut rng = rand::thread_rng();
         buffer.shuffle(&mut rng);
-        
+
         Ok(())
     }
 }

--- a/artichoke-backend/src/extn/core/array/backend/aggregate.rs
+++ b/artichoke-backend/src/extn/core/array/backend/aggregate.rs
@@ -340,10 +340,7 @@ impl ArrayType for Aggregate {
         Ok(Box::new(Self::with_parts(parts)))
     }
 
-    fn shuffle(
-        &mut self,
-        interp: &Artichoke,
-    ) -> Result<(), Box<dyn RubyException>> {
+    fn shuffle(&mut self, interp: &Artichoke) -> Result<(), Box<dyn RubyException>> {
         let _ = interp;
         let mut rng = rand::thread_rng();
         self.0.shuffle(&mut rng);

--- a/artichoke-backend/src/extn/core/array/backend/aggregate.rs
+++ b/artichoke-backend/src/extn/core/array/backend/aggregate.rs
@@ -1,3 +1,5 @@
+use rand::seq::SliceRandom;
+
 use crate::convert::Convert;
 use crate::extn::core::array::{backend, ArrayType};
 use crate::extn::core::exception::{RangeError, RubyException};
@@ -336,5 +338,12 @@ impl ArrayType for Aggregate {
             parts.push(self.0[idx].reverse(interp)?);
         }
         Ok(Box::new(Self::with_parts(parts)))
+    }
+
+    fn shuffle_bang(&mut self, interp: &Artichoke) -> Result<Box<dyn ArrayType>, Box<dyn RubyException>> {
+        let _ = interp;
+        let mut rng = rand::thread_rng();
+        self.0.shuffle(&mut rng); 
+        Ok(self.box_clone())
     }
 }

--- a/artichoke-backend/src/extn/core/array/backend/buffer.rs
+++ b/artichoke-backend/src/extn/core/array/backend/buffer.rs
@@ -235,13 +235,13 @@ impl ArrayType for Buffer {
         Ok(Box::new(Self(buffer)))
     }
 
-    fn shuffle_bang(
+    fn shuffle(
         &mut self,
         interp: &Artichoke,
-    ) -> Result<Box<dyn ArrayType>, Box<dyn RubyException>> {
+    ) -> Result<(), Box<dyn RubyException>> {
         let _ = interp;
         let mut rng = rand::thread_rng();
         self.0.shuffle(&mut rng);
-        Ok(self.box_clone())
+        Ok(())
     }
 }

--- a/artichoke-backend/src/extn/core/array/backend/buffer.rs
+++ b/artichoke-backend/src/extn/core/array/backend/buffer.rs
@@ -235,10 +235,7 @@ impl ArrayType for Buffer {
         Ok(Box::new(Self(buffer)))
     }
 
-    fn shuffle(
-        &mut self,
-        interp: &Artichoke,
-    ) -> Result<(), Box<dyn RubyException>> {
+    fn shuffle(&mut self, interp: &Artichoke) -> Result<(), Box<dyn RubyException>> {
         let _ = interp;
         let mut rng = rand::thread_rng();
         self.0.shuffle(&mut rng);

--- a/artichoke-backend/src/extn/core/array/backend/buffer.rs
+++ b/artichoke-backend/src/extn/core/array/backend/buffer.rs
@@ -1,5 +1,5 @@
-use std::iter;
 use rand::seq::SliceRandom;
+use std::iter;
 
 use crate::convert::Convert;
 use crate::extn::core::array::{backend, ArrayType};
@@ -235,10 +235,13 @@ impl ArrayType for Buffer {
         Ok(Box::new(Self(buffer)))
     }
 
-    fn shuffle_bang(&mut self, interp: &Artichoke) -> Result<Box<dyn ArrayType>, Box<dyn RubyException>> {
+    fn shuffle_bang(
+        &mut self,
+        interp: &Artichoke,
+    ) -> Result<Box<dyn ArrayType>, Box<dyn RubyException>> {
         let _ = interp;
         let mut rng = rand::thread_rng();
-        self.0.shuffle(&mut rng); 
+        self.0.shuffle(&mut rng);
         Ok(self.box_clone())
     }
 }

--- a/artichoke-backend/src/extn/core/array/backend/buffer.rs
+++ b/artichoke-backend/src/extn/core/array/backend/buffer.rs
@@ -1,4 +1,5 @@
 use std::iter;
+use rand::seq::SliceRandom;
 
 use crate::convert::Convert;
 use crate::extn::core::array::{backend, ArrayType};
@@ -232,5 +233,12 @@ impl ArrayType for Buffer {
             buffer.push(self.0[idx].clone());
         }
         Ok(Box::new(Self(buffer)))
+    }
+
+    fn shuffle_bang(&mut self, interp: &Artichoke) -> Result<Box<dyn ArrayType>, Box<dyn RubyException>> {
+        let _ = interp;
+        let mut rng = rand::thread_rng();
+        self.0.shuffle(&mut rng); 
+        Ok(self.box_clone())
     }
 }

--- a/artichoke-backend/src/extn/core/array/backend/fixed/empty.rs
+++ b/artichoke-backend/src/extn/core/array/backend/fixed/empty.rs
@@ -134,4 +134,9 @@ impl ArrayType for Empty {
         let _ = interp;
         Ok(backend::fixed::empty())
     }
+
+    fn shuffle_bang(&mut self, interp: &Artichoke) -> Result<Box<dyn ArrayType>, Box<dyn RubyException>> {
+        let _ = interp;
+        Ok(backend::fixed::empty())
+    }
 }

--- a/artichoke-backend/src/extn/core/array/backend/fixed/empty.rs
+++ b/artichoke-backend/src/extn/core/array/backend/fixed/empty.rs
@@ -135,10 +135,7 @@ impl ArrayType for Empty {
         Ok(backend::fixed::empty())
     }
 
-    fn shuffle(
-        &mut self,
-        interp: &Artichoke,
-    ) -> Result<(), Box<dyn RubyException>> {
+    fn shuffle(&mut self, interp: &Artichoke) -> Result<(), Box<dyn RubyException>> {
         let _ = interp;
         Ok(())
     }

--- a/artichoke-backend/src/extn/core/array/backend/fixed/empty.rs
+++ b/artichoke-backend/src/extn/core/array/backend/fixed/empty.rs
@@ -135,11 +135,11 @@ impl ArrayType for Empty {
         Ok(backend::fixed::empty())
     }
 
-    fn shuffle_bang(
+    fn shuffle(
         &mut self,
         interp: &Artichoke,
-    ) -> Result<Box<dyn ArrayType>, Box<dyn RubyException>> {
+    ) -> Result<(), Box<dyn RubyException>> {
         let _ = interp;
-        Ok(backend::fixed::empty())
+        Ok(())
     }
 }

--- a/artichoke-backend/src/extn/core/array/backend/fixed/empty.rs
+++ b/artichoke-backend/src/extn/core/array/backend/fixed/empty.rs
@@ -135,7 +135,10 @@ impl ArrayType for Empty {
         Ok(backend::fixed::empty())
     }
 
-    fn shuffle_bang(&mut self, interp: &Artichoke) -> Result<Box<dyn ArrayType>, Box<dyn RubyException>> {
+    fn shuffle_bang(
+        &mut self,
+        interp: &Artichoke,
+    ) -> Result<Box<dyn ArrayType>, Box<dyn RubyException>> {
         let _ = interp;
         Ok(backend::fixed::empty())
     }

--- a/artichoke-backend/src/extn/core/array/backend/fixed/hole.rs
+++ b/artichoke-backend/src/extn/core/array/backend/fixed/hole.rs
@@ -187,7 +187,10 @@ impl ArrayType for Hole {
         Ok(self.box_clone())
     }
 
-    fn shuffle_bang(&mut self, interp: &Artichoke) -> Result<Box<dyn ArrayType>, Box<dyn RubyException>> {
+    fn shuffle_bang(
+        &mut self,
+        interp: &Artichoke,
+    ) -> Result<Box<dyn ArrayType>, Box<dyn RubyException>> {
         let _ = interp;
         Ok(self.box_clone())
     }

--- a/artichoke-backend/src/extn/core/array/backend/fixed/hole.rs
+++ b/artichoke-backend/src/extn/core/array/backend/fixed/hole.rs
@@ -187,10 +187,7 @@ impl ArrayType for Hole {
         Ok(self.box_clone())
     }
 
-    fn shuffle(
-        &mut self,
-        interp: &Artichoke,
-    ) -> Result<(), Box<dyn RubyException>> {
+    fn shuffle(&mut self, interp: &Artichoke) -> Result<(), Box<dyn RubyException>> {
         let _ = interp;
         Ok(())
     }

--- a/artichoke-backend/src/extn/core/array/backend/fixed/hole.rs
+++ b/artichoke-backend/src/extn/core/array/backend/fixed/hole.rs
@@ -187,11 +187,11 @@ impl ArrayType for Hole {
         Ok(self.box_clone())
     }
 
-    fn shuffle_bang(
+    fn shuffle(
         &mut self,
         interp: &Artichoke,
-    ) -> Result<Box<dyn ArrayType>, Box<dyn RubyException>> {
+    ) -> Result<(), Box<dyn RubyException>> {
         let _ = interp;
-        Ok(self.box_clone())
+        Ok(())
     }
 }

--- a/artichoke-backend/src/extn/core/array/backend/fixed/hole.rs
+++ b/artichoke-backend/src/extn/core/array/backend/fixed/hole.rs
@@ -186,4 +186,9 @@ impl ArrayType for Hole {
         let _ = interp;
         Ok(self.box_clone())
     }
+
+    fn shuffle_bang(&mut self, interp: &Artichoke) -> Result<Box<dyn ArrayType>, Box<dyn RubyException>> {
+        let _ = interp;
+        Ok(self.box_clone())
+    }
 }

--- a/artichoke-backend/src/extn/core/array/backend/fixed/one.rs
+++ b/artichoke-backend/src/extn/core/array/backend/fixed/one.rs
@@ -179,10 +179,7 @@ impl ArrayType for One {
         Ok(self.box_clone())
     }
 
-    fn shuffle(
-        &mut self,
-        interp: &Artichoke,
-    ) -> Result<(), Box<dyn RubyException>> {
+    fn shuffle(&mut self, interp: &Artichoke) -> Result<(), Box<dyn RubyException>> {
         let _ = interp;
         Ok(())
     }

--- a/artichoke-backend/src/extn/core/array/backend/fixed/one.rs
+++ b/artichoke-backend/src/extn/core/array/backend/fixed/one.rs
@@ -178,4 +178,9 @@ impl ArrayType for One {
         let _ = interp;
         Ok(self.box_clone())
     }
+
+    fn shuffle_bang(&mut self, interp: &Artichoke) -> Result<Box<dyn ArrayType>, Box<dyn RubyException>> {
+        let _ = interp;
+        Ok(self.box_clone())
+    }
 }

--- a/artichoke-backend/src/extn/core/array/backend/fixed/one.rs
+++ b/artichoke-backend/src/extn/core/array/backend/fixed/one.rs
@@ -179,11 +179,11 @@ impl ArrayType for One {
         Ok(self.box_clone())
     }
 
-    fn shuffle_bang(
+    fn shuffle(
         &mut self,
         interp: &Artichoke,
-    ) -> Result<Box<dyn ArrayType>, Box<dyn RubyException>> {
+    ) -> Result<(), Box<dyn RubyException>> {
         let _ = interp;
-        Ok(self.box_clone())
+        Ok(())
     }
 }

--- a/artichoke-backend/src/extn/core/array/backend/fixed/one.rs
+++ b/artichoke-backend/src/extn/core/array/backend/fixed/one.rs
@@ -179,7 +179,10 @@ impl ArrayType for One {
         Ok(self.box_clone())
     }
 
-    fn shuffle_bang(&mut self, interp: &Artichoke) -> Result<Box<dyn ArrayType>, Box<dyn RubyException>> {
+    fn shuffle_bang(
+        &mut self,
+        interp: &Artichoke,
+    ) -> Result<Box<dyn ArrayType>, Box<dyn RubyException>> {
         let _ = interp;
         Ok(self.box_clone())
     }

--- a/artichoke-backend/src/extn/core/array/backend/fixed/two.rs
+++ b/artichoke-backend/src/extn/core/array/backend/fixed/two.rs
@@ -217,4 +217,12 @@ impl ArrayType for Two {
         let _ = interp;
         Ok(backend::fixed::two(self.1.clone(), self.0.clone()))
     }
+
+    fn shuffle_bang(&mut self, interp: &Artichoke) -> Result<Box<dyn ArrayType>, Box<dyn RubyException>> {
+        let _ = interp;
+        if rand::random() {
+            *self = Self(self.1.clone(), self.0.clone())
+        }
+        Ok(self.box_clone())
+    }
 }

--- a/artichoke-backend/src/extn/core/array/backend/fixed/two.rs
+++ b/artichoke-backend/src/extn/core/array/backend/fixed/two.rs
@@ -218,7 +218,10 @@ impl ArrayType for Two {
         Ok(backend::fixed::two(self.1.clone(), self.0.clone()))
     }
 
-    fn shuffle_bang(&mut self, interp: &Artichoke) -> Result<Box<dyn ArrayType>, Box<dyn RubyException>> {
+    fn shuffle_bang(
+        &mut self,
+        interp: &Artichoke,
+    ) -> Result<Box<dyn ArrayType>, Box<dyn RubyException>> {
         let _ = interp;
         if rand::random() {
             *self = Self(self.1.clone(), self.0.clone())

--- a/artichoke-backend/src/extn/core/array/backend/fixed/two.rs
+++ b/artichoke-backend/src/extn/core/array/backend/fixed/two.rs
@@ -1,3 +1,5 @@
+use std::mem;
+
 use crate::convert::Convert;
 use crate::extn::core::array::{backend, ArrayType};
 use crate::extn::core::exception::RubyException;
@@ -218,14 +220,14 @@ impl ArrayType for Two {
         Ok(backend::fixed::two(self.1.clone(), self.0.clone()))
     }
 
-    fn shuffle_bang(
+    fn shuffle(
         &mut self,
         interp: &Artichoke,
-    ) -> Result<Box<dyn ArrayType>, Box<dyn RubyException>> {
+    ) -> Result<(), Box<dyn RubyException>> {
         let _ = interp;
         if rand::random() {
-            *self = Self(self.1.clone(), self.0.clone())
+            mem::swap(&mut self.0, &mut self.1);
         }
-        Ok(self.box_clone())
+        Ok(())
     }
 }

--- a/artichoke-backend/src/extn/core/array/backend/fixed/two.rs
+++ b/artichoke-backend/src/extn/core/array/backend/fixed/two.rs
@@ -220,10 +220,7 @@ impl ArrayType for Two {
         Ok(backend::fixed::two(self.1.clone(), self.0.clone()))
     }
 
-    fn shuffle(
-        &mut self,
-        interp: &Artichoke,
-    ) -> Result<(), Box<dyn RubyException>> {
+    fn shuffle(&mut self, interp: &Artichoke) -> Result<(), Box<dyn RubyException>> {
         let _ = interp;
         if rand::random() {
             mem::swap(&mut self.0, &mut self.1);

--- a/artichoke-backend/src/extn/core/array/backend/repeated/value.rs
+++ b/artichoke-backend/src/extn/core/array/backend/repeated/value.rs
@@ -208,4 +208,9 @@ impl ArrayType for Value {
         let _ = interp;
         Ok(self.box_clone())
     }
+
+    fn shuffle_bang(&mut self, interp: &Artichoke) -> Result<Box<dyn ArrayType>, Box<dyn RubyException>> {
+        let _ = interp;
+        Ok(self.box_clone())
+    }
 }

--- a/artichoke-backend/src/extn/core/array/backend/repeated/value.rs
+++ b/artichoke-backend/src/extn/core/array/backend/repeated/value.rs
@@ -209,11 +209,11 @@ impl ArrayType for Value {
         Ok(self.box_clone())
     }
 
-    fn shuffle_bang(
+    fn shuffle(
         &mut self,
         interp: &Artichoke,
-    ) -> Result<Box<dyn ArrayType>, Box<dyn RubyException>> {
+    ) -> Result<(), Box<dyn RubyException>> {
         let _ = interp;
-        Ok(self.box_clone())
+        Ok(())
     }
 }

--- a/artichoke-backend/src/extn/core/array/backend/repeated/value.rs
+++ b/artichoke-backend/src/extn/core/array/backend/repeated/value.rs
@@ -209,7 +209,10 @@ impl ArrayType for Value {
         Ok(self.box_clone())
     }
 
-    fn shuffle_bang(&mut self, interp: &Artichoke) -> Result<Box<dyn ArrayType>, Box<dyn RubyException>> {
+    fn shuffle_bang(
+        &mut self,
+        interp: &Artichoke,
+    ) -> Result<Box<dyn ArrayType>, Box<dyn RubyException>> {
         let _ = interp;
         Ok(self.box_clone())
     }

--- a/artichoke-backend/src/extn/core/array/backend/repeated/value.rs
+++ b/artichoke-backend/src/extn/core/array/backend/repeated/value.rs
@@ -209,10 +209,7 @@ impl ArrayType for Value {
         Ok(self.box_clone())
     }
 
-    fn shuffle(
-        &mut self,
-        interp: &Artichoke,
-    ) -> Result<(), Box<dyn RubyException>> {
+    fn shuffle(&mut self, interp: &Artichoke) -> Result<(), Box<dyn RubyException>> {
         let _ = interp;
         Ok(())
     }

--- a/artichoke-backend/src/extn/core/array/mod.rs
+++ b/artichoke-backend/src/extn/core/array/mod.rs
@@ -522,7 +522,10 @@ pub trait ArrayType: Any {
     // like `Array#reverse!` and implement Array#reverse` in Ruby.
     fn reverse(&self, interp: &Artichoke) -> Result<Box<dyn ArrayType>, Box<dyn RubyException>>;
 
-    fn shuffle_bang(&mut self, interp: &Artichoke) -> Result<Box<dyn ArrayType>, Box<dyn RubyException>>;
+    fn shuffle_bang(
+        &mut self,
+        interp: &Artichoke,
+    ) -> Result<Box<dyn ArrayType>, Box<dyn RubyException>>;
 }
 
 downcast!(dyn ArrayType);

--- a/artichoke-backend/src/extn/core/array/mod.rs
+++ b/artichoke-backend/src/extn/core/array/mod.rs
@@ -442,6 +442,14 @@ impl Array {
         self.0 = reversed;
         Ok(())
     }
+
+    pub fn shuffle_bang(&mut self, interp: &Artichoke) -> Result<Value, Box<dyn RubyException>> {
+        let result = self.0.shuffle_bang(interp)?;
+        let result = Self(result);
+        let result = unsafe { result.try_into_ruby(interp, None) }
+            .map_err(|_| Fatal::new(interp, "Unable to initialize Ruby Array from Rust Array"))?;
+        Ok(result)
+    }
 }
 
 impl RustBackedValue for Array {
@@ -513,6 +521,8 @@ pub trait ArrayType: Any {
     // TODO: Change the semantics of this function to do an in place reverse
     // like `Array#reverse!` and implement Array#reverse` in Ruby.
     fn reverse(&self, interp: &Artichoke) -> Result<Box<dyn ArrayType>, Box<dyn RubyException>>;
+
+    fn shuffle_bang(&mut self, interp: &Artichoke) -> Result<Box<dyn ArrayType>, Box<dyn RubyException>>;
 }
 
 downcast!(dyn ArrayType);

--- a/artichoke-backend/src/extn/core/array/mod.rs
+++ b/artichoke-backend/src/extn/core/array/mod.rs
@@ -443,12 +443,9 @@ impl Array {
         Ok(())
     }
 
-    pub fn shuffle_bang(&mut self, interp: &Artichoke) -> Result<Value, Box<dyn RubyException>> {
-        let result = self.0.shuffle_bang(interp)?;
-        let result = Self(result);
-        let result = unsafe { result.try_into_ruby(interp, None) }
-            .map_err(|_| Fatal::new(interp, "Unable to initialize Ruby Array from Rust Array"))?;
-        Ok(result)
+    pub fn shuffle(&mut self, interp: &Artichoke) -> Result<(), Box<dyn RubyException>> {
+        self.0.shuffle(interp)?;
+        Ok(())
     }
 }
 
@@ -522,10 +519,10 @@ pub trait ArrayType: Any {
     // like `Array#reverse!` and implement Array#reverse` in Ruby.
     fn reverse(&self, interp: &Artichoke) -> Result<Box<dyn ArrayType>, Box<dyn RubyException>>;
 
-    fn shuffle_bang(
+    fn shuffle(
         &mut self,
         interp: &Artichoke,
-    ) -> Result<Box<dyn ArrayType>, Box<dyn RubyException>>;
+    ) -> Result<(), Box<dyn RubyException>>;
 }
 
 downcast!(dyn ArrayType);

--- a/artichoke-backend/src/extn/core/array/mod.rs
+++ b/artichoke-backend/src/extn/core/array/mod.rs
@@ -519,10 +519,7 @@ pub trait ArrayType: Any {
     // like `Array#reverse!` and implement Array#reverse` in Ruby.
     fn reverse(&self, interp: &Artichoke) -> Result<Box<dyn ArrayType>, Box<dyn RubyException>>;
 
-    fn shuffle(
-        &mut self,
-        interp: &Artichoke,
-    ) -> Result<(), Box<dyn RubyException>>;
+    fn shuffle(&mut self, interp: &Artichoke) -> Result<(), Box<dyn RubyException>>;
 }
 
 downcast!(dyn ArrayType);

--- a/artichoke-backend/src/extn/core/array/mruby.rs
+++ b/artichoke-backend/src/extn/core/array/mruby.rs
@@ -52,6 +52,9 @@ pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
         .add_method("reverse!", ary_reverse_bang, sys::mrb_args_none());
     array
         .borrow_mut()
+        .add_method("shuffle!", ary_shuffle_bang, sys::mrb_args_none());
+    array
+        .borrow_mut()
         .add_method("size", ary_len, sys::mrb_args_none());
     array.borrow().define(interp)?;
 
@@ -171,6 +174,17 @@ unsafe extern "C" fn ary_reverse_bang(
             sys::mrb_write_barrier(mrb, basic);
             value.inner()
         }
+        Err(exception) => exception::raise(interp, exception),
+    }
+}
+
+unsafe extern "C" fn ary_shuffle_bang(mrb: *mut sys::mrb_state, ary: sys::mrb_value) -> sys::mrb_value {
+    mrb_get_args!(mrb, none);
+    let interp = unwrap_interpreter!(mrb);
+    let ary = Value::new(&interp, ary);
+    let result = array::trampoline::shuffle_bang(&interp, ary);
+    match result {
+        Ok(value) => value.inner(),
         Err(exception) => exception::raise(interp, exception),
     }
 }

--- a/artichoke-backend/src/extn/core/array/mruby.rs
+++ b/artichoke-backend/src/extn/core/array/mruby.rs
@@ -178,7 +178,10 @@ unsafe extern "C" fn ary_reverse_bang(
     }
 }
 
-unsafe extern "C" fn ary_shuffle_bang(mrb: *mut sys::mrb_state, ary: sys::mrb_value) -> sys::mrb_value {
+unsafe extern "C" fn ary_shuffle_bang(
+    mrb: *mut sys::mrb_state,
+    ary: sys::mrb_value,
+) -> sys::mrb_value {
     mrb_get_args!(mrb, none);
     let interp = unwrap_interpreter!(mrb);
     let ary = Value::new(&interp, ary);

--- a/artichoke-backend/src/extn/core/array/mruby.rs
+++ b/artichoke-backend/src/extn/core/array/mruby.rs
@@ -185,7 +185,7 @@ unsafe extern "C" fn ary_shuffle_bang(
     mrb_get_args!(mrb, none);
     let interp = unwrap_interpreter!(mrb);
     let ary = Value::new(&interp, ary);
-    let result = array::trampoline::shuffle_bang(&interp, ary);
+    let result = array::trampoline::shuffle(&interp, ary);
     match result {
         Ok(value) => value.inner(),
         Err(exception) => exception::raise(interp, exception),

--- a/artichoke-backend/src/extn/core/array/trampoline.rs
+++ b/artichoke-backend/src/extn/core/array/trampoline.rs
@@ -146,7 +146,7 @@ pub fn push(interp: &Artichoke, ary: Value, value: Value) -> Result<Value, Box<d
     Ok(ary)
 }
 
-pub fn shuffle_bang(interp: &Artichoke, ary: Value) -> Result<Value, Box<dyn RubyException>> {
+pub fn shuffle(interp: &Artichoke, ary: Value) -> Result<Value, Box<dyn RubyException>> {
     if ary.is_frozen() {
         return Err(Box::new(FrozenError::new(
             interp,
@@ -161,7 +161,7 @@ pub fn shuffle_bang(interp: &Artichoke, ary: Value) -> Result<Value, Box<dyn Rub
     })?;
     let mut borrow = array.borrow_mut();
     let gc_was_enabled = interp.disable_gc();
-    borrow.shuffle_bang(interp)?;
+    borrow.shuffle(interp)?;
     if gc_was_enabled {
         interp.enable_gc();
     }

--- a/scripts/spec-compliance.sh
+++ b/scripts/spec-compliance.sh
@@ -142,7 +142,7 @@ register_spec core array reverse
 # register_spec core array sample
 # register_spec core array select
 register_spec core array shift
-# register_spec core array shuffle
+register_spec core array shuffle
 register_spec core array size
 # register_spec core array slice
 register_spec core array sort_by


### PR DESCRIPTION
I'm a Rubyist and new to Rust, so please be nice! ;-)

This is work in progress, missing:

- [x] hole.rs implementation of `shuffle_bang`? (I'm not exactly sure what a "hole" array is)
- [ ] options hash (passing a `Random` instance): `a.shuffle!(random: Random.new(1))  #=> [1, 3, 2]`