### PR TITLE
Remove unwraps

### DIFF
--- a/artichoke-backend/src/class.rs
+++ b/artichoke-backend/src/class.rs
@@ -110,7 +110,9 @@ impl Spec {
         T: Into<Cow<'static, str>>,
     {
         let name = name.into();
-        let cstring = CString::new(name.as_ref()).expect("name for data type");
+        let cstring = CString::new(name.as_ref()).unwrap_or_else(|_| unsafe {
+            CString::from_vec_unchecked(String::from("UnknownClass").into_bytes())
+        });
         let data_type = sys::mrb_data_type {
             struct_name: cstring.as_ptr(),
             dfree: free,

--- a/artichoke-backend/src/module.rs
+++ b/artichoke-backend/src/module.rs
@@ -81,7 +81,9 @@ impl Spec {
         T: Into<Cow<'static, str>>,
     {
         let name = name.into();
-        let cstring = CString::new(name.as_ref()).expect("name for data type");
+        let cstring = CString::new(name.as_ref()).unwrap_or_else(|_| unsafe {
+            CString::from_vec_unchecked(String::from("UnknownModule").into_bytes())
+        });
         Self {
             name,
             cstring,

--- a/artichoke-backend/src/sys/mod.rs
+++ b/artichoke-backend/src/sys/mod.rs
@@ -36,8 +36,8 @@ pub fn mruby_version(verbose: bool) -> String {
         let version = unsafe { CStr::from_bytes_with_nul_unchecked(MRUBY_RUBY_VERSION) };
         format!(
             "{} {} [{}]",
-            engine.to_str().expect("mruby engine name"),
-            version.to_str().expect("mruby engine version"),
+            engine.to_string_lossy(),
+            version.to_string_lossy(),
             env!("CARGO_PKG_VERSION")
         )
     } else {
@@ -95,7 +95,7 @@ impl DescribeState for *mut mrb_state {
         let version = unsafe { CStr::from_bytes_with_nul_unchecked(MRUBY_RUBY_VERSION) };
         format!(
             "{} (v{}.{}.{})",
-            version.to_str().expect("mruby engine version"),
+            version.to_string_lossy(),
             MRUBY_RELEASE_MAJOR,
             MRUBY_RELEASE_MINOR,
             MRUBY_RELEASE_TEENY,
@@ -111,8 +111,8 @@ impl fmt::Debug for mrb_state {
         write!(
             f,
             "{} {} (v{}.{}.{}) interpreter at {:p}",
-            engine.to_str().expect("mruby engine name"),
-            version.to_str().expect("mruby engine version"),
+            engine.to_string_lossy(),
+            version.to_string_lossy(),
             MRUBY_RELEASE_MAJOR,
             MRUBY_RELEASE_MINOR,
             MRUBY_RELEASE_TEENY,
@@ -129,8 +129,8 @@ impl fmt::Display for mrb_state {
         write!(
             f,
             "{} {}",
-            engine.to_str().expect("mruby engine name"),
-            version.to_str().expect("mruby engine version"),
+            engine.to_string_lossy(),
+            version.to_string_lossy(),
         )
     }
 }


### PR DESCRIPTION
Clean up sys module, class and module `CString` creation, and lazy regexp memoizing

Adds a clone interface to `RubyException`.