### PR TITLE
Make spec constructors and builders fallible

### DIFF
--- a/artichoke-backend/scripts/auto_import/rust_glue.rs.erb
+++ b/artichoke-backend/scripts/auto_import/rust_glue.rs.erb
@@ -5,10 +5,10 @@ use crate::{Artichoke, ArtichokeError};
 pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
     <% constants.each do |(constant, klass)| %>
     <% if klass == "Class" %>
-    let spec = crate::class::Spec::new("<%= constant %>", None, None);
+    let spec = crate::class::Spec::new("<%= constant %>", None, None)?;
     interp.0.borrow_mut().def_class::<<%= constant %>>(spec);
     <% elsif klass == "Module" %>
-    let spec = crate::module::Spec::new("<%= constant %>", None);
+    let spec = crate::module::Spec::new("<%= constant %>", None)?;
     interp.0.borrow_mut().def_module::<<%= constant %>>(spec);
     <% else %>
     // Skipping constant <%= constant %> with class <%= klass %>

--- a/artichoke-backend/src/class.rs
+++ b/artichoke-backend/src/class.rs
@@ -121,24 +121,27 @@ pub struct Spec {
 }
 
 impl Spec {
-    pub fn new<T>(name: T, enclosing_scope: Option<EnclosingRubyScope>, free: Option<Free>) -> Self
+    pub fn new<T>(
+        name: T,
+        enclosing_scope: Option<EnclosingRubyScope>,
+        free: Option<Free>,
+    ) -> Result<Self, ArtichokeError>
     where
         T: Into<Cow<'static, str>>,
     {
         let name = name.into();
-        let cstring = CString::new(name.as_ref()).unwrap_or_else(|_| unsafe {
-            CString::from_vec_unchecked(String::from("UnknownClass").into_bytes())
-        });
+        let cstring =
+            CString::new(name.as_ref()).map_err(|_| ArtichokeError::InvalidConstantName)?;
         let data_type = sys::mrb_data_type {
             struct_name: cstring.as_ptr(),
             dfree: free,
         };
-        Self {
+        Ok(Self {
             name,
             cstring,
             data_type,
             enclosing_scope: enclosing_scope.map(Box::new),
-        }
+        })
     }
 
     #[must_use]

--- a/artichoke-backend/src/class.rs
+++ b/artichoke-backend/src/class.rs
@@ -277,7 +277,7 @@ mod tests {
         let interp = crate::interpreter().expect("init");
         let borrow = interp.0.borrow();
         let standard_error = borrow.class_spec::<StandardError>().unwrap();
-        let spec = class::Spec::new("RustError", None, None);
+        let spec = class::Spec::new("RustError", None, None).unwrap();
         class::Builder::for_spec(&interp, &spec)
             .with_super_class(Some(&standard_error))
             .define()
@@ -298,7 +298,7 @@ mod tests {
     #[test]
     fn rclass_for_undef_root_class() {
         let interp = crate::interpreter().expect("init");
-        let spec = class::Spec::new("Foo", None, None);
+        let spec = class::Spec::new("Foo", None, None).unwrap();
         assert!(spec.rclass(&interp).is_none());
     }
 
@@ -307,7 +307,7 @@ mod tests {
         let interp = crate::interpreter().expect("init");
         let borrow = interp.0.borrow();
         let scope = borrow.module_spec::<Kernel>().unwrap();
-        let spec = class::Spec::new("Foo", Some(EnclosingRubyScope::module(scope)), None);
+        let spec = class::Spec::new("Foo", Some(EnclosingRubyScope::module(scope)), None).unwrap();
         drop(borrow);
         assert!(spec.rclass(&interp).is_none());
     }
@@ -326,8 +326,8 @@ mod tests {
         let _ = interp
             .eval(b"module Foo; class Bar; end; end")
             .expect("eval");
-        let spec = module::Spec::new("Foo", None);
-        let spec = class::Spec::new("Bar", Some(EnclosingRubyScope::module(&spec)), None);
+        let spec = module::Spec::new("Foo", None).unwrap();
+        let spec = class::Spec::new("Bar", Some(EnclosingRubyScope::module(&spec)), None).unwrap();
         assert!(spec.rclass(&interp).is_some());
     }
 
@@ -337,8 +337,8 @@ mod tests {
         let _ = interp
             .eval(b"class Foo; class Bar; end; end")
             .expect("eval");
-        let spec = class::Spec::new("Foo", None, None);
-        let spec = class::Spec::new("Bar", Some(EnclosingRubyScope::class(&spec)), None);
+        let spec = class::Spec::new("Foo", None, None).unwrap();
+        let spec = class::Spec::new("Bar", Some(EnclosingRubyScope::class(&spec)), None).unwrap();
         assert!(spec.rclass(&interp).is_some());
     }
 }

--- a/artichoke-backend/src/class.rs
+++ b/artichoke-backend/src/class.rs
@@ -43,16 +43,32 @@ impl<'a> Builder<'a> {
         self
     }
 
-    pub fn add_method(mut self, name: &str, method: Method, args: sys::mrb_aspec) -> Self {
-        let spec = method::Spec::new(method::Type::Instance, name, method, args);
+    pub fn add_method<T>(
+        mut self,
+        name: T,
+        method: Method,
+        args: sys::mrb_aspec,
+    ) -> Result<Self, ArtichokeError>
+    where
+        T: Into<Cow<'static, str>>,
+    {
+        let spec = method::Spec::new(method::Type::Instance, name, method, args)?;
         self.methods.insert(spec);
-        self
+        Ok(self)
     }
 
-    pub fn add_self_method(mut self, name: &str, method: Method, args: sys::mrb_aspec) -> Self {
-        let spec = method::Spec::new(method::Type::Class, name, method, args);
+    pub fn add_self_method<T>(
+        mut self,
+        name: T,
+        method: Method,
+        args: sys::mrb_aspec,
+    ) -> Result<Self, ArtichokeError>
+    where
+        T: Into<Cow<'static, str>>,
+    {
+        let spec = method::Spec::new(method::Type::Class, name, method, args)?;
         self.methods.insert(spec);
-        self
+        Ok(self)
     }
 
     pub fn define(self) -> Result<(), ArtichokeError> {

--- a/artichoke-backend/src/convert/object.rs
+++ b/artichoke-backend/src/convert/object.rs
@@ -194,10 +194,12 @@ mod tests {
     #[test]
     fn convert_obj_roundtrip() {
         let interp = crate::interpreter().expect("init");
-        let spec = class::Spec::new("Container", None, Some(def::rust_data_free::<Container>));
+        let spec =
+            class::Spec::new("Container", None, Some(def::rust_data_free::<Container>)).unwrap();
         class::Builder::for_spec(&interp, &spec)
             .value_is_rust_object()
             .add_method("value", Container::value, sys::mrb_args_none())
+            .unwrap()
             .define()
             .unwrap();
         interp.0.borrow_mut().def_class::<Container>(spec);
@@ -219,14 +221,16 @@ mod tests {
     #[test]
     fn convert_obj_not_data() {
         let interp = crate::interpreter().expect("init");
-        let spec = class::Spec::new("Container", None, Some(def::rust_data_free::<Container>));
+        let spec =
+            class::Spec::new("Container", None, Some(def::rust_data_free::<Container>)).unwrap();
         class::Builder::for_spec(&interp, &spec)
             .value_is_rust_object()
             .add_method("value", Container::value, sys::mrb_args_none())
+            .unwrap()
             .define()
             .unwrap();
         interp.0.borrow_mut().def_class::<Container>(spec);
-        let spec = class::Spec::new("Other", None, Some(def::rust_data_free::<Container>));
+        let spec = class::Spec::new("Other", None, Some(def::rust_data_free::<Container>)).unwrap();
         class::Builder::for_spec(&interp, &spec)
             .value_is_rust_object()
             .define()

--- a/artichoke-backend/src/def.rs
+++ b/artichoke-backend/src/def.rs
@@ -205,15 +205,17 @@ mod tests {
 
         // Setup: define module and class hierarchy
         let interp = crate::interpreter().expect("init");
-        let root = module::Spec::new("A", None);
-        let mod_under_root = module::Spec::new("B", Some(EnclosingRubyScope::module(&root)));
-        let cls_under_root = class::Spec::new("C", Some(EnclosingRubyScope::module(&root)), None);
+        let root = module::Spec::new("A", None).unwrap();
+        let mod_under_root =
+            module::Spec::new("B", Some(EnclosingRubyScope::module(&root))).unwrap();
+        let cls_under_root =
+            class::Spec::new("C", Some(EnclosingRubyScope::module(&root)), None).unwrap();
         let cls_under_mod =
-            class::Spec::new("D", Some(EnclosingRubyScope::module(&mod_under_root)), None);
+            class::Spec::new("D", Some(EnclosingRubyScope::module(&mod_under_root)), None).unwrap();
         let mod_under_cls =
-            module::Spec::new("E", Some(EnclosingRubyScope::class(&cls_under_root)));
+            module::Spec::new("E", Some(EnclosingRubyScope::class(&cls_under_root))).unwrap();
         let cls_under_cls =
-            class::Spec::new("F", Some(EnclosingRubyScope::class(&cls_under_root)), None);
+            class::Spec::new("F", Some(EnclosingRubyScope::class(&cls_under_root)), None).unwrap();
         module::Builder::for_spec(&interp, &root).define().unwrap();
         module::Builder::for_spec(&interp, &mod_under_root)
             .define()
@@ -312,17 +314,21 @@ mod tests {
                 }
             }
             let interp = crate::interpreter().expect("init");
-            let class = class::Spec::new("DefineMethodTestClass", None, None);
+            let class = class::Spec::new("DefineMethodTestClass", None, None).unwrap();
             class::Builder::for_spec(&interp, &class)
                 .add_method("value", value, sys::mrb_args_none())
+                .unwrap()
                 .add_self_method("value", value, sys::mrb_args_none())
+                .unwrap()
                 .define()
                 .unwrap();
             interp.0.borrow_mut().def_class::<Class>(class);
-            let module = module::Spec::new("DefineMethodTestModule", None);
+            let module = module::Spec::new("DefineMethodTestModule", None).unwrap();
             module::Builder::for_spec(&interp, &module)
                 .add_method("value", value, sys::mrb_args_none())
+                .unwrap()
                 .add_self_method("value", value, sys::mrb_args_none())
+                .unwrap()
                 .define()
                 .unwrap();
             interp.0.borrow_mut().def_module::<Module>(module);

--- a/artichoke-backend/src/eval.rs
+++ b/artichoke-backend/src/eval.rs
@@ -340,9 +340,9 @@ mod tests {
             type Artichoke = Artichoke;
 
             fn require(interp: &Artichoke) -> Result<(), ArtichokeError> {
-                let spec = module::Spec::new("NestedEval", None);
+                let spec = module::Spec::new("NestedEval", None)?;
                 module::Builder::for_spec(interp, &spec)
-                    .add_self_method("file", Self::nested_eval, sys::mrb_args_none())
+                    .add_self_method("file", Self::nested_eval, sys::mrb_args_none())?
                     .define()?;
                 interp.0.borrow_mut().def_module::<Self>(spec);
                 Ok(())

--- a/artichoke-backend/src/extn/core/array/mruby.rs
+++ b/artichoke-backend/src/extn/core/array/mruby.rs
@@ -26,23 +26,23 @@ pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
     let spec = class::Spec::new("Array", None, Some(def::rust_data_free::<array::Array>));
     class::Builder::for_spec(interp, &spec)
         .value_is_rust_object()
-        .add_method("[]", ary_element_reference, sys::mrb_args_req_and_opt(1, 1))
+        .add_method("[]", ary_element_reference, sys::mrb_args_req_and_opt(1, 1))?
         .add_method(
             "[]=",
             ary_element_assignment,
             sys::mrb_args_req_and_opt(2, 1),
-        )
-        .add_method("concat", ary_concat, sys::mrb_args_any())
+        )?
+        .add_method("concat", ary_concat, sys::mrb_args_any())?
         .add_method(
             "initialize",
             ary_initialize,
             sys::mrb_args_opt(2) | sys::mrb_args_block(),
-        )
-        .add_method("initialize_copy", ary_initialize_copy, sys::mrb_args_req(1))
-        .add_method("length", ary_len, sys::mrb_args_none())
-        .add_method("pop", ary_pop, sys::mrb_args_none())
-        .add_method("reverse!", ary_reverse_bang, sys::mrb_args_none())
-        .add_method("size", ary_len, sys::mrb_args_none())
+        )?
+        .add_method("initialize_copy", ary_initialize_copy, sys::mrb_args_req(1))?
+        .add_method("length", ary_len, sys::mrb_args_none())?
+        .add_method("pop", ary_pop, sys::mrb_args_none())?
+        .add_method("reverse!", ary_reverse_bang, sys::mrb_args_none())?
+        .add_method("size", ary_len, sys::mrb_args_none())?
         .define()?;
     interp.0.borrow_mut().def_class::<array::Array>(spec);
     let _ = interp.eval(&include_bytes!("array.rb")[..])?;

--- a/artichoke-backend/src/extn/core/array/mruby.rs
+++ b/artichoke-backend/src/extn/core/array/mruby.rs
@@ -23,7 +23,7 @@ pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
     if interp.0.borrow().class_spec::<array::Array>().is_some() {
         return Ok(());
     }
-    let spec = class::Spec::new("Array", None, Some(def::rust_data_free::<array::Array>));
+    let spec = class::Spec::new("Array", None, Some(def::rust_data_free::<array::Array>))?;
     class::Builder::for_spec(interp, &spec)
         .value_is_rust_object()
         .add_method("[]", ary_element_reference, sys::mrb_args_req_and_opt(1, 1))?

--- a/artichoke-backend/src/extn/core/artichoke/mod.rs
+++ b/artichoke-backend/src/extn/core/artichoke/mod.rs
@@ -5,14 +5,13 @@ pub fn init(interp: &crate::Artichoke) -> Result<(), ArtichokeError> {
     if interp.0.borrow().module_spec::<Artichoke>().is_some() {
         return Ok(());
     }
-    let spec = module::Spec::new("Artichoke", None);
+    let spec = module::Spec::new("Artichoke", None)?;
     module::Builder::for_spec(interp, &spec).define()?;
     interp.0.borrow_mut().def_module::<Artichoke>(spec);
     trace!("Patched Artichoke onto interpreter");
     Ok(())
 }
 
-#[allow(clippy::module_name_repetitions)]
 pub struct Artichoke;
 
 pub struct Kernel;

--- a/artichoke-backend/src/extn/core/comparable/mod.rs
+++ b/artichoke-backend/src/extn/core/comparable/mod.rs
@@ -7,7 +7,7 @@ pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
     if interp.0.borrow().module_spec::<Comparable>().is_some() {
         return Ok(());
     }
-    let spec = module::Spec::new("Comparable", None);
+    let spec = module::Spec::new("Comparable", None)?;
     module::Builder::for_spec(interp, &spec).define()?;
     interp.0.borrow_mut().def_module::<Comparable>(spec);
     let _ = interp.eval(&include_bytes!("comparable.rb")[..])?;

--- a/artichoke-backend/src/extn/core/enumerable/mod.rs
+++ b/artichoke-backend/src/extn/core/enumerable/mod.rs
@@ -7,7 +7,7 @@ pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
     if interp.0.borrow().module_spec::<Enumerable>().is_some() {
         return Ok(());
     }
-    let spec = module::Spec::new("Enumerable", None);
+    let spec = module::Spec::new("Enumerable", None)?;
     module::Builder::for_spec(interp, &spec).define()?;
     interp.0.borrow_mut().def_module::<Enumerable>(spec);
     let _ = interp.eval(&include_bytes!("enumerable.rb")[..])?;

--- a/artichoke-backend/src/extn/core/enumerator/mod.rs
+++ b/artichoke-backend/src/extn/core/enumerator/mod.rs
@@ -7,7 +7,7 @@ pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
     if interp.0.borrow().class_spec::<Enumerator>().is_some() {
         return Ok(());
     }
-    let spec = class::Spec::new("Enumerator", None, None);
+    let spec = class::Spec::new("Enumerator", None, None)?;
     interp.0.borrow_mut().def_class::<Enumerator>(spec);
     let _ = interp.eval(&include_bytes!("enumerator.rb")[..])?;
     let _ = interp.eval(&include_bytes!("lazy.rb")[..])?;

--- a/artichoke-backend/src/extn/core/env/mruby.rs
+++ b/artichoke-backend/src/extn/core/env/mruby.rs
@@ -23,7 +23,7 @@ pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
         "Environ",
         Some(scope),
         Some(def::rust_data_free::<env::Environ>),
-    );
+    )?;
     class::Builder::for_spec(interp, &spec)
         .value_is_rust_object()
         .add_method("[]", artichoke_env_element_reference, sys::mrb_args_req(1))?

--- a/artichoke-backend/src/extn/core/env/mruby.rs
+++ b/artichoke-backend/src/extn/core/env/mruby.rs
@@ -26,14 +26,14 @@ pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
     );
     class::Builder::for_spec(interp, &spec)
         .value_is_rust_object()
-        .add_method("[]", artichoke_env_element_reference, sys::mrb_args_req(1))
+        .add_method("[]", artichoke_env_element_reference, sys::mrb_args_req(1))?
         .add_method(
             "[]=",
             artichoke_env_element_assignment,
             sys::mrb_args_req(2),
-        )
-        .add_method("initialize", artichoke_env_initialize, sys::mrb_args_none())
-        .add_method("to_h", artichoke_env_to_h, sys::mrb_args_none())
+        )?
+        .add_method("initialize", artichoke_env_initialize, sys::mrb_args_none())?
+        .add_method("to_h", artichoke_env_to_h, sys::mrb_args_none())?
         .define()?;
     interp.0.borrow_mut().def_class::<env::Environ>(spec);
     let _ = interp.eval(&include_bytes!("env.rb")[..])?;

--- a/artichoke-backend/src/extn/core/exception/mod.rs
+++ b/artichoke-backend/src/extn/core/exception/mod.rs
@@ -568,9 +568,9 @@ mod tests {
         type Artichoke = Artichoke;
 
         fn require(interp: &Artichoke) -> Result<(), ArtichokeError> {
-            let spec = class::Spec::new("Run", None, None);
+            let spec = class::Spec::new("Run", None, None).unwrap();
             class::Builder::for_spec(interp, &spec)
-                .add_self_method("run", Self::run, sys::mrb_args_none())
+                .add_self_method("run", Self::run, sys::mrb_args_none())?
                 .define()?;
             interp.0.borrow_mut().def_class::<Self>(spec);
             Ok(())

--- a/artichoke-backend/src/extn/core/exception/mod.rs
+++ b/artichoke-backend/src/extn/core/exception/mod.rs
@@ -53,174 +53,174 @@ use crate::{Artichoke, ArtichokeError};
 pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
     let borrow = interp.0.borrow();
 
-    let exception_spec = class::Spec::new("Exception", None, None);
+    let exception_spec = class::Spec::new("Exception", None, None)?;
     class::Builder::for_spec(interp, &exception_spec)
         .with_super_class(None)
         .define()?;
 
-    let nomemory_spec = class::Spec::new("NoMemoryError", None, None);
+    let nomemory_spec = class::Spec::new("NoMemoryError", None, None)?;
     class::Builder::for_spec(interp, &nomemory_spec)
         .with_super_class(Some(&exception_spec))
         .define()?;
 
-    let script_spec = class::Spec::new("ScriptError", None, None);
+    let script_spec = class::Spec::new("ScriptError", None, None)?;
     class::Builder::for_spec(interp, &script_spec)
         .with_super_class(Some(&exception_spec))
         .define()?;
 
-    let load_spec = class::Spec::new("LoadError", None, None);
+    let load_spec = class::Spec::new("LoadError", None, None)?;
     class::Builder::for_spec(interp, &load_spec)
         .with_super_class(Some(&script_spec))
         .define()?;
 
-    let notimplemented_spec = class::Spec::new("NotImplementedError", None, None);
+    let notimplemented_spec = class::Spec::new("NotImplementedError", None, None)?;
     class::Builder::for_spec(interp, &notimplemented_spec)
         .with_super_class(Some(&script_spec))
         .define()?;
 
-    let syntax_spec = class::Spec::new("SyntaxError", None, None);
+    let syntax_spec = class::Spec::new("SyntaxError", None, None)?;
     class::Builder::for_spec(interp, &syntax_spec)
         .with_super_class(Some(&script_spec))
         .define()?;
 
-    let security_spec = class::Spec::new("SecurityError", None, None);
+    let security_spec = class::Spec::new("SecurityError", None, None)?;
     class::Builder::for_spec(interp, &security_spec)
         .with_super_class(Some(&exception_spec))
         .define()?;
 
-    let signal_spec = class::Spec::new("SignalException", None, None);
+    let signal_spec = class::Spec::new("SignalException", None, None)?;
     class::Builder::for_spec(interp, &signal_spec)
         .with_super_class(Some(&exception_spec))
         .define()?;
 
-    let interrupt_spec = class::Spec::new("Interrupt", None, None);
+    let interrupt_spec = class::Spec::new("Interrupt", None, None)?;
     class::Builder::for_spec(interp, &interrupt_spec)
         .with_super_class(Some(&signal_spec))
         .define()?;
 
     // Default for `rescue`.
-    let standard_spec = class::Spec::new("StandardError", None, None);
+    let standard_spec = class::Spec::new("StandardError", None, None)?;
     class::Builder::for_spec(interp, &standard_spec)
         .with_super_class(Some(&exception_spec))
         .define()?;
 
-    let argument_spec = class::Spec::new("ArgumentError", None, None);
+    let argument_spec = class::Spec::new("ArgumentError", None, None)?;
     class::Builder::for_spec(interp, &argument_spec)
         .with_super_class(Some(&standard_spec))
         .define()?;
 
-    let uncaughthrow_spec = class::Spec::new("UncaughtThrowError", None, None);
+    let uncaughthrow_spec = class::Spec::new("UncaughtThrowError", None, None)?;
     class::Builder::for_spec(interp, &uncaughthrow_spec)
         .with_super_class(Some(&argument_spec))
         .define()?;
 
-    let encoding_spec = class::Spec::new("EncodingError", None, None);
+    let encoding_spec = class::Spec::new("EncodingError", None, None)?;
     class::Builder::for_spec(interp, &encoding_spec)
         .with_super_class(Some(&standard_spec))
         .define()?;
 
-    let fiber_spec = class::Spec::new("FiberError", None, None);
+    let fiber_spec = class::Spec::new("FiberError", None, None)?;
     class::Builder::for_spec(interp, &fiber_spec)
         .with_super_class(Some(&standard_spec))
         .define()?;
 
-    let io_spec = class::Spec::new("IOError", None, None);
+    let io_spec = class::Spec::new("IOError", None, None)?;
     class::Builder::for_spec(interp, &io_spec)
         .with_super_class(Some(&standard_spec))
         .define()?;
 
-    let eof_spec = class::Spec::new("EOFError", None, None);
+    let eof_spec = class::Spec::new("EOFError", None, None)?;
     class::Builder::for_spec(interp, &eof_spec)
         .with_super_class(Some(&io_spec))
         .define()?;
 
-    let index_spec = class::Spec::new("IndexError", None, None);
+    let index_spec = class::Spec::new("IndexError", None, None)?;
     class::Builder::for_spec(interp, &index_spec)
         .with_super_class(Some(&standard_spec))
         .define()?;
 
-    let key_spec = class::Spec::new("KeyError", None, None);
+    let key_spec = class::Spec::new("KeyError", None, None)?;
     class::Builder::for_spec(interp, &key_spec)
         .with_super_class(Some(&index_spec))
         .define()?;
 
-    let stopiteration_spec = class::Spec::new("StopIteration", None, None);
+    let stopiteration_spec = class::Spec::new("StopIteration", None, None)?;
     class::Builder::for_spec(interp, &stopiteration_spec)
         .with_super_class(Some(&index_spec))
         .define()?;
 
-    let localjump_spec = class::Spec::new("LocalJumpError", None, None);
+    let localjump_spec = class::Spec::new("LocalJumpError", None, None)?;
     class::Builder::for_spec(interp, &localjump_spec)
         .with_super_class(Some(&standard_spec))
         .define()?;
 
-    let name_spec = class::Spec::new("NameError", None, None);
+    let name_spec = class::Spec::new("NameError", None, None)?;
     class::Builder::for_spec(interp, &name_spec)
         .with_super_class(Some(&standard_spec))
         .define()?;
 
-    let nomethod_spec = class::Spec::new("NoMethodError", None, None);
+    let nomethod_spec = class::Spec::new("NoMethodError", None, None)?;
     class::Builder::for_spec(interp, &nomethod_spec)
         .with_super_class(Some(&name_spec))
         .define()?;
 
-    let range_spec = class::Spec::new("RangeError", None, None);
+    let range_spec = class::Spec::new("RangeError", None, None)?;
     class::Builder::for_spec(interp, &range_spec)
         .with_super_class(Some(&standard_spec))
         .define()?;
 
-    let floatdomain_spec = class::Spec::new("FloatDomainError", None, None);
+    let floatdomain_spec = class::Spec::new("FloatDomainError", None, None)?;
     class::Builder::for_spec(interp, &floatdomain_spec)
         .with_super_class(Some(&range_spec))
         .define()?;
 
-    let regexp_spec = class::Spec::new("RegexpError", None, None);
+    let regexp_spec = class::Spec::new("RegexpError", None, None)?;
     class::Builder::for_spec(interp, &regexp_spec)
         .with_super_class(Some(&standard_spec))
         .define()?;
 
     // Default `Exception` type for `raise`.
-    let runtime_spec = class::Spec::new("RuntimeError", None, None);
+    let runtime_spec = class::Spec::new("RuntimeError", None, None)?;
     class::Builder::for_spec(interp, &runtime_spec)
         .with_super_class(Some(&standard_spec))
         .define()?;
 
-    let frozen_spec = class::Spec::new("FrozenError", None, None);
+    let frozen_spec = class::Spec::new("FrozenError", None, None)?;
     class::Builder::for_spec(interp, &frozen_spec)
         .with_super_class(Some(&runtime_spec))
         .define()?;
 
-    let systemcall_spec = class::Spec::new("SystemCallError", None, None);
+    let systemcall_spec = class::Spec::new("SystemCallError", None, None)?;
     class::Builder::for_spec(interp, &systemcall_spec)
         .with_super_class(Some(&standard_spec))
         .define()?;
 
-    let thread_spec = class::Spec::new("ThreadError", None, None);
+    let thread_spec = class::Spec::new("ThreadError", None, None)?;
     class::Builder::for_spec(interp, &thread_spec)
         .with_super_class(Some(&standard_spec))
         .define()?;
 
-    let type_spec = class::Spec::new("TypeError", None, None);
+    let type_spec = class::Spec::new("TypeError", None, None)?;
     class::Builder::for_spec(interp, &type_spec)
         .with_super_class(Some(&standard_spec))
         .define()?;
 
-    let zerodivision_spec = class::Spec::new("ZeroDivisionError", None, None);
+    let zerodivision_spec = class::Spec::new("ZeroDivisionError", None, None)?;
     class::Builder::for_spec(interp, &zerodivision_spec)
         .with_super_class(Some(&standard_spec))
         .define()?;
 
-    let systemexit_spec = class::Spec::new("SystemExit", None, None);
+    let systemexit_spec = class::Spec::new("SystemExit", None, None)?;
     class::Builder::for_spec(interp, &systemexit_spec)
         .with_super_class(Some(&exception_spec))
         .define()?;
 
-    let systemstack_spec = class::Spec::new("SystemStackError", None, None);
+    let systemstack_spec = class::Spec::new("SystemStackError", None, None)?;
     class::Builder::for_spec(interp, &systemstack_spec)
         .with_super_class(Some(&exception_spec))
         .define()?;
 
-    let fatal_spec = class::Spec::new("fatal", None, None);
+    let fatal_spec = class::Spec::new("fatal", None, None)?;
     class::Builder::for_spec(interp, &fatal_spec)
         .with_super_class(Some(&exception_spec))
         .define()?;

--- a/artichoke-backend/src/extn/core/float/mod.rs
+++ b/artichoke-backend/src/extn/core/float/mod.rs
@@ -8,7 +8,7 @@ pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
     if interp.0.borrow().class_spec::<Float>().is_some() {
         return Ok(());
     }
-    let spec = class::Spec::new("Float", None, None);
+    let spec = class::Spec::new("Float", None, None)?;
     interp.0.borrow_mut().def_class::<Float>(spec);
     let _ = interp.eval(&include_bytes!("float.rb")[..])?;
     // TODO: Add proper constant defs to class::Spec, see GH-158.

--- a/artichoke-backend/src/extn/core/hash/mod.rs
+++ b/artichoke-backend/src/extn/core/hash/mod.rs
@@ -7,7 +7,7 @@ pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
     if interp.0.borrow().class_spec::<Hash>().is_some() {
         return Ok(());
     }
-    let spec = class::Spec::new("Hash", None, None);
+    let spec = class::Spec::new("Hash", None, None)?;
     interp.0.borrow_mut().def_class::<Hash>(spec);
     let _ = interp.eval(&include_bytes!("hash.rb")[..])?;
     trace!("Patched Hash onto interpreter");

--- a/artichoke-backend/src/extn/core/integer/mod.rs
+++ b/artichoke-backend/src/extn/core/integer/mod.rs
@@ -19,9 +19,9 @@ pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
     }
     let spec = class::Spec::new("Integer", None, None);
     class::Builder::for_spec(interp, &spec)
-        .add_method("chr", Integer::chr, sys::mrb_args_opt(1))
-        .add_method("/", Integer::div, sys::mrb_args_req(1))
-        .add_method("size", Integer::size, sys::mrb_args_none())
+        .add_method("chr", Integer::chr, sys::mrb_args_opt(1))?
+        .add_method("/", Integer::div, sys::mrb_args_req(1))?
+        .add_method("size", Integer::size, sys::mrb_args_none())?
         .define()?;
     interp.0.borrow_mut().def_class::<Integer>(spec);
     let _ = interp.eval(&include_bytes!("integer.rb")[..])?;

--- a/artichoke-backend/src/extn/core/integer/mod.rs
+++ b/artichoke-backend/src/extn/core/integer/mod.rs
@@ -17,7 +17,7 @@ pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
     if interp.0.borrow().class_spec::<Integer>().is_some() {
         return Ok(());
     }
-    let spec = class::Spec::new("Integer", None, None);
+    let spec = class::Spec::new("Integer", None, None)?;
     class::Builder::for_spec(interp, &spec)
         .add_method("chr", Integer::chr, sys::mrb_args_opt(1))?
         .add_method("/", Integer::div, sys::mrb_args_req(1))?

--- a/artichoke-backend/src/extn/core/kernel/mod.rs
+++ b/artichoke-backend/src/extn/core/kernel/mod.rs
@@ -16,7 +16,7 @@ pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
     if interp.0.borrow().module_spec::<Kernel>().is_some() {
         return Ok(());
     }
-    let spec = module::Spec::new("Kernel", None);
+    let spec = module::Spec::new("Kernel", None)?;
     module::Builder::for_spec(interp, &spec)
         .add_method("require", Kernel::require, sys::mrb_args_rest())?
         .add_method(
@@ -37,7 +37,7 @@ pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
         .module_spec::<artichoke::Artichoke>()
         .map(EnclosingRubyScope::module)
         .ok_or(ArtichokeError::New)?;
-    let spec = module::Spec::new("Kernel", Some(scope));
+    let spec = module::Spec::new("Kernel", Some(scope))?;
     module::Builder::for_spec(interp, &spec)
         .add_method("Integer", Kernel::integer, sys::mrb_args_req_and_opt(1, 1))?
         .add_self_method("Integer", Kernel::integer, sys::mrb_args_req_and_opt(1, 1))?

--- a/artichoke-backend/src/extn/core/kernel/mod.rs
+++ b/artichoke-backend/src/extn/core/kernel/mod.rs
@@ -18,15 +18,15 @@ pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
     }
     let spec = module::Spec::new("Kernel", None);
     module::Builder::for_spec(interp, &spec)
-        .add_method("require", Kernel::require, sys::mrb_args_rest())
+        .add_method("require", Kernel::require, sys::mrb_args_rest())?
         .add_method(
             "require_relative",
             Kernel::require_relative,
             sys::mrb_args_rest(),
-        )
-        .add_method("load", Kernel::load, sys::mrb_args_rest())
-        .add_method("print", Kernel::print, sys::mrb_args_rest())
-        .add_method("puts", Kernel::puts, sys::mrb_args_rest())
+        )?
+        .add_method("load", Kernel::load, sys::mrb_args_rest())?
+        .add_method("print", Kernel::print, sys::mrb_args_rest())?
+        .add_method("puts", Kernel::puts, sys::mrb_args_rest())?
         .define()?;
     interp.0.borrow_mut().def_module::<Kernel>(spec);
     let _ = interp.eval(&include_bytes!("kernel.rb")[..])?;
@@ -39,8 +39,8 @@ pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
         .ok_or(ArtichokeError::New)?;
     let spec = module::Spec::new("Kernel", Some(scope));
     module::Builder::for_spec(interp, &spec)
-        .add_method("Integer", Kernel::integer, sys::mrb_args_req_and_opt(1, 1))
-        .add_self_method("Integer", Kernel::integer, sys::mrb_args_req_and_opt(1, 1))
+        .add_method("Integer", Kernel::integer, sys::mrb_args_req_and_opt(1, 1))?
+        .add_self_method("Integer", Kernel::integer, sys::mrb_args_req_and_opt(1, 1))?
         .define()?;
     interp.0.borrow_mut().def_module::<artichoke::Kernel>(spec);
     trace!("Patched Artichoke::Kernel onto interpreter");

--- a/artichoke-backend/src/extn/core/matchdata/mod.rs
+++ b/artichoke-backend/src/extn/core/matchdata/mod.rs
@@ -45,29 +45,29 @@ pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
     let spec = class::Spec::new("MatchData", None, Some(def::rust_data_free::<MatchData>));
     class::Builder::for_spec(interp, &spec)
         .value_is_rust_object()
-        .add_method("begin", MatchData::begin, sys::mrb_args_req(1))
-        .add_method("captures", MatchData::captures, sys::mrb_args_none())
+        .add_method("begin", MatchData::begin, sys::mrb_args_req(1))?
+        .add_method("captures", MatchData::captures, sys::mrb_args_none())?
         .add_method(
             "[]",
             MatchData::element_reference,
             sys::mrb_args_req_and_opt(1, 1),
-        )
-        .add_method("length", MatchData::length, sys::mrb_args_none())
+        )?
+        .add_method("length", MatchData::length, sys::mrb_args_none())?
         .add_method(
             "named_captures",
             MatchData::named_captures,
             sys::mrb_args_none(),
-        )
-        .add_method("names", MatchData::names, sys::mrb_args_none())
-        .add_method("offset", MatchData::offset, sys::mrb_args_req(1))
-        .add_method("post_match", MatchData::post_match, sys::mrb_args_none())
-        .add_method("pre_match", MatchData::pre_match, sys::mrb_args_none())
-        .add_method("regexp", MatchData::regexp, sys::mrb_args_none())
-        .add_method("size", MatchData::length, sys::mrb_args_none())
-        .add_method("string", MatchData::string, sys::mrb_args_none())
-        .add_method("to_a", MatchData::to_a, sys::mrb_args_none())
-        .add_method("to_s", MatchData::to_s, sys::mrb_args_none())
-        .add_method("end", MatchData::end, sys::mrb_args_req(1))
+        )?
+        .add_method("names", MatchData::names, sys::mrb_args_none())?
+        .add_method("offset", MatchData::offset, sys::mrb_args_req(1))?
+        .add_method("post_match", MatchData::post_match, sys::mrb_args_none())?
+        .add_method("pre_match", MatchData::pre_match, sys::mrb_args_none())?
+        .add_method("regexp", MatchData::regexp, sys::mrb_args_none())?
+        .add_method("size", MatchData::length, sys::mrb_args_none())?
+        .add_method("string", MatchData::string, sys::mrb_args_none())?
+        .add_method("to_a", MatchData::to_a, sys::mrb_args_none())?
+        .add_method("to_s", MatchData::to_s, sys::mrb_args_none())?
+        .add_method("end", MatchData::end, sys::mrb_args_req(1))?
         .define()?;
     interp.0.borrow_mut().def_class::<MatchData>(spec);
     let _ = interp.eval(&include_bytes!("matchdata.rb")[..])?;

--- a/artichoke-backend/src/extn/core/matchdata/mod.rs
+++ b/artichoke-backend/src/extn/core/matchdata/mod.rs
@@ -42,7 +42,7 @@ pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
     if interp.0.borrow().class_spec::<MatchData>().is_some() {
         return Ok(());
     }
-    let spec = class::Spec::new("MatchData", None, Some(def::rust_data_free::<MatchData>));
+    let spec = class::Spec::new("MatchData", None, Some(def::rust_data_free::<MatchData>))?;
     class::Builder::for_spec(interp, &spec)
         .value_is_rust_object()
         .add_method("begin", MatchData::begin, sys::mrb_args_req(1))?

--- a/artichoke-backend/src/extn/core/method/mod.rs
+++ b/artichoke-backend/src/extn/core/method/mod.rs
@@ -7,7 +7,7 @@ pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
     if interp.0.borrow().class_spec::<Method>().is_some() {
         return Ok(());
     }
-    let spec = class::Spec::new("Method", None, None);
+    let spec = class::Spec::new("Method", None, None)?;
     interp.0.borrow_mut().def_class::<Method>(spec);
     let _ = interp.eval(&include_bytes!("method.rb")[..])?;
     trace!("Patched Method onto interpreter");

--- a/artichoke-backend/src/extn/core/module/mod.rs
+++ b/artichoke-backend/src/extn/core/module/mod.rs
@@ -7,7 +7,7 @@ pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
     if interp.0.borrow().class_spec::<Module>().is_some() {
         return Ok(());
     }
-    let spec = class::Spec::new("Module", None, None);
+    let spec = class::Spec::new("Module", None, None)?;
     interp.0.borrow_mut().def_class::<Module>(spec);
     let _ = interp.eval(&include_bytes!("module.rb")[..])?;
     trace!("Patched Module onto interpreter");

--- a/artichoke-backend/src/extn/core/numeric/mod.rs
+++ b/artichoke-backend/src/extn/core/numeric/mod.rs
@@ -7,7 +7,7 @@ pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
     if interp.0.borrow().class_spec::<Numeric>().is_some() {
         return Ok(());
     }
-    let spec = class::Spec::new("Numeric", None, None);
+    let spec = class::Spec::new("Numeric", None, None)?;
     interp.0.borrow_mut().def_class::<Numeric>(spec);
     let _ = interp.eval(&include_bytes!("numeric.rb")[..])?;
     trace!("Patched Numeric onto interpreter");

--- a/artichoke-backend/src/extn/core/object/mod.rs
+++ b/artichoke-backend/src/extn/core/object/mod.rs
@@ -7,7 +7,7 @@ pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
     if interp.0.borrow().class_spec::<Object>().is_some() {
         return Ok(());
     }
-    let spec = class::Spec::new("Object", None, None);
+    let spec = class::Spec::new("Object", None, None)?;
     interp.0.borrow_mut().def_class::<Object>(spec);
     let _ = interp.eval(&include_bytes!("object.rb")[..])?;
     trace!("Patched Object onto interpreter");

--- a/artichoke-backend/src/extn/core/proc/mod.rs
+++ b/artichoke-backend/src/extn/core/proc/mod.rs
@@ -7,7 +7,7 @@ pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
     if interp.0.borrow().class_spec::<Proc>().is_some() {
         return Ok(());
     }
-    let spec = class::Spec::new("Proc", None, None);
+    let spec = class::Spec::new("Proc", None, None)?;
     interp.0.borrow_mut().def_class::<Proc>(spec);
     let _ = interp.eval(&include_bytes!("proc.rb")[..])?;
     trace!("Patched Proc onto interpreter");

--- a/artichoke-backend/src/extn/core/random/mruby.rs
+++ b/artichoke-backend/src/extn/core/random/mruby.rs
@@ -13,7 +13,7 @@ pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
     if interp.0.borrow().class_spec::<random::Random>().is_some() {
         return Ok(());
     }
-    let spec = class::Spec::new("Random", None, Some(def::rust_data_free::<random::Random>));
+    let spec = class::Spec::new("Random", None, Some(def::rust_data_free::<random::Random>))?;
     class::Builder::for_spec(interp, &spec)
         .value_is_rust_object()
         .add_self_method(

--- a/artichoke-backend/src/extn/core/random/mruby.rs
+++ b/artichoke-backend/src/extn/core/random/mruby.rs
@@ -20,22 +20,22 @@ pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
             "new_seed",
             artichoke_random_self_new_seed,
             sys::mrb_args_req(1),
-        )
-        .add_self_method("srand", artichoke_random_self_srand, sys::mrb_args_opt(1))
+        )?
+        .add_self_method("srand", artichoke_random_self_srand, sys::mrb_args_opt(1))?
         .add_self_method(
             "urandom",
             artichoke_random_self_urandom,
             sys::mrb_args_req(1),
-        )
+        )?
         .add_method(
             "initialize",
             artichoke_random_initialize,
             sys::mrb_args_opt(1),
-        )
-        .add_method("==", artichoke_random_eq, sys::mrb_args_opt(1))
-        .add_method("bytes", artichoke_random_bytes, sys::mrb_args_req(1))
-        .add_method("rand", artichoke_random_rand, sys::mrb_args_opt(1))
-        .add_method("seed", artichoke_random_seed, sys::mrb_args_none())
+        )?
+        .add_method("==", artichoke_random_eq, sys::mrb_args_opt(1))?
+        .add_method("bytes", artichoke_random_bytes, sys::mrb_args_req(1))?
+        .add_method("rand", artichoke_random_rand, sys::mrb_args_opt(1))?
+        .add_method("seed", artichoke_random_seed, sys::mrb_args_none())?
         .define()?;
     interp.0.borrow_mut().def_class::<random::Random>(spec);
 

--- a/artichoke-backend/src/extn/core/range/mod.rs
+++ b/artichoke-backend/src/extn/core/range/mod.rs
@@ -7,7 +7,7 @@ pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
     if interp.0.borrow().class_spec::<Range>().is_some() {
         return Ok(());
     }
-    let spec = class::Spec::new("Range", None, None);
+    let spec = class::Spec::new("Range", None, None)?;
     interp.0.borrow_mut().def_class::<Range>(spec);
     let _ = interp.eval(&include_bytes!("range.rb")[..])?;
     trace!("Patched Range onto interpreter");

--- a/artichoke-backend/src/extn/core/regexp/mruby.rs
+++ b/artichoke-backend/src/extn/core/regexp/mruby.rs
@@ -17,26 +17,26 @@ pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
     let spec = class::Spec::new("Regexp", None, Some(def::rust_data_free::<regexp::Regexp>));
     class::Builder::for_spec(interp, &spec)
         .value_is_rust_object()
-        .add_method("initialize", initialize, sys::mrb_args_req_and_opt(1, 2))
-        .add_self_method("compile", compile, sys::mrb_args_rest())
-        .add_self_method("escape", escape, sys::mrb_args_req(1))
-        .add_self_method("quote", escape, sys::mrb_args_req(1))
-        .add_self_method("union", union, sys::mrb_args_rest())
-        .add_method("==", eql, sys::mrb_args_req(1))
-        .add_method("===", case_compare, sys::mrb_args_req(1))
-        .add_method("=~", match_operator, sys::mrb_args_req(1))
-        .add_method("casefold?", casefold, sys::mrb_args_none())
-        .add_method("eql?", eql, sys::mrb_args_req(1))
-        .add_method("fixed_encoding?", fixed_encoding, sys::mrb_args_none())
-        .add_method("hash", hash, sys::mrb_args_none())
-        .add_method("inspect", inspect, sys::mrb_args_none())
-        .add_method("match?", match_q, sys::mrb_args_req_and_opt(1, 1))
-        .add_method("named_captures", named_captures, sys::mrb_args_none())
-        .add_method("match", match_, sys::mrb_args_req_and_opt(1, 1))
-        .add_method("names", names, sys::mrb_args_none())
-        .add_method("options", options, sys::mrb_args_none())
-        .add_method("source", source, sys::mrb_args_none())
-        .add_method("to_s", to_s, sys::mrb_args_none())
+        .add_method("initialize", initialize, sys::mrb_args_req_and_opt(1, 2))?
+        .add_self_method("compile", compile, sys::mrb_args_rest())?
+        .add_self_method("escape", escape, sys::mrb_args_req(1))?
+        .add_self_method("quote", escape, sys::mrb_args_req(1))?
+        .add_self_method("union", union, sys::mrb_args_rest())?
+        .add_method("==", eql, sys::mrb_args_req(1))?
+        .add_method("===", case_compare, sys::mrb_args_req(1))?
+        .add_method("=~", match_operator, sys::mrb_args_req(1))?
+        .add_method("casefold?", casefold, sys::mrb_args_none())?
+        .add_method("eql?", eql, sys::mrb_args_req(1))?
+        .add_method("fixed_encoding?", fixed_encoding, sys::mrb_args_none())?
+        .add_method("hash", hash, sys::mrb_args_none())?
+        .add_method("inspect", inspect, sys::mrb_args_none())?
+        .add_method("match?", match_q, sys::mrb_args_req_and_opt(1, 1))?
+        .add_method("named_captures", named_captures, sys::mrb_args_none())?
+        .add_method("match", match_, sys::mrb_args_req_and_opt(1, 1))?
+        .add_method("names", names, sys::mrb_args_none())?
+        .add_method("options", options, sys::mrb_args_none())?
+        .add_method("source", source, sys::mrb_args_none())?
+        .add_method("to_s", to_s, sys::mrb_args_none())?
         .define()?;
     interp.0.borrow_mut().def_class::<regexp::Regexp>(spec);
     let _ = interp.eval(&include_bytes!("regexp.rb")[..])?;

--- a/artichoke-backend/src/extn/core/regexp/mruby.rs
+++ b/artichoke-backend/src/extn/core/regexp/mruby.rs
@@ -14,7 +14,7 @@ pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
     if interp.0.borrow().class_spec::<regexp::Regexp>().is_some() {
         return Ok(());
     }
-    let spec = class::Spec::new("Regexp", None, Some(def::rust_data_free::<regexp::Regexp>));
+    let spec = class::Spec::new("Regexp", None, Some(def::rust_data_free::<regexp::Regexp>))?;
     class::Builder::for_spec(interp, &spec)
         .value_is_rust_object()
         .add_method("initialize", initialize, sys::mrb_args_req_and_opt(1, 2))?

--- a/artichoke-backend/src/extn/core/string.rs
+++ b/artichoke-backend/src/extn/core/string.rs
@@ -13,7 +13,7 @@ pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
     if interp.0.borrow().class_spec::<RString>().is_some() {
         return Ok(());
     }
-    let spec = class::Spec::new("String", None, None);
+    let spec = class::Spec::new("String", None, None)?;
     class::Builder::for_spec(interp, &spec)
         .add_method("ord", RString::ord, sys::mrb_args_none())?
         .add_method("scan", RString::scan, sys::mrb_args_req(1))?

--- a/artichoke-backend/src/extn/core/string.rs
+++ b/artichoke-backend/src/extn/core/string.rs
@@ -15,8 +15,8 @@ pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
     }
     let spec = class::Spec::new("String", None, None);
     class::Builder::for_spec(interp, &spec)
-        .add_method("ord", RString::ord, sys::mrb_args_none())
-        .add_method("scan", RString::scan, sys::mrb_args_req(1))
+        .add_method("ord", RString::ord, sys::mrb_args_none())?
+        .add_method("scan", RString::scan, sys::mrb_args_req(1))?
         .define()?;
     interp.0.borrow_mut().def_class::<RString>(spec);
     let _ = interp.eval(&include_bytes!("string.rb")[..])?;

--- a/artichoke-backend/src/extn/core/symbol/mod.rs
+++ b/artichoke-backend/src/extn/core/symbol/mod.rs
@@ -7,7 +7,7 @@ pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
     if interp.0.borrow().class_spec::<Symbol>().is_some() {
         return Ok(());
     }
-    let spec = class::Spec::new("Symbol", None, None);
+    let spec = class::Spec::new("Symbol", None, None)?;
     interp.0.borrow_mut().def_class::<Symbol>(spec);
     let _ = interp.eval(&include_bytes!("symbol.rb")[..])?;
     trace!("Patched Symbol onto interpreter");

--- a/artichoke-backend/src/extn/core/thread.rs
+++ b/artichoke-backend/src/extn/core/thread.rs
@@ -11,9 +11,9 @@ pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
     if interp.0.borrow().class_spec::<Mutex>().is_some() {
         return Ok(());
     }
-    let spec = class::Spec::new("Thread", None, None);
+    let spec = class::Spec::new("Thread", None, None)?;
     interp.0.borrow_mut().def_class::<Thread>(spec);
-    let spec = class::Spec::new("Mutex", None, None);
+    let spec = class::Spec::new("Mutex", None, None)?;
     interp.0.borrow_mut().def_class::<Mutex>(spec);
     interp.def_rb_source_file(b"thread.rb", &include_bytes!("thread.rb")[..])?;
     // Thread is loaded by default, so eval it on interpreter initialization

--- a/artichoke-backend/src/extn/core/time/mruby.rs
+++ b/artichoke-backend/src/extn/core/time/mruby.rs
@@ -12,7 +12,7 @@ pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
     if interp.0.borrow().class_spec::<time::Time>().is_some() {
         return Ok(());
     }
-    let spec = class::Spec::new("Time", None, Some(def::rust_data_free::<time::Time>));
+    let spec = class::Spec::new("Time", None, Some(def::rust_data_free::<time::Time>))?;
     class::Builder::for_spec(interp, &spec)
         .value_is_rust_object()
         .add_self_method("now", artichoke_time_self_now, sys::mrb_args_none())?

--- a/artichoke-backend/src/extn/core/time/mruby.rs
+++ b/artichoke-backend/src/extn/core/time/mruby.rs
@@ -15,21 +15,21 @@ pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
     let spec = class::Spec::new("Time", None, Some(def::rust_data_free::<time::Time>));
     class::Builder::for_spec(interp, &spec)
         .value_is_rust_object()
-        .add_self_method("now", artichoke_time_self_now, sys::mrb_args_none())
-        .add_method("day", artichoke_time_day, sys::mrb_args_none())
-        .add_method("hour", artichoke_time_hour, sys::mrb_args_none())
-        .add_method("min", artichoke_time_minute, sys::mrb_args_none())
-        .add_method("mon", artichoke_time_month, sys::mrb_args_none())
-        .add_method("month", artichoke_time_month, sys::mrb_args_none())
-        .add_method("nsec", artichoke_time_nanosecond, sys::mrb_args_none())
-        .add_method("sec", artichoke_time_second, sys::mrb_args_none())
-        .add_method("tv_nsec", artichoke_time_nanosecond, sys::mrb_args_none())
-        .add_method("tv_sec", artichoke_time_second, sys::mrb_args_none())
-        .add_method("tv_usec", artichoke_time_microsecond, sys::mrb_args_none())
-        .add_method("usec", artichoke_time_microsecond, sys::mrb_args_none())
-        .add_method("wday", artichoke_time_weekday, sys::mrb_args_none())
-        .add_method("yday", artichoke_time_year_day, sys::mrb_args_none())
-        .add_method("year", artichoke_time_year, sys::mrb_args_none())
+        .add_self_method("now", artichoke_time_self_now, sys::mrb_args_none())?
+        .add_method("day", artichoke_time_day, sys::mrb_args_none())?
+        .add_method("hour", artichoke_time_hour, sys::mrb_args_none())?
+        .add_method("min", artichoke_time_minute, sys::mrb_args_none())?
+        .add_method("mon", artichoke_time_month, sys::mrb_args_none())?
+        .add_method("month", artichoke_time_month, sys::mrb_args_none())?
+        .add_method("nsec", artichoke_time_nanosecond, sys::mrb_args_none())?
+        .add_method("sec", artichoke_time_second, sys::mrb_args_none())?
+        .add_method("tv_nsec", artichoke_time_nanosecond, sys::mrb_args_none())?
+        .add_method("tv_sec", artichoke_time_second, sys::mrb_args_none())?
+        .add_method("tv_usec", artichoke_time_microsecond, sys::mrb_args_none())?
+        .add_method("usec", artichoke_time_microsecond, sys::mrb_args_none())?
+        .add_method("wday", artichoke_time_weekday, sys::mrb_args_none())?
+        .add_method("yday", artichoke_time_year_day, sys::mrb_args_none())?
+        .add_method("year", artichoke_time_year, sys::mrb_args_none())?
         .define()?;
     interp.0.borrow_mut().def_class::<time::Time>(spec);
 

--- a/artichoke-backend/src/extn/core/warning/mod.rs
+++ b/artichoke-backend/src/extn/core/warning/mod.rs
@@ -7,7 +7,7 @@ pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
     if interp.0.borrow().module_spec::<Warning>().is_some() {
         return Ok(());
     }
-    let spec = module::Spec::new("Warning", None);
+    let spec = module::Spec::new("Warning", None)?;
     module::Builder::for_spec(interp, &spec).define()?;
     interp.0.borrow_mut().def_module::<Warning>(spec);
     let _ = interp.eval(&include_bytes!("warning.rb")[..])?;

--- a/artichoke-backend/src/extn/stdlib/abbrev.rs
+++ b/artichoke-backend/src/extn/stdlib/abbrev.rs
@@ -4,7 +4,7 @@ use crate::module;
 use crate::{Artichoke, ArtichokeError};
 
 pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
-    let spec = module::Spec::new("Abbrev", None);
+    let spec = module::Spec::new("Abbrev", None)?;
     interp.0.borrow_mut().def_module::<Abbrev>(spec);
     interp.def_rb_source_file(b"abbrev.rb", &include_bytes!("abbrev.rb")[..])?;
     Ok(())

--- a/artichoke-backend/src/extn/stdlib/delegate.rs
+++ b/artichoke-backend/src/extn/stdlib/delegate.rs
@@ -4,9 +4,9 @@ use crate::class;
 use crate::{Artichoke, ArtichokeError};
 
 pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
-    let spec = class::Spec::new("Delegator", None, None);
+    let spec = class::Spec::new("Delegator", None, None)?;
     interp.0.borrow_mut().def_class::<Delegator>(spec);
-    let spec = class::Spec::new("SimpleDelegator", None, None);
+    let spec = class::Spec::new("SimpleDelegator", None, None)?;
     interp.0.borrow_mut().def_class::<SimpleDelegator>(spec);
     interp.def_rb_source_file(b"delegate.rb", &include_bytes!("delegate.rb")[..])?;
     Ok(())

--- a/artichoke-backend/src/extn/stdlib/forwardable.rs
+++ b/artichoke-backend/src/extn/stdlib/forwardable.rs
@@ -4,7 +4,7 @@ use crate::module;
 use crate::{Artichoke, ArtichokeError};
 
 pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
-    let spec = module::Spec::new("Forwardable", None);
+    let spec = module::Spec::new("Forwardable", None)?;
     interp.0.borrow_mut().def_module::<Forwardable>(spec);
     interp.def_rb_source_file(b"forwardable.rb", &include_bytes!("forwardable.rb")[..])?;
     interp.def_rb_source_file(

--- a/artichoke-backend/src/extn/stdlib/monitor.rs
+++ b/artichoke-backend/src/extn/stdlib/monitor.rs
@@ -4,7 +4,7 @@ use crate::class;
 use crate::{Artichoke, ArtichokeError};
 
 pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
-    let spec = class::Spec::new("Monitor", None, None);
+    let spec = class::Spec::new("Monitor", None, None)?;
     interp.0.borrow_mut().def_class::<Monitor>(spec);
     interp.def_rb_source_file(b"monitor.rb", &include_bytes!("monitor.rb")[..])?;
     Ok(())

--- a/artichoke-backend/src/extn/stdlib/ostruct.rs
+++ b/artichoke-backend/src/extn/stdlib/ostruct.rs
@@ -4,7 +4,7 @@ use crate::class;
 use crate::{Artichoke, ArtichokeError};
 
 pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
-    let spec = class::Spec::new("OpenStruct", None, None);
+    let spec = class::Spec::new("OpenStruct", None, None)?;
     interp.0.borrow_mut().def_class::<OpenStruct>(spec);
     interp.def_rb_source_file(b"ostruct.rb", &include_bytes!("ostruct.rb")[..])?;
     Ok(())

--- a/artichoke-backend/src/extn/stdlib/set.rs
+++ b/artichoke-backend/src/extn/stdlib/set.rs
@@ -4,9 +4,9 @@ use crate::class;
 use crate::{Artichoke, ArtichokeError};
 
 pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
-    let spec = class::Spec::new("Set", None, None);
+    let spec = class::Spec::new("Set", None, None)?;
     interp.0.borrow_mut().def_class::<Set>(spec);
-    let spec = class::Spec::new("SortedSet", None, None);
+    let spec = class::Spec::new("SortedSet", None, None)?;
     interp.0.borrow_mut().def_class::<SortedSet>(spec);
     interp.def_rb_source_file(b"set.rb", &include_bytes!("set.rb")[..])?;
     Ok(())

--- a/artichoke-backend/src/extn/stdlib/strscan.rs
+++ b/artichoke-backend/src/extn/stdlib/strscan.rs
@@ -4,7 +4,7 @@ use crate::class;
 use crate::{Artichoke, ArtichokeError};
 
 pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
-    let spec = class::Spec::new("StringScanner", None, None);
+    let spec = class::Spec::new("StringScanner", None, None)?;
     interp.0.borrow_mut().def_class::<StringScanner>(spec);
     interp.def_rb_source_file(b"strscan.rb", &include_bytes!("strscan.rb")[..])?;
     Ok(())

--- a/artichoke-backend/src/module.rs
+++ b/artichoke-backend/src/module.rs
@@ -28,22 +28,46 @@ impl<'a> Builder<'a> {
         }
     }
 
-    pub fn add_method(mut self, name: &str, method: Method, args: sys::mrb_aspec) -> Self {
-        let spec = method::Spec::new(method::Type::Instance, name, method, args);
+    pub fn add_method<T>(
+        mut self,
+        name: T,
+        method: Method,
+        args: sys::mrb_aspec,
+    ) -> Result<Self, ArtichokeError>
+    where
+        T: Into<Cow<'static, str>>,
+    {
+        let spec = method::Spec::new(method::Type::Instance, name, method, args)?;
         self.methods.insert(spec);
-        self
+        Ok(self)
     }
 
-    pub fn add_self_method(mut self, name: &str, method: Method, args: sys::mrb_aspec) -> Self {
-        let spec = method::Spec::new(method::Type::Class, name, method, args);
+    pub fn add_self_method<T>(
+        mut self,
+        name: T,
+        method: Method,
+        args: sys::mrb_aspec,
+    ) -> Result<Self, ArtichokeError>
+    where
+        T: Into<Cow<'static, str>>,
+    {
+        let spec = method::Spec::new(method::Type::Class, name, method, args)?;
         self.methods.insert(spec);
-        self
+        Ok(self)
     }
 
-    pub fn add_module_method(mut self, name: &str, method: Method, args: sys::mrb_aspec) -> Self {
-        let spec = method::Spec::new(method::Type::Module, name, method, args);
+    pub fn add_module_method<T>(
+        mut self,
+        name: T,
+        method: Method,
+        args: sys::mrb_aspec,
+    ) -> Result<Self, ArtichokeError>
+    where
+        T: Into<Cow<'static, str>>,
+    {
+        let spec = method::Spec::new(method::Type::Module, name, method, args)?;
         self.methods.insert(spec);
-        self
+        Ok(self)
     }
 
     pub fn define(self) -> Result<(), ArtichokeError> {

--- a/artichoke-backend/src/module.rs
+++ b/artichoke-backend/src/module.rs
@@ -237,23 +237,23 @@ mod tests {
     #[test]
     fn rclass_for_undef_root_module() {
         let interp = crate::interpreter().expect("init");
-        let spec = Spec::new("Foo", None);
+        let spec = Spec::new("Foo", None).unwrap();
         assert!(spec.rclass(&interp).is_none());
     }
 
     #[test]
     fn rclass_for_undef_nested_module() {
         let interp = crate::interpreter().expect("init");
-        let scope = Spec::new("Kernel", None);
+        let scope = Spec::new("Kernel", None).unwrap();
         let scope = EnclosingRubyScope::module(&scope);
-        let spec = Spec::new("Foo", Some(scope));
+        let spec = Spec::new("Foo", Some(scope)).unwrap();
         assert!(spec.rclass(&interp).is_none());
     }
 
     #[test]
     fn rclass_for_root_module() {
         let interp = crate::interpreter().expect("init");
-        let spec = Spec::new("Kernel", None);
+        let spec = Spec::new("Kernel", None).unwrap();
         assert!(spec.rclass(&interp).is_some());
     }
 
@@ -263,9 +263,9 @@ mod tests {
         let _ = interp
             .eval(b"module Foo; module Bar; end; end")
             .expect("eval");
-        let scope = Spec::new("Foo", None);
+        let scope = Spec::new("Foo", None).unwrap();
         let scope = EnclosingRubyScope::module(&scope);
-        let spec = Spec::new("Bar", Some(scope));
+        let spec = Spec::new("Bar", Some(scope)).unwrap();
         assert!(spec.rclass(&interp).is_some());
     }
 
@@ -275,9 +275,9 @@ mod tests {
         let _ = interp
             .eval(b"class Foo; module Bar; end; end")
             .expect("eval");
-        let scope = class::Spec::new("Foo", None, None);
+        let scope = class::Spec::new("Foo", None, None).unwrap();
         let scope = EnclosingRubyScope::class(&scope);
-        let spec = Spec::new("Bar", Some(scope));
+        let spec = Spec::new("Bar", Some(scope)).unwrap();
         assert!(spec.rclass(&interp).is_some());
     }
 }

--- a/artichoke-backend/src/module.rs
+++ b/artichoke-backend/src/module.rs
@@ -100,20 +100,22 @@ pub struct Spec {
 }
 
 impl Spec {
-    pub fn new<T>(name: T, enclosing_scope: Option<EnclosingRubyScope>) -> Self
+    pub fn new<T>(
+        name: T,
+        enclosing_scope: Option<EnclosingRubyScope>,
+    ) -> Result<Self, ArtichokeError>
     where
         T: Into<Cow<'static, str>>,
     {
         let name = name.into();
-        let cstring = CString::new(name.as_ref()).unwrap_or_else(|_| unsafe {
-            CString::from_vec_unchecked(String::from("UnknownModule").into_bytes())
-        });
-        Self {
+        let cstring =
+            CString::new(name.as_ref()).map_err(|_| ArtichokeError::InvalidConstantName)?;
+        Ok(Self {
             name,
             cstring,
             sym: Cell::default(),
             enclosing_scope: enclosing_scope.map(Box::new),
-        }
+        })
     }
 
     pub fn value(&self, interp: &Artichoke) -> Option<Value> {

--- a/artichoke-backend/tests/leak_mrb_tt_data_rc.rs
+++ b/artichoke-backend/tests/leak_mrb_tt_data_rc.rs
@@ -77,10 +77,10 @@ impl File for Container {
     type Artichoke = Artichoke;
 
     fn require(interp: &Artichoke) -> Result<(), ArtichokeError> {
-        let spec = class::Spec::new("Container", None, Some(def::rust_data_free::<Self>));
+        let spec = class::Spec::new("Container", None, Some(def::rust_data_free::<Self>))?;
         class::Builder::for_spec(interp, &spec)
             .value_is_rust_object()
-            .add_method("initialize", Self::initialize, sys::mrb_args_req(1))
+            .add_method("initialize", Self::initialize, sys::mrb_args_req(1))?
             .define()?;
         interp.0.borrow_mut().def_class::<Self>(spec);
         Ok(())

--- a/artichoke-backend/tests/manual.rs
+++ b/artichoke-backend/tests/manual.rs
@@ -61,11 +61,11 @@ impl File for Container {
     type Artichoke = Artichoke;
 
     fn require(interp: &Artichoke) -> Result<(), ArtichokeError> {
-        let spec = class::Spec::new("Container", None, Some(def::rust_data_free::<Box<Self>>));
+        let spec = class::Spec::new("Container", None, Some(def::rust_data_free::<Box<Self>>))?;
         class::Builder::for_spec(interp, &spec)
             .value_is_rust_object()
-            .add_method("initialize", Self::initialize, sys::mrb_args_req(1))
-            .add_method("value", Self::value, sys::mrb_args_none())
+            .add_method("initialize", Self::initialize, sys::mrb_args_req(1))?
+            .add_method("value", Self::value, sys::mrb_args_none())?
             .define()?;
         interp.0.borrow_mut().def_class::<Box<Self>>(spec);
         Ok(())

--- a/artichoke-backend/tests/obj_new_borrow_mut.rs
+++ b/artichoke-backend/tests/obj_new_borrow_mut.rs
@@ -36,9 +36,10 @@ unsafe extern "C" fn initialize(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -
 #[test]
 fn obj_new_borrow_mut() {
     let interp = artichoke_backend::interpreter().expect("init");
-    let spec = class::Spec::new("Obj", None, None);
+    let spec = class::Spec::new("Obj", None, None).unwrap();
     class::Builder::for_spec(&interp, &spec)
         .add_method("initialize", initialize, sys::mrb_args_none())
+        .unwrap()
         .define()
         .unwrap();
     interp.0.borrow_mut().def_class::<Obj>(spec);

--- a/artichoke-core/src/lib.rs
+++ b/artichoke-core/src/lib.rs
@@ -52,6 +52,10 @@ pub enum ArtichokeError {
     /// See [`Eval`](eval::Eval).
     // TODO: disabled for migration Exec(exception::Exception),
     Exec(String),
+    /// Constant name is invalid for the VM backend.
+    ///
+    /// For example, if the name contains a NUL byte, or is invalid UTF-8.
+    InvalidConstantName,
     /// Unable to initalize interpreter.
     New,
     /// Class or module with this name is not defined in the artichoke VM.
@@ -96,6 +100,7 @@ impl fmt::Display for ArtichokeError {
                 write!(f, "Failed to convert from {} to {}", from, to)
             }
             Self::Exec(backtrace) => write!(f, "{}", backtrace),
+            Self::InvalidConstantName => write!(f, "Invalid constant name"),
             Self::New => write!(f, "Failed to create interpreter"),
             Self::NotDefined(fqname) => write!(f, "{} not defined", fqname),
             Self::TooManyArgs { given, max } => write!(


### PR DESCRIPTION
All specs own a `CString` of their name to pass into mruby.

Previously, turning the `name: &str` parameter into a `CString` called `expect` on the `Result`. This method is fallible if the `name` contains a `NUL` byte.

GH-434 made `Context` creation fallible for the same reasons. Pushing errors out to callers made `Kernel#require` behavior more predictable.

GH-430 attempted to solve this issue for class and module specs by using an unsafe API to provide a default `CString`. This masked failure with an implicit default rather than allowing callers to know they provided bad input.

This PR makes `class::Spec::new`, `module::Spec::new`, `method::Spec::new`, and the associated method builder functions on `class::Builder` and `module::Builder` fallible (return `Result<Self, ArtichokeError>`).

In practice this means inserting more `?` operators in `init` methods.

Two bonus changes:

- Remove stale clippy allow in `extn::core::artichoke`.
- Make `method::Spec.name` take a Cow to avoid an allocation when passing in a `&'static str`.