### PR TITLE
Partially implement Time core class

### DIFF
--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 arrayvec = "0.5"
 backtrace = { version = "0.3", optional = true }
 bstr = "0.2"
+chrono = "0.4"
 downcast = "0.10"
 log = "0.4"
 memchr = "2"

--- a/artichoke-backend/src/extn/core/mod.rs
+++ b/artichoke-backend/src/extn/core/mod.rs
@@ -28,6 +28,7 @@ pub mod regexp;
 pub mod string;
 pub mod symbol;
 pub mod thread;
+pub mod time;
 pub mod warning;
 
 pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
@@ -61,6 +62,7 @@ pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
     string::init(interp)?;
     symbol::init(interp)?;
     thread::init(interp)?;
+    time::mruby::init(interp)?;
     warning::init(interp)?;
     Ok(())
 }

--- a/artichoke-backend/src/extn/core/time/backend/chrono.rs
+++ b/artichoke-backend/src/extn/core/time/backend/chrono.rs
@@ -1,0 +1,101 @@
+use chrono::{DateTime, Datelike, Local, TimeZone, Timelike, Weekday};
+
+use crate::extn::core::time::backend::{MakeTime, TimeType};
+use crate::Artichoke;
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Chrono<T: 'static + TimeZone>(DateTime<T>);
+
+#[derive(Debug, Clone, Copy)]
+pub struct Factory;
+
+impl<T: TimeZone> Chrono<T> {
+    fn new(time: DateTime<T>) -> Self {
+        Self(time)
+    }
+}
+
+impl<T: TimeZone> TimeType for Chrono<T> {
+    fn day(&self) -> u32 {
+        self.0.day()
+    }
+
+    fn minute(&self) -> u32 {
+        self.0.minute()
+    }
+
+    fn month(&self) -> u32 {
+        self.0.month()
+    }
+
+    fn nanosecond(&self) -> u32 {
+        self.0.nanosecond()
+    }
+
+    fn second(&self) -> u32 {
+        self.0.second()
+    }
+
+    fn microsecond(&self) -> u32 {
+        self.0.nanosecond() / 1_000
+    }
+
+    fn weekday(&self) -> u32 {
+        self.0.weekday().num_days_from_sunday()
+    }
+
+    fn year_day(&self) -> u32 {
+        self.0.ordinal()
+    }
+
+    fn year(&self) -> i32 {
+        self.0.year()
+    }
+
+    fn to_float(&self) -> f64 {
+        #[allow(clippy::cast_precision_loss)]
+        let sec = self.0.timestamp() as f64;
+        let nanos_fractional = f64::from(self.0.timestamp_subsec_nanos()) / 1_000_000_000_f64;
+        sec + nanos_fractional
+    }
+
+    fn to_int(&self) -> i64 {
+        self.0.timestamp()
+    }
+
+    fn is_monday(&self) -> bool {
+        self.0.weekday() == Weekday::Mon
+    }
+
+    fn is_tuesday(&self) -> bool {
+        self.0.weekday() == Weekday::Tue
+    }
+
+    fn is_wednesday(&self) -> bool {
+        self.0.weekday() == Weekday::Wed
+    }
+
+    fn is_thursday(&self) -> bool {
+        self.0.weekday() == Weekday::Thu
+    }
+
+    fn is_friday(&self) -> bool {
+        self.0.weekday() == Weekday::Fri
+    }
+
+    fn is_saturday(&self) -> bool {
+        self.0.weekday() == Weekday::Sat
+    }
+
+    fn is_sunday(&self) -> bool {
+        self.0.weekday() == Weekday::Sun
+    }
+}
+
+impl MakeTime for Factory {
+    #[must_use]
+    fn now(&self, interp: &Artichoke) -> Box<dyn TimeType> {
+        let _ = interp;
+        Box::new(Chrono::new(Local::now()))
+    }
+}

--- a/artichoke-backend/src/extn/core/time/backend/mod.rs
+++ b/artichoke-backend/src/extn/core/time/backend/mod.rs
@@ -1,0 +1,73 @@
+use std::any::Any;
+
+use crate::Artichoke;
+
+pub mod chrono;
+
+/// Common API for [`Time`](crate::extn::core::time::Time) backends.
+pub trait TimeType: Any {
+    /// Returns the day of the month (1..n) for time.
+    fn day(&self) -> u32;
+
+    /// Returns the minute of the hour (0..59) for time.
+    fn minute(&self) -> u32;
+
+    /// Returns the month of the year (1..12) for time.
+    fn month(&self) -> u32;
+
+    /// Returns the number of nanoseconds for time.
+    fn nanosecond(&self) -> u32;
+
+    /// Returns the second of the minute (0..60) for time.
+    ///
+    /// *Note*: Seconds range from zero to 60 to allow the system to inject leap
+    /// seconds. See <https://en.wikipedia.org/wiki/Leap_second> for further
+    /// details.
+    fn second(&self) -> u32;
+
+    /// Returns the number of microseconds for time.
+    fn microsecond(&self) -> u32;
+
+    /// Returns an integer representing the day of the week, 0..6, with Sunday
+    /// == 0.
+    fn weekday(&self) -> u32;
+
+    /// Returns an integer representing the day of the year, 1..366.
+    fn year_day(&self) -> u32;
+
+    /// Returns the year for time (including the century).
+    fn year(&self) -> i32;
+
+    /// Returns the value of time as a floating point number of seconds since
+    /// the Epoch.
+    fn to_float(&self) -> f64;
+
+    /// Returns the value of time as an integer number of seconds since the
+    /// Epoch.
+    fn to_int(&self) -> i64;
+
+    /// Returns `true` if time represents Monday.
+    fn is_monday(&self) -> bool;
+
+    /// Returns `true` if time represents Tuesday.
+    fn is_tuesday(&self) -> bool;
+
+    /// Returns `true` if time represents Wednesday.
+    fn is_wednesday(&self) -> bool;
+
+    /// Returns `true` if time represents Thursday.
+    fn is_thursday(&self) -> bool;
+
+    /// Returns `true` if time represents Friday.
+    fn is_friday(&self) -> bool;
+
+    /// Returns `true` if time represents Saturday.
+    fn is_saturday(&self) -> bool;
+
+    /// Returns `true` if time represents Sunday.
+    fn is_sunday(&self) -> bool;
+}
+
+pub trait MakeTime: Any {
+    fn now(&self, interp: &Artichoke) -> Box<dyn TimeType>;
+}

--- a/artichoke-backend/src/extn/core/time/mod.rs
+++ b/artichoke-backend/src/extn/core/time/mod.rs
@@ -1,0 +1,27 @@
+use crate::convert::RustBackedValue;
+
+pub mod backend;
+pub mod mruby;
+pub mod trampoline;
+
+use backend::{chrono, MakeTime, TimeType};
+
+#[must_use]
+pub fn factory() -> impl MakeTime {
+    chrono::Factory
+}
+
+pub struct Time(Box<dyn TimeType>);
+
+impl Time {
+    fn inner(&self) -> &dyn TimeType {
+        self.0.as_ref()
+    }
+}
+
+impl RustBackedValue for Time {
+    #[must_use]
+    fn ruby_type_name() -> &'static str {
+        "Time"
+    }
+}

--- a/artichoke-backend/src/extn/core/time/mruby.rs
+++ b/artichoke-backend/src/extn/core/time/mruby.rs
@@ -1,0 +1,167 @@
+use artichoke_core::eval::Eval;
+
+use crate::class;
+use crate::def;
+use crate::extn::core::exception;
+use crate::extn::core::time::{self, trampoline};
+use crate::sys;
+use crate::value::Value;
+use crate::{Artichoke, ArtichokeError};
+
+pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
+    if interp.0.borrow().class_spec::<time::Time>().is_some() {
+        return Ok(());
+    }
+    let spec = class::Spec::new("Time", None, Some(def::rust_data_free::<time::Time>));
+    class::Builder::for_spec(interp, &spec)
+        .value_is_rust_object()
+        .add_self_method("now", artichoke_time_self_now, sys::mrb_args_none())
+        .add_method("min", artichoke_time_minute, sys::mrb_args_none())
+        .add_method("mon", artichoke_time_month, sys::mrb_args_none())
+        .add_method("nsec", artichoke_time_nanosecond, sys::mrb_args_none())
+        .add_method("sec", artichoke_time_second, sys::mrb_args_none())
+        .add_method("usec", artichoke_time_microsecond, sys::mrb_args_none())
+        .add_method("wday", artichoke_time_weekday, sys::mrb_args_none())
+        .add_method("yday", artichoke_time_year_day, sys::mrb_args_none())
+        .add_method("year", artichoke_time_year, sys::mrb_args_none())
+        .define()?;
+    interp.0.borrow_mut().def_class::<time::Time>(spec);
+
+    let _ = interp.eval(&include_bytes!("time.rb")[..])?;
+    trace!("Patched Random onto interpreter");
+    Ok(())
+}
+
+#[no_mangle]
+unsafe extern "C" fn artichoke_time_self_now(
+    mrb: *mut sys::mrb_state,
+    _slf: sys::mrb_value,
+) -> sys::mrb_value {
+    mrb_get_args!(mrb, none);
+    let interp = unwrap_interpreter!(mrb);
+    let result = trampoline::now(&interp);
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => exception::raise(interp, exception),
+    }
+}
+
+#[no_mangle]
+unsafe extern "C" fn artichoke_time_minute(
+    mrb: *mut sys::mrb_state,
+    slf: sys::mrb_value,
+) -> sys::mrb_value {
+    mrb_get_args!(mrb, none);
+    let interp = unwrap_interpreter!(mrb);
+    let time = Value::new(&interp, slf);
+    let result = trampoline::minute(&interp, time);
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => exception::raise(interp, exception),
+    }
+}
+
+#[no_mangle]
+unsafe extern "C" fn artichoke_time_month(
+    mrb: *mut sys::mrb_state,
+    slf: sys::mrb_value,
+) -> sys::mrb_value {
+    mrb_get_args!(mrb, none);
+    let interp = unwrap_interpreter!(mrb);
+    let time = Value::new(&interp, slf);
+    let result = trampoline::month(&interp, time);
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => exception::raise(interp, exception),
+    }
+}
+
+#[no_mangle]
+unsafe extern "C" fn artichoke_time_nanosecond(
+    mrb: *mut sys::mrb_state,
+    slf: sys::mrb_value,
+) -> sys::mrb_value {
+    mrb_get_args!(mrb, none);
+    let interp = unwrap_interpreter!(mrb);
+    let time = Value::new(&interp, slf);
+    let result = trampoline::nanosecond(&interp, time);
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => exception::raise(interp, exception),
+    }
+}
+
+#[no_mangle]
+unsafe extern "C" fn artichoke_time_second(
+    mrb: *mut sys::mrb_state,
+    slf: sys::mrb_value,
+) -> sys::mrb_value {
+    mrb_get_args!(mrb, none);
+    let interp = unwrap_interpreter!(mrb);
+    let time = Value::new(&interp, slf);
+    let result = trampoline::second(&interp, time);
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => exception::raise(interp, exception),
+    }
+}
+
+#[no_mangle]
+unsafe extern "C" fn artichoke_time_microsecond(
+    mrb: *mut sys::mrb_state,
+    slf: sys::mrb_value,
+) -> sys::mrb_value {
+    mrb_get_args!(mrb, none);
+    let interp = unwrap_interpreter!(mrb);
+    let time = Value::new(&interp, slf);
+    let result = trampoline::microsecond(&interp, time);
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => exception::raise(interp, exception),
+    }
+}
+
+#[no_mangle]
+unsafe extern "C" fn artichoke_time_weekday(
+    mrb: *mut sys::mrb_state,
+    slf: sys::mrb_value,
+) -> sys::mrb_value {
+    mrb_get_args!(mrb, none);
+    let interp = unwrap_interpreter!(mrb);
+    let time = Value::new(&interp, slf);
+    let result = trampoline::weekday(&interp, time);
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => exception::raise(interp, exception),
+    }
+}
+
+#[no_mangle]
+unsafe extern "C" fn artichoke_time_year_day(
+    mrb: *mut sys::mrb_state,
+    slf: sys::mrb_value,
+) -> sys::mrb_value {
+    mrb_get_args!(mrb, none);
+    let interp = unwrap_interpreter!(mrb);
+    let time = Value::new(&interp, slf);
+    let result = trampoline::year_day(&interp, time);
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => exception::raise(interp, exception),
+    }
+}
+
+#[no_mangle]
+unsafe extern "C" fn artichoke_time_year(
+    mrb: *mut sys::mrb_state,
+    slf: sys::mrb_value,
+) -> sys::mrb_value {
+    mrb_get_args!(mrb, none);
+    let interp = unwrap_interpreter!(mrb);
+    let time = Value::new(&interp, slf);
+    let result = trampoline::year(&interp, time);
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => exception::raise(interp, exception),
+    }
+}

--- a/artichoke-backend/src/extn/core/time/time.rb
+++ b/artichoke-backend/src/extn/core/time/time.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class Time
+end

--- a/artichoke-backend/src/extn/core/time/trampoline.rs
+++ b/artichoke-backend/src/extn/core/time/trampoline.rs
@@ -1,0 +1,102 @@
+use crate::convert::{Convert, RustBackedValue};
+use crate::extn::core::exception::{Fatal, RubyException};
+use crate::extn::core::time::backend::MakeTime;
+use crate::extn::core::time::{self, Time};
+use crate::value::Value;
+use crate::Artichoke;
+
+pub fn now(interp: &Artichoke) -> Result<Value, Box<dyn RubyException>> {
+    let now = Time(time::factory().now(interp));
+    let result = now
+        .try_into_ruby(&interp, None)
+        .map_err(|_| Fatal::new(interp, "Unable to initialize Ruby Time with Rust Time"))?;
+    Ok(result)
+}
+
+pub fn minute(interp: &Artichoke, time: Value) -> Result<Value, Box<dyn RubyException>> {
+    let time = unsafe { Time::try_from_ruby(interp, &time) }.map_err(|_| {
+        Fatal::new(
+            interp,
+            "Unable to extract Rust Time from Ruby Time receiver",
+        )
+    })?;
+    let minute = time.borrow().inner().minute();
+    Ok(interp.convert(minute))
+}
+
+pub fn month(interp: &Artichoke, time: Value) -> Result<Value, Box<dyn RubyException>> {
+    let time = unsafe { Time::try_from_ruby(interp, &time) }.map_err(|_| {
+        Fatal::new(
+            interp,
+            "Unable to extract Rust Time from Ruby Time receiver",
+        )
+    })?;
+    let month = time.borrow().inner().month();
+    Ok(interp.convert(month))
+}
+
+pub fn nanosecond(interp: &Artichoke, time: Value) -> Result<Value, Box<dyn RubyException>> {
+    let time = unsafe { Time::try_from_ruby(interp, &time) }.map_err(|_| {
+        Fatal::new(
+            interp,
+            "Unable to extract Rust Time from Ruby Time receiver",
+        )
+    })?;
+    let nanosecond = time.borrow().inner().nanosecond();
+    Ok(interp.convert(nanosecond))
+}
+
+pub fn second(interp: &Artichoke, time: Value) -> Result<Value, Box<dyn RubyException>> {
+    let time = unsafe { Time::try_from_ruby(interp, &time) }.map_err(|_| {
+        Fatal::new(
+            interp,
+            "Unable to extract Rust Time from Ruby Time receiver",
+        )
+    })?;
+    let second = time.borrow().inner().second();
+    Ok(interp.convert(second))
+}
+
+pub fn microsecond(interp: &Artichoke, time: Value) -> Result<Value, Box<dyn RubyException>> {
+    let time = unsafe { Time::try_from_ruby(interp, &time) }.map_err(|_| {
+        Fatal::new(
+            interp,
+            "Unable to extract Rust Time from Ruby Time receiver",
+        )
+    })?;
+    let microsecond = time.borrow().inner().microsecond();
+    Ok(interp.convert(microsecond))
+}
+
+pub fn weekday(interp: &Artichoke, time: Value) -> Result<Value, Box<dyn RubyException>> {
+    let time = unsafe { Time::try_from_ruby(interp, &time) }.map_err(|_| {
+        Fatal::new(
+            interp,
+            "Unable to extract Rust Time from Ruby Time receiver",
+        )
+    })?;
+    let weekday = time.borrow().inner().weekday();
+    Ok(interp.convert(weekday))
+}
+
+pub fn year_day(interp: &Artichoke, time: Value) -> Result<Value, Box<dyn RubyException>> {
+    let time = unsafe { Time::try_from_ruby(interp, &time) }.map_err(|_| {
+        Fatal::new(
+            interp,
+            "Unable to extract Rust Time from Ruby Time receiver",
+        )
+    })?;
+    let year_day = time.borrow().inner().year_day();
+    Ok(interp.convert(year_day))
+}
+
+pub fn year(interp: &Artichoke, time: Value) -> Result<Value, Box<dyn RubyException>> {
+    let time = unsafe { Time::try_from_ruby(interp, &time) }.map_err(|_| {
+        Fatal::new(
+            interp,
+            "Unable to extract Rust Time from Ruby Time receiver",
+        )
+    })?;
+    let year = time.borrow().inner().year();
+    Ok(interp.convert(year))
+}


### PR DESCRIPTION
This PR implements the `Time` class backed by the `chrono` crate. This
PR implements `Time::now` with local timezone and many of the date
accessors like `Time#year` and `Time#sec`.

This PR follows the same approach used in other core classes. There is a
public `Time` type that wraps a boxed trait object containing one of
potentially many backend implementations of the Ruby `Time`
functionality.

This code cannot pass ruby/spec because it does not expose fixed time
constructors.

Progress on GH-33.