### PR TITLE
Reduce allocations of Symbols backed by &'static byte strings

### DIFF
--- a/artichoke-backend/src/extn/core/regexp/backend/onig.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/onig.rs
@@ -219,13 +219,16 @@ impl RegexpType for Onig {
         let mrb = interp.0.borrow().mrb;
         if let Some(captures) = self.regex.captures(pattern) {
             let globals_to_set = cmp::max(interp.0.borrow().active_regexp_globals, captures.len());
-            let sym = interp.0.borrow_mut().sym_intern("$&");
+            let sym = interp.0.borrow_mut().sym_intern("$&".as_bytes());
             let value = interp.convert(captures.at(0));
             unsafe {
                 sys::mrb_gv_set(mrb, sym, value.inner());
             }
             for group in 1..=globals_to_set {
-                let sym = interp.0.borrow_mut().sym_intern(&format!("${}", group));
+                let sym = interp
+                    .0
+                    .borrow_mut()
+                    .sym_intern(format!("${}", group).into_bytes());
                 let value = interp.convert(captures.at(group));
                 unsafe {
                     sys::mrb_gv_set(mrb, sym, value.inner());
@@ -236,8 +239,8 @@ impl RegexpType for Onig {
             if let Some(match_pos) = captures.pos(0) {
                 let pre_match = &pattern[..match_pos.0];
                 let post_match = &pattern[match_pos.1..];
-                let pre_match_sym = interp.0.borrow_mut().sym_intern("$`");
-                let post_match_sym = interp.0.borrow_mut().sym_intern("$'");
+                let pre_match_sym = interp.0.borrow_mut().sym_intern("$`".as_bytes());
+                let post_match_sym = interp.0.borrow_mut().sym_intern("$'".as_bytes());
                 unsafe {
                     sys::mrb_gv_set(mrb, pre_match_sym, interp.convert(pre_match).inner());
                     sys::mrb_gv_set(mrb, post_match_sym, interp.convert(post_match).inner());
@@ -252,14 +255,14 @@ impl RegexpType for Onig {
             let matchdata = unsafe { matchdata.try_into_ruby(&interp, None) }.map_err(|_| {
                 Fatal::new(interp, "Could not create Ruby Value from Rust MatchData")
             })?;
-            let matchdata_sym = interp.0.borrow_mut().sym_intern("$~");
+            let matchdata_sym = interp.0.borrow_mut().sym_intern("$~".as_bytes());
             unsafe {
                 sys::mrb_gv_set(mrb, matchdata_sym, matchdata.inner());
             }
             Ok(true)
         } else {
-            let pre_match_sym = interp.0.borrow_mut().sym_intern("$`");
-            let post_match_sym = interp.0.borrow_mut().sym_intern("$'");
+            let pre_match_sym = interp.0.borrow_mut().sym_intern("$`".as_bytes());
+            let post_match_sym = interp.0.borrow_mut().sym_intern("$'".as_bytes());
             unsafe {
                 sys::mrb_gv_set(mrb, pre_match_sym, interp.convert(None::<Value>).inner());
                 sys::mrb_gv_set(mrb, post_match_sym, interp.convert(None::<Value>).inner());
@@ -343,13 +346,16 @@ impl RegexpType for Onig {
         let match_target = &pattern[byte_offset..];
         if let Some(captures) = self.regex.captures(match_target) {
             let globals_to_set = cmp::max(interp.0.borrow().active_regexp_globals, captures.len());
-            let sym = interp.0.borrow_mut().sym_intern("$&");
+            let sym = interp.0.borrow_mut().sym_intern("$&".as_bytes());
             let value = interp.convert(captures.at(0));
             unsafe {
                 sys::mrb_gv_set(mrb, sym, value.inner());
             }
             for group in 1..=globals_to_set {
-                let sym = interp.0.borrow_mut().sym_intern(&format!("${}", group));
+                let sym = interp
+                    .0
+                    .borrow_mut()
+                    .sym_intern(format!("${}", group).into_bytes());
                 let value = interp.convert(captures.at(group));
                 unsafe {
                     sys::mrb_gv_set(mrb, sym, value.inner());
@@ -366,8 +372,8 @@ impl RegexpType for Onig {
             if let Some(match_pos) = captures.pos(0) {
                 let pre_match = &match_target[..match_pos.0];
                 let post_match = &match_target[match_pos.1..];
-                let pre_match_sym = interp.0.borrow_mut().sym_intern("$`");
-                let post_match_sym = interp.0.borrow_mut().sym_intern("$'");
+                let pre_match_sym = interp.0.borrow_mut().sym_intern("$`".as_bytes());
+                let post_match_sym = interp.0.borrow_mut().sym_intern("$'".as_bytes());
                 unsafe {
                     sys::mrb_gv_set(mrb, pre_match_sym, interp.convert(pre_match).inner());
                     sys::mrb_gv_set(mrb, post_match_sym, interp.convert(post_match).inner());
@@ -380,7 +386,7 @@ impl RegexpType for Onig {
                     "Failed to initialize Ruby MatchData Value with Rust MatchData",
                 )
             })?;
-            let matchdata_sym = interp.0.borrow_mut().sym_intern("$~");
+            let matchdata_sym = interp.0.borrow_mut().sym_intern("$~".as_bytes());
             unsafe {
                 sys::mrb_gv_set(mrb, matchdata_sym, data.inner());
             }
@@ -396,9 +402,9 @@ impl RegexpType for Onig {
                 Ok(data)
             }
         } else {
-            let last_match_sym = interp.0.borrow_mut().sym_intern("$~");
-            let pre_match_sym = interp.0.borrow_mut().sym_intern("$`");
-            let post_match_sym = interp.0.borrow_mut().sym_intern("$'");
+            let last_match_sym = interp.0.borrow_mut().sym_intern("$~".as_bytes());
+            let pre_match_sym = interp.0.borrow_mut().sym_intern("$`".as_bytes());
+            let post_match_sym = interp.0.borrow_mut().sym_intern("$'".as_bytes());
             unsafe {
                 sys::mrb_gv_set(mrb, last_match_sym, interp.convert(None::<Value>).inner());
                 sys::mrb_gv_set(mrb, pre_match_sym, interp.convert(None::<Value>).inner());
@@ -422,13 +428,16 @@ impl RegexpType for Onig {
         })?;
         if let Some(captures) = self.regex.captures(pattern) {
             let globals_to_set = cmp::max(interp.0.borrow().active_regexp_globals, captures.len());
-            let sym = interp.0.borrow_mut().sym_intern("$&");
+            let sym = interp.0.borrow_mut().sym_intern("$&".as_bytes());
             let value = interp.convert(captures.at(0));
             unsafe {
                 sys::mrb_gv_set(mrb, sym, value.inner());
             }
             for group in 1..=globals_to_set {
-                let sym = interp.0.borrow_mut().sym_intern(&format!("${}", group));
+                let sym = interp
+                    .0
+                    .borrow_mut()
+                    .sym_intern(format!("${}", group).into_bytes());
                 let value = interp.convert(captures.at(group));
                 unsafe {
                     sys::mrb_gv_set(mrb, sym, value.inner());
@@ -448,15 +457,15 @@ impl RegexpType for Onig {
                     "Failed to initialize Ruby MatchData Value with Rust MatchData",
                 )
             })?;
-            let matchdata_sym = interp.0.borrow_mut().sym_intern("$~");
+            let matchdata_sym = interp.0.borrow_mut().sym_intern("$~".as_bytes());
             unsafe {
                 sys::mrb_gv_set(mrb, matchdata_sym, matchdata.inner());
             }
             if let Some(match_pos) = captures.pos(0) {
                 let pre_match = interp.convert(&pattern[..match_pos.0]);
                 let post_match = interp.convert(&pattern[match_pos.1..]);
-                let pre_match_sym = interp.0.borrow_mut().sym_intern("$`");
-                let post_match_sym = interp.0.borrow_mut().sym_intern("$'");
+                let pre_match_sym = interp.0.borrow_mut().sym_intern("$`".as_bytes());
+                let post_match_sym = interp.0.borrow_mut().sym_intern("$'".as_bytes());
                 unsafe {
                     sys::mrb_gv_set(mrb, pre_match_sym, pre_match.inner());
                     sys::mrb_gv_set(mrb, post_match_sym, post_match.inner());
@@ -469,9 +478,9 @@ impl RegexpType for Onig {
                 Ok(Some(0))
             }
         } else {
-            let last_match_sym = interp.0.borrow_mut().sym_intern("$~");
-            let pre_match_sym = interp.0.borrow_mut().sym_intern("$`");
-            let post_match_sym = interp.0.borrow_mut().sym_intern("$'");
+            let last_match_sym = interp.0.borrow_mut().sym_intern("$~".as_bytes());
+            let pre_match_sym = interp.0.borrow_mut().sym_intern("$`".as_bytes());
+            let post_match_sym = interp.0.borrow_mut().sym_intern("$'".as_bytes());
             let nil = interp.convert(None::<Value>).inner();
             unsafe {
                 sys::mrb_gv_set(mrb, last_match_sym, nil);
@@ -605,7 +614,7 @@ impl RegexpType for Onig {
             )
         })?;
         let mrb = interp.0.borrow().mrb;
-        let last_match_sym = interp.0.borrow_mut().sym_intern("$~");
+        let last_match_sym = interp.0.borrow_mut().sym_intern("$~".as_bytes());
         let mut matchdata = MatchData::new(
             haystack.as_bytes().to_vec(),
             Regexp::from(self.box_clone()),
@@ -619,7 +628,10 @@ impl RegexpType for Onig {
                 // zero old globals
                 let globals = interp.0.borrow().active_regexp_globals;
                 for group in 1..=globals {
-                    let sym = interp.0.borrow_mut().sym_intern(&format!("${}", group));
+                    let sym = interp
+                        .0
+                        .borrow_mut()
+                        .sym_intern(format!("${}", group).into_bytes());
                     unsafe {
                         sys::mrb_gv_set(mrb, sym, sys::mrb_sys_nil_value());
                     }
@@ -633,14 +645,17 @@ impl RegexpType for Onig {
                     return Ok(value);
                 }
                 for captures in iter {
-                    let fullmatch = interp.0.borrow_mut().sym_intern("$&");
+                    let fullmatch = interp.0.borrow_mut().sym_intern("$&".as_bytes());
                     let fullcapture = interp.convert(captures.at(0));
                     unsafe {
                         sys::mrb_gv_set(mrb, fullmatch, fullcapture.inner());
                     }
                     let mut groups = vec![];
                     for group in 1..=len {
-                        let sym = interp.0.borrow_mut().sym_intern(&format!("${}", group));
+                        let sym = interp
+                            .0
+                            .borrow_mut()
+                            .sym_intern(format!("${}", group).into_bytes());
                         let capture = interp.convert(captures.at(group));
                         groups.push(captures.at(group));
                         unsafe {
@@ -699,7 +714,10 @@ impl RegexpType for Onig {
                 // zero old globals
                 let globals = interp.0.borrow().active_regexp_globals;
                 for group in 1..=globals {
-                    let sym = interp.0.borrow_mut().sym_intern(&format!("${}", group));
+                    let sym = interp
+                        .0
+                        .borrow_mut()
+                        .sym_intern(format!("${}", group).into_bytes());
                     unsafe {
                         sys::mrb_gv_set(mrb, sym, sys::mrb_sys_nil_value());
                     }
@@ -731,14 +749,17 @@ impl RegexpType for Onig {
                 }
                 let mut iter = collected.iter();
                 if let Some(fullcapture) = iter.next() {
-                    let fullmatch = interp.0.borrow_mut().sym_intern("$&");
+                    let fullmatch = interp.0.borrow_mut().sym_intern("$&".as_bytes());
                     let fullcapture = interp.convert(fullcapture.as_slice());
                     unsafe {
                         sys::mrb_gv_set(mrb, fullmatch, fullcapture.inner());
                     }
                 }
                 for (group, capture) in iter.enumerate() {
-                    let sym = interp.0.borrow_mut().sym_intern(&format!("${}", group));
+                    let sym = interp
+                        .0
+                        .borrow_mut()
+                        .sym_intern(format!("${}", group).into_bytes());
                     let capture = interp.convert(capture.as_slice());
                     unsafe {
                         sys::mrb_gv_set(mrb, sym, capture.inner());
@@ -766,7 +787,7 @@ impl RegexpType for Onig {
                     sys::mrb_gv_set(mrb, last_match_sym, data.inner());
                 }
                 if let Some(fullcapture) = collected.last().copied() {
-                    let fullmatch = interp.0.borrow_mut().sym_intern("$&");
+                    let fullmatch = interp.0.borrow_mut().sym_intern("$&".as_bytes());
                     let fullcapture = interp.convert(fullcapture);
                     unsafe {
                         sys::mrb_gv_set(mrb, fullmatch, fullcapture.inner());

--- a/artichoke-backend/src/extn/core/regexp/backend/regex_utf8.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/regex_utf8.rs
@@ -223,7 +223,7 @@ impl RegexpType for RegexUtf8 {
         let mrb = interp.0.borrow().mrb;
         if let Some(captures) = self.regex.captures(pattern) {
             let globals_to_set = cmp::max(interp.0.borrow().active_regexp_globals, captures.len());
-            let sym = interp.0.borrow_mut().sym_intern("$&");
+            let sym = interp.0.borrow_mut().sym_intern("$&".as_bytes());
             let value = interp.convert(
                 captures
                     .get(0)
@@ -235,7 +235,10 @@ impl RegexpType for RegexUtf8 {
                 sys::mrb_gv_set(mrb, sym, value.inner());
             }
             for group in 1..=globals_to_set {
-                let sym = interp.0.borrow_mut().sym_intern(&format!("${}", group));
+                let sym = interp
+                    .0
+                    .borrow_mut()
+                    .sym_intern(format!("${}", group).into_bytes());
                 let value = interp.convert(
                     captures
                         .get(0)
@@ -252,8 +255,8 @@ impl RegexpType for RegexUtf8 {
             if let Some(match_pos) = captures.get(0) {
                 let pre_match = &pattern[..match_pos.start()];
                 let post_match = &pattern[match_pos.end()..];
-                let pre_match_sym = interp.0.borrow_mut().sym_intern("$`");
-                let post_match_sym = interp.0.borrow_mut().sym_intern("$'");
+                let pre_match_sym = interp.0.borrow_mut().sym_intern("$`".as_bytes());
+                let post_match_sym = interp.0.borrow_mut().sym_intern("$'".as_bytes());
                 unsafe {
                     sys::mrb_gv_set(mrb, pre_match_sym, interp.convert(pre_match).inner());
                     sys::mrb_gv_set(mrb, post_match_sym, interp.convert(post_match).inner());
@@ -268,14 +271,14 @@ impl RegexpType for RegexUtf8 {
             let matchdata = unsafe { matchdata.try_into_ruby(&interp, None) }.map_err(|_| {
                 Fatal::new(interp, "Could not create Ruby Value from Rust MatchData")
             })?;
-            let matchdata_sym = interp.0.borrow_mut().sym_intern("$~");
+            let matchdata_sym = interp.0.borrow_mut().sym_intern("$~".as_bytes());
             unsafe {
                 sys::mrb_gv_set(mrb, matchdata_sym, matchdata.inner());
             }
             Ok(true)
         } else {
-            let pre_match_sym = interp.0.borrow_mut().sym_intern("$`");
-            let post_match_sym = interp.0.borrow_mut().sym_intern("$'");
+            let pre_match_sym = interp.0.borrow_mut().sym_intern("$`".as_bytes());
+            let post_match_sym = interp.0.borrow_mut().sym_intern("$'".as_bytes());
             unsafe {
                 sys::mrb_gv_set(mrb, pre_match_sym, interp.convert(None::<Value>).inner());
                 sys::mrb_gv_set(mrb, post_match_sym, interp.convert(None::<Value>).inner());
@@ -359,7 +362,7 @@ impl RegexpType for RegexUtf8 {
         let match_target = &pattern[byte_offset..];
         if let Some(captures) = self.regex.captures(match_target) {
             let globals_to_set = cmp::max(interp.0.borrow().active_regexp_globals, captures.len());
-            let sym = interp.0.borrow_mut().sym_intern("$&");
+            let sym = interp.0.borrow_mut().sym_intern("$&".as_bytes());
             let value = interp.convert(
                 captures
                     .get(0)
@@ -371,7 +374,10 @@ impl RegexpType for RegexUtf8 {
                 sys::mrb_gv_set(mrb, sym, value.inner());
             }
             for group in 1..=globals_to_set {
-                let sym = interp.0.borrow_mut().sym_intern(&format!("${}", group));
+                let sym = interp
+                    .0
+                    .borrow_mut()
+                    .sym_intern(format!("${}", group).into_bytes());
                 let value = interp.convert(
                     captures
                         .get(0)
@@ -394,8 +400,8 @@ impl RegexpType for RegexUtf8 {
             if let Some(match_pos) = captures.get(0) {
                 let pre_match = &match_target[..match_pos.start()];
                 let post_match = &match_target[match_pos.end()..];
-                let pre_match_sym = interp.0.borrow_mut().sym_intern("$`");
-                let post_match_sym = interp.0.borrow_mut().sym_intern("$'");
+                let pre_match_sym = interp.0.borrow_mut().sym_intern("$`".as_bytes());
+                let post_match_sym = interp.0.borrow_mut().sym_intern("$'".as_bytes());
                 unsafe {
                     sys::mrb_gv_set(mrb, pre_match_sym, interp.convert(pre_match).inner());
                     sys::mrb_gv_set(mrb, post_match_sym, interp.convert(post_match).inner());
@@ -411,7 +417,7 @@ impl RegexpType for RegexUtf8 {
                     "Failed to initialize Ruby MatchData Value with Rust MatchData",
                 )
             })?;
-            let matchdata_sym = interp.0.borrow_mut().sym_intern("$~");
+            let matchdata_sym = interp.0.borrow_mut().sym_intern("$~".as_bytes());
             unsafe {
                 sys::mrb_gv_set(mrb, matchdata_sym, data.inner());
             }
@@ -427,9 +433,9 @@ impl RegexpType for RegexUtf8 {
                 Ok(data)
             }
         } else {
-            let last_match_sym = interp.0.borrow_mut().sym_intern("$~");
-            let pre_match_sym = interp.0.borrow_mut().sym_intern("$`");
-            let post_match_sym = interp.0.borrow_mut().sym_intern("$'");
+            let last_match_sym = interp.0.borrow_mut().sym_intern("$~".as_bytes());
+            let pre_match_sym = interp.0.borrow_mut().sym_intern("$`".as_bytes());
+            let post_match_sym = interp.0.borrow_mut().sym_intern("$'".as_bytes());
             unsafe {
                 sys::mrb_gv_set(mrb, last_match_sym, interp.convert(None::<Value>).inner());
                 sys::mrb_gv_set(mrb, pre_match_sym, interp.convert(None::<Value>).inner());
@@ -453,7 +459,7 @@ impl RegexpType for RegexUtf8 {
         })?;
         if let Some(captures) = self.regex.captures(pattern) {
             let globals_to_set = cmp::max(interp.0.borrow().active_regexp_globals, captures.len());
-            let sym = interp.0.borrow_mut().sym_intern("$&");
+            let sym = interp.0.borrow_mut().sym_intern("$&".as_bytes());
             let value = interp.convert(
                 captures
                     .get(0)
@@ -465,7 +471,10 @@ impl RegexpType for RegexUtf8 {
                 sys::mrb_gv_set(mrb, sym, value.inner());
             }
             for group in 1..=globals_to_set {
-                let sym = interp.0.borrow_mut().sym_intern(&format!("${}", group));
+                let sym = interp
+                    .0
+                    .borrow_mut()
+                    .sym_intern(format!("${}", group).into_bytes());
                 let value = interp.convert(
                     captures
                         .get(0)
@@ -491,15 +500,15 @@ impl RegexpType for RegexUtf8 {
                     "Failed to initialize Ruby MatchData Value with Rust MatchData",
                 )
             })?;
-            let matchdata_sym = interp.0.borrow_mut().sym_intern("$~");
+            let matchdata_sym = interp.0.borrow_mut().sym_intern("$~".as_bytes());
             unsafe {
                 sys::mrb_gv_set(mrb, matchdata_sym, matchdata.inner());
             }
             if let Some(match_pos) = captures.get(0) {
                 let pre_match = interp.convert(&pattern[..match_pos.start()]);
                 let post_match = interp.convert(&pattern[match_pos.end()..]);
-                let pre_match_sym = interp.0.borrow_mut().sym_intern("$`");
-                let post_match_sym = interp.0.borrow_mut().sym_intern("$'");
+                let pre_match_sym = interp.0.borrow_mut().sym_intern("$`".as_bytes());
+                let post_match_sym = interp.0.borrow_mut().sym_intern("$'".as_bytes());
                 unsafe {
                     sys::mrb_gv_set(mrb, pre_match_sym, pre_match.inner());
                     sys::mrb_gv_set(mrb, post_match_sym, post_match.inner());
@@ -512,9 +521,9 @@ impl RegexpType for RegexUtf8 {
                 Ok(Some(0))
             }
         } else {
-            let last_match_sym = interp.0.borrow_mut().sym_intern("$~");
-            let pre_match_sym = interp.0.borrow_mut().sym_intern("$`");
-            let post_match_sym = interp.0.borrow_mut().sym_intern("$'");
+            let last_match_sym = interp.0.borrow_mut().sym_intern("$~".as_bytes());
+            let pre_match_sym = interp.0.borrow_mut().sym_intern("$`".as_bytes());
+            let post_match_sym = interp.0.borrow_mut().sym_intern("$'".as_bytes());
             let nil = interp.convert(None::<Value>).inner();
             unsafe {
                 sys::mrb_gv_set(mrb, last_match_sym, nil);
@@ -639,7 +648,7 @@ impl RegexpType for RegexUtf8 {
             )
         })?;
         let mrb = interp.0.borrow().mrb;
-        let last_match_sym = interp.0.borrow_mut().sym_intern("$~");
+        let last_match_sym = interp.0.borrow_mut().sym_intern("$~".as_bytes());
         let mut matchdata = MatchData::new(
             haystack.as_bytes().to_vec(),
             Regexp::from(self.box_clone()),
@@ -654,7 +663,10 @@ impl RegexpType for RegexUtf8 {
                 // zero old globals
                 let globals = interp.0.borrow().active_regexp_globals;
                 for group in 1..=globals {
-                    let sym = interp.0.borrow_mut().sym_intern(&format!("${}", group));
+                    let sym = interp
+                        .0
+                        .borrow_mut()
+                        .sym_intern(format!("${}", group).into_bytes());
                     unsafe {
                         sys::mrb_gv_set(mrb, sym, sys::mrb_sys_nil_value());
                     }
@@ -674,13 +686,16 @@ impl RegexpType for RegexUtf8 {
                         .map(regex::Match::as_str)
                         .map(str::as_bytes);
                     let capture = interp.convert(matched);
-                    let fullmatch = interp.0.borrow_mut().sym_intern("$&");
+                    let fullmatch = interp.0.borrow_mut().sym_intern("$&".as_bytes());
                     unsafe {
                         sys::mrb_gv_set(mrb, fullmatch, capture.inner());
                     }
                     let mut groups = vec![];
                     for group in 1..=len {
-                        let sym = interp.0.borrow_mut().sym_intern(&format!("${}", group));
+                        let sym = interp
+                            .0
+                            .borrow_mut()
+                            .sym_intern(format!("${}", group).into_bytes());
                         let matched = captures
                             .get(group)
                             .as_ref()
@@ -744,7 +759,10 @@ impl RegexpType for RegexUtf8 {
                 // zero old globals
                 let globals = interp.0.borrow().active_regexp_globals;
                 for group in 1..=globals {
-                    let sym = interp.0.borrow_mut().sym_intern(&format!("${}", group));
+                    let sym = interp
+                        .0
+                        .borrow_mut()
+                        .sym_intern(format!("${}", group).into_bytes());
                     unsafe {
                         sys::mrb_gv_set(mrb, sym, sys::mrb_sys_nil_value());
                     }
@@ -781,14 +799,17 @@ impl RegexpType for RegexUtf8 {
                 }
                 let mut iter = collected.iter();
                 if let Some(fullcapture) = iter.next() {
-                    let fullmatch = interp.0.borrow_mut().sym_intern("$&");
+                    let fullmatch = interp.0.borrow_mut().sym_intern("$&".as_bytes());
                     let fullcapture = interp.convert(fullcapture.as_slice());
                     unsafe {
                         sys::mrb_gv_set(mrb, fullmatch, fullcapture.inner());
                     }
                 }
                 for (group, capture) in iter.enumerate() {
-                    let sym = interp.0.borrow_mut().sym_intern(&format!("${}", group));
+                    let sym = interp
+                        .0
+                        .borrow_mut()
+                        .sym_intern(format!("${}", group).into_bytes());
                     let capture = interp.convert(capture.as_slice());
                     unsafe {
                         sys::mrb_gv_set(mrb, sym, capture.inner());
@@ -816,7 +837,7 @@ impl RegexpType for RegexUtf8 {
                     sys::mrb_gv_set(mrb, last_match_sym, data.inner());
                 }
                 if let Some(fullcapture) = collected.last().copied() {
-                    let fullmatch = interp.0.borrow_mut().sym_intern("$&");
+                    let fullmatch = interp.0.borrow_mut().sym_intern("$&".as_bytes());
                     let fullcapture = interp.convert(fullcapture);
                     unsafe {
                         sys::mrb_gv_set(mrb, fullmatch, fullcapture.inner());

--- a/artichoke-backend/src/extn/core/regexp/mod.rs
+++ b/artichoke-backend/src/extn/core/regexp/mod.rs
@@ -298,7 +298,7 @@ impl Regexp {
         } else if let Ok(pattern) = other.funcall::<&[u8]>("to_str", &[], None) {
             pattern
         } else {
-            let sym = interp.0.borrow_mut().sym_intern("$~");
+            let sym = interp.0.borrow_mut().sym_intern("$~".as_bytes());
             let mrb = interp.0.borrow().mrb;
             unsafe {
                 sys::mrb_gv_set(mrb, sym, interp.convert(None::<Value>).inner());
@@ -412,7 +412,7 @@ impl Regexp {
             pattern
         } else {
             let mrb = interp.0.borrow().mrb;
-            let sym = interp.0.borrow_mut().sym_intern("$~");
+            let sym = interp.0.borrow_mut().sym_intern("$~".as_bytes());
             let matchdata = interp.convert(None::<Value>);
             unsafe {
                 sys::mrb_gv_set(mrb, sym, matchdata.inner());

--- a/artichoke-backend/src/extn/core/regexp/mod.rs
+++ b/artichoke-backend/src/extn/core/regexp/mod.rs
@@ -5,6 +5,7 @@
 //! the `Args` struct for invoking the function.
 
 use artichoke_core::value::Value as _;
+use std::borrow::Cow;
 use std::collections::hash_map::DefaultHasher;
 use std::collections::HashMap;
 use std::convert::TryFrom;
@@ -41,6 +42,51 @@ pub const FIXEDENCODING: Int = 16;
 pub const NOENCODING: Int = 32;
 
 pub const LITERAL: Int = 128;
+
+/// The string matched by the last successful match.
+pub const LAST_MATCHED_STRING: &[u8] = b"$&";
+/// The string to the left of the last successful match.
+pub const STRING_LEFT_OF_MATCH: &[u8] = b"$`";
+/// The string to the right of the last successful match.
+pub const STRING_RIGHT_OF_MATCH: &[u8] = b"$'";
+/// The highest group matched by the last successful match.
+// TODO: implement this.
+pub const HIGHEST_MATCH_GROUP: &[u8] = b"$+";
+/// The information about the last match in the current scope.
+pub const LAST_MATCH: &[u8] = b"$~";
+
+/// The Nth group of the last successful match. May be > 1.
+#[inline]
+pub fn nth_match_group(group: usize) -> Cow<'static, [u8]> {
+    match group {
+        0 => panic!("$0 is the name of the current script, not a capture group"),
+        1 => b"$1".as_ref().into(),
+        2 => b"$2".as_ref().into(),
+        3 => b"$3".as_ref().into(),
+        4 => b"$4".as_ref().into(),
+        5 => b"$5".as_ref().into(),
+        6 => b"$6".as_ref().into(),
+        7 => b"$7".as_ref().into(),
+        8 => b"$8".as_ref().into(),
+        9 => b"$9".as_ref().into(),
+        10 => b"$10".as_ref().into(),
+        11 => b"$11".as_ref().into(),
+        12 => b"$12".as_ref().into(),
+        13 => b"$13".as_ref().into(),
+        14 => b"$14".as_ref().into(),
+        15 => b"$15".as_ref().into(),
+        16 => b"$16".as_ref().into(),
+        17 => b"$17".as_ref().into(),
+        18 => b"$18".as_ref().into(),
+        19 => b"$19".as_ref().into(),
+        20 => b"$20".as_ref().into(),
+        num => {
+            let mut buf = Vec::from(b"$".as_ref());
+            buf.extend(num.to_string().as_bytes());
+            buf.into()
+        }
+    }
+}
 
 #[derive(Debug, Clone, Hash)]
 pub struct Regexp(Box<dyn RegexpType>);
@@ -298,7 +344,7 @@ impl Regexp {
         } else if let Ok(pattern) = other.funcall::<&[u8]>("to_str", &[], None) {
             pattern
         } else {
-            let sym = interp.0.borrow_mut().sym_intern("$~".as_bytes());
+            let sym = interp.0.borrow_mut().sym_intern(LAST_MATCH);
             let mrb = interp.0.borrow().mrb;
             unsafe {
                 sys::mrb_gv_set(mrb, sym, interp.convert(None::<Value>).inner());
@@ -412,7 +458,7 @@ impl Regexp {
             pattern
         } else {
             let mrb = interp.0.borrow().mrb;
-            let sym = interp.0.borrow_mut().sym_intern("$~".as_bytes());
+            let sym = interp.0.borrow_mut().sym_intern(LAST_MATCH);
             let matchdata = interp.convert(None::<Value>);
             unsafe {
                 sys::mrb_gv_set(mrb, sym, matchdata.inner());

--- a/artichoke-backend/src/extn/core/string/scan.rs
+++ b/artichoke-backend/src/extn/core/string/scan.rs
@@ -3,7 +3,7 @@ use bstr::ByteSlice;
 use crate::convert::{Convert, RustBackedValue};
 use crate::extn::core::exception::{Fatal, RubyException, TypeError};
 use crate::extn::core::matchdata::MatchData;
-use crate::extn::core::regexp::Regexp;
+use crate::extn::core::regexp::{self, Regexp};
 use crate::sys;
 use crate::types::Ruby;
 use crate::value::{Block, Value, ValueLike};
@@ -34,7 +34,7 @@ pub fn method(
         if let Some(ref block) = block {
             let mrb = interp.0.borrow().mrb;
             let regex = Regexp::lazy(pattern_bytes);
-            let last_match_sym = interp.0.borrow_mut().sym_intern("$~".as_bytes());
+            let last_match_sym = interp.0.borrow_mut().sym_intern(regexp::LAST_MATCH);
             let mut matchdata = MatchData::new(string.to_vec(), regex, 0, string.len());
             let patlen = pattern_bytes.len();
             let mut restore_nil = true;
@@ -72,7 +72,7 @@ pub fn method(
             if matches > 0 {
                 let regex = Regexp::lazy(pattern_bytes);
                 let mrb = interp.0.borrow().mrb;
-                let last_match_sym = interp.0.borrow_mut().sym_intern("$~".as_bytes());
+                let last_match_sym = interp.0.borrow_mut().sym_intern(regexp::LAST_MATCH);
                 let mut matchdata = MatchData::new(string.to_vec(), regex, 0, string.len());
                 matchdata.set_region(last_pos, last_pos + pattern_bytes.len());
                 let data = unsafe { matchdata.clone().try_into_ruby(interp, None) }
@@ -82,9 +82,10 @@ pub fn method(
                 }
             } else {
                 let mrb = interp.0.borrow().mrb;
-                let last_match_sym = interp.0.borrow_mut().sym_intern("$~".as_bytes());
+                let last_match_sym = interp.0.borrow_mut().sym_intern(regexp::LAST_MATCH);
+                let nil = interp.convert(None::<Value>).inner();
                 unsafe {
-                    sys::mrb_gv_set(mrb, last_match_sym, sys::mrb_sys_nil_value());
+                    sys::mrb_gv_set(mrb, last_match_sym, nil);
                 }
             }
             Ok(interp.convert(result))
@@ -98,7 +99,7 @@ pub fn method(
             if let Some(ref block) = block {
                 let regex = Regexp::lazy(pattern_bytes);
                 let mrb = interp.0.borrow().mrb;
-                let last_match_sym = interp.0.borrow_mut().sym_intern("$~".as_bytes());
+                let last_match_sym = interp.0.borrow_mut().sym_intern(regexp::LAST_MATCH);
                 let mut matchdata = MatchData::new(string.to_vec(), regex, 0, string.len());
                 let patlen = pattern_bytes.len();
                 let mut restore_nil = true;
@@ -138,7 +139,7 @@ pub fn method(
                 if matches > 0 {
                     let regex = Regexp::lazy(pattern_bytes);
                     let mrb = interp.0.borrow().mrb;
-                    let last_match_sym = interp.0.borrow_mut().sym_intern("$~".as_bytes());
+                    let last_match_sym = interp.0.borrow_mut().sym_intern(regexp::LAST_MATCH);
                     let mut matchdata = MatchData::new(string.to_vec(), regex, 0, string.len());
                     matchdata.set_region(last_pos, last_pos + pattern_bytes.len());
                     let data =
@@ -150,7 +151,7 @@ pub fn method(
                     }
                 } else {
                     let mrb = interp.0.borrow().mrb;
-                    let last_match_sym = interp.0.borrow_mut().sym_intern("$~".as_bytes());
+                    let last_match_sym = interp.0.borrow_mut().sym_intern(regexp::LAST_MATCH);
                     unsafe {
                         sys::mrb_gv_set(mrb, last_match_sym, sys::mrb_sys_nil_value());
                     }

--- a/artichoke-backend/src/extn/core/string/scan.rs
+++ b/artichoke-backend/src/extn/core/string/scan.rs
@@ -34,7 +34,7 @@ pub fn method(
         if let Some(ref block) = block {
             let mrb = interp.0.borrow().mrb;
             let regex = Regexp::lazy(pattern_bytes);
-            let last_match_sym = interp.0.borrow_mut().sym_intern("$~");
+            let last_match_sym = interp.0.borrow_mut().sym_intern("$~".as_bytes());
             let mut matchdata = MatchData::new(string.to_vec(), regex, 0, string.len());
             let patlen = pattern_bytes.len();
             let mut restore_nil = true;
@@ -72,7 +72,7 @@ pub fn method(
             if matches > 0 {
                 let regex = Regexp::lazy(pattern_bytes);
                 let mrb = interp.0.borrow().mrb;
-                let last_match_sym = interp.0.borrow_mut().sym_intern("$~");
+                let last_match_sym = interp.0.borrow_mut().sym_intern("$~".as_bytes());
                 let mut matchdata = MatchData::new(string.to_vec(), regex, 0, string.len());
                 matchdata.set_region(last_pos, last_pos + pattern_bytes.len());
                 let data = unsafe { matchdata.clone().try_into_ruby(interp, None) }
@@ -82,7 +82,7 @@ pub fn method(
                 }
             } else {
                 let mrb = interp.0.borrow().mrb;
-                let last_match_sym = interp.0.borrow_mut().sym_intern("$~");
+                let last_match_sym = interp.0.borrow_mut().sym_intern("$~".as_bytes());
                 unsafe {
                     sys::mrb_gv_set(mrb, last_match_sym, sys::mrb_sys_nil_value());
                 }
@@ -98,7 +98,7 @@ pub fn method(
             if let Some(ref block) = block {
                 let regex = Regexp::lazy(pattern_bytes);
                 let mrb = interp.0.borrow().mrb;
-                let last_match_sym = interp.0.borrow_mut().sym_intern("$~");
+                let last_match_sym = interp.0.borrow_mut().sym_intern("$~".as_bytes());
                 let mut matchdata = MatchData::new(string.to_vec(), regex, 0, string.len());
                 let patlen = pattern_bytes.len();
                 let mut restore_nil = true;
@@ -138,7 +138,7 @@ pub fn method(
                 if matches > 0 {
                     let regex = Regexp::lazy(pattern_bytes);
                     let mrb = interp.0.borrow().mrb;
-                    let last_match_sym = interp.0.borrow_mut().sym_intern("$~");
+                    let last_match_sym = interp.0.borrow_mut().sym_intern("$~".as_bytes());
                     let mut matchdata = MatchData::new(string.to_vec(), regex, 0, string.len());
                     matchdata.set_region(last_pos, last_pos + pattern_bytes.len());
                     let data =
@@ -150,7 +150,7 @@ pub fn method(
                     }
                 } else {
                     let mrb = interp.0.borrow().mrb;
-                    let last_match_sym = interp.0.borrow_mut().sym_intern("$~");
+                    let last_match_sym = interp.0.borrow_mut().sym_intern("$~".as_bytes());
                     unsafe {
                         sys::mrb_gv_set(mrb, last_match_sym, sys::mrb_sys_nil_value());
                     }

--- a/artichoke-backend/src/module.rs
+++ b/artichoke-backend/src/module.rs
@@ -63,7 +63,10 @@ impl ClassLike for Spec {
 
     fn rclass(&self, interp: &Artichoke) -> Option<*mut sys::RClass> {
         let mrb = interp.0.borrow().mrb;
-        let sym = interp.0.borrow_mut().sym_intern(self.name.as_str());
+        let sym = interp
+            .0
+            .borrow_mut()
+            .sym_intern(self.name.as_bytes().to_vec());
         if let Some(ref scope) = self.enclosing_scope {
             if let Some(scope) = scope.rclass(interp) {
                 let defined = unsafe {

--- a/artichoke-backend/src/value.rs
+++ b/artichoke-backend/src/value.rs
@@ -213,7 +213,11 @@ impl ValueLike for Value {
             args.len(),
             if block.is_some() { " and block" } else { "" }
         );
-        let func = self.interp.0.borrow_mut().sym_intern(func.as_ref());
+        let func = self
+            .interp
+            .0
+            .borrow_mut()
+            .sym_intern(func.as_bytes().to_vec());
         let mut protect = Protect::new(self.inner(), func, args.as_ref());
         if let Some(block) = block {
             protect = protect.with_block(block.inner());
@@ -287,7 +291,11 @@ impl ValueLike for Value {
             args.len(),
             if block.is_some() { " and block" } else { "" }
         );
-        let func = self.interp.0.borrow_mut().sym_intern(func.as_ref());
+        let func = self
+            .interp
+            .0
+            .borrow_mut()
+            .sym_intern(func.as_bytes().to_vec());
         let mut protect = Protect::new(self.inner(), func, args.as_ref());
         if let Some(block) = block {
             protect = protect.with_block(block.inner());

--- a/artichoke-frontend/src/ruby.rs
+++ b/artichoke-frontend/src/ruby.rs
@@ -96,7 +96,7 @@ fn execute_inline_eval(commands: Vec<OsString>, fixture: Option<&Path>) -> Resul
                 format!("No such file or directory -- {:?} (LoadError)", fixture)
             }
         })?;
-        let sym = interp.0.borrow_mut().sym_intern("$fixture");
+        let sym = interp.0.borrow_mut().sym_intern("$fixture".as_bytes());
         let mrb = interp.0.borrow().mrb;
         let value = interp.convert(data);
         unsafe {
@@ -129,7 +129,7 @@ fn execute_program_file(programfile: &Path, fixture: Option<&Path>) -> Result<()
                 format!("No such file or directory -- {:?} (LoadError)", fixture)
             }
         })?;
-        let sym = interp.0.borrow_mut().sym_intern("$fixture");
+        let sym = interp.0.borrow_mut().sym_intern("$fixture".as_bytes());
         let mrb = interp.0.borrow().mrb;
         let value = interp.convert(data);
         unsafe {

--- a/artichoke-frontend/src/ruby.rs
+++ b/artichoke-frontend/src/ruby.rs
@@ -96,7 +96,7 @@ fn execute_inline_eval(commands: Vec<OsString>, fixture: Option<&Path>) -> Resul
                 format!("No such file or directory -- {:?} (LoadError)", fixture)
             }
         })?;
-        let sym = interp.0.borrow_mut().sym_intern("$fixture".as_bytes());
+        let sym = interp.0.borrow_mut().sym_intern(b"$fixture".as_ref());
         let mrb = interp.0.borrow().mrb;
         let value = interp.convert(data);
         unsafe {
@@ -129,7 +129,7 @@ fn execute_program_file(programfile: &Path, fixture: Option<&Path>) -> Result<()
                 format!("No such file or directory -- {:?} (LoadError)", fixture)
             }
         })?;
-        let sym = interp.0.borrow_mut().sym_intern("$fixture".as_bytes());
+        let sym = interp.0.borrow_mut().sym_intern(b"$fixture".as_ref());
         let mrb = interp.0.borrow().mrb;
         let value = interp.convert(data);
         unsafe {


### PR DESCRIPTION
The `Symbol` cache in `State` held owned `String`s as the keys.
This was suboptimal because:

1. Symbols can contain arbitrary byte content.
2. Most symbols are known at compile time and have &'static lifetime.

This PR changes the type of the keys in the `Symbol` cache to
`Cow<'static, [u8]>`. This allows the state to avoid allocating a byte
vector unless it needs to to satisy ownership constraints.

Fixes GH-317.