### PR TITLE
Fix ruby spec example doc

### DIFF
--- a/doc/ruby-spec.md
+++ b/doc/ruby-spec.md
@@ -27,7 +27,7 @@ ruby scripts/spec.rb artichoke library uri
 For `Array#each`:
 
 ```shell
-ruby scripts/spec.rb core array each
+ruby scripts/spec.rb artichoke core array each
 ```
 
 ### Performance testing


### PR DESCRIPTION
The example she’ll code was missing the interpreter arg