### PR TITLE
Eagerly parse a Context filename into a CString

### DIFF
--- a/artichoke-backend/src/extn/core/kernel/require.rs
+++ b/artichoke-backend/src/extn/core/kernel/require.rs
@@ -62,7 +62,8 @@ pub fn load(interp: &Artichoke, filename: Value) -> Result<Value, Box<dyn RubyEx
     // and module with `LoadSources` and Ruby files can require
     // arbitrary other files, including some child sources that may
     // depend on these module definitions.
-    let context = Context::new(filename.to_vec());
+    let context = Context::new(fs::osstr_to_bytes(interp, path.as_os_str())?.to_vec())
+        .ok_or_else(|| ArgumentError::new(interp, "path name contains null byte"))?;
     interp.push_context(context);
     // Require Rust File first because an File may define classes and
     // module with `LoadSources` and Ruby files can require arbitrary
@@ -153,7 +154,8 @@ pub fn require(
             // and module with `LoadSources` and Ruby files can require
             // arbitrary other files, including some child sources that may
             // depend on these module definitions.
-            let context = Context::new(fs::osstr_to_bytes(interp, path.as_os_str())?.to_vec());
+            let context = Context::new(fs::osstr_to_bytes(interp, path.as_os_str())?.to_vec())
+                .ok_or_else(|| ArgumentError::new(interp, "path name contains null byte"))?;
             interp.push_context(context);
             // Require Rust File first because an File may define classes and
             // module with `LoadSources` and Ruby files can require arbitrary
@@ -220,7 +222,8 @@ pub fn require(
                 // and module with `LoadSources` and Ruby files can require
                 // arbitrary other files, including some child sources that may
                 // depend on these module definitions.
-                let context = Context::new(fs::osstr_to_bytes(interp, path.as_os_str())?.to_vec());
+                let context = Context::new(fs::osstr_to_bytes(interp, path.as_os_str())?.to_vec())
+                    .ok_or_else(|| ArgumentError::new(interp, "path name contains null byte"))?;
                 interp.push_context(context);
                 // Require Rust File first because an File may define classes and
                 // module with `LoadSources` and Ruby files can require arbitrary
@@ -304,7 +307,8 @@ pub fn require(
     // and module with `LoadSources` and Ruby files can require
     // arbitrary other files, including some child sources that may
     // depend on these module definitions.
-    let context = Context::new(fs::osstr_to_bytes(interp, path.as_os_str())?.to_vec());
+    let context = Context::new(fs::osstr_to_bytes(interp, path.as_os_str())?.to_vec())
+        .ok_or_else(|| ArgumentError::new(interp, "path name contains null byte"))?;
     interp.push_context(context);
     // Require Rust File first because an File may define classes and
     // module with `LoadSources` and Ruby files can require arbitrary
@@ -359,7 +363,7 @@ pub fn require_relative(interp: &Artichoke, file: Value) -> Result<Value, Box<dy
     let context = interp
         .peek_context()
         .ok_or_else(|| Fatal::new(interp, "relative require with no context stack"))?;
-    let current = fs::bytes_to_osstr(interp, context.filename.as_ref())?;
+    let current = fs::bytes_to_osstr(interp, context.filename())?;
     let base = if let Some(base) = Path::new(current).parent() {
         base
     } else {


### PR DESCRIPTION
The API for constructing a `Context` allowed creating Contexts that
could never be used as Contexts. `Context::new` takes effectively a byte
slice and is infallible. `Context` is used as a `CString` by
`Artichoke`'s `Eval` implementation to set the filename on the mruby
parser.

This restriction means that the byte slice used to make the Context
cannot contain any NUL bytes. This restriction also means that getting a
`CString` from the `Context` now must be fallible. Falliblilty when
getting the `Context`'s `CString` is inconvenient in APIs like
`unchecked_eval` which themselves are infallible.

This PR alters the constructor `Context::new` to return
`Option<Context>`. This changes `Context` so that it parses the
`CString` on create instead of validating at use whether the object is
valid.

This change produces better code because callers of `Context::new` can
handle errors locally at the time they are encountered instead of silent
corruption later on. A good example of this is the require code, which
it turns out already has to eforce variants around NUL bytes to be
ruby/spec compliant.

For cases where filenames are static and known to the interpreter at
compile time (like the `-e` or `(eval)` names), an unsafe function
called `Context::new_unchecked` can be used.