### PR TITLE
Integer division

### DIFF
--- a/artichoke-backend/src/extn/core/float/mod.rs
+++ b/artichoke-backend/src/extn/core/float/mod.rs
@@ -21,4 +21,7 @@ pub struct Float;
 
 impl Float {
     pub const EPSILON: types::Float = std::f64::EPSILON;
+    pub const INFINITY: types::Float = std::f64::INFINITY;
+    pub const NEG_INFINITY: types::Float = std::f64::NEG_INFINITY;
+    pub const NAN: types::Float = std::f64::NAN;
 }

--- a/artichoke-backend/src/extn/core/integer/div.rs
+++ b/artichoke-backend/src/extn/core/integer/div.rs
@@ -1,8 +1,9 @@
 use artichoke_core::value::Value as _;
 
 use crate::convert::Convert;
-use crate::extn::core::exception::{Fatal, RubyException, TypeError};
-use crate::types::{Float, Int};
+use crate::extn::core::exception::{Fatal, RubyException, TypeError, ZeroDivisionError};
+use crate::extn::core::float::Float;
+use crate::types::{self, Int};
 use crate::value::Value;
 use crate::Artichoke;
 
@@ -19,10 +20,25 @@ pub fn method(
     })?;
     let pretty_name = other.pretty_name();
     if let Ok(y) = other.clone().try_into::<Int>() {
-        Ok(interp.convert(x / y))
-    } else if let Ok(y) = other.try_into::<Float>() {
-        #[allow(clippy::cast_precision_loss)]
-        Ok(interp.convert(x as Float / y))
+        if y == 0 {
+            Err(Box::new(ZeroDivisionError::new(interp, "divided by 0")))
+        } else {
+            Ok(interp.convert(x / y))
+        }
+    } else if let Ok(y) = other.try_into::<types::Float>() {
+        if y == 0.0 {
+            if x > 0 {
+                Ok(interp.convert(Float::INFINITY))
+            } else if x < 0 {
+                Ok(interp.convert(Float::NEG_INFINITY))
+            } else {
+                // x == 0
+                Ok(interp.convert(Float::NAN))
+            }
+        } else {
+            #[allow(clippy::cast_precision_loss)]
+            Ok(interp.convert(x as types::Float / y))
+        }
     } else {
         Err(Box::new(TypeError::new(
             interp,

--- a/artichoke-backend/src/extn/core/integer/div.rs
+++ b/artichoke-backend/src/extn/core/integer/div.rs
@@ -1,0 +1,32 @@
+use artichoke_core::value::Value as _;
+
+use crate::convert::Convert;
+use crate::extn::core::exception::{Fatal, RubyException, TypeError};
+use crate::types::{Float, Int};
+use crate::value::Value;
+use crate::Artichoke;
+
+pub fn method(
+    interp: &Artichoke,
+    value: Value,
+    other: Value,
+) -> Result<Value, Box<dyn RubyException>> {
+    let x = value.try_into::<Int>().map_err(|_| {
+        Fatal::new(
+            interp,
+            "Unable to extract Rust Integer from Ruby Integer receiver",
+        )
+    })?;
+    let pretty_name = other.pretty_name();
+    if let Ok(y) = other.clone().try_into::<Int>() {
+        Ok(interp.convert(x / y))
+    } else if let Ok(y) = other.try_into::<Float>() {
+        #[allow(clippy::cast_precision_loss)]
+        Ok(interp.convert(x as Float / y))
+    } else {
+        Err(Box::new(TypeError::new(
+            interp,
+            format!("{} can't be coerced into Integer", pretty_name),
+        )))
+    }
+}

--- a/artichoke-backend/src/extn/core/integer/div.rs
+++ b/artichoke-backend/src/extn/core/integer/div.rs
@@ -80,4 +80,30 @@ mod tests {
         }
         result
     }
+
+    #[quickcheck]
+    fn integer_division_send(x: Int, y: Int) -> bool {
+        let interp = crate::interpreter().expect("init");
+        let mut result = true;
+        match (x, y) {
+            (0, 0) => result &= interp.eval(b"0.send('/', 0)").is_err(),
+            (x, 0) | (0, x) => {
+                let expr = format!("{}.send('/', 0)", x).into_bytes();
+                result &= interp.eval(expr.as_slice()).is_err();
+                let expr = format!("0.send('/', {})", x).into_bytes();
+                let division = interp
+                    .eval(expr.as_slice())
+                    .and_then(Value::try_into::<Int>);
+                result &= division == Ok(0)
+            }
+            (x, y) => {
+                let expr = format!("{}.send('/', {})", x, y).into_bytes();
+                let division = interp
+                    .eval(expr.as_slice())
+                    .and_then(Value::try_into::<Int>);
+                result &= division == Ok(x / y)
+            }
+        }
+        result
+    }
 }

--- a/artichoke-backend/vendor/mruby/src/vm.c
+++ b/artichoke-backend/vendor/mruby/src/vm.c
@@ -2261,35 +2261,80 @@ RETRY_TRY_BLOCK:
     }
 
     CASE(OP_DIV, B) {
-#ifndef MRB_WITHOUT_FLOAT
-      double x, y, f;
-#endif
-
       /* need to check if op is overridden */
       switch (TYPES2(mrb_type(regs[a]),mrb_type(regs[a+1]))) {
       case TYPES2(MRB_TT_FIXNUM,MRB_TT_FIXNUM):
-#ifdef MRB_WITHOUT_FLOAT
         {
           mrb_int x = mrb_fixnum(regs[a]);
           mrb_int y = mrb_fixnum(regs[a+1]);
+#ifdef ARTICHOKE
+          if (y == 0) {
+            mrb_raise(mrb, mrb_exc_get(mrb, "ZeroDivisionError"), "divided by 0");
+          }
+#endif
           SET_INT_VALUE(regs[a], y ? x / y : 0);
         }
         break;
-#else
-        x = (mrb_float)mrb_fixnum(regs[a]);
-        y = (mrb_float)mrb_fixnum(regs[a+1]);
-        break;
+#ifndef MRB_WITHOUT_FLOAT
       case TYPES2(MRB_TT_FIXNUM,MRB_TT_FLOAT):
-        x = (mrb_float)mrb_fixnum(regs[a]);
-        y = mrb_float(regs[a+1]);
+        {
+          mrb_float x = (mrb_float)mrb_fixnum(regs[a]);
+          mrb_float y = mrb_float(regs[a+1]);
+          mrb_float f;
+          if (y == 0) {
+            if (x > 0) {
+              f = INFINITY;
+            } else if (x < 0) {
+              f = -INFINITY;
+            } else /* if (x == 0) */ {
+              f = NAN;
+            }
+          }
+          else {
+            f = x / y;
+          }
+          SET_FLOAT_VALUE(mrb, regs[a], f);
+        }
         break;
       case TYPES2(MRB_TT_FLOAT,MRB_TT_FIXNUM):
-        x = mrb_float(regs[a]);
-        y = (mrb_float)mrb_fixnum(regs[a+1]);
+        {
+          mrb_float x = mrb_float(regs[a]);
+          mrb_float y = (mrb_float)mrb_fixnum(regs[a+1]);
+          mrb_float f;
+          if (y == 0) {
+            if (x > 0) {
+              f = INFINITY;
+            } else if (x < 0) {
+              f = -INFINITY;
+            } else /* if (x == 0) */ {
+              f = NAN;
+            }
+          }
+          else {
+            f = x / y;
+          }
+          SET_FLOAT_VALUE(mrb, regs[a], f);
+        }
         break;
       case TYPES2(MRB_TT_FLOAT,MRB_TT_FLOAT):
-        x = mrb_float(regs[a]);
-        y = mrb_float(regs[a+1]);
+        {
+          mrb_float x = mrb_float(regs[a]);
+          mrb_float y = mrb_float(regs[a+1]);
+          mrb_float f;
+          if (y == 0) {
+            if (x > 0) {
+              f = INFINITY;
+            } else if (x < 0) {
+              f = -INFINITY;
+            } else /* if (x == 0) */ {
+              f = NAN;
+            }
+          }
+          else {
+            f = x / y;
+          }
+          SET_FLOAT_VALUE(mrb, regs[a], f);
+        }
         break;
 #endif
       default:
@@ -2297,18 +2342,6 @@ RETRY_TRY_BLOCK:
         mid = mrb_intern_lit(mrb, "/");
         goto L_SEND_SYM;
       }
-
-#ifndef MRB_WITHOUT_FLOAT
-      if (y == 0) {
-        if (x > 0) f = INFINITY;
-        else if (x < 0) f = -INFINITY;
-        else /* if (x == 0) */ f = NAN;
-      }
-      else {
-        f = x / y;
-      }
-      SET_FLOAT_VALUE(mrb, regs[a], f);
-#endif
       NEXT;
     }
 


### PR DESCRIPTION
@CodeGradox Thanks for reporting GH-410. 💪 💎 

This PR overrides the implementation of `/` method attached to `Integer` class.

This PR also modifies the implementation of the `OP_DIV` opcode in the murby VM.

For speed, mruby pulls `/` out of the normal method dispatch flow and attempts to process operands as `Integer`s and `Float`s before falling back to method dispatch. This approach was hardcoded to return `Float` and promoted all `Integer` operands to `Float`s. This PR adds special handling for the two `Integer` operand case and adds a `raise ZeroDivisionError` in case of a zero divisor.

```console
$ RUST_BACKTRACE=1 cargo run --bin airb
artichoke 0.1.0 (2019-12-08 revision 2171) [x86_64-darwin]
[Rust 1.39.0 (rev 4560ea7) on x86_64-apple-darwin]
>>> x = 3
=> 3
>>> y = 2
=> 2
>>> x.send('/', y)
=> 1
>>> y.send('/', x)
=> 0
>>> x / y
=> 1
>>> y / x
=> 0
>>>
```

This code doesn't pass ruby/spec because Artichoke doesn't have BIGINT support.

Closes GH-410.