### PR TITLE
Avoid dependency on std::env::current_dir with path-dedot

### DIFF
--- a/artichoke-backend/src/fs.rs
+++ b/artichoke-backend/src/fs.rs
@@ -121,16 +121,16 @@ impl Default for Metadata {
 }
 
 fn absolutize_relative_to(path: &Path, cwd: &Path) -> Result<PathBuf, ArtichokeError> {
-    let path = path
-        .parse_dot()
-        .map_err(io::Error::from)
-        .map_err(ArtichokeError::Vfs)?;
-    let path = if path.is_relative() {
+    if path.is_relative() {
         cwd.join(path)
+            .parse_dot()
+            .map_err(io::Error::from)
+            .map_err(ArtichokeError::Vfs)
     } else {
-        path
-    };
-    Ok(path)
+        path.parse_dot()
+            .map_err(io::Error::from)
+            .map_err(ArtichokeError::Vfs)
+    }
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
fs module always passes the relative cwd, so eagerly prefix the path if
it is relative.

Followup to GH-403.