### PR TITLE
Null out the mruby host build

### DIFF
--- a/artichoke-backend/bootstrap.gembox
+++ b/artichoke-backend/bootstrap.gembox
@@ -9,6 +9,4 @@
 # This gembox can become empty and the default build nulled out once the
 # Artichoke runtime is complete.
 MRuby::GemBox.new do |conf|
-  conf.gem core: 'mruby-compiler'
-  conf.gem core: 'mruby-bin-mrbc'
 end

--- a/artichoke-backend/build.rs
+++ b/artichoke-backend/build.rs
@@ -28,7 +28,7 @@ mod buildpath {
 
         pub fn mruby_build_config(target: &Triple) -> PathBuf {
             let _ = target;
-            super::crate_root().join("build_config.rb")
+            super::crate_root().join("mruby_build_config_null.rb")
         }
 
         pub fn mruby_bootstrap_gembox() -> PathBuf {

--- a/artichoke-backend/mruby_build_config_null.rb
+++ b/artichoke-backend/mruby_build_config_null.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'fileutils'
+
 # mruby requires a "default" build. This default build bootstraps the
 # compilation of the "sys" build.
 #
@@ -8,22 +10,8 @@
 #
 # This build can be nulled out once the Artichoke runtime is complete.
 MRuby::Build.new do |conf|
-  # Gets set by the VS command prompts.
-  if ENV['VisualStudioVersion'] || ENV['VSINSTALLDIR']
-    toolchain :visualcpp
-  else
-    toolchain :clang
-  end
-  conf.gperf.command = 'true'
-  conf.gperf.compile_options = ''
+  def build_mrbc_exec; end
 
-  conf.bins = ['mrbc']
-  conf.gembox File.join(File.dirname(File.absolute_path(__FILE__)), 'bootstrap')
-end
-
-# This cross-build generates C sources so `build.rs` can compile them into a
-# static lib.
-MRuby::CrossBuild.new('sys') do |conf|
   conf.cc.command = 'true'
   conf.cxx.command = 'true'
   conf.objc.command = 'true'
@@ -32,6 +20,29 @@ MRuby::CrossBuild.new('sys') do |conf|
   conf.gperf.compile_options = ''
   conf.linker.command = 'true'
   conf.archiver.command = 'true'
+  conf.mrbc.command = 'true'
+
+  conf.bins = []
+  conf.gembox File.join(File.dirname(File.absolute_path(__FILE__)), 'bootstrap')
+
+  FileUtils.mkdir_p("#{build_dir}/bin")
+  FileUtils.touch("#{build_dir}/bin/mrbc")
+end
+
+# This cross-build generates C sources so `build.rs` can compile them into a
+# static lib.
+MRuby::CrossBuild.new('sys') do |conf|
+  def build_mrbc_exec; end
+
+  conf.cc.command = 'true'
+  conf.cxx.command = 'true'
+  conf.objc.command = 'true'
+  conf.asm.command = 'true'
+  conf.gperf.command = 'true'
+  conf.gperf.compile_options = ''
+  conf.linker.command = 'true'
+  conf.archiver.command = 'true'
+  conf.mrbc.command = 'true'
 
   # C compiler settings
   # https://github.com/mruby/mruby/blob/master/doc/guides/mrbconf.md#other-configuration
@@ -41,4 +52,7 @@ MRuby::CrossBuild.new('sys') do |conf|
 
   # gemset for mruby artichoke static lib
   conf.gembox File.join(File.dirname(File.absolute_path(__FILE__)), 'sys')
+
+  FileUtils.mkdir_p("#{build_dir}/bin")
+  FileUtils.touch("#{build_dir}/bin/mrbc")
 end

--- a/artichoke-backend/vendor/mruby/lib/mruby/gem.rb
+++ b/artichoke-backend/vendor/mruby/lib/mruby/gem.rb
@@ -165,14 +165,14 @@ module MRuby
       def generate_gem_init(fname)
         open(fname, 'w') do |f|
           print_gem_init_header f
-          build.mrbc.run f, rbfiles, "gem_mrblib_irep_#{funcname}" unless rbfiles.empty?
+          build.mrbc.run f, rbfiles, "gem_mrblib_irep_#{funcname}" unless rbfiles.empty? || true # Disabled by Artichoke build
           f.puts %Q[void mrb_#{funcname}_gem_init(mrb_state *mrb);]
           f.puts %Q[void mrb_#{funcname}_gem_final(mrb_state *mrb);]
           f.puts %Q[]
           f.puts %Q[void GENERATED_TMP_mrb_#{funcname}_gem_init(mrb_state *mrb) {]
           f.puts %Q[  int ai = mrb_gc_arena_save(mrb);]
           f.puts %Q[  mrb_#{funcname}_gem_init(mrb);] if objs != [objfile("#{build_dir}/gem_init")]
-          unless rbfiles.empty?
+          unless rbfiles.empty? || true # Disabled by Artichoke build
             f.puts %Q[  mrb_load_irep(mrb, gem_mrblib_irep_#{funcname});]
             f.puts %Q[  if (mrb->exc) {]
             f.puts %Q[    mrb_print_error(mrb);]


### PR DESCRIPTION
mruby requires a host build that is not configurable enough to build
Artichoke. This has meant that Artichoke builds the host build to
bootstrap a 'sys' crossbuild that is used to produce the static library.

In the beginning, mruby's build process was used directly to produce
the static library that build.rs would link into Artichoke. More
recently, the sys crossbuild would only do C source generation and
build.rs would discover and compile these sources with the cc
crate.

Now that Artichoke no longer depends on mrblib or Ruby sources in
mrbgems, mrbc is no longer required and the host build is no longer
needed.

This PR replaces the host build with a noop. This changes the code
emitted by the mruby build process to eliminate gem irep embedding.
The bootstrap gembox no longer includes or builds any mrbgems.

Fixes GH-303.

This PR was extracted from GH-338.