### PR TITLE
Revamp crate READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 <br>
 [![Backend documentation](https://img.shields.io/badge/docs-artichoke--backend-blue.svg)](https://artichoke.github.io/artichoke/artichoke_backend/)
 [![Core documentation](https://img.shields.io/badge/docs-artichoke--core-blue.svg)](https://artichoke.github.io/artichoke/artichoke_core/)
+[![Frontend documentation](https://img.shields.io/badge/docs-artichoke--frontend-blue.svg)](https://artichoke.github.io/artichoke/artichoke_frontend/)
 [![Virtual filesystem documentation](https://img.shields.io/badge/docs-artichoke--vfs-blue.svg)](https://artichoke.github.io/artichoke/artichoke_vfs/)
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Discord](https://img.shields.io/discord/607683947496734760)](https://discord.gg/QCe2tp2)
 [![Twitter](https://img.shields.io/twitter/follow/artichokeruby?label=Follow&style=social)](https://twitter.com/artichokeruby)
 <br>
-[![mruby backend documentation](https://img.shields.io/badge/docs-artichoke--backend-blue.svg)](https://artichoke.github.io/artichoke/artichoke_backend/)
+[![Backend documentation](https://img.shields.io/badge/docs-artichoke--backend-blue.svg)](https://artichoke.github.io/artichoke/artichoke_backend/)
 [![Core documentation](https://img.shields.io/badge/docs-artichoke--core-blue.svg)](https://artichoke.github.io/artichoke/artichoke_core/)
 [![Virtual filesystem documentation](https://img.shields.io/badge/docs-artichoke--vfs-blue.svg)](https://artichoke.github.io/artichoke/artichoke_vfs/)
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 [![Discord](https://img.shields.io/discord/607683947496734760)](https://discord.gg/QCe2tp2)
 [![Twitter](https://img.shields.io/twitter/follow/artichokeruby?label=Follow&style=social)](https://twitter.com/artichokeruby)
 <br>
+[![mruby backend documentation](https://img.shields.io/badge/docs-artichoke--backend-blue.svg)](https://artichoke.github.io/artichoke/artichoke_backend/)
 [![Core documentation](https://img.shields.io/badge/docs-artichoke--core-blue.svg)](https://artichoke.github.io/artichoke/artichoke_core/)
 [![Virtual filesystem documentation](https://img.shields.io/badge/docs-artichoke--vfs-blue.svg)](https://artichoke.github.io/artichoke/artichoke_vfs/)
-[![mruby backend documentation](https://img.shields.io/badge/docs-artichoke--backend-blue.svg)](https://artichoke.github.io/artichoke/artichoke_backend/)
 
 <p align="center">
   <a href="https://artichoke.run">
@@ -14,11 +14,9 @@
   </a>
 </p>
 
-Artichoke is a platform for building
-[MRI-compatible](https://github.com/ruby/spec) Ruby implementations. Artichoke
-provides a Ruby runtime implemented in Rust that can be loaded into many VM
-backends. Rubies implemented with Artichoke will be source and C API compatible
-with MRI Ruby 2.6.3.
+Artichoke is a Ruby implementation written in Rust and Ruby. Artichoke intends
+to be [MRI-compatible](https://github.com/ruby/spec) and targets Ruby 2.6.3.
+Artichoke provides a Ruby runtime implemented in Rust and Ruby.
 
 ## Try Artichoke
 
@@ -82,3 +80,11 @@ please file one before beginning to work on a PR.
 
 If you'd like to engage in a discussion outside of GitHub, you can
 [join Artichoke's public Discord server](https://discord.gg/QCe2tp2).
+
+## License
+
+artichoke is licensed with the [MIT License](/LICENSE) (c) Ryan Lopopolo.
+
+Some portions of Artichoke are derived from third party sources. The READMEs in
+each crate discusses which third party licenses are applicable to the sources
+and derived works in Artichoke.

--- a/artichoke-backend/README.md
+++ b/artichoke-backend/README.md
@@ -15,24 +15,14 @@ artichoke-backend crate exposes eval on the `State` with the `Eval` trait. Side
 effects from eval are persisted across invocations.
 
 ```rust
-use artichoke_backend::eval::Eval;
-use artichoke_core::value::Value as ValueLike;
+use artichoke_core::eval::Eval;
+use artichoke_core::value::Value as _;
 
 let interp = artichoke_backend::interpreter().unwrap();
-let result = interp.eval("10 * 10").unwrap();
+let result = interp.eval(b"10 * 10").unwrap();
 let result = result.try_into::<i64>();
 assert_eq!(result, Ok(100));
 ```
-
-### Calling Ruby Functions from Rust
-
-The `ValueLike` trait exposes a _funcall interface_ which can call Ruby
-functions on a `Value` using a `String` function name and a `Vec<Value>` of
-arguments. funcall takes a type parameter bound by `TryConvert` and converts the
-result of the function call to a Rust type (which may be `Value` or another
-"native" type).
-
-artichoke-backend limits functions to a maximum of 16 arguments.
 
 ## Virtual Filesystem and `Kernel#require`
 
@@ -47,149 +37,22 @@ as a `Vec<u8>` and evaled with `Eval::eval_with_context`. For Rust sources,
 `File::require` methods are stored as custom metadata on `File` nodes in the
 VFS.
 
-```rust
-use artichoke_backend::eval::Eval;
-use artichoke_backend::load::LoadSources;
-use artichoke_core::value::Value as ValueLike;
+## Embed Rust Types in Ruby `Value`s
 
-let mut interp = artichoke_backend::interpreter().unwrap();
-let code = "
-def source_location
-  __FILE__
-end
-";
-interp.def_rb_source_file("source.rb", code).unwrap();
-interp.eval("require 'source'").unwrap();
-let result = interp.eval("source_location").unwrap();
-let result = result.try_into::<&str>().unwrap();
-assert_eq!(result, "/src/lib/source.rb");
-```
+Rust types that implement `RustBackedValue` can be injected into the interpreter
+as the backend for a Ruby object.
 
-## Embed Rust Objects in `mrb_value`
+Examples of `RustBackedValues` include:
 
-The `mrb_value` struct is a data type that represents a Ruby object. The
-concrete type of an `mrb_value` is specified by its type tag, an `mrb_vtype`
-enum value.
-
-One `mrb_vtype` is `MRB_TT_DATA`, which allows an `mrb_value` to store an owned
-`c_void` pointer. artichoke-backend crate leverages this to store an owned copy
-of an `Rc<RefCell<T>>` for any `T` that implements `RustBackedValue`.
-
-`RustBackedValue` provides two methods for working with `MRB_TT_DATA`:
-
-- `RustBackedValue::try_into_ruby` consumes `self` and returns a live
-  `mrb_value` that wraps `T`.
-- `RustBackedValue::try_from_ruby` extracts an `Rc<RefCell<T>>` from an
-  `mrb_value` and manages the strong count of the `Rc` smart pointer to ensure
-  that the `mrb_value` continues to point to valid memory.
-
-These `mrb_value`s with type tag `MRB_TT_DATA` can be used to implement Ruby
-`Class`es and `Module`s with Rust structs. An example of this is the
-[`Regexp`](src/extn/core/regexp) class which wraps an Oniguruma regex provided
-by the [`onig`] crate.
-
-```rust
-#[macro_use]
-extern crate artichoke_backend;
-
-use artichoke_backend::convert::{Convert, RustBackedValue, TryConvert};
-use artichoke_backend::def::{rust_data_free, ClassLike, Define};
-use artichoke_backend::eval::Eval;
-use artichoke_backend::file::File;
-use artichoke_backend::load::LoadSources;
-use artichoke_backend::sys;
-use artichoke_backend::value::Value;
-use artichoke_backend::{Artichoke, ArtichokeError};
-use artichoke_core::value::Value as ValueLike;
-use std::io::Write;
-use std::mem;
-
-struct Container { inner: i64 }
-
-impl Container {
-    unsafe extern "C" fn initialize(mrb: *mut sys::mrb_state, mut slf: sys::mrb_value) -> sys::mrb_value {
-        let inner = mrb_get_args!(mrb, required = 1);
-        let interp = unwrap_interpreter!(mrb);
-        let inner = Value::new(&interp, inner);
-        let inner = inner.try_into::<i64>().unwrap_or_default();
-        let cont = Self { inner };
-        cont
-            .try_into_ruby(&interp, Some(slf))
-            .unwrap_or_else(|_| interp.convert(None::<Value>))
-            .inner()
-    }
-
-    unsafe extern "C" fn value(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
-        let interp = unwrap_interpreter!(mrb);
-        let container = Value::new(&interp, slf);
-        if let Ok(cont) = Self::try_from_ruby(&interp, &container) {
-            let borrow = cont.borrow();
-            interp.convert(borrow.inner).inner()
-        } else {
-            interp.convert(None::<Value>).inner()
-        }
-    }
-}
-
-impl RustBackedValue for Container {}
-
-impl File for Container {
-  fn require(interp: Artichoke) -> Result<(), ArtichokeError> {
-        let spec = interp.0.borrow_mut().def_class::<Self>("Container", None, Some(rust_data_free::<Self>));
-        spec.borrow_mut().add_method("initialize", Self::initialize, sys::mrb_args_req(1));
-        spec.borrow_mut().add_method("value", Self::value, sys::mrb_args_none());
-        spec.borrow_mut().mrb_value_is_rust_backed(true);
-        spec.borrow().define(&interp)?;
-        Ok(())
-    }
-}
-
-fn main() {
-    let interp = artichoke_backend::interpreter().unwrap();
-    interp.def_file_for_type::<_, Container>("container.rb").unwrap();
-    interp.eval("require 'container'").unwrap();
-    let result = interp.eval("Container.new(15).value * 24").unwrap();
-    assert_eq!(result.try_into::<i64>(), Ok(360));
-}
-```
+- `Regexp` and `MatchData`, which are backed by regular expressions from the
+  `onig` and `regex` crates.
+- `ENV` which glues Ruby to an environ backend.
 
 ## Converters Between Ruby and Rust Types
 
 The [`convert` module](src/convert) provides implementations for conversions
-between `mrb_value` Ruby types and native Rust types like `i64` and
+between boxed Ruby values and native Rust types like `i64` and
 `HashMap<String, Option<Vec<u8>>>` using an `Artichoke` interpreter.
-
-There are two converter traits:
-
-- `Convert` provides infallible conversions that return `Self`. Converting from
-  a Rust native type to a Ruby `mrb_value` is usually an infallible conversion.
-- `TryConvert` provides fallible conversions that return `Result<Self, Error>`.
-  Converting from a Ruby `mrb_value` to a Rust native type is always an fallible
-  conversion because an `mrb_value` may be any type tag.
-
-Supported conversions:
-
-- Ruby _primitive types_ to Rust types. Primitive Ruby types are `TrueClass`,
-  `FalseClass`, `String` (both UTF-8 and binary), `Fixnum` (`i64`), `Float`
-  (`f64`).
-- Rust types to Ruby types. Supported Rust types are `bool`, `Vec<u8>`, `&[u8]`,
-  integer types that losslessly convert to `i64` (`i64`, `i32`, `i16`, `i8`,
-  `u32`, `u16`, `u8`), `f64`, `String`, `&str`.
-- Ruby `nil`able types to Rust `Option<T>`.
-- Rust `Option<T>` types to Ruby `nil` or an `mrb_value` converted from `T`.
-- Ruby `Array` to Rust `Vec<T>` where `T` corresponds to a Ruby _primitive
-  type_.
-- Rust `Vec<T>` to Ruby `Array` where `T` corresponds to a Ruby _primitive
-  type_.
-- Ruby `Hash` to Rust `Vec<(Key, Value)>` or `HashMap<Key, Value>` where `Key`
-  and `Value` correspond to Ruby _primitive types_.
-- Rust `Vec<(Key, Value)>` or `HashMap<Key, Value>` to Ruby `Hash` where `Key`
-  and `Value` correspond to Ruby _primitive types_.
-- Identity conversion from `Value` to `Value`, which is useful when working with
-  collection types.
-
-The infallible converters are safe Rust functions. The fallibile converters are
-`unsafe` Rust functions.
 
 ## License
 

--- a/artichoke-backend/README.md
+++ b/artichoke-backend/README.md
@@ -1,5 +1,11 @@
 # artichoke-backend
 
+[![CircleCI](https://circleci.com/gh/artichoke/artichoke.svg?style=svg)](https://circleci.com/gh/artichoke/artichoke)
+[![Discord](https://img.shields.io/discord/607683947496734760)](https://discord.gg/QCe2tp2)
+[![Twitter](https://img.shields.io/twitter/follow/artichokeruby?label=Follow&style=social)](https://twitter.com/artichokeruby)
+<br>
+[![Backend documentation](https://img.shields.io/badge/docs-artichoke--backend-blue.svg)](https://artichoke.github.io/artichoke/artichoke_backend/)
+
 artichoke-backend crate provides a Ruby interpreter. It currently is implemented
 with [mruby](https://github.com/mruby/mruby) bindings exported by the
 [`sys`](src/sys) module.

--- a/artichoke-backend/src/lib.rs
+++ b/artichoke-backend/src/lib.rs
@@ -5,20 +5,19 @@
 
 //! # artichoke-backend
 //!
-//! artichoke-backend crate provides a Ruby interpreter. It currently is
-//! implemented with [mruby](https://github.com/mruby/mruby) bindings exported
-//! by the [`sys`] module.
+//! artichoke-backend crate provides a Ruby interpreter. It currently is implemented
+//! with [mruby](https://github.com/mruby/mruby) bindings exported by the
+//! [`sys`] module.
 //!
 //! ## Execute Ruby Code
 //!
-//! artichoke-backend crate exposes several mechanisms for executing Ruby code
-//! on the interpreter.
+//! artichoke-backend crate exposes several mechanisms for executing Ruby code on
+//! the interpreter.
 //!
 //! ### Evaling Source Code
 //!
-//! artichoke-backend crate exposes eval on the `State` with the
-//! [`Eval`](eval::Eval) trait. Side effects from eval are persisted
-//! across invocations.
+//! artichoke-backend crate exposes eval on the `State` with the `Eval` trait. Side
+//! effects from eval are persisted across invocations.
 //!
 //! ```rust
 //! use artichoke_core::eval::Eval;
@@ -30,191 +29,63 @@
 //! assert_eq!(result, Ok(100));
 //! ```
 //!
-//! ### Calling Ruby Functions from Rust
-//!
-//! The [`ValueLike`](value::ValueLike) trait exposes a _funcall interface_
-//! which can call Ruby functions on a [`Value`](value::Value) using a `String`
-//! function name and a `Vec<Value>` of arguments. funcall takes a type
-//! parameter bound by [`TryConvert`](convert::TryConvert) and converts the
-//! result of the function call to a Rust type (which may be `Value` or another
-//! "native" type).
-//!
-//! artichoke-backend limits functions to a maximum of 16 arguments.
-//!
 //! ## Virtual Filesystem and `Kernel#require`
 //!
-//! The artichoke-backend [`State`](state::State) embeds an
-//! [in-memory virtual Unix filesystem](artichoke_vfs). The VFS stores Ruby
-//! sources that are either pure Ruby, implemented with a Rust
-//! [`File`](file::File), or both.
+//! The artichoke-backend `State` embeds an
+//! [in-memory virtual Unix filesystem](/artichoke-vfs). The VFS stores Ruby sources
+//! that are either pure Ruby, implemented with a Rust `File`, or both.
 //!
 //! artichoke-backend crate implements
-//! [`Kernel#require` and `Kernel#require_relative`](extn::core::kernel::Kernel)
-//! which loads sources from the VFS. For Ruby sources, the source is loaded
-//! from the VFS as a `Vec<u8>` and evaled with
-//! [`Eval::eval_with_context`](eval::Eval::eval_with_context). For Rust
-//! sources, [`File::require`](file::File::require) methods are stored as
-//! custom metadata on [`File`](artichoke_vfs::FakeFileSystem) nodes in the VFS.
+//! [`Kernel#require` and `Kernel#require_relative`](src/extn/core/kernel) which
+//! loads sources from the VFS. For Ruby sources, the source is loaded from the VFS
+//! as a `Vec<u8>` and evaled with `Eval::eval_with_context`. For Rust sources,
+//! `File::require` methods are stored as custom metadata on `File` nodes in the
+//! VFS.
 //!
-//! ```rust
-//! use artichoke_core::eval::Eval;
-//! use artichoke_core::load::LoadSources;
-//! use artichoke_core::value::Value as _;
+//! ## Embed Rust Types in Ruby `Value`s
 //!
-//! let mut interp = artichoke_backend::interpreter().unwrap();
-//! let code = b"
-//! def source_location
-//!   __FILE__
-//! end
-//! ";
-//! interp.def_rb_source_file(b"source.rb", &code[..]).unwrap();
-//! interp.eval(b"require 'source'").unwrap();
-//! let result = interp.eval(b"source_location").unwrap();
-//! let result = result.try_into::<&str>().unwrap();
-//! assert_eq!(result, "/src/lib/source.rb");
-//! ```
+//! Rust types that implement `RustBackedValue` can be injected into the interpreter
+//! as the backend for a Ruby object.
 //!
-//! ## Embed Rust Objects in `mrb_value`
+//! Examples of `RustBackedValues` include:
 //!
-//! The [`mrb_value`](sys::mrb_value) struct is a data type that represents a
-//! Ruby object. The concrete type of an `mrb_value` is specified by its type
-//! tag, an [`mrb_vtype`](sys::mrb_vtype) enum value.
-//!
-//! One `mrb_vtype` is `MRB_TT_DATA`, which allows an `mrb_value` to store an
-//! owned `c_void` pointer. artichoke-backend crate leverages this to store an
-//! owned copy of an `Rc<RefCell<T>>` for any `T` that implements
-//! [`RustBackedValue`](convert::RustBackedValue).
-//!
-//! [`RustBackedValue`](convert::RustBackedValue) provides two methods for working with
-//! `MRB_TT_DATA`:
-//!
-//! - [`RustBackedValue::try_into_ruby`](convert::RustBackedValue::try_into_ruby)
-//!   consumes `self` and returns a live
-//!   `mrb_value` that wraps `T`.
-//! - [`RustBackedValue::try_from_ruby`](convert::RustBackedValue::try_from_ruby)
-//!   extracts an `Rc<RefCell<T>>` from an `mrb_value` and manages the strong
-//!   count of the `Rc` smart pointer to ensure that the `mrb_value` continues
-//!   to point to valid memory.
-//!
-//! These `mrb_value`s with type tag `MRB_TT_DATA` can be used to implement Ruby
-//! `Class`es and `Module`s with Rust structs. An example of this is the
-//! [`Regexp`](extn::core::regexp::Regexp) class which wraps an Oniguruma regex
-//! provided by the [`onig`] crate.
-//!
-//! ```rust
-//! #[macro_use]
-//! extern crate artichoke_backend;
-//!
-//! use artichoke_backend::class;
-//! use artichoke_backend::convert::{Convert, RustBackedValue, TryConvert};
-//! use artichoke_backend::def;
-//! use artichoke_backend::sys;
-//! use artichoke_backend::value::Value;
-//! use artichoke_backend::{Artichoke, ArtichokeError};
-//! use artichoke_core::eval::Eval;
-//! use artichoke_core::file::File;
-//! use artichoke_core::load::LoadSources;
-//! use artichoke_core::value::Value as _;
-//! use std::io::Write;
-//! use std::mem;
-//!
-//! struct Container { inner: i64 }
-//!
-//! impl Container {
-//!     unsafe extern "C" fn initialize(mrb: *mut sys::mrb_state, mut slf: sys::mrb_value) -> sys::mrb_value {
-//!         let inner = mrb_get_args!(mrb, required = 1);
-//!         let interp = unwrap_interpreter!(mrb);
-//!         let inner = Value::new(&interp, inner);
-//!         let inner = inner.try_into::<i64>().unwrap_or_default();
-//!         let cont = Self { inner };
-//!         cont
-//!             .try_into_ruby(&interp, Some(slf))
-//!             .unwrap_or_else(|_| interp.convert(None::<Value>))
-//!             .inner()
-//!     }
-//!
-//!     unsafe extern "C" fn value(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
-//!         let interp = unwrap_interpreter!(mrb);
-//!         let container = Value::new(&interp, slf);
-//!         if let Ok(cont) = Self::try_from_ruby(&interp, &container) {
-//!             let borrow = cont.borrow();
-//!             interp.convert(borrow.inner).inner()
-//!         } else {
-//!             interp.convert(None::<Value>).inner()
-//!         }
-//!     }
-//! }
-//!
-//! impl RustBackedValue for Container {
-//!     fn ruby_type_name() -> &'static str {
-//!         "Container"
-//!     }
-//! }
-//!
-//! impl File for Container {
-//!     type Artichoke = Artichoke;
-//!
-//!     fn require(interp: &Artichoke) -> Result<(), ArtichokeError> {
-//!         let spec = class::Spec::new("Container", None, Some(def::rust_data_free::<Self>));
-//!         class::Builder::for_spec(interp, &spec)
-//!             .value_is_rust_object()
-//!             .add_method("initialize", Self::initialize, sys::mrb_args_req(1))
-//!             .add_method("value", Self::value, sys::mrb_args_none())
-//!             .define()?;
-//!         interp.0.borrow_mut().def_class::<Self>(spec);
-//!         Ok(())
-//!     }
-//! }
-//!
-//! fn main() {
-//!     let interp = artichoke_backend::interpreter().unwrap();
-//!     interp.def_file_for_type::<Container>(b"container.rb").unwrap();
-//!     interp.eval(b"require 'container'").unwrap();
-//!     let result = interp.eval(b"Container.new(15).value * 24").unwrap();
-//!     assert_eq!(result.try_into::<i64>(), Ok(360));
-//! }
-//! ```
+//! - `Regexp` and `MatchData`, which are backed by regular expressions from the
+//!   `onig` and `regex` crates.
+//! - `ENV` which glues Ruby to an environ backend.
 //!
 //! ## Converters Between Ruby and Rust Types
 //!
-//! The [`convert` module](convert) provides implementations for conversions
-//! between `mrb_value` Ruby types and native Rust types like `i64` and
-//! `HashMap<String, Option<Vec<u8>>>` using an [`Artichoke`](interpreter::Artichoke)
-//! interpreter.
+//! The [`convert`] module provides implementations for conversions
+//! between boxed Ruby values and native Rust types like `i64` and
+//! `HashMap<String, Option<Vec<u8>>>` using an `Artichoke` interpreter.
 //!
-//! There are two converter traits:
+//! ## License
 //!
-//! - [`Convert`](convert::Convert) provides infallible conversions that return
-//!   `Self`. Converting from a Rust native type to a Ruby `mrb_value` is
-//!   usually an infallible conversion.
-//! - [`TryConvert`](convert::TryConvert) provides fallible conversions that
-//!   return `Result<Self, Error>`. Converting from a Ruby `mrb_value` to a Rust
-//!   native type is always an fallible conversion because an `mrb_value` may be
-//!   any type tag.
+//! artichoke-backend is licensed with the [MIT License](/LICENSE) (c) Ryan
+//! Lopopolo.
 //!
-//! Supported conversions:
+//! Some portions of artichoke-backend are derived from
+//! [mruby](https://github.com/mruby/mruby) which is Copyright (c) 2019 mruby
+//! developers. mruby is licensed with the
+//! [MIT License](https://github.com/mruby/mruby/blob/master/LICENSE).
 //!
-//! - Ruby _primitive types_ to Rust types. Primitive Ruby types are
-//!   `TrueClass`, `FalseClass`, `String` (both UTF-8 and binary), `Fixnum`
-//!   (`i64`), `Float` (`f64`).
-//! - Rust types to Ruby types. Supported Rust types are `bool`, `Vec<u8>`,
-//!   `&[u8]`, integer types that losslessly convert to `i64` (`i64`, `i32`,
-//!   `i16`, `i8`, `u32`, `u16`, `u8`), `f64`, `String`, `&str`.
-//! - Ruby `nil`able types to Rust `Option<T>`.
-//! - Rust `Option<T>` types to Ruby `nil` or an `mrb_value` converted from `T`.
-//! - Ruby `Array` to Rust `Vec<T>` where `T` corresponds to a Ruby _primitive
-//!   type_.
-//! - Rust `Vec<T>` to Ruby `Array` where `T` corresponds to a Ruby _primitive
-//!   type_.
-//! - Ruby `Hash` to Rust `Vec<(Key, Value)>` or `HashMap<Key, Value>` where
-//!   `Key` and `Value` correspond to Ruby _primitive types_.
-//! - Rust `Vec<(Key, Value)>` or `HashMap<Key, Value>` to Ruby `Hash` where
-//!   `Key` and `Value` correspond to Ruby _primitive types_.
-//! - Identity conversion from `Value` to `Value`, which is useful when working
-//!   with collection types.
+//! Some portions of artichoke-backend are derived from Ruby @
+//! [2.6.3](https://github.com/ruby/ruby/tree/v2_6_3) which is copyright Yukihiro
+//! Matsumoto \<matz@netlab.jp\>. Ruby is licensed with the
+//! [2-clause BSDL License](https://github.com/ruby/ruby/blob/v2_6_3/COPYING).
 //!
-//! The infallible converters are safe Rust functions. The fallibile converters are
-//! `unsafe` Rust functions.
+//! artichoke-backend vendors headers provided by
+//! [emsdk](https://github.com/emscripten-core/emsdk) which is Copyright (c) 2018
+//! Emscripten authors. emsdk is licensed with the
+//! [MIT/Expat License](https://github.com/emscripten-core/emsdk/blob/master/LICENSE).
+//!
+//! artichoke-backend contains a fork of path_abs @
+//! [8370838](https://github.com/vitiral/path_abs/tree/8370838b6110786c2ba7cf7fd984a4783f37701c)
+//! which is copyright (c) 2018 Garrett Berg, vitiral@gmail.com. path_abs is dual
+//! licensed with the
+//! [MIT License](https://github.com/vitiral/path_abs/blob/8370838b6110786c2ba7cf7fd984a4783f37701c/LICENSE-MIT)
+//! and
+//! [Apache 2.0 License](https://github.com/vitiral/path_abs/blob/8370838b6110786c2ba7cf7fd984a4783f37701c/LICENSE-APACHE).
 
 #[macro_use]
 extern crate downcast;

--- a/artichoke-core/README.md
+++ b/artichoke-core/README.md
@@ -1,5 +1,11 @@
 # artichoke-core
 
+[![CircleCI](https://circleci.com/gh/artichoke/artichoke.svg?style=svg)](https://circleci.com/gh/artichoke/artichoke)
+[![Discord](https://img.shields.io/discord/607683947496734760)](https://discord.gg/QCe2tp2)
+[![Twitter](https://img.shields.io/twitter/follow/artichokeruby?label=Follow&style=social)](https://twitter.com/artichokeruby)
+<br>
+[![Core documentation](https://img.shields.io/badge/docs-artichoke--core-blue.svg)](https://artichoke.github.io/artichoke/artichoke_core/)
+
 `artichoke-core` crate provides a set of traits that, when implemented, create a
 complete Ruby interpreter.
 

--- a/artichoke-core/README.md
+++ b/artichoke-core/README.md
@@ -5,3 +5,7 @@ complete Ruby interpreter.
 
 [`artichoke-backend`](/artichoke-backend) is one implementation of the
 `artichoke-core` traits.
+
+## License
+
+artichoke-core is licensed with the [MIT License](/LICENSE) (c) Ryan Lopopolo.

--- a/artichoke-core/src/lib.rs
+++ b/artichoke-core/src/lib.rs
@@ -11,6 +11,10 @@
 //!
 //! [`artichoke-backend`](https://artichoke.github.io/artichoke/artichoke_backend/)
 //! is one implementation of the `artichoke-core` traits.
+//!
+//! ## License
+//!
+//! artichoke-core is licensed with the [MIT License](/LICENSE) (c) Ryan Lopopolo.
 
 use std::borrow::Cow;
 use std::error;

--- a/artichoke-frontend/README.md
+++ b/artichoke-frontend/README.md
@@ -3,50 +3,48 @@
 Crate artichoke-frontend provides binaries for interacting with the Ruby
 interpreter implemented in the [artichoke-backend](/artichoke-backend).
 
-## airb
+## `airb`
 
 `airb` is the Artichoke implementation of `irb` and is an interactive Ruby shell
 and [REPL](https://en.wikipedia.org/wiki/Read%E2%80%93eval%E2%80%93print_loop).
-`airb` includes all extensions that are implemented as part of the
-`artichoke-backend` crate.
 
 `airb` is a readline enabled shell, although it does not persist history.
 
 To invoke `airb`, run:
 
 ```shell
-cargo run -p artichoke-frontend --bin airb
+cargo run --bin airb
 ```
 
-The REPL looks like this:
+## `artichoke`
+
+`artichoke`, which is also aliased to `ruby`, is the `ruby` binary frontend to
+Artichoke.
+
+`artichoke` supports executing programs via files, stdin, or inline with one or
+more `-e` flags.
+
+Artichoke does not yet support reading from the local filesystem. A temporary
+workaround is to inject data into the interpreter with the `--with-fixture`
+flag, which reads file contents into a `$fixture` global.
 
 ```console
-mruby 2.0 [2.0.1-sys.3.c078758]
-[Compiled with rustc 1.36.0-nightly a19cf18 2019-05-06]
->>> 12 +
-... 25
-=> 37
->>> 12.times.map do |i|
-...   i.to_s
-... end
-=> ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11"]
->>> def foo
-...   'bar'
-... end
-=> :foo
->>> foo
-=> "bar"
->>> not_foo
-Backtrace:
-    (rirb):10: undefined method 'not_foo' (NoMethodError)
-    (rirb):10
->>> raise "oh no!"
-Backtrace:
-    (rirb):11: oh no! (RuntimeError)
-    (rirb):11
->>> [3, 6, 9].inject(0) do |sum, i|
-...   sum += i
-...
-^C
->>>
+$ cargo run --bin artichoke -- --help
+artichoke 0.1.0
+Artichoke is a Ruby made with Rust.
+
+USAGE:
+    artichoke [FLAGS] [OPTIONS] [--] [programfile]
+
+FLAGS:
+        --copyright    print the copyright
+    -h, --help         Prints help information
+    -V, --version      Prints version information
+
+OPTIONS:
+    -e <commands>...                one line of script. Several -e's allowed. Omit [programfile]
+        --with-fixture <fixture>
+
+ARGS:
+    <programfile>
 ```

--- a/artichoke-frontend/README.md
+++ b/artichoke-frontend/README.md
@@ -1,5 +1,11 @@
 # artichoke-frontend
 
+[![CircleCI](https://circleci.com/gh/artichoke/artichoke.svg?style=svg)](https://circleci.com/gh/artichoke/artichoke)
+[![Discord](https://img.shields.io/discord/607683947496734760)](https://discord.gg/QCe2tp2)
+[![Twitter](https://img.shields.io/twitter/follow/artichokeruby?label=Follow&style=social)](https://twitter.com/artichokeruby)
+<br>
+[![Frontend documentation](https://img.shields.io/badge/docs-artichoke--frontend-blue.svg)](https://artichoke.github.io/artichoke/artichoke_frontend/)
+
 Crate artichoke-frontend provides binaries for interacting with the Ruby
 interpreter implemented in the [artichoke-backend](/artichoke-backend).
 

--- a/artichoke-vfs/Cargo.toml
+++ b/artichoke-vfs/Cargo.toml
@@ -2,21 +2,16 @@
 name = "artichoke-vfs"
 version = "0.5.0-alpha"
 description = "Fake implementation of a unix file system for artichoke"
-authors = ["Isobel Redelmeier <iredelmeier@gmail.com>", "Ryan Lopopolo <rjl@hyperbo.la>"]
+authors = [
+  "Isobel Redelmeier <iredelmeier@gmail.com>",
+  "Ryan Lopopolo <rjl@hyperbo.la>"
+]
 edition = "2018"
 license = "MIT"
 repository = "https://github.com/artichoke/artichoke"
 readme = "README.md"
-categories = [
-  "development-tools::testing",
-  "filesystem"
-]
-keywords = [
-  "filesystem",
-  "testing",
-  "virtual",
-  "fake"
-]
+categories = ["development-tools::testing", "filesystem"]
+keywords = ["filesystem", "testing", "virtual", "fake"]
 
 [lib]
 bench = false

--- a/artichoke-vfs/Cargo.toml
+++ b/artichoke-vfs/Cargo.toml
@@ -2,7 +2,7 @@
 name = "artichoke-vfs"
 version = "0.5.0-alpha"
 description = "Fake implementation of a unix file system for artichoke"
-authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
+authors = ["Isobel Redelmeier <iredelmeier@gmail.com>", "Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2018"
 license = "MIT"
 repository = "https://github.com/artichoke/artichoke"
@@ -27,4 +27,4 @@ test = false
 name = "fs"
 
 [dependencies.rand]
-version = "0.7.0"
+version = "0.7"

--- a/artichoke-vfs/README.md
+++ b/artichoke-vfs/README.md
@@ -1,6 +1,10 @@
 # artichoke-vfs
 
-[![Documentation](https://img.shields.io/badge/docs-artichoke--vfs-blue.svg)](https://artichoke.github.io/artichoke/artichoke_vfs/)
+[![CircleCI](https://circleci.com/gh/artichoke/artichoke.svg?style=svg)](https://circleci.com/gh/artichoke/artichoke)
+[![Discord](https://img.shields.io/discord/607683947496734760)](https://discord.gg/QCe2tp2)
+[![Twitter](https://img.shields.io/twitter/follow/artichokeruby?label=Follow&style=social)](https://twitter.com/artichokeruby)
+<br>
+[![Virtual filesystem documentation](https://img.shields.io/badge/docs-artichoke--vfs-blue.svg)](https://artichoke.github.io/artichoke/artichoke_vfs/)
 
 artichoke-vfs is an in memory virtual unix filesystem that is used to back an
 artichoke interpreter implementation.

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-prettier": "^3.0.1",
     "eslint-plugin-react": "^7.14.3",
-    "eslint-plugin-react-hooks": "^1.7.0"
+    "eslint-plugin-react-hooks": "^1.7.0",
+    "prettier-plugin-toml": "^0.3.1"
   },
   "babel": {
     "presets": ["@babel/preset-env"]

--- a/scripts/lint.js
+++ b/scripts/lint.js
@@ -161,6 +161,7 @@ async function prettierFormatter(files) {
     ["html", "html"],
     ["json", "json"],
     ["md", "markdown"],
+    ["toml", "toml"],
     ["yaml", "yaml"],
     ["yml", "yaml"]
   ];

--- a/spec-runner/Cargo.toml
+++ b/spec-runner/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies.artichoke-backend]
 path = "../artichoke-backend"
 

--- a/spec-runner/README.md
+++ b/spec-runner/README.md
@@ -8,9 +8,13 @@
 
 `spec-runner` is a binary crate that produces the `spec-runner` executable.
 
-`spec-runner` is a wrapper around MSpec and ruby/spec that works with the Artichoke [virtual filesystem](/artichoke-vfs).
+`spec-runner` is a wrapper around MSpec and ruby/spec that works with the
+Artichoke [virtual filesystem](/artichoke-vfs).
 
-`spec-runner` is invokable directly by passing paths to spec files as command line argumemts. `spec-runner` is sensitive to CWD relative to the specs it wraps, so in practice it is easier to invoke `spec-runner` via the `spec.rb` wrapper in `scripts`.
+`spec-runner` is invokable directly by passing paths to spec files as command
+line arguments. `spec-runner` is sensitive to CWD relative to the specs it
+wraps, so in practice it is easier to invoke `spec-runner` via the `spec.rb`
+wrapper in `scripts`.
 
 ```console
 $ ruby scripts/spec.rb --help

--- a/spec-runner/README.md
+++ b/spec-runner/README.md
@@ -1,0 +1,29 @@
+# spec-runner
+
+[![CircleCI](https://circleci.com/gh/artichoke/artichoke.svg?style=svg)](https://circleci.com/gh/artichoke/artichoke)
+[![Discord](https://img.shields.io/discord/607683947496734760)](https://discord.gg/QCe2tp2)
+[![Twitter](https://img.shields.io/twitter/follow/artichokeruby?label=Follow&style=social)](https://twitter.com/artichokeruby)
+<br>
+[![Spec runner documentation](https://img.shields.io/badge/docs-spec--runner-blue.svg)](https://artichoke.github.io/artichoke/spec_runner/)
+
+`spec-runner` is a binary crate that produces the `spec-runner` executable.
+
+`spec-runner` is a wrapper around MSpec and ruby/spec that works with the Artichoke [virtual filesystem](/artichoke-vfs).
+
+`spec-runner` is invokable directly by passing paths to spec files as command line argumemts. `spec-runner` is sensitive to CWD relative to the specs it wraps, so in practice it is easier to invoke `spec-runner` via the `spec.rb` wrapper in `scripts`.
+
+```console
+$ ruby scripts/spec.rb --help
+spec.rb runs ruby/specs against Artichoke and MRI.
+
+Usage: scripts/spec.rb artichoke [ --timed ITERATIONS | --profile ] [ passing | family [ component [ spec ] ] ]
+Usage: scripts/spec.rb ruby [ --timed ITERATIONS ] family [ component [ spec ] ]
+
+Examples:
+    $ scripts/spec.rb artichoke passing
+    $ scripts/spec.rb artichoke core
+    $ scripts/spec.rb artichoke core string
+    $ scripts/spec.rb ruby core string scan
+    $ scripts/spec.rb artichoke --timed 30 core string scan
+    $ scripts/spec.rb artichoke --profile passing
+```

--- a/yarn.lock
+++ b/yarn.lock
@@ -657,6 +657,21 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
+"@toml-tools/lexer@^0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@toml-tools/lexer/-/lexer-0.3.1.tgz#f5a4b04ee075b2862f08825972d24e73c6bea367"
+  integrity sha512-CCKHQb5OWpgFu47MQ2rcql4AnE9GaehNk/c1oJOyOBovED6XmdzQPXsvPSu+NJ9lToqJNoX+nLXQsB8WyQGdzQ==
+  dependencies:
+    chevrotain "4.1.1"
+
+"@toml-tools/parser@^0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@toml-tools/parser/-/parser-0.3.1.tgz#85484372c50d8caad10e01b24a59193c63f5dcff"
+  integrity sha512-vadwVx5TkgByt19dbp/rfIUKPkDdn5werANYvziiGK9wHlqPA0BWnvOloQw/dPDxF31+Ag0+zarXJpPDdRsPPg==
+  dependencies:
+    "@toml-tools/lexer" "^0.3.1"
+    chevrotain "4.1.1"
+
 acorn-jsx@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.1.0.tgz#294adb71b57398b0680015f0a38c563ee1db5384"
@@ -815,6 +830,13 @@ chardet@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
+
+chevrotain@4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/chevrotain/-/chevrotain-4.1.1.tgz#e1e601bf099e96e6a3377671b7d5a40c631cf8ce"
+  integrity sha512-NQky1HQyiAzxsxpq4Ppt47SYO2U3JLtmfs85QPf3kYSzGBjjp5AA8kqjH8hCjGFRpaQ781QOk1ragQIOkBgUTA==
+  dependencies:
+    regexp-to-ast "0.3.5"
 
 clang-format@^1.2.4:
   version "1.3.0"
@@ -1867,7 +1889,15 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@^1.15.3:
+prettier-plugin-toml@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-toml/-/prettier-plugin-toml-0.3.1.tgz#71b5291ef9c2a20865d2dfe1dbc24435bcb596b5"
+  integrity sha512-j47DEO/dN/acU1nSL/B7q4A4Z2SYJhpWPCLPkcmfAXIQC6A5GD6Ao/bi9HRHZ8ueIDOauqjuAQbnvRxLXMjazA==
+  dependencies:
+    "@toml-tools/parser" "^0.3.1"
+    prettier "^1.16.0"
+
+prettier@^1.15.3, prettier@^1.16.0:
   version "1.19.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
   integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
@@ -1950,6 +1980,11 @@ regenerator-transform@^0.14.0:
   integrity sha512-flVuee02C3FKRISbxhXl9mGzdbWUVHubl1SMaknjxkFB1/iqpJhArQUvRxOOPEc/9tAiX0BaQ28FJH10E4isSQ==
   dependencies:
     private "^0.1.6"
+
+regexp-to-ast@0.3.5:
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/regexp-to-ast/-/regexp-to-ast-0.3.5.tgz#dedadd11bbb5f849df76b4e84b0b5335831c0473"
+  integrity sha512-1CJygtdvsfNFwiyjaMLBWtg2tfEqx/jSZ8S6TV+GlNL8kiH8rb4cm5Pb7A/C2BpyM/fA8ZJEudlCwi/jvAY+Ow==
 
 regexpp@^2.0.1:
   version "2.0.1"


### PR DESCRIPTION
Fixes GH-262.

This PR adds toml formatting to `scripts/lint.js`.