### PR TITLE
Disable backtrace generation in non-debug builds

### DIFF
--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2018"
 
 [dependencies]
-backtrace = "0.3"
+backtrace = { version = "0.3", optional = true }
 bstr = "0.2"
 downcast = "0.10"
 log = "0.4"
@@ -43,4 +43,5 @@ default-features = false
 [features]
 default = ["artichoke-array", "artichoke-system-environ"]
 artichoke-array = []
+artichoke-debug = ["backtrace"]
 artichoke-system-environ = []


### PR DESCRIPTION
Backtrace generation was profiled to be 10% of all execution time during
a run of the spec suite. These backtraces are only useful in debug mode,
so hide them behind a crate feature.