### PR TITLE
Reimplement Array with a buffer type that optionally inlines

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "artichoke-backend"
 version = "0.1.0"
 dependencies = [
+ "arrayvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "artichoke-core 0.1.0",
  "artichoke-vfs 0.5.0-alpha",
  "backtrace 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2018"
 
 [dependencies]
+arrayvec = "0.5"
 backtrace = { version = "0.3", optional = true }
 bstr = "0.2"
 downcast = "0.10"

--- a/artichoke-backend/mruby-sys/include/mruby-sys/artichoke.h
+++ b/artichoke-backend/mruby-sys/include/mruby-sys/artichoke.h
@@ -17,7 +17,7 @@ mrb_value artichoke_ary_shift(mrb_state *mrb, mrb_value self);
 mrb_value artichoke_ary_unshift(mrb_state *mrb, mrb_value self, mrb_value item);
 mrb_int artichoke_ary_len(mrb_state *mrb, mrb_value self);
 void artichoke_ary_set_len(mrb_state *mrb, mrb_value self, mrb_int len);
-mrb_value* artichoke_ary_ptr(mrb_state *mrb, mrb_value self);
+mrb_value *artichoke_ary_ptr(mrb_state *mrb, mrb_value self);
 mrb_bool artichoke_ary_check(mrb_state *mrb, mrb_value ary);
 
 // GC

--- a/artichoke-backend/mruby-sys/include/mruby-sys/artichoke.h
+++ b/artichoke-backend/mruby-sys/include/mruby-sys/artichoke.h
@@ -3,21 +3,21 @@
 #include <mruby/value.h>
 
 // Array overrides
-mrb_value artichoke_value_to_ary(mrb_state *mrb, mrb_value value);
 mrb_value artichoke_ary_new(mrb_state *mrb);
 mrb_value artichoke_ary_new_capa(mrb_state *, mrb_int);
 mrb_value artichoke_ary_new_from_values(mrb_state *mrb, mrb_int size,
                                         const mrb_value *vals);
 mrb_value artichoke_ary_splat(mrb_state *mrb, mrb_value value);
-mrb_value artichoke_ary_clone(mrb_state *mrb, mrb_value value);
-mrb_value artichoke_ary_ref(mrb_state *mrb, mrb_value ary, mrb_int n);
+void artichoke_ary_concat(mrb_state *mrb, mrb_value self, mrb_value other);
 mrb_value artichoke_ary_pop(mrb_state *mrb, mrb_value ary);
+void artichoke_ary_push(mrb_state *mrb, mrb_value array, mrb_value value);
+mrb_value artichoke_ary_ref(mrb_state *mrb, mrb_value ary, mrb_int n);
+void artichoke_ary_set(mrb_state *mrb, mrb_value ary, mrb_int n, mrb_value val);
 mrb_value artichoke_ary_shift(mrb_state *mrb, mrb_value self);
 mrb_value artichoke_ary_unshift(mrb_state *mrb, mrb_value self, mrb_value item);
 mrb_int artichoke_ary_len(mrb_state *mrb, mrb_value self);
-void artichoke_ary_concat(mrb_state *mrb, mrb_value self, mrb_value other);
-void artichoke_ary_push(mrb_state *mrb, mrb_value array, mrb_value value);
-void artichoke_ary_set(mrb_state *mrb, mrb_value ary, mrb_int n, mrb_value val);
+void artichoke_ary_set_len(mrb_state *mrb, mrb_value self, mrb_int len);
+mrb_value* artichoke_ary_ptr(mrb_state *mrb, mrb_value self);
 mrb_bool artichoke_ary_check(mrb_state *mrb, mrb_value ary);
 
 // GC

--- a/artichoke-backend/src/convert/array.rs
+++ b/artichoke-backend/src/convert/array.rs
@@ -4,7 +4,7 @@ use std::convert::TryFrom;
 use crate::convert::float::Float;
 use crate::convert::{Convert, TryConvert};
 #[cfg(feature = "artichoke-array")]
-use crate::extn::core::array::{backend, Array};
+use crate::extn::core::array::{Array, InlineBuffer};
 use crate::sys;
 use crate::types::{Int, Ruby, Rust};
 use crate::value::{Value, ValueLike};
@@ -15,7 +15,7 @@ impl Convert<&[Value], Value> for Artichoke {
     #[cfg(feature = "artichoke-array")]
     fn convert(&self, value: &[Value]) -> Value {
         use crate::convert::RustBackedValue;
-        let ary = Array::new(Box::new(backend::buffer::Buffer::from(value)));
+        let ary = Array::new(InlineBuffer::from(value));
         unsafe { ary.try_into_ruby(self, None) }.expect("Array into Value")
     }
 
@@ -40,7 +40,7 @@ impl Convert<Vec<Value>, Value> for Artichoke {
     #[cfg(feature = "artichoke-array")]
     fn convert(&self, value: Vec<Value>) -> Value {
         use crate::convert::RustBackedValue;
-        let ary = Array::new(Box::new(backend::buffer::Buffer::from(value)));
+        let ary = Array::new(InlineBuffer::from(value));
         unsafe { ary.try_into_ruby(self, None) }.expect("Array into Value")
     }
 

--- a/artichoke-backend/src/extn/core/array/backend/mod.rs
+++ b/artichoke-backend/src/extn/core/array/backend/mod.rs
@@ -1,5 +1,75 @@
+use std::any::Any;
+
+use crate::extn::core::exception::RubyException;
+use crate::value::Value;
+use crate::Artichoke;
+
 pub mod aggregate;
 pub mod buffer;
 pub mod fixed;
 pub mod integer_range;
 pub mod repeated;
+
+pub trait ArrayType: Any {
+    fn box_clone(&self) -> Box<dyn ArrayType>;
+
+    fn gc_mark(&self, interp: &Artichoke);
+
+    fn real_children(&self) -> usize;
+
+    fn len(&self) -> usize;
+
+    fn is_empty(&self) -> bool;
+
+    fn get(&self, interp: &Artichoke, index: usize) -> Result<Value, Box<dyn RubyException>>;
+
+    fn slice(
+        &self,
+        interp: &Artichoke,
+        start: usize,
+        len: usize,
+    ) -> Result<Box<dyn ArrayType>, Box<dyn RubyException>>;
+
+    fn set(
+        &mut self,
+        interp: &Artichoke,
+        index: usize,
+        elem: Value,
+        realloc: &mut Option<Vec<Box<dyn ArrayType>>>,
+    ) -> Result<(), Box<dyn RubyException>>;
+
+    fn set_with_drain(
+        &mut self,
+        interp: &Artichoke,
+        start: usize,
+        drain: usize,
+        with: Value,
+        realloc: &mut Option<Vec<Box<dyn ArrayType>>>,
+    ) -> Result<usize, Box<dyn RubyException>>;
+
+    fn set_slice(
+        &mut self,
+        interp: &Artichoke,
+        start: usize,
+        drain: usize,
+        with: Box<dyn ArrayType>,
+        realloc: &mut Option<Vec<Box<dyn ArrayType>>>,
+    ) -> Result<usize, Box<dyn RubyException>>;
+
+    fn concat(
+        &mut self,
+        interp: &Artichoke,
+        other: Box<dyn ArrayType>,
+        realloc: &mut Option<Vec<Box<dyn ArrayType>>>,
+    ) -> Result<(), Box<dyn RubyException>>;
+
+    fn pop(
+        &mut self,
+        interp: &Artichoke,
+        realloc: &mut Option<Vec<Box<dyn ArrayType>>>,
+    ) -> Result<Value, Box<dyn RubyException>>;
+
+    fn reverse(&mut self, interp: &Artichoke) -> Result<(), Box<dyn RubyException>>;
+}
+
+downcast!(dyn ArrayType);

--- a/artichoke-backend/src/extn/core/array/ffi.rs
+++ b/artichoke-backend/src/extn/core/array/ffi.rs
@@ -3,7 +3,7 @@ use std::ptr;
 use std::slice;
 
 use crate::convert::{Convert, RustBackedValue};
-use crate::extn::core::array::{Array, InlineBuffer};
+use crate::extn::core::array::{Array, ArrayType, InlineBuffer};
 use crate::extn::core::exception::{self, Fatal};
 use crate::gc::MrbGarbageCollection;
 use crate::sys;

--- a/artichoke-backend/src/extn/core/array/inline_buffer.rs
+++ b/artichoke-backend/src/extn/core/array/inline_buffer.rs
@@ -1,0 +1,649 @@
+use arrayvec::ArrayVec;
+
+use crate::convert::Convert;
+use crate::extn::core::exception::RubyException;
+use crate::gc::MrbGarbageCollection;
+use crate::sys;
+use crate::value::Value;
+use crate::Artichoke;
+
+#[derive(Clone)]
+pub struct InlineBuffer {
+    dynamic: Option<Vec<sys::mrb_value>>,
+    inline: ArrayVec<[sys::mrb_value; 8]>,
+}
+
+impl Default for InlineBuffer {
+    fn default() -> Self {
+        Self {
+            dynamic: None,
+            inline: ArrayVec::new(),
+        }
+    }
+}
+
+impl From<Vec<sys::mrb_value>> for InlineBuffer {
+    fn from(values: Vec<sys::mrb_value>) -> Self {
+        let mut inline = ArrayVec::new();
+        if values.len() < inline.capacity() {
+            for elem in values {
+                unsafe { inline.push_unchecked(elem) };
+            }
+            Self {
+                dynamic: None,
+                inline,
+            }
+        } else {
+            Self {
+                dynamic: Some(values),
+                inline,
+            }
+        }
+    }
+}
+
+impl From<Vec<Value>> for InlineBuffer {
+    fn from(values: Vec<Value>) -> Self {
+        Self::from(values.as_slice())
+    }
+}
+
+impl<'a> From<&'a [sys::mrb_value]> for InlineBuffer {
+    fn from(values: &'a [sys::mrb_value]) -> Self {
+        let mut inline = ArrayVec::new();
+        if values.len() < inline.capacity() {
+            for elem in values {
+                unsafe { inline.push_unchecked(*elem) };
+            }
+            Self {
+                dynamic: None,
+                inline,
+            }
+        } else {
+            Self {
+                dynamic: Some(values.to_vec()),
+                inline,
+            }
+        }
+    }
+}
+
+impl<'a> From<&'a [Value]> for InlineBuffer {
+    fn from(values: &'a [Value]) -> Self {
+        let mut inline = ArrayVec::new();
+        if values.len() < inline.capacity() {
+            for elem in values {
+                unsafe { inline.push_unchecked(elem.inner()) };
+            }
+            Self {
+                dynamic: None,
+                inline,
+            }
+        } else {
+            Self {
+                dynamic: Some(values.iter().map(Value::inner).collect()),
+                inline,
+            }
+        }
+    }
+}
+
+impl InlineBuffer {
+    pub fn with_capacity(capacity: usize) -> Self {
+        let mut buffer = Self::default();
+        if capacity > buffer.inline.capacity() {
+            buffer.dynamic = Some(Vec::with_capacity(capacity));
+        }
+        buffer
+    }
+
+    pub fn as_vec(&self, interp: &Artichoke) -> Vec<Value> {
+        if let Some(ref buffer) = self.dynamic {
+            buffer
+                .iter()
+                .map(|value| Value::new(interp, *value))
+                .collect()
+        } else {
+            self.inline
+                .iter()
+                .map(|value| Value::new(interp, *value))
+                .collect()
+        }
+    }
+
+    pub fn as_ptr(&self) -> *const sys::mrb_value {
+        if let Some(ref buffer) = self.dynamic {
+            buffer.as_ptr()
+        } else {
+            self.inline.as_ptr()
+        }
+    }
+
+    pub fn as_mut_ptr(&mut self) -> *mut sys::mrb_value {
+        if let Some(ref mut buffer) = self.dynamic {
+            buffer.as_mut_ptr()
+        } else {
+            self.inline.as_mut_ptr()
+        }
+    }
+
+    pub unsafe fn set_len(&mut self, len: usize) {
+        if let Some(ref mut buffer) = self.dynamic {
+            buffer.set_len(len);
+        } else {
+            self.inline.set_len(len);
+        }
+    }
+
+    pub fn clear(&mut self) {
+        self.inline.clear();
+        if let Some(ref mut buffer) = self.dynamic {
+            buffer.clear();
+        }
+    }
+
+    pub fn gc_mark(&self, interp: &Artichoke) {
+        if let Some(ref buffer) = self.dynamic {
+            for element in buffer {
+                interp.mark_value(&Value::new(interp, *element));
+            }
+        } else {
+            for element in &self.inline {
+                interp.mark_value(&Value::new(interp, *element));
+            }
+        }
+    }
+
+    pub fn real_children(&self) -> usize {
+        if let Some(ref buffer) = self.dynamic {
+            buffer.len()
+        } else {
+            self.inline.len()
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        if let Some(ref buffer) = self.dynamic {
+            buffer.len()
+        } else {
+            self.inline.len()
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        if let Some(ref buffer) = self.dynamic {
+            buffer.is_empty()
+        } else {
+            self.inline.is_empty()
+        }
+    }
+
+    pub fn get(&self, interp: &Artichoke, index: usize) -> Result<Value, Box<dyn RubyException>> {
+        if let Some(ref buffer) = self.dynamic {
+            Ok(interp.convert(buffer.get(index).map(|elem| Value::new(interp, *elem))))
+        } else {
+            let elem = self.inline.get(index).map(|elem| Value::new(interp, *elem));
+            Ok(interp.convert(elem))
+        }
+    }
+
+    pub fn slice(
+        &self,
+        interp: &Artichoke,
+        start: usize,
+        len: usize,
+    ) -> Result<Self, Box<dyn RubyException>> {
+        let _ = interp;
+        if start < self.len() {
+            if let Some(ref buffer) = self.dynamic {
+                let iter = buffer.iter().skip(start).take(len);
+                Ok(Self::from(iter.cloned().collect::<Vec<_>>()))
+            } else {
+                let iter = self.inline.iter().skip(start).take(len);
+                Ok(Self::from(iter.cloned().collect::<Vec<_>>()))
+            }
+        } else {
+            Ok(Self::default())
+        }
+    }
+
+    pub fn set(
+        &mut self,
+        interp: &Artichoke,
+        index: usize,
+        elem: Value,
+    ) -> Result<(), Box<dyn RubyException>> {
+        let _ = interp;
+        let buflen = self.len();
+        if index < buflen {
+            if let Some(ref mut buffer) = self.dynamic {
+                buffer[index] = elem.inner();
+            } else {
+                self.inline[index] = elem.inner();
+            }
+        } else {
+            if let Some(ref mut buffer) = self.dynamic {
+                buffer.extend(vec![unsafe { sys::mrb_sys_nil_value() }; index - buflen]);
+                buffer.push(elem.inner());
+            } else if index < self.inline.capacity() {
+                for _ in buflen..index {
+                    unsafe {
+                        self.inline.push_unchecked(sys::mrb_sys_nil_value());
+                    }
+                }
+                unsafe {
+                    self.inline.push_unchecked(elem.inner());
+                }
+            } else {
+                let mut buffer = Vec::from(self.inline.as_slice());
+                buffer.extend(vec![unsafe { sys::mrb_sys_nil_value() }; index - buflen]);
+                buffer.push(elem.inner());
+                self.dynamic = Some(buffer);
+            }
+        }
+        Ok(())
+    }
+
+    pub fn set_with_drain(
+        &mut self,
+        interp: &Artichoke,
+        start: usize,
+        drain: usize,
+        with: Value,
+    ) -> Result<usize, Box<dyn RubyException>> {
+        let _ = interp;
+        let buflen = self.len();
+        let drained = std::cmp::min(buflen.checked_sub(start).unwrap_or_default(), drain);
+        if start > buflen {
+            set_with_drain_sparse(self, start, with);
+        } else if (buflen + 1).checked_sub(drain).unwrap_or_default() < self.inline.capacity() {
+            set_with_drain_to_inline(self, start, drain, with);
+        } else {
+            if let Some(ref mut buffer) = self.dynamic {
+                buffer.push(with.inner());
+            } else {
+                let mut buffer = self.inline.as_slice().to_vec();
+                let nil = unsafe { sys::mrb_sys_nil_value() };
+                for _ in buflen..start {
+                    buffer.push(nil);
+                }
+                buffer.push(with.inner());
+                self.dynamic = Some(buffer);
+            }
+        }
+        Ok(drained)
+    }
+
+    pub fn set_slice(
+        &mut self,
+        interp: &Artichoke,
+        start: usize,
+        drain: usize,
+        with: &Self,
+    ) -> Result<usize, Box<dyn RubyException>> {
+        let _ = interp;
+        let buflen = self.len();
+        let drained = std::cmp::min(buflen.checked_sub(start).unwrap_or_default(), drain);
+        let newlen = start
+            + buflen
+                .checked_sub(start)
+                .and_then(|tail| tail.checked_sub(drain))
+                .unwrap_or_default()
+            + with.len();
+        if start > buflen {
+            set_slice_with_drain_sparse(self, start, with);
+        } else if newlen < self.inline.capacity() {
+            set_slice_with_drain_to_inline(self, start, drain, with);
+        } else {
+            set_slice_with_drain_to_dynamic(self, start, drain, with);
+        }
+        Ok(drained)
+    }
+
+    pub fn concat(
+        &mut self,
+        interp: &Artichoke,
+        other: &Self,
+    ) -> Result<(), Box<dyn RubyException>> {
+        let _ = interp;
+        if self.len() + other.len() < self.inline.capacity() {
+            concat_to_inline(self, other);
+        } else {
+            concat_to_dynamic(self, other);
+        }
+        Ok(())
+    }
+
+    pub fn pop(&mut self, interp: &Artichoke) -> Result<Value, Box<dyn RubyException>> {
+        let value = if let Some(ref mut buffer) = self.dynamic {
+            buffer.pop()
+        } else {
+            self.inline.pop()
+        };
+        Ok(interp.convert(value.map(|value| Value::new(interp, value))))
+    }
+
+    pub fn reverse(&mut self, interp: &Artichoke) -> Result<(), Box<dyn RubyException>> {
+        let _ = interp;
+        if let Some(ref mut buffer) = self.dynamic {
+            buffer.reverse();
+        } else if !self.inline.is_empty() {
+            let mut left = 0;
+            let mut right = self.inline.len() - 1;
+            while left < right {
+                self.inline.swap(left, right);
+                left += 1;
+                right -= 1;
+            }
+        }
+        Ok(())
+    }
+}
+
+fn set_with_drain_sparse(ary: &mut InlineBuffer, start: usize, elem: Value) {
+    let nil = unsafe { sys::mrb_sys_nil_value() };
+    let buflen = ary.len();
+    if start < ary.inline.capacity() {
+        if let Some(ref buffer) = ary.dynamic {
+            for idx in 0..buflen {
+                ary.inline[idx] = unsafe { *buffer.get_unchecked(idx) };
+            }
+            for idx in buflen..start {
+                ary.inline[idx] = nil;
+            }
+            ary.inline.insert(start, elem.inner());
+            ary.dynamic = None;
+        } else {
+            for idx in buflen..start {
+                ary.inline[idx] = nil;
+            }
+            ary.inline.insert(start, elem.inner());
+        }
+        unsafe {
+            ary.inline.set_len(start + 1);
+        }
+    } else {
+        if let Some(ref mut buffer) = ary.dynamic {
+            for _ in buflen..start {
+                buffer.push(nil);
+            }
+            buffer.push(elem.inner());
+        } else {
+            let mut buffer = Vec::with_capacity(start + 1);
+            for elem in &ary.inline {
+                buffer.push(*elem);
+            }
+            for _ in buflen..start {
+                buffer.push(nil);
+            }
+            buffer.push(elem.inner());
+            ary.dynamic = Some(buffer);
+        }
+    }
+}
+
+fn set_with_drain_to_inline(ary: &mut InlineBuffer, start: usize, drain: usize, elem: Value) {
+    let buflen = ary.len();
+    if let Some(ref buffer) = ary.dynamic {
+        for idx in 0..start {
+            ary.inline[idx] = unsafe { *buffer.get_unchecked(idx) };
+        }
+        ary.inline.insert(start, elem.inner());
+        if start + drain > ary.inline.len() {
+            unsafe {
+                ary.inline.set_len(start + 1);
+            }
+        } else {
+            for _ in 0..drain {
+                ary.inline.remove(start + 1);
+            }
+            unsafe {
+                ary.inline.set_len(buflen - drain + 1);
+            }
+        }
+        ary.dynamic = None;
+    } else {
+        ary.inline.insert(start, elem.inner());
+        if start + drain > ary.inline.len() {
+            unsafe {
+                ary.inline.set_len(start + 1);
+            }
+        } else {
+            for _ in 0..drain {
+                ary.inline.remove(start + 1);
+            }
+            unsafe {
+                ary.inline.set_len(buflen - drain + 1);
+            }
+        }
+    }
+}
+
+fn set_slice_with_drain_sparse(ary: &mut InlineBuffer, start: usize, with: &InlineBuffer) {
+    let buflen = ary.len();
+    let nil = unsafe { sys::mrb_sys_nil_value() };
+    if let Some(ref mut buffer) = ary.dynamic {
+        for _ in buflen..start {
+            buffer.push(nil);
+        }
+        if let Some(ref other) = with.dynamic {
+            buffer.extend(other.clone());
+        } else {
+            for elem in &with.inline {
+                buffer.push(*elem);
+            }
+        }
+    } else if start + with.len() < ary.inline.capacity() {
+        for _ in buflen..start {
+            unsafe {
+                ary.inline.push_unchecked(nil);
+            }
+        }
+        if let Some(ref other) = with.dynamic {
+            for elem in other {
+                unsafe {
+                    ary.inline.push_unchecked(*elem);
+                }
+            }
+        } else {
+            for elem in &with.inline {
+                unsafe {
+                    ary.inline.push_unchecked(*elem);
+                }
+            }
+        }
+    }
+}
+
+fn set_slice_with_drain_to_inline(
+    ary: &mut InlineBuffer,
+    start: usize,
+    drain: usize,
+    with: &InlineBuffer,
+) {
+    if let Some(ref mut buffer) = ary.dynamic {
+        ary.inline.clear();
+        for elem in buffer.drain(0..start) {
+            unsafe {
+                ary.inline.push_unchecked(elem);
+            }
+        }
+        buffer.drain(0..drain);
+        if let Some(ref other) = with.dynamic {
+            for elem in other {
+                unsafe {
+                    ary.inline.push_unchecked(*elem);
+                }
+            }
+        } else {
+            for elem in &with.inline {
+                unsafe {
+                    ary.inline.push_unchecked(*elem);
+                }
+            }
+        }
+        for elem in buffer.drain(..) {
+            unsafe {
+                ary.inline.push_unchecked(elem);
+            }
+        }
+        ary.dynamic = None;
+    } else {
+        if start + drain > ary.inline.len() {
+            unsafe {
+                ary.inline.set_len(start);
+            }
+            if let Some(ref buffer) = with.dynamic {
+                for elem in buffer {
+                    unsafe {
+                        ary.inline.push_unchecked(*elem);
+                    }
+                }
+            } else {
+                for elem in &with.inline {
+                    unsafe {
+                        ary.inline.push_unchecked(*elem);
+                    }
+                }
+            }
+        } else {
+            if drain >= with.len() {
+                if let Some(ref buffer) = with.dynamic {
+                    for (idx, elem) in buffer.iter().enumerate() {
+                        ary.inline[start + idx] = *elem;
+                    }
+                } else {
+                    for (idx, elem) in with.inline.iter().enumerate() {
+                        ary.inline[start + idx] = *elem;
+                    }
+                }
+                for _ in with.len()..drain {
+                    ary.inline.remove(start + with.len());
+                }
+            } else {
+                if let Some(ref buffer) = with.dynamic {
+                    for idx in 0..drain {
+                        ary.inline[start + idx] = unsafe { *buffer.get_unchecked(idx) };
+                    }
+                    for idx in (drain..with.len()).rev() {
+                        ary.inline
+                            .insert(start + drain, unsafe { *buffer.get_unchecked(idx) });
+                    }
+                } else {
+                    for idx in 0..drain {
+                        ary.inline[start + idx] = unsafe { *with.inline.get_unchecked(idx) };
+                    }
+                    for idx in (drain..with.len()).rev() {
+                        ary.inline
+                            .insert(start + drain, unsafe { *with.inline.get_unchecked(idx) });
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn set_slice_with_drain_to_dynamic(
+    ary: &mut InlineBuffer,
+    start: usize,
+    drain: usize,
+    with: &InlineBuffer,
+) {
+    if let Some(ref mut buffer) = ary.dynamic {
+        if let Some(ref other) = with.dynamic {
+            buffer.splice(start..start + drain, other.clone());
+        } else {
+            buffer.splice(start..start + drain, with.inline.as_slice().to_vec());
+        }
+    } else {
+        let mut buffer = ary.inline.as_slice().to_vec();
+        if let Some(ref other) = with.dynamic {
+            buffer.splice(start..start + drain, other.clone());
+        } else {
+            buffer.splice(start..start + drain, with.inline.as_slice().to_vec());
+        }
+        ary.dynamic = Some(buffer);
+    }
+}
+
+fn concat_to_inline(ary: &mut InlineBuffer, other: &InlineBuffer) {
+    match (ary.dynamic.as_mut(), other.dynamic.as_ref()) {
+        (Some(buf), Some(otherbuf)) => {
+            unsafe {
+                ary.inline.set_len(0);
+            }
+            for elem in buf {
+                unsafe {
+                    ary.inline.push_unchecked(*elem);
+                }
+            }
+            for elem in otherbuf {
+                unsafe {
+                    ary.inline.push_unchecked(*elem);
+                }
+            }
+            ary.dynamic = None;
+        }
+        (Some(buf), None) => {
+            unsafe {
+                ary.inline.set_len(0);
+            }
+            for elem in buf {
+                unsafe {
+                    ary.inline.push_unchecked(*elem);
+                }
+            }
+            for elem in &other.inline {
+                unsafe {
+                    ary.inline.push_unchecked(*elem);
+                }
+            }
+            ary.dynamic = None;
+        }
+        (None, Some(otherbuf)) => {
+            for elem in otherbuf {
+                unsafe {
+                    ary.inline.push_unchecked(*elem);
+                }
+            }
+        }
+        (None, None) => {
+            for elem in &other.inline {
+                unsafe {
+                    ary.inline.push_unchecked(*elem);
+                }
+            }
+        }
+    };
+}
+
+fn concat_to_dynamic(ary: &mut InlineBuffer, other: &InlineBuffer) {
+    match (ary.dynamic.as_mut(), other.dynamic.as_ref()) {
+        (Some(buf), Some(otherbuf)) => {
+            buf.extend(otherbuf.clone());
+        }
+        (Some(buf), None) => {
+            for elem in &other.inline {
+                buf.push(*elem);
+            }
+        }
+        (None, Some(otherbuf)) => {
+            let mut buf = ary.inline.as_slice().to_vec();
+            buf.reserve(otherbuf.len());
+            for elem in otherbuf {
+                buf.push(*elem);
+            }
+            ary.dynamic = Some(buf);
+        }
+        (None, None) => {
+            let mut buf = Vec::with_capacity(ary.len() + other.len());
+            for elem in &ary.inline {
+                buf.push(*elem);
+            }
+            for elem in &other.inline {
+                buf.push(*elem);
+            }
+            ary.dynamic = Some(buf);
+        }
+    };
+}

--- a/artichoke-backend/src/extn/core/array/inline_buffer.rs
+++ b/artichoke-backend/src/extn/core/array/inline_buffer.rs
@@ -7,10 +7,12 @@ use crate::sys;
 use crate::value::Value;
 use crate::Artichoke;
 
+const INLINE_CAPACITY: usize = 8;
+
 #[derive(Clone)]
 pub struct InlineBuffer {
     dynamic: Option<Vec<sys::mrb_value>>,
-    inline: ArrayVec<[sys::mrb_value; 8]>,
+    inline: ArrayVec<[sys::mrb_value; INLINE_CAPACITY]>,
 }
 
 impl Default for InlineBuffer {

--- a/artichoke-backend/src/extn/core/array/mruby.rs
+++ b/artichoke-backend/src/extn/core/array/mruby.rs
@@ -1,12 +1,18 @@
+#[cfg(feature = "artichoke-array")]
 use std::convert::TryFrom;
 
+#[cfg(feature = "artichoke-array")]
 use crate::convert::Convert;
 #[cfg(feature = "artichoke-array")]
 use crate::def::{rust_data_free, ClassLike, Define};
 use crate::eval::Eval;
+#[cfg(feature = "artichoke-array")]
 use crate::extn::core::array;
+#[cfg(feature = "artichoke-array")]
 use crate::extn::core::exception;
+#[cfg(feature = "artichoke-array")]
 use crate::sys;
+#[cfg(feature = "artichoke-array")]
 use crate::value::Value;
 use crate::{Artichoke, ArtichokeError};
 
@@ -62,6 +68,7 @@ pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
     Ok(())
 }
 
+#[cfg(feature = "artichoke-array")]
 unsafe extern "C" fn ary_pop(mrb: *mut sys::mrb_state, ary: sys::mrb_value) -> sys::mrb_value {
     let interp = unwrap_interpreter!(mrb);
     let array = Value::new(&interp, ary);
@@ -76,6 +83,7 @@ unsafe extern "C" fn ary_pop(mrb: *mut sys::mrb_state, ary: sys::mrb_value) -> s
     }
 }
 
+#[cfg(feature = "artichoke-array")]
 unsafe extern "C" fn ary_len(mrb: *mut sys::mrb_state, ary: sys::mrb_value) -> sys::mrb_value {
     mrb_get_args!(mrb, none);
     let interp = unwrap_interpreter!(mrb);
@@ -88,7 +96,9 @@ unsafe extern "C" fn ary_len(mrb: *mut sys::mrb_state, ary: sys::mrb_value) -> s
     }
 }
 
+#[cfg(feature = "artichoke-array")]
 unsafe extern "C" fn ary_concat(mrb: *mut sys::mrb_state, ary: sys::mrb_value) -> sys::mrb_value {
+    println!("ary concat C");
     let other = mrb_get_args!(mrb, optional = 1);
     let interp = unwrap_interpreter!(mrb);
     let array = Value::new(&interp, ary);
@@ -104,6 +114,7 @@ unsafe extern "C" fn ary_concat(mrb: *mut sys::mrb_state, ary: sys::mrb_value) -
     }
 }
 
+#[cfg(feature = "artichoke-array")]
 unsafe extern "C" fn ary_initialize(
     mrb: *mut sys::mrb_state,
     ary: sys::mrb_value,
@@ -124,6 +135,7 @@ unsafe extern "C" fn ary_initialize(
     }
 }
 
+#[cfg(feature = "artichoke-array")]
 unsafe extern "C" fn ary_initialize_copy(
     mrb: *mut sys::mrb_state,
     ary: sys::mrb_value,
@@ -143,6 +155,7 @@ unsafe extern "C" fn ary_initialize_copy(
     }
 }
 
+#[cfg(feature = "artichoke-array")]
 unsafe extern "C" fn ary_reverse_bang(
     mrb: *mut sys::mrb_state,
     ary: sys::mrb_value,
@@ -161,6 +174,7 @@ unsafe extern "C" fn ary_reverse_bang(
     }
 }
 
+#[cfg(feature = "artichoke-array")]
 unsafe extern "C" fn ary_element_reference(
     mrb: *mut sys::mrb_state,
     ary: sys::mrb_value,
@@ -177,6 +191,7 @@ unsafe extern "C" fn ary_element_reference(
     }
 }
 
+#[cfg(feature = "artichoke-array")]
 unsafe extern "C" fn ary_element_assignment(
     mrb: *mut sys::mrb_state,
     ary: sys::mrb_value,

--- a/artichoke-backend/src/ffi.rs
+++ b/artichoke-backend/src/ffi.rs
@@ -83,9 +83,6 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
-    // This test is no longer valid now that initializing the core creates
-    // `Array` objects which clone the interpreter.
     fn from_user_data_rc_refcount() {
         let interp = crate::interpreter().expect("init");
         assert_eq!(Rc::strong_count(&interp.0), 1);

--- a/artichoke-backend/vendor/mruby/include/mrbconf.h
+++ b/artichoke-backend/vendor/mruby/include/mrbconf.h
@@ -225,6 +225,8 @@
 #  define ARY_SHIFT(mrb, ary)                  artichoke_ary_shift(mrb, ary)
 #  define ARY_UNSHIFT(mrb, ary, val)           artichoke_ary_unshift(mrb, ary, val)
 #  define ARRAY_LEN(mrb, ary)                  artichoke_ary_len(mrb, ary)
+#  define ARRAY_SET_LEN(mrb, ary, len)         artichoke_ary_set_len(mrb, ary, len)
+#  define ARRAY_PTR(mrb, ary)                  artichoke_ary_ptr(mrb, ary)
 #  define ARY_CHECK(mrb, ary)                  artichoke_ary_check(mrb, ary)
 #else
 #  define ARY_NEW(mrb)                         mrb_ary_new(mrb)
@@ -239,6 +241,8 @@
 #  define ARY_SHIFT(mrb, ary)                  mrb_ary_shift(mrb, ary)
 #  define ARY_UNSHIFT(mrb, ary, val)           mrb_ary_unshift(mrb, ary, val)
 #  define ARRAY_LEN(mrb, ary)                  RARRAY_LEN(ary)
+#  define ARRAY_SET_LEN(mrb, ary, len)         ARY_SET_LEN(mrb_ary_ptr(ary), len)
+#  define ARRAY_PTR(mrb, ary)                  RARRAY_PTR(ary)
 #  define ARY_CHECK(mrb, ary)                  mrb_array_p(ary)
 #endif
 

--- a/artichoke-backend/vendor/mruby/src/class.c
+++ b/artichoke-backend/vendor/mruby/src/class.c
@@ -544,15 +544,7 @@ mrb_get_argv(mrb_state *mrb)
   mrb_int argc = mrb->c->ci->argc;
   mrb_value *array_argv;
   if (argc < 0) {
-    mrb_int argc = ARRAY_LEN(mrb, mrb->c->stack[1]);
-    mrb_gc_protect(mrb, mrb->c->stack[1]);
-    mrb_value argv_mrb = mrb_ary_new_capa(mrb, argc);
-    mrb_gc_protect(mrb, argv_mrb);
-    array_argv = RARRAY_PTR(argv_mrb);
-    int udx;
-    for (udx = 0; udx < argc; udx++) {
-      array_argv[udx] = ARY_REF(mrb, mrb->c->stack[1], udx);
-    }
+    array_argv = ARRAY_PTR(mrb, mrb->c->stack[1]);
   }
   else {
     array_argv = NULL;

--- a/artichoke-backend/vendor/mruby/src/error.c
+++ b/artichoke-backend/vendor/mruby/src/error.c
@@ -175,10 +175,12 @@ set_backtrace(mrb_state *mrb, mrb_value exc, mrb_value backtrace)
     mrb_raise(mrb, E_TYPE_ERROR, "backtrace must be Array of String");
   }
   else {
-    int i;
-    for (i = 0; i < ARRAY_LEN(mrb, backtrace); i++) {
-      mrb_value p = ARY_REF(mrb, backtrace, i);
-      if (!mrb_string_p(p)) goto type_err;
+    const mrb_value *p = ARRAY_PTR(mrb, backtrace);
+    const mrb_value *pend = p + ARRAY_LEN(mrb, backtrace);
+
+    while (p < pend) {
+      if (!mrb_string_p(*p)) goto type_err;
+      p++;
     }
   }
   mrb_iv_set(mrb, exc, mrb_intern_lit(mrb, "backtrace"), backtrace);

--- a/artichoke-backend/vendor/mruby/src/init.c
+++ b/artichoke-backend/vendor/mruby/src/init.c
@@ -49,7 +49,5 @@ mrb_init_core(mrb_state *mrb)
   mrb_init_range(mrb); DONE;
   mrb_init_gc(mrb); DONE;
   mrb_init_version(mrb); DONE;
-#ifndef ARTICHOKE
-  mrb_init_mrblib(mrb); DONE;
-#endif
+  // mrb_init_mrblib(mrb); DONE;
 }

--- a/scripts/lint.js
+++ b/scripts/lint.js
@@ -35,13 +35,11 @@ const walk = dir => {
                 if (error) {
                   pathReject(error);
                 } else if (stats.isDirectory()) {
-                  if (!IGNORE_DIRECTORIES.includes(file)) {
-                    walk(filepath).then(pathResolve);
-                  } else {
-                    pathResolve(null);
-                  }
+                  walk(filepath).then(pathResolve);
                 } else if (stats.isFile()) {
                   pathResolve(filepath);
+                } else {
+                  pathReject(filepath);
                 }
               });
             });

--- a/scripts/lint.js
+++ b/scripts/lint.js
@@ -302,29 +302,16 @@ async function rustFormatter() {
 
 async function clippyLinter() {
   return new Promise((resolve, reject) => {
-    if (checkMode) {
-      execAsync("cargo", ["clippy", "--", "-D", "warnings"], (err, code) => {
-        if (err) {
-          reject(err);
-        } else if (code === 0) {
-          resolve(true);
-        } else {
-          console.error("KO: cargo clippy");
-          resolve(false);
-        }
-      });
-    } else {
-      execAsync("cargo", ["clippy"], (err, code) => {
-        if (err) {
-          reject(err);
-        } else if (code === 0) {
-          resolve(true);
-        } else {
-          console.error("KO: cargo clippy");
-          resolve(false);
-        }
-      });
-    }
+    execAsync("cargo", ["clippy", "--", "-D", "warnings"], (err, code) => {
+      if (err) {
+        reject(err);
+      } else if (code === 0) {
+        resolve(true);
+      } else {
+        console.error("KO: cargo clippy");
+        resolve(false);
+      }
+    });
   });
 }
 


### PR DESCRIPTION
`InlineBuffer` is a new Array implementation based on `Vec` and
`ArrayVec`. `Array`s with 8 elements or fewer are inlined into the
struct body. Larger `Arrays` are stored elsewhere on the heap in a
`Vec`.

`InlineBuffer` has a similar but not identical API to `ArrayType`. It partially implements `ArrayType` with this API. The other `ArrayType` backends are disabled with this
commit.

`InlineBuffer` supports moving `Array` contents from inline to dynamic
storage and back according to resizes and mutations.

`InlineBuffer` comes with a massive simplification of the modifications
to the mruby VM required to inject an Artichoke `Array`. This is
possible because:

- `InlineBuffer` stores `sys::mrb_value` rather than `Value`.
- `InlineBuffer` is coercable to `*const sys::mrb_value` and
  `*mut sys::mrb_value`.
- `InlineBuffer` supports a `set_len` API to enable mutating via raw
  pointers in the mruby VM.

This patch speeds up execution of the passing ruby/specs slightly.

I hope this patch will eliminate the segfaults and allow deploying the
playground with all features and maybe upgrading to the LLVM emcc
backend.