### PR TITLE
Stop allocating a vfs metadata struct when defining a source file

### DIFF
--- a/artichoke-backend/src/load.rs
+++ b/artichoke-backend/src/load.rs
@@ -104,8 +104,6 @@ impl LoadSources for Artichoke {
             api.vfs.create_dir_all(parent)?;
         }
         api.vfs.write_file(&path, contents.as_ref())?;
-        let metadata = api.vfs.metadata(&path).unwrap_or_default();
-        api.vfs.set_metadata(&path, metadata)?;
         trace!("Added pure ruby source file -- {:?}", &path);
         Ok(())
     }


### PR DESCRIPTION
Metadata structs are lazily allocated anyway when attaching Rust extensions or
requiring. There is no need to eagerly allocate.

This allocation was visible when profiling the ruby/spec runner.