### PR TITLE
Make checkout the first step of every job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,6 @@ commands:
   setup-linux-builder:
     description: Setup Artichoke Linux builder image
     steps:
-      - checkout
       - run:
           name: Install Rust Toolchain
           command: |
@@ -36,7 +35,6 @@ commands:
   setup-windows-builder:
     description: Setup Artichoke Windows builder image
     steps:
-      - checkout
       - restore_cache:
           name: Restore sccache cache
           key: v2-sccache-cache-stable-{{ arch }}-{{ .Environment.CIRCLE_JOB }}
@@ -135,6 +133,7 @@ jobs:
       - image: circleci/ruby:2.6.3-buster
     resource_class: large
     steps:
+      - checkout
       - restore_cache:
           name: Restore sccache cache
           key: v2-sccache-cache-stable-{{ arch }}-{{ .Environment.CIRCLE_JOB }}
@@ -165,6 +164,7 @@ jobs:
     executor:
       name: win/default
     steps:
+      - checkout
       - restore_cache:
           name: Restore sccache cache
           key: v2-sccache-cache-stable-{{ arch }}-{{ .Environment.CIRCLE_JOB }}
@@ -198,6 +198,7 @@ jobs:
       - image: circleci/ruby:2.6.3-buster
     resource_class: large
     steps:
+      - checkout
       - restore_cache:
           name: Restore sccache cache
           key: v2-sccache-cache-stable-{{ arch }}-{{ .Environment.CIRCLE_JOB }}
@@ -217,6 +218,7 @@ jobs:
       - image: circleci/ruby:2.6.3-buster-node
     resource_class: large
     steps:
+      - checkout
       - restore_cache:
           key: v2-node-modules-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum "yarn.lock" }}
       - restore_cache:


### PR DESCRIPTION
Without this change, caches that depend on checksums of lockfiles fail to load, like yarn deps.