### PR TITLE
Implement Random core class and random functions in Kernel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,6 +49,7 @@ dependencies = [
  "onig 5.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck_macros 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -677,6 +678,7 @@ dependencies = [
  "rand_chacha 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_pcg 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -728,6 +730,14 @@ dependencies = [
  "rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1248,6 +1258,7 @@ dependencies = [
 "checksum rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 "checksum rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 "checksum rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
+"checksum rand_pcg 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
 "checksum rayon 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "83a27732a533a1be0a0035a111fe76db89ad312f6f0347004c220c57f209a123"
 "checksum rayon-core 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "98dcf634205083b17d0861252431eb2acbfb698ab7478a2d20de07954f47ec7b"
 "checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -21,6 +21,11 @@ path = "../artichoke-core"
 [dependencies.artichoke-vfs]
 path = "../artichoke-vfs"
 
+[dependencies.rand]
+version = "0.7"
+optional = true
+features = ["small_rng"]
+
 [dev-dependencies]
 env_logger = "0.7"
 libc = "0.2"
@@ -42,7 +47,8 @@ version = "0.51.1"
 default-features = false
 
 [features]
-default = ["artichoke-array", "artichoke-system-environ"]
+default = ["artichoke-array", "artichoke-random", "artichoke-system-environ"]
 artichoke-array = []
 artichoke-debug = ["backtrace"]
+artichoke-random = ["rand"]
 artichoke-system-environ = []

--- a/artichoke-backend/src/convert/array.rs
+++ b/artichoke-backend/src/convert/array.rs
@@ -1,12 +1,11 @@
 // use std::collections::HashMap;
 use std::convert::TryFrom;
 
-use crate::convert::float::Float;
 use crate::convert::{Convert, TryConvert};
 #[cfg(feature = "artichoke-array")]
 use crate::extn::core::array::{Array, InlineBuffer};
 use crate::sys;
-use crate::types::{Int, Ruby, Rust};
+use crate::types::{Float, Int, Ruby, Rust};
 use crate::value::{Value, ValueLike};
 use crate::{Artichoke, ArtichokeError};
 

--- a/artichoke-backend/src/convert/float.rs
+++ b/artichoke-backend/src/convert/float.rs
@@ -1,10 +1,8 @@
 use crate::convert::{Convert, TryConvert};
 use crate::sys;
-use crate::types::{Ruby, Rust};
+use crate::types::{Float, Ruby, Rust};
 use crate::value::Value;
 use crate::{Artichoke, ArtichokeError};
-
-pub type Float = f64;
 
 impl Convert<Float, Value> for Artichoke {
     fn convert(&self, value: Float) -> Value {
@@ -32,11 +30,10 @@ impl TryConvert<Value, Float> for Artichoke {
 mod tests {
     use quickcheck_macros::quickcheck;
 
-    use crate::convert::float::Float;
     use crate::convert::Convert;
     use crate::eval::Eval;
     use crate::sys;
-    use crate::types::{Ruby, Rust};
+    use crate::types::{Float, Ruby, Rust};
     use crate::value::ValueLike;
     use crate::ArtichokeError;
 

--- a/artichoke-backend/src/convert/hash.rs
+++ b/artichoke-backend/src/convert/hash.rs
@@ -2,12 +2,11 @@ use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::hash::BuildHasher;
 
-use crate::convert::float::Float;
 use crate::convert::{Convert, TryConvert};
 #[cfg(feature = "artichoke-array")]
 use crate::extn::core::array;
 use crate::sys;
-use crate::types::{Int, Ruby, Rust};
+use crate::types::{Float, Int, Ruby, Rust};
 use crate::value::{Value, ValueLike};
 use crate::{Artichoke, ArtichokeError};
 

--- a/artichoke-backend/src/convert/nilable.rs
+++ b/artichoke-backend/src/convert/nilable.rs
@@ -3,10 +3,9 @@
 
 use std::collections::HashMap;
 
-use crate::convert::float::Float;
 use crate::convert::{Convert, TryConvert};
 use crate::sys;
-use crate::types::{Int, Ruby};
+use crate::types::{Float, Int, Ruby};
 use crate::value::{Value, ValueLike};
 use crate::{Artichoke, ArtichokeError};
 

--- a/artichoke-backend/src/extn/core/float/mod.rs
+++ b/artichoke-backend/src/extn/core/float/mod.rs
@@ -1,4 +1,5 @@
 use crate::eval::Eval;
+use crate::types;
 use crate::{Artichoke, ArtichokeError};
 
 pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
@@ -15,5 +16,5 @@ pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
 pub struct Float;
 
 impl Float {
-    pub const EPSILON: f64 = std::f64::EPSILON;
+    pub const EPSILON: types::Float = std::f64::EPSILON;
 }

--- a/artichoke-backend/src/extn/core/kernel/kernel.rb
+++ b/artichoke-backend/src/extn/core/kernel/kernel.rb
@@ -111,6 +111,18 @@ module Kernel
     e.result
   end
 
+  def rand(max = 0)
+    if max == 0 # rubocop:disable Style/NumericPredicate
+      Random.rand
+    else
+      Random.rand(max)
+    end
+  end
+
+  def srand(number = Random.new_seed)
+    Random.srand(number)
+  end
+
   # 11.4.4 Step c)
   def !~(other)
     !(self =~ other) # rubocop:disable Style/InverseMethods

--- a/artichoke-backend/src/extn/core/mod.rs
+++ b/artichoke-backend/src/extn/core/mod.rs
@@ -20,6 +20,8 @@ pub mod module;
 pub mod numeric;
 pub mod object;
 pub mod proc;
+#[cfg(feature = "artichoke-random")]
+pub mod random;
 pub mod range;
 pub mod regexp;
 pub mod string;
@@ -51,6 +53,8 @@ pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
     module::init(interp)?;
     object::init(interp)?;
     proc::init(interp)?;
+    #[cfg(feature = "artichoke-random")]
+    random::mruby::init(interp)?;
     range::init(interp)?;
     regexp::mruby::init(interp)?;
     string::init(interp)?;

--- a/artichoke-backend/src/extn/core/random/backend/default.rs
+++ b/artichoke-backend/src/extn/core/random/backend/default.rs
@@ -1,0 +1,47 @@
+use crate::extn::core::exception::RubyException;
+use crate::extn::core::random;
+use crate::types::{Float, Int};
+use crate::Artichoke;
+
+#[derive(Default, Debug, Clone, Copy)]
+pub struct Default;
+
+impl random::Rand for Default {
+    fn bytes(&mut self, interp: &Artichoke, buf: &mut [u8]) -> Result<(), Box<dyn RubyException>> {
+        let mut borrow = interp.0.borrow_mut();
+        let prng = borrow.prng_mut();
+        prng.inner_mut().bytes(interp, buf)?;
+        Ok(())
+    }
+
+    fn seed(&self, interp: &Artichoke) -> Result<u64, Box<dyn RubyException>> {
+        let borrow = interp.0.borrow_mut();
+        let prng = borrow.prng();
+        let seed = prng.inner().seed(interp)?;
+        Ok(seed)
+    }
+
+    fn has_same_internal_state(&self, interp: &Artichoke, other: &dyn random::Rand) -> bool {
+        let borrow = interp.0.borrow_mut();
+        let prng = borrow.prng();
+        prng.inner().has_same_internal_state(interp, other)
+    }
+
+    fn rand_int(&mut self, interp: &Artichoke, max: Int) -> Result<Int, Box<dyn RubyException>> {
+        let mut borrow = interp.0.borrow_mut();
+        let prng = borrow.prng_mut();
+        let rand = prng.inner_mut().rand_int(interp, max)?;
+        Ok(rand)
+    }
+
+    fn rand_float(
+        &mut self,
+        interp: &Artichoke,
+        max: Option<Float>,
+    ) -> Result<Float, Box<dyn RubyException>> {
+        let mut borrow = interp.0.borrow_mut();
+        let prng = borrow.prng_mut();
+        let rand = prng.inner_mut().rand_float(interp, max)?;
+        Ok(rand)
+    }
+}

--- a/artichoke-backend/src/extn/core/random/backend/default.rs
+++ b/artichoke-backend/src/extn/core/random/backend/default.rs
@@ -1,12 +1,16 @@
 use crate::extn::core::exception::RubyException;
-use crate::extn::core::random;
+use crate::extn::core::random::backend;
 use crate::types::{Float, Int};
 use crate::Artichoke;
+
+pub fn new() -> Box<dyn backend::Rand> {
+    Box::new(Default::default())
+}
 
 #[derive(Default, Debug, Clone, Copy)]
 pub struct Default;
 
-impl random::Rand for Default {
+impl backend::Rand for Default {
     fn bytes(&mut self, interp: &Artichoke, buf: &mut [u8]) -> Result<(), Box<dyn RubyException>> {
         let mut borrow = interp.0.borrow_mut();
         let prng = borrow.prng_mut();
@@ -21,7 +25,7 @@ impl random::Rand for Default {
         Ok(seed)
     }
 
-    fn has_same_internal_state(&self, interp: &Artichoke, other: &dyn random::Rand) -> bool {
+    fn has_same_internal_state(&self, interp: &Artichoke, other: &dyn backend::Rand) -> bool {
         let borrow = interp.0.borrow_mut();
         let prng = borrow.prng();
         prng.inner().has_same_internal_state(interp, other)

--- a/artichoke-backend/src/extn/core/random/backend/mod.rs
+++ b/artichoke-backend/src/extn/core/random/backend/mod.rs
@@ -1,0 +1,2 @@
+pub mod default;
+pub mod rand;

--- a/artichoke-backend/src/extn/core/random/backend/mod.rs
+++ b/artichoke-backend/src/extn/core/random/backend/mod.rs
@@ -1,2 +1,36 @@
+use std::any::Any;
+
+use crate::extn::core::exception::RubyException;
+use crate::types::{Float, Int};
+use crate::Artichoke;
+
 pub mod default;
 pub mod rand;
+
+/// Common API for [`Random`](crate::extn::core::random::Random) backends.
+pub trait Rand: Any {
+    /// Completely fill a buffer with random bytes.
+    fn bytes(&mut self, interp: &Artichoke, buf: &mut [u8]) -> Result<(), Box<dyn RubyException>>;
+
+    /// Return the value this backend was seeded with.
+    fn seed(&self, interp: &Artichoke) -> Result<u64, Box<dyn RubyException>>;
+
+    /// Return true if this and `other` would return the same sequence of random
+    /// data.
+    fn has_same_internal_state(&self, interp: &Artichoke, other: &dyn Rand) -> bool;
+
+    /// Return a random `Integer` between 0 and `max` -- `[0, max)`.
+    fn rand_int(&mut self, interp: &Artichoke, max: Int) -> Result<Int, Box<dyn RubyException>>;
+
+    /// Return a random `Float` between 0 and `max` -- `[0, max)`.
+    ///
+    /// If `max` is `None`, return a random `Float between 0 and 1.0 --
+    /// `[0, 1.0)`.
+    fn rand_float(
+        &mut self,
+        interp: &Artichoke,
+        max: Option<Float>,
+    ) -> Result<Float, Box<dyn RubyException>>;
+}
+
+downcast!(dyn Rand);

--- a/artichoke-backend/src/extn/core/random/backend/rand.rs
+++ b/artichoke-backend/src/extn/core/random/backend/rand.rs
@@ -1,0 +1,76 @@
+use rand::distributions::{Distribution, Uniform};
+use rand::rngs::SmallRng;
+use rand::{self, Rng, SeedableRng};
+
+use crate::extn::core::exception::RubyException;
+use crate::extn::core::random;
+use crate::types::{Float, Int};
+use crate::Artichoke;
+
+pub fn new(seed: Option<u64>) -> Box<dyn random::Rand> {
+    Box::new(Rand::<SmallRng>::new(seed))
+}
+
+#[derive(Debug, Clone)]
+pub struct Rand<T> {
+    rng: T,
+    seed: u64,
+}
+
+impl<T> Rand<T>
+where
+    T: SeedableRng,
+{
+    pub fn new(seed: Option<u64>) -> Self {
+        if let Some(seed) = seed {
+            let rng = T::seed_from_u64(seed);
+            Self { rng, seed }
+        } else {
+            let seed = rand::random();
+            let rng = T::seed_from_u64(seed);
+            Self { rng, seed }
+        }
+    }
+}
+
+impl<T> random::Rand for Rand<T>
+where
+    T: 'static + Rng,
+{
+    fn bytes(&mut self, interp: &Artichoke, buf: &mut [u8]) -> Result<(), Box<dyn RubyException>> {
+        let _ = interp;
+        self.rng.fill_bytes(buf);
+        Ok(())
+    }
+
+    fn seed(&self, interp: &Artichoke) -> Result<u64, Box<dyn RubyException>> {
+        let _ = interp;
+        Ok(self.seed)
+    }
+
+    fn has_same_internal_state(&self, interp: &Artichoke, other: &dyn random::Rand) -> bool {
+        let _ = interp;
+        if let Ok(other) = other.downcast_ref::<Self>() {
+            self.seed == other.seed
+        } else {
+            false
+        }
+    }
+
+    fn rand_int(&mut self, interp: &Artichoke, max: Int) -> Result<Int, Box<dyn RubyException>> {
+        let _ = interp;
+        let between = Uniform::from(0..max);
+        Ok(between.sample(&mut self.rng))
+    }
+
+    fn rand_float(
+        &mut self,
+        interp: &Artichoke,
+        max: Option<Float>,
+    ) -> Result<Float, Box<dyn RubyException>> {
+        let _ = interp;
+        let max = max.unwrap_or(1.0);
+        let between = Uniform::from(0.0..max);
+        Ok(between.sample(&mut self.rng))
+    }
+}

--- a/artichoke-backend/src/extn/core/random/backend/rand.rs
+++ b/artichoke-backend/src/extn/core/random/backend/rand.rs
@@ -22,14 +22,9 @@ where
     T: SeedableRng,
 {
     pub fn new(seed: Option<u64>) -> Self {
-        if let Some(seed) = seed {
-            let rng = T::seed_from_u64(seed);
-            Self { rng, seed }
-        } else {
-            let seed = rand::random();
-            let rng = T::seed_from_u64(seed);
-            Self { rng, seed }
-        }
+        let seed = seed.unwrap_or_else(rand::random);
+        let rng = T::seed_from_u64(seed);
+        Self { rng, seed }
     }
 }
 

--- a/artichoke-backend/src/extn/core/random/backend/rand.rs
+++ b/artichoke-backend/src/extn/core/random/backend/rand.rs
@@ -3,11 +3,11 @@ use rand::rngs::SmallRng;
 use rand::{self, Rng, SeedableRng};
 
 use crate::extn::core::exception::RubyException;
-use crate::extn::core::random;
+use crate::extn::core::random::backend;
 use crate::types::{Float, Int};
 use crate::Artichoke;
 
-pub fn new(seed: Option<u64>) -> Box<dyn random::Rand> {
+pub fn new(seed: Option<u64>) -> Box<dyn backend::Rand> {
     Box::new(Rand::<SmallRng>::new(seed))
 }
 
@@ -33,7 +33,7 @@ where
     }
 }
 
-impl<T> random::Rand for Rand<T>
+impl<T> backend::Rand for Rand<T>
 where
     T: 'static + Rng,
 {
@@ -48,9 +48,11 @@ where
         Ok(self.seed)
     }
 
-    fn has_same_internal_state(&self, interp: &Artichoke, other: &dyn random::Rand) -> bool {
+    fn has_same_internal_state(&self, interp: &Artichoke, other: &dyn backend::Rand) -> bool {
         let _ = interp;
         if let Ok(other) = other.downcast_ref::<Self>() {
+            // This is not quite right. It needs to take into account bytes
+            // read from the PRNG.
             self.seed == other.seed
         } else {
             false

--- a/artichoke-backend/src/extn/core/random/mod.rs
+++ b/artichoke-backend/src/extn/core/random/mod.rs
@@ -1,6 +1,5 @@
 use artichoke_core::value::Value as _;
 use rand::{self, Rng, RngCore};
-use std::any::Any;
 use std::convert::TryFrom;
 use std::ptr;
 
@@ -19,31 +18,17 @@ pub fn new(seed: Option<u64>) -> Random {
 }
 
 pub fn default() -> Random {
-    Random(Box::new(backend::default::Default::default()))
+    Random(backend::default::new())
 }
 
-pub trait Rand: Any {
-    fn bytes(&mut self, interp: &Artichoke, buf: &mut [u8]) -> Result<(), Box<dyn RubyException>>;
-    fn seed(&self, interp: &Artichoke) -> Result<u64, Box<dyn RubyException>>;
-    fn has_same_internal_state(&self, interp: &Artichoke, other: &dyn Rand) -> bool;
-    fn rand_int(&mut self, interp: &Artichoke, max: Int) -> Result<Int, Box<dyn RubyException>>;
-    fn rand_float(
-        &mut self,
-        interp: &Artichoke,
-        max: Option<Float>,
-    ) -> Result<Float, Box<dyn RubyException>>;
-}
-
-downcast!(dyn Rand);
-
-pub struct Random(Box<dyn Rand>);
+pub struct Random(Box<dyn backend::Rand>);
 
 impl Random {
-    fn inner(&self) -> &dyn Rand {
+    fn inner(&self) -> &dyn backend::Rand {
         self.0.as_ref()
     }
 
-    fn inner_mut(&mut self) -> &mut dyn Rand {
+    fn inner_mut(&mut self) -> &mut dyn backend::Rand {
         self.0.as_mut()
     }
 }

--- a/artichoke-backend/src/extn/core/random/mod.rs
+++ b/artichoke-backend/src/extn/core/random/mod.rs
@@ -46,6 +46,7 @@ pub fn initialize(
 ) -> Result<Value, Box<dyn RubyException>> {
     let rand = if let Some(seed) = seed {
         let seed = seed.implicitly_convert_to_int()?;
+        #[allow(clippy::cast_possible_wrap, clippy::cast_sign_loss)]
         Random(backend::rand::new(Some(seed as u64)))
     } else {
         Random(backend::rand::new(None))
@@ -136,36 +137,36 @@ pub fn rand(
     match max {
         Max::Float(max) => {
             if max < 0.0 {
-                return Err(Box::new(ArgumentError::new(
+                Err(Box::new(ArgumentError::new(
                     interp,
                     format!("invalid argument - {}", max),
-                )));
+                )))
             } else if max == 0.0 {
                 let mut borrow = rand.borrow_mut();
-                let rand = borrow.inner_mut().rand_float(interp, None)?;
-                Ok(interp.convert(rand))
+                let number = borrow.inner_mut().rand_float(interp, None)?;
+                Ok(interp.convert(number))
             } else {
                 let mut borrow = rand.borrow_mut();
-                let rand = borrow.inner_mut().rand_float(interp, Some(max))?;
-                Ok(interp.convert(rand))
+                let number = borrow.inner_mut().rand_float(interp, Some(max))?;
+                Ok(interp.convert(number))
             }
         }
         Max::Int(max) => {
             if max < 1 {
-                return Err(Box::new(ArgumentError::new(
+                Err(Box::new(ArgumentError::new(
                     interp,
                     format!("invalid argument - {}", max),
-                )));
+                )))
             } else {
                 let mut borrow = rand.borrow_mut();
-                let rand = borrow.inner_mut().rand_int(interp, max)?;
-                Ok(interp.convert(rand))
+                let number = borrow.inner_mut().rand_int(interp, max)?;
+                Ok(interp.convert(number))
             }
         }
         Max::None => {
             let mut borrow = rand.borrow_mut();
-            let rand = borrow.inner_mut().rand_float(interp, None)?;
-            Ok(interp.convert(rand))
+            let number = borrow.inner_mut().rand_float(interp, None)?;
+            Ok(interp.convert(number))
         }
     }
 }
@@ -174,6 +175,7 @@ pub fn seed(interp: &Artichoke, rand: Value) -> Result<Value, Box<dyn RubyExcept
     if let Ok(rand) = unsafe { Random::try_from_ruby(interp, &rand) } {
         let borrow = rand.borrow();
         let seed = borrow.inner().seed(interp)?;
+        #[allow(clippy::cast_possible_wrap, clippy::cast_sign_loss)]
         Ok(interp.convert(seed as Int))
     } else {
         Err(Box::new(Fatal::new(
@@ -193,6 +195,7 @@ pub fn srand(interp: &Artichoke, number: Option<Value>) -> Result<Value, Box<dyn
     let _ = number;
     let new_seed = if let Some(number) = number {
         let new_seed = number.implicitly_convert_to_int()?;
+        #[allow(clippy::cast_possible_wrap, clippy::cast_sign_loss)]
         Some(new_seed as u64)
     } else {
         None
@@ -201,6 +204,7 @@ pub fn srand(interp: &Artichoke, number: Option<Value>) -> Result<Value, Box<dyn
     let prng = borrow.prng_mut();
     let old_seed = prng.inner().seed(interp)?;
     prng.0 = backend::rand::new(new_seed);
+    #[allow(clippy::cast_possible_wrap)]
     Ok(interp.convert(old_seed as Int))
 }
 

--- a/artichoke-backend/src/extn/core/random/mod.rs
+++ b/artichoke-backend/src/extn/core/random/mod.rs
@@ -1,0 +1,230 @@
+use artichoke_core::value::Value as _;
+use rand::{self, Rng, RngCore};
+use std::any::Any;
+use std::convert::TryFrom;
+use std::ptr;
+
+use crate::convert::{Convert, RustBackedValue};
+use crate::extn::core::exception::{ArgumentError, Fatal, RubyException};
+use crate::sys;
+use crate::types::{Float, Int};
+use crate::value::Value;
+use crate::Artichoke;
+
+pub mod backend;
+pub mod mruby;
+
+pub fn new(seed: Option<u64>) -> Random {
+    Random(backend::rand::new(seed))
+}
+
+pub fn default() -> Random {
+    Random(Box::new(backend::default::Default::default()))
+}
+
+pub trait Rand: Any {
+    fn bytes(&mut self, interp: &Artichoke, buf: &mut [u8]) -> Result<(), Box<dyn RubyException>>;
+    fn seed(&self, interp: &Artichoke) -> Result<u64, Box<dyn RubyException>>;
+    fn has_same_internal_state(&self, interp: &Artichoke, other: &dyn Rand) -> bool;
+    fn rand_int(&mut self, interp: &Artichoke, max: Int) -> Result<Int, Box<dyn RubyException>>;
+    fn rand_float(
+        &mut self,
+        interp: &Artichoke,
+        max: Option<Float>,
+    ) -> Result<Float, Box<dyn RubyException>>;
+}
+
+downcast!(dyn Rand);
+
+pub struct Random(Box<dyn Rand>);
+
+impl Random {
+    fn inner(&self) -> &dyn Rand {
+        self.0.as_ref()
+    }
+
+    fn inner_mut(&mut self) -> &mut dyn Rand {
+        self.0.as_mut()
+    }
+}
+
+impl RustBackedValue for Random {
+    fn ruby_type_name() -> &'static str {
+        "Random"
+    }
+}
+
+pub fn initialize(
+    interp: &Artichoke,
+    seed: Option<Value>,
+    into: Option<sys::mrb_value>,
+) -> Result<Value, Box<dyn RubyException>> {
+    let rand = if let Some(seed) = seed {
+        let seed = seed.implicitly_convert_to_int()?;
+        Random(backend::rand::new(Some(seed as u64)))
+    } else {
+        Random(backend::rand::new(None))
+    };
+    let result = unsafe { rand.try_into_ruby(&interp, into) }
+        .map_err(|_| Fatal::new(interp, "Unable to initialize Ruby Random with Rust Random"))?;
+    Ok(result)
+}
+
+pub fn eql(interp: &Artichoke, rand: Value, other: Value) -> Result<Value, Box<dyn RubyException>> {
+    if let Ok(rand) = unsafe { Random::try_from_ruby(interp, &rand) } {
+        if let Ok(other) = unsafe { Random::try_from_ruby(interp, &other) } {
+            if ptr::eq(rand.as_ref(), other.as_ref()) {
+                Ok(interp.convert(true))
+            } else {
+                let this_seed = rand.borrow().inner().seed(interp)?;
+                let other_seed = other.borrow().inner().seed(interp)?;
+                Ok(interp.convert(this_seed == other_seed))
+            }
+        } else {
+            Ok(interp.convert(false))
+        }
+    } else {
+        Err(Box::new(Fatal::new(
+            interp,
+            "Failed to extract Rust Random from Ruby Random receiver",
+        )))
+    }
+}
+
+pub fn bytes(
+    interp: &Artichoke,
+    rand: Value,
+    size: Value,
+) -> Result<Value, Box<dyn RubyException>> {
+    let rand = if let Ok(rand) = unsafe { Random::try_from_ruby(interp, &rand) } {
+        rand
+    } else {
+        return Err(Box::new(Fatal::new(
+            interp,
+            "Failed to extract Rust Random from Ruby Random receiver",
+        )));
+    };
+    let size = size.implicitly_convert_to_int()?;
+    if let Ok(size) = usize::try_from(size) {
+        let mut buf = vec![0; size];
+        let mut borrow = rand.borrow_mut();
+        borrow.inner_mut().bytes(interp, buf.as_mut_slice())?;
+        Ok(interp.convert(buf))
+    } else {
+        Err(Box::new(ArgumentError::new(
+            interp,
+            "negative string size (or size too big)",
+        )))
+    }
+}
+
+pub fn rand(
+    interp: &Artichoke,
+    rand: Value,
+    max: Option<Value>,
+) -> Result<Value, Box<dyn RubyException>> {
+    #[derive(Debug, Clone, Copy)]
+    enum Max {
+        Float(Float),
+        Int(Int),
+        None,
+    }
+    let rand = if let Ok(rand) = unsafe { Random::try_from_ruby(interp, &rand) } {
+        rand
+    } else {
+        return Err(Box::new(Fatal::new(
+            interp,
+            "Failed to extract Rust Random from Ruby Random receiver",
+        )));
+    };
+    let max = if let Some(max) = max {
+        if let Ok(max) = max.clone().try_into::<Int>() {
+            Max::Int(max)
+        } else if let Ok(max) = max.clone().try_into::<Float>() {
+            Max::Float(max)
+        } else {
+            Max::Int(max.implicitly_convert_to_int()?)
+        }
+    } else {
+        Max::None
+    };
+    match max {
+        Max::Float(max) => {
+            if max < 0.0 {
+                return Err(Box::new(ArgumentError::new(
+                    interp,
+                    format!("invalid argument - {}", max),
+                )));
+            } else if max == 0.0 {
+                let mut borrow = rand.borrow_mut();
+                let rand = borrow.inner_mut().rand_float(interp, None)?;
+                Ok(interp.convert(rand))
+            } else {
+                let mut borrow = rand.borrow_mut();
+                let rand = borrow.inner_mut().rand_float(interp, Some(max))?;
+                Ok(interp.convert(rand))
+            }
+        }
+        Max::Int(max) => {
+            if max < 1 {
+                return Err(Box::new(ArgumentError::new(
+                    interp,
+                    format!("invalid argument - {}", max),
+                )));
+            } else {
+                let mut borrow = rand.borrow_mut();
+                let rand = borrow.inner_mut().rand_int(interp, max)?;
+                Ok(interp.convert(rand))
+            }
+        }
+        Max::None => {
+            let mut borrow = rand.borrow_mut();
+            let rand = borrow.inner_mut().rand_float(interp, None)?;
+            Ok(interp.convert(rand))
+        }
+    }
+}
+
+pub fn seed(interp: &Artichoke, rand: Value) -> Result<Value, Box<dyn RubyException>> {
+    if let Ok(rand) = unsafe { Random::try_from_ruby(interp, &rand) } {
+        let borrow = rand.borrow();
+        let seed = borrow.inner().seed(interp)?;
+        Ok(interp.convert(seed as Int))
+    } else {
+        Err(Box::new(Fatal::new(
+            interp,
+            "Failed to extract Rust Random from Ruby Random receiver",
+        )))
+    }
+}
+
+pub fn new_seed(interp: &Artichoke) -> Result<Value, Box<dyn RubyException>> {
+    let mut rng = rand::thread_rng();
+    let result = rng.gen::<Int>();
+    Ok(interp.convert(result))
+}
+
+pub fn srand(interp: &Artichoke, number: Option<Value>) -> Result<Value, Box<dyn RubyException>> {
+    let _ = number;
+    let new_seed = if let Some(number) = number {
+        let new_seed = number.implicitly_convert_to_int()?;
+        Some(new_seed as u64)
+    } else {
+        None
+    };
+    let mut borrow = interp.0.borrow_mut();
+    let prng = borrow.prng_mut();
+    let old_seed = prng.inner().seed(interp)?;
+    prng.0 = backend::rand::new(new_seed);
+    Ok(interp.convert(old_seed as Int))
+}
+
+pub fn urandom(interp: &Artichoke, size: Value) -> Result<Value, Box<dyn RubyException>> {
+    let size = size.implicitly_convert_to_int()?;
+    let size = usize::try_from(size)
+        .map_err(|_| ArgumentError::new(interp, "negative string size (or size too big)"))?;
+    let mut bytes = vec![0; size];
+    let mut rng = rand::thread_rng();
+    rng.fill_bytes(bytes.as_mut_slice());
+    Ok(interp.convert(bytes))
+}

--- a/artichoke-backend/src/extn/core/random/mruby.rs
+++ b/artichoke-backend/src/extn/core/random/mruby.rs
@@ -1,0 +1,190 @@
+use crate::convert::RustBackedValue;
+use crate::def::{rust_data_free, ClassLike, Define};
+use crate::eval::Eval;
+use crate::extn::core::exception;
+use crate::extn::core::random;
+use crate::sys;
+use crate::value::Value;
+use crate::{Artichoke, ArtichokeError};
+
+pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
+    if interp.0.borrow().class_spec::<random::Random>().is_some() {
+        return Ok(());
+    }
+
+    let spec = interp.0.borrow_mut().def_class::<random::Random>(
+        "Random",
+        None,
+        Some(rust_data_free::<random::Random>),
+    );
+    spec.borrow_mut().add_self_method(
+        "new_seed",
+        artichoke_random_self_new_seed,
+        sys::mrb_args_req(1),
+    );
+    spec.borrow_mut()
+        .add_self_method("srand", artichoke_random_self_srand, sys::mrb_args_opt(1));
+    spec.borrow_mut().add_self_method(
+        "urandom",
+        artichoke_random_self_urandom,
+        sys::mrb_args_req(1),
+    );
+    spec.borrow_mut().add_method(
+        "initialize",
+        artichoke_random_initialize,
+        sys::mrb_args_opt(1),
+    );
+
+    spec.borrow_mut()
+        .add_method("==", artichoke_random_eq, sys::mrb_args_opt(1));
+    spec.borrow_mut()
+        .add_method("bytes", artichoke_random_bytes, sys::mrb_args_req(1));
+    spec.borrow_mut()
+        .add_method("rand", artichoke_random_rand, sys::mrb_args_opt(1));
+    spec.borrow_mut()
+        .add_method("seed", artichoke_random_seed, sys::mrb_args_none());
+    spec.borrow_mut().mrb_value_is_rust_backed(true);
+    spec.borrow().define(interp)?;
+
+    let default = random::default();
+    let default = unsafe { default.try_into_ruby(interp, None) }?;
+    let mrb = interp.0.borrow().mrb;
+    let rclass = spec.borrow().rclass(interp).ok_or(ArtichokeError::New)?;
+    unsafe {
+        sys::mrb_define_const(
+            mrb,
+            rclass,
+            b"DEFAULT\0".as_ptr() as *const i8,
+            default.inner(),
+        );
+    }
+
+    interp.eval(&include_bytes!("random.rb")[..])?;
+    trace!("Patched ENV onto interpreter");
+    Ok(())
+}
+
+#[no_mangle]
+unsafe extern "C" fn artichoke_random_initialize(
+    mrb: *mut sys::mrb_state,
+    slf: sys::mrb_value,
+) -> sys::mrb_value {
+    let seed = mrb_get_args!(mrb, optional = 1);
+    let interp = unwrap_interpreter!(mrb);
+    let result = random::initialize(
+        &interp,
+        seed.map(|seed| Value::new(&interp, seed)),
+        Some(slf),
+    );
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => exception::raise(interp, exception),
+    }
+}
+
+#[no_mangle]
+unsafe extern "C" fn artichoke_random_eq(
+    mrb: *mut sys::mrb_state,
+    slf: sys::mrb_value,
+) -> sys::mrb_value {
+    let other = mrb_get_args!(mrb, required = 1);
+    let interp = unwrap_interpreter!(mrb);
+    let rand = Value::new(&interp, slf);
+    let other = Value::new(&interp, other);
+    let result = random::eql(&interp, rand, other);
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => exception::raise(interp, exception),
+    }
+}
+
+#[no_mangle]
+unsafe extern "C" fn artichoke_random_bytes(
+    mrb: *mut sys::mrb_state,
+    slf: sys::mrb_value,
+) -> sys::mrb_value {
+    let size = mrb_get_args!(mrb, required = 1);
+    let interp = unwrap_interpreter!(mrb);
+    let rand = Value::new(&interp, slf);
+    let size = Value::new(&interp, size);
+    let result = random::bytes(&interp, rand, size);
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => exception::raise(interp, exception),
+    }
+}
+
+#[no_mangle]
+unsafe extern "C" fn artichoke_random_rand(
+    mrb: *mut sys::mrb_state,
+    slf: sys::mrb_value,
+) -> sys::mrb_value {
+    let max = mrb_get_args!(mrb, optional = 1);
+    let interp = unwrap_interpreter!(mrb);
+    let rand = Value::new(&interp, slf);
+    let max = max.map(|max| Value::new(&interp, max));
+    let result = random::rand(&interp, rand, max);
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => exception::raise(interp, exception),
+    }
+}
+
+#[no_mangle]
+unsafe extern "C" fn artichoke_random_seed(
+    mrb: *mut sys::mrb_state,
+    slf: sys::mrb_value,
+) -> sys::mrb_value {
+    mrb_get_args!(mrb, none);
+    let interp = unwrap_interpreter!(mrb);
+    let rand = Value::new(&interp, slf);
+    let result = random::seed(&interp, rand);
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => exception::raise(interp, exception),
+    }
+}
+
+#[no_mangle]
+unsafe extern "C" fn artichoke_random_self_new_seed(
+    mrb: *mut sys::mrb_state,
+    _slf: sys::mrb_value,
+) -> sys::mrb_value {
+    mrb_get_args!(mrb, none);
+    let interp = unwrap_interpreter!(mrb);
+    let result = random::new_seed(&interp);
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => exception::raise(interp, exception),
+    }
+}
+
+#[no_mangle]
+unsafe extern "C" fn artichoke_random_self_srand(
+    mrb: *mut sys::mrb_state,
+    _slf: sys::mrb_value,
+) -> sys::mrb_value {
+    let number = mrb_get_args!(mrb, optional = 1);
+    let interp = unwrap_interpreter!(mrb);
+    let number = number.map(|number| Value::new(&interp, number));
+    let result = random::srand(&interp, number);
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => exception::raise(interp, exception),
+    }
+}
+
+#[no_mangle]
+unsafe extern "C" fn artichoke_random_self_urandom(
+    mrb: *mut sys::mrb_state,
+    _slf: sys::mrb_value,
+) -> sys::mrb_value {
+    let size = mrb_get_args!(mrb, required = 1);
+    let interp = unwrap_interpreter!(mrb);
+    let size = Value::new(&interp, size);
+    let result = random::urandom(&interp, size);
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => exception::raise(interp, exception),
+    }
+}

--- a/artichoke-backend/src/extn/core/random/random.rb
+++ b/artichoke-backend/src/extn/core/random/random.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class Random
+  def self.bytes(size)
+    DEFAULT.bytes(size)
+  end
+
+  def self.rand(max = (not_set = true))
+    if not_set
+      DEFAULT.rand
+    else
+      DEFAULT.rand(max)
+    end
+  end
+end

--- a/artichoke-backend/src/state.rs
+++ b/artichoke-backend/src/state.rs
@@ -25,6 +25,8 @@ pub struct State {
     pub active_regexp_globals: usize,
     symbol_cache: HashMap<Cow<'static, [u8]>, sys::mrb_sym>,
     captured_output: Option<String>,
+    #[cfg(feature = "artichoke-random")]
+    prng: crate::extn::core::random::Random,
 }
 
 impl State {
@@ -42,7 +44,19 @@ impl State {
             active_regexp_globals: 0,
             symbol_cache: HashMap::default(),
             captured_output: None,
+            #[cfg(feature = "artichoke-random")]
+            prng: crate::extn::core::random::new(None),
         }
+    }
+
+    #[cfg(feature = "artichoke-random")]
+    pub fn prng(&self) -> &crate::extn::core::random::Random {
+        &self.prng
+    }
+
+    #[cfg(feature = "artichoke-random")]
+    pub fn prng_mut(&mut self) -> &mut crate::extn::core::random::Random {
+        &mut self.prng
     }
 
     pub fn capture_output(&mut self) {

--- a/artichoke-backend/src/types.rs
+++ b/artichoke-backend/src/types.rs
@@ -1,5 +1,7 @@
 use crate::sys;
 
+pub type Float = f64;
+
 // Parameterize Fixnum integer type based on architecture.
 #[cfg(not(target_arch = "wasm32"))]
 pub type Int = i64;

--- a/artichoke-backend/src/value.rs
+++ b/artichoke-backend/src/value.rs
@@ -166,7 +166,7 @@ impl Value {
             int
         } else {
             let pretty_name = self.pretty_name();
-            if let Ok(maybe_int) = self.funcall::<Value>("to_int", &[], None) {
+            if let Ok(maybe_int) = self.funcall::<Self>("to_int", &[], None) {
                 let gives_pretty_name = maybe_int.pretty_name();
                 if let Ok(int) = maybe_int.try_into::<Int>() {
                     int

--- a/artichoke-backend/src/value.rs
+++ b/artichoke-backend/src/value.rs
@@ -5,8 +5,7 @@ use std::mem;
 
 use crate::convert::{Convert, TryConvert};
 use crate::exception::{ExceptionHandler, LastError};
-#[cfg(feature = "artichoke-array")]
-use crate::extn::core::array::Array;
+use crate::extn::core::exception::{RubyException, TypeError};
 use crate::gc::MrbGarbageCollection;
 use crate::sys;
 use crate::types::{self, Int, Ruby};
@@ -110,14 +109,7 @@ impl Value {
             "false"
         } else if let Ok(None) = Self::new(&self.interp, self.value).try_into::<Option<Self>>() {
             "nil"
-        } else if self.ruby_type() == Ruby::Data {
-            #[cfg(feature = "artichoke-array")]
-            {
-                use crate::convert::RustBackedValue;
-                if unsafe { Array::try_from_ruby(&self.interp, self) }.is_ok() {
-                    return "Array";
-                }
-            }
+        } else if let Ruby::Data | Ruby::Object = self.ruby_type() {
             self.funcall::<Self>("class", &[], None)
                 .and_then(|class| class.funcall::<&'a str>("name", &[], None))
                 .unwrap_or_default()
@@ -167,6 +159,34 @@ impl Value {
     /// This function can never fail.
     pub fn to_s_debug(&self) -> String {
         format!("{}<{}>", self.ruby_type().class_name(), self.inspect())
+    }
+
+    pub fn implicitly_convert_to_int(&self) -> Result<Int, Box<dyn RubyException>> {
+        let int = if let Ok(int) = self.clone().try_into::<Int>() {
+            int
+        } else {
+            let pretty_name = self.pretty_name();
+            if let Ok(maybe_int) = self.funcall::<Value>("to_int", &[], None) {
+                let gives_pretty_name = maybe_int.pretty_name();
+                if let Ok(int) = maybe_int.try_into::<Int>() {
+                    int
+                } else {
+                    return Err(Box::new(TypeError::new(
+                        &self.interp,
+                        format!(
+                            "can't convert {} to Integer ({}#to_int gives {})",
+                            pretty_name, pretty_name, gives_pretty_name
+                        ),
+                    )));
+                }
+            } else {
+                return Err(Box::new(TypeError::new(
+                    &self.interp,
+                    format!("no implicit conversion of {} into Integer", pretty_name),
+                )));
+            }
+        };
+        Ok(int)
     }
 }
 


### PR DESCRIPTION
This commit implements all APIs of `Random` except for the internal
private method `Random#state` and `Random::Formatter`.

Random is implemented with the `rand` crate's not cryptographically
secure `SmallRng`. For cryptographically secure APIs like
`Random::urandom`, the re-seeding `rand::thread_rng` is used.

`Random` is gated behind a crate feature.

To support the `Random::DEFAULT` interpreter-widre PRNG, the interpreter
stores a `Random` on the `State` and injects a special backend to allow
the `DEFAULT` constant to target this `State`-owned `Random`.

`Random` is implemented with multiple backends and has a small API which
would make supporting a future CRuby algorithm possible. The `Rand`
backend is generic over the `rand::Rng` implementation.

This commit passes 30 ruby/specs and fails 14:

    $ ./scripts/spec.rb artichoke core random
    Passed 30, skipped 0, not implemented 0, failed 14 specs.

The specs that fail fall into the following categories:

- Core class not implemented: Bignum, Struct, Complex, Rational.
- Private methods not implemented.
- PRNG is not the same implementation as the one in CRuby.
- `Encoding` not implemented, particularly `Encoding::ASCII-8BIT`.

This PR does some small refactorings:

- Implement `Value::implicitly_convert_to_int` to simplify arg handling
  in `random` trampoline. All of Artichoke is not fully migrated.
- Move `Float` type alias from float converter to `types` module.

This PR implements the `Random` core class and `Kernel` random
functions. This PR is a partial implementation of GH-34.