### PR TITLE
Changes .inspect/.to_s to return Vec<u8>

### DIFF
--- a/artichoke-backend/src/convert/hash.rs
+++ b/artichoke-backend/src/convert/hash.rs
@@ -574,7 +574,7 @@ mod tests {
         ];
 
         let value: Value = interp.convert(map);
-        assert_eq!("{1=>2, 7=>8}", value.to_s());
+        assert_eq!(value.to_s(), b"{1=>2, 7=>8}");
 
         let pairs = value.try_into::<Vec<(Value, Value)>>().expect("convert");
         let map = pairs

--- a/artichoke-backend/src/convert/object.rs
+++ b/artichoke-backend/src/convert/object.rs
@@ -203,7 +203,7 @@ mod tests {
 
         let value = unsafe { obj.try_into_ruby(&interp, None) }.expect("convert");
         let class = value.funcall::<Value>("class", &[], None).expect("funcall");
-        assert_eq!(class.to_s(), "Container");
+        assert_eq!(class.to_s(), b"Container");
         let data = unsafe { Container::try_from_ruby(&interp, &value) }.expect("convert");
         assert_eq!(Rc::strong_count(&data), 2);
         assert_eq!(&data.borrow().inner, "contained string contents");
@@ -234,13 +234,13 @@ mod tests {
 
         let value = interp.convert("string");
         let class = value.funcall::<Value>("class", &[], None).expect("funcall");
-        assert_eq!(class.to_s(), "String");
+        assert_eq!(class.to_s(), b"String");
         let data = unsafe { Container::try_from_ruby(&interp, &value) };
         assert!(data.is_err());
         let value =
             unsafe { Box::new(Other::default()).try_into_ruby(&interp, None) }.expect("convert");
         let class = value.funcall::<Value>("class", &[], None).expect("funcall");
-        assert_eq!(class.to_s(), "Other");
+        assert_eq!(class.to_s(), b"Other");
         let data = unsafe { Container::try_from_ruby(&interp, &value) };
         assert!(data.is_err());
     }

--- a/artichoke-backend/src/convert/string.rs
+++ b/artichoke-backend/src/convert/string.rs
@@ -25,8 +25,14 @@ impl Convert<&str, Value> for Artichoke {
 
 impl TryConvert<Value, String> for Artichoke {
     fn try_convert(&self, value: Value) -> Result<String, ArtichokeError> {
-        let result: Result<&str, _> = self.try_convert(value);
-        result.map(String::from)
+        let type_tag = value.ruby_type();
+        let bytes = value
+            .try_into::<&[u8]>()
+            .map_err(|_| ArtichokeError::ConvertToRust {
+                from: type_tag,
+                to: Rust::String,
+            })?;
+        Ok(String::from_utf8_lossy(bytes).to_string())
     }
 }
 

--- a/artichoke-backend/src/convert/string.rs
+++ b/artichoke-backend/src/convert/string.rs
@@ -25,14 +25,8 @@ impl Convert<&str, Value> for Artichoke {
 
 impl TryConvert<Value, String> for Artichoke {
     fn try_convert(&self, value: Value) -> Result<String, ArtichokeError> {
-        let type_tag = value.ruby_type();
-        let bytes = value
-            .try_into::<&[u8]>()
-            .map_err(|_| ArtichokeError::ConvertToRust {
-                from: type_tag,
-                to: Rust::String,
-            })?;
-        Ok(String::from_utf8_lossy(bytes).to_string())
+        let result: Result<&str, _> = self.try_convert(value);
+        result.map(String::from)
     }
 }
 
@@ -99,7 +93,7 @@ mod tests {
     fn string_with_value(s: String) -> bool {
         let interp = crate::interpreter().expect("init");
         let value = interp.convert(s.clone());
-        value.to_s() == s
+        value.to_s() == s.as_bytes()
     }
 
     #[allow(clippy::needless_pass_by_value)]

--- a/artichoke-backend/src/extn/core/integer/mod.rs
+++ b/artichoke-backend/src/extn/core/integer/mod.rs
@@ -50,7 +50,7 @@ impl Integer {
                 &interp,
                 format!(
                     "encoding parameter of Integer#chr (given {}) not supported",
-                    encoding.inspect()
+                    String::from_utf8_lossy(&encoding.inspect()).to_string()
                 ),
             )))
         } else {

--- a/artichoke-backend/src/extn/core/integer/mod.rs
+++ b/artichoke-backend/src/extn/core/integer/mod.rs
@@ -49,10 +49,7 @@ impl Integer {
             let mut message = b"encoding parameter of Integer#chr (given".to_vec();
             message.extend(encoding.inspect());
             message.extend(b") not supported");
-            Err(Box::new(NotImplementedError::new_raw(
-                &interp,
-                message,
-            )))
+            Err(Box::new(NotImplementedError::new_raw(&interp, message)))
         } else {
             // When no encoding is supplied, MRI assumes the encoding is
             // either ASCII or ASCII-8BIT.

--- a/artichoke-backend/src/extn/core/integer/mod.rs
+++ b/artichoke-backend/src/extn/core/integer/mod.rs
@@ -46,7 +46,7 @@ impl Integer {
         let interp = unwrap_interpreter!(mrb);
         let encoding = encoding.map(|encoding| Value::new(&interp, encoding));
         let result: Result<Value, Box<dyn RubyException>> = if let Some(encoding) = encoding {
-            let mut message = b"encoding parameter of Integer#chr (given".to_vec();
+            let mut message = b"encoding parameter of Integer#chr (given ".to_vec();
             message.extend(encoding.inspect());
             message.extend(b") not supported");
             Err(Box::new(NotImplementedError::new_raw(&interp, message)))

--- a/artichoke-backend/src/extn/core/integer/mod.rs
+++ b/artichoke-backend/src/extn/core/integer/mod.rs
@@ -46,12 +46,12 @@ impl Integer {
         let interp = unwrap_interpreter!(mrb);
         let encoding = encoding.map(|encoding| Value::new(&interp, encoding));
         let result: Result<Value, Box<dyn RubyException>> = if let Some(encoding) = encoding {
-            Err(Box::new(NotImplementedError::new(
+            let mut message = b"encoding parameter of Integer#chr (given".to_vec();
+            message.extend(encoding.inspect());
+            message.extend(b") not supported");
+            Err(Box::new(NotImplementedError::new_raw(
                 &interp,
-                format!(
-                    "encoding parameter of Integer#chr (given {}) not supported",
-                    String::from_utf8_lossy(&encoding.inspect()).to_string()
-                ),
+                message,
             )))
         } else {
             // When no encoding is supplied, MRI assumes the encoding is

--- a/artichoke-backend/src/extn/core/kernel/mod.rs
+++ b/artichoke-backend/src/extn/core/kernel/mod.rs
@@ -90,7 +90,7 @@ impl Kernel {
         let interp = unwrap_interpreter!(mrb);
 
         for value in args.iter() {
-            let s = Value::new(&interp, *value).to_s();
+            let s = String::from_utf8_lossy(&Value::new(&interp, *value).to_s()).to_string();
             interp.0.borrow_mut().print(s.as_str());
         }
         sys::mrb_sys_nil_value()
@@ -103,7 +103,7 @@ impl Kernel {
                     do_puts(interp, &value);
                 }
             } else {
-                let s = value.to_s();
+                let s = String::from_utf8_lossy(&value.to_s()).to_string();
                 interp.0.borrow_mut().puts(s.as_str());
             }
         }

--- a/artichoke-backend/src/extn/core/kernel/mod.rs
+++ b/artichoke-backend/src/extn/core/kernel/mod.rs
@@ -90,8 +90,9 @@ impl Kernel {
         let interp = unwrap_interpreter!(mrb);
 
         for value in args.iter() {
-            let s = String::from_utf8_lossy(&Value::new(&interp, *value).to_s()).to_string();
-            interp.0.borrow_mut().print(s.as_str());
+            let to_s = Value::new(&interp, *value).to_s();
+            let converted_s = String::from_utf8_lossy(to_s.as_slice());
+            interp.0.borrow_mut().print(converted_s.as_ref());
         }
         sys::mrb_sys_nil_value()
     }
@@ -103,9 +104,10 @@ impl Kernel {
                     do_puts(interp, &value);
                 }
             } else {
-                let s = String::from_utf8_lossy(&value.to_s()).to_string();
+                let to_s = value.to_s();
                 // TODO convert `puts` to take a Vec<u8>
-                interp.0.borrow_mut().puts(s.as_str());
+                let converted_s = String::from_utf8_lossy(to_s.as_slice());
+                interp.0.borrow_mut().puts(converted_s.as_ref());
             }
         }
 

--- a/artichoke-backend/src/extn/core/kernel/mod.rs
+++ b/artichoke-backend/src/extn/core/kernel/mod.rs
@@ -104,6 +104,7 @@ impl Kernel {
                 }
             } else {
                 let s = String::from_utf8_lossy(&value.to_s()).to_string();
+                // TODO convert `puts` to take a Vec<u8>
                 interp.0.borrow_mut().puts(s.as_str());
             }
         }

--- a/artichoke-backend/src/extn/core/regexp/mod.rs
+++ b/artichoke-backend/src/extn/core/regexp/mod.rs
@@ -135,7 +135,7 @@ impl Regexp {
                 Ok(encoding) => Some(encoding),
                 Err(enc::Error::InvalidEncoding) => {
                     let encoding_bytes = encoding.to_s();
-                    let encoding_string = String::from_utf8_lossy(&encoding_bytes);
+                    let encoding_string = String::from_utf8_lossy(encoding_bytes.as_slice());
                     let warning = format!("encoding option is ignored -- {}", encoding_string);
                     interp
                         .warn(warning.as_bytes())
@@ -149,7 +149,8 @@ impl Regexp {
             let encoding = match enc::parse(&options) {
                 Ok(encoding) => Some(encoding),
                 Err(enc::Error::InvalidEncoding) => {
-                    let options_string = String::from_utf8_lossy(&options.to_s()).to_string();
+                    let options_bytes = options.to_s();
+                    let options_string = String::from_utf8_lossy(options_bytes.as_slice());
                     let warning = format!("encoding option is ignored -- {}", options_string);
                     interp
                         .warn(warning.as_bytes())

--- a/artichoke-backend/src/extn/core/regexp/mod.rs
+++ b/artichoke-backend/src/extn/core/regexp/mod.rs
@@ -134,7 +134,9 @@ impl Regexp {
             let encoding = match enc::parse(&encoding) {
                 Ok(encoding) => Some(encoding),
                 Err(enc::Error::InvalidEncoding) => {
-                    let warning = format!("encoding option is ignored -- {}", encoding.to_s());
+                    let encoding_bytes = encoding.to_s();
+                    let encoding_string = String::from_utf8_lossy(&encoding_bytes);
+                    let warning = format!("encoding option is ignored -- {}", encoding_string);
                     interp
                         .warn(warning.as_bytes())
                         .map_err(|_| Fatal::new(interp, "Warn for ignored encoding failed"))?;
@@ -147,7 +149,8 @@ impl Regexp {
             let encoding = match enc::parse(&options) {
                 Ok(encoding) => Some(encoding),
                 Err(enc::Error::InvalidEncoding) => {
-                    let warning = format!("encoding option is ignored -- {}", options.to_s());
+                    let options_string = String::from_utf8_lossy(&options.to_s()).to_string();
+                    let warning = format!("encoding option is ignored -- {}", options_string);
                     interp
                         .warn(warning.as_bytes())
                         .map_err(|_| Fatal::new(interp, "Warn for ignored encoding failed"))?;

--- a/artichoke-backend/src/value.rs
+++ b/artichoke-backend/src/value.rs
@@ -487,7 +487,7 @@ mod tests {
 
         let value = interp.convert(true);
         let string = value.to_s();
-        assert_eq!(string, "true");
+        assert_eq!(string, b"true");
     }
 
     #[test]
@@ -505,7 +505,7 @@ mod tests {
 
         let value = interp.convert(true);
         let debug = value.inspect();
-        assert_eq!(debug, "true");
+        assert_eq!(debug, b"true");
     }
 
     #[test]
@@ -514,7 +514,7 @@ mod tests {
 
         let value = interp.convert(false);
         let string = value.to_s();
-        assert_eq!(string, "false");
+        assert_eq!(string, b"false");
     }
 
     #[test]
@@ -532,7 +532,7 @@ mod tests {
 
         let value = interp.convert(false);
         let debug = value.inspect();
-        assert_eq!(debug, "false");
+        assert_eq!(debug, b"false");
     }
 
     #[test]
@@ -541,7 +541,7 @@ mod tests {
 
         let value = interp.convert(None::<Value>);
         let string = value.to_s();
-        assert_eq!(string, "");
+        assert_eq!(string, b"");
     }
 
     #[test]
@@ -559,7 +559,7 @@ mod tests {
 
         let value = interp.convert(None::<Value>);
         let debug = value.inspect();
-        assert_eq!(debug, "nil");
+        assert_eq!(debug, b"nil");
     }
 
     #[test]
@@ -568,7 +568,7 @@ mod tests {
 
         let value: Value = interp.convert(255);
         let string = value.to_s();
-        assert_eq!(string, "255");
+        assert_eq!(string, b"255");
     }
 
     #[test]
@@ -586,7 +586,7 @@ mod tests {
 
         let value: Value = interp.convert(255);
         let debug = value.inspect();
-        assert_eq!(debug, "255");
+        assert_eq!(debug, b"255");
     }
 
     #[test]
@@ -595,7 +595,7 @@ mod tests {
 
         let value = interp.convert("interstate");
         let string = value.to_s();
-        assert_eq!(string, "interstate");
+        assert_eq!(string, b"interstate");
     }
 
     #[test]
@@ -613,7 +613,7 @@ mod tests {
 
         let value = interp.convert("interstate");
         let debug = value.inspect();
-        assert_eq!(debug, r#""interstate""#);
+        assert_eq!(debug, br#""interstate""#);
     }
 
     #[test]
@@ -622,7 +622,7 @@ mod tests {
 
         let value = interp.convert("");
         let string = value.to_s();
-        assert_eq!(string, "");
+        assert_eq!(string, b"");
     }
 
     #[test]
@@ -640,7 +640,7 @@ mod tests {
 
         let value = interp.convert("");
         let debug = value.inspect();
-        assert_eq!(debug, r#""""#);
+        assert_eq!(debug, br#""""#);
     }
 
     #[test]

--- a/artichoke-backend/src/value.rs
+++ b/artichoke-backend/src/value.rs
@@ -158,8 +158,8 @@ impl Value {
     ///
     /// This function can never fail.
     pub fn to_s_debug(&self) -> String {
-        let inspected_str = String::from_utf8_lossy(&self.inspect()).to_string();
-        format!("{}<{}>", self.ruby_type().class_name(), inspected_str)
+        let inspect = self.inspect();
+        format!("{}<{}>", self.ruby_type().class_name(), String::from_utf8_lossy(&inspect))
     }
 
     pub fn implicitly_convert_to_int(&self) -> Result<Int, Box<dyn RubyException>> {
@@ -370,7 +370,7 @@ impl ValueLike for Value {
 
     fn inspect(&self) -> Vec<u8> {
         self.funcall::<Vec<u8>>("inspect", &[], None)
-            .unwrap_or_else(|_| Vec::new())
+            .unwrap_or_default()
     }
 
     fn is_nil(&self) -> bool {
@@ -384,7 +384,7 @@ impl ValueLike for Value {
 
     fn to_s(&self) -> Vec<u8> {
         self.funcall::<Vec<u8>>("to_s", &[], None)
-            .unwrap_or_else(|_| Vec::new())
+            .unwrap_or_default()
     }
 }
 
@@ -396,8 +396,8 @@ impl Convert<Value, Value> for Artichoke {
 
 impl fmt::Display for Value {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let string_repr = String::from_utf8_lossy(&self.to_s()).to_string();
-        write!(f, "{}", string_repr)
+        let string_repr = &self.to_s();
+        write!(f, "{}", String::from_utf8_lossy(string_repr))
     }
 }
 

--- a/artichoke-backend/src/value.rs
+++ b/artichoke-backend/src/value.rs
@@ -159,7 +159,11 @@ impl Value {
     /// This function can never fail.
     pub fn to_s_debug(&self) -> String {
         let inspect = self.inspect();
-        format!("{}<{}>", self.ruby_type().class_name(), String::from_utf8_lossy(&inspect))
+        format!(
+            "{}<{}>",
+            self.ruby_type().class_name(),
+            String::from_utf8_lossy(&inspect)
+        )
     }
 
     pub fn implicitly_convert_to_int(&self) -> Result<Int, Box<dyn RubyException>> {

--- a/artichoke-backend/src/value.rs
+++ b/artichoke-backend/src/value.rs
@@ -158,7 +158,8 @@ impl Value {
     ///
     /// This function can never fail.
     pub fn to_s_debug(&self) -> String {
-        format!("{}<{}>", self.ruby_type().class_name(), self.inspect())
+        let inspected_str = String::from_utf8_lossy(&self.inspect()).to_string();
+        format!("{}<{}>", self.ruby_type().class_name(), inspected_str)
     }
 
     pub fn implicitly_convert_to_int(&self) -> Result<Int, Box<dyn RubyException>> {
@@ -367,9 +368,9 @@ impl ValueLike for Value {
         unsafe { sys::mrb_sys_obj_frozen(mrb, inner) }
     }
 
-    fn inspect(&self) -> String {
-        self.funcall::<String>("inspect", &[], None)
-            .unwrap_or_else(|_| "<unknown>".to_owned())
+    fn inspect(&self) -> Vec<u8> {
+        self.funcall::<Vec<u8>>("inspect", &[], None)
+            .unwrap_or_else(|_| Vec::new())
     }
 
     fn is_nil(&self) -> bool {
@@ -381,9 +382,9 @@ impl ValueLike for Value {
         self.funcall::<bool>("respond_to?", &[method], None)
     }
 
-    fn to_s(&self) -> String {
-        self.funcall::<String>("to_s", &[], None)
-            .unwrap_or_else(|_| "<unknown>".to_owned())
+    fn to_s(&self) -> Vec<u8> {
+        self.funcall::<Vec<u8>>("to_s", &[], None)
+            .unwrap_or_else(|_| Vec::new())
     }
 }
 
@@ -395,7 +396,8 @@ impl Convert<Value, Value> for Artichoke {
 
 impl fmt::Display for Value {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.to_s())
+        let string_repr = String::from_utf8_lossy(&self.to_s()).to_string();
+        write!(f, "{}", string_repr)
     }
 }
 

--- a/artichoke-backend/tests/leak_unbounded_arena_growth.rs
+++ b/artichoke-backend/tests/leak_unbounded_arena_growth.rs
@@ -71,7 +71,7 @@ end
             let arena = interp.create_arena_savepoint();
             let result = interp.eval(b"'a' * 1024 * 1024").expect("eval");
             arena.restore();
-            assert_eq!(result.to_s(), expected);
+            assert_eq!(result.to_s(), expected.as_bytes());
             drop(result);
             interp.incremental_gc();
         },

--- a/artichoke-core/src/value.rs
+++ b/artichoke-core/src/value.rs
@@ -67,10 +67,10 @@ where
     /// Call `#inspect` on this [`Value`].
     ///
     /// This function can never fail.
-    fn inspect(&self) -> String;
+    fn inspect(&self) -> Vec<u8>;
 
     /// Call `#to_s` on this [`Value`].
     ///
     /// This function can never fail.
-    fn to_s(&self) -> String;
+    fn to_s(&self) -> Vec<u8>;
 }

--- a/artichoke-frontend/src/repl.rs
+++ b/artichoke-frontend/src/repl.rs
@@ -116,9 +116,14 @@ pub fn run(
                 }
                 match interp.eval(buf.as_bytes()) {
                     Ok(value) => {
-                        let value_inspect = String::from_utf8_lossy(&value.inspect()).to_string();
-                        writeln!(output, "{}{}", config.result_prefix, value_inspect)
-                            .map_err(Error::Io)?
+                        let result = value.inspect();
+                        writeln!(
+                            output,
+                            "{}{}",
+                            config.result_prefix,
+                            String::from_utf8_lossy(result)
+                        )
+                        .map_err(Error::Io)?
                     }
                     Err(ArtichokeError::Exec(backtrace)) => {
                         writeln!(error, "Backtrace:").map_err(Error::Io)?;

--- a/artichoke-frontend/src/repl.rs
+++ b/artichoke-frontend/src/repl.rs
@@ -121,7 +121,7 @@ pub fn run(
                             output,
                             "{}{}",
                             config.result_prefix,
-                            String::from_utf8_lossy(result)
+                            String::from_utf8_lossy(result.as_slice())
                         )
                         .map_err(Error::Io)?
                     }

--- a/artichoke-frontend/src/repl.rs
+++ b/artichoke-frontend/src/repl.rs
@@ -115,8 +115,11 @@ pub fn run(
                     continue;
                 }
                 match interp.eval(buf.as_bytes()) {
-                    Ok(value) => writeln!(output, "{}{}", config.result_prefix, value.inspect())
-                        .map_err(Error::Io)?,
+                    Ok(value) => {
+                        let value_inspect = String::from_utf8_lossy(&value.inspect()).to_string();
+                        writeln!(output, "{}{}", config.result_prefix, value_inspect)
+                            .map_err(Error::Io)?
+                    }
                     Err(ArtichokeError::Exec(backtrace)) => {
                         writeln!(error, "Backtrace:").map_err(Error::Io)?;
                         for frame in backtrace.lines() {


### PR DESCRIPTION
Fixes #390. The root of the bug stems from `Value::to_s` cannot convert some byte sequences to UTF-8, so the fix suggested is to use the lossy UTF-8 conversion. I tried doing this in the implementation of `TryConvert<Value, &'a str> for Artichoke`, but ran into temporary value issues.