### PR TITLE
Remove unused deps from artichoke-core and artichoke-backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "artichoke-backend"
 version = "0.1.0"
 dependencies = [
- "arrayvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "artichoke-core 0.1.0",
  "artichoke-vfs 0.5.0-alpha",
  "backtrace 0.3.41 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -62,9 +61,6 @@ dependencies = [
 [[package]]
 name = "artichoke-core"
 version = "0.1.0"
-dependencies = [
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "artichoke-frontend"

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2018"
 
 [dependencies]
-arrayvec = "0.5"
 backtrace = { version = "0.3", optional = true }
 bstr = "0.2"
 chrono = "0.4"

--- a/artichoke-core/Cargo.toml
+++ b/artichoke-core/Cargo.toml
@@ -5,4 +5,3 @@ authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2018"
 
 [dependencies]
-log = "0.4"


### PR DESCRIPTION
`log` in artichoke-core.
`arrayvec` in artichoke-backend (this was replaced by `smallvec`).