### PR TITLE
Write Binary content to stdout

### DIFF
--- a/artichoke-backend/src/extn/core/kernel/mod.rs
+++ b/artichoke-backend/src/extn/core/kernel/mod.rs
@@ -79,10 +79,9 @@ impl Kernel {
         let args = mrb_get_args!(mrb, *args);
         let interp = unwrap_interpreter!(mrb);
 
-        for value in args.iter() {
-            let to_s = Value::new(&interp, *value).to_s();
-            let converted_s = String::from_utf8_lossy(to_s.as_slice());
-            interp.0.borrow_mut().print(converted_s.as_ref());
+        for value in args.iter().copied() {
+            let to_s = Value::new(&interp, value).to_s();
+            interp.0.borrow_mut().print(to_s.as_slice());
         }
         sys::mrb_sys_nil_value()
     }
@@ -95,16 +94,14 @@ impl Kernel {
                 }
             } else {
                 let to_s = value.to_s();
-                // TODO convert `puts` to take a Vec<u8>
-                let converted_s = String::from_utf8_lossy(to_s.as_slice());
-                interp.0.borrow_mut().puts(converted_s.as_ref());
+                interp.0.borrow_mut().puts(to_s.as_slice());
             }
         }
 
         let args = mrb_get_args!(mrb, *args);
         let interp = unwrap_interpreter!(mrb);
         if args.is_empty() {
-            interp.0.borrow_mut().puts("");
+            interp.0.borrow_mut().puts(&[]);
         }
         for value in args.iter() {
             do_puts(&interp, &Value::new(&interp, *value));

--- a/artichoke-backend/src/extn/core/kernel/mod.rs
+++ b/artichoke-backend/src/extn/core/kernel/mod.rs
@@ -79,22 +79,24 @@ impl Kernel {
         let args = mrb_get_args!(mrb, *args);
         let interp = unwrap_interpreter!(mrb);
 
+        let mut buf = vec![];
         for value in args.iter().copied() {
             let to_s = Value::new(&interp, value).to_s();
-            interp.0.borrow_mut().print(to_s.as_slice());
+            buf.extend(to_s);
         }
+        interp.0.borrow_mut().print(buf.as_slice());
         sys::mrb_sys_nil_value()
     }
 
     unsafe extern "C" fn puts(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {
-        fn do_puts(interp: &Artichoke, value: &Value) {
+        fn do_puts(interp: &Artichoke, value: &Value, buf: &mut Vec<u8>) {
             if let Ok(array) = value.clone().try_into::<Vec<Value>>() {
                 for value in array {
-                    do_puts(interp, &value);
+                    do_puts(interp, &value, buf);
                 }
             } else {
-                let to_s = value.to_s();
-                interp.0.borrow_mut().puts(to_s.as_slice());
+                buf.extend(value.to_s());
+                buf.push(b'\n');
             }
         }
 
@@ -102,9 +104,12 @@ impl Kernel {
         let interp = unwrap_interpreter!(mrb);
         if args.is_empty() {
             interp.0.borrow_mut().puts(&[]);
-        }
-        for value in args.iter() {
-            do_puts(&interp, &Value::new(&interp, *value));
+        } else {
+            let mut buf = vec![];
+            for value in args.iter().copied() {
+                do_puts(&interp, &Value::new(&interp, value), &mut buf);
+            }
+            interp.0.borrow_mut().print(buf.as_slice());
         }
         sys::mrb_sys_nil_value()
     }

--- a/artichoke-frontend/src/repl.rs
+++ b/artichoke-frontend/src/repl.rs
@@ -118,13 +118,12 @@ pub fn run(
                 match interp.eval(buf.as_bytes()) {
                     Ok(value) => {
                         let result = value.inspect();
-                        writeln!(
-                            output,
-                            "{}{}",
-                            config.result_prefix,
-                            String::from_utf8_lossy(result.as_slice())
-                        )
-                        .map_err(Error::Io)?
+                        io::stdout()
+                            .write_all(config.result_prefix.as_bytes())
+                            .map_err(Error::Io)?;
+                        io::stdout()
+                            .write_all(result.as_slice())
+                            .map_err(Error::Io)?;
                     }
                     Err(ArtichokeError::Exec(backtrace)) => {
                         writeln!(error, "Backtrace:").map_err(Error::Io)?;


### PR DESCRIPTION
Ruby `String`s are equivalent to Rust's `Vec<u8>`, but not every Ruby
`String` could be printed by Artichoke because the `State::puts` and
`State::print` APIs took `&str`.

This commit is a followup to GH-406 which altered the `Value::to_s` and
`Value::inspect` APIs to return `Vec<u8>`. That PR pushed Rust UTF-8
`String` conversion to the `State` and `repl` frontend.

This commit changes the `State` APIs and `repl` to write binary content
to `io::stdout()` using Rust's `io::Write` trait. The internal capture
buffer for `wasm` targets is now a `Vec<u8>`.

Fixes GH-415.

To test, I used the `artichoke` binary to print some invalid UTF-8 and
dumped it with `xxd`. Before this patch, the program prints the UTF-8
replacement character. After this patch, the program prints `0xFF`.

Before:

```console
$ ./target/debug/artichoke -e 'puts "\xFF"' | xxd
00000000: efbf bd0a                                ....
```

After:

```console
$ ./target/debug/artichoke -e 'puts "\xFF"' | xxd
00000000: ff0a                                     ..
```