### PR TITLE
Improve CircleCI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,11 @@ jobs:
       - image: debian:buster-slim
     resource_class: large
     steps:
+      - run:
+          name: Setup Imagr
+          command: |
+            apt-get update
+            apt-get install -y curl git ssh
       - checkout
       - restore_cache:
           name: Restore sccache cache
@@ -39,7 +44,6 @@ jobs:
       - run:
           name: Install Rust Toolchain
           command: |
-            apt-get install -y curl
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y -q --profile minimal --default-toolchain "$(cat rust-toolchain)"
       - run:
           name: Install Toolchain

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,7 @@ jobs:
       - run:
           name: Install Ruby
           command: |
+            apt-get install -y autoconf bison build-essential libssl-dev libyaml-dev libreadline6-dev zlib1g-dev libncurses5-dev libffi-dev libgdbm5 libgdbm-dev
             ruby-build "$(cat .ruby-version)" /usr/local
       - run:
           name: Install sccache
@@ -157,6 +158,12 @@ jobs:
       - image: debian:buster-slim
     resource_class: large
     steps:
+    steps:
+      - run:
+          name: Setup Image
+          command: |
+            apt-get update
+            apt-get install -y curl git ssh
       - checkout
       - restore_cache:
           name: Restore sccache cache
@@ -164,7 +171,6 @@ jobs:
       - run:
           name: Install Rust Toolchain
           command: |
-            apt-get install -y curl
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y -q --profile minimal --default-toolchain "$(cat rust-toolchain)"
       - run:
           name: Install Toolchain
@@ -173,6 +179,10 @@ jobs:
             apt-get install -y clang bison
             git clone https://github.com/rbenv/ruby-build.git
             PREFIX=/usr/local ./ruby-build/install.sh
+      - run:
+          name: Install Ruby
+          command: |
+            apt-get install -y autoconf bison build-essential libssl-dev libyaml-dev libreadline6-dev zlib1g-dev libncurses5-dev libffi-dev libgdbm5 libgdbm-dev
             ruby-build "$(cat .ruby-version)" /usr/local
       - run:
           name: Install sccache
@@ -202,6 +212,12 @@ jobs:
     docker:
       - image: debian:buster-slim
     steps:
+    steps:
+      - run:
+          name: Setup Image
+          command: |
+            apt-get update
+            apt-get install -y curl git ssh
       - checkout
       - restore_cache:
           key: v1-node-modules-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum "yarn.lock" }}
@@ -211,7 +227,6 @@ jobs:
       - run:
           name: Install Rust Toolchain
           command: |
-            apt-get install -y curl
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y -q --profile minimal --default-toolchain "$(cat rust-toolchain)" --component rustfmt clippy
       - run:
           name: Install Toolchain
@@ -219,8 +234,6 @@ jobs:
           command: |
             git clone https://github.com/rbenv/ruby-build.git
             PREFIX=/usr/local ./ruby-build/install.sh
-            ruby-build "$(cat .ruby-version)" /usr/local
-            gem install bundler
             curl -sSfL https://deb.nodesource.com/setup_13.x | bash -
             apt-get install -y nodejs
             curl -sSf https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
@@ -233,6 +246,12 @@ jobs:
             chmod +x /usr/local/bin/shellcheck
             curl -o/usr/local/bin/shfmt -sSfL https://github.com/mvdan/sh/releases/download/v2.6.4/shfmt_v2.6.4_linux_amd64
             chmod +x /usr/local/bin/shfmt
+      - run:
+          name: Install Ruby
+          command: |
+            apt-get install -y autoconf bison build-essential libssl-dev libyaml-dev libreadline6-dev zlib1g-dev libncurses5-dev libffi-dev libgdbm5 libgdbm-dev
+            ruby-build "$(cat .ruby-version)" /usr/local
+            gem install bundler
       - run:
           name: Install sccache
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ jobs:
       - run:
           name: Install Ruby
           command: |
-            apt-get install -y autoconf bison build-essential libssl-dev libyaml-dev libreadline6-dev zlib1g-dev libncurses5-dev libffi-dev libgdbm5 libgdbm-dev
+            apt-get install -y autoconf bison build-essential libssl-dev libyaml-dev libreadline6-dev zlib1g-dev libncurses5-dev libffi-dev libgdbm6 libgdbm-dev
             ruby-build "$(cat .ruby-version)" /usr/local
       - run:
           name: Install sccache
@@ -181,7 +181,7 @@ jobs:
       - run:
           name: Install Ruby
           command: |
-            apt-get install -y autoconf bison build-essential libssl-dev libyaml-dev libreadline6-dev zlib1g-dev libncurses5-dev libffi-dev libgdbm5 libgdbm-dev
+            apt-get install -y autoconf bison build-essential libssl-dev libyaml-dev libreadline6-dev zlib1g-dev libncurses5-dev libffi-dev libgdbm6 libgdbm-dev
             ruby-build "$(cat .ruby-version)" /usr/local
       - run:
           name: Install sccache
@@ -247,7 +247,7 @@ jobs:
       - run:
           name: Install Ruby
           command: |
-            apt-get install -y autoconf bison build-essential libssl-dev libyaml-dev libreadline6-dev zlib1g-dev libncurses5-dev libffi-dev libgdbm5 libgdbm-dev
+            apt-get install -y autoconf bison build-essential libssl-dev libyaml-dev libreadline6-dev zlib1g-dev libncurses5-dev libffi-dev libgdbm6 libgdbm-dev
             ruby-build "$(cat .ruby-version)" /usr/local
             gem install bundler
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,7 +113,7 @@ jobs:
             $toolchain = Get-Content rust-toolchain | Select-Object -First 1
             .\rustup-init.exe -y --profile minimal --default-toolchain "$($toolchain)-msvc"
             # This is necessary because otherwise cargo fails when trying to use git?
-            Add-Content %USERPROFILE%\.cargo\config "[net]`ngit-fetch-with-cli = true"
+            Add-Content "$env:USERPROFILE\.cargo\config" "[net]`ngit-fetch-with-cli = true"
             choco install ruby --no-progress --version=2.6.3.1
             choco install visualstudio2019-workload-vctools
             choco install llvm
@@ -234,7 +234,6 @@ jobs:
           name: Install Toolchain
           working_directory: "~"
           command: |
-            apt-get install -y clang-format
             git clone https://github.com/rbenv/ruby-build.git
             PREFIX=/usr/local ./ruby-build/install.sh
             curl -sSfL https://deb.nodesource.com/setup_13.x | bash -
@@ -243,12 +242,15 @@ jobs:
             echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
             apt-get update
             apt-get install --no-install-recommends -y yarn
-            yarn install
             curl -o- -sSfL https://storage.googleapis.com/shellcheck/shellcheck-stable.linux.x86_64.tar.xz | tar xJf -
             mv shellcheck-stable/shellcheck /usr/local/bin
             chmod +x /usr/local/bin/shellcheck
             curl -o/usr/local/bin/shfmt -sSfL https://github.com/mvdan/sh/releases/download/v2.6.4/shfmt_v2.6.4_linux_amd64
             chmod +x /usr/local/bin/shfmt
+      - run:
+          name: Install JS Packages
+          command: |
+            yarn install
       - run:
           name: Install Ruby
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,125 @@ version: 2.1
 orbs:
   win: circleci/windows@2.1.0
 commands:
+  setup-linux-builder:
+    description: Setup Artichoke Linux builder image
+    steps:
+      - run:
+          name: Setup Image
+          command: |
+            apt-get update
+            apt-get install -y curl git ssh
+      - checkout
+      - run:
+          name: Install Rust Toolchain
+          command: |
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y -q --profile minimal --default-toolchain "$(cat rust-toolchain)"
+            echo 'export "PATH"="$HOME/.cargo/bin:$PATH"' >> $BASH_ENV
+      - run:
+          name: Install Toolchain
+          working_directory: "~"
+          command: |
+            apt-get install -y clang bison
+            git clone https://github.com/rbenv/ruby-build.git
+            PREFIX=/usr/local ./ruby-build/install.sh
+      - run:
+          name: Install Ruby
+          command: |
+            apt-get install -y autoconf bison build-essential libssl-dev libyaml-dev libreadline6-dev zlib1g-dev libncurses5-dev libffi-dev libgdbm6 libgdbm-dev
+            ruby-build "$(cat .ruby-version)" /usr/local
+      - run:
+          name: Install sccache
+          command: |
+            apt-get install -y pkg-config libssl-dev
+            cargo install sccache
+            echo 'export "RUSTC_WRAPPER"="sccache"' >> $BASH_ENV
+            echo 'export "SCCACHE_CACHE_SIZE"="1G"' >> $BASH_ENV
+      - run:
+          name: Installed Toolchain Versions
+          command: |
+            rustc --version --verbose
+            cargo --version --verbose
+            ruby --version
+            clang --version
+            bison --version
+  setup-windows-builder:
+    description: Setup Artichoke Windows builder image
+    steps:
+      - checkout
+      - restore_cache:
+          name: Restore sccache cache
+          key: v1-sccache-cache-stable-{{ arch }}-{{ .Environment.CIRCLE_JOB }}
+      - run:
+          name: Install Toolchain
+          command: |
+            # Install rustup
+            $client = new-object System.Net.WebClient
+            $client.DownloadFile('https://win.rustup.rs', "$env:USERPROFILE\rustup-init.exe")
+            $toolchain = Get-Content rust-toolchain | Select-Object -First 1
+            $env:USERPROFILE\rustup-init.exe -y --profile minimal --default-toolchain "$($toolchain)-msvc"
+            # This is necessary because otherwise cargo fails when trying to use git?
+            Add-Content "$env:USERPROFILE\.cargo\config" "[net]`ngit-fetch-with-cli = true"
+            choco install ruby --no-progress --version=2.6.3.1
+            choco install visualstudio2019-workload-vctools --no-progress
+            choco install llvm --no-progress
+            choco install winflexbison3 --ignore-checksums --no-progress
+      - run:
+          name: Install sccache
+          command: |
+            cargo install sccache
+      - run:
+          name: Installed Toolchain Versions
+          command: |
+            rustc --version --verbose
+            cargo --version --verbose
+            ruby --version
+            clang --version
+            win_bison --version
+  setup-linux-linter:
+    description: Setup Artichoke Windows linter image
+    steps:
+      - setup-linux-builder
+      - run:
+          name: Install JS Toolchain
+          working_directory: "~"
+          command: |
+            curl -sSfL https://deb.nodesource.com/setup_13.x | bash -
+            apt-get install -y nodejs
+            curl -sSf https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+            echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+            apt-get update
+            apt-get install --no-install-recommends -y yarn
+      - run:
+          name: Install Shell Toolchain
+          working_directory: "~"
+          command: |
+            curl -o- -sSfL https://storage.googleapis.com/shellcheck/shellcheck-stable.linux.x86_64.tar.xz | tar xJf -
+            mv shellcheck-stable/shellcheck /usr/local/bin
+            chmod +x /usr/local/bin/shellcheck
+            curl -o/usr/local/bin/shfmt -sSfL https://github.com/mvdan/sh/releases/download/v2.6.4/shfmt_v2.6.4_linux_amd64
+            chmod +x /usr/local/bin/shfmt
+      - run:
+          name: Install JS Packages
+          command: |
+            yarn install
+      - run:
+          name: Install Bundler
+          command: |
+            gem install bundler
+      - run:
+          name: Installed Toolchain Versions
+          command: |
+            rustc --version --verbose
+            cargo --version --verbose
+            sccache --version
+            rustfmt --version
+            cargo clippy -- --version
+            ruby --version
+            node --version
+            yarn --version
+            yarn --silent clang-format --version
+            shellcheck --version
+            shfmt -version
   rubocop:
     description: Lint Ruby sources with RuboCop
     parameters:
@@ -27,57 +146,19 @@ commands:
           paths:
             - "~/vendor"
 jobs:
-  artichoke-x86_64-linux:
+  x86_64-linux:
     docker:
       - image: debian:buster-slim
     resource_class: large
     steps:
-      - run:
-          name: Setup Image
-          command: |
-            apt-get update
-            apt-get install -y curl git ssh
-      - checkout
+      - setup-linux-builder
       - restore_cache:
           name: Restore sccache cache
           key: v1-sccache-cache-stable-{{ arch }}-{{ .Environment.CIRCLE_JOB }}
       - run:
-          name: Install Rust Toolchain
-          command: |
-            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y -q --profile minimal --default-toolchain "$(cat rust-toolchain)"
-            echo 'export "PATH"="$HOME/.cargo/bin:$PATH"' >> $BASH_ENV
-      - run:
-          name: Install Toolchain
-          working_directory: "~"
-          command: |
-            apt-get install -y clang bison
-            git clone https://github.com/rbenv/ruby-build.git
-            PREFIX=/usr/local ./ruby-build/install.sh
-      - run:
-          name: Install Ruby
-          command: |
-            apt-get install -y autoconf bison build-essential libssl-dev libyaml-dev libreadline6-dev zlib1g-dev libncurses5-dev libffi-dev libgdbm6 libgdbm-dev
-            ruby-build "$(cat .ruby-version)" /usr/local
-      - run:
-          name: Install sccache
-          command: |
-            apt-get install -y pkg-config libssl-dev
-            cargo install sccache
-            echo 'export "RUSTC_WRAPPER"="sccache"' >> $BASH_ENV
-            echo 'export "SCCACHE_CACHE_SIZE"="1G"' >> $BASH_ENV
-      - run:
-          name: Installed Toolchain Versions
-          command: |
-            rustc --version --verbose
-            cargo --version --verbose
-            ruby --version
-            clang --version
-            bison --version
-      - run:
           name: Build workspace without default features
           command: |
             cargo build -p artichoke-backend --no-default-features
-            touch artichoke-backend/build.rs
           environment:
             RUST_BACKTRACE: 1
       - run:
@@ -96,40 +177,14 @@ jobs:
           key: v1-sccache-cache-stable-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ epoch }}
           paths:
             - "~/.cache/sccache"
-  artichoke-x86_64-windows:
+  x86_64-windows:
     executor:
       name: win/default
     steps:
-      - checkout
+      - setup-windows-builder
       - restore_cache:
           name: Restore sccache cache
           key: v1-sccache-cache-stable-{{ arch }}-{{ .Environment.CIRCLE_JOB }}
-      - run:
-          name: Install Toolchain
-          command: |
-            # Install rustup
-            $client = new-object System.Net.WebClient
-            $client.DownloadFile('https://win.rustup.rs', "$pwd\rustup-init.exe")
-            $toolchain = Get-Content rust-toolchain | Select-Object -First 1
-            .\rustup-init.exe -y --profile minimal --default-toolchain "$($toolchain)-msvc"
-            # This is necessary because otherwise cargo fails when trying to use git?
-            Add-Content "$env:USERPROFILE\.cargo\config" "[net]`ngit-fetch-with-cli = true"
-            choco install ruby --no-progress --version=2.6.3.1
-            choco install visualstudio2019-workload-vctools
-            choco install llvm
-            choco install winflexbison3 --ignore-checksums
-      - run:
-          name: Install sccache
-          command: |
-            cargo install sccache
-      - run:
-          name: Installed Toolchain Versions
-          command: |
-            rustc --version --verbose
-            cargo --version --verbose
-            ruby --version
-            clang --version
-            win_bison --version
       - run:
           name: Build Workspace
           command: |
@@ -154,52 +209,15 @@ jobs:
           key: v1-sccache-cache-stable-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ epoch }}
           paths:
             - "%LOCALAPPDATA%\\Mozilla\\sccache"
-  artichoke-ruby-spec:
+  ruby-spec:
     docker:
       - image: debian:buster-slim
     resource_class: large
     steps:
-      - run:
-          name: Setup Image
-          command: |
-            apt-get update
-            apt-get install -y curl git ssh
-      - checkout
+      - setup-linux-builder
       - restore_cache:
           name: Restore sccache cache
           key: v1-sccache-cache-stable-{{ arch }}-{{ .Environment.CIRCLE_JOB }}
-      - run:
-          name: Install Rust Toolchain
-          command: |
-            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y -q --profile minimal --default-toolchain "$(cat rust-toolchain)"
-            echo 'export "PATH"="$HOME/.cargo/bin:$PATH"' >> $BASH_ENV
-      - run:
-          name: Install Toolchain
-          working_directory: "~"
-          command: |
-            apt-get install -y clang bison
-            git clone https://github.com/rbenv/ruby-build.git
-            PREFIX=/usr/local ./ruby-build/install.sh
-      - run:
-          name: Install Ruby
-          command: |
-            apt-get install -y autoconf bison build-essential libssl-dev libyaml-dev libreadline6-dev zlib1g-dev libncurses5-dev libffi-dev libgdbm6 libgdbm-dev
-            ruby-build "$(cat .ruby-version)" /usr/local
-      - run:
-          name: Install sccache
-          command: |
-            apt-get install -y pkg-config libssl-dev
-            cargo install sccache
-            echo 'export "RUSTC_WRAPPER"="sccache"' >> $BASH_ENV
-            echo 'export "SCCACHE_CACHE_SIZE"="1G"' >> $BASH_ENV
-      - run:
-          name: Installed Toolchain Versions
-          command: |
-            rustc --version --verbose
-            cargo --version --verbose
-            ruby --version
-            clang --version
-            bison --version
       - run:
           name: ruby/spec Compliance Regression Test
           command: |
@@ -213,71 +231,14 @@ jobs:
   linter:
     docker:
       - image: debian:buster-slim
+    resource_class: large
     steps:
-      - run:
-          name: Setup Image
-          command: |
-            apt-get update
-            apt-get install -y curl git ssh
-      - checkout
+      - setup-linux-linter
       - restore_cache:
           key: v1-node-modules-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum "yarn.lock" }}
       - restore_cache:
           name: Restore sccache cache
           key: v1-sccache-cache-stable-{{ arch }}-{{ .Environment.CIRCLE_JOB }}
-      - run:
-          name: Install Rust Toolchain
-          command: |
-            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y -q --profile minimal --default-toolchain "$(cat rust-toolchain)" --component rustfmt clippy
-            echo 'export "PATH"="$HOME/.cargo/bin:$PATH"' >> $BASH_ENV
-      - run:
-          name: Install Toolchain
-          working_directory: "~"
-          command: |
-            git clone https://github.com/rbenv/ruby-build.git
-            PREFIX=/usr/local ./ruby-build/install.sh
-            curl -sSfL https://deb.nodesource.com/setup_13.x | bash -
-            apt-get install -y nodejs
-            curl -sSf https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
-            echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
-            apt-get update
-            apt-get install --no-install-recommends -y yarn
-            curl -o- -sSfL https://storage.googleapis.com/shellcheck/shellcheck-stable.linux.x86_64.tar.xz | tar xJf -
-            mv shellcheck-stable/shellcheck /usr/local/bin
-            chmod +x /usr/local/bin/shellcheck
-            curl -o/usr/local/bin/shfmt -sSfL https://github.com/mvdan/sh/releases/download/v2.6.4/shfmt_v2.6.4_linux_amd64
-            chmod +x /usr/local/bin/shfmt
-      - run:
-          name: Install JS Packages
-          command: |
-            yarn install
-      - run:
-          name: Install Ruby
-          command: |
-            apt-get install -y autoconf bison build-essential libssl-dev libyaml-dev libreadline6-dev zlib1g-dev libncurses5-dev libffi-dev libgdbm6 libgdbm-dev
-            ruby-build "$(cat .ruby-version)" /usr/local
-            gem install bundler
-      - run:
-          name: Install sccache
-          command: |
-            apt-get install -y pkg-config libssl-dev
-            cargo install sccache
-            echo 'export "RUSTC_WRAPPER"="sccache"' >> $BASH_ENV
-            echo 'export "SCCACHE_CACHE_SIZE"="1G"' >> $BASH_ENV
-      - run:
-          name: Installed Toolchain Versions
-          command: |
-            rustc --version --verbose
-            cargo --version --verbose
-            sccache --version
-            rustfmt --version
-            cargo clippy -- --version
-            ruby --version
-            node --version
-            yarn --version
-            yarn --silent clang-format --version
-            shellcheck --version
-            shfmt -version
       - run:
           name: Format Rust Sources
           command: |
@@ -290,6 +251,29 @@ jobs:
           name: Check Rust Docs
           command: |
             cargo doc --no-deps --all
+      - rubocop:
+          target: .
+      - run:
+          name: Format C Sources
+          command: |
+            ./scripts/format-c.sh --check
+      - run:
+          name: Format Shell Sources
+          command: |
+            shfmt -f . | grep -v target/ | grep -v node_modules/ | grep -v vendor/ | xargs shfmt -i 2 -ci -s -d
+      - run:
+          name: Lint Shell Sources
+          command: |
+            shfmt -f . | grep -v target/ | grep -v node_modules/ | grep -v vendor/ | xargs shellcheck
+      - run:
+          name: yarn check
+          command: |
+            yarn check --integrity
+            yarn check --verify-tree
+      - run:
+          name: Lint JavaScript with eslint
+          command: |
+            yarn run eslint --ext .html,.js .
       - run:
           name: Format Text Sources
           command: |
@@ -300,29 +284,6 @@ jobs:
             ./scripts/format-text.sh --check "yaml"
             ./scripts/format-text.sh --check "yml"
             ./scripts/format-text.sh --check "md"
-      - run:
-          name: Format Shell Sources
-          command: |
-            shfmt -f . | grep -v target/ | grep -v node_modules/ | grep -v vendor/ | xargs shfmt -i 2 -ci -s -d
-      - run:
-          name: Lint Shell Sources
-          command: |
-            shfmt -f . | grep -v target/ | grep -v node_modules/ | grep -v vendor/ | xargs shellcheck
-      - run:
-          name: Format C Sources
-          command: |
-            ./scripts/format-c.sh --check
-      - run:
-          name: yarn check
-          command: |
-            yarn check --integrity
-            yarn check --verify-tree
-      - run:
-          name: Lint JavaScript with eslint
-          command: |
-            yarn run eslint --ext .html,.js .
-      - rubocop:
-          target: .
       - save_cache:
           name: Save sccache cache
           key: v1-sccache-cache-stable-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ epoch }}
@@ -337,7 +298,7 @@ jobs:
           root: target
           paths:
             - "doc"
-  gh-pages-deploy:
+  deploy:
     docker:
       - image: node:lts
     steps:
@@ -369,12 +330,14 @@ workflows:
   version: 2
   build:
     jobs:
-      - artichoke-x86_64-linux
-      - artichoke-x86_64-windows
-      - artichoke-ruby-spec
+      - x86_64-linux
+      - x86_64-windows
+      - ruby-spec
       - linter
-      - gh-pages-deploy:
+      - deploy:
           requires:
+            - x86_64-linux
+            - x86_64-windows
             - linter
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,7 @@ jobs:
       - run:
           name: Install Rust Toolchain
           command: |
+            apt-get install -y curl
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y -q --profile minimal --default-toolchain "$(cat rust-toolchain)"
       - run:
           name: Install Toolchain
@@ -156,6 +157,7 @@ jobs:
       - run:
           name: Install Rust Toolchain
           command: |
+            apt-get install -y curl
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y -q --profile minimal --default-toolchain "$(cat rust-toolchain)"
       - run:
           name: Install Toolchain
@@ -202,6 +204,7 @@ jobs:
       - run:
           name: Install Rust Toolchain
           command: |
+            apt-get install -y curl
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y -q --profile minimal --default-toolchain "$(cat rust-toolchain)" --component rustfmt clippy
       - run:
           name: Install Toolchain

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ commands:
             $client = new-object System.Net.WebClient
             $client.DownloadFile('https://github.com/mozilla/sccache/releases/download/0.2.12/sccache-0.2.12-x86_64-pc-windows-msvc.tar.gz', "$pwd\sccache.tar.gz")
             tar -xvzf .\sccache.tar.gz
-            Move-Item -Path .\sccache-0.2.12-x86_64-pc-windows-msvc\sccache.exe .\.cargo\bin\sccache.exe
+            Move-Item -Path .\sccache-0.2.12-x86_64-pc-windows-msvc\sccache.exe -Destination .\.cargo\bin\sccache.exe
       - run:
           name: Installed Toolchain Versions
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,7 @@ jobs:
       - run:
           name: Install sccache
           command: |
+            apt-get install -y pkg-config libssl-dev
             cargo install sccache
             echo 'export "RUSTC_WRAPPER"="sccache"' >> $BASH_ENV
             echo 'export "SCCACHE_CACHE_SIZE"="1G"' >> $BASH_ENV
@@ -188,6 +189,7 @@ jobs:
       - run:
           name: Install sccache
           command: |
+            apt-get install -y pkg-config libssl-dev
             cargo install sccache
             echo 'export "RUSTC_WRAPPER"="sccache"' >> $BASH_ENV
             echo 'export "SCCACHE_CACHE_SIZE"="1G"' >> $BASH_ENV
@@ -256,6 +258,7 @@ jobs:
       - run:
           name: Install sccache
           command: |
+            apt-get install -y pkg-config libssl-dev
             cargo install sccache
             echo 'export "RUSTC_WRAPPER"="sccache"' >> $BASH_ENV
             echo 'export "SCCACHE_CACHE_SIZE"="1G"' >> $BASH_ENV

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -196,7 +196,7 @@ jobs:
       - setup-windows-builder
       - restore_cache:
           name: Restore sccache cache
-          key: v1-sccache-cache-stable-{{ arch }}-{{ .Environment.CIRCLE_JOB }}
+          key: v2-sccache-cache-stable-{{ arch }}-{{ .Environment.CIRCLE_JOB }}
       - run:
           name: Build Workspace
           command: |
@@ -218,9 +218,9 @@ jobs:
             LIBCLANG_PATH: C:\Program Files\LLVM\bin
       - save_cache:
           name: Save sccache cache
-          key: v1-sccache-cache-stable-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ epoch }}
+          key: v2-sccache-cache-stable-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ epoch }}
           paths:
-            - "%LOCALAPPDATA%\\Mozilla\\sccache"
+            - "C:\\Users\\circleci\\AppData\\Local\\Mozilla\\sccache"
   ruby-spec:
     docker:
       - image: debian:buster-slim

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,7 @@ jobs:
           name: Install Rust Toolchain
           command: |
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y -q --profile minimal --default-toolchain "$(cat rust-toolchain)"
+            echo export "PATH"="$HOME/.cargo/bin:$PATH"' >> $BASH_ENV
       - run:
           name: Install Toolchain
           working_directory: "~"
@@ -171,6 +172,7 @@ jobs:
           name: Install Rust Toolchain
           command: |
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y -q --profile minimal --default-toolchain "$(cat rust-toolchain)"
+            echo export "PATH"="$HOME/.cargo/bin:$PATH"' >> $BASH_ENV
       - run:
           name: Install Toolchain
           working_directory: "~"
@@ -226,6 +228,7 @@ jobs:
           name: Install Rust Toolchain
           command: |
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y -q --profile minimal --default-toolchain "$(cat rust-toolchain)" --component rustfmt clippy
+            echo export "PATH"="$HOME/.cargo/bin:$PATH"' >> $BASH_ENV
       - run:
           name: Install Toolchain
           working_directory: "~"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,9 +30,11 @@ commands:
             ruby-build "$(cat .ruby-version)" /usr/local
       - run:
           name: Install sccache
+          working_directory: "~"
           command: |
             apt-get install -y pkg-config libssl-dev
-            cargo install sccache
+            curl -o- -sSLf https://github.com/mozilla/sccache/releases/download/0.2.12/sccache-0.2.12-x86_64-unknown-linux-musl.tar.gz | tar xzf -
+            mv sccache-0.2.12-x86_64-unknown-linux-musl/sccache .cargo/bin/sccache
             echo 'export "RUSTC_WRAPPER"="sccache"' >> $BASH_ENV
             echo 'export "SCCACHE_CACHE_SIZE"="1G"' >> $BASH_ENV
       - run:
@@ -68,7 +70,10 @@ commands:
       - run:
           name: Install sccache
           command: |
-            cargo install sccache
+            $client = new-object System.Net.WebClient
+            $client.DownloadFile('https://github.com/mozilla/sccache/releases/download/0.2.12/sccache-0.2.12-x86_64-pc-windows-msvc.tar.gz', "$pwd\sccache.tar.gz")
+            tar -xvzf .\sccache.tar.gz
+            Move-Item -Path .\sccache-0.2.12-x86_64-pc-windows-msvc\sccache.exe .\.cargo\bin\sccache.exe
       - run:
           name: Installed Toolchain Versions
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
     resource_class: large
     steps:
       - run:
-          name: Setup Imagr
+          name: Setup Image
           command: |
             apt-get update
             apt-get install -y curl git ssh
@@ -52,6 +52,9 @@ jobs:
             apt-get install -y clang bison
             git clone https://github.com/rbenv/ruby-build.git
             PREFIX=/usr/local ./ruby-build/install.sh
+      - run:
+          name: Install Ruby
+          command: |
             ruby-build "$(cat .ruby-version)" /usr/local
       - run:
           name: Install sccache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,8 +113,7 @@ jobs:
             $toolchain = Get-Content rust-toolchain | Select-Object -First 1
             .\rustup-init.exe -y --profile minimal --default-toolchain "$($toolchain)-msvc"
             # This is necessary because otherwise cargo fails when trying to use git?
-            mkdir .cargo
-            Add-Content .cargo\config "[net]`ngit-fetch-with-cli = true"
+            Add-Content %USERPROFILE%\.cargo\config "[net]`ngit-fetch-with-cli = true"
             choco install ruby --no-progress --version=2.6.3.1
             choco install visualstudio2019-workload-vctools
             choco install llvm
@@ -235,6 +234,7 @@ jobs:
           name: Install Toolchain
           working_directory: "~"
           command: |
+            apt-get install -y clang-format
             git clone https://github.com/rbenv/ruby-build.git
             PREFIX=/usr/local ./ruby-build/install.sh
             curl -sSfL https://deb.nodesource.com/setup_13.x | bash -

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,6 +70,7 @@ commands:
       - run:
           name: Install sccache
           command: |
+            Set-Location "$env:USERPROFILE"
             $client = new-object System.Net.WebClient
             $client.DownloadFile('https://github.com/mozilla/sccache/releases/download/0.2.12/sccache-0.2.12-x86_64-pc-windows-msvc.tar.gz', "$pwd\sccache.tar.gz")
             tar -xvzf .\sccache.tar.gz

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,7 +144,7 @@ jobs:
           key: v1-sccache-cache-stable-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ epoch }}
           paths:
             - "%LOCALAPPDATA%\\Mozilla\\sccache"
-  artichoke-ruby/spec:
+  artichoke-ruby-spec:
     docker:
       - image: debian:buster-slim
     resource_class: large
@@ -336,7 +336,7 @@ workflows:
     jobs:
       - artichoke-x86_64-linux
       - artichoke-x86_64-windows
-      - artichoke-ruby/spec
+      - artichoke-ruby-spec
       - linter
       - gh-pages-deploy:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -244,7 +244,7 @@ jobs:
             apt-get update
             apt-get install --no-install-recommends -y yarn
             yarn install
-            curl -o- -sSfL https://storage.googleapis.com/shellcheck/shellcheck-stable.linux.x86_64.tar.xz | tar x shellcheck-stable/shellcheck
+            curl -o- -sSfL https://storage.googleapis.com/shellcheck/shellcheck-stable.linux.x86_64.tar.xz | tar xJf -
             mv shellcheck-stable/shellcheck /usr/local/bin
             chmod +x /usr/local/bin/shellcheck
             curl -o/usr/local/bin/shfmt -sSfL https://github.com/mvdan/sh/releases/download/v2.6.4/shfmt_v2.6.4_linux_amd64

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,7 +158,6 @@ jobs:
       - image: debian:buster-slim
     resource_class: large
     steps:
-    steps:
       - run:
           name: Setup Image
           command: |
@@ -211,7 +210,6 @@ jobs:
   linter:
     docker:
       - image: debian:buster-slim
-    steps:
     steps:
       - run:
           name: Setup Image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
           name: Install Rust Toolchain
           command: |
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y -q --profile minimal --default-toolchain "$(cat rust-toolchain)"
-            echo export "PATH"="$HOME/.cargo/bin:$PATH"' >> $BASH_ENV
+            echo 'export "PATH"="$HOME/.cargo/bin:$PATH"' >> $BASH_ENV
       - run:
           name: Install Toolchain
           working_directory: "~"
@@ -172,7 +172,7 @@ jobs:
           name: Install Rust Toolchain
           command: |
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y -q --profile minimal --default-toolchain "$(cat rust-toolchain)"
-            echo export "PATH"="$HOME/.cargo/bin:$PATH"' >> $BASH_ENV
+            echo 'export "PATH"="$HOME/.cargo/bin:$PATH"' >> $BASH_ENV
       - run:
           name: Install Toolchain
           working_directory: "~"
@@ -228,7 +228,7 @@ jobs:
           name: Install Rust Toolchain
           command: |
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y -q --profile minimal --default-toolchain "$(cat rust-toolchain)" --component rustfmt clippy
-            echo export "PATH"="$HOME/.cargo/bin:$PATH"' >> $BASH_ENV
+            echo 'export "PATH"="$HOME/.cargo/bin:$PATH"' >> $BASH_ENV
       - run:
           name: Install Toolchain
           working_directory: "~"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,5 @@
 version: 2.1
 orbs:
-  shellcheck: circleci/shellcheck@1
   win: circleci/windows@2.1.0
 commands:
   rubocop:
@@ -11,111 +10,91 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - ruby-bundler-v2-extn-{{ checksum "<< parameters.target >>/Gemfile.lock" }}
+            - v1-bundler-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum "<< parameters.target >>/Gemfile.lock" }}
       - run:
           name: Bundle Install
-          working_directory: << parameters.target >>
-          command: bundle install --path "$HOME/vendor/$LOCKFILE_CHECKSUM"
-          environment:
-            LOCKFILE_CHECKSUM: "{{ checksum '<< parameters.target >>/Gemfile.lock' }}"
+          working_directory: "<< parameters.target >>"
+          command: |
+            bundle install --path ~/vendor
       - run:
           name: Lint Ruby With RuboCop
-          working_directory: << parameters.target >>
+          working_directory: "<< parameters.target >>"
           command: |
             bundle exec rubocop --version
             bundle exec rubocop
       - save_cache:
-          key: ruby-bundler-v2-extn-{{ checksum "<< parameters.target >>/Gemfile.lock" }}
+          key: v1-bundler-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum "<< parameters.target >>/Gemfile.lock" }}
           paths:
-            - ~/vendor/{{ checksum "<< parameters.target >>/Gemfile.lock" }}
+            - "~/vendor"
 jobs:
-  rust:
+  artichoke-x86_64-linux:
     docker:
-      - image: circleci/rust:1.39.0-buster
+      - image: debian:buster-slim
     resource_class: large
     steps:
       - checkout
       - restore_cache:
-          key: rust-cargo-v4-{{ checksum "Cargo.lock" }}
+          name: Restore sccache cache
+          key: v1-sccache-cache-stable-{{ arch }}-{{ .Environment.CIRCLE_JOB }}
       - run:
           name: Install Rust Toolchain
           command: |
-            rustup toolchain install "$(cat rust-toolchain)"
-            rustup component add rustfmt
-            rustup component add clippy
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y -q --profile minimal --default-toolchain "$(cat rust-toolchain)"
+      - run:
+          name: Install Toolchain
+          working_directory: "~"
+          command: |
+            apt-get install -y clang bison
+            git clone https://github.com/rbenv/ruby-build.git
+            PREFIX=/usr/local ./ruby-build/install.sh
+            ruby-build "$(cat .ruby-version)" /usr/local
+      - run:
+          name: Install sccache
+          command: |
+            cargo install sccache
+            echo 'export "RUSTC_WRAPPER"="sccache"' >> $BASH_ENV
+            echo 'export "SCCACHE_CACHE_SIZE"="1G"' >> $BASH_ENV
+      - run:
+          name: Installed Toolchain Versions
+          command: |
             rustc --version --verbose
             cargo --version --verbose
-            rustfmt --version
-            cargo clippy -- --version
-      - run:
-          # Debian Buster includes ruby 2.5
-          # FIXME: we should really be installing 2.6.3 since that is our stdlib dep.
-          name: Install MRI Ruby
-          command: |
-            sudo apt-get install -y ruby-full
             ruby --version
-      - run:
-          # https://github.com/mruby/mruby/blob/master/doc/guides/compile.md#prerequisites
-          name: Install mruby Build Dependencies
-          command: |
-            sudo apt-get install -y bison
-            bison --version
-      - run:
-          # needed for cc crate in build.rs
-          name: Install clang
-          command: |
-            sudo apt-get install -y clang
             clang --version
+            bison --version
       - run:
           name: Build workspace without default features
           command: |
             cargo build -p artichoke-backend --no-default-features
             touch artichoke-backend/build.rs
+          environment:
+            RUST_BACKTRACE: 1
       - run:
           name: Build Workspace
           command: |
             cargo build
+          environment:
+            RUST_BACKTRACE: 1
       - run:
           name: Test Workspace
           command: cargo test --all-features
           environment:
             RUST_BACKTRACE: 1
-      - run:
-          name: Format Rust Sources
-          command: |
-            rustfmt --version
-            cargo fmt -- --check --color=auto
-      - run:
-          name: Lint Rust With Clippy
-          command: |
-            cargo clippy -- --version
-            cargo clippy --all-targets --all-features
-      - run:
-          name: Check Docs
-          command: |
-            cargo doc --no-deps --all
-      - run:
-          name: ruby/spec Compliance Regression Test
-          command: |
-            ./scripts/spec-compliance.sh --artichoke
       - save_cache:
-          key: rust-cargo-v4-{{ checksum "Cargo.lock" }}
+          name: Save sccache cache
+          key: v1-sccache-cache-stable-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ epoch }}
           paths:
-            - "~/.cargo"
-            - "./target"
-      - persist_to_workspace:
-          root: target
-          paths:
-            - doc
+            - "~/.cache/sccache"
   artichoke-x86_64-windows:
     executor:
       name: win/default
     steps:
       - checkout
       - restore_cache:
-          key: rust-win-cargo-v1-{{ checksum "Cargo.lock" }}
+          name: Restore sccache cache
+          key: v1-sccache-cache-stable-{{ arch }}-{{ .Environment.CIRCLE_JOB }}
       - run:
-          name: Install Rust Toolchain
+          name: Install Toolchain
           command: |
             # Install rustup
             $client = new-object System.Net.WebClient
@@ -125,20 +104,14 @@ jobs:
             # This is necessary because otherwise cargo fails when trying to use git?
             mkdir .cargo
             Add-Content .cargo\config "[net]`ngit-fetch-with-cli = true"
-      - run:
-          name: Install MRI Ruby
-          command: |
             choco install ruby --no-progress --version=2.6.3.1
-      - run:
-          # needed for cc crate in build.rs
-          name: Install clang
-          command: |
             choco install visualstudio2019-workload-vctools
             choco install llvm
-      - run:
-          name: Install bison
-          command: |
             choco install winflexbison3 --ignore-checksums
+      - run:
+          name: Install sccache
+          command: |
+            cargo install sccache
       - run:
           name: Installed Toolchain Versions
           command: |
@@ -153,6 +126,8 @@ jobs:
             cargo build
           environment:
             RUST_BACKTRACE: 1
+            RUSTC_WRAPPER: sccache
+            SCCACHE_CACHE_SIZE: 1G
             LIBCLANG_PATH: C:\Program Files\LLVM\bin
       - run:
           name: Test Workspace
@@ -161,84 +136,125 @@ jobs:
             % 'suppressing test failures. See GH-359.'
           environment:
             RUST_BACKTRACE: 1
+            RUSTC_WRAPPER: sccache
+            SCCACHE_CACHE_SIZE: 1G
             LIBCLANG_PATH: C:\Program Files\LLVM\bin
       - save_cache:
-          key: rust-win-cargo-v1-{{ checksum "Cargo.lock" }}
+          name: Save sccache cache
+          key: v1-sccache-cache-stable-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ epoch }}
           paths:
-            - C:\Users\cicleci\.cargo
-            - target
-  c:
+            - %LOCALAPPDATA%\Mozilla\sccache
+  artichoke-ruby/spec:
     docker:
-      - image: circleci/node:lts
+      - image: debian:buster-slim
+    resource_class: large
     steps:
       - checkout
       - restore_cache:
-          key: c-yarn-v2-{{ checksum "yarn.lock" }}
+          name: Restore sccache cache
+          key: v1-sccache-cache-stable-{{ arch }}-{{ .Environment.CIRCLE_JOB }}
       - run:
-          name: Yarn Install
-          command: yarn install
+          name: Install Rust Toolchain
+          command: |
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y -q --profile minimal --default-toolchain "$(cat rust-toolchain)"
+      - run:
+          name: Install Toolchain
+          working_directory: "~"
+          command: |
+            apt-get install -y clang bison
+            git clone https://github.com/rbenv/ruby-build.git
+            PREFIX=/usr/local ./ruby-build/install.sh
+            ruby-build "$(cat .ruby-version)" /usr/local
+      - run:
+          name: Install sccache
+          command: |
+            cargo install sccache
+            echo 'export "RUSTC_WRAPPER"="sccache"' >> $BASH_ENV
+            echo 'export "SCCACHE_CACHE_SIZE"="1G"' >> $BASH_ENV
+      - run:
+          name: Installed Toolchain Versions
+          command: |
+            rustc --version --verbose
+            cargo --version --verbose
+            ruby --version
+            clang --version
+            bison --version
+      - run:
+          name: ruby/spec Compliance Regression Test
+          command: |
+            # Suppress failures from spec suite
+            ./scripts/spec-compliance.sh --artichoke || :
       - save_cache:
-          key: c-yarn-v2-{{ checksum "yarn.lock" }}
+          name: Save sccache cache
+          key: v1-sccache-cache-stable-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ epoch }}
           paths:
-            - ~/.cache/yarn
-            - node_modules
-      - run:
-          name: Format C Sources
-          command: ./scripts/format-c.sh --check
-  ruby:
+            - "~/.cache/sccache"
+  linter:
     docker:
-      - image: circleci/ruby:2.6.3
-    steps:
-      - checkout
-      - run:
-          name: Install bundler 2
-          command: sudo gem install bundler
-      - rubocop:
-          target: .
-  js:
-    docker:
-      - image: circleci/node:lts
+      - image: debian:buster-slim
     steps:
       - checkout
       - restore_cache:
-          key: js-yarn-v2-{{ checksum "yarn.lock" }}
-      - run: yarn install
-      - save_cache:
-          key: js-yarn-v2-{{ checksum "yarn.lock" }}
-          paths:
-            - ~/.cache/yarn
-            - node_modules
+          key: v1-node-modules-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum "yarn.lock" }}
+      - restore_cache:
+          name: Restore sccache cache
+          key: v1-sccache-cache-stable-{{ arch }}-{{ .Environment.CIRCLE_JOB }}
       - run:
-          name: yarn check
+          name: Install Rust Toolchain
           command: |
-            yarn check --integrity
-            yarn check --verify-tree
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y -q --profile minimal --default-toolchain "$(cat rust-toolchain)" --component rustfmt clippy
       - run:
-          name: Lint JavaScript with eslint
-          command: yarn run eslint --ext .html,.js .
-  shell-format:
-    docker:
-      - image: peterdavehello/shfmt:latest
-    steps:
-      - checkout
-      - run:
-          name: Format Shell Sources
+          name: Install Toolchain
+          working_directory: "~"
           command: |
+            git clone https://github.com/rbenv/ruby-build.git
+            PREFIX=/usr/local ./ruby-build/install.sh
+            ruby-build "$(cat .ruby-version)" /usr/local
+            gem install bundler
+            curl -sSfL https://deb.nodesource.com/setup_13.x | bash -
+            apt-get install -y nodejs
+            curl -sSf https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+            echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+            apt-get update
+            apt-get install --no-install-recommends -y yarn
+            yarn install
+            curl -o- -sSfL https://storage.googleapis.com/shellcheck/shellcheck-stable.linux.x86_64.tar.xz | tar x shellcheck-stable/shellcheck
+            mv shellcheck-stable/shellcheck /usr/local/bin
+            chmod +x /usr/local/bin/shellcheck
+            curl -o/usr/local/bin/shfmt -sSfL https://github.com/mvdan/sh/releases/download/v2.6.4/shfmt_v2.6.4_linux_amd64
+            chmod +x /usr/local/bin/shfmt
+      - run:
+          name: Install sccache
+          command: |
+            cargo install sccache
+            echo 'export "RUSTC_WRAPPER"="sccache"' >> $BASH_ENV
+            echo 'export "SCCACHE_CACHE_SIZE"="1G"' >> $BASH_ENV
+      - run:
+          name: Installed Toolchain Versions
+          command: |
+            rustc --version --verbose
+            cargo --version --verbose
+            sccache --version
+            rustfmt --version
+            cargo clippy -- --version
+            ruby --version
+            node --version
+            yarn --version
+            yarn --silent clang-format --version
+            shellcheck --version
             shfmt -version
-            shfmt -f . | grep -v target/ | grep -v node_modules/ | grep -v vendor/ | xargs shfmt -i 2 -ci -s -w
-  text:
-    docker:
-      - image: circleci/node:lts
-    steps:
-      - checkout
-      - restore_cache:
-          key: text-yarn-v2-{{ checksum "yarn.lock" }}
-      - run: yarn install
-      - save_cache:
-          key: text-yarn-v2-{{ checksum "yarn.lock" }}
-          paths:
-            - ~/.cache/yarn
-            - node_modules
+      - run:
+          name: Format Rust Sources
+          command: |
+            cargo fmt -- --check --color=auto
+      - run:
+          name: Lint Rust With Clippy
+          command: |
+            cargo clippy --all-targets --all-features
+      - run:
+          name: Check Rust Docs
+          command: |
+            cargo doc --no-deps --all
       - run:
           name: Format Text Sources
           command: |
@@ -249,9 +265,46 @@ jobs:
             ./scripts/format-text.sh --check "yaml"
             ./scripts/format-text.sh --check "yml"
             ./scripts/format-text.sh --check "md"
+      - run:
+          name: Format Shell Sources
+          command: |
+            shfmt -f . | grep -v target/ | grep -v node_modules/ | grep -v vendor/ | xargs shfmt -i 2 -ci -s -d
+      - run:
+          name: Lint Shell Sources
+          command: |
+            shfmt -f . | grep -v target/ | grep -v node_modules/ | grep -v vendor/ | xargs shellcheck
+      - run:
+          name: Format C Sources
+          command: |
+            ./scripts/format-c.sh --check
+      - run:
+          name: yarn check
+          command: |
+            yarn check --integrity
+            yarn check --verify-tree
+      - run:
+          name: Lint JavaScript with eslint
+          command: |
+            yarn run eslint --ext .html,.js .
+      - rubocop:
+          target: .
+      - save_cache:
+          name: Save sccache cache
+          key: v1-sccache-cache-stable-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ epoch }}
+          paths:
+            - "~/.cache/sccache"
+      - save_cache:
+          key: v1-node-modules-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum "yarn.lock" }}
+          paths:
+            - "~/.cache/yarn"
+            - "node_modules"
+      - persist_to_workspace:
+          root: target
+          paths:
+            - "doc"
   gh-pages-deploy:
     docker:
-      - image: node:8.10.0
+      - image: node:lts
     steps:
       - checkout
       - add_ssh_keys:
@@ -260,15 +313,10 @@ jobs:
       - attach_workspace:
           at: target
       - restore_cache:
-          key: docs-yarn-v1-{{ checksum "yarn.lock" }}
+          key: v1-node-modules-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum "yarn.lock" }}
       - run: yarn install
-      - save_cache:
-          key: docs-yarn-v1-{{ checksum "yarn.lock" }}
-          paths:
-            - ~/.cache/yarn
-            - node_modules
       - run:
-          name: Copy playground redirect
+          name: Copy doc asset overrides
           command: cp assets/* target/doc
       - run:
           name: Deploy docs to gh-pages branch
@@ -277,22 +325,22 @@ jobs:
               --user "ci-build <ci-build@hyperbo.la>" \
               --message "[skip ci] build docs" \
               --dist target/doc
+      - save_cache:
+          key: v1-node-modules-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum "yarn.lock" }}
+          paths:
+            - "~/.cache/yarn"
+            - "node_modules"
 workflows:
   version: 2
   build:
     jobs:
-      - rust
+      - artichoke-x86_64-linux
       - artichoke-x86_64-windows
-      - c
-      - ruby
-      - js
-      - shell-format
-      - shellcheck/check:
-          exclude: "*/vendor/*"
-      - text
+      - artichoke-ruby/spec
+      - linter
       - gh-pages-deploy:
           requires:
-            - rust
+            - linter
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,7 +143,7 @@ jobs:
           name: Save sccache cache
           key: v1-sccache-cache-stable-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ epoch }}
           paths:
-            - %LOCALAPPDATA%\Mozilla\sccache
+            - "%LOCALAPPDATA%\\Mozilla\\sccache"
   artichoke-ruby/spec:
     docker:
       - image: debian:buster-slim

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,11 +53,12 @@ commands:
       - run:
           name: Install Toolchain
           command: |
+            $toolchain = Get-Content rust-toolchain | Select-Object -First 1
+            Set-Location "$env:USERPROFILE"
             # Install rustup
             $client = new-object System.Net.WebClient
-            $client.DownloadFile('https://win.rustup.rs', "$env:USERPROFILE\rustup-init.exe")
-            $toolchain = Get-Content rust-toolchain | Select-Object -First 1
-            $env:USERPROFILE\rustup-init.exe -y --profile minimal --default-toolchain "$($toolchain)-msvc"
+            $client.DownloadFile('https://win.rustup.rs', "$pwd\rustup-init.exe")
+            .\rustup-init.exe -y --profile minimal --default-toolchain "$($toolchain)-msvc"
             # This is necessary because otherwise cargo fails when trying to use git?
             Add-Content "$env:USERPROFILE\.cargo\config" "[net]`ngit-fetch-with-cli = true"
             choco install ruby --no-progress --version=2.6.3.1
@@ -80,6 +81,11 @@ commands:
     description: Setup Artichoke Windows linter image
     steps:
       - setup-linux-builder
+      - run:
+          name: Install Rust Toolchain
+          command: |
+            rustup component add rustfmt
+            rustup component add clippy
       - run:
           name: Install JS Toolchain
           working_directory: "~"


### PR DESCRIPTION
- Add sccache on Linux and Windows.
- Unify all linting tasks into a single job.
- Rename `rust` build and test on Linux to
  match Windows job.
- Use `debian:buster-slim` as the base image
  on Linux.
- Bump docs deploy base image to LTS node.
- Split ruby/spec suite testing into its own job.
- Suppress errors in ruby/spec job.
- Use `shfmt` to discover sources for `shellcheck`.