### PR TITLE
Add a NOOP ruby script tha emulates Unix 'true' on Windows

### DIFF
--- a/artichoke-backend/build.rs
+++ b/artichoke-backend/build.rs
@@ -35,6 +35,10 @@ mod buildpath {
         pub fn mruby_bootstrap_gembox() -> PathBuf {
             super::crate_root().join("bootstrap.gembox")
         }
+
+        pub fn mruby_noop() -> PathBuf {
+            super::crate_root().join("scripts").join("noop.rb")
+        }
     }
 }
 
@@ -72,6 +76,10 @@ mod libmruby {
 
     pub fn bootstrap_gembox() -> PathBuf {
         mruby_source_dir().join("bootstrap.gembox")
+    }
+
+    pub fn builder_noop() -> PathBuf {
+        mruby_source_dir().join("noop.rb")
     }
 
     fn ext_source_dir() -> PathBuf {
@@ -666,6 +674,12 @@ mod build {
         file::copy(
             buildpath::source::mruby_bootstrap_gembox(),
             libmruby::bootstrap_gembox(),
+            &opts,
+        )
+        .unwrap();
+        file::copy(
+            buildpath::source::mruby_noop(),
+            libmruby::builder_noop(),
             &opts,
         )
         .unwrap();

--- a/artichoke-backend/mruby_build_config_null.rb
+++ b/artichoke-backend/mruby_build_config_null.rb
@@ -7,6 +7,8 @@ def windows?
   /mswin|msys|mingw|cygwin|bccwin|wince|emc/.match?(RbConfig::CONFIG['host_os'])
 end
 
+NOOP = File.join(File.dirname(File.absolute_path(__FILE__)), 'noop.rb')
+
 # mruby requires a "default" build. This default build bootstraps the
 # compilation of the "sys" build.
 #
@@ -17,15 +19,15 @@ end
 MRuby::Build.new do |conf|
   def build_mrbc_exec; end
 
-  conf.cc.command = 'true'
-  conf.cxx.command = 'true'
-  conf.objc.command = 'true'
-  conf.asm.command = 'true'
-  conf.gperf.command = 'true'
+  conf.cc.command = "ruby #{NOOP}"
+  conf.cxx.command = "ruby #{NOOP}"
+  conf.objc.command = "ruby #{NOOP}"
+  conf.asm.command = "ruby #{NOOP}"
+  conf.gperf.command = "ruby #{NOOP}"
   conf.gperf.compile_options = ''
-  conf.linker.command = 'true'
-  conf.archiver.command = 'true'
-  conf.mrbc.command = 'true'
+  conf.linker.command = "ruby #{NOOP}"
+  conf.archiver.command = "ruby #{NOOP}"
+  conf.mrbc.command = "ruby #{NOOP}"
 
   conf.yacc.command = 'win_bison' if windows?
 
@@ -42,15 +44,15 @@ end
 MRuby::CrossBuild.new('sys') do |conf|
   def build_mrbc_exec; end
 
-  conf.cc.command = 'true'
-  conf.cxx.command = 'true'
-  conf.objc.command = 'true'
-  conf.asm.command = 'true'
-  conf.gperf.command = 'true'
+  conf.cc.command = "ruby #{NOOP}"
+  conf.cxx.command = "ruby #{NOOP}"
+  conf.objc.command = "ruby #{NOOP}"
+  conf.asm.command = "ruby #{NOOP}"
+  conf.gperf.command = "ruby #{NOOP}"
   conf.gperf.compile_options = ''
-  conf.linker.command = 'true'
-  conf.archiver.command = 'true'
-  conf.mrbc.command = 'true'
+  conf.linker.command = "ruby #{NOOP}"
+  conf.archiver.command = "ruby #{NOOP}"
+  conf.mrbc.command = "ruby #{NOOP}"
 
   conf.yacc.command = 'win_bison' if windows?
 

--- a/artichoke-backend/scripts/noop.rb
+++ b/artichoke-backend/scripts/noop.rb
@@ -1,0 +1,9 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# This script is an empty script that always exits successfully.
+#
+# This script is meant to emulate the Unix command `true`. `noop.rb` exits with
+# a success status code and swallows all arguments.
+#
+# This script is a compatibility shim to enable the NOOP mruby build on Windows.


### PR DESCRIPTION
This compatibility layer enables building on Windows without Cygwin or
bash installed in a native PowerShell environment.