### PR TITLE
Update CONTRIBUTING.md for accuracy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,7 +142,8 @@ rbenv rehash
 ```
 
 To lint Ruby sources, Artichoke uses
-[RuboCop](https://github.com/rubocop-hq/rubocop). You can install RuboCop and other ruby dependencies by running:
+[RuboCop](https://github.com/rubocop-hq/rubocop). You can install RuboCop and
+other Ruby dependencies by running:
 
 ```sh
 bundle install

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,18 +118,6 @@ On macOS, you can install Node.js and Yarn with
 brew install node yarn
 ```
 
-### Node.js Packages
-
-Once you have Yarn installed, you can install the packages specified in
-[`package.json`](/package.json) by running:
-
-```sh
-yarn install
-```
-
-You can check to see that this worked by running `yarn lint` and observing no
-errors.
-
 ### Ruby
 
 Artichoke requires a recent Ruby 2.x and [bundler](https://bundler.io/) 2.x. The
@@ -159,6 +147,18 @@ To lint Ruby sources, Artichoke uses
 ```sh
 bundle install
 ```
+
+### Node.js Packages
+
+Once you have Yarn installed, you can install the packages specified in
+[`package.json`](/package.json) by running:
+
+```sh
+yarn install
+```
+
+You can check to see that this worked by running `yarn lint` and observing no
+errors.
 
 ### Shell
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,8 +154,11 @@ rbenv rehash
 ```
 
 To lint Ruby sources, Artichoke uses
-[RuboCop](https://github.com/rubocop-hq/rubocop). `yarn lint` installs RuboCop
-and all other gems automatically.
+[RuboCop](https://github.com/rubocop-hq/rubocop). You can install RuboCop and other ruby dependencies by running:
+
+```sh
+bundle install
+```
 
 ### Shell
 


### PR DESCRIPTION
The Ruby dependencies aren't installed automatically like the documentation suggests. Running `yarn lint` will fail with the following message unless you have first run `bundle install`:

```
Could not find jaro_winkler-1.5.4 in any of the sources
Run `bundle install` to install missing gems.
```

This PR updates the documentation to include an explicit mention of `bundle install` and moves the Ruby section above the Node.js section since the gems are a dependency of `yarn lint`.