### PR TITLE
Use prebuilt images with Ruby 2.6.3 and node

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,12 +15,12 @@ commands:
           name: Install Toolchain
           working_directory: "~"
           command: |
-            apt-get install -y clang bison
+            sudo apt-get install -y clang bison
       - run:
           name: Install sccache
           working_directory: "~"
           command: |
-            apt-get install -y pkg-config libssl-dev
+            sudo apt-get install -y pkg-config libssl-dev
             curl -o- -sSLf https://github.com/mozilla/sccache/releases/download/0.2.12/sccache-0.2.12-x86_64-unknown-linux-musl.tar.gz | tar xzf -
             mv sccache-0.2.12-x86_64-unknown-linux-musl/sccache .cargo/bin/sccache
             echo 'export "RUSTC_WRAPPER"="sccache"' >> $BASH_ENV

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ commands:
       - checkout
       - restore_cache:
           name: Restore sccache cache
-          key: v1-sccache-cache-stable-{{ arch }}-{{ .Environment.CIRCLE_JOB }}
+          key: v2-sccache-cache-stable-{{ arch }}-{{ .Environment.CIRCLE_JOB }}
       - run:
           name: Install Toolchain
           command: |
@@ -144,7 +144,7 @@ jobs:
       - setup-linux-builder
       - restore_cache:
           name: Restore sccache cache
-          key: v1-sccache-cache-stable-{{ arch }}-{{ .Environment.CIRCLE_JOB }}
+          key: v2-sccache-cache-stable-{{ arch }}-{{ .Environment.CIRCLE_JOB }}
       - run:
           name: Build workspace without default features
           command: |
@@ -164,7 +164,7 @@ jobs:
             RUST_BACKTRACE: 1
       - save_cache:
           name: Save sccache cache
-          key: v1-sccache-cache-stable-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ epoch }}
+          key: v2-sccache-cache-stable-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ epoch }}
           paths:
             - "~/.cache/sccache"
   x86_64-windows:
@@ -207,7 +207,7 @@ jobs:
       - setup-linux-builder
       - restore_cache:
           name: Restore sccache cache
-          key: v1-sccache-cache-stable-{{ arch }}-{{ .Environment.CIRCLE_JOB }}
+          key: v2-sccache-cache-stable-{{ arch }}-{{ .Environment.CIRCLE_JOB }}
       - run:
           name: ruby/spec Compliance Regression Test
           command: |
@@ -215,7 +215,7 @@ jobs:
             ./scripts/spec-compliance.sh --artichoke || :
       - save_cache:
           name: Save sccache cache
-          key: v1-sccache-cache-stable-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ epoch }}
+          key: v2-sccache-cache-stable-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ epoch }}
           paths:
             - "~/.cache/sccache"
   linter:
@@ -228,7 +228,7 @@ jobs:
           key: v1-node-modules-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum "yarn.lock" }}
       - restore_cache:
           name: Restore sccache cache
-          key: v1-sccache-cache-stable-{{ arch }}-{{ .Environment.CIRCLE_JOB }}
+          key: v2-sccache-cache-stable-{{ arch }}-{{ .Environment.CIRCLE_JOB }}
       - run:
           name: Format Rust Sources
           command: |
@@ -276,7 +276,7 @@ jobs:
             ./scripts/format-text.sh --check "md"
       - save_cache:
           name: Save sccache cache
-          key: v1-sccache-cache-stable-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ epoch }}
+          key: v2-sccache-cache-stable-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ epoch }}
           paths:
             - "~/.cache/sccache"
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,10 +85,10 @@ commands:
           working_directory: "~"
           command: |
             curl -o- -sSfL https://storage.googleapis.com/shellcheck/shellcheck-stable.linux.x86_64.tar.xz | tar xJf -
-            mv shellcheck-stable/shellcheck /usr/local/bin
-            chmod +x /usr/local/bin/shellcheck
-            curl -o/usr/local/bin/shfmt -sSfL https://github.com/mvdan/sh/releases/download/v2.6.4/shfmt_v2.6.4_linux_amd64
-            chmod +x /usr/local/bin/shfmt
+            sudo mv shellcheck-stable/shellcheck /usr/local/bin
+            sudo chmod +x /usr/local/bin/shellcheck
+            sudo curl -o/usr/local/bin/shfmt -sSfL https://github.com/mvdan/sh/releases/download/v2.6.4/shfmt_v2.6.4_linux_amd64
+            sudo chmod +x /usr/local/bin/shfmt
       - run:
           name: Install JS Packages
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,7 +119,7 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - v1-bundler-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum "<< parameters.target >>/Gemfile.lock" }}
+            - v2-bundler-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum "<< parameters.target >>/Gemfile.lock" }}
       - run:
           name: Bundle Install
           working_directory: "<< parameters.target >>"
@@ -132,7 +132,7 @@ commands:
             bundle exec rubocop --version
             bundle exec rubocop
       - save_cache:
-          key: v1-bundler-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum "<< parameters.target >>/Gemfile.lock" }}
+          key: v2-bundler-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum "<< parameters.target >>/Gemfile.lock" }}
           paths:
             - "~/vendor"
 jobs:
@@ -225,7 +225,7 @@ jobs:
     steps:
       - setup-linux-linter
       - restore_cache:
-          key: v1-node-modules-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum "yarn.lock" }}
+          key: v2-node-modules-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum "yarn.lock" }}
       - restore_cache:
           name: Restore sccache cache
           key: v2-sccache-cache-stable-{{ arch }}-{{ .Environment.CIRCLE_JOB }}
@@ -280,7 +280,7 @@ jobs:
           paths:
             - "~/.cache/sccache"
       - save_cache:
-          key: v1-node-modules-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum "yarn.lock" }}
+          key: v2-node-modules-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum "yarn.lock" }}
           paths:
             - "~/.cache/yarn"
             - "node_modules"
@@ -299,7 +299,7 @@ jobs:
       - attach_workspace:
           at: target
       - restore_cache:
-          key: v1-node-modules-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum "yarn.lock" }}
+          key: v2-node-modules-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum "yarn.lock" }}
       - run: yarn install
       - run:
           name: Copy doc asset overrides
@@ -312,7 +312,7 @@ jobs:
               --message "[skip ci] build docs" \
               --dist target/doc
       - save_cache:
-          key: v1-node-modules-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum "yarn.lock" }}
+          key: v2-node-modules-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum "yarn.lock" }}
           paths:
             - "~/.cache/yarn"
             - "node_modules"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,11 +5,6 @@ commands:
   setup-linux-builder:
     description: Setup Artichoke Linux builder image
     steps:
-      - run:
-          name: Setup Image
-          command: |
-            apt-get update
-            apt-get install -y curl git ssh
       - checkout
       - run:
           name: Install Rust Toolchain
@@ -21,13 +16,6 @@ commands:
           working_directory: "~"
           command: |
             apt-get install -y clang bison
-            git clone https://github.com/rbenv/ruby-build.git
-            PREFIX=/usr/local ./ruby-build/install.sh
-      - run:
-          name: Install Ruby
-          command: |
-            apt-get install -y autoconf bison build-essential libssl-dev libyaml-dev libreadline6-dev zlib1g-dev libncurses5-dev libffi-dev libgdbm6 libgdbm-dev
-            ruby-build "$(cat .ruby-version)" /usr/local
       - run:
           name: Install sccache
           working_directory: "~"
@@ -93,16 +81,6 @@ commands:
             rustup component add rustfmt
             rustup component add clippy
       - run:
-          name: Install JS Toolchain
-          working_directory: "~"
-          command: |
-            curl -sSfL https://deb.nodesource.com/setup_13.x | bash -
-            apt-get install -y nodejs
-            curl -sSf https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
-            echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
-            apt-get update
-            apt-get install --no-install-recommends -y yarn
-      - run:
           name: Install Shell Toolchain
           working_directory: "~"
           command: |
@@ -160,7 +138,7 @@ commands:
 jobs:
   x86_64-linux:
     docker:
-      - image: debian:buster-slim
+      - image: circleci/ruby:2.6.3-buster
     resource_class: large
     steps:
       - setup-linux-builder
@@ -223,7 +201,7 @@ jobs:
             - "C:\\Users\\circleci\\AppData\\Local\\Mozilla\\sccache"
   ruby-spec:
     docker:
-      - image: debian:buster-slim
+      - image: circleci/ruby:2.6.3-buster
     resource_class: large
     steps:
       - setup-linux-builder
@@ -242,7 +220,7 @@ jobs:
             - "~/.cache/sccache"
   linter:
     docker:
-      - image: debian:buster-slim
+      - image: circleci/ruby:2.6.3-buster-node
     resource_class: large
     steps:
       - setup-linux-linter


### PR DESCRIPTION
CircleCI provides buster images with Ruby and node preinstalled.
Rust installs in ~30 seconds whereas building Ruby 2.6.3 from
source takes over 2 minutes, so use the Ruby images over the
Rust ones.