### PR TITLE
Lint buildfix

### DIFF
--- a/artichoke-backend/src/extn/core/env/env.rb
+++ b/artichoke-backend/src/extn/core/env/env.rb
@@ -113,11 +113,11 @@ class << ENV
     select! { |key, value| yield key, value }
   end
 
-  def has_key?(name) # rubocop:disable PredicateName
+  def has_key?(name) # rubocop:disable Naming/PredicateName
     to_h.key?(name)
   end
 
-  def has_value?(value) # rubocop:disable PredicateName
+  def has_value?(value) # rubocop:disable Naming/PredicateName
     to_h.value?(value)
   end
 

--- a/artichoke-frontend/src/ruby.rs
+++ b/artichoke-frontend/src/ruby.rs
@@ -10,7 +10,7 @@ use artichoke_core::ArtichokeError;
 use bstr::BStr;
 use std::ffi::OsString;
 use std::io::{self, Read};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
@@ -63,104 +63,114 @@ pub fn entrypoint() -> Result<(), Error> {
     if opt.copyright {
         let interp = artichoke_backend::interpreter()?;
         interp.eval("puts RUBY_COPYRIGHT")?;
+        Ok(())
     } else if !opt.commands.is_empty() {
-        let interp = artichoke_backend::interpreter()?;
-        interp.push_context(Context::new(b"-e".as_ref()));
-        if let Some(ref fixture) = opt.fixture {
-            let data = std::fs::read(fixture).map_err(|_| {
-                if let Ok(file) = fs::osstr_to_bytes(&interp, fixture.as_os_str()) {
-                    let file = format!("{:?}", <&BStr>::from(file));
-                    format!(
-                        "No such file or directory -- {} (LoadError)",
-                        &file[1..file.len() - 1]
-                    )
-                } else {
-                    format!("No such file or directory -- {:?} (LoadError)", fixture)
-                }
-            })?;
-            let sym = interp.0.borrow_mut().sym_intern("$fixture");
-            let mrb = interp.0.borrow().mrb;
-            let value = interp.convert(data);
-            unsafe {
-                sys::mrb_gv_set(mrb, sym, value.inner());
-            }
-        }
-        for command in opt.commands {
-            if let Ok(command) = fs::osstr_to_bytes(&interp, command.as_os_str()) {
-                interp.eval(command)?;
-            } else {
-                return Err(Error::from(
-                    "Unable to parse non-UTF-8 command line arguments on this platform",
-                ));
-            }
-        }
+        execute_inline_eval(opt.commands, opt.fixture.as_ref().map(Path::new))
     } else if let Some(programfile) = opt.programfile {
-        let interp = artichoke_backend::interpreter()?;
-        if let Some(ref fixture) = opt.fixture {
-            let data = std::fs::read(fixture).map_err(|_| {
-                if let Ok(file) = fs::osstr_to_bytes(&interp, fixture.as_os_str()) {
-                    let file = format!("{:?}", <&BStr>::from(file));
-                    format!(
-                        "No such file or directory -- {} (LoadError)",
-                        &file[1..file.len() - 1]
-                    )
-                } else {
-                    format!("No such file or directory -- {:?} (LoadError)", fixture)
-                }
-            })?;
-            let sym = interp.0.borrow_mut().sym_intern("$fixture");
-            let mrb = interp.0.borrow().mrb;
-            let value = interp.convert(data);
-            unsafe {
-                sys::mrb_gv_set(mrb, sym, value.inner());
-            }
-        }
-        let program = std::fs::read(programfile.as_path()).map_err(|err| match err.kind() {
-            io::ErrorKind::NotFound => {
-                if let Ok(file) = fs::osstr_to_bytes(&interp, programfile.as_os_str()) {
-                    let file = format!("{:?}", <&BStr>::from(file));
-                    format!(
-                        "No such file or directory -- {} (LoadError)",
-                        &file[1..file.len() - 1]
-                    )
-                } else {
-                    format!("No such file or directory -- {:?} (LoadError)", programfile)
-                }
-            }
-            io::ErrorKind::PermissionDenied => {
-                if let Ok(file) = fs::osstr_to_bytes(&interp, programfile.as_os_str()) {
-                    let file = format!("{:?}", <&BStr>::from(file));
-                    format!(
-                        "Permission denied -- {} (LoadError)",
-                        &file[1..file.len() - 1]
-                    )
-                } else {
-                    format!("Permission denied -- {:?} (LoadError)", programfile)
-                }
-            }
-            _ => {
-                if let Ok(file) = fs::osstr_to_bytes(&interp, programfile.as_os_str()) {
-                    let file = format!("{:?}", <&BStr>::from(file));
-                    format!(
-                        "Could not read file -- {} (LoadError)",
-                        &file[1..file.len() - 1]
-                    )
-                } else {
-                    format!("Could not read file -- {:?} (LoadError)", programfile)
-                }
-            }
-        })?;
-        interp.eval(program.as_slice())?;
+        execute_program_file(programfile.as_path(), opt.fixture.as_ref().map(Path::new))
     } else {
         let mut program = Vec::new();
         let result = io::stdin().read_to_end(&mut program);
         if result.is_ok() {
             let interp = artichoke_backend::interpreter()?;
             interp.eval(program.as_slice())?;
+            Ok(())
         } else {
-            return Err(Error::from("Could not read program from STDIN"));
+            Err(Error::from("Could not read program from STDIN"))
         }
     }
+}
 
+fn execute_inline_eval(commands: Vec<OsString>, fixture: Option<&Path>) -> Result<(), Error> {
+    let interp = artichoke_backend::interpreter()?;
+    interp.push_context(Context::new(b"-e".as_ref()));
+    if let Some(ref fixture) = fixture {
+        let data = std::fs::read(fixture).map_err(|_| {
+            if let Ok(file) = fs::osstr_to_bytes(&interp, fixture.as_os_str()) {
+                let file = format!("{:?}", <&BStr>::from(file));
+                format!(
+                    "No such file or directory -- {} (LoadError)",
+                    &file[1..file.len() - 1]
+                )
+            } else {
+                format!("No such file or directory -- {:?} (LoadError)", fixture)
+            }
+        })?;
+        let sym = interp.0.borrow_mut().sym_intern("$fixture");
+        let mrb = interp.0.borrow().mrb;
+        let value = interp.convert(data);
+        unsafe {
+            sys::mrb_gv_set(mrb, sym, value.inner());
+        }
+    }
+    for command in commands {
+        if let Ok(command) = fs::osstr_to_bytes(&interp, command.as_os_str()) {
+            interp.eval(command)?;
+        } else {
+            return Err(Error::from(
+                "Unable to parse non-UTF-8 command line arguments on this platform",
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn execute_program_file(programfile: &Path, fixture: Option<&Path>) -> Result<(), Error> {
+    let interp = artichoke_backend::interpreter()?;
+    if let Some(ref fixture) = fixture {
+        let data = std::fs::read(fixture).map_err(|_| {
+            if let Ok(file) = fs::osstr_to_bytes(&interp, fixture.as_os_str()) {
+                let file = format!("{:?}", <&BStr>::from(file));
+                format!(
+                    "No such file or directory -- {} (LoadError)",
+                    &file[1..file.len() - 1]
+                )
+            } else {
+                format!("No such file or directory -- {:?} (LoadError)", fixture)
+            }
+        })?;
+        let sym = interp.0.borrow_mut().sym_intern("$fixture");
+        let mrb = interp.0.borrow().mrb;
+        let value = interp.convert(data);
+        unsafe {
+            sys::mrb_gv_set(mrb, sym, value.inner());
+        }
+    }
+    let program = std::fs::read(programfile).map_err(|err| match err.kind() {
+        io::ErrorKind::NotFound => {
+            if let Ok(file) = fs::osstr_to_bytes(&interp, programfile.as_os_str()) {
+                let file = format!("{:?}", <&BStr>::from(file));
+                format!(
+                    "No such file or directory -- {} (LoadError)",
+                    &file[1..file.len() - 1]
+                )
+            } else {
+                format!("No such file or directory -- {:?} (LoadError)", programfile)
+            }
+        }
+        io::ErrorKind::PermissionDenied => {
+            if let Ok(file) = fs::osstr_to_bytes(&interp, programfile.as_os_str()) {
+                let file = format!("{:?}", <&BStr>::from(file));
+                format!(
+                    "Permission denied -- {} (LoadError)",
+                    &file[1..file.len() - 1]
+                )
+            } else {
+                format!("Permission denied -- {:?} (LoadError)", programfile)
+            }
+        }
+        _ => {
+            if let Ok(file) = fs::osstr_to_bytes(&interp, programfile.as_os_str()) {
+                let file = format!("{:?}", <&BStr>::from(file));
+                format!(
+                    "Could not read file -- {} (LoadError)",
+                    &file[1..file.len() - 1]
+                )
+            } else {
+                format!("Could not read file -- {:?} (LoadError)", programfile)
+            }
+        }
+    })?;
+    interp.eval(program.as_slice())?;
     Ok(())
 }


### PR DESCRIPTION
Fix lint failures on master for Rust clippy and Ruby rubocop.

- Split apart `artichoke_frontend::ruby::entrypoint` to make smaller functions by breaking out program file and inline eval cases.
- run `rubocop -a --only Migration/DepartmentName`.