### PR TITLE
Latest rustup is installing i686 Rust

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ commands:
             # Install rustup
             $client = new-object System.Net.WebClient
             $client.DownloadFile('https://win.rustup.rs', "$pwd\rustup-init.exe")
-            .\rustup-init.exe -y --profile minimal --default-toolchain "$($toolchain)-x86_64-msvc"
+            .\rustup-init.exe -y --profile minimal --default-toolchain "$($toolchain)-msvc"
             # This is necessary because otherwise cargo fails when trying to use git?
             Add-Content "$env:USERPROFILE\.cargo\config" "[net]`ngit-fetch-with-cli = true"
             choco install ruby --no-progress --version=2.6.3.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ commands:
             # Install rustup
             $client = new-object System.Net.WebClient
             $client.DownloadFile('https://win.rustup.rs', "$pwd\rustup-init.exe")
-            .\rustup-init.exe -y --profile minimal --default-toolchain "$($toolchain)-msvc"
+            .\rustup-init.exe -y --profile minimal --default-toolchain "$($toolchain)-msvc" --default-host x86_64-pc-windows-msvc
             # This is necessary because otherwise cargo fails when trying to use git?
             Add-Content "$env:USERPROFILE\.cargo\config" "[net]`ngit-fetch-with-cli = true"
             choco install ruby --no-progress --version=2.6.3.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ commands:
             # Install rustup
             $client = new-object System.Net.WebClient
             $client.DownloadFile('https://win.rustup.rs', "$pwd\rustup-init.exe")
-            .\rustup-init.exe -y --profile minimal --default-toolchain "$($toolchain)-msvc"
+            .\rustup-init.exe -y --profile minimal --default-toolchain "$($toolchain)-msvc" --default-host
             # This is necessary because otherwise cargo fails when trying to use git?
             Add-Content "$env:USERPROFILE\.cargo\config" "[net]`ngit-fetch-with-cli = true"
             choco install ruby --no-progress --version=2.6.3.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ commands:
             # Install rustup
             $client = new-object System.Net.WebClient
             $client.DownloadFile('https://win.rustup.rs', "$pwd\rustup-init.exe")
-            .\rustup-init.exe -y --profile minimal --default-toolchain "$($toolchain)-msvc"
+            .\rustup-init.exe -y --profile minimal --default-toolchain "$($toolchain)"
             # This is necessary because otherwise cargo fails when trying to use git?
             Add-Content "$env:USERPROFILE\.cargo\config" "[net]`ngit-fetch-with-cli = true"
             choco install ruby --no-progress --version=2.6.3.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ commands:
             # Install rustup
             $client = new-object System.Net.WebClient
             $client.DownloadFile('https://win.rustup.rs', "$pwd\rustup-init.exe")
-            .\rustup-init.exe -y --profile minimal --default-toolchain "$($toolchain)-msvc"
+            .\rustup-init.exe -y --profile minimal --default-toolchain "$($toolchain)-x86_64-msvc"
             # This is necessary because otherwise cargo fails when trying to use git?
             Add-Content "$env:USERPROFILE\.cargo\config" "[net]`ngit-fetch-with-cli = true"
             choco install ruby --no-progress --version=2.6.3.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ commands:
             # Install rustup
             $client = new-object System.Net.WebClient
             $client.DownloadFile('https://win.rustup.rs', "$pwd\rustup-init.exe")
-            .\rustup-init.exe -y --profile minimal --default-toolchain "$($toolchain)-msvc" --default-host
+            .\rustup-init.exe -y --profile minimal --default-toolchain "$($toolchain)-msvc"
             # This is necessary because otherwise cargo fails when trying to use git?
             Add-Content "$env:USERPROFILE\.cargo\config" "[net]`ngit-fetch-with-cli = true"
             choco install ruby --no-progress --version=2.6.3.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ commands:
             # Install rustup
             $client = new-object System.Net.WebClient
             $client.DownloadFile('https://win.rustup.rs', "$pwd\rustup-init.exe")
-            .\rustup-init.exe -y --profile minimal --default-toolchain "$($toolchain)"
+            .\rustup-init.exe -y --profile minimal --default-toolchain "$($toolchain)-msvc"
             # This is necessary because otherwise cargo fails when trying to use git?
             Add-Content "$env:USERPROFILE\.cargo\config" "[net]`ngit-fetch-with-cli = true"
             choco install ruby --no-progress --version=2.6.3.1


### PR DESCRIPTION
From https://circleci.com/gh/artichoke/artichoke/5205

```
#!powershell.exe -ExecutionPolicy Bypass
rustc --version --verbose
cargo --version --verbose
ruby --version
clang --version
win_bison --version
rustc 1.39.0 (4560ea788 2019-11-04)
binary: rustc
commit-hash: 4560ea788cb760f0a34127156c78e2552949f734
commit-date: 2019-11-04
host: i686-pc-windows-msvc
release: 1.39.0
LLVM version: 9.0
cargo 1.39.0 (1c6ec66d5 2019-09-30)
release: 1.39.0
commit-hash: 1c6ec66d5bae40e9dfd2fb82f091b5172c212d73
commit-date: 2019-09-30
ruby 2.6.3p62 (2019-04-16 revision 67580) [x64-mingw32]
clang version 9.0.0 (tags/RELEASE_900/final)
Target: x86_64-pc-windows-msvc
Thread model: posix
InstalledDir: C:\Program Files\LLVM\bin
bison (GNU Bison) 3.3.2
Written by Robert Corbett and Richard Stallman.

Copyright (C) 2019 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```