### PR TITLE
Remove docs on loc flamegraph

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -257,25 +257,3 @@ If after running `yarn upgrade` there are still outdated packages reported by
 would like to update the dependency and deal with any breakage, please do;
 otherwise, please
 [file an issue](https://github.com/artichoke/artichoke/issues/new).
-
-## Code Analysis
-
-### Source Code Statistics
-
-To view statistics about the source code in Artichoke, you can run `yarn loc`,
-which depends on [loc](https://github.com/cgag/loc). You can install loc by
-running:
-
-```sh
-cargo install loc
-```
-
-### Flamegraphs
-
-To generate flamegraphs with, you need the
-[inferno flamegraph implementation](https://github.com/jonhoo/inferno). You can
-install inferno by running:
-
-```sh
-cargo install inferno
-```

--- a/package.json
+++ b/package.json
@@ -83,7 +83,6 @@
   "scripts": {
     "eslint-check": "eslint --print-config package.json | eslint-config-prettier-check",
     "lint": "node scripts/lint.js",
-    "loc": "loc --exclude target vendor fixtures",
     "spec": "ruby scripts/spec.rb artichoke passing"
   }
 }


### PR DESCRIPTION
the flamegraph docs are handled better by the --profile option in
the spec runner.