### PR TITLE
Fix some typos in the new crate READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,5 +87,5 @@ If you'd like to engage in a discussion outside of GitHub, you can
 artichoke is licensed with the [MIT License](/LICENSE) (c) Ryan Lopopolo.
 
 Some portions of Artichoke are derived from third party sources. The READMEs in
-each crate discusses which third party licenses are applicable to the sources
-and derived works in Artichoke.
+each crate discuss which third party licenses are applicable to the sources and
+derived works in Artichoke.

--- a/artichoke-backend/README.md
+++ b/artichoke-backend/README.md
@@ -52,7 +52,7 @@ Examples of `RustBackedValues` include:
 
 - `Regexp` and `MatchData`, which are backed by regular expressions from the
   `onig` and `regex` crates.
-- `ENV` which glues Ruby to an environ backend.
+- `ENV`, which glues Ruby to an environ backend.
 
 ## Converters Between Ruby and Rust Types
 


### PR DESCRIPTION
Fix some typos introduced in GH-399.