### PR TITLE
Use mrb_intern_static for interned Symbols from Rust

### DIFF
--- a/artichoke-backend/src/state.rs
+++ b/artichoke-backend/src/state.rs
@@ -257,7 +257,7 @@ impl State {
         let interned = self
             .symbol_cache
             .entry(sym)
-            .or_insert_with(|| unsafe { sys::mrb_intern(mrb, ptr as *const i8, len) });
+            .or_insert_with(|| unsafe { sys::mrb_intern_static(mrb, ptr as *const i8, len) });
         *interned
     }
 }


### PR DESCRIPTION
mruby has a basic notion of lifetimes with two APIs for creating
Symbols:

- `mrb_intern`, which takes ownership of a borrowed Symbol by doing an
  allocation and a memcpy.
- `mrb_intern_static`, which takes a Symbol whose lifetime outlives the
  `mrb_state` and does no copy or free.

`mrb_intern_static` is only ergonomic for static String literals in C,
but when adding a `Cow<'static, [u8]>` to a `HashMap` in Rust, the bytes
will be cleaned up automatically when the interpreter closes.

This avoids an allocation for every `Symbol` created in Rust.