### PR TITLE
Handle uninitialized objects in RustBackedValue::try_from_ruby

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -206,8 +206,7 @@ jobs:
       - run:
           name: ruby/spec Compliance Regression Test
           command: |
-            # Suppress failures from spec suite
-            ruby scripts/spec.rb artichoke passing || :
+            ruby scripts/spec.rb artichoke passing
       - save_cache:
           name: Save sccache cache
           key: v2-sccache-cache-stable-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ epoch }}

--- a/artichoke-backend/src/convert/object.rs
+++ b/artichoke-backend/src/convert/object.rs
@@ -105,12 +105,11 @@ where
                 to: Rust::Object,
             });
         }
-        let ptr = sys::mrb_data_get_ptr(mrb, slf.inner(), spec.data_type());
+        let ptr = sys::mrb_data_check_get_ptr(mrb, slf.inner(), spec.data_type());
         if ptr.is_null() {
-            panic!(
-                "got null pointer when extracting {}",
-                Self::ruby_type_name()
-            );
+            // `Object#allocate` can be used to create `MRB_TT_DATA` without calling
+            // `#initialize`. These objects will return a NULL pointer.
+            return Err(ArtichokeError::UninitializedValue(Self::ruby_type_name()));
         }
         let data = Rc::from_raw(ptr as *const RefCell<Self>);
         let value = Rc::clone(&data);

--- a/artichoke-backend/src/extn/core/regexp/trampoline.rs
+++ b/artichoke-backend/src/extn/core/regexp/trampoline.rs
@@ -1,8 +1,8 @@
 use crate::convert::RustBackedValue;
-use crate::extn::core::exception::{Fatal, RubyException};
+use crate::extn::core::exception::{Fatal, RubyException, TypeError};
 use crate::extn::core::regexp::Regexp;
 use crate::value::{Block, Value};
-use crate::Artichoke;
+use crate::{Artichoke, ArtichokeError};
 
 pub fn initialize(
     interp: &Artichoke,
@@ -28,11 +28,17 @@ pub fn is_match(
     pattern: Value,
     pos: Option<Value>,
 ) -> Result<Value, Box<dyn RubyException>> {
-    let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }.map_err(|_| {
-        Fatal::new(
-            interp,
-            "Unable to extract Rust Regexp from Ruby Regexp receiver",
-        )
+    let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }.map_err(|err| {
+        let err: Box<dyn RubyException> = if let ArtichokeError::UninitializedValue("Regexp") = err
+        {
+            Box::new(TypeError::new(interp, "uninitialized Regexp"))
+        } else {
+            Box::new(Fatal::new(
+                interp,
+                "Unable to extract Rust Regexp from Ruby Regexp receiver",
+            ))
+        };
+        err
     })?;
     let borrow = regexp.borrow();
     borrow.is_match(interp, pattern, pos)
@@ -45,11 +51,17 @@ pub fn match_(
     pos: Option<Value>,
     block: Option<Block>,
 ) -> Result<Value, Box<dyn RubyException>> {
-    let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }.map_err(|_| {
-        Fatal::new(
-            interp,
-            "Unable to extract Rust Regexp from Ruby Regexp receiver",
-        )
+    let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }.map_err(|err| {
+        let err: Box<dyn RubyException> = if let ArtichokeError::UninitializedValue("Regexp") = err
+        {
+            Box::new(TypeError::new(interp, "uninitialized Regexp"))
+        } else {
+            Box::new(Fatal::new(
+                interp,
+                "Unable to extract Rust Regexp from Ruby Regexp receiver",
+            ))
+        };
+        err
     })?;
     let borrow = regexp.borrow();
     borrow.match_(interp, pattern, pos, block)
@@ -60,11 +72,17 @@ pub fn eql(
     regexp: Value,
     other: Value,
 ) -> Result<Value, Box<dyn RubyException>> {
-    let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }.map_err(|_| {
-        Fatal::new(
-            interp,
-            "Unable to extract Rust Regexp from Ruby Regexp receiver",
-        )
+    let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }.map_err(|err| {
+        let err: Box<dyn RubyException> = if let ArtichokeError::UninitializedValue("Regexp") = err
+        {
+            Box::new(TypeError::new(interp, "uninitialized Regexp"))
+        } else {
+            Box::new(Fatal::new(
+                interp,
+                "Unable to extract Rust Regexp from Ruby Regexp receiver",
+            ))
+        };
+        err
     })?;
     let borrow = regexp.borrow();
     borrow.eql(interp, other)
@@ -75,11 +93,17 @@ pub fn case_compare(
     regexp: Value,
     other: Value,
 ) -> Result<Value, Box<dyn RubyException>> {
-    let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }.map_err(|_| {
-        Fatal::new(
-            interp,
-            "Unable to extract Rust Regexp from Ruby Regexp receiver",
-        )
+    let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }.map_err(|err| {
+        let err: Box<dyn RubyException> = if let ArtichokeError::UninitializedValue("Regexp") = err
+        {
+            Box::new(TypeError::new(interp, "uninitialized Regexp"))
+        } else {
+            Box::new(Fatal::new(
+                interp,
+                "Unable to extract Rust Regexp from Ruby Regexp receiver",
+            ))
+        };
+        err
     })?;
     let borrow = regexp.borrow();
     borrow.case_compare(interp, other)
@@ -90,22 +114,34 @@ pub fn match_operator(
     regexp: Value,
     pattern: Value,
 ) -> Result<Value, Box<dyn RubyException>> {
-    let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }.map_err(|_| {
-        Fatal::new(
-            interp,
-            "Unable to extract Rust Regexp from Ruby Regexp receiver",
-        )
+    let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }.map_err(|err| {
+        let err: Box<dyn RubyException> = if let ArtichokeError::UninitializedValue("Regexp") = err
+        {
+            Box::new(TypeError::new(interp, "uninitialized Regexp"))
+        } else {
+            Box::new(Fatal::new(
+                interp,
+                "Unable to extract Rust Regexp from Ruby Regexp receiver",
+            ))
+        };
+        err
     })?;
     let borrow = regexp.borrow();
     borrow.match_operator(interp, pattern)
 }
 
 pub fn is_casefold(interp: &Artichoke, regexp: Value) -> Result<Value, Box<dyn RubyException>> {
-    let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }.map_err(|_| {
-        Fatal::new(
-            interp,
-            "Unable to extract Rust Regexp from Ruby Regexp receiver",
-        )
+    let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }.map_err(|err| {
+        let err: Box<dyn RubyException> = if let ArtichokeError::UninitializedValue("Regexp") = err
+        {
+            Box::new(TypeError::new(interp, "uninitialized Regexp"))
+        } else {
+            Box::new(Fatal::new(
+                interp,
+                "Unable to extract Rust Regexp from Ruby Regexp receiver",
+            ))
+        };
+        err
     })?;
     let borrow = regexp.borrow();
     borrow.is_casefold(interp)
@@ -115,88 +151,136 @@ pub fn is_fixed_encoding(
     interp: &Artichoke,
     regexp: Value,
 ) -> Result<Value, Box<dyn RubyException>> {
-    let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }.map_err(|_| {
-        Fatal::new(
-            interp,
-            "Unable to extract Rust Regexp from Ruby Regexp receiver",
-        )
+    let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }.map_err(|err| {
+        let err: Box<dyn RubyException> = if let ArtichokeError::UninitializedValue("Regexp") = err
+        {
+            Box::new(TypeError::new(interp, "uninitialized Regexp"))
+        } else {
+            Box::new(Fatal::new(
+                interp,
+                "Unable to extract Rust Regexp from Ruby Regexp receiver",
+            ))
+        };
+        err
     })?;
     let borrow = regexp.borrow();
     borrow.is_fixed_encoding(interp)
 }
 
 pub fn hash(interp: &Artichoke, regexp: Value) -> Result<Value, Box<dyn RubyException>> {
-    let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }.map_err(|_| {
-        Fatal::new(
-            interp,
-            "Unable to extract Rust Regexp from Ruby Regexp receiver",
-        )
+    let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }.map_err(|err| {
+        let err: Box<dyn RubyException> = if let ArtichokeError::UninitializedValue("Regexp") = err
+        {
+            Box::new(TypeError::new(interp, "uninitialized Regexp"))
+        } else {
+            Box::new(Fatal::new(
+                interp,
+                "Unable to extract Rust Regexp from Ruby Regexp receiver",
+            ))
+        };
+        err
     })?;
     let borrow = regexp.borrow();
     borrow.hash(interp)
 }
 
 pub fn inspect(interp: &Artichoke, regexp: Value) -> Result<Value, Box<dyn RubyException>> {
-    let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }.map_err(|_| {
-        Fatal::new(
-            interp,
-            "Unable to extract Rust Regexp from Ruby Regexp receiver",
-        )
+    let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }.map_err(|err| {
+        let err: Box<dyn RubyException> = if let ArtichokeError::UninitializedValue("Regexp") = err
+        {
+            Box::new(TypeError::new(interp, "uninitialized Regexp"))
+        } else {
+            Box::new(Fatal::new(
+                interp,
+                "Unable to extract Rust Regexp from Ruby Regexp receiver",
+            ))
+        };
+        err
     })?;
     let borrow = regexp.borrow();
     borrow.inspect(interp)
 }
 
 pub fn named_captures(interp: &Artichoke, regexp: Value) -> Result<Value, Box<dyn RubyException>> {
-    let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }.map_err(|_| {
-        Fatal::new(
-            interp,
-            "Unable to extract Rust Regexp from Ruby Regexp receiver",
-        )
+    let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }.map_err(|err| {
+        let err: Box<dyn RubyException> = if let ArtichokeError::UninitializedValue("Regexp") = err
+        {
+            Box::new(TypeError::new(interp, "uninitialized Regexp"))
+        } else {
+            Box::new(Fatal::new(
+                interp,
+                "Unable to extract Rust Regexp from Ruby Regexp receiver",
+            ))
+        };
+        err
     })?;
     let borrow = regexp.borrow();
     borrow.named_captures(interp)
 }
 
 pub fn names(interp: &Artichoke, regexp: Value) -> Result<Value, Box<dyn RubyException>> {
-    let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }.map_err(|_| {
-        Fatal::new(
-            interp,
-            "Unable to extract Rust Regexp from Ruby Regexp receiver",
-        )
+    let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }.map_err(|err| {
+        let err: Box<dyn RubyException> = if let ArtichokeError::UninitializedValue("Regexp") = err
+        {
+            Box::new(TypeError::new(interp, "uninitialized Regexp"))
+        } else {
+            Box::new(Fatal::new(
+                interp,
+                "Unable to extract Rust Regexp from Ruby Regexp receiver",
+            ))
+        };
+        err
     })?;
     let borrow = regexp.borrow();
     borrow.names(interp)
 }
 
 pub fn options(interp: &Artichoke, regexp: Value) -> Result<Value, Box<dyn RubyException>> {
-    let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }.map_err(|_| {
-        Fatal::new(
-            interp,
-            "Unable to extract Rust Regexp from Ruby Regexp receiver",
-        )
+    let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }.map_err(|err| {
+        let err: Box<dyn RubyException> = if let ArtichokeError::UninitializedValue("Regexp") = err
+        {
+            Box::new(TypeError::new(interp, "uninitialized Regexp"))
+        } else {
+            Box::new(Fatal::new(
+                interp,
+                "Unable to extract Rust Regexp from Ruby Regexp receiver",
+            ))
+        };
+        err
     })?;
     let borrow = regexp.borrow();
     borrow.options(interp)
 }
 
 pub fn source(interp: &Artichoke, regexp: Value) -> Result<Value, Box<dyn RubyException>> {
-    let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }.map_err(|_| {
-        Fatal::new(
-            interp,
-            "Unable to extract Rust Regexp from Ruby Regexp receiver",
-        )
+    let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }.map_err(|err| {
+        let err: Box<dyn RubyException> = if let ArtichokeError::UninitializedValue("Regexp") = err
+        {
+            Box::new(TypeError::new(interp, "uninitialized Regexp"))
+        } else {
+            Box::new(Fatal::new(
+                interp,
+                "Unable to extract Rust Regexp from Ruby Regexp receiver",
+            ))
+        };
+        err
     })?;
     let borrow = regexp.borrow();
     borrow.source(interp)
 }
 
 pub fn to_s(interp: &Artichoke, regexp: Value) -> Result<Value, Box<dyn RubyException>> {
-    let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }.map_err(|_| {
-        Fatal::new(
-            interp,
-            "Unable to extract Rust Regexp from Ruby Regexp receiver",
-        )
+    let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }.map_err(|err| {
+        let err: Box<dyn RubyException> = if let ArtichokeError::UninitializedValue("Regexp") = err
+        {
+            Box::new(TypeError::new(interp, "uninitialized Regexp"))
+        } else {
+            Box::new(Fatal::new(
+                interp,
+                "Unable to extract Rust Regexp from Ruby Regexp receiver",
+            ))
+        };
+        err
     })?;
     let borrow = regexp.borrow();
     borrow.string(interp)

--- a/artichoke-backend/src/warn.rs
+++ b/artichoke-backend/src/warn.rs
@@ -10,13 +10,15 @@ use crate::{Artichoke, ArtichokeError};
 impl Warn for Artichoke {
     fn warn(&self, message: &[u8]) -> Result<(), ArtichokeError> {
         warn!("rb warning: {}", String::from_utf8_lossy(message));
-        let borrow = self.0.borrow();
-        let warning = borrow.module_spec::<Warning>().ok_or_else(|| {
-            ArtichokeError::NotDefined(Cow::Borrowed("Warn with uninitialized Warning"))
-        })?;
-        let warning = warning.value(self).ok_or_else(|| {
-            ArtichokeError::NotDefined(Cow::Borrowed("Warn with uninitialized Warning"))
-        })?;
+        let warning = {
+            let borrow = self.0.borrow();
+            let spec = borrow.module_spec::<Warning>().ok_or_else(|| {
+                ArtichokeError::NotDefined(Cow::Borrowed("Warn with uninitialized Warning"))
+            })?;
+            spec.value(self).ok_or_else(|| {
+                ArtichokeError::NotDefined(Cow::Borrowed("Warn with uninitialized Warning"))
+            })?
+        };
         warning.funcall::<Value>("warn", &[self.convert(message)], None)?;
         Ok(())
     }

--- a/artichoke-core/src/lib.rs
+++ b/artichoke-core/src/lib.rs
@@ -101,7 +101,7 @@ impl fmt::Display for ArtichokeError {
             Self::Uninitialized => write!(f, "Interpreter not initialized"),
             Self::UninitializedValue(class) => write!(
                 f,
-                "Attempted to extract pointer from uninitialized Value iwth class {}",
+                "Attempted to extract pointer from uninitialized Value with class {}",
                 class
             ),
             Self::UnreachableValue => write!(f, "Extracted unreachable type from interpreter"),


### PR DESCRIPTION
`Object#allocate` is a Ruby API that creates uninitialized objects.
These objects have the correct class, but have not had the class's
`#initialize` method called on the allocated instance.

In the case of `MRB_TT_DATA`, this means that objects have the correct
class, but they do not have a valid `Rc` stored in the `DATA_PTR` and
they do not have a valid `mrb_data_type`.

Since GH-398 was merged, calling `RustBackedValue::try_from_ruby` with
an object created via `#allocate` would cause a borrow on the
interpreter to not get cleaned up because mruby would unwind past it.
This bad state was surfaced in the spec suite as a `AlreadyBorrowed`
panic when attempting a mutable borrow on the `Artichoke` interpreter.

This commit changes which APIs `RustBackedValue` calls when extracting
pointers from `mrb_value`s with type `MRB_TT_DATA`.

The existing code called the `mrb_data_get_ptr` API, which validates
that the `mrb_data_type` of the target matches the supplied data type.
If there is a mismatch, the function calls `mrb_raise` with a
`TypeError`.

Prior to GH-398, getting a reference to the data type for calling this
API called `interp.0.borrow().class_spec::<Self>()`, which returned a
clone of the `Rc`-wrapped `class::Spec`. Because the returned spec was
an owned `Rc`, the borrow on the interp was implicitly dropped after its
last use. Because the borrow was dropped, the hidden unwind from the C
API did not leave any dangling borrows on the interpreter, but it likely
caused some memory to leak.

The new code introduced in this commit calls `mrb_data_check_get_ptr`
which returns `NULL` instead of raising if the data type is not
validated. Since a `NULL` is now a valid possible return type,
`RustBackedValue::try_from_ruby` returns a new
`ArtichokeError::UninitializedValue` variant so calling trampolines can
return the appropriate `TypeError` to the unsafe C trampoline.

`RustBackedValue::try_from_ruby` is not normally called in an
`mrb_protect` context and the `Artichoke` interpreter is already
extracted. It is not safe to unwind from `RustBackedValue`.

`RustBackedValue` should never should have worked with partially
initialized Ruby values, but did so on accident. This fragile state was
made an error with chnges to borrowing semantics on the interpreter with
the API changes to `class::Spec` in GH-398.