### PR TITLE
Change ArrayType::reverse to do an in-place reversal

### DIFF
--- a/artichoke-backend/src/extn/core/array/array.rb
+++ b/artichoke-backend/src/extn/core/array/array.rb
@@ -1121,6 +1121,10 @@ class Array
     self
   end
 
+  def reverse
+    dup.reverse!
+  end
+
   def reverse_each(&block)
     return to_enum :reverse_each unless block
 

--- a/artichoke-backend/src/extn/core/array/backend/aggregate.rs
+++ b/artichoke-backend/src/extn/core/array/backend/aggregate.rs
@@ -331,13 +331,14 @@ impl ArrayType for Aggregate {
     }
 
     fn reverse(&mut self, interp: &Artichoke) -> Result<(), Box<dyn RubyException>> {
-        let ln = self.0.len();
         let mut i = 0;
-        while i < ln / 2 {
-            self.0.swap(i, ln - i - 1);
+        let mut j = self.0.len() - 1;
+        while i < j {
+            self.0.swap(i, j);
             self.0[i].reverse(interp)?;
-            self.0[ln - i - 1].reverse(interp)?;
+            self.0[j].reverse(interp)?;
             i += 1;
+            j -= 1;
         }
         Ok(())
     }

--- a/artichoke-backend/src/extn/core/array/backend/aggregate.rs
+++ b/artichoke-backend/src/extn/core/array/backend/aggregate.rs
@@ -330,11 +330,15 @@ impl ArrayType for Aggregate {
         }
     }
 
-    fn reverse(&self, interp: &Artichoke) -> Result<Box<dyn ArrayType>, Box<dyn RubyException>> {
-        let mut parts = Vec::with_capacity(self.0.len());
-        for idx in (0..self.0.len()).rev() {
-            parts.push(self.0[idx].reverse(interp)?);
+    fn reverse(&mut self, interp: &Artichoke) -> Result<(), Box<dyn RubyException>> {
+        let ln = self.0.len();
+        let mut i = 0;
+        while i < ln / 2 {
+            self.0.swap(i, ln - i - 1);
+            self.0[i].reverse(interp)?;
+            self.0[ln - i - 1].reverse(interp)?;
+            i += 1;
         }
-        Ok(Box::new(Self::with_parts(parts)))
+        Ok(())
     }
 }

--- a/artichoke-backend/src/extn/core/array/backend/aggregate.rs
+++ b/artichoke-backend/src/extn/core/array/backend/aggregate.rs
@@ -332,7 +332,7 @@ impl ArrayType for Aggregate {
 
     fn reverse(&mut self, interp: &Artichoke) -> Result<(), Box<dyn RubyException>> {
         self.0.reverse();
-        for part in self.0.iter_mut() {
+        for part in &mut self.0 {
             part.reverse(interp)?;
         }
         Ok(())

--- a/artichoke-backend/src/extn/core/array/backend/aggregate.rs
+++ b/artichoke-backend/src/extn/core/array/backend/aggregate.rs
@@ -331,14 +331,9 @@ impl ArrayType for Aggregate {
     }
 
     fn reverse(&mut self, interp: &Artichoke) -> Result<(), Box<dyn RubyException>> {
-        let mut i = 0;
-        let mut j = self.0.len() - 1;
-        while i < j {
-            self.0.swap(i, j);
-            self.0[i].reverse(interp)?;
-            self.0[j].reverse(interp)?;
-            i += 1;
-            j -= 1;
+        self.0.reverse();
+        for part in self.0.iter_mut() {
+            part.reverse(interp)?;
         }
         Ok(())
     }

--- a/artichoke-backend/src/extn/core/array/backend/buffer.rs
+++ b/artichoke-backend/src/extn/core/array/backend/buffer.rs
@@ -227,11 +227,12 @@ impl ArrayType for Buffer {
 
     fn reverse(&mut self, interp: &Artichoke) -> Result<(), Box<dyn RubyException>> {
         let _ = interp;
-        let ln = self.0.len();
         let mut i = 0;
-        while i < ln / 2 {
-            self.0.swap(i, ln - i - 1);
+        let mut j = self.0.len() - 1;
+        while i < j {
+            self.0.swap(i, j);
             i += 1;
+            j -= 1;
         }
         Ok(())
     }

--- a/artichoke-backend/src/extn/core/array/backend/buffer.rs
+++ b/artichoke-backend/src/extn/core/array/backend/buffer.rs
@@ -225,12 +225,14 @@ impl ArrayType for Buffer {
         Ok(interp.convert(self.0.pop()))
     }
 
-    fn reverse(&self, interp: &Artichoke) -> Result<Box<dyn ArrayType>, Box<dyn RubyException>> {
+    fn reverse(&mut self, interp: &Artichoke) -> Result<(), Box<dyn RubyException>> {
         let _ = interp;
-        let mut buffer = Vec::with_capacity(self.0.len());
-        for idx in (0..self.0.len()).rev() {
-            buffer.push(self.0[idx].clone());
+        let ln = self.0.len();
+        let mut i = 0;
+        while i < ln / 2 {
+            self.0.swap(i, ln - i - 1);
+            i += 1;
         }
-        Ok(Box::new(Self(buffer)))
+        Ok(())
     }
 }

--- a/artichoke-backend/src/extn/core/array/backend/buffer.rs
+++ b/artichoke-backend/src/extn/core/array/backend/buffer.rs
@@ -227,7 +227,7 @@ impl ArrayType for Buffer {
 
     fn reverse(&mut self, interp: &Artichoke) -> Result<(), Box<dyn RubyException>> {
         let _ = interp;
-        self.0.reverse(); 
+        self.0.reverse();
         Ok(())
     }
 }

--- a/artichoke-backend/src/extn/core/array/backend/buffer.rs
+++ b/artichoke-backend/src/extn/core/array/backend/buffer.rs
@@ -227,13 +227,7 @@ impl ArrayType for Buffer {
 
     fn reverse(&mut self, interp: &Artichoke) -> Result<(), Box<dyn RubyException>> {
         let _ = interp;
-        let mut i = 0;
-        let mut j = self.0.len() - 1;
-        while i < j {
-            self.0.swap(i, j);
-            i += 1;
-            j -= 1;
-        }
+        self.0.reverse(); 
         Ok(())
     }
 }

--- a/artichoke-backend/src/extn/core/array/backend/fixed/empty.rs
+++ b/artichoke-backend/src/extn/core/array/backend/fixed/empty.rs
@@ -130,8 +130,8 @@ impl ArrayType for Empty {
         Ok(interp.convert(None::<Value>))
     }
 
-    fn reverse(&self, interp: &Artichoke) -> Result<Box<dyn ArrayType>, Box<dyn RubyException>> {
+    fn reverse(&mut self, interp: &Artichoke) -> Result<(), Box<dyn RubyException>> {
         let _ = interp;
-        Ok(backend::fixed::empty())
+        Ok(())
     }
 }

--- a/artichoke-backend/src/extn/core/array/backend/fixed/hole.rs
+++ b/artichoke-backend/src/extn/core/array/backend/fixed/hole.rs
@@ -182,8 +182,8 @@ impl ArrayType for Hole {
         Ok(interp.convert(None::<Value>))
     }
 
-    fn reverse(&self, interp: &Artichoke) -> Result<Box<dyn ArrayType>, Box<dyn RubyException>> {
+    fn reverse(&mut self, interp: &Artichoke) -> Result<(), Box<dyn RubyException>> {
         let _ = interp;
-        Ok(self.box_clone())
+        Ok(())
     }
 }

--- a/artichoke-backend/src/extn/core/array/backend/fixed/one.rs
+++ b/artichoke-backend/src/extn/core/array/backend/fixed/one.rs
@@ -174,8 +174,8 @@ impl ArrayType for One {
         Ok(self.0.clone())
     }
 
-    fn reverse(&self, interp: &Artichoke) -> Result<Box<dyn ArrayType>, Box<dyn RubyException>> {
+    fn reverse(&mut self, interp: &Artichoke) -> Result<(), Box<dyn RubyException>> {
         let _ = interp;
-        Ok(self.box_clone())
+        Ok(())
     }
 }

--- a/artichoke-backend/src/extn/core/array/backend/fixed/two.rs
+++ b/artichoke-backend/src/extn/core/array/backend/fixed/two.rs
@@ -213,8 +213,13 @@ impl ArrayType for Two {
         Ok(self.1.clone())
     }
 
-    fn reverse(&self, interp: &Artichoke) -> Result<Box<dyn ArrayType>, Box<dyn RubyException>> {
+    fn reverse(&mut self, interp: &Artichoke) -> Result<(), Box<dyn RubyException>> {
         let _ = interp;
-        Ok(backend::fixed::two(self.1.clone(), self.0.clone()))
+        let mut realloc = None;
+        let pa = self.get(interp, 0)?;
+        let pb = self.get(interp, 1)?;
+        self.set(interp, 0, pb, &mut realloc)?;
+        self.set(interp, 1, pa, &mut realloc)?;
+        Ok(())
     }
 }

--- a/artichoke-backend/src/extn/core/array/backend/fixed/two.rs
+++ b/artichoke-backend/src/extn/core/array/backend/fixed/two.rs
@@ -1,3 +1,5 @@
+use std::mem;
+
 use crate::convert::Convert;
 use crate::extn::core::array::{backend, ArrayType};
 use crate::extn::core::exception::RubyException;
@@ -215,11 +217,7 @@ impl ArrayType for Two {
 
     fn reverse(&mut self, interp: &Artichoke) -> Result<(), Box<dyn RubyException>> {
         let _ = interp;
-        let mut realloc = None;
-        let pa = self.get(interp, 0)?;
-        let pb = self.get(interp, 1)?;
-        self.set(interp, 0, pb, &mut realloc)?;
-        self.set(interp, 1, pa, &mut realloc)?;
+        mem::swap(&mut self.0, &mut self.1);
         Ok(())
     }
 }

--- a/artichoke-backend/src/extn/core/array/backend/repeated/value.rs
+++ b/artichoke-backend/src/extn/core/array/backend/repeated/value.rs
@@ -204,8 +204,8 @@ impl ArrayType for Value {
         Ok(self.0.clone())
     }
 
-    fn reverse(&self, interp: &Artichoke) -> Result<Box<dyn ArrayType>, Box<dyn RubyException>> {
+    fn reverse(&mut self, interp: &Artichoke) -> Result<(), Box<dyn RubyException>> {
         let _ = interp;
-        Ok(self.box_clone())
+        Ok(())
     }
 }

--- a/artichoke-backend/src/extn/core/array/mod.rs
+++ b/artichoke-backend/src/extn/core/array/mod.rs
@@ -429,15 +429,7 @@ impl Array {
         Ok(popped)
     }
 
-    pub fn reverse(&self, interp: &Artichoke) -> Result<Value, Box<dyn RubyException>> {
-        let mut result = self.clone();
-        result.reverse_in_place(interp)?;
-        let result = unsafe { result.try_into_ruby(interp, None) }
-            .map_err(|_| Fatal::new(interp, "Unable to initialize Ruby Array from Rust Array"))?;
-        Ok(result)
-    }
-
-    pub fn reverse_in_place(&mut self, interp: &Artichoke) -> Result<(), Box<dyn RubyException>> {
+    pub fn reverse(&mut self, interp: &Artichoke) -> Result<(), Box<dyn RubyException>> {
         self.0.reverse(interp)?;
         Ok(())
     }

--- a/artichoke-backend/src/extn/core/array/mod.rs
+++ b/artichoke-backend/src/extn/core/array/mod.rs
@@ -430,16 +430,15 @@ impl Array {
     }
 
     pub fn reverse(&self, interp: &Artichoke) -> Result<Value, Box<dyn RubyException>> {
-        let result = self.0.reverse(interp)?;
-        let result = Self(result);
+        let mut result = self.clone();
+        result.reverse_in_place(interp)?;
         let result = unsafe { result.try_into_ruby(interp, None) }
             .map_err(|_| Fatal::new(interp, "Unable to initialize Ruby Array from Rust Array"))?;
         Ok(result)
     }
 
     pub fn reverse_in_place(&mut self, interp: &Artichoke) -> Result<(), Box<dyn RubyException>> {
-        let reversed = self.0.reverse(interp)?;
-        self.0 = reversed;
+        self.0.reverse(interp)?;
         Ok(())
     }
 }
@@ -510,9 +509,7 @@ pub trait ArrayType: Any {
         realloc: &mut Option<Vec<Box<dyn ArrayType>>>,
     ) -> Result<Value, Box<dyn RubyException>>;
 
-    // TODO: Change the semantics of this function to do an in place reverse
-    // like `Array#reverse!` and implement Array#reverse` in Ruby.
-    fn reverse(&self, interp: &Artichoke) -> Result<Box<dyn ArrayType>, Box<dyn RubyException>>;
+    fn reverse(&mut self, interp: &Artichoke) -> Result<(), Box<dyn RubyException>>;
 }
 
 downcast!(dyn ArrayType);

--- a/artichoke-backend/src/extn/core/array/mruby.rs
+++ b/artichoke-backend/src/extn/core/array/mruby.rs
@@ -46,9 +46,6 @@ pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
         .add_method("pop", ary_pop, sys::mrb_args_none());
     array
         .borrow_mut()
-        .add_method("reverse", ary_reverse, sys::mrb_args_none());
-    array
-        .borrow_mut()
         .add_method("reverse!", ary_reverse_bang, sys::mrb_args_none());
     array
         .borrow_mut()
@@ -142,17 +139,6 @@ unsafe extern "C" fn ary_initialize_copy(
             sys::mrb_write_barrier(mrb, basic);
             value.inner()
         }
-        Err(exception) => exception::raise(interp, exception),
-    }
-}
-
-unsafe extern "C" fn ary_reverse(mrb: *mut sys::mrb_state, ary: sys::mrb_value) -> sys::mrb_value {
-    mrb_get_args!(mrb, none);
-    let interp = unwrap_interpreter!(mrb);
-    let ary = Value::new(&interp, ary);
-    let result = array::trampoline::reverse(&interp, ary);
-    match result {
-        Ok(value) => value.inner(),
         Err(exception) => exception::raise(interp, exception),
     }
 }

--- a/artichoke-backend/src/extn/core/array/trampoline.rs
+++ b/artichoke-backend/src/extn/core/array/trampoline.rs
@@ -146,17 +146,6 @@ pub fn push(interp: &Artichoke, ary: Value, value: Value) -> Result<Value, Box<d
     Ok(ary)
 }
 
-pub fn reverse(interp: &Artichoke, ary: Value) -> Result<Value, Box<dyn RubyException>> {
-    let array = unsafe { Array::try_from_ruby(interp, &ary) }.map_err(|_| {
-        Fatal::new(
-            interp,
-            "Unable to extract Rust Array from Ruby Array receiver",
-        )
-    })?;
-    let borrow = array.borrow();
-    borrow.reverse(interp)
-}
-
 pub fn reverse_bang(interp: &Artichoke, ary: Value) -> Result<Value, Box<dyn RubyException>> {
     if ary.is_frozen() {
         return Err(Box::new(FrozenError::new(
@@ -172,7 +161,7 @@ pub fn reverse_bang(interp: &Artichoke, ary: Value) -> Result<Value, Box<dyn Rub
     })?;
     let mut borrow = array.borrow_mut();
     let gc_was_enabled = interp.disable_gc();
-    borrow.reverse_in_place(interp)?;
+    borrow.reverse(interp)?;
     if gc_was_enabled {
         interp.enable_gc();
     }


### PR DESCRIPTION
This PR addresses #335. 

- Implement `Array#reverse` in ruby
- Update `ArrayType::reverse` to do an in-place reversal
- Cleanup the now unused `reverse` function in trampoline and update `reverse_bang` to use the in-place reversal
- Cleanup `ary_reverse` method in mruby