### PR TITLE
[WIP] Destructure State

### DIFF
--- a/artichoke-backend/scripts/auto_import/rust_glue.rs.erb
+++ b/artichoke-backend/scripts/auto_import/rust_glue.rs.erb
@@ -1,13 +1,13 @@
 use crate::extn::prelude::*;
 
-pub fn init(interp: &Artichoke) -> InitializeResult<()> {
+pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     <% constants.each do |(constant, klass)| %>
     <% if klass == "Class" %>
     let spec = crate::class::Spec::new("<%= constant %>", None, None)?;
-    interp.0.borrow_mut().def_class::<<%= constant %>>(spec);
+    interp.state_mut().def_class::<<%= constant %>>(spec);
     <% elsif klass == "Module" %>
     let spec = crate::module::Spec::new("<%= constant %>", None)?;
-    interp.0.borrow_mut().def_module::<<%= constant %>>(spec);
+    interp.state_mut().def_module::<<%= constant %>>(spec);
     <% else %>
     // Skipping constant <%= constant %> with class <%= klass %>
     <% end %>

--- a/artichoke-backend/scripts/auto_import/rust_glue.rs.erb
+++ b/artichoke-backend/scripts/auto_import/rust_glue.rs.erb
@@ -6,7 +6,7 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     let spec = crate::class::Spec::new("<%= constant %>", None, None)?;
     interp.state_mut().def_class::<<%= constant %>>(spec);
     <% elsif klass == "Module" %>
-    let spec = crate::module::Spec::new("<%= constant %>", None)?;
+    let spec = crate::module::Spec::new(interp, "<%= constant %>", None)?;
     interp.state_mut().def_module::<<%= constant %>>(spec);
     <% else %>
     // Skipping constant <%= constant %> with class <%= klass %>

--- a/artichoke-backend/src/class.rs
+++ b/artichoke-backend/src/class.rs
@@ -150,11 +150,10 @@ impl Spec {
 
     #[must_use]
     pub fn new_instance(&self, interp: &mut Artichoke, args: &[Value]) -> Option<Value> {
-        let mrb = interp.mrb_mut();
         let rclass = self.rclass(interp)?;
         let args = args.iter().map(Value::inner).collect::<Vec<_>>();
-        let arglen = Int::try_from(args.len()).unwrap_or_default();
-        let value = unsafe { sys::mrb_obj_new(mrb, rclass, arglen, args.as_ptr()) };
+        let arglen = Int::try_from(args.len()).ok()?;
+        let value = unsafe { sys::mrb_obj_new(interp.mrb_mut(), rclass, arglen, args.as_ptr()) };
         Some(Value::new(interp, value))
     }
 

--- a/artichoke-backend/src/class.rs
+++ b/artichoke-backend/src/class.rs
@@ -198,11 +198,15 @@ impl Spec {
 
     #[must_use]
     pub fn rclass(&self, interp: &mut Artichoke) -> Option<*mut sys::RClass> {
-        let mrb = interp.mrb_mut();
         if let Some(ref scope) = self.enclosing_scope {
             if let Some(scope) = scope.rclass(interp) {
-                if unsafe { sys::mrb_class_defined_under(mrb, scope, self.name_c_str().as_ptr()) }
-                    == 0
+                if unsafe {
+                    sys::mrb_class_defined_under(
+                        interp.mrb_mut(),
+                        scope,
+                        self.name_c_str().as_ptr(),
+                    )
+                } == 0
                 {
                     // Enclosing scope exists.
                     // Class is not defined under the enclosing scope.
@@ -211,19 +215,23 @@ impl Spec {
                     // Enclosing scope exists.
                     // Class is defined under the enclosing scope.
                     Some(unsafe {
-                        sys::mrb_class_get_under(mrb, scope, self.name_c_str().as_ptr())
+                        sys::mrb_class_get_under(
+                            interp.mrb_mut(),
+                            scope,
+                            self.name_c_str().as_ptr(),
+                        )
                     })
                 }
             } else {
                 // Enclosing scope does not exist.
                 None
             }
-        } else if unsafe { sys::mrb_class_defined(mrb, self.cstring.as_ptr()) } == 0 {
+        } else if unsafe { sys::mrb_class_defined(interp.mrb_mut(), self.cstring.as_ptr()) } == 0 {
             // Class does not exist in root scope.
             None
         } else {
             // Class exists in root scope.
-            Some(unsafe { sys::mrb_class_get(mrb, self.name_c_str().as_ptr()) })
+            Some(unsafe { sys::mrb_class_get(interp.mrb_mut(), self.name_c_str().as_ptr()) })
         }
     }
 }

--- a/artichoke-backend/src/class.rs
+++ b/artichoke-backend/src/class.rs
@@ -145,19 +145,17 @@ impl Spec {
     }
 
     #[must_use]
-    pub fn new_instance(&self, interp: &Artichoke, args: &[Value]) -> Option<Value> {
-        let mrb = interp.0.borrow().mrb;
+    pub fn new_instance(&self, interp: &mut Artichoke, args: &[Value]) -> Option<Value> {
+        let mrb = interp.mrb_mut();
         let rclass = self.rclass(interp)?;
         let args = args.iter().map(Value::inner).collect::<Vec<_>>();
         let arglen = Int::try_from(args.len()).unwrap_or_default();
-        let value = unsafe {
-            sys::mrb_obj_new(mrb, rclass, arglen, args.as_ptr() as *const sys::mrb_value)
-        };
+        let value = unsafe { sys::mrb_obj_new(mrb, rclass, arglen, args.as_ptr()) };
         Some(Value::new(interp, value))
     }
 
     #[must_use]
-    pub fn value(&self, interp: &Artichoke) -> Option<Value> {
+    pub fn value(&self, interp: &mut Artichoke) -> Option<Value> {
         let rclass = self.rclass(interp)?;
         let module = unsafe { sys::mrb_sys_class_value(rclass) };
         Some(Value::new(interp, module))
@@ -196,8 +194,8 @@ impl Spec {
     }
 
     #[must_use]
-    pub fn rclass(&self, interp: &Artichoke) -> Option<*mut sys::RClass> {
-        let mrb = interp.0.borrow().mrb;
+    pub fn rclass(&self, interp: &mut Artichoke) -> Option<*mut sys::RClass> {
+        let mrb = interp.mrb_mut();
         if let Some(ref scope) = self.enclosing_scope {
             if let Some(scope) = scope.rclass(interp) {
                 if unsafe { sys::mrb_class_defined_under(mrb, scope, self.name_c_str().as_ptr()) }

--- a/artichoke-backend/src/convert/boolean.rs
+++ b/artichoke-backend/src/convert/boolean.rs
@@ -5,7 +5,7 @@ use crate::value::Value;
 use crate::{Artichoke, ArtichokeError};
 
 impl Convert<bool, Value> for Artichoke {
-    fn convert(&self, value: bool) -> Value {
+    fn convert(&mut self, value: bool) -> Value {
         if value {
             Value::new(self, unsafe { sys::mrb_sys_true_value() })
         } else {
@@ -15,7 +15,7 @@ impl Convert<bool, Value> for Artichoke {
 }
 
 impl TryConvert<Value, bool> for Artichoke {
-    fn try_convert(&self, value: Value) -> Result<bool, ArtichokeError> {
+    fn try_convert(&mut self, value: Value) -> Result<bool, ArtichokeError> {
         match value.ruby_type() {
             Ruby::Bool => {
                 let value = value.inner();

--- a/artichoke-backend/src/convert/bytes.rs
+++ b/artichoke-backend/src/convert/bytes.rs
@@ -16,14 +16,14 @@ impl Convert<Vec<u8>, Value> for Artichoke {
 
 impl Convert<&[u8], Value> for Artichoke {
     fn convert(&mut self, value: &[u8]) -> Value {
-        let mrb = self.mrb_mut();
         // Ruby strings contain raw bytes, so we can convert from a &[u8] to a
         // `char *` and `size_t`.
         let raw = value.as_ptr() as *const i8;
         let len = value.len();
         // `mrb_str_new` copies the `char *` to the mruby heap so we do not have
         // to worry about the lifetime of the slice passed into this converter.
-        Value::new(self, unsafe { sys::mrb_str_new(mrb, raw, len) })
+        let value = unsafe { sys::mrb_str_new(self.mrb_mut(), raw, len) };
+        Value::new(self, value)
     }
 }
 

--- a/artichoke-backend/src/convert/fixnum.rs
+++ b/artichoke-backend/src/convert/fixnum.rs
@@ -7,14 +7,14 @@ use crate::value::Value;
 use crate::{Artichoke, ArtichokeError};
 
 impl Convert<u8, Value> for Artichoke {
-    fn convert(&self, value: u8) -> Value {
+    fn convert(&mut self, value: u8) -> Value {
         let value = Int::from(value);
         Value::new(self, unsafe { sys::mrb_sys_fixnum_value(value) })
     }
 }
 
 impl Convert<u16, Value> for Artichoke {
-    fn convert(&self, value: u16) -> Value {
+    fn convert(&mut self, value: u16) -> Value {
         let value = Int::from(value);
         Value::new(self, unsafe { sys::mrb_sys_fixnum_value(value) })
     }
@@ -22,7 +22,7 @@ impl Convert<u16, Value> for Artichoke {
 
 #[cfg(not(target_arch = "wasm32"))]
 impl Convert<u32, Value> for Artichoke {
-    fn convert(&self, value: u32) -> Value {
+    fn convert(&mut self, value: u32) -> Value {
         let value = Int::from(value);
         Value::new(self, unsafe { sys::mrb_sys_fixnum_value(value) })
     }
@@ -30,7 +30,7 @@ impl Convert<u32, Value> for Artichoke {
 
 #[cfg(target_arch = "wasm32")]
 impl TryConvert<u32, Value> for Artichoke {
-    fn try_convert(&self, value: u32) -> Result<Value, ArtichokeError> {
+    fn try_convert(&mut self, value: u32) -> Result<Value, ArtichokeError> {
         let value = Int::try_from(value).map_err(|_| ArtichokeError::ConvertToRuby {
             from: Rust::UnsignedInt,
             to: Ruby::Fixnum,
@@ -42,7 +42,7 @@ impl TryConvert<u32, Value> for Artichoke {
 }
 
 impl TryConvert<u64, Value> for Artichoke {
-    fn try_convert(&self, value: u64) -> Result<Value, ArtichokeError> {
+    fn try_convert(&mut self, value: u64) -> Result<Value, ArtichokeError> {
         let value = Int::try_from(value).map_err(|_| ArtichokeError::ConvertToRuby {
             from: Rust::UnsignedInt,
             to: Ruby::Fixnum,
@@ -54,21 +54,21 @@ impl TryConvert<u64, Value> for Artichoke {
 }
 
 impl Convert<i8, Value> for Artichoke {
-    fn convert(&self, value: i8) -> Value {
+    fn convert(&mut self, value: i8) -> Value {
         let value = Int::from(value);
         Value::new(self, unsafe { sys::mrb_sys_fixnum_value(value) })
     }
 }
 
 impl Convert<i16, Value> for Artichoke {
-    fn convert(&self, value: i16) -> Value {
+    fn convert(&mut self, value: i16) -> Value {
         let value = Int::from(value);
         Value::new(self, unsafe { sys::mrb_sys_fixnum_value(value) })
     }
 }
 
 impl Convert<i32, Value> for Artichoke {
-    fn convert(&self, value: i32) -> Value {
+    fn convert(&mut self, value: i32) -> Value {
         let value = Int::from(value);
         Value::new(self, unsafe { sys::mrb_sys_fixnum_value(value) })
     }
@@ -76,14 +76,14 @@ impl Convert<i32, Value> for Artichoke {
 
 #[cfg(not(target_arch = "wasm32"))]
 impl Convert<i64, Value> for Artichoke {
-    fn convert(&self, value: i64) -> Value {
+    fn convert(&mut self, value: i64) -> Value {
         Value::new(self, unsafe { sys::mrb_sys_fixnum_value(value) })
     }
 }
 
 #[cfg(target_arch = "wasm32")]
 impl TryConvert<i64, Value> for Artichoke {
-    fn try_convert(&self, value: i64) -> Result<Value, ArtichokeError> {
+    fn try_convert(&mut self, value: i64) -> Result<Value, ArtichokeError> {
         let value = Int::try_from(value).map_err(|_| ArtichokeError::ConvertToRuby {
             from: Rust::UnsignedInt,
             to: Ruby::Fixnum,
@@ -95,7 +95,7 @@ impl TryConvert<i64, Value> for Artichoke {
 }
 
 impl TryConvert<Value, Int> for Artichoke {
-    fn try_convert(&self, value: Value) -> Result<Int, ArtichokeError> {
+    fn try_convert(&mut self, value: Value) -> Result<Int, ArtichokeError> {
         match value.ruby_type() {
             Ruby::Fixnum => {
                 let value = value.inner();
@@ -110,7 +110,7 @@ impl TryConvert<Value, Int> for Artichoke {
 }
 
 impl TryConvert<Value, usize> for Artichoke {
-    fn try_convert(&self, value: Value) -> Result<usize, ArtichokeError> {
+    fn try_convert(&mut self, value: Value) -> Result<usize, ArtichokeError> {
         let value: Int = self
             .try_convert(value)
             .map_err(|_| ArtichokeError::ConvertToRust {

--- a/artichoke-backend/src/convert/float.rs
+++ b/artichoke-backend/src/convert/float.rs
@@ -6,8 +6,8 @@ use crate::{Artichoke, ArtichokeError};
 
 impl Convert<Float, Value> for Artichoke {
     fn convert(&mut self, value: Float) -> Value {
-        let mrb = self.mrb_mut();
-        Value::new(self, unsafe { sys::mrb_sys_float_value(mrb, value) })
+        let value = unsafe { sys::mrb_sys_float_value(self.mrb_mut(), value) };
+        Value::new(self, value)
     }
 }
 

--- a/artichoke-backend/src/convert/float.rs
+++ b/artichoke-backend/src/convert/float.rs
@@ -5,14 +5,14 @@ use crate::value::Value;
 use crate::{Artichoke, ArtichokeError};
 
 impl Convert<Float, Value> for Artichoke {
-    fn convert(&self, value: Float) -> Value {
-        let mrb = self.0.borrow().mrb;
+    fn convert(&mut self, value: Float) -> Value {
+        let mrb = self.mrb_mut();
         Value::new(self, unsafe { sys::mrb_sys_float_value(mrb, value) })
     }
 }
 
 impl TryConvert<Value, Float> for Artichoke {
-    fn try_convert(&self, value: Value) -> Result<Float, ArtichokeError> {
+    fn try_convert(&mut self, value: Value) -> Result<Float, ArtichokeError> {
         match value.ruby_type() {
             Ruby::Float => {
                 let value = value.inner();

--- a/artichoke-backend/src/convert/nilable.rs
+++ b/artichoke-backend/src/convert/nilable.rs
@@ -12,7 +12,7 @@ use crate::{Artichoke, ArtichokeError};
 
 // bail out implementation for mixed-type collections
 impl Convert<Option<Value>, Value> for Artichoke {
-    fn convert(&self, value: Option<Value>) -> Value {
+    fn convert(&mut self, value: Option<Value>) -> Value {
         if let Some(value) = value {
             value
         } else {
@@ -22,14 +22,14 @@ impl Convert<Option<Value>, Value> for Artichoke {
 }
 
 impl Convert<Option<&Value>, Value> for Artichoke {
-    fn convert(&self, value: Option<&Value>) -> Value {
-        self.convert(value.cloned())
+    fn convert(&mut self, value: Option<&Value>) -> Value {
+        self.convert(value.copied())
     }
 }
 
 impl Convert<Value, Option<Value>> for Artichoke {
     #[must_use]
-    fn convert(&self, value: Value) -> Option<Value> {
+    fn convert(&mut self, value: Value) -> Option<Value> {
         if let Ruby::Nil = value.ruby_type() {
             None
         } else {
@@ -41,7 +41,7 @@ impl Convert<Value, Option<Value>> for Artichoke {
 macro_rules! option_to_ruby {
     ($elem:ty) => {
         impl<'a> Convert<Option<$elem>, Value> for Artichoke {
-            fn convert(&self, value: Option<$elem>) -> Value {
+            fn convert(&mut self, value: Option<$elem>) -> Value {
                 if let Some(value) = value {
                     self.convert(value)
                 } else {
@@ -55,9 +55,9 @@ macro_rules! option_to_ruby {
 macro_rules! ruby_to_option {
     ($elem:ty) => {
         impl<'a> TryConvert<Value, Option<$elem>> for Artichoke {
-            fn try_convert(&self, value: Value) -> Result<Option<$elem>, ArtichokeError> {
+            fn try_convert(&mut self, value: Value) -> Result<Option<$elem>, ArtichokeError> {
                 if let Some(value) = self.convert(value) {
-                    value.try_into::<$elem>().map(Some)
+                    value.try_into::<$elem>(self).map(Some)
                 } else {
                     Ok(None)
                 }

--- a/artichoke-backend/src/convert/string.rs
+++ b/artichoke-backend/src/convert/string.rs
@@ -7,16 +7,15 @@ use crate::value::Value;
 use crate::{Artichoke, ArtichokeError};
 
 impl Convert<String, Value> for Artichoke {
-    fn convert(&self, value: String) -> Value {
+    fn convert(&mut self, value: String) -> Value {
         // Ruby `String`s are just bytes, so get a pointer to the underlying
         // `&[u8]` infallibly and convert that to a `Value`.
-        let result: Value = self.convert(value.as_bytes());
-        result
+        self.convert(value.as_bytes())
     }
 }
 
 impl Convert<&str, Value> for Artichoke {
-    fn convert(&self, value: &str) -> Value {
+    fn convert(&mut self, value: &str) -> Value {
         // Ruby `String`s are just bytes, so get a pointer to the underlying
         // `&[u8]` infallibly and convert that to a `Value`.
         let result: Value = self.convert(value.as_bytes());
@@ -25,17 +24,16 @@ impl Convert<&str, Value> for Artichoke {
 }
 
 impl TryConvert<Value, String> for Artichoke {
-    fn try_convert(&self, value: Value) -> Result<String, ArtichokeError> {
-        let result: Result<&str, _> = self.try_convert(value);
-        result.map(String::from)
+    fn try_convert(&mut self, value: Value) -> Result<String, ArtichokeError> {
+        TryConvert::<_, &str>::try_convert(self, value).map(String::from)
     }
 }
 
 impl<'a> TryConvert<Value, &'a str> for Artichoke {
-    fn try_convert(&self, value: Value) -> Result<&'a str, ArtichokeError> {
+    fn try_convert(&mut self, value: Value) -> Result<&'a str, ArtichokeError> {
         let type_tag = value.ruby_type();
         let bytes = value
-            .try_into::<&[u8]>()
+            .try_into::<&[u8]>(self)
             .map_err(|_| ArtichokeError::ConvertToRust {
                 from: type_tag,
                 to: Rust::String,

--- a/artichoke-backend/src/def.rs
+++ b/artichoke-backend/src/def.rs
@@ -8,7 +8,6 @@ use crate::class;
 use crate::convert::RustBackedValue;
 use crate::module;
 use crate::sys;
-use crate::Artichoke;
 
 /// Typedef for an mruby free function for an [`mrb_value`](sys::mrb_value) with
 /// `tt` [`MRB_TT_DATA`](sys::mrb_vtype::MRB_TT_DATA).
@@ -136,10 +135,10 @@ impl EnclosingRubyScope {
     ///
     /// The current implemention results in recursive calls to this function
     /// for each enclosing scope.
-    pub fn rclass(&self, interp: &mut Artichoke) -> Option<*mut sys::RClass> {
+    pub fn rclass(&self, mrb: &mut sys::mrb_state) -> Option<*mut sys::RClass> {
         match self {
-            Self::Class { spec } => spec.rclass(interp),
-            Self::Module { spec } => spec.rclass(interp),
+            Self::Class { spec } => spec.rclass(mrb),
+            Self::Module { spec } => spec.rclass(mrb),
         }
     }
 

--- a/artichoke-backend/src/def.rs
+++ b/artichoke-backend/src/def.rs
@@ -136,7 +136,7 @@ impl EnclosingRubyScope {
     ///
     /// The current implemention results in recursive calls to this function
     /// for each enclosing scope.
-    pub fn rclass(&self, interp: &Artichoke) -> Option<*mut sys::RClass> {
+    pub fn rclass(&self, interp: &mut Artichoke) -> Option<*mut sys::RClass> {
         match self {
             Self::Class { spec } => spec.rclass(interp),
             Self::Module { spec } => spec.rclass(interp),

--- a/artichoke-backend/src/eval.rs
+++ b/artichoke-backend/src/eval.rs
@@ -180,8 +180,10 @@ impl Eval for Artichoke {
             );
             let mut state = mem::MaybeUninit::<sys::mrb_bool>::uninit();
 
+            self.deinitialize_to_cross_into_ffi_boundary();
             let value =
                 sys::mrb_protect(self.mrb_mut(), Some(Protect::run), data, state.as_mut_ptr());
+            self.reinitialize_to_return_from_ffi_boundary();
             if state.assume_init() != 0 {
                 self.mrb_mut().exc = sys::mrb_sys_obj_ptr(value);
             }

--- a/artichoke-backend/src/exception.rs
+++ b/artichoke-backend/src/exception.rs
@@ -73,12 +73,12 @@ impl From<Box<dyn RubyException>> for Exception {
 /// Because this precondition must hold for all frames between the caller and
 /// the closest [`sys::mrb_protect`] landing pad, this function should only be
 /// called in the entrypoint into Rust from mruby.
-pub unsafe fn raise(mut interp: Artichoke, exception: impl RubyException) -> ! {
+pub unsafe fn raise(mut interp: Artichoke, exception: impl RubyException + fmt::Debug) -> ! {
     let exc = if let Some(exc) = exception.as_mrb_value(&mut interp) {
         exc
     } else {
-        error!("unable to raise {}", exception.name());
-        panic!("unable to raise {}", exception.name());
+        error!("unable to raise {:?}", exception);
+        panic!("unable to raise {:?}", exception);
     };
     // `mrb_sys_raise` will call longjmp which will unwind the stack.
     // Any non-`Copy` objects that we haven't cleaned up at this point will

--- a/artichoke-backend/src/exception_handler.rs
+++ b/artichoke-backend/src/exception_handler.rs
@@ -4,7 +4,7 @@ use std::mem;
 use std::ptr::{self, NonNull};
 
 use crate::exception::{CaughtException, Exception};
-use crate::gc::MrbGarbageCollection;
+// use crate::gc::MrbGarbageCollection;
 use crate::sys;
 use crate::value::Value;
 use crate::Artichoke;
@@ -21,15 +21,15 @@ pub trait ExceptionHandler {
 
 impl ExceptionHandler for Artichoke {
     fn last_error(&mut self) -> Result<Option<Exception>, Exception> {
-        let _arena = self.create_arena_savepoint();
-        let mrb = self.mrb_mut();
+        // TODO: fix arena
+        // let _arena = self.create_arena_savepoint();
         // Clear the current exception from the mruby interpreter so subsequent
         // calls to the mruby VM are not tainted by an error they did not
         // generate. We must do this at the beginning of `current_exception` so
         // we can use the mruby VM to inspect the exception once we turn it into
         // an `mrb_value`. `Value::funcall` handles errors by calling this
         // function, so not clearing the exception results in a stack overflow.
-        let exc = mem::replace(&mut mrb.exc, ptr::null_mut());
+        let exc = mem::replace(&mut self.mrb_mut().exc, ptr::null_mut());
         let exc = if let Some(exc) = NonNull::new(exc) {
             exc
         } else {

--- a/artichoke-backend/src/exception_handler.rs
+++ b/artichoke-backend/src/exception_handler.rs
@@ -52,7 +52,7 @@ impl ExceptionHandler for Artichoke {
         // folllowing print statement will at least get you the exception class
         // and message, which should help debugging.
         //
-        // println!("{}", exception.to_s_debug(self));
+        println!("{}", exception.to_s_debug(self));
         let classname = exception
             .funcall::<Value>(self, "class", &[], None)
             .and_then(|exception| exception.funcall::<&str>(self, "name", &[], None))?;

--- a/artichoke-backend/src/extn/core/array/args.rs
+++ b/artichoke-backend/src/extn/core/array/args.rs
@@ -260,7 +260,7 @@ unsafe fn is_range(
 ) -> Result<Option<(Int, usize)>, Exception> {
     let mut start = mem::MaybeUninit::<sys::mrb_int>::uninit();
     let mut len = mem::MaybeUninit::<sys::mrb_int>::uninit();
-    let mrb = interp.0.borrow().mrb;
+    let mrb = interp.mrb_mut();
     // `mrb_range_beg_len` can raise.
     // TODO: Wrap this in a call to `mrb_protect`.
     let check_range = sys::mrb_range_beg_len(

--- a/artichoke-backend/src/extn/core/array/args.rs
+++ b/artichoke-backend/src/extn/core/array/args.rs
@@ -18,7 +18,7 @@ pub fn element_reference(
     ary_len: usize,
 ) -> Result<ElementReference, Exception> {
     if let Some(len) = len {
-        let start = if let Ok(start) = elem.clone().try_into::<Int>() {
+        let start = if let Ok(start) = elem.try_into::<Int>(interp) {
             start
         } else if let Ok(start) = elem.funcall::<Int>("to_int", &[], None) {
             start
@@ -29,7 +29,7 @@ pub fn element_reference(
                 format!("no implicit conversion of {} into Integer", elem_type_name),
             )));
         };
-        let len = if let Ok(len) = len.clone().try_into::<Int>() {
+        let len = if let Ok(len) = len.try_into::<Int>(interp) {
             len
         } else if let Ok(len) = len.funcall::<Int>("to_int", &[], None) {
             len
@@ -47,7 +47,7 @@ pub fn element_reference(
         }
     } else {
         let name = elem.pretty_name();
-        if let Ok(index) = elem.clone().try_into::<Int>() {
+        if let Ok(index) = elem.try_into::<Int>(interp) {
             Ok(ElementReference::Index(index))
         } else if let Ok(index) = elem.funcall::<Int>("to_int", &[], None) {
             Ok(ElementReference::Index(index))
@@ -76,7 +76,7 @@ pub fn element_assignment(
     if let Some(elem) = third {
         let start = first;
         let start_type_name = start.pretty_name();
-        let start = if let Ok(start) = start.clone().try_into::<Int>() {
+        let start = if let Ok(start) = start.try_into::<Int>(interp) {
             start
         } else if let Ok(start) = start.funcall::<Int>("to_int", &[], None) {
             start
@@ -102,7 +102,7 @@ pub fn element_assignment(
         };
         let len = second;
         let len_type_name = len.pretty_name();
-        let len = if let Ok(len) = len.clone().try_into::<Int>() {
+        let len = if let Ok(len) = len.try_into::<Int>(interp) {
             len
         } else if let Ok(len) = len.funcall::<Int>("to_int", &[], None) {
             len
@@ -120,7 +120,7 @@ pub fn element_assignment(
                 format!("negative length ({})", len),
             )))
         }
-    } else if let Ok(index) = first.clone().try_into::<Int>() {
+    } else if let Ok(index) = first.try_into::<Int>(interp) {
         if let Ok(index) = usize::try_from(index) {
             Ok((index, None, second))
         } else {
@@ -170,7 +170,7 @@ pub fn element_assignment(
                         "Unable to extract first from Range",
                     )));
                 };
-                let start = if let Ok(start) = start.clone().try_into::<Int>() {
+                let start = if let Ok(start) = start.try_into::<Int>(interp) {
                     start
                 } else if let Ok(start) = start.funcall::<Int>("to_int", &[], None) {
                     start
@@ -191,7 +191,7 @@ pub fn element_assignment(
                         "Unable to extract first from Range",
                     )));
                 };
-                let end = if let Ok(end) = end.clone().try_into::<Int>() {
+                let end = if let Ok(end) = end.try_into::<Int>(interp) {
                     end
                 } else if let Ok(end) = end.funcall::<Int>("to_int", &[], None) {
                     end

--- a/artichoke-backend/src/extn/core/array/backend/mod.rs
+++ b/artichoke-backend/src/extn/core/array/backend/mod.rs
@@ -11,7 +11,7 @@ use crate::extn::prelude::*;
 pub trait ArrayType: Any {
     fn box_clone(&self) -> Box<dyn ArrayType>;
 
-    fn gc_mark(&self, interp: &Artichoke);
+    fn gc_mark(&self, interp: &mut Artichoke);
 
     fn real_children(&self) -> usize;
 
@@ -19,7 +19,7 @@ pub trait ArrayType: Any {
 
     fn is_empty(&self) -> bool;
 
-    fn get(&self, interp: &Artichoke, index: usize) -> Result<Value, Exception>;
+    fn get(&self, interp: &mut Artichoke, index: usize) -> Result<Value, Exception>;
 
     fn slice(
         &self,
@@ -30,7 +30,7 @@ pub trait ArrayType: Any {
 
     fn set(
         &mut self,
-        interp: &Artichoke,
+        interp: &mut Artichoke,
         index: usize,
         elem: Value,
         realloc: &mut Option<Vec<Box<dyn ArrayType>>>,
@@ -38,7 +38,7 @@ pub trait ArrayType: Any {
 
     fn set_with_drain(
         &mut self,
-        interp: &Artichoke,
+        interp: &mut Artichoke,
         start: usize,
         drain: usize,
         with: Value,
@@ -47,7 +47,7 @@ pub trait ArrayType: Any {
 
     fn set_slice(
         &mut self,
-        interp: &Artichoke,
+        interp: &mut Artichoke,
         start: usize,
         drain: usize,
         with: Box<dyn ArrayType>,
@@ -63,7 +63,7 @@ pub trait ArrayType: Any {
 
     fn pop(
         &mut self,
-        interp: &Artichoke,
+        interp: &mut Artichoke,
         realloc: &mut Option<Vec<Box<dyn ArrayType>>>,
     ) -> Result<Value, Exception>;
 

--- a/artichoke-backend/src/extn/core/array/backend/mod.rs
+++ b/artichoke-backend/src/extn/core/array/backend/mod.rs
@@ -2,11 +2,11 @@ use std::any::Any;
 
 use crate::extn::prelude::*;
 
-pub mod aggregate;
-pub mod buffer;
-pub mod fixed;
-pub mod integer_range;
-pub mod repeated;
+// pub mod aggregate;
+// pub mod buffer;
+// pub mod fixed;
+// pub mod integer_range;
+// pub mod repeated;
 
 pub trait ArrayType: Any {
     fn box_clone(&self) -> Box<dyn ArrayType>;

--- a/artichoke-backend/src/extn/core/array/ffi.rs
+++ b/artichoke-backend/src/extn/core/array/ffi.rs
@@ -128,7 +128,7 @@ unsafe extern "C" fn artichoke_ary_pop(
     let result = if let Ok(array) = Array::try_from_ruby(&mut interp, &ary) {
         let mut borrow = array.borrow_mut();
         let gc_was_enabled = interp.disable_gc();
-        let result = borrow.pop(&interp);
+        let result = borrow.pop(&mut interp);
         if gc_was_enabled {
             interp.enable_gc();
         }
@@ -160,7 +160,7 @@ unsafe extern "C" fn artichoke_ary_push(
         let idx = array.borrow().len();
         let mut borrow = array.borrow_mut();
         let gc_was_enabled = interp.disable_gc();
-        let result = borrow.set(&interp, idx, value);
+        let result = borrow.set(&mut interp, idx, value);
         if gc_was_enabled {
             interp.enable_gc();
         }
@@ -191,7 +191,7 @@ unsafe extern "C" fn artichoke_ary_ref(
     let result = if let Ok(array) = Array::try_from_ruby(&mut interp, &ary) {
         let borrow = array.borrow();
         let gc_was_enabled = interp.disable_gc();
-        let result = borrow.0.get(&interp, offset);
+        let result = borrow.0.get(&mut interp, offset);
         if gc_was_enabled {
             interp.enable_gc();
         }
@@ -235,7 +235,7 @@ unsafe extern "C" fn artichoke_ary_set(
         } else {
             let mut borrow = array.borrow_mut();
             let gc_was_enabled = interp.disable_gc();
-            let result = borrow.set(&interp, offset, value.clone());
+            let result = borrow.set(&mut interp, offset, value.clone());
             if gc_was_enabled {
                 interp.enable_gc();
             }
@@ -264,8 +264,8 @@ unsafe extern "C" fn artichoke_ary_shift(
     let result = if let Ok(array) = Array::try_from_ruby(&mut interp, &array) {
         let mut borrow = array.borrow_mut();
         let gc_was_enabled = interp.disable_gc();
-        let result = borrow.get(&interp, 0);
-        let _ = borrow.set_slice(&interp, 0, 1, &InlineBuffer::default());
+        let result = borrow.get(&mut interp, 0);
+        let _ = borrow.set_slice(&mut interp, 0, 1, &InlineBuffer::default());
         if gc_was_enabled {
             interp.enable_gc();
         }
@@ -295,7 +295,7 @@ unsafe extern "C" fn artichoke_ary_unshift(
     if let Ok(array) = Array::try_from_ruby(&mut interp, &array) {
         let mut borrow = array.borrow_mut();
         let gc_was_enabled = interp.disable_gc();
-        let _ = borrow.set_with_drain(&interp, 0, 0, value.clone());
+        let _ = borrow.set_with_drain(&mut interp, 0, 0, value.clone());
         if gc_was_enabled {
             interp.enable_gc();
         }
@@ -366,11 +366,11 @@ unsafe extern "C" fn artichoke_ary_check(
 
 #[no_mangle]
 unsafe extern "C" fn artichoke_gc_mark_ary(mrb: *mut sys::mrb_state, ary: sys::mrb_value) {
-    let interp = unwrap_interpreter!(mrb, or_else = ());
+    let mut interp = unwrap_interpreter!(mrb, or_else = ());
     let array = Value::new(&interp, ary);
     if let Ok(array) = Array::try_from_ruby(&mut interp, &array) {
         let borrow = array.borrow();
-        borrow.gc_mark(&interp);
+        borrow.gc_mark(&mut interp);
     }
 }
 
@@ -379,7 +379,7 @@ unsafe extern "C" fn artichoke_gc_mark_ary_size(
     mrb: *mut sys::mrb_state,
     ary: sys::mrb_value,
 ) -> usize {
-    let interp = unwrap_interpreter!(mrb, or_else = 0);
+    let mut interp = unwrap_interpreter!(mrb, or_else = 0);
     let array = Value::new(&interp, ary);
     if let Ok(array) = Array::try_from_ruby(&mut interp, &array) {
         let borrow = array.borrow();

--- a/artichoke-backend/src/extn/core/array/ffi.rs
+++ b/artichoke-backend/src/extn/core/array/ffi.rs
@@ -310,7 +310,7 @@ unsafe extern "C" fn artichoke_ary_len(
     mrb: *mut sys::mrb_state,
     ary: sys::mrb_value,
 ) -> sys::mrb_int {
-    let interp = unwrap_interpreter!(mrb, or_else = 0);
+    let mut interp = unwrap_interpreter!(mrb, or_else = 0);
     let ary = Value::new(&interp, ary);
     if let Ok(array) = Array::try_from_ruby(&mut interp, &ary) {
         let borrow = array.borrow();
@@ -326,7 +326,7 @@ unsafe extern "C" fn artichoke_ary_set_len(
     ary: sys::mrb_value,
     len: sys::mrb_int,
 ) {
-    let interp = unwrap_interpreter!(mrb, or_else = ());
+    let mut interp = unwrap_interpreter!(mrb, or_else = ());
     let ary = Value::new(&interp, ary);
     if let Ok(array) = Array::try_from_ruby(&mut interp, &ary) {
         let len = usize::try_from(len).unwrap_or_default();
@@ -340,7 +340,7 @@ unsafe extern "C" fn artichoke_ary_ptr(
     mrb: *mut sys::mrb_state,
     ary: sys::mrb_value,
 ) -> *mut sys::mrb_value {
-    let interp = unwrap_interpreter!(mrb, or_else = ptr::null_mut());
+    let mut interp = unwrap_interpreter!(mrb, or_else = ptr::null_mut());
     let ary = Value::new(&interp, ary);
     if let Ok(array) = Array::try_from_ruby(&mut interp, &ary) {
         let mut borrow = array.borrow_mut();
@@ -355,7 +355,7 @@ unsafe extern "C" fn artichoke_ary_check(
     mrb: *mut sys::mrb_state,
     ary: sys::mrb_value,
 ) -> sys::mrb_bool {
-    let interp = unwrap_interpreter!(mrb, or_else = 0);
+    let mut interp = unwrap_interpreter!(mrb, or_else = 0);
     let ary = Value::new(&interp, ary);
     if Array::try_from_ruby(&mut interp, &ary).is_ok() {
         1

--- a/artichoke-backend/src/extn/core/array/ffi.rs
+++ b/artichoke-backend/src/extn/core/array/ffi.rs
@@ -9,7 +9,7 @@ use crate::gc::MrbGarbageCollection;
 // MRB_API mrb_value mrb_ary_new(mrb_state *mrb);
 #[no_mangle]
 unsafe extern "C" fn artichoke_ary_new(mrb: *mut sys::mrb_state) -> sys::mrb_value {
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let result = Array(InlineBuffer::default());
     let result = result
         .try_into_ruby(&mut interp, None)
@@ -26,7 +26,7 @@ unsafe extern "C" fn artichoke_ary_new_capa(
     mrb: *mut sys::mrb_state,
     capa: sys::mrb_int,
 ) -> sys::mrb_value {
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let result = Array(InlineBuffer::with_capacity(
         usize::try_from(capa).unwrap_or_default(),
     ));
@@ -46,7 +46,7 @@ unsafe extern "C" fn artichoke_ary_new_from_values(
     size: sys::mrb_int,
     vals: *const sys::mrb_value,
 ) -> sys::mrb_value {
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let size = usize::try_from(size).unwrap_or_default();
     let values = slice::from_raw_parts(vals, size);
     let result = InlineBuffer::from(values);
@@ -70,7 +70,7 @@ unsafe extern "C" fn artichoke_ary_splat(
     mrb: *mut sys::mrb_state,
     value: sys::mrb_value,
 ) -> sys::mrb_value {
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let value = Value::new(&interp, value);
     if Array::try_from_ruby(&mut interp, &value).is_ok() {
         return value.inner();
@@ -93,7 +93,7 @@ unsafe extern "C" fn artichoke_ary_concat(
     ary: sys::mrb_value,
     other: sys::mrb_value,
 ) -> sys::mrb_value {
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let ary = Value::new(&interp, ary);
     let other = Value::new(&interp, other);
     let result = if let Ok(array) = Array::try_from_ruby(&mut interp, &ary) {
@@ -123,7 +123,7 @@ unsafe extern "C" fn artichoke_ary_pop(
     mrb: *mut sys::mrb_state,
     ary: sys::mrb_value,
 ) -> sys::mrb_value {
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let ary = Value::new(&interp, ary);
     let result = if let Ok(array) = Array::try_from_ruby(&mut interp, &ary) {
         let mut borrow = array.borrow_mut();
@@ -153,7 +153,7 @@ unsafe extern "C" fn artichoke_ary_push(
     ary: sys::mrb_value,
     value: sys::mrb_value,
 ) -> sys::mrb_value {
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let ary = Value::new(&interp, ary);
     let value = Value::new(&interp, value);
     let result = if let Ok(array) = Array::try_from_ruby(&mut interp, &ary) {
@@ -185,7 +185,7 @@ unsafe extern "C" fn artichoke_ary_ref(
     ary: sys::mrb_value,
     offset: sys::mrb_int,
 ) -> sys::mrb_value {
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let ary = Value::new(&interp, ary);
     let offset = usize::try_from(offset).unwrap_or_default();
     let result = if let Ok(array) = Array::try_from_ruby(&mut interp, &ary) {
@@ -213,7 +213,7 @@ unsafe extern "C" fn artichoke_ary_set(
     offset: sys::mrb_int,
     value: sys::mrb_value,
 ) -> sys::mrb_value {
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let ary = Value::new(&interp, ary);
     let value = Value::new(&interp, value);
     let result = if let Ok(array) = Array::try_from_ruby(&mut interp, &ary) {
@@ -259,7 +259,7 @@ unsafe extern "C" fn artichoke_ary_shift(
     mrb: *mut sys::mrb_state,
     ary: sys::mrb_value,
 ) -> sys::mrb_value {
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let array = Value::new(&interp, ary);
     let result = if let Ok(array) = Array::try_from_ruby(&mut interp, &array) {
         let mut borrow = array.borrow_mut();
@@ -289,7 +289,7 @@ unsafe extern "C" fn artichoke_ary_unshift(
     ary: sys::mrb_value,
     value: sys::mrb_value,
 ) -> sys::mrb_value {
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let array = Value::new(&interp, ary);
     let value = Value::new(&interp, value);
     if let Ok(array) = Array::try_from_ruby(&mut interp, &array) {

--- a/artichoke-backend/src/extn/core/array/ffi.rs
+++ b/artichoke-backend/src/extn/core/array/ffi.rs
@@ -99,7 +99,7 @@ unsafe extern "C" fn artichoke_ary_concat(
     let result = if let Ok(array) = Array::try_from_ruby(&interp, &ary) {
         let mut borrow = array.borrow_mut();
         let gc_was_enabled = interp.disable_gc();
-        let result = borrow.concat(&interp, other);
+        let result = borrow.concat(&mut interp, other);
         if gc_was_enabled {
             interp.enable_gc();
         }

--- a/artichoke-backend/src/extn/core/array/ffi.rs
+++ b/artichoke-backend/src/extn/core/array/ffi.rs
@@ -15,7 +15,7 @@ unsafe extern "C" fn artichoke_ary_new(mrb: *mut sys::mrb_state) -> sys::mrb_val
         .try_into_ruby(&mut interp, None)
         .map_err(|_| Fatal::new(&interp, "Unable to initialize Ruby Array from Rust Array"));
     match result {
-        Ok(value) => value.inner(),
+        Ok(value) => ffi::return_into_vm(interp, value),
         Err(exception) => exception::raise(interp, exception),
     }
 }
@@ -34,7 +34,7 @@ unsafe extern "C" fn artichoke_ary_new_capa(
         .try_into_ruby(&mut interp, None)
         .map_err(|_| Fatal::new(&interp, "Unable to initialize Ruby Array from Rust Array"));
     match result {
-        Ok(value) => value.inner(),
+        Ok(value) => ffi::return_into_vm(interp, value),
         Err(exception) => exception::raise(interp, exception),
     }
 }
@@ -81,7 +81,7 @@ unsafe extern "C" fn artichoke_ary_splat(
         .try_into_ruby(&mut interp, None)
         .map_err(|_| Fatal::new(&interp, "Unable to initialize Ruby Array from Rust Array"));
     match result {
-        Ok(value) => value.inner(),
+        Ok(value) => ffi::return_into_vm(interp, value),
         Err(exception) => exception::raise(interp, exception),
     }
 }
@@ -200,7 +200,7 @@ unsafe extern "C" fn artichoke_ary_ref(
         Ok(interp.convert(None::<Value>))
     };
     match result {
-        Ok(value) => value.inner(),
+        Ok(value) => ffi::return_into_vm(interp, value),
         Err(exception) => exception::raise(interp, exception),
     }
 }

--- a/artichoke-backend/src/extn/core/array/inline_buffer.rs
+++ b/artichoke-backend/src/extn/core/array/inline_buffer.rs
@@ -45,7 +45,7 @@ impl ArrayType for InlineBuffer {
         Box::new(self.clone())
     }
 
-    fn gc_mark(&self, interp: &Artichoke) {
+    fn gc_mark(&self, interp: &mut Artichoke) {
         for elem in self.0.iter().copied() {
             let value = Value::new(interp, elem);
             interp.mark_value(&value);
@@ -67,7 +67,7 @@ impl ArrayType for InlineBuffer {
         self.0.is_empty()
     }
 
-    fn get(&self, interp: &Artichoke, index: usize) -> Result<Value, Exception> {
+    fn get(&self, interp: &mut Artichoke, index: usize) -> Result<Value, Exception> {
         Self::get(self, interp, index)
     }
 
@@ -85,7 +85,7 @@ impl ArrayType for InlineBuffer {
 
     fn set(
         &mut self,
-        interp: &Artichoke,
+        interp: &mut Artichoke,
         index: usize,
         elem: Value,
         realloc: &mut Option<Vec<Box<dyn ArrayType>>>,
@@ -96,7 +96,7 @@ impl ArrayType for InlineBuffer {
 
     fn set_with_drain(
         &mut self,
-        interp: &Artichoke,
+        interp: &mut Artichoke,
         start: usize,
         drain: usize,
         with: Value,
@@ -108,7 +108,7 @@ impl ArrayType for InlineBuffer {
 
     fn set_slice(
         &mut self,
-        interp: &Artichoke,
+        interp: &mut Artichoke,
         start: usize,
         drain: usize,
         with: Box<dyn ArrayType>,
@@ -138,7 +138,7 @@ impl ArrayType for InlineBuffer {
 
     fn pop(
         &mut self,
-        interp: &Artichoke,
+        interp: &mut Artichoke,
         realloc: &mut Option<Vec<Box<dyn ArrayType>>>,
     ) -> Result<Value, Exception> {
         let _ = realloc;
@@ -198,7 +198,7 @@ impl InlineBuffer {
         self.0.clear();
     }
 
-    pub fn get(&self, interp: &Artichoke, index: usize) -> Result<Value, Exception> {
+    pub fn get(&self, interp: &mut Artichoke, index: usize) -> Result<Value, Exception> {
         let elem = self.0.get(index);
         let elem = elem.copied().map(|elem| Value::new(interp, elem));
         Ok(interp.convert(elem))
@@ -217,7 +217,12 @@ impl InlineBuffer {
         }
     }
 
-    pub fn set(&mut self, interp: &Artichoke, index: usize, elem: Value) -> Result<(), Exception> {
+    pub fn set(
+        &mut self,
+        interp: &mut Artichoke,
+        index: usize,
+        elem: Value,
+    ) -> Result<(), Exception> {
         let _ = interp;
         let buflen = self.len();
         match index {
@@ -237,7 +242,7 @@ impl InlineBuffer {
 
     pub fn set_with_drain(
         &mut self,
-        interp: &Artichoke,
+        interp: &mut Artichoke,
         start: usize,
         drain: usize,
         with: Value,
@@ -267,7 +272,7 @@ impl InlineBuffer {
 
     pub fn set_slice(
         &mut self,
-        interp: &Artichoke,
+        interp: &mut Artichoke,
         start: usize,
         drain: usize,
         with: &Self,
@@ -314,9 +319,9 @@ impl InlineBuffer {
         Ok(())
     }
 
-    pub fn pop(&mut self, interp: &Artichoke) -> Result<Value, Exception> {
-        let value = self.0.pop();
-        Ok(interp.convert(value.map(|value| Value::new(interp, value))))
+    pub fn pop(&mut self, interp: &mut Artichoke) -> Result<Value, Exception> {
+        let value = self.0.pop().map(|value| Value::new(interp, value));
+        Ok(interp.convert(value))
     }
 
     pub fn reverse(&mut self, interp: &Artichoke) -> Result<(), Exception> {

--- a/artichoke-backend/src/extn/core/array/mod.rs
+++ b/artichoke-backend/src/extn/core/array/mod.rs
@@ -32,7 +32,7 @@ impl Array {
         self.0.as_vec(interp)
     }
 
-    fn gc_mark(&self, interp: &Artichoke) {
+    fn gc_mark(&self, interp: &mut Artichoke) {
         self.0.gc_mark(interp)
     }
 
@@ -232,7 +232,7 @@ impl Array {
         Ok(elem)
     }
 
-    pub fn get(&self, interp: &Artichoke, index: usize) -> Result<Value, Exception> {
+    pub fn get(&self, interp: &mut Artichoke, index: usize) -> Result<Value, Exception> {
         self.0.get(interp, index)
     }
 
@@ -245,14 +245,19 @@ impl Array {
         self.0.slice(interp, start, len)
     }
 
-    pub fn set(&mut self, interp: &Artichoke, index: usize, elem: Value) -> Result<(), Exception> {
+    pub fn set(
+        &mut self,
+        interp: &mut Artichoke,
+        index: usize,
+        elem: Value,
+    ) -> Result<(), Exception> {
         self.0.set(interp, index, elem)?;
         Ok(())
     }
 
     fn set_with_drain(
         &mut self,
-        interp: &Artichoke,
+        interp: &mut Artichoke,
         start: usize,
         drain: usize,
         with: Value,
@@ -263,7 +268,7 @@ impl Array {
 
     fn set_slice(
         &mut self,
-        interp: &Artichoke,
+        interp: &mut Artichoke,
         start: usize,
         drain: usize,
         with: &InlineBuffer,
@@ -319,7 +324,7 @@ impl Array {
         self.0.is_empty()
     }
 
-    pub fn pop(&mut self, interp: &Artichoke) -> Result<Value, Exception> {
+    pub fn pop(&mut self, interp: &mut Artichoke) -> Result<Value, Exception> {
         let popped = self.0.pop(interp)?;
         Ok(popped)
     }

--- a/artichoke-backend/src/extn/core/array/mod.rs
+++ b/artichoke-backend/src/extn/core/array/mod.rs
@@ -54,7 +54,7 @@ impl Array {
         let result = if let Some(first) = first {
             if let Ok(ary) = unsafe { Self::try_from_ruby(interp, &first) } {
                 ary.borrow().0.clone()
-            } else if let Ok(len) = first.clone().try_into::<Int>() {
+            } else if let Ok(len) = first.try_into::<Int>(interp) {
                 let len = usize::try_from(len)
                     .map_err(|_| ArgumentError::new(interp, "negative array size"))?;
                 if let Some(block) = block {

--- a/artichoke-backend/src/extn/core/array/mruby.rs
+++ b/artichoke-backend/src/extn/core/array/mruby.rs
@@ -6,8 +6,8 @@ use crate::extn::core::array;
 use crate::extn::prelude::*;
 
 #[cfg(feature = "artichoke-array")]
-pub fn init(interp: &Artichoke) -> InitializeResult<()> {
-    if interp.0.borrow().class_spec::<array::Array>().is_some() {
+pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
+    if interp.state().class_spec::<array::Array>().is_some() {
         return Ok(());
     }
     let spec = class::Spec::new("Array", None, Some(def::rust_data_free::<array::Array>))?;
@@ -31,14 +31,14 @@ pub fn init(interp: &Artichoke) -> InitializeResult<()> {
         .add_method("reverse!", ary_reverse_bang, sys::mrb_args_none())?
         .add_method("size", ary_len, sys::mrb_args_none())?
         .define()?;
-    interp.0.borrow_mut().def_class::<array::Array>(spec);
+    interp.state_mut().def_class::<array::Array>(spec);
     let _ = interp.eval(&include_bytes!("array.rb")[..])?;
     trace!("Patched Array onto interpreter");
     Ok(())
 }
 
 #[cfg(not(feature = "artichoke-array"))]
-pub fn init(interp: &Artichoke) -> InitializeResult<()> {
+pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     let _ = interp.eval(&include_bytes!("array.rb")[..])?;
     trace!("Patched Array onto interpreter");
     Ok(())

--- a/artichoke-backend/src/extn/core/array/mruby.rs
+++ b/artichoke-backend/src/extn/core/array/mruby.rs
@@ -64,7 +64,7 @@ unsafe extern "C" fn ary_len(mrb: *mut sys::mrb_state, ary: sys::mrb_value) -> s
     mrb_get_args!(mrb, none);
     let interp = unwrap_interpreter!(mrb);
     let ary = Value::new(&interp, ary);
-    let result = array::trampoline::len(&interp, ary)
+    let result = array::trampoline::len(&mut interp, ary)
         .map(|len| sys::mrb_int::try_from(len).unwrap_or_default());
     match result {
         Ok(len) => interp.convert(len).inner(),
@@ -120,7 +120,7 @@ unsafe extern "C" fn ary_initialize_copy(
     let interp = unwrap_interpreter!(mrb);
     let array = Value::new(&interp, ary);
     let other = Value::new(&interp, other);
-    let result = array::trampoline::initialize_copy(&interp, array, other);
+    let result = array::trampoline::initialize_copy(&mut interp, array, other);
     match result {
         Ok(value) => {
             let basic = sys::mrb_sys_basic_ptr(ary);

--- a/artichoke-backend/src/extn/core/array/mruby.rs
+++ b/artichoke-backend/src/extn/core/array/mruby.rs
@@ -46,7 +46,7 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
 
 #[cfg(feature = "artichoke-array")]
 unsafe extern "C" fn ary_pop(mrb: *mut sys::mrb_state, ary: sys::mrb_value) -> sys::mrb_value {
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let array = Value::new(&interp, ary);
     let result = array::trampoline::pop(&mut interp, array);
     match result {
@@ -62,7 +62,7 @@ unsafe extern "C" fn ary_pop(mrb: *mut sys::mrb_state, ary: sys::mrb_value) -> s
 #[cfg(feature = "artichoke-array")]
 unsafe extern "C" fn ary_len(mrb: *mut sys::mrb_state, ary: sys::mrb_value) -> sys::mrb_value {
     mrb_get_args!(mrb, none);
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let ary = Value::new(&interp, ary);
     let result = array::trampoline::len(&mut interp, ary)
         .map(|len| sys::mrb_int::try_from(len).unwrap_or_default());
@@ -76,7 +76,7 @@ unsafe extern "C" fn ary_len(mrb: *mut sys::mrb_state, ary: sys::mrb_value) -> s
 unsafe extern "C" fn ary_concat(mrb: *mut sys::mrb_state, ary: sys::mrb_value) -> sys::mrb_value {
     println!("ary concat C");
     let other = mrb_get_args!(mrb, optional = 1);
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let array = Value::new(&interp, ary);
     let other = other.map(|other| Value::new(&interp, other));
     let result = array::trampoline::concat(&mut interp, array, other);
@@ -96,7 +96,7 @@ unsafe extern "C" fn ary_initialize(
     ary: sys::mrb_value,
 ) -> sys::mrb_value {
     let (first, second, block) = mrb_get_args!(mrb, optional = 2, &block);
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let array = Value::new(&interp, ary);
     let first = first.map(|first| Value::new(&interp, first));
     let second = second.map(|second| Value::new(&interp, second));
@@ -117,7 +117,7 @@ unsafe extern "C" fn ary_initialize_copy(
     ary: sys::mrb_value,
 ) -> sys::mrb_value {
     let other = mrb_get_args!(mrb, required = 1);
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let array = Value::new(&interp, ary);
     let other = Value::new(&interp, other);
     let result = array::trampoline::initialize_copy(&mut interp, array, other);
@@ -137,7 +137,7 @@ unsafe extern "C" fn ary_reverse_bang(
     ary: sys::mrb_value,
 ) -> sys::mrb_value {
     mrb_get_args!(mrb, none);
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let array = Value::new(&interp, ary);
     let result = array::trampoline::reverse_bang(&mut interp, array);
     match result {
@@ -156,7 +156,7 @@ unsafe extern "C" fn ary_element_reference(
     ary: sys::mrb_value,
 ) -> sys::mrb_value {
     let (elem, len) = mrb_get_args!(mrb, required = 1, optional = 1);
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let elem = Value::new(&interp, elem);
     let len = len.map(|len| Value::new(&interp, len));
     let array = Value::new(&interp, ary);
@@ -173,7 +173,7 @@ unsafe extern "C" fn ary_element_assignment(
     ary: sys::mrb_value,
 ) -> sys::mrb_value {
     let (first, second, third) = mrb_get_args!(mrb, required = 2, optional = 1);
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let first = Value::new(&interp, first);
     let second = Value::new(&interp, second);
     let third = third.map(|third| Value::new(&interp, third));

--- a/artichoke-backend/src/extn/core/array/mruby.rs
+++ b/artichoke-backend/src/extn/core/array/mruby.rs
@@ -48,7 +48,7 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
 unsafe extern "C" fn ary_pop(mrb: *mut sys::mrb_state, ary: sys::mrb_value) -> sys::mrb_value {
     let interp = unwrap_interpreter!(mrb);
     let array = Value::new(&interp, ary);
-    let result = array::trampoline::pop(&interp, array);
+    let result = array::trampoline::pop(&mut interp, array);
     match result {
         Ok(value) => {
             let basic = sys::mrb_sys_basic_ptr(ary);
@@ -79,7 +79,7 @@ unsafe extern "C" fn ary_concat(mrb: *mut sys::mrb_state, ary: sys::mrb_value) -
     let interp = unwrap_interpreter!(mrb);
     let array = Value::new(&interp, ary);
     let other = other.map(|other| Value::new(&interp, other));
-    let result = array::trampoline::concat(&interp, array, other);
+    let result = array::trampoline::concat(&mut interp, array, other);
     match result {
         Ok(value) => {
             let basic = sys::mrb_sys_basic_ptr(ary);
@@ -100,7 +100,7 @@ unsafe extern "C" fn ary_initialize(
     let array = Value::new(&interp, ary);
     let first = first.map(|first| Value::new(&interp, first));
     let second = second.map(|second| Value::new(&interp, second));
-    let result = array::trampoline::initialize(&interp, array, first, second, block);
+    let result = array::trampoline::initialize(&mut interp, array, first, second, block);
     match result {
         Ok(value) => {
             let basic = sys::mrb_sys_basic_ptr(ary);
@@ -139,7 +139,7 @@ unsafe extern "C" fn ary_reverse_bang(
     mrb_get_args!(mrb, none);
     let interp = unwrap_interpreter!(mrb);
     let array = Value::new(&interp, ary);
-    let result = array::trampoline::reverse_bang(&interp, array);
+    let result = array::trampoline::reverse_bang(&mut interp, array);
     match result {
         Ok(value) => {
             let basic = sys::mrb_sys_basic_ptr(ary);
@@ -160,7 +160,7 @@ unsafe extern "C" fn ary_element_reference(
     let elem = Value::new(&interp, elem);
     let len = len.map(|len| Value::new(&interp, len));
     let array = Value::new(&interp, ary);
-    let result = array::trampoline::element_reference(&interp, array, elem, len);
+    let result = array::trampoline::element_reference(&mut interp, array, elem, len);
     match result {
         Ok(value) => value.inner(),
         Err(exception) => exception::raise(interp, exception),
@@ -178,7 +178,7 @@ unsafe extern "C" fn ary_element_assignment(
     let second = Value::new(&interp, second);
     let third = third.map(|third| Value::new(&interp, third));
     let array = Value::new(&interp, ary);
-    let result = array::trampoline::element_assignment(&interp, array, first, second, third);
+    let result = array::trampoline::element_assignment(&mut interp, array, first, second, third);
     match result {
         Ok(value) => {
             let basic = sys::mrb_sys_basic_ptr(ary);

--- a/artichoke-backend/src/extn/core/array/mruby.rs
+++ b/artichoke-backend/src/extn/core/array/mruby.rs
@@ -53,7 +53,7 @@ unsafe extern "C" fn ary_pop(mrb: *mut sys::mrb_state, ary: sys::mrb_value) -> s
         Ok(value) => {
             let basic = sys::mrb_sys_basic_ptr(ary);
             sys::mrb_write_barrier(mrb, basic);
-            value.inner()
+            ffi::return_into_vm(interp, value)
         }
         Err(exception) => exception::raise(interp, exception),
     }
@@ -65,9 +65,10 @@ unsafe extern "C" fn ary_len(mrb: *mut sys::mrb_state, ary: sys::mrb_value) -> s
     let mut interp = unwrap_interpreter!(mrb);
     let ary = Value::new(&interp, ary);
     let result = array::trampoline::len(&mut interp, ary)
-        .map(|len| sys::mrb_int::try_from(len).unwrap_or_default());
+        .map(|len| sys::mrb_int::try_from(len).unwrap_or_default())
+        .map(|len| interp.convert(len));
     match result {
-        Ok(len) => interp.convert(len).inner(),
+        Ok(len) => ffi::return_into_vm(interp, len),
         Err(exception) => exception::raise(interp, exception),
     }
 }
@@ -84,7 +85,7 @@ unsafe extern "C" fn ary_concat(mrb: *mut sys::mrb_state, ary: sys::mrb_value) -
         Ok(value) => {
             let basic = sys::mrb_sys_basic_ptr(ary);
             sys::mrb_write_barrier(mrb, basic);
-            value.inner()
+            ffi::return_into_vm(interp, value)
         }
         Err(exception) => exception::raise(interp, exception),
     }
@@ -105,7 +106,7 @@ unsafe extern "C" fn ary_initialize(
         Ok(value) => {
             let basic = sys::mrb_sys_basic_ptr(ary);
             sys::mrb_write_barrier(mrb, basic);
-            value.inner()
+            ffi::return_into_vm(interp, value)
         }
         Err(exception) => exception::raise(interp, exception),
     }
@@ -125,7 +126,7 @@ unsafe extern "C" fn ary_initialize_copy(
         Ok(value) => {
             let basic = sys::mrb_sys_basic_ptr(ary);
             sys::mrb_write_barrier(mrb, basic);
-            value.inner()
+            ffi::return_into_vm(interp, value)
         }
         Err(exception) => exception::raise(interp, exception),
     }
@@ -144,7 +145,7 @@ unsafe extern "C" fn ary_reverse_bang(
         Ok(value) => {
             let basic = sys::mrb_sys_basic_ptr(ary);
             sys::mrb_write_barrier(mrb, basic);
-            value.inner()
+            ffi::return_into_vm(interp, value)
         }
         Err(exception) => exception::raise(interp, exception),
     }
@@ -162,7 +163,7 @@ unsafe extern "C" fn ary_element_reference(
     let array = Value::new(&interp, ary);
     let result = array::trampoline::element_reference(&mut interp, array, elem, len);
     match result {
-        Ok(value) => value.inner(),
+        Ok(value) => ffi::return_into_vm(interp, value),
         Err(exception) => exception::raise(interp, exception),
     }
 }
@@ -183,7 +184,7 @@ unsafe extern "C" fn ary_element_assignment(
         Ok(value) => {
             let basic = sys::mrb_sys_basic_ptr(ary);
             sys::mrb_write_barrier(mrb, basic);
-            value.inner()
+            ffi::return_into_vm(interp, value)
         }
         Err(exception) => exception::raise(interp, exception),
     }

--- a/artichoke-backend/src/extn/core/array/trampoline.rs
+++ b/artichoke-backend/src/extn/core/array/trampoline.rs
@@ -163,7 +163,7 @@ pub fn reverse_bang(interp: &mut Artichoke, ary: Value) -> Result<Value, Excepti
     Ok(ary)
 }
 
-pub fn len(interp: &Artichoke, ary: Value) -> Result<usize, Exception> {
+pub fn len(interp: &mut Artichoke, ary: Value) -> Result<usize, Exception> {
     let array = unsafe { Array::try_from_ruby(interp, &ary) }.map_err(|_| {
         Fatal::new(
             interp,
@@ -184,7 +184,11 @@ pub fn initialize(
     Array::initialize(interp, first, second, block, ary)
 }
 
-pub fn initialize_copy(interp: &Artichoke, ary: Value, from: Value) -> Result<Value, Exception> {
+pub fn initialize_copy(
+    interp: &mut Artichoke,
+    ary: Value,
+    from: Value,
+) -> Result<Value, Exception> {
     let from = unsafe { Array::try_from_ruby(interp, &from) }.map_err(|_| {
         Fatal::new(
             interp,

--- a/artichoke-backend/src/extn/core/array/trampoline.rs
+++ b/artichoke-backend/src/extn/core/array/trampoline.rs
@@ -2,8 +2,8 @@ use crate::extn::core::array::Array;
 use crate::extn::prelude::*;
 use crate::gc::MrbGarbageCollection;
 
-pub fn clear(interp: &Artichoke, ary: Value) -> Result<Value, Exception> {
-    if ary.is_frozen() {
+pub fn clear(interp: &mut Artichoke, ary: Value) -> Result<Value, Exception> {
+    if ary.is_frozen(interp) {
         return Err(Exception::from(FrozenError::new(
             interp,
             "can't modify frozen Array",
@@ -21,7 +21,7 @@ pub fn clear(interp: &Artichoke, ary: Value) -> Result<Value, Exception> {
 }
 
 pub fn element_reference(
-    interp: &Artichoke,
+    interp: &mut Artichoke,
     ary: Value,
     first: Value,
     second: Option<Value>,
@@ -37,13 +37,13 @@ pub fn element_reference(
 }
 
 pub fn element_assignment(
-    interp: &Artichoke,
+    interp: &mut Artichoke,
     ary: Value,
     first: Value,
     second: Value,
     third: Option<Value>,
 ) -> Result<Value, Exception> {
-    if ary.is_frozen() {
+    if ary.is_frozen(interp) {
         return Err(Exception::from(FrozenError::new(
             interp,
             "can't modify frozen Array",
@@ -68,8 +68,8 @@ pub fn element_assignment(
     result
 }
 
-pub fn pop(interp: &Artichoke, ary: Value) -> Result<Value, Exception> {
-    if ary.is_frozen() {
+pub fn pop(interp: &mut Artichoke, ary: Value) -> Result<Value, Exception> {
+    if ary.is_frozen(interp) {
         return Err(Exception::from(FrozenError::new(
             interp,
             "can't modify frozen Array",
@@ -90,8 +90,12 @@ pub fn pop(interp: &Artichoke, ary: Value) -> Result<Value, Exception> {
     result
 }
 
-pub fn concat(interp: &Artichoke, ary: Value, other: Option<Value>) -> Result<Value, Exception> {
-    if ary.is_frozen() {
+pub fn concat(
+    interp: &mut Artichoke,
+    ary: Value,
+    other: Option<Value>,
+) -> Result<Value, Exception> {
+    if ary.is_frozen(interp) {
         return Err(Exception::from(FrozenError::new(
             interp,
             "can't modify frozen Array",
@@ -114,8 +118,8 @@ pub fn concat(interp: &Artichoke, ary: Value, other: Option<Value>) -> Result<Va
     Ok(ary)
 }
 
-pub fn push(interp: &Artichoke, ary: Value, value: Value) -> Result<Value, Exception> {
-    if ary.is_frozen() {
+pub fn push(interp: &mut Artichoke, ary: Value, value: Value) -> Result<Value, Exception> {
+    if ary.is_frozen(interp) {
         return Err(Exception::from(FrozenError::new(
             interp,
             "can't modify frozen Array",
@@ -137,8 +141,8 @@ pub fn push(interp: &Artichoke, ary: Value, value: Value) -> Result<Value, Excep
     Ok(ary)
 }
 
-pub fn reverse_bang(interp: &Artichoke, ary: Value) -> Result<Value, Exception> {
-    if ary.is_frozen() {
+pub fn reverse_bang(interp: &mut Artichoke, ary: Value) -> Result<Value, Exception> {
+    if ary.is_frozen(interp) {
         return Err(Exception::from(FrozenError::new(
             interp,
             "can't modify frozen Array",
@@ -171,7 +175,7 @@ pub fn len(interp: &Artichoke, ary: Value) -> Result<usize, Exception> {
 }
 
 pub fn initialize(
-    interp: &Artichoke,
+    interp: &mut Artichoke,
     ary: Value,
     first: Option<Value>,
     second: Option<Value>,

--- a/artichoke-backend/src/extn/core/array/trampoline.rs
+++ b/artichoke-backend/src/extn/core/array/trampoline.rs
@@ -148,7 +148,8 @@ pub fn reverse_bang(interp: &mut Artichoke, ary: Value) -> Result<Value, Excepti
             "can't modify frozen Array",
         )));
     }
-    let array = unsafe { Array::try_from_ruby(interp, &ary) }.map_err(|_| {
+    let array = unsafe { Array::try_from_ruby(interp, &ary) }.map_err(|err| {
+        println!("{:?}", err);
         Fatal::new(
             interp,
             "Unable to extract Rust Array from Ruby Array receiver",

--- a/artichoke-backend/src/extn/core/artichoke/mod.rs
+++ b/artichoke-backend/src/extn/core/artichoke/mod.rs
@@ -4,7 +4,7 @@ pub fn init(interp: &mut crate::Artichoke) -> InitializeResult<()> {
     if interp.state().module_spec::<Artichoke>().is_some() {
         return Ok(());
     }
-    let spec = module::Spec::new("Artichoke", None)?;
+    let spec = module::Spec::new(interp, "Artichoke", None)?;
     module::Builder::for_spec(interp, &spec).define()?;
     interp.state_mut().def_module::<Artichoke>(spec);
     trace!("Patched Artichoke onto interpreter");

--- a/artichoke-backend/src/extn/core/artichoke/mod.rs
+++ b/artichoke-backend/src/extn/core/artichoke/mod.rs
@@ -1,6 +1,6 @@
 use crate::extn::prelude::*;
 
-pub fn init(interp: &crate::Artichoke) -> InitializeResult<()> {
+pub fn init(interp: &mut crate::Artichoke) -> InitializeResult<()> {
     if interp.state().module_spec::<Artichoke>().is_some() {
         return Ok(());
     }

--- a/artichoke-backend/src/extn/core/artichoke/mod.rs
+++ b/artichoke-backend/src/extn/core/artichoke/mod.rs
@@ -1,12 +1,12 @@
 use crate::extn::prelude::*;
 
 pub fn init(interp: &crate::Artichoke) -> InitializeResult<()> {
-    if interp.0.borrow().module_spec::<Artichoke>().is_some() {
+    if interp.state().module_spec::<Artichoke>().is_some() {
         return Ok(());
     }
     let spec = module::Spec::new("Artichoke", None)?;
     module::Builder::for_spec(interp, &spec).define()?;
-    interp.0.borrow_mut().def_module::<Artichoke>(spec);
+    interp.state_mut().def_module::<Artichoke>(spec);
     trace!("Patched Artichoke onto interpreter");
     Ok(())
 }

--- a/artichoke-backend/src/extn/core/comparable/mod.rs
+++ b/artichoke-backend/src/extn/core/comparable/mod.rs
@@ -4,7 +4,7 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     if interp.state().module_spec::<Comparable>().is_some() {
         return Ok(());
     }
-    let spec = module::Spec::new("Comparable", None)?;
+    let spec = module::Spec::new(interp, "Comparable", None)?;
     module::Builder::for_spec(interp, &spec).define()?;
     interp.state_mut().def_module::<Comparable>(spec);
     let _ = interp.eval(&include_bytes!("comparable.rb")[..])?;

--- a/artichoke-backend/src/extn/core/comparable/mod.rs
+++ b/artichoke-backend/src/extn/core/comparable/mod.rs
@@ -1,12 +1,12 @@
 use crate::extn::prelude::*;
 
-pub fn init(interp: &Artichoke) -> InitializeResult<()> {
-    if interp.0.borrow().module_spec::<Comparable>().is_some() {
+pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
+    if interp.state().module_spec::<Comparable>().is_some() {
         return Ok(());
     }
     let spec = module::Spec::new("Comparable", None)?;
     module::Builder::for_spec(interp, &spec).define()?;
-    interp.0.borrow_mut().def_module::<Comparable>(spec);
+    interp.state_mut().def_module::<Comparable>(spec);
     let _ = interp.eval(&include_bytes!("comparable.rb")[..])?;
     trace!("Patched Comparable onto interpreter");
     Ok(())

--- a/artichoke-backend/src/extn/core/enumerable/mod.rs
+++ b/artichoke-backend/src/extn/core/enumerable/mod.rs
@@ -1,12 +1,12 @@
 use crate::extn::prelude::*;
 
-pub fn init(interp: &Artichoke) -> InitializeResult<()> {
-    if interp.0.borrow().module_spec::<Enumerable>().is_some() {
+pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
+    if interp.state().module_spec::<Enumerable>().is_some() {
         return Ok(());
     }
     let spec = module::Spec::new("Enumerable", None)?;
     module::Builder::for_spec(interp, &spec).define()?;
-    interp.0.borrow_mut().def_module::<Enumerable>(spec);
+    interp.state_mut().def_module::<Enumerable>(spec);
     let _ = interp.eval(&include_bytes!("enumerable.rb")[..])?;
     trace!("Patched Enumerable onto interpreter");
     Ok(())

--- a/artichoke-backend/src/extn/core/enumerable/mod.rs
+++ b/artichoke-backend/src/extn/core/enumerable/mod.rs
@@ -4,7 +4,7 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     if interp.state().module_spec::<Enumerable>().is_some() {
         return Ok(());
     }
-    let spec = module::Spec::new("Enumerable", None)?;
+    let spec = module::Spec::new(interp, "Enumerable", None)?;
     module::Builder::for_spec(interp, &spec).define()?;
     interp.state_mut().def_module::<Enumerable>(spec);
     let _ = interp.eval(&include_bytes!("enumerable.rb")[..])?;

--- a/artichoke-backend/src/extn/core/enumerator/mod.rs
+++ b/artichoke-backend/src/extn/core/enumerator/mod.rs
@@ -1,11 +1,11 @@
 use crate::extn::prelude::*;
 
-pub fn init(interp: &Artichoke) -> InitializeResult<()> {
-    if interp.0.borrow().class_spec::<Enumerator>().is_some() {
+pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
+    if interp.state().class_spec::<Enumerator>().is_some() {
         return Ok(());
     }
     let spec = class::Spec::new("Enumerator", None, None)?;
-    interp.0.borrow_mut().def_class::<Enumerator>(spec);
+    interp.state_mut().def_class::<Enumerator>(spec);
     let _ = interp.eval(&include_bytes!("enumerator.rb")[..])?;
     let _ = interp.eval(&include_bytes!("lazy.rb")[..])?;
     trace!("Patched Enumerator onto interpreter");

--- a/artichoke-backend/src/extn/core/env/backend/memory.rs
+++ b/artichoke-backend/src/extn/core/env/backend/memory.rs
@@ -16,7 +16,7 @@ impl Memory {
 }
 
 impl Env for Memory {
-    fn get(&self, interp: &Artichoke, name: &[u8]) -> Result<Value, Exception> {
+    fn get(&self, interp: &Artichoke, name: &[u8]) -> Result<Option<Vec<u8>>, Exception> {
         // Per Rust docs for `std::env::set_var` and `std::env::remove_var`:
         // https://doc.rust-lang.org/std/env/fn.set_var.html
         // https://doc.rust-lang.org/std/env/fn.remove_var.html
@@ -27,7 +27,7 @@ impl Env for Memory {
         if name.is_empty() {
             // MRI accepts empty names on get and should always return `nil`
             // since empty names are invalid at the OS level.
-            Ok(interp.convert(None::<Value>))
+            Ok(None)
         } else if memchr::memchr(b'\0', name).is_some() {
             Err(Exception::from(ArgumentError::new(
                 interp,
@@ -36,11 +36,11 @@ impl Env for Memory {
         } else if memchr::memchr(b'=', name).is_some() {
             // MRI accepts names containing '=' on get and should always return
             // `nil` since these names are invalid at the OS level.
-            Ok(interp.convert(None::<Value>))
+            Ok(None)
         } else if let Some(value) = self.store.get(name) {
-            Ok(interp.convert(value.clone()))
+            Ok(Some(value.clone()))
         } else {
-            Ok(interp.convert(None::<Value>))
+            Ok(None)
         }
     }
 

--- a/artichoke-backend/src/extn/core/env/mod.rs
+++ b/artichoke-backend/src/extn/core/env/mod.rs
@@ -6,13 +6,15 @@ pub mod backend;
 pub mod mruby;
 
 pub trait Env {
-    fn get(&self, interp: &Artichoke, name: &[u8]) -> Result<Value, Exception>;
+    fn get(&self, interp: &Artichoke, name: &[u8]) -> Result<Option<Vec<u8>>, Exception>;
+
     fn put(
         &mut self,
         interp: &Artichoke,
         name: &[u8],
         value: Option<&[u8]>,
     ) -> Result<(), Exception>;
+
     fn as_map(&self, interp: &Artichoke) -> Result<HashMap<Vec<u8>, Vec<u8>>, Exception>;
 }
 
@@ -68,7 +70,7 @@ pub fn element_reference(
         )));
     };
     let result = obj.borrow().0.get(interp, name)?;
-    Ok(result)
+    Ok(interp.convert(result))
 }
 
 pub fn element_assignment(

--- a/artichoke-backend/src/extn/core/env/mod.rs
+++ b/artichoke-backend/src/extn/core/env/mod.rs
@@ -47,7 +47,7 @@ pub fn element_reference(interp: &Artichoke, obj: Value, name: &Value) -> Result
     let obj = unsafe { Environ::try_from_ruby(interp, &obj) }
         .map_err(|_| Fatal::new(interp, "Unable to extract Rust ENV from Ruby ENV receiver"))?;
     let ruby_type = name.pretty_name();
-    let name = if let Ok(name) = name.clone().try_into::<&[u8]>() {
+    let name = if let Ok(name) = name.try_into::<&[u8]>(interp) {
         name
     } else if let Ok(name) = name.funcall::<&[u8]>("to_str", &[], None) {
         name
@@ -70,7 +70,7 @@ pub fn element_assignment(
     let obj = unsafe { Environ::try_from_ruby(interp, &obj) }
         .map_err(|_| Fatal::new(interp, "Unable to extract Rust ENV from Ruby ENV receiver"))?;
     let name_type_name = name.pretty_name();
-    let name = if let Ok(name) = name.clone().try_into::<&[u8]>() {
+    let name = if let Ok(name) = name.try_into::<&[u8]>(interp) {
         name
     } else if let Ok(name) = name.funcall::<&[u8]>("to_str", &[], None) {
         name
@@ -81,7 +81,7 @@ pub fn element_assignment(
         )));
     };
     let value_type_name = value.pretty_name();
-    let value = if let Ok(value) = value.clone().try_into::<Option<&[u8]>>() {
+    let value = if let Ok(value) = value.try_into::<Option<&[u8]>>(interp) {
         value
     } else if let Ok(value) = value.clone().funcall::<&[u8]>("to_str", &[], None) {
         Some(value)

--- a/artichoke-backend/src/extn/core/env/mod.rs
+++ b/artichoke-backend/src/extn/core/env/mod.rs
@@ -26,19 +26,25 @@ impl RustBackedValue for Environ {
 }
 
 #[cfg(feature = "artichoke-system-environ")]
-pub fn initialize(interp: &Artichoke, into: Option<sys::mrb_value>) -> Result<Value, Exception> {
+pub fn initialize(
+    interp: &mut Artichoke,
+    into: Option<sys::mrb_value>,
+) -> Result<Value, Exception> {
     let obj = Environ(Box::new(backend::system::System::new()));
     let result = obj
-        .try_into_ruby(&interp, into)
+        .try_into_ruby(interp, into)
         .map_err(|_| Fatal::new(interp, "Unable to initialize Ruby ENV with Rust ENV"))?;
     Ok(result)
 }
 
 #[cfg(not(feature = "artichoke-system-environ"))]
-pub fn initialize(interp: &Artichoke, into: Option<sys::mrb_value>) -> Result<Value, Exception> {
+pub fn initialize(
+    interp: &mut Artichoke,
+    into: Option<sys::mrb_value>,
+) -> Result<Value, Exception> {
     let obj = Environ(Box::new(backend::memory::Memory::new()));
     let result = obj
-        .try_into_ruby(&interp, into)
+        .try_into_ruby(interp, into)
         .map_err(|_| Fatal::new(interp, "Unable to initialize Ruby ENV with Rust ENV"))?;
     Ok(result)
 }
@@ -100,7 +106,7 @@ pub fn element_assignment(
     Ok(interp.convert(value))
 }
 
-pub fn to_h(interp: &Artichoke, obj: Value) -> Result<Value, Exception> {
+pub fn to_h(interp: &mut Artichoke, obj: Value) -> Result<Value, Exception> {
     let obj = unsafe { Environ::try_from_ruby(interp, &obj) }
         .map_err(|_| Fatal::new(interp, "Unable to extract Rust ENV from Ruby ENV receiver"))?;
     let result = obj.borrow().0.as_map(interp)?;

--- a/artichoke-backend/src/extn/core/env/mruby.rs
+++ b/artichoke-backend/src/extn/core/env/mruby.rs
@@ -2,8 +2,8 @@ use crate::extn::core::artichoke;
 use crate::extn::core::env;
 use crate::extn::prelude::*;
 
-pub fn init(interp: &Artichoke) -> InitializeResult<()> {
-    if interp.0.borrow().class_spec::<env::Environ>().is_some() {
+pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
+    if interp.state().class_spec::<env::Environ>().is_some() {
         return Ok(());
     }
     let scope = interp
@@ -28,7 +28,7 @@ pub fn init(interp: &Artichoke) -> InitializeResult<()> {
         .add_method("initialize", artichoke_env_initialize, sys::mrb_args_none())?
         .add_method("to_h", artichoke_env_to_h, sys::mrb_args_none())?
         .define()?;
-    interp.0.borrow_mut().def_class::<env::Environ>(spec);
+    interp.state_mut().def_class::<env::Environ>(spec);
     let _ = interp.eval(&include_bytes!("env.rb")[..])?;
     trace!("Patched ENV onto interpreter");
     trace!("Patched Artichoke::Environ onto interpreter");

--- a/artichoke-backend/src/extn/core/env/mruby.rs
+++ b/artichoke-backend/src/extn/core/env/mruby.rs
@@ -7,8 +7,7 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
         return Ok(());
     }
     let scope = interp
-        .0
-        .borrow_mut()
+        .state()
         .module_spec::<artichoke::Artichoke>()
         .map(EnclosingRubyScope::module)
         .ok_or(ArtichokeError::New)?;
@@ -58,7 +57,7 @@ unsafe extern "C" fn artichoke_env_element_reference(
     let interp = unwrap_interpreter!(mrb);
     let obj = Value::new(&interp, slf);
     let name = Value::new(&interp, name);
-    let result = env::element_reference(&interp, obj, &name);
+    let result = env::element_reference(&mut interp, obj, &name);
     match result {
         Ok(value) => value.inner(),
         Err(exception) => exception::raise(interp, exception),
@@ -75,7 +74,7 @@ unsafe extern "C" fn artichoke_env_element_assignment(
     let obj = Value::new(&interp, slf);
     let name = Value::new(&interp, name);
     let value = Value::new(&interp, value);
-    let result = env::element_assignment(&interp, obj, &name, value);
+    let result = env::element_assignment(&mut interp, obj, &name, value);
     match result {
         Ok(value) => value.inner(),
         Err(exception) => exception::raise(interp, exception),

--- a/artichoke-backend/src/extn/core/env/mruby.rs
+++ b/artichoke-backend/src/extn/core/env/mruby.rs
@@ -43,7 +43,7 @@ unsafe extern "C" fn artichoke_env_initialize(
     let mut interp = unwrap_interpreter!(mrb);
     let result = env::initialize(&mut interp, Some(slf));
     match result {
-        Ok(value) => value.inner(),
+        Ok(value) => ffi::return_into_vm(interp, value),
         Err(exception) => exception::raise(interp, exception),
     }
 }
@@ -59,7 +59,7 @@ unsafe extern "C" fn artichoke_env_element_reference(
     let name = Value::new(&interp, name);
     let result = env::element_reference(&mut interp, obj, &name);
     match result {
-        Ok(value) => value.inner(),
+        Ok(value) => ffi::return_into_vm(interp, value),
         Err(exception) => exception::raise(interp, exception),
     }
 }
@@ -76,7 +76,7 @@ unsafe extern "C" fn artichoke_env_element_assignment(
     let value = Value::new(&interp, value);
     let result = env::element_assignment(&mut interp, obj, &name, value);
     match result {
-        Ok(value) => value.inner(),
+        Ok(value) => ffi::return_into_vm(interp, value),
         Err(exception) => exception::raise(interp, exception),
     }
 }
@@ -91,7 +91,7 @@ unsafe extern "C" fn artichoke_env_to_h(
     let obj = Value::new(&interp, slf);
     let result = env::to_h(&mut interp, obj);
     match result {
-        Ok(value) => value.inner(),
+        Ok(value) => ffi::return_into_vm(interp, value),
         Err(exception) => exception::raise(interp, exception),
     }
 }

--- a/artichoke-backend/src/extn/core/env/mruby.rs
+++ b/artichoke-backend/src/extn/core/env/mruby.rs
@@ -40,7 +40,7 @@ unsafe extern "C" fn artichoke_env_initialize(
     slf: sys::mrb_value,
 ) -> sys::mrb_value {
     mrb_get_args!(mrb, none);
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let result = env::initialize(&mut interp, Some(slf));
     match result {
         Ok(value) => value.inner(),
@@ -54,7 +54,7 @@ unsafe extern "C" fn artichoke_env_element_reference(
     slf: sys::mrb_value,
 ) -> sys::mrb_value {
     let name = mrb_get_args!(mrb, required = 1);
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let obj = Value::new(&interp, slf);
     let name = Value::new(&interp, name);
     let result = env::element_reference(&mut interp, obj, &name);
@@ -70,7 +70,7 @@ unsafe extern "C" fn artichoke_env_element_assignment(
     slf: sys::mrb_value,
 ) -> sys::mrb_value {
     let (name, value) = mrb_get_args!(mrb, required = 2);
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let obj = Value::new(&interp, slf);
     let name = Value::new(&interp, name);
     let value = Value::new(&interp, value);
@@ -87,7 +87,7 @@ unsafe extern "C" fn artichoke_env_to_h(
     slf: sys::mrb_value,
 ) -> sys::mrb_value {
     mrb_get_args!(mrb, none);
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let obj = Value::new(&interp, slf);
     let result = env::to_h(&mut interp, obj);
     match result {

--- a/artichoke-backend/src/extn/core/env/mruby.rs
+++ b/artichoke-backend/src/extn/core/env/mruby.rs
@@ -41,7 +41,7 @@ unsafe extern "C" fn artichoke_env_initialize(
 ) -> sys::mrb_value {
     mrb_get_args!(mrb, none);
     let interp = unwrap_interpreter!(mrb);
-    let result = env::initialize(&interp, Some(slf));
+    let result = env::initialize(&mut interp, Some(slf));
     match result {
         Ok(value) => value.inner(),
         Err(exception) => exception::raise(interp, exception),
@@ -89,7 +89,7 @@ unsafe extern "C" fn artichoke_env_to_h(
     mrb_get_args!(mrb, none);
     let interp = unwrap_interpreter!(mrb);
     let obj = Value::new(&interp, slf);
-    let result = env::to_h(&interp, obj);
+    let result = env::to_h(&mut interp, obj);
     match result {
         Ok(value) => value.inner(),
         Err(exception) => exception::raise(interp, exception),

--- a/artichoke-backend/src/extn/core/exception/mod.rs
+++ b/artichoke-backend/src/extn/core/exception/mod.rs
@@ -384,12 +384,10 @@ macro_rules! ruby_exception_impl {
 
             #[must_use]
             fn as_mrb_value(&self, interp: &mut Artichoke) -> Option<sys::mrb_value> {
-                interp
-                    .state()
-                    .class_spec::<Self>()
-                    .and_then(|spec| spec.new_instance(interp, &[interp.convert(self.message())]))
-                    .as_ref()
-                    .map(Value::inner)
+                let spec = interp.state().class_spec::<Self>()?.clone();
+                let message = interp.convert(self.message());
+                let value = spec.new_instance(interp, &[message])?;
+                Some(value.inner())
             }
         }
 

--- a/artichoke-backend/src/extn/core/exception/mod.rs
+++ b/artichoke-backend/src/extn/core/exception/mod.rs
@@ -485,7 +485,7 @@ mod tests {
 
     impl Run {
         unsafe extern "C" fn run(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {
-            let interp = unwrap_interpreter!(mrb);
+            let mut interp = unwrap_interpreter!(mrb);
             let exc = RuntimeError::new(&interp, "something went wrong");
             exception::raise(interp, exc)
         }

--- a/artichoke-backend/src/extn/core/float/mod.rs
+++ b/artichoke-backend/src/extn/core/float/mod.rs
@@ -1,12 +1,12 @@
 use crate::extn::prelude::*;
 use crate::types;
 
-pub fn init(interp: &Artichoke) -> InitializeResult<()> {
-    if interp.0.borrow().class_spec::<Float>().is_some() {
+pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
+    if interp.state().class_spec::<Float>().is_some() {
         return Ok(());
     }
     let spec = class::Spec::new("Float", None, None)?;
-    interp.0.borrow_mut().def_class::<Float>(spec);
+    interp.state_mut().def_class::<Float>(spec);
     let _ = interp.eval(&include_bytes!("float.rb")[..])?;
     // TODO: Add proper constant defs to class::Spec, see GH-158.
     let _ = interp.eval(format!("class Float; EPSILON={} end", Float::EPSILON).as_bytes())?;

--- a/artichoke-backend/src/extn/core/hash/mod.rs
+++ b/artichoke-backend/src/extn/core/hash/mod.rs
@@ -1,11 +1,11 @@
 use crate::extn::prelude::*;
 
-pub fn init(interp: &Artichoke) -> InitializeResult<()> {
-    if interp.0.borrow().class_spec::<Hash>().is_some() {
+pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
+    if interp.state().class_spec::<Hash>().is_some() {
         return Ok(());
     }
     let spec = class::Spec::new("Hash", None, None)?;
-    interp.0.borrow_mut().def_class::<Hash>(spec);
+    interp.state_mut().def_class::<Hash>(spec);
     let _ = interp.eval(&include_bytes!("hash.rb")[..])?;
     trace!("Patched Hash onto interpreter");
     Ok(())

--- a/artichoke-backend/src/extn/core/integer/div.rs
+++ b/artichoke-backend/src/extn/core/integer/div.rs
@@ -10,7 +10,7 @@ pub fn method(interp: &Artichoke, value: Value, other: Value) -> Result<Value, E
         )
     })?;
     let pretty_name = other.pretty_name();
-    if let Ok(y) = other.clone().try_into::<Int>() {
+    if let Ok(y) = other.try_into::<Int>(interp) {
         if y == 0 {
             Err(Exception::from(ZeroDivisionError::new(
                 interp,

--- a/artichoke-backend/src/extn/core/integer/div.rs
+++ b/artichoke-backend/src/extn/core/integer/div.rs
@@ -2,14 +2,14 @@ use crate::extn::core::float::Float;
 use crate::extn::prelude::*;
 use crate::types;
 
-pub fn method(interp: &Artichoke, value: Value, other: Value) -> Result<Value, Exception> {
-    let x = value.try_into::<Int>().map_err(|_| {
+pub fn method(interp: &mut Artichoke, value: Value, other: Value) -> Result<Value, Exception> {
+    let x = value.try_into::<Int>(interp).map_err(|_| {
         Fatal::new(
             interp,
             "Unable to extract Rust Integer from Ruby Integer receiver",
         )
     })?;
-    let pretty_name = other.pretty_name();
+    let pretty_name = other.pretty_name(interp);
     if let Ok(y) = other.try_into::<Int>(interp) {
         if y == 0 {
             Err(Exception::from(ZeroDivisionError::new(
@@ -19,7 +19,7 @@ pub fn method(interp: &Artichoke, value: Value, other: Value) -> Result<Value, E
         } else {
             Ok(interp.convert(x / y))
         }
-    } else if let Ok(y) = other.try_into::<types::Float>() {
+    } else if let Ok(y) = other.try_into::<types::Float>(interp) {
         if y == 0.0 {
             match x {
                 x if x > 0 => Ok(interp.convert(Float::INFINITY)),

--- a/artichoke-backend/src/extn/core/integer/mod.rs
+++ b/artichoke-backend/src/extn/core/integer/mod.rs
@@ -83,7 +83,7 @@ impl Integer {
             }
         };
         match result {
-            Ok(value) => value.inner(),
+            Ok(value) => ffi::return_into_vm(interp, value),
             Err(exception) => exception::raise(interp, exception),
         }
     }
@@ -95,7 +95,7 @@ impl Integer {
         let other = Value::new(&interp, other);
         let result = div::method(&mut interp, value, other);
         match result {
-            Ok(value) => value.inner(),
+            Ok(value) => ffi::return_into_vm(interp, value),
             Err(exception) => exception::raise(interp, exception),
         }
     }
@@ -107,7 +107,7 @@ impl Integer {
             .map(|size| interp.convert(size))
             .map_err(|_| Fatal::new(&interp, "sizeof Integer does not fit in Integer max"));
         match result {
-            Ok(value) => value.inner(),
+            Ok(value) => ffi::return_into_vm(interp, value),
             Err(exception) => exception::raise(interp, exception),
         }
     }

--- a/artichoke-backend/src/extn/core/integer/mod.rs
+++ b/artichoke-backend/src/extn/core/integer/mod.rs
@@ -30,7 +30,7 @@ impl Integer {
         let encoding = encoding.map(|encoding| Value::new(&interp, encoding));
         let result: Result<Value, Exception> = if let Some(encoding) = encoding {
             let mut message = b"encoding parameter of Integer#chr (given ".to_vec();
-            message.extend(encoding.inspect());
+            message.extend(encoding.inspect(&mut interp));
             message.extend(b") not supported");
             Err(Exception::from(NotImplementedError::new_raw(
                 &interp, message,
@@ -63,7 +63,7 @@ impl Integer {
             //         1: from (irb):9:in `chr'
             // RangeError (256 out of char range)
             // ```
-            if let Ok(chr) = Value::new(&interp, slf).try_into::<Int>() {
+            if let Ok(chr) = Value::new(&interp, slf).try_into::<Int>(&mut interp) {
                 match u8::try_from(chr) {
                     Ok(chr @ 0..=127) | Ok(chr @ 128..=255) => {
                         // ASCII encoding | Binary/ASCII-8BIT encoding
@@ -93,7 +93,7 @@ impl Integer {
         let interp = unwrap_interpreter!(mrb);
         let value = Value::new(&interp, slf);
         let other = Value::new(&interp, other);
-        let result = div::method(&interp, value, other);
+        let result = div::method(&mut interp, value, other);
         match result {
             Ok(value) => value.inner(),
             Err(exception) => exception::raise(interp, exception),

--- a/artichoke-backend/src/extn/core/integer/mod.rs
+++ b/artichoke-backend/src/extn/core/integer/mod.rs
@@ -26,7 +26,7 @@ pub struct Integer;
 impl Integer {
     unsafe extern "C" fn chr(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
         let encoding = mrb_get_args!(mrb, optional = 1);
-        let interp = unwrap_interpreter!(mrb);
+        let mut interp = unwrap_interpreter!(mrb);
         let encoding = encoding.map(|encoding| Value::new(&interp, encoding));
         let result: Result<Value, Exception> = if let Some(encoding) = encoding {
             let mut message = b"encoding parameter of Integer#chr (given ".to_vec();
@@ -90,7 +90,7 @@ impl Integer {
 
     unsafe extern "C" fn div(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
         let other = mrb_get_args!(mrb, required = 1);
-        let interp = unwrap_interpreter!(mrb);
+        let mut interp = unwrap_interpreter!(mrb);
         let value = Value::new(&interp, slf);
         let other = Value::new(&interp, other);
         let result = div::method(&mut interp, value, other);
@@ -102,7 +102,7 @@ impl Integer {
 
     unsafe extern "C" fn size(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {
         mrb_get_args!(mrb, none);
-        let interp = unwrap_interpreter!(mrb);
+        let mut interp = unwrap_interpreter!(mrb);
         let result = Int::try_from(mem::size_of::<Int>())
             .map(|size| interp.convert(size))
             .map_err(|_| Fatal::new(&interp, "sizeof Integer does not fit in Integer max"));

--- a/artichoke-backend/src/extn/core/integer/mod.rs
+++ b/artichoke-backend/src/extn/core/integer/mod.rs
@@ -5,8 +5,8 @@ use crate::extn::prelude::*;
 
 pub mod div;
 
-pub fn init(interp: &Artichoke) -> InitializeResult<()> {
-    if interp.0.borrow().class_spec::<Integer>().is_some() {
+pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
+    if interp.state().class_spec::<Integer>().is_some() {
         return Ok(());
     }
     let spec = class::Spec::new("Integer", None, None)?;
@@ -15,7 +15,7 @@ pub fn init(interp: &Artichoke) -> InitializeResult<()> {
         .add_method("/", Integer::div, sys::mrb_args_req(1))?
         .add_method("size", Integer::size, sys::mrb_args_none())?
         .define()?;
-    interp.0.borrow_mut().def_class::<Integer>(spec);
+    interp.state_mut().def_class::<Integer>(spec);
     let _ = interp.eval(&include_bytes!("integer.rb")[..])?;
     trace!("Patched Integer onto interpreter");
     Ok(())

--- a/artichoke-backend/src/extn/core/kernel/integer.rs
+++ b/artichoke-backend/src/extn/core/kernel/integer.rs
@@ -5,7 +5,11 @@ use std::str::{self, FromStr};
 
 use crate::extn::prelude::*;
 
-pub fn method(interp: &Artichoke, arg: Value, radix: Option<Value>) -> Result<Value, Exception> {
+pub fn method(
+    interp: &mut Artichoke,
+    arg: Value,
+    radix: Option<Value>,
+) -> Result<Value, Exception> {
     #[derive(Debug, Clone, Copy)]
     enum Sign {
         Pos,
@@ -20,7 +24,7 @@ pub fn method(interp: &Artichoke, arg: Value, radix: Option<Value>) -> Result<Va
     let radix = if let Some(radix) = radix {
         if let Ok(radix) = radix.try_into::<Int>(interp) {
             Some(radix)
-        } else if let Ok(radix) = radix.funcall::<Int>("to_int", &[], None) {
+        } else if let Ok(radix) = radix.funcall::<Int>(interp, "to_int", &[], None) {
             Some(radix)
         } else {
             None
@@ -44,10 +48,10 @@ pub fn method(interp: &Artichoke, arg: Value, radix: Option<Value>) -> Result<Va
         }
         None => None,
     };
-    let ruby_type = arg.pretty_name();
+    let ruby_type = arg.pretty_name(interp);
     let arg = if let Ok(arg) = arg.try_into::<&[u8]>(interp) {
         arg
-    } else if let Ok(arg) = arg.funcall::<&[u8]>("to_str", &[], None) {
+    } else if let Ok(arg) = arg.funcall::<&[u8]>(interp, "to_str", &[], None) {
         arg
     } else {
         return Err(Exception::from(TypeError::new(

--- a/artichoke-backend/src/extn/core/kernel/integer.rs
+++ b/artichoke-backend/src/extn/core/kernel/integer.rs
@@ -18,7 +18,7 @@ pub fn method(interp: &Artichoke, arg: Value, radix: Option<Value>) -> Result<Va
         Accumulate(Sign, String),
     }
     let radix = if let Some(radix) = radix {
-        if let Ok(radix) = radix.clone().try_into::<Int>() {
+        if let Ok(radix) = radix.try_into::<Int>(interp) {
             Some(radix)
         } else if let Ok(radix) = radix.funcall::<Int>("to_int", &[], None) {
             Some(radix)
@@ -45,7 +45,7 @@ pub fn method(interp: &Artichoke, arg: Value, radix: Option<Value>) -> Result<Va
         None => None,
     };
     let ruby_type = arg.pretty_name();
-    let arg = if let Ok(arg) = arg.clone().try_into::<&[u8]>() {
+    let arg = if let Ok(arg) = arg.try_into::<&[u8]>(interp) {
         arg
     } else if let Ok(arg) = arg.funcall::<&[u8]>("to_str", &[], None) {
         arg

--- a/artichoke-backend/src/extn/core/kernel/mod.rs
+++ b/artichoke-backend/src/extn/core/kernel/mod.rs
@@ -44,11 +44,9 @@ impl Kernel {
     unsafe extern "C" fn integer(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {
         let (arg, base) = mrb_get_args!(mrb, required = 1, optional = 1);
         let mut interp = unwrap_interpreter!(mrb);
-        let result = integer::method(
-            &mut interp,
-            Value::new(&interp, arg),
-            base.map(|base| Value::new(&interp, base)),
-        );
+        let arg = Value::new(&interp, arg);
+        let base = base.map(|base| Value::new(&interp, base));
+        let result = integer::method(&mut interp, arg, base);
         match result {
             Ok(value) => value.inner(),
             Err(exception) => exception::raise(interp, exception),
@@ -72,8 +70,8 @@ impl Kernel {
 
         let mut buf = vec![];
         for value in args.iter().copied() {
-            let to_s = Value::new(&interp, value).to_s(&mut interp);
-            buf.extend(to_s);
+            let value = Value::new(&interp, value);
+            buf.extend(value.to_s(&mut interp));
         }
         interp.state_mut().print(buf.as_slice());
         sys::mrb_sys_nil_value()
@@ -98,7 +96,8 @@ impl Kernel {
         } else {
             let mut buf = vec![];
             for value in args.iter().copied() {
-                do_puts(&mut interp, &Value::new(&interp, value), &mut buf);
+                let value = Value::new(&interp, value);
+                do_puts(&mut interp, &value, &mut buf);
             }
             interp.state_mut().print(buf.as_slice());
         }

--- a/artichoke-backend/src/extn/core/kernel/mod.rs
+++ b/artichoke-backend/src/extn/core/kernel/mod.rs
@@ -8,7 +8,7 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     if interp.state().module_spec::<Kernel>().is_some() {
         return Ok(());
     }
-    let spec = module::Spec::new("Kernel", None)?;
+    let spec = module::Spec::new(interp, "Kernel", None)?;
     module::Builder::for_spec(interp, &spec)
         .add_method("require", Kernel::require, sys::mrb_args_rest())?
         .add_method(
@@ -28,7 +28,7 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
         .module_spec::<artichoke::Artichoke>()
         .map(EnclosingRubyScope::module)
         .ok_or(ArtichokeError::New)?;
-    let spec = module::Spec::new("Kernel", Some(scope))?;
+    let spec = module::Spec::new(interp, "Kernel", Some(scope))?;
     module::Builder::for_spec(interp, &spec)
         .add_method("Integer", Kernel::integer, sys::mrb_args_req_and_opt(1, 1))?
         .add_self_method("Integer", Kernel::integer, sys::mrb_args_req_and_opt(1, 1))?

--- a/artichoke-backend/src/extn/core/kernel/mod.rs
+++ b/artichoke-backend/src/extn/core/kernel/mod.rs
@@ -4,8 +4,8 @@ use crate::extn::prelude::*;
 pub mod integer;
 pub mod require;
 
-pub fn init(interp: &Artichoke) -> InitializeResult<()> {
-    if interp.0.borrow().module_spec::<Kernel>().is_some() {
+pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
+    if interp.state().module_spec::<Kernel>().is_some() {
         return Ok(());
     }
     let spec = module::Spec::new("Kernel", None)?;
@@ -20,7 +20,7 @@ pub fn init(interp: &Artichoke) -> InitializeResult<()> {
         .add_method("print", Kernel::print, sys::mrb_args_rest())?
         .add_method("puts", Kernel::puts, sys::mrb_args_rest())?
         .define()?;
-    interp.0.borrow_mut().def_module::<Kernel>(spec);
+    interp.state_mut().def_module::<Kernel>(spec);
     let _ = interp.eval(&include_bytes!("kernel.rb")[..])?;
     trace!("Patched Kernel onto interpreter");
     let scope = interp
@@ -34,7 +34,7 @@ pub fn init(interp: &Artichoke) -> InitializeResult<()> {
         .add_method("Integer", Kernel::integer, sys::mrb_args_req_and_opt(1, 1))?
         .add_self_method("Integer", Kernel::integer, sys::mrb_args_req_and_opt(1, 1))?
         .define()?;
-    interp.0.borrow_mut().def_module::<artichoke::Kernel>(spec);
+    interp.state_mut().def_module::<artichoke::Kernel>(spec);
     trace!("Patched Artichoke::Kernel onto interpreter");
     Ok(())
 }

--- a/artichoke-backend/src/extn/core/kernel/mod.rs
+++ b/artichoke-backend/src/extn/core/kernel/mod.rs
@@ -48,7 +48,7 @@ impl Kernel {
         let base = base.map(|base| Value::new(&interp, base));
         let result = integer::method(&mut interp, arg, base);
         match result {
-            Ok(value) => value.inner(),
+            Ok(value) => ffi::return_into_vm(interp, value),
             Err(exception) => exception::raise(interp, exception),
         }
     }
@@ -59,7 +59,7 @@ impl Kernel {
         let file = Value::new(&interp, file);
         let result = require::load(&mut interp, file);
         match result {
-            Ok(value) => value.inner(),
+            Ok(value) => ffi::return_into_vm(interp, value),
             Err(exception) => exception::raise(interp, exception),
         }
     }
@@ -110,7 +110,7 @@ impl Kernel {
         let file = Value::new(&interp, file);
         let result = require::require(&mut interp, file, None);
         match result {
-            Ok(value) => value.inner(),
+            Ok(value) => ffi::return_into_vm(interp, value),
             Err(exception) => exception::raise(interp, exception),
         }
     }
@@ -124,7 +124,7 @@ impl Kernel {
         let file = Value::new(&interp, file);
         let result = require::require_relative(&mut interp, file);
         match result {
-            Ok(value) => value.inner(),
+            Ok(value) => ffi::return_into_vm(interp, value),
             Err(exception) => exception::raise(interp, exception),
         }
     }

--- a/artichoke-backend/src/extn/core/kernel/mod.rs
+++ b/artichoke-backend/src/extn/core/kernel/mod.rs
@@ -43,7 +43,7 @@ pub struct Kernel;
 impl Kernel {
     unsafe extern "C" fn integer(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {
         let (arg, base) = mrb_get_args!(mrb, required = 1, optional = 1);
-        let interp = unwrap_interpreter!(mrb);
+        let mut interp = unwrap_interpreter!(mrb);
         let result = integer::method(
             &mut interp,
             Value::new(&interp, arg),
@@ -57,7 +57,7 @@ impl Kernel {
 
     unsafe extern "C" fn load(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {
         let file = mrb_get_args!(mrb, required = 1);
-        let interp = unwrap_interpreter!(mrb);
+        let mut interp = unwrap_interpreter!(mrb);
         let file = Value::new(&interp, file);
         let result = require::load(&mut interp, file);
         match result {
@@ -68,7 +68,7 @@ impl Kernel {
 
     unsafe extern "C" fn print(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {
         let args = mrb_get_args!(mrb, *args);
-        let interp = unwrap_interpreter!(mrb);
+        let mut interp = unwrap_interpreter!(mrb);
 
         let mut buf = vec![];
         for value in args.iter().copied() {
@@ -92,7 +92,7 @@ impl Kernel {
         }
 
         let args = mrb_get_args!(mrb, *args);
-        let interp = unwrap_interpreter!(mrb);
+        let mut interp = unwrap_interpreter!(mrb);
         if args.is_empty() {
             interp.state_mut().puts(&[]);
         } else {
@@ -107,7 +107,7 @@ impl Kernel {
 
     unsafe extern "C" fn require(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {
         let file = mrb_get_args!(mrb, required = 1);
-        let interp = unwrap_interpreter!(mrb);
+        let mut interp = unwrap_interpreter!(mrb);
         let file = Value::new(&interp, file);
         let result = require::require(&mut interp, file, None);
         match result {
@@ -121,7 +121,7 @@ impl Kernel {
         _slf: sys::mrb_value,
     ) -> sys::mrb_value {
         let file = mrb_get_args!(mrb, required = 1);
-        let interp = unwrap_interpreter!(mrb);
+        let mut interp = unwrap_interpreter!(mrb);
         let file = Value::new(&interp, file);
         let result = require::require_relative(&mut interp, file);
         match result {

--- a/artichoke-backend/src/extn/core/kernel/mod.rs
+++ b/artichoke-backend/src/extn/core/kernel/mod.rs
@@ -45,7 +45,7 @@ impl Kernel {
         let (arg, base) = mrb_get_args!(mrb, required = 1, optional = 1);
         let interp = unwrap_interpreter!(mrb);
         let result = integer::method(
-            &interp,
+            &mut interp,
             Value::new(&interp, arg),
             base.map(|base| Value::new(&interp, base)),
         );

--- a/artichoke-backend/src/extn/core/kernel/mod.rs
+++ b/artichoke-backend/src/extn/core/kernel/mod.rs
@@ -24,8 +24,7 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     let _ = interp.eval(&include_bytes!("kernel.rb")[..])?;
     trace!("Patched Kernel onto interpreter");
     let scope = interp
-        .0
-        .borrow()
+        .state()
         .module_spec::<artichoke::Artichoke>()
         .map(EnclosingRubyScope::module)
         .ok_or(ArtichokeError::New)?;
@@ -60,7 +59,7 @@ impl Kernel {
         let file = mrb_get_args!(mrb, required = 1);
         let interp = unwrap_interpreter!(mrb);
         let file = Value::new(&interp, file);
-        let result = require::load(&interp, file);
+        let result = require::load(&mut interp, file);
         match result {
             Ok(value) => value.inner(),
             Err(exception) => exception::raise(interp, exception),
@@ -73,21 +72,21 @@ impl Kernel {
 
         let mut buf = vec![];
         for value in args.iter().copied() {
-            let to_s = Value::new(&interp, value).to_s();
+            let to_s = Value::new(&interp, value).to_s(&mut interp);
             buf.extend(to_s);
         }
-        interp.0.borrow_mut().print(buf.as_slice());
+        interp.state_mut().print(buf.as_slice());
         sys::mrb_sys_nil_value()
     }
 
     unsafe extern "C" fn puts(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {
-        fn do_puts(interp: &Artichoke, value: &Value, buf: &mut Vec<u8>) {
-            if let Ok(array) = value.clone().try_into::<Vec<Value>>() {
+        fn do_puts(interp: &mut Artichoke, value: &Value, buf: &mut Vec<u8>) {
+            if let Ok(array) = value.try_into::<Vec<Value>>(interp) {
                 for value in array {
                     do_puts(interp, &value, buf);
                 }
             } else {
-                buf.extend(value.to_s());
+                buf.extend(value.to_s(interp));
                 buf.push(b'\n');
             }
         }
@@ -95,13 +94,13 @@ impl Kernel {
         let args = mrb_get_args!(mrb, *args);
         let interp = unwrap_interpreter!(mrb);
         if args.is_empty() {
-            interp.0.borrow_mut().puts(&[]);
+            interp.state_mut().puts(&[]);
         } else {
             let mut buf = vec![];
             for value in args.iter().copied() {
-                do_puts(&interp, &Value::new(&interp, value), &mut buf);
+                do_puts(&mut interp, &Value::new(&interp, value), &mut buf);
             }
-            interp.0.borrow_mut().print(buf.as_slice());
+            interp.state_mut().print(buf.as_slice());
         }
         sys::mrb_sys_nil_value()
     }
@@ -110,7 +109,7 @@ impl Kernel {
         let file = mrb_get_args!(mrb, required = 1);
         let interp = unwrap_interpreter!(mrb);
         let file = Value::new(&interp, file);
-        let result = require::require(&interp, file, None);
+        let result = require::require(&mut interp, file, None);
         match result {
             Ok(value) => value.inner(),
             Err(exception) => exception::raise(interp, exception),
@@ -124,7 +123,7 @@ impl Kernel {
         let file = mrb_get_args!(mrb, required = 1);
         let interp = unwrap_interpreter!(mrb);
         let file = Value::new(&interp, file);
-        let result = require::require_relative(&interp, file);
+        let result = require::require_relative(&mut interp, file);
         match result {
             Ok(value) => value.inner(),
             Err(exception) => exception::raise(interp, exception),

--- a/artichoke-backend/src/extn/core/kernel/require.rs
+++ b/artichoke-backend/src/extn/core/kernel/require.rs
@@ -2,7 +2,7 @@
 
 use bstr::BStr;
 use std::ffi::OsStr;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::eval::Context;
 use crate::extn::prelude::*;
@@ -309,9 +309,9 @@ pub fn require_relative(interp: &mut Artichoke, file: Value) -> Result<Value, Ex
         .ok_or_else(|| Fatal::new(interp, "relative require with no context stack"))?;
     let current = fs::bytes_to_osstr(interp, context.filename())?;
     let base = if let Some(base) = Path::new(current).parent() {
-        base
+        base.to_path_buf()
     } else {
-        Path::new("/")
+        PathBuf::from("/")
     };
-    require(interp, file, Some(base))
+    require(interp, file, Some(base.as_path()))
 }

--- a/artichoke-backend/src/extn/core/matchdata/begin.rs
+++ b/artichoke-backend/src/extn/core/matchdata/begin.rs
@@ -30,7 +30,7 @@ impl<'a> Args<'a> {
     }
 }
 
-pub fn method(interp: &Artichoke, args: Args, value: &Value) -> Result<Value, Exception> {
+pub fn method(interp: &mut Artichoke, args: Args, value: &Value) -> Result<Value, Exception> {
     let data = unsafe { MatchData::try_from_ruby(interp, value) }.map_err(|_| {
         Fatal::new(
             interp,

--- a/artichoke-backend/src/extn/core/matchdata/begin.rs
+++ b/artichoke-backend/src/extn/core/matchdata/begin.rs
@@ -13,13 +13,13 @@ pub enum Args<'a> {
 }
 
 impl<'a> Args<'a> {
-    pub fn extract(interp: &Artichoke, at: Value) -> Result<Self, Exception> {
-        let name = at.pretty_name();
-        if let Ok(index) = at.clone().try_into::<Int>() {
+    pub fn extract(interp: &mut Artichoke, at: Value) -> Result<Self, Exception> {
+        let name = at.pretty_name(interp);
+        if let Ok(index) = at.try_into::<Int>(interp) {
             Ok(Self::Index(index))
-        } else if let Ok(name) = at.clone().try_into::<&str>() {
+        } else if let Ok(name) = at.try_into::<&str>(interp) {
             Ok(Self::Name(name))
-        } else if let Ok(index) = at.funcall::<Int>("to_int", &[], None) {
+        } else if let Ok(index) = at.funcall::<Int>(interp, "to_int", &[], None) {
             Ok(Self::Index(index))
         } else {
             Err(Exception::from(TypeError::new(

--- a/artichoke-backend/src/extn/core/matchdata/captures.rs
+++ b/artichoke-backend/src/extn/core/matchdata/captures.rs
@@ -3,7 +3,7 @@
 use crate::extn::core::matchdata::MatchData;
 use crate::extn::prelude::*;
 
-pub fn method(interp: &Artichoke, value: &Value) -> Result<Value, Exception> {
+pub fn method(interp: &mut Artichoke, value: &Value) -> Result<Value, Exception> {
     let data = unsafe { MatchData::try_from_ruby(interp, value) }.map_err(|_| {
         Fatal::new(
             interp,

--- a/artichoke-backend/src/extn/core/matchdata/element_reference.rs
+++ b/artichoke-backend/src/extn/core/matchdata/element_reference.rs
@@ -93,7 +93,7 @@ impl<'a> Args<'a> {
     ) -> Result<Option<Self>, Exception> {
         let mut start = mem::MaybeUninit::<sys::mrb_int>::uninit();
         let mut len = mem::MaybeUninit::<sys::mrb_int>::uninit();
-        let mrb = interp.0.borrow().mrb;
+        let mrb = interp.mrb_mut();
         // `mrb_range_beg_len` can raise.
         // TODO: Wrap this in a call to `mrb_protect`.
         let check_range = sys::mrb_range_beg_len(

--- a/artichoke-backend/src/extn/core/matchdata/element_reference.rs
+++ b/artichoke-backend/src/extn/core/matchdata/element_reference.rs
@@ -16,7 +16,7 @@ pub enum Args<'a> {
 }
 
 impl<'a> Args<'a> {
-    pub fn num_captures(interp: &Artichoke, value: &Value) -> Result<usize, Exception> {
+    pub fn num_captures(interp: &mut Artichoke, value: &Value) -> Result<usize, Exception> {
         let data = unsafe { MatchData::try_from_ruby(interp, value) }.map_err(|_| {
             Fatal::new(
                 interp,
@@ -116,7 +116,7 @@ impl<'a> Args<'a> {
     }
 }
 
-pub fn method(interp: &Artichoke, args: Args, value: &Value) -> Result<Value, Exception> {
+pub fn method(interp: &mut Artichoke, args: Args, value: &Value) -> Result<Value, Exception> {
     let data = unsafe { MatchData::try_from_ruby(interp, value) }.map_err(|_| {
         Fatal::new(
             interp,

--- a/artichoke-backend/src/extn/core/matchdata/element_reference.rs
+++ b/artichoke-backend/src/extn/core/matchdata/element_reference.rs
@@ -87,17 +87,16 @@ impl<'a> Args<'a> {
     }
 
     unsafe fn is_range(
-        interp: &Artichoke,
+        interp: &mut Artichoke,
         first: &Value,
         length: Int,
     ) -> Result<Option<Self>, Exception> {
         let mut start = mem::MaybeUninit::<sys::mrb_int>::uninit();
         let mut len = mem::MaybeUninit::<sys::mrb_int>::uninit();
-        let mrb = interp.mrb_mut();
         // `mrb_range_beg_len` can raise.
         // TODO: Wrap this in a call to `mrb_protect`.
         let check_range = sys::mrb_range_beg_len(
-            mrb,
+            interp.mrb_mut(),
             first.inner(),
             start.as_mut_ptr(),
             len.as_mut_ptr(),

--- a/artichoke-backend/src/extn/core/matchdata/element_reference.rs
+++ b/artichoke-backend/src/extn/core/matchdata/element_reference.rs
@@ -28,16 +28,16 @@ impl<'a> Args<'a> {
     }
 
     pub fn extract(
-        interp: &Artichoke,
+        interp: &mut Artichoke,
         elem: Value,
         len: Option<Value>,
         num_captures: usize,
     ) -> Result<Self, Exception> {
         if let Some(len) = len {
-            let elem_type_name = elem.pretty_name();
-            let start = if let Ok(start) = elem.clone().try_into::<Int>() {
+            let elem_type_name = elem.pretty_name(interp);
+            let start = if let Ok(start) = elem.try_into::<Int>(interp) {
                 start
-            } else if let Ok(start) = elem.funcall::<Int>("to_int", &[], None) {
+            } else if let Ok(start) = elem.funcall::<Int>(interp, "to_int", &[], None) {
                 start
             } else {
                 return Err(Exception::from(TypeError::new(
@@ -45,10 +45,10 @@ impl<'a> Args<'a> {
                     format!("no implicit conversion of {} into Integer", elem_type_name),
                 )));
             };
-            let len_type_name = len.pretty_name();
-            let len = if let Ok(len) = len.clone().try_into::<Int>() {
+            let len_type_name = len.pretty_name(interp);
+            let len = if let Ok(len) = len.try_into::<Int>(interp) {
                 len
-            } else if let Ok(len) = len.funcall::<Int>("to_int", &[], None) {
+            } else if let Ok(len) = len.funcall::<Int>(interp, "to_int", &[], None) {
                 len
             } else {
                 return Err(Exception::from(TypeError::new(
@@ -62,14 +62,14 @@ impl<'a> Args<'a> {
                 Ok(Self::Empty)
             }
         } else {
-            let name = elem.pretty_name();
-            if let Ok(index) = elem.clone().try_into::<Int>() {
+            let name = elem.pretty_name(interp);
+            if let Ok(index) = elem.try_into::<Int>(interp) {
                 Ok(Self::Index(index))
-            } else if let Ok(name) = elem.clone().try_into::<&[u8]>() {
+            } else if let Ok(name) = elem.try_into::<&[u8]>(interp) {
                 Ok(Self::Name(name))
-            } else if let Ok(name) = elem.funcall::<&[u8]>("to_str", &[], None) {
+            } else if let Ok(name) = elem.funcall::<&[u8]>(interp, "to_str", &[], None) {
                 Ok(Self::Name(name))
-            } else if let Ok(index) = elem.funcall::<Int>("to_int", &[], None) {
+            } else if let Ok(index) = elem.funcall::<Int>(interp, "to_int", &[], None) {
                 Ok(Self::Index(index))
             } else {
                 let rangelen = Int::try_from(num_captures)

--- a/artichoke-backend/src/extn/core/matchdata/end.rs
+++ b/artichoke-backend/src/extn/core/matchdata/end.rs
@@ -30,7 +30,7 @@ impl<'a> Args<'a> {
     }
 }
 
-pub fn method(interp: &Artichoke, args: Args, value: &Value) -> Result<Value, Exception> {
+pub fn method(interp: &mut Artichoke, args: Args, value: &Value) -> Result<Value, Exception> {
     let data = unsafe { MatchData::try_from_ruby(interp, value) }.map_err(|_| {
         Fatal::new(
             interp,

--- a/artichoke-backend/src/extn/core/matchdata/end.rs
+++ b/artichoke-backend/src/extn/core/matchdata/end.rs
@@ -13,13 +13,13 @@ pub enum Args<'a> {
 }
 
 impl<'a> Args<'a> {
-    pub fn extract(interp: &Artichoke, at: Value) -> Result<Self, Exception> {
-        let name = at.pretty_name();
-        if let Ok(index) = at.clone().try_into::<Int>() {
+    pub fn extract(interp: &mut Artichoke, at: Value) -> Result<Self, Exception> {
+        let name = at.pretty_name(interp);
+        if let Ok(index) = at.try_into::<Int>(interp) {
             Ok(Self::Index(index))
-        } else if let Ok(name) = at.clone().try_into::<&str>() {
+        } else if let Ok(name) = at.try_into::<&str>(interp) {
             Ok(Self::Name(name))
-        } else if let Ok(index) = at.funcall::<Int>("to_int", &[], None) {
+        } else if let Ok(index) = at.funcall::<Int>(interp, "to_int", &[], None) {
             Ok(Self::Index(index))
         } else {
             Err(Exception::from(TypeError::new(

--- a/artichoke-backend/src/extn/core/matchdata/length.rs
+++ b/artichoke-backend/src/extn/core/matchdata/length.rs
@@ -5,7 +5,7 @@ use std::convert::TryFrom;
 use crate::extn::core::matchdata::MatchData;
 use crate::extn::prelude::*;
 
-pub fn method(interp: &Artichoke, value: &Value) -> Result<Value, Exception> {
+pub fn method(interp: &mut Artichoke, value: &Value) -> Result<Value, Exception> {
     let data = unsafe { MatchData::try_from_ruby(interp, value) }.map_err(|_| {
         Fatal::new(
             interp,

--- a/artichoke-backend/src/extn/core/matchdata/mod.rs
+++ b/artichoke-backend/src/extn/core/matchdata/mod.rs
@@ -107,7 +107,7 @@ impl MatchData {
         let interp = unwrap_interpreter!(mrb);
         let value = Value::new(&interp, slf);
         let result = begin::Args::extract(&mut interp, Value::new(&interp, begin))
-            .and_then(|args| begin::method(&interp, args, &value));
+            .and_then(|args| begin::method(&mut interp, args, &value));
         match result {
             Ok(result) => result.inner(),
             Err(exception) => exception::raise(interp, exception),
@@ -118,7 +118,7 @@ impl MatchData {
         mrb_get_args!(mrb, none);
         let interp = unwrap_interpreter!(mrb);
         let value = Value::new(&interp, slf);
-        let result = captures::method(&interp, &value);
+        let result = captures::method(&mut interp, &value);
         match result {
             Ok(result) => result.inner(),
             Err(exception) => exception::raise(interp, exception),
@@ -132,7 +132,7 @@ impl MatchData {
         let (elem, len) = mrb_get_args!(mrb, required = 1, optional = 1);
         let interp = unwrap_interpreter!(mrb);
         let value = Value::new(&interp, slf);
-        let result = element_reference::Args::num_captures(&interp, &value)
+        let result = element_reference::Args::num_captures(&mut interp, &value)
             .and_then(|num_captures| {
                 element_reference::Args::extract(
                     &mut interp,
@@ -141,7 +141,7 @@ impl MatchData {
                     num_captures,
                 )
             })
-            .and_then(|args| element_reference::method(&interp, args, &value));
+            .and_then(|args| element_reference::method(&mut interp, args, &value));
         match result {
             Ok(result) => result.inner(),
             Err(exception) => exception::raise(interp, exception),
@@ -154,7 +154,7 @@ impl MatchData {
         // TODO: Value should be consumed before the call to `exception::raise`.
         let value = Value::new(&interp, slf);
         let result = end::Args::extract(&mut interp, Value::new(&interp, end))
-            .and_then(|args| end::method(&interp, args, &value));
+            .and_then(|args| end::method(&mut interp, args, &value));
         match result {
             Ok(result) => result.inner(),
             Err(exception) => exception::raise(interp, exception),
@@ -165,7 +165,7 @@ impl MatchData {
         mrb_get_args!(mrb, none);
         let interp = unwrap_interpreter!(mrb);
         let value = Value::new(&interp, slf);
-        let result = length::method(&interp, &value);
+        let result = length::method(&mut interp, &value);
         match result {
             Ok(result) => result.inner(),
             Err(exception) => exception::raise(interp, exception),
@@ -179,7 +179,7 @@ impl MatchData {
         mrb_get_args!(mrb, none);
         let interp = unwrap_interpreter!(mrb);
         let value = Value::new(&interp, slf);
-        let result = named_captures::method(&interp, &value);
+        let result = named_captures::method(&mut interp, &value);
         match result {
             Ok(result) => result.inner(),
             Err(exception) => exception::raise(interp, exception),
@@ -202,7 +202,7 @@ impl MatchData {
         let interp = unwrap_interpreter!(mrb);
         let value = Value::new(&interp, slf);
         let result = offset::Args::extract(&mut interp, Value::new(&interp, elem))
-            .and_then(|args| offset::method(&interp, args, &value));
+            .and_then(|args| offset::method(&mut interp, args, &value));
         match result {
             Ok(result) => result.inner(),
             Err(exception) => exception::raise(interp, exception),
@@ -216,7 +216,7 @@ impl MatchData {
         mrb_get_args!(mrb, none);
         let interp = unwrap_interpreter!(mrb);
         let value = Value::new(&interp, slf);
-        let result = post_match::method(&interp, &value);
+        let result = post_match::method(&mut interp, &value);
         match result {
             Ok(result) => result.inner(),
             Err(exception) => exception::raise(interp, exception),
@@ -230,7 +230,7 @@ impl MatchData {
         mrb_get_args!(mrb, none);
         let interp = unwrap_interpreter!(mrb);
         let value = Value::new(&interp, slf);
-        let result = pre_match::method(&interp, &value);
+        let result = pre_match::method(&mut interp, &value);
         match result {
             Ok(result) => result.inner(),
             Err(exception) => exception::raise(interp, exception),
@@ -241,7 +241,7 @@ impl MatchData {
         mrb_get_args!(mrb, none);
         let interp = unwrap_interpreter!(mrb);
         let value = Value::new(&interp, slf);
-        let result = regexp::method(&interp, &value);
+        let result = regexp::method(&mut interp, &value);
         match result {
             Ok(result) => result.inner(),
             Err(exception) => exception::raise(interp, exception),
@@ -264,7 +264,7 @@ impl MatchData {
         mrb_get_args!(mrb, none);
         let interp = unwrap_interpreter!(mrb);
         let value = Value::new(&interp, slf);
-        let result = to_a::method(&interp, &value);
+        let result = to_a::method(&mut interp, &value);
         match result {
             Ok(result) => result.inner(),
             Err(exception) => exception::raise(interp, exception),

--- a/artichoke-backend/src/extn/core/matchdata/mod.rs
+++ b/artichoke-backend/src/extn/core/matchdata/mod.rs
@@ -30,8 +30,8 @@ pub mod string;
 pub mod to_a;
 pub mod to_s;
 
-pub fn init(interp: &Artichoke) -> InitializeResult<()> {
-    if interp.0.borrow().class_spec::<MatchData>().is_some() {
+pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
+    if interp.state().class_spec::<MatchData>().is_some() {
         return Ok(());
     }
     let spec = class::Spec::new("MatchData", None, Some(def::rust_data_free::<MatchData>))?;
@@ -61,7 +61,7 @@ pub fn init(interp: &Artichoke) -> InitializeResult<()> {
         .add_method("to_s", MatchData::to_s, sys::mrb_args_none())?
         .add_method("end", MatchData::end, sys::mrb_args_req(1))?
         .define()?;
-    interp.0.borrow_mut().def_class::<MatchData>(spec);
+    interp.state_mut().def_class::<MatchData>(spec);
     let _ = interp.eval(&include_bytes!("matchdata.rb")[..])?;
     trace!("Patched MatchData onto interpreter");
     Ok(())

--- a/artichoke-backend/src/extn/core/matchdata/mod.rs
+++ b/artichoke-backend/src/extn/core/matchdata/mod.rs
@@ -106,7 +106,7 @@ impl MatchData {
         let begin = mrb_get_args!(mrb, required = 1);
         let interp = unwrap_interpreter!(mrb);
         let value = Value::new(&interp, slf);
-        let result = begin::Args::extract(&interp, Value::new(&interp, begin))
+        let result = begin::Args::extract(&mut interp, Value::new(&interp, begin))
             .and_then(|args| begin::method(&interp, args, &value));
         match result {
             Ok(result) => result.inner(),
@@ -135,7 +135,7 @@ impl MatchData {
         let result = element_reference::Args::num_captures(&interp, &value)
             .and_then(|num_captures| {
                 element_reference::Args::extract(
-                    &interp,
+                    &mut interp,
                     Value::new(&interp, elem),
                     len.map(|len| Value::new(&interp, len)),
                     num_captures,
@@ -153,7 +153,7 @@ impl MatchData {
         let interp = unwrap_interpreter!(mrb);
         // TODO: Value should be consumed before the call to `exception::raise`.
         let value = Value::new(&interp, slf);
-        let result = end::Args::extract(&interp, Value::new(&interp, end))
+        let result = end::Args::extract(&mut interp, Value::new(&interp, end))
             .and_then(|args| end::method(&interp, args, &value));
         match result {
             Ok(result) => result.inner(),
@@ -190,7 +190,7 @@ impl MatchData {
         mrb_get_args!(mrb, none);
         let interp = unwrap_interpreter!(mrb);
         let value = Value::new(&interp, slf);
-        let result = names::method(&interp, &value);
+        let result = names::method(&mut interp, &value);
         match result {
             Ok(result) => result.inner(),
             Err(exception) => exception::raise(interp, exception),
@@ -201,7 +201,7 @@ impl MatchData {
         let elem = mrb_get_args!(mrb, required = 1);
         let interp = unwrap_interpreter!(mrb);
         let value = Value::new(&interp, slf);
-        let result = offset::Args::extract(&interp, Value::new(&interp, elem))
+        let result = offset::Args::extract(&mut interp, Value::new(&interp, elem))
             .and_then(|args| offset::method(&interp, args, &value));
         match result {
             Ok(result) => result.inner(),
@@ -252,7 +252,7 @@ impl MatchData {
         mrb_get_args!(mrb, none);
         let interp = unwrap_interpreter!(mrb);
         let value = Value::new(&interp, slf);
-        let result = string::method(&interp, &value);
+        let result = string::method(&mut interp, &value);
         match result {
             Ok(result) => result.inner(),
             Err(exception) => exception::raise(interp, exception),
@@ -276,7 +276,7 @@ impl MatchData {
         mrb_get_args!(mrb, none);
         let interp = unwrap_interpreter!(mrb);
         let value = Value::new(&interp, slf);
-        let result = to_s::method(&interp, &value);
+        let result = to_s::method(&mut interp, &value);
         match result {
             Ok(result) => result.inner(),
             Err(exception) => exception::raise(interp, exception),

--- a/artichoke-backend/src/extn/core/matchdata/mod.rs
+++ b/artichoke-backend/src/extn/core/matchdata/mod.rs
@@ -106,7 +106,8 @@ impl MatchData {
         let begin = mrb_get_args!(mrb, required = 1);
         let mut interp = unwrap_interpreter!(mrb);
         let value = Value::new(&interp, slf);
-        let result = begin::Args::extract(&mut interp, Value::new(&interp, begin))
+        let begin = Value::new(&interp, begin);
+        let result = begin::Args::extract(&mut interp, begin)
             .and_then(|args| begin::method(&mut interp, args, &value));
         match result {
             Ok(result) => result.inner(),
@@ -132,14 +133,11 @@ impl MatchData {
         let (elem, len) = mrb_get_args!(mrb, required = 1, optional = 1);
         let mut interp = unwrap_interpreter!(mrb);
         let value = Value::new(&interp, slf);
+        let elem = Value::new(&interp, elem);
+        let len = len.map(|len| Value::new(&interp, len));
         let result = element_reference::Args::num_captures(&mut interp, &value)
             .and_then(|num_captures| {
-                element_reference::Args::extract(
-                    &mut interp,
-                    Value::new(&interp, elem),
-                    len.map(|len| Value::new(&interp, len)),
-                    num_captures,
-                )
+                element_reference::Args::extract(&mut interp, elem, len, num_captures)
             })
             .and_then(|args| element_reference::method(&mut interp, args, &value));
         match result {
@@ -153,7 +151,8 @@ impl MatchData {
         let mut interp = unwrap_interpreter!(mrb);
         // TODO: Value should be consumed before the call to `exception::raise`.
         let value = Value::new(&interp, slf);
-        let result = end::Args::extract(&mut interp, Value::new(&interp, end))
+        let end = Value::new(&interp, end);
+        let result = end::Args::extract(&mut interp, end)
             .and_then(|args| end::method(&mut interp, args, &value));
         match result {
             Ok(result) => result.inner(),
@@ -201,7 +200,8 @@ impl MatchData {
         let elem = mrb_get_args!(mrb, required = 1);
         let mut interp = unwrap_interpreter!(mrb);
         let value = Value::new(&interp, slf);
-        let result = offset::Args::extract(&mut interp, Value::new(&interp, elem))
+        let elem = Value::new(&interp, elem);
+        let result = offset::Args::extract(&mut interp, elem)
             .and_then(|args| offset::method(&mut interp, args, &value));
         match result {
             Ok(result) => result.inner(),

--- a/artichoke-backend/src/extn/core/matchdata/mod.rs
+++ b/artichoke-backend/src/extn/core/matchdata/mod.rs
@@ -110,7 +110,7 @@ impl MatchData {
         let result = begin::Args::extract(&mut interp, begin)
             .and_then(|args| begin::method(&mut interp, args, &value));
         match result {
-            Ok(result) => result.inner(),
+            Ok(result) => ffi::return_into_vm(interp, result),
             Err(exception) => exception::raise(interp, exception),
         }
     }
@@ -121,7 +121,7 @@ impl MatchData {
         let value = Value::new(&interp, slf);
         let result = captures::method(&mut interp, &value);
         match result {
-            Ok(result) => result.inner(),
+            Ok(result) => ffi::return_into_vm(interp, result),
             Err(exception) => exception::raise(interp, exception),
         }
     }
@@ -141,7 +141,7 @@ impl MatchData {
             })
             .and_then(|args| element_reference::method(&mut interp, args, &value));
         match result {
-            Ok(result) => result.inner(),
+            Ok(result) => ffi::return_into_vm(interp, result),
             Err(exception) => exception::raise(interp, exception),
         }
     }
@@ -155,7 +155,7 @@ impl MatchData {
         let result = end::Args::extract(&mut interp, end)
             .and_then(|args| end::method(&mut interp, args, &value));
         match result {
-            Ok(result) => result.inner(),
+            Ok(result) => ffi::return_into_vm(interp, result),
             Err(exception) => exception::raise(interp, exception),
         }
     }
@@ -166,7 +166,7 @@ impl MatchData {
         let value = Value::new(&interp, slf);
         let result = length::method(&mut interp, &value);
         match result {
-            Ok(result) => result.inner(),
+            Ok(result) => ffi::return_into_vm(interp, result),
             Err(exception) => exception::raise(interp, exception),
         }
     }
@@ -180,7 +180,7 @@ impl MatchData {
         let value = Value::new(&interp, slf);
         let result = named_captures::method(&mut interp, &value);
         match result {
-            Ok(result) => result.inner(),
+            Ok(result) => ffi::return_into_vm(interp, result),
             Err(exception) => exception::raise(interp, exception),
         }
     }
@@ -191,7 +191,7 @@ impl MatchData {
         let value = Value::new(&interp, slf);
         let result = names::method(&mut interp, &value);
         match result {
-            Ok(result) => result.inner(),
+            Ok(result) => ffi::return_into_vm(interp, result),
             Err(exception) => exception::raise(interp, exception),
         }
     }
@@ -204,7 +204,7 @@ impl MatchData {
         let result = offset::Args::extract(&mut interp, elem)
             .and_then(|args| offset::method(&mut interp, args, &value));
         match result {
-            Ok(result) => result.inner(),
+            Ok(result) => ffi::return_into_vm(interp, result),
             Err(exception) => exception::raise(interp, exception),
         }
     }
@@ -218,7 +218,7 @@ impl MatchData {
         let value = Value::new(&interp, slf);
         let result = post_match::method(&mut interp, &value);
         match result {
-            Ok(result) => result.inner(),
+            Ok(result) => ffi::return_into_vm(interp, result),
             Err(exception) => exception::raise(interp, exception),
         }
     }
@@ -232,7 +232,7 @@ impl MatchData {
         let value = Value::new(&interp, slf);
         let result = pre_match::method(&mut interp, &value);
         match result {
-            Ok(result) => result.inner(),
+            Ok(result) => ffi::return_into_vm(interp, result),
             Err(exception) => exception::raise(interp, exception),
         }
     }
@@ -243,7 +243,7 @@ impl MatchData {
         let value = Value::new(&interp, slf);
         let result = regexp::method(&mut interp, &value);
         match result {
-            Ok(result) => result.inner(),
+            Ok(result) => ffi::return_into_vm(interp, result),
             Err(exception) => exception::raise(interp, exception),
         }
     }
@@ -254,7 +254,7 @@ impl MatchData {
         let value = Value::new(&interp, slf);
         let result = string::method(&mut interp, &value);
         match result {
-            Ok(result) => result.inner(),
+            Ok(result) => ffi::return_into_vm(interp, result),
             Err(exception) => exception::raise(interp, exception),
         }
     }
@@ -266,7 +266,7 @@ impl MatchData {
         let value = Value::new(&interp, slf);
         let result = to_a::method(&mut interp, &value);
         match result {
-            Ok(result) => result.inner(),
+            Ok(result) => ffi::return_into_vm(interp, result),
             Err(exception) => exception::raise(interp, exception),
         }
     }
@@ -278,7 +278,7 @@ impl MatchData {
         let value = Value::new(&interp, slf);
         let result = to_s::method(&mut interp, &value);
         match result {
-            Ok(result) => result.inner(),
+            Ok(result) => ffi::return_into_vm(interp, result),
             Err(exception) => exception::raise(interp, exception),
         }
     }

--- a/artichoke-backend/src/extn/core/matchdata/mod.rs
+++ b/artichoke-backend/src/extn/core/matchdata/mod.rs
@@ -104,7 +104,7 @@ impl MatchData {
 
     unsafe extern "C" fn begin(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
         let begin = mrb_get_args!(mrb, required = 1);
-        let interp = unwrap_interpreter!(mrb);
+        let mut interp = unwrap_interpreter!(mrb);
         let value = Value::new(&interp, slf);
         let result = begin::Args::extract(&mut interp, Value::new(&interp, begin))
             .and_then(|args| begin::method(&mut interp, args, &value));
@@ -116,7 +116,7 @@ impl MatchData {
 
     unsafe extern "C" fn captures(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
         mrb_get_args!(mrb, none);
-        let interp = unwrap_interpreter!(mrb);
+        let mut interp = unwrap_interpreter!(mrb);
         let value = Value::new(&interp, slf);
         let result = captures::method(&mut interp, &value);
         match result {
@@ -130,7 +130,7 @@ impl MatchData {
         slf: sys::mrb_value,
     ) -> sys::mrb_value {
         let (elem, len) = mrb_get_args!(mrb, required = 1, optional = 1);
-        let interp = unwrap_interpreter!(mrb);
+        let mut interp = unwrap_interpreter!(mrb);
         let value = Value::new(&interp, slf);
         let result = element_reference::Args::num_captures(&mut interp, &value)
             .and_then(|num_captures| {
@@ -150,7 +150,7 @@ impl MatchData {
 
     unsafe extern "C" fn end(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
         let end = mrb_get_args!(mrb, required = 1);
-        let interp = unwrap_interpreter!(mrb);
+        let mut interp = unwrap_interpreter!(mrb);
         // TODO: Value should be consumed before the call to `exception::raise`.
         let value = Value::new(&interp, slf);
         let result = end::Args::extract(&mut interp, Value::new(&interp, end))
@@ -163,7 +163,7 @@ impl MatchData {
 
     unsafe extern "C" fn length(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
         mrb_get_args!(mrb, none);
-        let interp = unwrap_interpreter!(mrb);
+        let mut interp = unwrap_interpreter!(mrb);
         let value = Value::new(&interp, slf);
         let result = length::method(&mut interp, &value);
         match result {
@@ -177,7 +177,7 @@ impl MatchData {
         slf: sys::mrb_value,
     ) -> sys::mrb_value {
         mrb_get_args!(mrb, none);
-        let interp = unwrap_interpreter!(mrb);
+        let mut interp = unwrap_interpreter!(mrb);
         let value = Value::new(&interp, slf);
         let result = named_captures::method(&mut interp, &value);
         match result {
@@ -188,7 +188,7 @@ impl MatchData {
 
     unsafe extern "C" fn names(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
         mrb_get_args!(mrb, none);
-        let interp = unwrap_interpreter!(mrb);
+        let mut interp = unwrap_interpreter!(mrb);
         let value = Value::new(&interp, slf);
         let result = names::method(&mut interp, &value);
         match result {
@@ -199,7 +199,7 @@ impl MatchData {
 
     unsafe extern "C" fn offset(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
         let elem = mrb_get_args!(mrb, required = 1);
-        let interp = unwrap_interpreter!(mrb);
+        let mut interp = unwrap_interpreter!(mrb);
         let value = Value::new(&interp, slf);
         let result = offset::Args::extract(&mut interp, Value::new(&interp, elem))
             .and_then(|args| offset::method(&mut interp, args, &value));
@@ -214,7 +214,7 @@ impl MatchData {
         slf: sys::mrb_value,
     ) -> sys::mrb_value {
         mrb_get_args!(mrb, none);
-        let interp = unwrap_interpreter!(mrb);
+        let mut interp = unwrap_interpreter!(mrb);
         let value = Value::new(&interp, slf);
         let result = post_match::method(&mut interp, &value);
         match result {
@@ -228,7 +228,7 @@ impl MatchData {
         slf: sys::mrb_value,
     ) -> sys::mrb_value {
         mrb_get_args!(mrb, none);
-        let interp = unwrap_interpreter!(mrb);
+        let mut interp = unwrap_interpreter!(mrb);
         let value = Value::new(&interp, slf);
         let result = pre_match::method(&mut interp, &value);
         match result {
@@ -239,7 +239,7 @@ impl MatchData {
 
     unsafe extern "C" fn regexp(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
         mrb_get_args!(mrb, none);
-        let interp = unwrap_interpreter!(mrb);
+        let mut interp = unwrap_interpreter!(mrb);
         let value = Value::new(&interp, slf);
         let result = regexp::method(&mut interp, &value);
         match result {
@@ -250,7 +250,7 @@ impl MatchData {
 
     unsafe extern "C" fn string(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
         mrb_get_args!(mrb, none);
-        let interp = unwrap_interpreter!(mrb);
+        let mut interp = unwrap_interpreter!(mrb);
         let value = Value::new(&interp, slf);
         let result = string::method(&mut interp, &value);
         match result {
@@ -262,7 +262,7 @@ impl MatchData {
     #[allow(clippy::wrong_self_convention)]
     unsafe extern "C" fn to_a(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
         mrb_get_args!(mrb, none);
-        let interp = unwrap_interpreter!(mrb);
+        let mut interp = unwrap_interpreter!(mrb);
         let value = Value::new(&interp, slf);
         let result = to_a::method(&mut interp, &value);
         match result {
@@ -274,7 +274,7 @@ impl MatchData {
     #[allow(clippy::wrong_self_convention)]
     unsafe extern "C" fn to_s(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
         mrb_get_args!(mrb, none);
-        let interp = unwrap_interpreter!(mrb);
+        let mut interp = unwrap_interpreter!(mrb);
         let value = Value::new(&interp, slf);
         let result = to_s::method(&mut interp, &value);
         match result {

--- a/artichoke-backend/src/extn/core/matchdata/named_captures.rs
+++ b/artichoke-backend/src/extn/core/matchdata/named_captures.rs
@@ -3,7 +3,7 @@
 use crate::extn::core::matchdata::MatchData;
 use crate::extn::prelude::*;
 
-pub fn method(interp: &Artichoke, value: &Value) -> Result<Value, Exception> {
+pub fn method(interp: &mut Artichoke, value: &Value) -> Result<Value, Exception> {
     let data = unsafe { MatchData::try_from_ruby(interp, value) }.map_err(|_| {
         Fatal::new(
             interp,

--- a/artichoke-backend/src/extn/core/matchdata/names.rs
+++ b/artichoke-backend/src/extn/core/matchdata/names.rs
@@ -3,7 +3,7 @@
 use crate::extn::core::matchdata::MatchData;
 use crate::extn::prelude::*;
 
-pub fn method(interp: &Artichoke, value: &Value) -> Result<Value, Exception> {
+pub fn method(interp: &mut Artichoke, value: &Value) -> Result<Value, Exception> {
     let data = unsafe { MatchData::try_from_ruby(interp, value) }.map_err(|_| {
         Fatal::new(
             interp,

--- a/artichoke-backend/src/extn/core/matchdata/offset.rs
+++ b/artichoke-backend/src/extn/core/matchdata/offset.rs
@@ -30,7 +30,7 @@ impl<'a> Args<'a> {
     }
 }
 
-pub fn method(interp: &Artichoke, args: Args, value: &Value) -> Result<Value, Exception> {
+pub fn method(interp: &mut Artichoke, args: Args, value: &Value) -> Result<Value, Exception> {
     let data = unsafe { MatchData::try_from_ruby(interp, value) }.map_err(|_| {
         Fatal::new(
             interp,

--- a/artichoke-backend/src/extn/core/matchdata/offset.rs
+++ b/artichoke-backend/src/extn/core/matchdata/offset.rs
@@ -13,13 +13,13 @@ pub enum Args<'a> {
 }
 
 impl<'a> Args<'a> {
-    pub fn extract(interp: &Artichoke, elem: Value) -> Result<Self, Exception> {
-        let name = elem.pretty_name();
-        if let Ok(index) = elem.clone().try_into::<Int>() {
+    pub fn extract(interp: &mut Artichoke, elem: Value) -> Result<Self, Exception> {
+        let name = elem.pretty_name(interp);
+        if let Ok(index) = elem.try_into::<Int>(interp) {
             Ok(Self::Index(index))
-        } else if let Ok(name) = elem.funcall::<&str>("to_str", &[], None) {
+        } else if let Ok(name) = elem.funcall::<&str>(interp, "to_str", &[], None) {
             Ok(Self::Name(name))
-        } else if let Ok(index) = elem.funcall::<Int>("to_int", &[], None) {
+        } else if let Ok(index) = elem.funcall::<Int>(interp, "to_int", &[], None) {
             Ok(Self::Index(index))
         } else {
             Err(Exception::from(TypeError::new(

--- a/artichoke-backend/src/extn/core/matchdata/post_match.rs
+++ b/artichoke-backend/src/extn/core/matchdata/post_match.rs
@@ -3,7 +3,7 @@
 use crate::extn::core::matchdata::MatchData;
 use crate::extn::prelude::*;
 
-pub fn method(interp: &Artichoke, value: &Value) -> Result<Value, Exception> {
+pub fn method(interp: &mut Artichoke, value: &Value) -> Result<Value, Exception> {
     let data = unsafe { MatchData::try_from_ruby(interp, value) }.map_err(|_| {
         Fatal::new(
             interp,

--- a/artichoke-backend/src/extn/core/matchdata/pre_match.rs
+++ b/artichoke-backend/src/extn/core/matchdata/pre_match.rs
@@ -3,7 +3,7 @@
 use crate::extn::core::matchdata::MatchData;
 use crate::extn::prelude::*;
 
-pub fn method(interp: &Artichoke, value: &Value) -> Result<Value, Exception> {
+pub fn method(interp: &mut Artichoke, value: &Value) -> Result<Value, Exception> {
     let data = unsafe { MatchData::try_from_ruby(interp, value) }.map_err(|_| {
         Fatal::new(
             interp,

--- a/artichoke-backend/src/extn/core/matchdata/regexp.rs
+++ b/artichoke-backend/src/extn/core/matchdata/regexp.rs
@@ -3,7 +3,7 @@
 use crate::extn::core::matchdata::MatchData;
 use crate::extn::prelude::*;
 
-pub fn method(interp: &Artichoke, value: &Value) -> Result<Value, Exception> {
+pub fn method(interp: &mut Artichoke, value: &Value) -> Result<Value, Exception> {
     let data = unsafe { MatchData::try_from_ruby(interp, value) }.map_err(|_| {
         Fatal::new(
             interp,

--- a/artichoke-backend/src/extn/core/matchdata/string.rs
+++ b/artichoke-backend/src/extn/core/matchdata/string.rs
@@ -3,7 +3,7 @@
 use crate::extn::core::matchdata::MatchData;
 use crate::extn::prelude::*;
 
-pub fn method(interp: &Artichoke, value: &Value) -> Result<Value, Exception> {
+pub fn method(interp: &mut Artichoke, value: &Value) -> Result<Value, Exception> {
     let data = unsafe { MatchData::try_from_ruby(interp, value) }.map_err(|_| {
         Fatal::new(
             interp,
@@ -11,8 +11,6 @@ pub fn method(interp: &Artichoke, value: &Value) -> Result<Value, Exception> {
         )
     })?;
     let mut result = interp.convert(data.borrow().string.as_slice());
-    result
-        .freeze()
-        .map_err(|_| Fatal::new(interp, "Unable to freeze MatchData#string result"))?;
+    result.freeze(interp)?;
     Ok(result)
 }

--- a/artichoke-backend/src/extn/core/matchdata/to_a.rs
+++ b/artichoke-backend/src/extn/core/matchdata/to_a.rs
@@ -3,7 +3,7 @@
 use crate::extn::core::matchdata::MatchData;
 use crate::extn::prelude::*;
 
-pub fn method(interp: &Artichoke, value: &Value) -> Result<Value, Exception> {
+pub fn method(interp: &mut Artichoke, value: &Value) -> Result<Value, Exception> {
     let data = unsafe { MatchData::try_from_ruby(interp, value) }.map_err(|_| {
         Fatal::new(
             interp,

--- a/artichoke-backend/src/extn/core/matchdata/to_s.rs
+++ b/artichoke-backend/src/extn/core/matchdata/to_s.rs
@@ -3,7 +3,7 @@
 use crate::extn::core::matchdata::MatchData;
 use crate::extn::prelude::*;
 
-pub fn method(interp: &Artichoke, value: &Value) -> Result<Value, Exception> {
+pub fn method(interp: &mut Artichoke, value: &Value) -> Result<Value, Exception> {
     let data = unsafe { MatchData::try_from_ruby(interp, value) }.map_err(|_| {
         Fatal::new(
             interp,

--- a/artichoke-backend/src/extn/core/method/mod.rs
+++ b/artichoke-backend/src/extn/core/method/mod.rs
@@ -1,11 +1,11 @@
 use crate::extn::prelude::*;
 
-pub fn init(interp: &Artichoke) -> InitializeResult<()> {
-    if interp.0.borrow().class_spec::<Method>().is_some() {
+pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
+    if interp.state().class_spec::<Method>().is_some() {
         return Ok(());
     }
     let spec = class::Spec::new("Method", None, None)?;
-    interp.0.borrow_mut().def_class::<Method>(spec);
+    interp.state_mut().def_class::<Method>(spec);
     let _ = interp.eval(&include_bytes!("method.rb")[..])?;
     trace!("Patched Method onto interpreter");
     Ok(())

--- a/artichoke-backend/src/extn/core/mod.rs
+++ b/artichoke-backend/src/extn/core/mod.rs
@@ -36,6 +36,7 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     enumerable::init(interp)?;
     // `Array` depends on: `Enumerable`
     array::mruby::init(interp)?;
+    let _ = interp.eval(&b"[].reverse!"[..])?;
     module::init(interp)?;
     // Some `Exception`s depend on: `attr_accessor` (defined in `Module`)
     exception::init(interp)?;

--- a/artichoke-backend/src/extn/core/mod.rs
+++ b/artichoke-backend/src/extn/core/mod.rs
@@ -29,7 +29,7 @@ pub mod thread;
 pub mod time;
 pub mod warning;
 
-pub fn init(interp: &Artichoke) -> InitializeResult<()> {
+pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     // These core classes are ordered according to the dependency DAG between
     // them.
     let _ = interp.eval(&include_bytes!("object.rb")[..])?;

--- a/artichoke-backend/src/extn/core/module/mod.rs
+++ b/artichoke-backend/src/extn/core/module/mod.rs
@@ -1,11 +1,11 @@
 use crate::extn::prelude::*;
 
-pub fn init(interp: &Artichoke) -> InitializeResult<()> {
-    if interp.0.borrow().class_spec::<Module>().is_some() {
+pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
+    if interp.state().class_spec::<Module>().is_some() {
         return Ok(());
     }
     let spec = class::Spec::new("Module", None, None)?;
-    interp.0.borrow_mut().def_class::<Module>(spec);
+    interp.state_mut().def_class::<Module>(spec);
     let _ = interp.eval(&include_bytes!("module.rb")[..])?;
     trace!("Patched Module onto interpreter");
     Ok(())

--- a/artichoke-backend/src/extn/core/numeric/mod.rs
+++ b/artichoke-backend/src/extn/core/numeric/mod.rs
@@ -1,11 +1,11 @@
 use crate::extn::prelude::*;
 
-pub fn init(interp: &Artichoke) -> InitializeResult<()> {
-    if interp.0.borrow().class_spec::<Numeric>().is_some() {
+pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
+    if interp.state().class_spec::<Numeric>().is_some() {
         return Ok(());
     }
     let spec = class::Spec::new("Numeric", None, None)?;
-    interp.0.borrow_mut().def_class::<Numeric>(spec);
+    interp.state_mut().def_class::<Numeric>(spec);
     let _ = interp.eval(&include_bytes!("numeric.rb")[..])?;
     trace!("Patched Numeric onto interpreter");
     Ok(())

--- a/artichoke-backend/src/extn/core/object/mod.rs
+++ b/artichoke-backend/src/extn/core/object/mod.rs
@@ -1,11 +1,11 @@
 use crate::extn::prelude::*;
 
-pub fn init(interp: &Artichoke) -> InitializeResult<()> {
-    if interp.0.borrow().class_spec::<Object>().is_some() {
+pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
+    if interp.state().class_spec::<Object>().is_some() {
         return Ok(());
     }
     let spec = class::Spec::new("Object", None, None)?;
-    interp.0.borrow_mut().def_class::<Object>(spec);
+    interp.state_mut().def_class::<Object>(spec);
     let _ = interp.eval(&include_bytes!("object.rb")[..])?;
     trace!("Patched Object onto interpreter");
     Ok(())

--- a/artichoke-backend/src/extn/core/proc/mod.rs
+++ b/artichoke-backend/src/extn/core/proc/mod.rs
@@ -1,11 +1,11 @@
 use crate::extn::prelude::*;
 
-pub fn init(interp: &Artichoke) -> InitializeResult<()> {
-    if interp.0.borrow().class_spec::<Proc>().is_some() {
+pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
+    if interp.state().class_spec::<Proc>().is_some() {
         return Ok(());
     }
     let spec = class::Spec::new("Proc", None, None)?;
-    interp.0.borrow_mut().def_class::<Proc>(spec);
+    interp.state_mut().def_class::<Proc>(spec);
     let _ = interp.eval(&include_bytes!("proc.rb")[..])?;
     trace!("Patched Proc onto interpreter");
     Ok(())

--- a/artichoke-backend/src/extn/core/random/backend/default.rs
+++ b/artichoke-backend/src/extn/core/random/backend/default.rs
@@ -10,36 +10,28 @@ pub fn new() -> Box<dyn backend::Rand> {
 pub struct Default;
 
 impl backend::Rand for Default {
-    fn bytes(&mut self, interp: &mut Artichoke, buf: &mut [u8]) -> Result<(), Exception> {
+    fn bytes(&mut self, interp: &mut Artichoke, buf: &mut [u8]) {
         let prng = interp.state_mut().prng_mut();
-        prng.inner_mut().bytes(interp, buf)?;
-        Ok(())
+        prng.bytes(buf);
     }
 
-    fn seed(&self, interp: &Artichoke) -> Result<u64, Exception> {
+    fn seed(&self, interp: &Artichoke) -> u64 {
         let prng = interp.state().prng();
-        let seed = prng.inner().seed(interp)?;
-        Ok(seed)
+        prng.seed()
     }
 
     fn has_same_internal_state(&self, interp: &Artichoke, other: &dyn backend::Rand) -> bool {
         let prng = interp.state().prng();
-        prng.inner().has_same_internal_state(interp, other)
+        prng.has_same_internal_state(other)
     }
 
-    fn rand_int(&mut self, interp: &mut Artichoke, max: Int) -> Result<Int, Exception> {
+    fn rand_int(&mut self, interp: &mut Artichoke, max: Int) -> Int {
         let prng = interp.state_mut().prng_mut();
-        let rand = prng.inner_mut().rand_int(interp, max)?;
-        Ok(rand)
+        prng.rand_int(max)
     }
 
-    fn rand_float(
-        &mut self,
-        interp: &mut Artichoke,
-        max: Option<Float>,
-    ) -> Result<Float, Exception> {
+    fn rand_float(&mut self, interp: &mut Artichoke, max: Option<Float>) -> Float {
         let prng = interp.state_mut().prng_mut();
-        let rand = prng.inner_mut().rand_float(interp, max)?;
-        Ok(rand)
+        prng.rand_float(max)
     }
 }

--- a/artichoke-backend/src/extn/core/random/backend/default.rs
+++ b/artichoke-backend/src/extn/core/random/backend/default.rs
@@ -10,36 +10,35 @@ pub fn new() -> Box<dyn backend::Rand> {
 pub struct Default;
 
 impl backend::Rand for Default {
-    fn bytes(&mut self, interp: &Artichoke, buf: &mut [u8]) -> Result<(), Exception> {
-        let mut borrow = interp.0.borrow_mut();
-        let prng = borrow.prng_mut();
+    fn bytes(&mut self, interp: &mut Artichoke, buf: &mut [u8]) -> Result<(), Exception> {
+        let prng = interp.state_mut().prng_mut();
         prng.inner_mut().bytes(interp, buf)?;
         Ok(())
     }
 
     fn seed(&self, interp: &Artichoke) -> Result<u64, Exception> {
-        let borrow = interp.0.borrow_mut();
-        let prng = borrow.prng();
+        let prng = interp.state().prng();
         let seed = prng.inner().seed(interp)?;
         Ok(seed)
     }
 
     fn has_same_internal_state(&self, interp: &Artichoke, other: &dyn backend::Rand) -> bool {
-        let borrow = interp.0.borrow_mut();
-        let prng = borrow.prng();
+        let prng = interp.state().prng();
         prng.inner().has_same_internal_state(interp, other)
     }
 
-    fn rand_int(&mut self, interp: &Artichoke, max: Int) -> Result<Int, Exception> {
-        let mut borrow = interp.0.borrow_mut();
-        let prng = borrow.prng_mut();
+    fn rand_int(&mut self, interp: &mut Artichoke, max: Int) -> Result<Int, Exception> {
+        let prng = interp.state_mut().prng_mut();
         let rand = prng.inner_mut().rand_int(interp, max)?;
         Ok(rand)
     }
 
-    fn rand_float(&mut self, interp: &Artichoke, max: Option<Float>) -> Result<Float, Exception> {
-        let mut borrow = interp.0.borrow_mut();
-        let prng = borrow.prng_mut();
+    fn rand_float(
+        &mut self,
+        interp: &mut Artichoke,
+        max: Option<Float>,
+    ) -> Result<Float, Exception> {
+        let prng = interp.state_mut().prng_mut();
         let rand = prng.inner_mut().rand_float(interp, max)?;
         Ok(rand)
     }

--- a/artichoke-backend/src/extn/core/random/backend/mod.rs
+++ b/artichoke-backend/src/extn/core/random/backend/mod.rs
@@ -8,7 +8,7 @@ pub mod rand;
 /// Common API for [`Random`](crate::extn::core::random::Random) backends.
 pub trait Rand: Any {
     /// Completely fill a buffer with random bytes.
-    fn bytes(&mut self, interp: &Artichoke, buf: &mut [u8]) -> Result<(), Exception>;
+    fn bytes(&mut self, interp: &mut Artichoke, buf: &mut [u8]) -> Result<(), Exception>;
 
     /// Return the value this backend was seeded with.
     fn seed(&self, interp: &Artichoke) -> Result<u64, Exception>;
@@ -18,13 +18,17 @@ pub trait Rand: Any {
     fn has_same_internal_state(&self, interp: &Artichoke, other: &dyn Rand) -> bool;
 
     /// Return a random `Integer` between 0 and `max` -- `[0, max)`.
-    fn rand_int(&mut self, interp: &Artichoke, max: Int) -> Result<Int, Exception>;
+    fn rand_int(&mut self, interp: &mut Artichoke, max: Int) -> Result<Int, Exception>;
 
     /// Return a random `Float` between 0 and `max` -- `[0, max)`.
     ///
     /// If `max` is `None`, return a random `Float between 0 and 1.0 --
     /// `[0, 1.0)`.
-    fn rand_float(&mut self, interp: &Artichoke, max: Option<Float>) -> Result<Float, Exception>;
+    fn rand_float(
+        &mut self,
+        interp: &mut Artichoke,
+        max: Option<Float>,
+    ) -> Result<Float, Exception>;
 }
 
 #[allow(clippy::missing_safety_doc)]

--- a/artichoke-backend/src/extn/core/random/backend/mod.rs
+++ b/artichoke-backend/src/extn/core/random/backend/mod.rs
@@ -8,27 +8,23 @@ pub mod rand;
 /// Common API for [`Random`](crate::extn::core::random::Random) backends.
 pub trait Rand: Any {
     /// Completely fill a buffer with random bytes.
-    fn bytes(&mut self, interp: &mut Artichoke, buf: &mut [u8]) -> Result<(), Exception>;
+    fn bytes(&mut self, interp: &mut Artichoke, buf: &mut [u8]);
 
     /// Return the value this backend was seeded with.
-    fn seed(&self, interp: &Artichoke) -> Result<u64, Exception>;
+    fn seed(&self, interp: &Artichoke) -> u64;
 
     /// Return true if this and `other` would return the same sequence of random
     /// data.
     fn has_same_internal_state(&self, interp: &Artichoke, other: &dyn Rand) -> bool;
 
     /// Return a random `Integer` between 0 and `max` -- `[0, max)`.
-    fn rand_int(&mut self, interp: &mut Artichoke, max: Int) -> Result<Int, Exception>;
+    fn rand_int(&mut self, interp: &mut Artichoke, max: Int) -> Int;
 
     /// Return a random `Float` between 0 and `max` -- `[0, max)`.
     ///
     /// If `max` is `None`, return a random `Float between 0 and 1.0 --
     /// `[0, 1.0)`.
-    fn rand_float(
-        &mut self,
-        interp: &mut Artichoke,
-        max: Option<Float>,
-    ) -> Result<Float, Exception>;
+    fn rand_float(&mut self, interp: &mut Artichoke, max: Option<Float>) -> Float;
 }
 
 #[allow(clippy::missing_safety_doc)]

--- a/artichoke-backend/src/extn/core/random/backend/rand.rs
+++ b/artichoke-backend/src/extn/core/random/backend/rand.rs
@@ -27,23 +27,17 @@ where
     }
 }
 
-impl<T> backend::Rand for Rand<T>
+impl<T> Rand<T> {
+    pub fn seed(&self) -> u64 {
+        self.seed
+    }
+}
+
+impl<T> Rand<T>
 where
-    T: 'static + Rng,
+    T: 'static,
 {
-    fn bytes(&mut self, interp: &mut Artichoke, buf: &mut [u8]) -> Result<(), Exception> {
-        let _ = interp;
-        self.rng.fill_bytes(buf);
-        Ok(())
-    }
-
-    fn seed(&self, interp: &Artichoke) -> Result<u64, Exception> {
-        let _ = interp;
-        Ok(self.seed)
-    }
-
-    fn has_same_internal_state(&self, interp: &Artichoke, other: &dyn backend::Rand) -> bool {
-        let _ = interp;
+    pub fn has_same_internal_state(&self, other: &dyn backend::Rand) -> bool {
         if let Ok(other) = other.downcast_ref::<Self>() {
             // This is not quite right. It needs to take into account bytes
             // read from the PRNG.
@@ -52,21 +46,54 @@ where
             false
         }
     }
+}
 
-    fn rand_int(&mut self, interp: &mut Artichoke, max: Int) -> Result<Int, Exception> {
-        let _ = interp;
-        let between = Uniform::from(0..max);
-        Ok(between.sample(&mut self.rng))
+impl<T> Rand<T>
+where
+    T: Rng,
+{
+    pub fn bytes(&mut self, buf: &mut [u8]) {
+        self.rng.fill_bytes(buf);
     }
 
-    fn rand_float(
-        &mut self,
-        interp: &mut Artichoke,
-        max: Option<Float>,
-    ) -> Result<Float, Exception> {
-        let _ = interp;
+    pub fn rand_int(&mut self, max: Int) -> Int {
+        let between = Uniform::from(0..max);
+        between.sample(&mut self.rng)
+    }
+
+    pub fn rand_float(&mut self, max: Option<Float>) -> Float {
         let max = max.unwrap_or(1.0);
         let between = Uniform::from(0.0..max);
-        Ok(between.sample(&mut self.rng))
+        between.sample(&mut self.rng)
+    }
+}
+
+impl<T> backend::Rand for Rand<T>
+where
+    T: 'static + Rng,
+{
+    fn bytes(&mut self, interp: &mut Artichoke, buf: &mut [u8]) {
+        let _ = interp;
+        self.bytes(buf);
+    }
+
+    fn seed(&self, interp: &Artichoke) -> u64 {
+        let _ = interp;
+        self.seed()
+    }
+
+    fn has_same_internal_state(&self, interp: &Artichoke, other: &dyn backend::Rand) -> bool {
+        let _ = interp;
+        self.has_same_internal_state(other)
+    }
+
+    fn rand_int(&mut self, interp: &mut Artichoke, max: Int) -> Int {
+        let _ = interp;
+        self.rand_int(max)
+    }
+
+    fn rand_float(&mut self, interp: &mut Artichoke, max: Option<Float>) -> Float {
+        let _ = interp;
+        self.rand_float(max)
     }
 }

--- a/artichoke-backend/src/extn/core/random/backend/rand.rs
+++ b/artichoke-backend/src/extn/core/random/backend/rand.rs
@@ -31,7 +31,7 @@ impl<T> backend::Rand for Rand<T>
 where
     T: 'static + Rng,
 {
-    fn bytes(&mut self, interp: &Artichoke, buf: &mut [u8]) -> Result<(), Exception> {
+    fn bytes(&mut self, interp: &mut Artichoke, buf: &mut [u8]) -> Result<(), Exception> {
         let _ = interp;
         self.rng.fill_bytes(buf);
         Ok(())
@@ -53,13 +53,17 @@ where
         }
     }
 
-    fn rand_int(&mut self, interp: &Artichoke, max: Int) -> Result<Int, Exception> {
+    fn rand_int(&mut self, interp: &mut Artichoke, max: Int) -> Result<Int, Exception> {
         let _ = interp;
         let between = Uniform::from(0..max);
         Ok(between.sample(&mut self.rng))
     }
 
-    fn rand_float(&mut self, interp: &Artichoke, max: Option<Float>) -> Result<Float, Exception> {
+    fn rand_float(
+        &mut self,
+        interp: &mut Artichoke,
+        max: Option<Float>,
+    ) -> Result<Float, Exception> {
         let _ = interp;
         let max = max.unwrap_or(1.0);
         let between = Uniform::from(0.0..max);

--- a/artichoke-backend/src/extn/core/random/mod.rs
+++ b/artichoke-backend/src/extn/core/random/mod.rs
@@ -59,7 +59,7 @@ pub fn initialize(
     Ok(result)
 }
 
-pub fn eql(interp: &Artichoke, rand: Value, other: Value) -> Result<Value, Exception> {
+pub fn eql(interp: &mut Artichoke, rand: Value, other: Value) -> Result<Value, Exception> {
     if let Ok(rand) = unsafe { Random::try_from_ruby(interp, &rand) } {
         if let Ok(other) = unsafe { Random::try_from_ruby(interp, &other) } {
             if ptr::eq(rand.as_ref(), other.as_ref()) {
@@ -161,7 +161,7 @@ pub fn rand(interp: &mut Artichoke, rand: Value, max: Option<Value>) -> Result<V
     }
 }
 
-pub fn seed(interp: &Artichoke, rand: Value) -> Result<Value, Exception> {
+pub fn seed(interp: &mut Artichoke, rand: Value) -> Result<Value, Exception> {
     if let Ok(rand) = unsafe { Random::try_from_ruby(interp, &rand) } {
         let borrow = rand.borrow();
         let seed = borrow.inner().seed(interp)?;

--- a/artichoke-backend/src/extn/core/random/mod.rs
+++ b/artichoke-backend/src/extn/core/random/mod.rs
@@ -175,7 +175,7 @@ pub fn seed(interp: &mut Artichoke, rand: Value) -> Result<Value, Exception> {
     }
 }
 
-pub fn new_seed(interp: &Artichoke) -> Result<Value, Exception> {
+pub fn new_seed(interp: &mut Artichoke) -> Result<Value, Exception> {
     let mut rng = rand::thread_rng();
     let result = rng.gen::<Int>();
     Ok(interp.convert(result))

--- a/artichoke-backend/src/extn/core/random/mod.rs
+++ b/artichoke-backend/src/extn/core/random/mod.rs
@@ -65,8 +65,8 @@ pub fn eql(interp: &mut Artichoke, rand: Value, other: Value) -> Result<Value, E
             if ptr::eq(rand.as_ref(), other.as_ref()) {
                 Ok(interp.convert(true))
             } else {
-                let this_seed = rand.borrow().inner().seed(interp)?;
-                let other_seed = other.borrow().inner().seed(interp)?;
+                let this_seed = rand.borrow().inner().seed(interp);
+                let other_seed = other.borrow().inner().seed(interp);
                 Ok(interp.convert(this_seed == other_seed))
             }
         } else {
@@ -93,7 +93,7 @@ pub fn bytes(interp: &mut Artichoke, rand: Value, size: Value) -> Result<Value, 
     if let Ok(size) = usize::try_from(size) {
         let mut buf = vec![0; size];
         let mut borrow = rand.borrow_mut();
-        borrow.inner_mut().bytes(interp, buf.as_mut_slice())?;
+        borrow.inner_mut().bytes(interp, buf.as_mut_slice());
         Ok(interp.convert(buf))
     } else {
         Err(Exception::from(ArgumentError::new(
@@ -136,12 +136,12 @@ pub fn rand(interp: &mut Artichoke, rand: Value, max: Option<Value>) -> Result<V
         ))),
         Max::Float(max) if max == 0.0 => {
             let mut borrow = rand.borrow_mut();
-            let number = borrow.inner_mut().rand_float(interp, None)?;
+            let number = borrow.inner_mut().rand_float(interp, None);
             Ok(interp.convert(number))
         }
         Max::Float(max) => {
             let mut borrow = rand.borrow_mut();
-            let number = borrow.inner_mut().rand_float(interp, Some(max))?;
+            let number = borrow.inner_mut().rand_float(interp, Some(max));
             Ok(interp.convert(number))
         }
         Max::Int(max) if max < 1 => Err(Exception::from(ArgumentError::new(
@@ -150,12 +150,12 @@ pub fn rand(interp: &mut Artichoke, rand: Value, max: Option<Value>) -> Result<V
         ))),
         Max::Int(max) => {
             let mut borrow = rand.borrow_mut();
-            let number = borrow.inner_mut().rand_int(interp, max)?;
+            let number = borrow.inner_mut().rand_int(interp, max);
             Ok(interp.convert(number))
         }
         Max::None => {
             let mut borrow = rand.borrow_mut();
-            let number = borrow.inner_mut().rand_float(interp, None)?;
+            let number = borrow.inner_mut().rand_float(interp, None);
             Ok(interp.convert(number))
         }
     }
@@ -164,7 +164,7 @@ pub fn rand(interp: &mut Artichoke, rand: Value, max: Option<Value>) -> Result<V
 pub fn seed(interp: &mut Artichoke, rand: Value) -> Result<Value, Exception> {
     if let Ok(rand) = unsafe { Random::try_from_ruby(interp, &rand) } {
         let borrow = rand.borrow();
-        let seed = borrow.inner().seed(interp)?;
+        let seed = borrow.inner().seed(interp);
         #[allow(clippy::cast_possible_wrap, clippy::cast_sign_loss)]
         Ok(interp.convert(seed as Int))
     } else {
@@ -191,8 +191,8 @@ pub fn srand(interp: &mut Artichoke, number: Option<Value>) -> Result<Value, Exc
         None
     };
     let prng = interp.state_mut().prng_mut();
-    let old_seed = prng.inner().seed(interp)?;
-    prng.0 = backend::rand::new(new_seed);
+    let old_seed = prng.seed();
+    *prng = backend::rand::Rand::new(new_seed);
     #[allow(clippy::cast_possible_wrap)]
     Ok(interp.convert(old_seed as Int))
 }

--- a/artichoke-backend/src/extn/core/random/mruby.rs
+++ b/artichoke-backend/src/extn/core/random/mruby.rs
@@ -1,8 +1,8 @@
 use crate::extn::core::random;
 use crate::extn::prelude::*;
 
-pub fn init(interp: &Artichoke) -> InitializeResult<()> {
-    if interp.0.borrow().class_spec::<random::Random>().is_some() {
+pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
+    if interp.state().class_spec::<random::Random>().is_some() {
         return Ok(());
     }
     let spec = class::Spec::new("Random", None, Some(def::rust_data_free::<random::Random>))?;
@@ -29,7 +29,7 @@ pub fn init(interp: &Artichoke) -> InitializeResult<()> {
         .add_method("rand", artichoke_random_rand, sys::mrb_args_opt(1))?
         .add_method("seed", artichoke_random_seed, sys::mrb_args_none())?
         .define()?;
-    interp.0.borrow_mut().def_class::<random::Random>(spec);
+    interp.state_mut().def_class::<random::Random>(spec);
 
     let default = random::default();
     let default = default.try_into_ruby(interp, None)?;

--- a/artichoke-backend/src/extn/core/random/mruby.rs
+++ b/artichoke-backend/src/extn/core/random/mruby.rs
@@ -62,7 +62,7 @@ unsafe extern "C" fn artichoke_random_initialize(
     let seed = seed.map(|seed| Value::new(&interp, seed));
     let result = random::initialize(&mut interp, seed, Some(slf));
     match result {
-        Ok(value) => value.inner(),
+        Ok(value) => ffi::return_into_vm(interp, value),
         Err(exception) => exception::raise(interp, exception),
     }
 }
@@ -78,7 +78,7 @@ unsafe extern "C" fn artichoke_random_eq(
     let other = Value::new(&interp, other);
     let result = random::eql(&mut interp, rand, other);
     match result {
-        Ok(value) => value.inner(),
+        Ok(value) => ffi::return_into_vm(interp, value),
         Err(exception) => exception::raise(interp, exception),
     }
 }
@@ -94,7 +94,7 @@ unsafe extern "C" fn artichoke_random_bytes(
     let size = Value::new(&interp, size);
     let result = random::bytes(&mut interp, rand, size);
     match result {
-        Ok(value) => value.inner(),
+        Ok(value) => ffi::return_into_vm(interp, value),
         Err(exception) => exception::raise(interp, exception),
     }
 }
@@ -110,7 +110,7 @@ unsafe extern "C" fn artichoke_random_rand(
     let max = max.map(|max| Value::new(&interp, max));
     let result = random::rand(&mut interp, rand, max);
     match result {
-        Ok(value) => value.inner(),
+        Ok(value) => ffi::return_into_vm(interp, value),
         Err(exception) => exception::raise(interp, exception),
     }
 }
@@ -125,7 +125,7 @@ unsafe extern "C" fn artichoke_random_seed(
     let rand = Value::new(&interp, slf);
     let result = random::seed(&mut interp, rand);
     match result {
-        Ok(value) => value.inner(),
+        Ok(value) => ffi::return_into_vm(interp, value),
         Err(exception) => exception::raise(interp, exception),
     }
 }
@@ -139,7 +139,7 @@ unsafe extern "C" fn artichoke_random_self_new_seed(
     let mut interp = unwrap_interpreter!(mrb);
     let result = random::new_seed(&mut interp);
     match result {
-        Ok(value) => value.inner(),
+        Ok(value) => ffi::return_into_vm(interp, value),
         Err(exception) => exception::raise(interp, exception),
     }
 }
@@ -154,7 +154,7 @@ unsafe extern "C" fn artichoke_random_self_srand(
     let number = number.map(|number| Value::new(&interp, number));
     let result = random::srand(&mut interp, number);
     match result {
-        Ok(value) => value.inner(),
+        Ok(value) => ffi::return_into_vm(interp, value),
         Err(exception) => exception::raise(interp, exception),
     }
 }
@@ -169,7 +169,7 @@ unsafe extern "C" fn artichoke_random_self_urandom(
     let size = Value::new(&interp, size);
     let result = random::urandom(&mut interp, size);
     match result {
-        Ok(value) => value.inner(),
+        Ok(value) => ffi::return_into_vm(interp, value),
         Err(exception) => exception::raise(interp, exception),
     }
 }

--- a/artichoke-backend/src/extn/core/random/mruby.rs
+++ b/artichoke-backend/src/extn/core/random/mruby.rs
@@ -38,7 +38,7 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
         .class_spec::<random::Random>()
         .ok_or(ArtichokeError::New)?
         .clone();
-    let rclass = spec.rclass(interp).ok_or(ArtichokeError::New)?;
+    let rclass = spec.rclass(interp.mrb_mut()).ok_or(ArtichokeError::New)?;
     unsafe {
         sys::mrb_define_const(
             interp.mrb_mut(),

--- a/artichoke-backend/src/extn/core/random/mruby.rs
+++ b/artichoke-backend/src/extn/core/random/mruby.rs
@@ -78,7 +78,7 @@ unsafe extern "C" fn artichoke_random_eq(
     let interp = unwrap_interpreter!(mrb);
     let rand = Value::new(&interp, slf);
     let other = Value::new(&interp, other);
-    let result = random::eql(&interp, rand, other);
+    let result = random::eql(&mut interp, rand, other);
     match result {
         Ok(value) => value.inner(),
         Err(exception) => exception::raise(interp, exception),
@@ -125,7 +125,7 @@ unsafe extern "C" fn artichoke_random_seed(
     mrb_get_args!(mrb, none);
     let interp = unwrap_interpreter!(mrb);
     let rand = Value::new(&interp, slf);
-    let result = random::seed(&interp, rand);
+    let result = random::seed(&mut interp, rand);
     match result {
         Ok(value) => value.inner(),
         Err(exception) => exception::raise(interp, exception),

--- a/artichoke-backend/src/extn/core/random/mruby.rs
+++ b/artichoke-backend/src/extn/core/random/mruby.rs
@@ -57,7 +57,7 @@ unsafe extern "C" fn artichoke_random_initialize(
     slf: sys::mrb_value,
 ) -> sys::mrb_value {
     let seed = mrb_get_args!(mrb, optional = 1);
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let result = random::initialize(
         &mut interp,
         seed.map(|seed| Value::new(&interp, seed)),
@@ -75,7 +75,7 @@ unsafe extern "C" fn artichoke_random_eq(
     slf: sys::mrb_value,
 ) -> sys::mrb_value {
     let other = mrb_get_args!(mrb, required = 1);
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let rand = Value::new(&interp, slf);
     let other = Value::new(&interp, other);
     let result = random::eql(&mut interp, rand, other);
@@ -91,7 +91,7 @@ unsafe extern "C" fn artichoke_random_bytes(
     slf: sys::mrb_value,
 ) -> sys::mrb_value {
     let size = mrb_get_args!(mrb, required = 1);
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let rand = Value::new(&interp, slf);
     let size = Value::new(&interp, size);
     let result = random::bytes(&mut interp, rand, size);
@@ -107,7 +107,7 @@ unsafe extern "C" fn artichoke_random_rand(
     slf: sys::mrb_value,
 ) -> sys::mrb_value {
     let max = mrb_get_args!(mrb, optional = 1);
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let rand = Value::new(&interp, slf);
     let max = max.map(|max| Value::new(&interp, max));
     let result = random::rand(&mut interp, rand, max);
@@ -123,7 +123,7 @@ unsafe extern "C" fn artichoke_random_seed(
     slf: sys::mrb_value,
 ) -> sys::mrb_value {
     mrb_get_args!(mrb, none);
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let rand = Value::new(&interp, slf);
     let result = random::seed(&mut interp, rand);
     match result {
@@ -138,7 +138,7 @@ unsafe extern "C" fn artichoke_random_self_new_seed(
     _slf: sys::mrb_value,
 ) -> sys::mrb_value {
     mrb_get_args!(mrb, none);
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let result = random::new_seed(&interp);
     match result {
         Ok(value) => value.inner(),
@@ -152,7 +152,7 @@ unsafe extern "C" fn artichoke_random_self_srand(
     _slf: sys::mrb_value,
 ) -> sys::mrb_value {
     let number = mrb_get_args!(mrb, optional = 1);
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let number = number.map(|number| Value::new(&interp, number));
     let result = random::srand(&mut interp, number);
     match result {
@@ -167,7 +167,7 @@ unsafe extern "C" fn artichoke_random_self_urandom(
     _slf: sys::mrb_value,
 ) -> sys::mrb_value {
     let size = mrb_get_args!(mrb, required = 1);
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let size = Value::new(&interp, size);
     let result = random::urandom(&mut interp, size);
     match result {

--- a/artichoke-backend/src/extn/core/range/mod.rs
+++ b/artichoke-backend/src/extn/core/range/mod.rs
@@ -1,11 +1,11 @@
 use crate::extn::prelude::*;
 
-pub fn init(interp: &Artichoke) -> InitializeResult<()> {
-    if interp.0.borrow().class_spec::<Range>().is_some() {
+pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
+    if interp.state().class_spec::<Range>().is_some() {
         return Ok(());
     }
     let spec = class::Spec::new("Range", None, None)?;
-    interp.0.borrow_mut().def_class::<Range>(spec);
+    interp.state_mut().def_class::<Range>(spec);
     let _ = interp.eval(&include_bytes!("range.rb")[..])?;
     trace!("Patched Range onto interpreter");
     Ok(())

--- a/artichoke-backend/src/extn/core/regexp/backend/lazy.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/lazy.rs
@@ -21,7 +21,7 @@ impl Lazy {
         }
     }
 
-    pub fn regexp(&self, interp: &mut Artichoke) -> Result<&Regexp, Exception> {
+    pub fn regexp(&self, interp: &Artichoke) -> Result<&Regexp, Exception> {
         self.regexp.get_or_try_init(|| {
             Regexp::new(
                 interp,
@@ -68,7 +68,7 @@ impl RegexpType for Lazy {
 
     fn captures(
         &self,
-        interp: &mut Artichoke,
+        interp: &Artichoke,
         haystack: &[u8],
     ) -> Result<Option<Vec<Option<Vec<u8>>>>, Exception> {
         self.regexp(interp)?.inner().captures(interp, haystack)
@@ -76,7 +76,7 @@ impl RegexpType for Lazy {
 
     fn capture_indexes_for_name(
         &self,
-        interp: &mut Artichoke,
+        interp: &Artichoke,
         name: &[u8],
     ) -> Result<Option<Vec<usize>>, Exception> {
         self.regexp(interp)?
@@ -86,7 +86,7 @@ impl RegexpType for Lazy {
 
     fn captures_len(
         &self,
-        interp: &mut Artichoke,
+        interp: &Artichoke,
         haystack: Option<&[u8]>,
     ) -> Result<usize, Exception> {
         self.regexp(interp)?.inner().captures_len(interp, haystack)
@@ -94,7 +94,7 @@ impl RegexpType for Lazy {
 
     fn capture0<'a>(
         &self,
-        interp: &mut Artichoke,
+        interp: &Artichoke,
         haystack: &'a [u8],
     ) -> Result<Option<&'a [u8]>, Exception> {
         self.regexp(interp)?.inner().capture0(interp, haystack)
@@ -116,13 +116,13 @@ impl RegexpType for Lazy {
         &self.encoding
     }
 
-    fn inspect(&self, interp: &mut Artichoke) -> Vec<u8> {
+    fn inspect(&self, interp: &Artichoke) -> Vec<u8> {
         self.regexp(interp)
             .map(|regexp| regexp.inner().inspect(interp))
             .unwrap_or_default()
     }
 
-    fn string(&self, interp: &mut Artichoke) -> &[u8] {
+    fn string(&self, interp: &Artichoke) -> &[u8] {
         self.regexp(interp)
             .map(|regexp| regexp.inner().string(interp))
             .unwrap_or_default()
@@ -134,7 +134,7 @@ impl RegexpType for Lazy {
 
     fn is_match(
         &self,
-        interp: &mut Artichoke,
+        interp: &Artichoke,
         pattern: &[u8],
         pos: Option<Int>,
     ) -> Result<bool, Exception> {
@@ -161,16 +161,13 @@ impl RegexpType for Lazy {
         self.regexp(interp)?.inner().match_operator(interp, pattern)
     }
 
-    fn named_captures(
-        &self,
-        interp: &mut Artichoke,
-    ) -> Result<Vec<(Vec<u8>, Vec<Int>)>, Exception> {
+    fn named_captures(&self, interp: &Artichoke) -> Result<Vec<(Vec<u8>, Vec<Int>)>, Exception> {
         self.regexp(interp)?.inner().named_captures(interp)
     }
 
     fn named_captures_for_haystack(
         &self,
-        interp: &mut Artichoke,
+        interp: &Artichoke,
         haystack: &[u8],
     ) -> Result<Option<HashMap<Vec<u8>, Option<Vec<u8>>>>, Exception> {
         self.regexp(interp)?
@@ -178,7 +175,7 @@ impl RegexpType for Lazy {
             .named_captures_for_haystack(interp, haystack)
     }
 
-    fn names(&self, interp: &mut Artichoke) -> Vec<Vec<u8>> {
+    fn names(&self, interp: &Artichoke) -> Vec<Vec<u8>> {
         self.regexp(interp)
             .map(|regexp| regexp.inner().names(interp))
             .unwrap_or_default()
@@ -186,7 +183,7 @@ impl RegexpType for Lazy {
 
     fn pos(
         &self,
-        interp: &mut Artichoke,
+        interp: &Artichoke,
         haystack: &[u8],
         at: usize,
     ) -> Result<Option<(usize, usize)>, Exception> {

--- a/artichoke-backend/src/extn/core/regexp/backend/lazy.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/lazy.rs
@@ -21,7 +21,7 @@ impl Lazy {
         }
     }
 
-    pub fn regexp(&self, interp: &Artichoke) -> Result<&Regexp, Exception> {
+    pub fn regexp(&self, interp: &mut Artichoke) -> Result<&Regexp, Exception> {
         self.regexp.get_or_try_init(|| {
             Regexp::new(
                 interp,
@@ -68,7 +68,7 @@ impl RegexpType for Lazy {
 
     fn captures(
         &self,
-        interp: &Artichoke,
+        interp: &mut Artichoke,
         haystack: &[u8],
     ) -> Result<Option<Vec<Option<Vec<u8>>>>, Exception> {
         self.regexp(interp)?.inner().captures(interp, haystack)
@@ -76,7 +76,7 @@ impl RegexpType for Lazy {
 
     fn capture_indexes_for_name(
         &self,
-        interp: &Artichoke,
+        interp: &mut Artichoke,
         name: &[u8],
     ) -> Result<Option<Vec<usize>>, Exception> {
         self.regexp(interp)?
@@ -86,7 +86,7 @@ impl RegexpType for Lazy {
 
     fn captures_len(
         &self,
-        interp: &Artichoke,
+        interp: &mut Artichoke,
         haystack: Option<&[u8]>,
     ) -> Result<usize, Exception> {
         self.regexp(interp)?.inner().captures_len(interp, haystack)
@@ -94,7 +94,7 @@ impl RegexpType for Lazy {
 
     fn capture0<'a>(
         &self,
-        interp: &Artichoke,
+        interp: &mut Artichoke,
         haystack: &'a [u8],
     ) -> Result<Option<&'a [u8]>, Exception> {
         self.regexp(interp)?.inner().capture0(interp, haystack)
@@ -116,25 +116,25 @@ impl RegexpType for Lazy {
         &self.encoding
     }
 
-    fn inspect(&self, interp: &Artichoke) -> Vec<u8> {
+    fn inspect(&self, interp: &mut Artichoke) -> Vec<u8> {
         self.regexp(interp)
             .map(|regexp| regexp.inner().inspect(interp))
             .unwrap_or_default()
     }
 
-    fn string(&self, interp: &Artichoke) -> &[u8] {
+    fn string(&self, interp: &mut Artichoke) -> &[u8] {
         self.regexp(interp)
             .map(|regexp| regexp.inner().string(interp))
             .unwrap_or_default()
     }
 
-    fn case_match(&self, interp: &Artichoke, pattern: &[u8]) -> Result<bool, Exception> {
+    fn case_match(&self, interp: &mut Artichoke, pattern: &[u8]) -> Result<bool, Exception> {
         self.regexp(interp)?.inner().case_match(interp, pattern)
     }
 
     fn is_match(
         &self,
-        interp: &Artichoke,
+        interp: &mut Artichoke,
         pattern: &[u8],
         pos: Option<Int>,
     ) -> Result<bool, Exception> {
@@ -143,7 +143,7 @@ impl RegexpType for Lazy {
 
     fn match_(
         &self,
-        interp: &Artichoke,
+        interp: &mut Artichoke,
         pattern: &[u8],
         pos: Option<Int>,
         block: Option<Block>,
@@ -153,17 +153,24 @@ impl RegexpType for Lazy {
             .match_(interp, pattern, pos, block)
     }
 
-    fn match_operator(&self, interp: &Artichoke, pattern: &[u8]) -> Result<Option<Int>, Exception> {
+    fn match_operator(
+        &self,
+        interp: &mut Artichoke,
+        pattern: &[u8],
+    ) -> Result<Option<Int>, Exception> {
         self.regexp(interp)?.inner().match_operator(interp, pattern)
     }
 
-    fn named_captures(&self, interp: &Artichoke) -> Result<Vec<(Vec<u8>, Vec<Int>)>, Exception> {
+    fn named_captures(
+        &self,
+        interp: &mut Artichoke,
+    ) -> Result<Vec<(Vec<u8>, Vec<Int>)>, Exception> {
         self.regexp(interp)?.inner().named_captures(interp)
     }
 
     fn named_captures_for_haystack(
         &self,
-        interp: &Artichoke,
+        interp: &mut Artichoke,
         haystack: &[u8],
     ) -> Result<Option<HashMap<Vec<u8>, Option<Vec<u8>>>>, Exception> {
         self.regexp(interp)?
@@ -171,7 +178,7 @@ impl RegexpType for Lazy {
             .named_captures_for_haystack(interp, haystack)
     }
 
-    fn names(&self, interp: &Artichoke) -> Vec<Vec<u8>> {
+    fn names(&self, interp: &mut Artichoke) -> Vec<Vec<u8>> {
         self.regexp(interp)
             .map(|regexp| regexp.inner().names(interp))
             .unwrap_or_default()
@@ -179,7 +186,7 @@ impl RegexpType for Lazy {
 
     fn pos(
         &self,
-        interp: &Artichoke,
+        interp: &mut Artichoke,
         haystack: &[u8],
         at: usize,
     ) -> Result<Option<(usize, usize)>, Exception> {
@@ -188,7 +195,7 @@ impl RegexpType for Lazy {
 
     fn scan(
         &self,
-        interp: &Artichoke,
+        interp: &mut Artichoke,
         haystack: Value,
         block: Option<Block>,
     ) -> Result<Value, Exception> {

--- a/artichoke-backend/src/extn/core/regexp/backend/onig.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/onig.rs
@@ -20,7 +20,7 @@ pub struct Onig {
 
 impl Onig {
     pub fn new(
-        interp: &mut Artichoke,
+        interp: &Artichoke,
         literal: Config,
         derived: Config,
         encoding: Encoding,
@@ -80,7 +80,7 @@ impl RegexpType for Onig {
 
     fn captures(
         &self,
-        interp: &mut Artichoke,
+        interp: &Artichoke,
         haystack: &[u8],
     ) -> Result<Option<Vec<Option<Vec<u8>>>>, Exception> {
         let haystack = str::from_utf8(haystack).map_err(|_| {
@@ -100,7 +100,7 @@ impl RegexpType for Onig {
 
     fn capture_indexes_for_name(
         &self,
-        interp: &mut Artichoke,
+        interp: &Artichoke,
         name: &[u8],
     ) -> Result<Option<Vec<usize>>, Exception> {
         let _ = interp;
@@ -124,7 +124,7 @@ impl RegexpType for Onig {
 
     fn captures_len(
         &self,
-        interp: &mut Artichoke,
+        interp: &Artichoke,
         haystack: Option<&[u8]>,
     ) -> Result<usize, Exception> {
         let result = if let Some(haystack) = haystack {
@@ -146,7 +146,7 @@ impl RegexpType for Onig {
 
     fn capture0<'a>(
         &self,
-        interp: &mut Artichoke,
+        interp: &Artichoke,
         haystack: &'a [u8],
     ) -> Result<Option<&'a [u8]>, Exception> {
         let haystack = str::from_utf8(haystack).map_err(|_| {
@@ -183,7 +183,7 @@ impl RegexpType for Onig {
     }
 
     #[must_use]
-    fn inspect(&self, interp: &mut Artichoke) -> Vec<u8> {
+    fn inspect(&self, interp: &Artichoke) -> Vec<u8> {
         let _ = interp;
         // pattern length + 2x '/' + mix + encoding
         let mut inspect = Vec::with_capacity(self.literal.pattern.len() + 2 + 4);
@@ -200,7 +200,7 @@ impl RegexpType for Onig {
     }
 
     #[must_use]
-    fn string(&self, interp: &mut Artichoke) -> &[u8] {
+    fn string(&self, interp: &Artichoke) -> &[u8] {
         let _ = interp;
         self.derived.pattern.as_slice()
     }
@@ -270,7 +270,7 @@ impl RegexpType for Onig {
 
     fn is_match(
         &self,
-        interp: &mut Artichoke,
+        interp: &Artichoke,
         pattern: &[u8],
         pos: Option<Int>,
     ) -> Result<bool, Exception> {
@@ -484,10 +484,7 @@ impl RegexpType for Onig {
         }
     }
 
-    fn named_captures(
-        &self,
-        interp: &mut Artichoke,
-    ) -> Result<Vec<(Vec<u8>, Vec<Int>)>, Exception> {
+    fn named_captures(&self, interp: &Artichoke) -> Result<Vec<(Vec<u8>, Vec<Int>)>, Exception> {
         // Use a Vec of key-value pairs because insertion order matters for spec
         // compliance.
         let mut map = vec![];
@@ -517,7 +514,7 @@ impl RegexpType for Onig {
 
     fn named_captures_for_haystack(
         &self,
-        interp: &mut Artichoke,
+        interp: &Artichoke,
         haystack: &[u8],
     ) -> Result<Option<HashMap<Vec<u8>, Option<Vec<u8>>>>, Exception> {
         let haystack = str::from_utf8(haystack).map_err(|_| {
@@ -547,7 +544,7 @@ impl RegexpType for Onig {
     }
 
     #[must_use]
-    fn names(&self, interp: &mut Artichoke) -> Vec<Vec<u8>> {
+    fn names(&self, interp: &Artichoke) -> Vec<Vec<u8>> {
         let _ = interp;
         let mut names = vec![];
         let mut capture_names = vec![];
@@ -570,7 +567,7 @@ impl RegexpType for Onig {
 
     fn pos(
         &self,
-        interp: &mut Artichoke,
+        interp: &Artichoke,
         haystack: &[u8],
         at: usize,
     ) -> Result<Option<(usize, usize)>, Exception> {

--- a/artichoke-backend/src/extn/core/regexp/backend/onig.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/onig.rs
@@ -248,7 +248,7 @@ impl RegexpType for Onig {
                 0,
                 pattern.len(),
             );
-            let matchdata = matchdata.try_into_ruby(&interp, None).map_err(|_| {
+            let matchdata = matchdata.try_into_ruby(interp, None).map_err(|_| {
                 Fatal::new(interp, "Could not create Ruby Value from Rust MatchData")
             })?;
             let matchdata_sym = interp.sym_intern(regexp::LAST_MATCH);

--- a/artichoke-backend/src/extn/core/regexp/backend/regex_utf8.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/regex_utf8.rs
@@ -258,7 +258,7 @@ impl RegexpType for RegexUtf8 {
                 0,
                 pattern.len(),
             );
-            let matchdata = matchdata.try_into_ruby(&interp, None).map_err(|_| {
+            let matchdata = matchdata.try_into_ruby(interp, None).map_err(|_| {
                 Fatal::new(interp, "Could not create Ruby Value from Rust MatchData")
             })?;
             let matchdata_sym = interp.sym_intern(regexp::LAST_MATCH);

--- a/artichoke-backend/src/extn/core/regexp/backend/regex_utf8.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/regex_utf8.rs
@@ -19,7 +19,7 @@ pub struct RegexUtf8 {
 
 impl RegexUtf8 {
     pub fn new(
-        interp: &mut Artichoke,
+        interp: &Artichoke,
         literal: Config,
         derived: Config,
         encoding: Encoding,
@@ -80,7 +80,7 @@ impl RegexpType for RegexUtf8 {
 
     fn captures(
         &self,
-        interp: &mut Artichoke,
+        interp: &Artichoke,
         haystack: &[u8],
     ) -> Result<Option<Vec<Option<Vec<u8>>>>, Exception> {
         let haystack = str::from_utf8(haystack).map_err(|_| {
@@ -106,7 +106,7 @@ impl RegexpType for RegexUtf8 {
 
     fn capture_indexes_for_name(
         &self,
-        interp: &mut Artichoke,
+        interp: &Artichoke,
         name: &[u8],
     ) -> Result<Option<Vec<usize>>, Exception> {
         let _ = interp;
@@ -125,7 +125,7 @@ impl RegexpType for RegexUtf8 {
 
     fn captures_len(
         &self,
-        interp: &mut Artichoke,
+        interp: &Artichoke,
         haystack: Option<&[u8]>,
     ) -> Result<usize, Exception> {
         let result = if let Some(haystack) = haystack {
@@ -147,7 +147,7 @@ impl RegexpType for RegexUtf8 {
 
     fn capture0<'a>(
         &self,
-        interp: &mut Artichoke,
+        interp: &Artichoke,
         haystack: &'a [u8],
     ) -> Result<Option<&'a [u8]>, Exception> {
         let haystack = str::from_utf8(haystack).map_err(|_| {
@@ -182,7 +182,7 @@ impl RegexpType for RegexUtf8 {
         &self.encoding
     }
 
-    fn inspect(&self, interp: &mut Artichoke) -> Vec<u8> {
+    fn inspect(&self, interp: &Artichoke) -> Vec<u8> {
         let _ = interp;
         // pattern length + 2x '/' + mix + encoding
         let mut inspect = Vec::with_capacity(self.literal.pattern.len() + 2 + 4);
@@ -198,7 +198,7 @@ impl RegexpType for RegexUtf8 {
         inspect
     }
 
-    fn string(&self, interp: &mut Artichoke) -> &[u8] {
+    fn string(&self, interp: &Artichoke) -> &[u8] {
         let _ = interp;
         self.derived.pattern.as_slice()
     }
@@ -280,7 +280,7 @@ impl RegexpType for RegexUtf8 {
 
     fn is_match(
         &self,
-        interp: &mut Artichoke,
+        interp: &Artichoke,
         pattern: &[u8],
         pos: Option<Int>,
     ) -> Result<bool, Exception> {
@@ -521,10 +521,7 @@ impl RegexpType for RegexUtf8 {
         }
     }
 
-    fn named_captures(
-        &self,
-        interp: &mut Artichoke,
-    ) -> Result<Vec<(Vec<u8>, Vec<Int>)>, Exception> {
+    fn named_captures(&self, interp: &Artichoke) -> Result<Vec<(Vec<u8>, Vec<Int>)>, Exception> {
         // Use a Vec of key-value pairs because insertion order matters for spec
         // compliance.
         let mut map = vec![];
@@ -550,7 +547,7 @@ impl RegexpType for RegexUtf8 {
 
     fn named_captures_for_haystack(
         &self,
-        interp: &mut Artichoke,
+        interp: &Artichoke,
         haystack: &[u8],
     ) -> Result<Option<HashMap<Vec<u8>, Option<Vec<u8>>>>, Exception> {
         let haystack = str::from_utf8(haystack).map_err(|_| {
@@ -578,7 +575,7 @@ impl RegexpType for RegexUtf8 {
         }
     }
 
-    fn names(&self, interp: &mut Artichoke) -> Vec<Vec<u8>> {
+    fn names(&self, interp: &Artichoke) -> Vec<Vec<u8>> {
         let mut names = vec![];
         let mut capture_names = self.named_captures(interp).unwrap_or_default();
         capture_names.sort_by(|left, right| {
@@ -596,7 +593,7 @@ impl RegexpType for RegexUtf8 {
 
     fn pos(
         &self,
-        interp: &mut Artichoke,
+        interp: &Artichoke,
         haystack: &[u8],
         at: usize,
     ) -> Result<Option<(usize, usize)>, Exception> {

--- a/artichoke-backend/src/extn/core/regexp/enc.rs
+++ b/artichoke-backend/src/extn/core/regexp/enc.rs
@@ -65,8 +65,8 @@ impl PartialEq for Encoding {
 
 impl Eq for Encoding {}
 
-pub fn parse(value: &Value) -> Result<Encoding, Error> {
-    if let Ok(encoding) = value.itself::<Int>() {
+pub fn parse(interp: &mut Artichoke, value: &Value) -> Result<Encoding, Error> {
+    if let Ok(encoding) = value.itself::<Int>(interp) {
         // Only deal with Encoding opts
         let encoding = encoding & !regexp::ALL_REGEXP_OPTS;
         if encoding == regexp::FIXEDENCODING {
@@ -78,7 +78,7 @@ pub fn parse(value: &Value) -> Result<Encoding, Error> {
         } else {
             Err(Error::InvalidEncoding)
         }
-    } else if let Ok(encoding) = value.itself::<&str>() {
+    } else if let Ok(encoding) = value.itself::<&str>(interp) {
         if encoding.contains('u') && encoding.contains('n') {
             return Err(Error::InvalidEncoding);
         }

--- a/artichoke-backend/src/extn/core/regexp/mod.rs
+++ b/artichoke-backend/src/extn/core/regexp/mod.rs
@@ -184,13 +184,11 @@ impl Regexp {
                 options: options.unwrap_or_default(),
             }
         } else {
-            return Err(Exception::from(TypeError::new(
-                interp,
-                format!(
-                    "no implicit conversion of {} into String",
-                    pattern.pretty_name(interp)
-                ),
-            )));
+            let message = format!(
+                "no implicit conversion of {} into String",
+                pattern.pretty_name(interp)
+            );
+            return Err(Exception::from(TypeError::new(interp, message)));
         };
         let (pattern, options) =
             opts::parse_pattern(literal_config.pattern.as_slice(), literal_config.options);
@@ -355,7 +353,8 @@ impl Regexp {
             }
             return Ok(interp.convert(false));
         };
-        Ok(interp.convert(self.0.case_match(interp, pattern)?))
+        let result = self.0.case_match(interp, pattern)?;
+        Ok(interp.convert(result))
     }
 
     pub fn eql(&self, interp: &mut Artichoke, other: Value) -> Result<Value, Exception> {
@@ -405,13 +404,11 @@ impl Regexp {
         } else if let Ok(pattern) = pattern.funcall::<Option<&[u8]>>(interp, "to_str", &[], None) {
             pattern
         } else {
-            return Err(Exception::from(TypeError::new(
-                interp,
-                format!(
-                    "no implicit conversion of {} into String",
-                    pattern.pretty_name(interp)
-                ),
-            )));
+            let message = format!(
+                "no implicit conversion of {} into String",
+                pattern.pretty_name(interp)
+            );
+            return Err(Exception::from(TypeError::new(interp, message)));
         };
         let pattern = if let Some(pattern) = pattern {
             pattern
@@ -419,19 +416,7 @@ impl Regexp {
             return Ok(interp.convert(false));
         };
         let pos = if let Some(pos) = pos {
-            if let Ok(pos) = pos.try_into::<Int>(interp) {
-                Some(pos)
-            } else if let Ok(pos) = pos.funcall::<Int>(interp, "to_int", &[], None) {
-                Some(pos)
-            } else {
-                return Err(Exception::from(TypeError::new(
-                    interp,
-                    format!(
-                        "no implicit conversion of {} into Integer",
-                        pos.pretty_name(interp)
-                    ),
-                )));
-            }
+            Some(pos.implicitly_convert_to_int(interp)?)
         } else {
             None
         };
@@ -450,43 +435,29 @@ impl Regexp {
         } else if let Ok(pattern) = pattern.funcall::<Option<&[u8]>>(interp, "to_str", &[], None) {
             pattern
         } else {
-            return Err(Exception::from(TypeError::new(
-                interp,
-                format!(
-                    "no implicit conversion of {} into String",
-                    pattern.pretty_name(interp)
-                ),
-            )));
+            let message = format!(
+                "no implicit conversion of {} into String",
+                pattern.pretty_name(interp)
+            );
+            return Err(Exception::from(TypeError::new(interp, message)));
         };
         let pattern = if let Some(pattern) = pattern {
             pattern
         } else {
-            let mrb = interp.mrb_mut();
             let sym = interp.sym_intern(LAST_MATCH);
             let matchdata = interp.convert(None::<Value>);
             unsafe {
-                sys::mrb_gv_set(mrb, sym, matchdata.inner());
+                sys::mrb_gv_set(interp.mrb_mut(), sym, matchdata.inner());
             }
             return Ok(matchdata);
         };
         let pos = if let Some(pos) = pos {
-            if let Ok(pos) = pos.try_into::<Int>(interp) {
-                Some(pos)
-            } else if let Ok(pos) = pos.funcall::<Int>(interp, "to_int", &[], None) {
-                Some(pos)
-            } else {
-                return Err(Exception::from(TypeError::new(
-                    interp,
-                    format!(
-                        "no implicit conversion of {} into Integer",
-                        pos.pretty_name(interp)
-                    ),
-                )));
-            }
+            Some(pos.implicitly_convert_to_int(interp)?)
         } else {
             None
         };
-        Ok(interp.convert(self.0.match_(interp, pattern, pos, block)?))
+        let result = self.0.match_(interp, pattern, pos, block)?;
+        Ok(interp.convert(result))
     }
 
     pub fn match_operator(
@@ -499,24 +470,24 @@ impl Regexp {
         } else if let Ok(pattern) = pattern.funcall::<Option<&[u8]>>(interp, "to_str", &[], None) {
             pattern
         } else {
-            return Err(Exception::from(TypeError::new(
-                interp,
-                format!(
-                    "no implicit conversion of {} into String",
-                    pattern.pretty_name(interp)
-                ),
-            )));
+            let message = format!(
+                "no implicit conversion of {} into String",
+                pattern.pretty_name(interp)
+            );
+            return Err(Exception::from(TypeError::new(interp, message)));
         };
         let pattern = if let Some(pattern) = pattern {
             pattern
         } else {
             return Ok(interp.convert(None::<Value>));
         };
-        Ok(interp.convert(self.0.match_operator(interp, pattern)?))
+        let result = self.0.match_operator(interp, pattern)?;
+        Ok(interp.convert(result))
     }
 
     pub fn named_captures(&self, interp: &mut Artichoke) -> Result<Value, Exception> {
-        Ok(interp.convert(self.0.named_captures(interp)?))
+        let result = self.0.named_captures(interp)?;
+        Ok(interp.convert(result))
     }
 
     pub fn names(&self, interp: &mut Artichoke) -> Result<Value, Exception> {

--- a/artichoke-backend/src/extn/core/regexp/mod.rs
+++ b/artichoke-backend/src/extn/core/regexp/mod.rs
@@ -342,8 +342,8 @@ impl Regexp {
         } else if let Ok(pattern) = other.funcall::<&[u8]>("to_str", &[], None) {
             pattern
         } else {
-            let sym = interp.0.borrow_mut().sym_intern(LAST_MATCH);
-            let mrb = interp.0.borrow().mrb;
+            let sym = interp.sym_intern(LAST_MATCH);
+            let mrb = interp.mrb_mut();
             unsafe {
                 sys::mrb_gv_set(mrb, sym, interp.convert(None::<Value>).inner());
             }
@@ -455,8 +455,8 @@ impl Regexp {
         let pattern = if let Some(pattern) = pattern {
             pattern
         } else {
-            let mrb = interp.0.borrow().mrb;
-            let sym = interp.0.borrow_mut().sym_intern(LAST_MATCH);
+            let mrb = interp.mrb_mut();
+            let sym = interp.sym_intern(LAST_MATCH);
             let matchdata = interp.convert(None::<Value>);
             unsafe {
                 sys::mrb_gv_set(mrb, sym, matchdata.inner());

--- a/artichoke-backend/src/extn/core/regexp/mod.rs
+++ b/artichoke-backend/src/extn/core/regexp/mod.rs
@@ -236,7 +236,7 @@ impl Regexp {
                 #[cfg(feature = "artichoke-array")]
                 let ary = unsafe { crate::extn::core::array::Array::try_from_ruby(interp, &first) };
                 #[cfg(not(feature = "artichoke-array"))]
-                let ary = first.clone().try_into::<Vec<Value>>();
+                let ary = first.try_into::<Vec<Value>>(interp);
                 if let Ok(ary) = ary {
                     #[cfg(feature = "artichoke-array")]
                     let borrow = ary.borrow();

--- a/artichoke-backend/src/extn/core/regexp/mruby.rs
+++ b/artichoke-backend/src/extn/core/regexp/mruby.rs
@@ -55,7 +55,7 @@ unsafe extern "C" fn initialize(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -
     let encoding = encoding.map(|encoding| Value::new(&interp, encoding));
     let result = regexp::trampoline::initialize(&mut interp, pattern, options, encoding, Some(slf));
     match result {
-        Ok(value) => value.inner(),
+        Ok(value) => ffi::return_into_vm(interp, value),
         Err(exception) => exception::raise(interp, exception),
     }
 }
@@ -78,7 +78,7 @@ unsafe extern "C" fn escape(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> s
     let pattern = Value::new(&interp, pattern);
     let result = regexp::trampoline::escape(&mut interp, pattern);
     match result {
-        Ok(result) => result.inner(),
+        Ok(result) => ffi::return_into_vm(interp, result),
         Err(exception) => exception::raise(interp, exception),
     }
 }
@@ -94,7 +94,7 @@ unsafe extern "C" fn union(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sy
     let result = regexp::trampoline::union(&mut interp, args.as_slice());
     drop(args);
     match result {
-        Ok(result) => result.inner(),
+        Ok(result) => ffi::return_into_vm(interp, result),
         Err(exception) => exception::raise(interp, exception),
     }
 }
@@ -107,7 +107,7 @@ unsafe extern "C" fn match_q(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> s
     let pos = pos.map(|pos| Value::new(&interp, pos));
     let result = regexp::trampoline::is_match(&mut interp, value, pattern, pos);
     match result {
-        Ok(result) => result.inner(),
+        Ok(result) => ffi::return_into_vm(interp, result),
         Err(exception) => exception::raise(interp, exception),
     }
 }
@@ -120,7 +120,7 @@ unsafe extern "C" fn match_(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sy
     let pos = pos.map(|pos| Value::new(&interp, pos));
     let result = regexp::trampoline::match_(&mut interp, value, pattern, pos, block);
     match result {
-        Ok(result) => result.inner(),
+        Ok(result) => ffi::return_into_vm(interp, result),
         Err(exception) => exception::raise(interp, exception),
     }
 }
@@ -132,7 +132,7 @@ unsafe extern "C" fn eql(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::
     let other = Value::new(&interp, other);
     let result = regexp::trampoline::eql(&mut interp, value, other);
     match result {
-        Ok(result) => result.inner(),
+        Ok(result) => ffi::return_into_vm(interp, result),
         Err(exception) => exception::raise(interp, exception),
     }
 }
@@ -144,7 +144,7 @@ unsafe extern "C" fn case_compare(mrb: *mut sys::mrb_state, slf: sys::mrb_value)
     let pattern = Value::new(&interp, pattern);
     let result = regexp::trampoline::case_compare(&mut interp, value, pattern);
     match result {
-        Ok(result) => result.inner(),
+        Ok(result) => ffi::return_into_vm(interp, result),
         Err(exception) => exception::raise(interp, exception),
     }
 }
@@ -159,7 +159,7 @@ unsafe extern "C" fn match_operator(
     let pattern = Value::new(&interp, pattern);
     let result = regexp::trampoline::match_operator(&mut interp, value, pattern);
     match result {
-        Ok(result) => result.inner(),
+        Ok(result) => ffi::return_into_vm(interp, result),
         Err(exception) => exception::raise(interp, exception),
     }
 }
@@ -170,7 +170,7 @@ unsafe extern "C" fn casefold(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> 
     let value = Value::new(&interp, slf);
     let result = regexp::trampoline::is_casefold(&mut interp, value);
     match result {
-        Ok(result) => result.inner(),
+        Ok(result) => ffi::return_into_vm(interp, result),
         Err(exception) => exception::raise(interp, exception),
     }
 }
@@ -184,7 +184,7 @@ unsafe extern "C" fn fixed_encoding(
     let value = Value::new(&interp, slf);
     let result = regexp::trampoline::is_fixed_encoding(&mut interp, value);
     match result {
-        Ok(result) => result.inner(),
+        Ok(result) => ffi::return_into_vm(interp, result),
         Err(exception) => exception::raise(interp, exception),
     }
 }
@@ -195,7 +195,7 @@ unsafe extern "C" fn hash(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys:
     let value = Value::new(&interp, slf);
     let result = regexp::trampoline::hash(&mut interp, value);
     match result {
-        Ok(result) => result.inner(),
+        Ok(result) => ffi::return_into_vm(interp, result),
         Err(exception) => exception::raise(interp, exception),
     }
 }
@@ -206,7 +206,7 @@ unsafe extern "C" fn inspect(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> s
     let value = Value::new(&interp, slf);
     let result = regexp::trampoline::inspect(&mut interp, value);
     match result {
-        Ok(result) => result.inner(),
+        Ok(result) => ffi::return_into_vm(interp, result),
         Err(exception) => exception::raise(interp, exception),
     }
 }
@@ -220,7 +220,7 @@ unsafe extern "C" fn named_captures(
     let value = Value::new(&interp, slf);
     let result = regexp::trampoline::named_captures(&mut interp, value);
     match result {
-        Ok(result) => result.inner(),
+        Ok(result) => ffi::return_into_vm(interp, result),
         Err(exception) => exception::raise(interp, exception),
     }
 }
@@ -231,7 +231,7 @@ unsafe extern "C" fn names(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys
     let value = Value::new(&interp, slf);
     let result = regexp::trampoline::names(&mut interp, value);
     match result {
-        Ok(result) => result.inner(),
+        Ok(result) => ffi::return_into_vm(interp, result),
         Err(exception) => exception::raise(interp, exception),
     }
 }
@@ -242,7 +242,7 @@ unsafe extern "C" fn options(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> s
     let value = Value::new(&interp, slf);
     let result = regexp::trampoline::options(&mut interp, value);
     match result {
-        Ok(result) => result.inner(),
+        Ok(result) => ffi::return_into_vm(interp, result),
         Err(exception) => exception::raise(interp, exception),
     }
 }
@@ -253,7 +253,7 @@ unsafe extern "C" fn source(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sy
     let value = Value::new(&interp, slf);
     let result = regexp::trampoline::source(&mut interp, value);
     match result {
-        Ok(result) => result.inner(),
+        Ok(result) => ffi::return_into_vm(interp, result),
         Err(exception) => exception::raise(interp, exception),
     }
 }
@@ -264,7 +264,7 @@ unsafe extern "C" fn to_s(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys:
     let value = Value::new(&interp, slf);
     let result = regexp::trampoline::to_s(&mut interp, value);
     match result {
-        Ok(result) => result.inner(),
+        Ok(result) => ffi::return_into_vm(interp, result),
         Err(exception) => exception::raise(interp, exception),
     }
 }

--- a/artichoke-backend/src/extn/core/regexp/mruby.rs
+++ b/artichoke-backend/src/extn/core/regexp/mruby.rs
@@ -3,8 +3,8 @@ use std::convert::TryFrom;
 use crate::extn::core::regexp;
 use crate::extn::prelude::*;
 
-pub fn init(interp: &Artichoke) -> InitializeResult<()> {
-    if interp.0.borrow().class_spec::<regexp::Regexp>().is_some() {
+pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
+    if interp.state().class_spec::<regexp::Regexp>().is_some() {
         return Ok(());
     }
     let spec = class::Spec::new("Regexp", None, Some(def::rust_data_free::<regexp::Regexp>))?;
@@ -31,7 +31,7 @@ pub fn init(interp: &Artichoke) -> InitializeResult<()> {
         .add_method("source", source, sys::mrb_args_none())?
         .add_method("to_s", to_s, sys::mrb_args_none())?
         .define()?;
-    interp.0.borrow_mut().def_class::<regexp::Regexp>(spec);
+    interp.state_mut().def_class::<regexp::Regexp>(spec);
     let _ = interp.eval(&include_bytes!("regexp.rb")[..])?;
     // TODO: Add proper constant defs to class::Spec, see GH-27.
     let _ = interp.eval(format!(

--- a/artichoke-backend/src/extn/core/regexp/mruby.rs
+++ b/artichoke-backend/src/extn/core/regexp/mruby.rs
@@ -48,7 +48,7 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
 
 unsafe extern "C" fn initialize(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
     let (pattern, options, encoding) = mrb_get_args!(mrb, required = 1, optional = 2);
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let result = regexp::trampoline::initialize(
         &mut interp,
         Value::new(&mut interp, pattern),
@@ -77,7 +77,7 @@ unsafe extern "C" fn compile(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> s
 
 unsafe extern "C" fn escape(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {
     let pattern = mrb_get_args!(mrb, required = 1);
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let result = regexp::trampoline::escape(&mut interp, Value::new(&mut interp, pattern));
     match result {
         Ok(result) => result.inner(),
@@ -87,7 +87,7 @@ unsafe extern "C" fn escape(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> s
 
 unsafe extern "C" fn union(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {
     let args = mrb_get_args!(mrb, *args);
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let args = args
         .iter()
         .map(|arg| Value::new(&mut interp, *arg))
@@ -102,7 +102,7 @@ unsafe extern "C" fn union(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sy
 
 unsafe extern "C" fn match_q(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
     let (pattern, pos) = mrb_get_args!(mrb, required = 1, optional = 1);
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let value = Value::new(&mut interp, slf);
     let result = regexp::trampoline::is_match(
         &mut interp,
@@ -118,7 +118,7 @@ unsafe extern "C" fn match_q(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> s
 
 unsafe extern "C" fn match_(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
     let (pattern, pos, block) = mrb_get_args!(mrb, required = 1, optional = 1, &block);
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let value = Value::new(&mut interp, slf);
     let result = regexp::trampoline::match_(
         &mut interp,
@@ -135,7 +135,7 @@ unsafe extern "C" fn match_(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sy
 
 unsafe extern "C" fn eql(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
     let other = mrb_get_args!(mrb, required = 1);
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let value = Value::new(&mut interp, slf);
     let other = Value::new(&mut interp, other);
     let result = regexp::trampoline::eql(&mut interp, value, other);
@@ -147,7 +147,7 @@ unsafe extern "C" fn eql(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::
 
 unsafe extern "C" fn case_compare(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
     let pattern = mrb_get_args!(mrb, required = 1);
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let value = Value::new(&mut interp, slf);
     let result =
         regexp::trampoline::case_compare(&mut interp, value, Value::new(&mut interp, pattern));
@@ -162,7 +162,7 @@ unsafe extern "C" fn match_operator(
     slf: sys::mrb_value,
 ) -> sys::mrb_value {
     let pattern = mrb_get_args!(mrb, required = 1);
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let value = Value::new(&mut interp, slf);
     let result =
         regexp::trampoline::match_operator(&mut interp, value, Value::new(&mut interp, pattern));
@@ -174,7 +174,7 @@ unsafe extern "C" fn match_operator(
 
 unsafe extern "C" fn casefold(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
     mrb_get_args!(mrb, none);
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let value = Value::new(&mut interp, slf);
     let result = regexp::trampoline::is_casefold(&mut interp, value);
     match result {
@@ -188,7 +188,7 @@ unsafe extern "C" fn fixed_encoding(
     slf: sys::mrb_value,
 ) -> sys::mrb_value {
     mrb_get_args!(mrb, none);
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let value = Value::new(&mut interp, slf);
     let result = regexp::trampoline::is_fixed_encoding(&mut interp, value);
     match result {
@@ -199,7 +199,7 @@ unsafe extern "C" fn fixed_encoding(
 
 unsafe extern "C" fn hash(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
     mrb_get_args!(mrb, none);
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let value = Value::new(&mut interp, slf);
     let result = regexp::trampoline::hash(&mut interp, value);
     match result {
@@ -210,7 +210,7 @@ unsafe extern "C" fn hash(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys:
 
 unsafe extern "C" fn inspect(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
     mrb_get_args!(mrb, none);
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let value = Value::new(&mut interp, slf);
     let result = regexp::trampoline::inspect(&mut interp, value);
     match result {
@@ -224,7 +224,7 @@ unsafe extern "C" fn named_captures(
     slf: sys::mrb_value,
 ) -> sys::mrb_value {
     mrb_get_args!(mrb, none);
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let value = Value::new(&mut interp, slf);
     let result = regexp::trampoline::named_captures(&mut interp, value);
     match result {
@@ -235,7 +235,7 @@ unsafe extern "C" fn named_captures(
 
 unsafe extern "C" fn names(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
     mrb_get_args!(mrb, none);
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let value = Value::new(&mut interp, slf);
     let result = regexp::trampoline::names(&mut interp, value);
     match result {
@@ -246,7 +246,7 @@ unsafe extern "C" fn names(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys
 
 unsafe extern "C" fn options(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
     mrb_get_args!(mrb, none);
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let value = Value::new(&mut interp, slf);
     let result = regexp::trampoline::options(&mut interp, value);
     match result {
@@ -257,7 +257,7 @@ unsafe extern "C" fn options(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> s
 
 unsafe extern "C" fn source(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
     mrb_get_args!(mrb, none);
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let value = Value::new(&mut interp, slf);
     let result = regexp::trampoline::source(&mut interp, value);
     match result {
@@ -268,7 +268,7 @@ unsafe extern "C" fn source(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sy
 
 unsafe extern "C" fn to_s(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
     mrb_get_args!(mrb, none);
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let value = Value::new(&mut interp, slf);
     let result = regexp::trampoline::to_s(&mut interp, value);
     match result {

--- a/artichoke-backend/src/extn/core/regexp/mruby.rs
+++ b/artichoke-backend/src/extn/core/regexp/mruby.rs
@@ -50,11 +50,11 @@ unsafe extern "C" fn initialize(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -
     let (pattern, options, encoding) = mrb_get_args!(mrb, required = 1, optional = 2);
     let interp = unwrap_interpreter!(mrb);
     let result = regexp::trampoline::initialize(
-        &interp,
-        Value::new(&interp, pattern),
-        options.map(|options| Value::new(&interp, options)),
-        encoding.map(|encoding| Value::new(&interp, encoding)),
-        Some(Value::new(&interp, slf)),
+        &mut interp,
+        Value::new(&mut interp, pattern),
+        options.map(|options| Value::new(&mut interp, options)),
+        encoding.map(|encoding| Value::new(&mut interp, encoding)),
+        Some(Value::new(&mut interp, slf)),
     );
     match result {
         Ok(value) => value.inner(),
@@ -78,7 +78,7 @@ unsafe extern "C" fn compile(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> s
 unsafe extern "C" fn escape(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {
     let pattern = mrb_get_args!(mrb, required = 1);
     let interp = unwrap_interpreter!(mrb);
-    let result = regexp::trampoline::escape(&interp, Value::new(&interp, pattern));
+    let result = regexp::trampoline::escape(&mut interp, Value::new(&mut interp, pattern));
     match result {
         Ok(result) => result.inner(),
         Err(exception) => exception::raise(interp, exception),
@@ -90,9 +90,9 @@ unsafe extern "C" fn union(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sy
     let interp = unwrap_interpreter!(mrb);
     let args = args
         .iter()
-        .map(|arg| Value::new(&interp, *arg))
+        .map(|arg| Value::new(&mut interp, *arg))
         .collect::<Vec<_>>();
-    let result = regexp::trampoline::union(&interp, args.as_slice());
+    let result = regexp::trampoline::union(&mut interp, args.as_slice());
     drop(args);
     match result {
         Ok(result) => result.inner(),
@@ -103,12 +103,12 @@ unsafe extern "C" fn union(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sy
 unsafe extern "C" fn match_q(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
     let (pattern, pos) = mrb_get_args!(mrb, required = 1, optional = 1);
     let interp = unwrap_interpreter!(mrb);
-    let value = Value::new(&interp, slf);
+    let value = Value::new(&mut interp, slf);
     let result = regexp::trampoline::is_match(
-        &interp,
+        &mut interp,
         value,
-        Value::new(&interp, pattern),
-        pos.map(|pos| Value::new(&interp, pos)),
+        Value::new(&mut interp, pattern),
+        pos.map(|pos| Value::new(&mut interp, pos)),
     );
     match result {
         Ok(result) => result.inner(),
@@ -119,12 +119,12 @@ unsafe extern "C" fn match_q(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> s
 unsafe extern "C" fn match_(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
     let (pattern, pos, block) = mrb_get_args!(mrb, required = 1, optional = 1, &block);
     let interp = unwrap_interpreter!(mrb);
-    let value = Value::new(&interp, slf);
+    let value = Value::new(&mut interp, slf);
     let result = regexp::trampoline::match_(
-        &interp,
+        &mut interp,
         value,
-        Value::new(&interp, pattern),
-        pos.map(|pos| Value::new(&interp, pos)),
+        Value::new(&mut interp, pattern),
+        pos.map(|pos| Value::new(&mut interp, pos)),
         block,
     );
     match result {
@@ -136,9 +136,9 @@ unsafe extern "C" fn match_(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sy
 unsafe extern "C" fn eql(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
     let other = mrb_get_args!(mrb, required = 1);
     let interp = unwrap_interpreter!(mrb);
-    let value = Value::new(&interp, slf);
-    let other = Value::new(&interp, other);
-    let result = regexp::trampoline::eql(&interp, value, other);
+    let value = Value::new(&mut interp, slf);
+    let other = Value::new(&mut interp, other);
+    let result = regexp::trampoline::eql(&mut interp, value, other);
     match result {
         Ok(result) => result.inner(),
         Err(exception) => exception::raise(interp, exception),
@@ -148,8 +148,9 @@ unsafe extern "C" fn eql(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::
 unsafe extern "C" fn case_compare(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
     let pattern = mrb_get_args!(mrb, required = 1);
     let interp = unwrap_interpreter!(mrb);
-    let value = Value::new(&interp, slf);
-    let result = regexp::trampoline::case_compare(&interp, value, Value::new(&interp, pattern));
+    let value = Value::new(&mut interp, slf);
+    let result =
+        regexp::trampoline::case_compare(&mut interp, value, Value::new(&mut interp, pattern));
     match result {
         Ok(result) => result.inner(),
         Err(exception) => exception::raise(interp, exception),
@@ -162,8 +163,9 @@ unsafe extern "C" fn match_operator(
 ) -> sys::mrb_value {
     let pattern = mrb_get_args!(mrb, required = 1);
     let interp = unwrap_interpreter!(mrb);
-    let value = Value::new(&interp, slf);
-    let result = regexp::trampoline::match_operator(&interp, value, Value::new(&interp, pattern));
+    let value = Value::new(&mut interp, slf);
+    let result =
+        regexp::trampoline::match_operator(&mut interp, value, Value::new(&mut interp, pattern));
     match result {
         Ok(result) => result.inner(),
         Err(exception) => exception::raise(interp, exception),
@@ -173,8 +175,8 @@ unsafe extern "C" fn match_operator(
 unsafe extern "C" fn casefold(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
     mrb_get_args!(mrb, none);
     let interp = unwrap_interpreter!(mrb);
-    let value = Value::new(&interp, slf);
-    let result = regexp::trampoline::is_casefold(&interp, value);
+    let value = Value::new(&mut interp, slf);
+    let result = regexp::trampoline::is_casefold(&mut interp, value);
     match result {
         Ok(result) => result.inner(),
         Err(exception) => exception::raise(interp, exception),
@@ -187,8 +189,8 @@ unsafe extern "C" fn fixed_encoding(
 ) -> sys::mrb_value {
     mrb_get_args!(mrb, none);
     let interp = unwrap_interpreter!(mrb);
-    let value = Value::new(&interp, slf);
-    let result = regexp::trampoline::is_fixed_encoding(&interp, value);
+    let value = Value::new(&mut interp, slf);
+    let result = regexp::trampoline::is_fixed_encoding(&mut interp, value);
     match result {
         Ok(result) => result.inner(),
         Err(exception) => exception::raise(interp, exception),
@@ -198,8 +200,8 @@ unsafe extern "C" fn fixed_encoding(
 unsafe extern "C" fn hash(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
     mrb_get_args!(mrb, none);
     let interp = unwrap_interpreter!(mrb);
-    let value = Value::new(&interp, slf);
-    let result = regexp::trampoline::hash(&interp, value);
+    let value = Value::new(&mut interp, slf);
+    let result = regexp::trampoline::hash(&mut interp, value);
     match result {
         Ok(result) => result.inner(),
         Err(exception) => exception::raise(interp, exception),
@@ -209,8 +211,8 @@ unsafe extern "C" fn hash(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys:
 unsafe extern "C" fn inspect(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
     mrb_get_args!(mrb, none);
     let interp = unwrap_interpreter!(mrb);
-    let value = Value::new(&interp, slf);
-    let result = regexp::trampoline::inspect(&interp, value);
+    let value = Value::new(&mut interp, slf);
+    let result = regexp::trampoline::inspect(&mut interp, value);
     match result {
         Ok(result) => result.inner(),
         Err(exception) => exception::raise(interp, exception),
@@ -223,8 +225,8 @@ unsafe extern "C" fn named_captures(
 ) -> sys::mrb_value {
     mrb_get_args!(mrb, none);
     let interp = unwrap_interpreter!(mrb);
-    let value = Value::new(&interp, slf);
-    let result = regexp::trampoline::named_captures(&interp, value);
+    let value = Value::new(&mut interp, slf);
+    let result = regexp::trampoline::named_captures(&mut interp, value);
     match result {
         Ok(result) => result.inner(),
         Err(exception) => exception::raise(interp, exception),
@@ -234,8 +236,8 @@ unsafe extern "C" fn named_captures(
 unsafe extern "C" fn names(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
     mrb_get_args!(mrb, none);
     let interp = unwrap_interpreter!(mrb);
-    let value = Value::new(&interp, slf);
-    let result = regexp::trampoline::names(&interp, value);
+    let value = Value::new(&mut interp, slf);
+    let result = regexp::trampoline::names(&mut interp, value);
     match result {
         Ok(result) => result.inner(),
         Err(exception) => exception::raise(interp, exception),
@@ -245,8 +247,8 @@ unsafe extern "C" fn names(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys
 unsafe extern "C" fn options(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
     mrb_get_args!(mrb, none);
     let interp = unwrap_interpreter!(mrb);
-    let value = Value::new(&interp, slf);
-    let result = regexp::trampoline::options(&interp, value);
+    let value = Value::new(&mut interp, slf);
+    let result = regexp::trampoline::options(&mut interp, value);
     match result {
         Ok(result) => result.inner(),
         Err(exception) => exception::raise(interp, exception),
@@ -256,8 +258,8 @@ unsafe extern "C" fn options(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> s
 unsafe extern "C" fn source(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
     mrb_get_args!(mrb, none);
     let interp = unwrap_interpreter!(mrb);
-    let value = Value::new(&interp, slf);
-    let result = regexp::trampoline::source(&interp, value);
+    let value = Value::new(&mut interp, slf);
+    let result = regexp::trampoline::source(&mut interp, value);
     match result {
         Ok(result) => result.inner(),
         Err(exception) => exception::raise(interp, exception),
@@ -267,8 +269,8 @@ unsafe extern "C" fn source(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sy
 unsafe extern "C" fn to_s(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
     mrb_get_args!(mrb, none);
     let interp = unwrap_interpreter!(mrb);
-    let value = Value::new(&interp, slf);
-    let result = regexp::trampoline::to_s(&interp, value);
+    let value = Value::new(&mut interp, slf);
+    let result = regexp::trampoline::to_s(&mut interp, value);
     match result {
         Ok(result) => result.inner(),
         Err(exception) => exception::raise(interp, exception),

--- a/artichoke-backend/src/extn/core/regexp/opts.rs
+++ b/artichoke-backend/src/extn/core/regexp/opts.rs
@@ -73,24 +73,24 @@ impl Options {
     }
 }
 
-pub fn parse(value: &Value) -> Options {
+pub fn parse(interp: &mut Artichoke, value: &Value) -> Options {
     // If options is an Integer, it should be one or more of the constants
     // Regexp::EXTENDED, Regexp::IGNORECASE, and Regexp::MULTILINE, logically
     // or-ed together. Otherwise, if options is not nil or false, the regexp
     // will be case insensitive.
-    if let Ok(options) = value.itself::<Int>() {
+    if let Ok(options) = value.itself::<Int>(interp) {
         Options {
             multiline: options & regexp::MULTILINE > 0,
             ignore_case: options & regexp::IGNORECASE > 0,
             extended: options & regexp::EXTENDED > 0,
             literal: options & regexp::LITERAL > 0,
         }
-    } else if let Ok(options) = value.itself::<Option<bool>>() {
+    } else if let Ok(options) = value.itself::<Option<bool>>(interp) {
         match options {
             Some(false) | None => Options::default(),
             _ => Options::ignore_case(),
         }
-    } else if let Ok(options) = value.itself::<Option<&str>>() {
+    } else if let Ok(options) = value.itself::<Option<&str>>(interp) {
         if let Some(options) = options {
             Options {
                 multiline: options.contains('m'),

--- a/artichoke-backend/src/extn/core/regexp/trampoline.rs
+++ b/artichoke-backend/src/extn/core/regexp/trampoline.rs
@@ -2,7 +2,7 @@ use crate::extn::core::regexp::Regexp;
 use crate::extn::prelude::*;
 
 pub fn initialize(
-    interp: &Artichoke,
+    interp: &mut Artichoke,
     pattern: Value,
     options: Option<Value>,
     encoding: Option<Value>,
@@ -11,16 +11,16 @@ pub fn initialize(
     Regexp::initialize(interp, pattern, options, encoding, into)
 }
 
-pub fn escape(interp: &Artichoke, pattern: Value) -> Result<Value, Exception> {
+pub fn escape(interp: &mut Artichoke, pattern: Value) -> Result<Value, Exception> {
     Regexp::escape(interp, pattern)
 }
 
-pub fn union(interp: &Artichoke, patterns: &[Value]) -> Result<Value, Exception> {
+pub fn union(interp: &mut Artichoke, patterns: &[Value]) -> Result<Value, Exception> {
     Regexp::union(interp, patterns)
 }
 
 pub fn is_match(
-    interp: &Artichoke,
+    interp: &mut Artichoke,
     regexp: Value,
     pattern: Value,
     pos: Option<Value>,
@@ -40,7 +40,7 @@ pub fn is_match(
 }
 
 pub fn match_(
-    interp: &Artichoke,
+    interp: &mut Artichoke,
     regexp: Value,
     pattern: Value,
     pos: Option<Value>,
@@ -60,7 +60,7 @@ pub fn match_(
     borrow.match_(interp, pattern, pos, block)
 }
 
-pub fn eql(interp: &Artichoke, regexp: Value, other: Value) -> Result<Value, Exception> {
+pub fn eql(interp: &mut Artichoke, regexp: Value, other: Value) -> Result<Value, Exception> {
     let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }.map_err(|err| {
         if let ArtichokeError::UninitializedValue("Regexp") = err {
             Exception::from(TypeError::new(interp, "uninitialized Regexp"))
@@ -75,7 +75,11 @@ pub fn eql(interp: &Artichoke, regexp: Value, other: Value) -> Result<Value, Exc
     borrow.eql(interp, other)
 }
 
-pub fn case_compare(interp: &Artichoke, regexp: Value, other: Value) -> Result<Value, Exception> {
+pub fn case_compare(
+    interp: &mut Artichoke,
+    regexp: Value,
+    other: Value,
+) -> Result<Value, Exception> {
     let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }.map_err(|err| {
         if let ArtichokeError::UninitializedValue("Regexp") = err {
             Exception::from(TypeError::new(interp, "uninitialized Regexp"))
@@ -91,7 +95,7 @@ pub fn case_compare(interp: &Artichoke, regexp: Value, other: Value) -> Result<V
 }
 
 pub fn match_operator(
-    interp: &Artichoke,
+    interp: &mut Artichoke,
     regexp: Value,
     pattern: Value,
 ) -> Result<Value, Exception> {
@@ -109,7 +113,7 @@ pub fn match_operator(
     borrow.match_operator(interp, pattern)
 }
 
-pub fn is_casefold(interp: &Artichoke, regexp: Value) -> Result<Value, Exception> {
+pub fn is_casefold(interp: &mut Artichoke, regexp: Value) -> Result<Value, Exception> {
     let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }.map_err(|err| {
         if let ArtichokeError::UninitializedValue("Regexp") = err {
             Exception::from(TypeError::new(interp, "uninitialized Regexp"))
@@ -124,7 +128,7 @@ pub fn is_casefold(interp: &Artichoke, regexp: Value) -> Result<Value, Exception
     borrow.is_casefold(interp)
 }
 
-pub fn is_fixed_encoding(interp: &Artichoke, regexp: Value) -> Result<Value, Exception> {
+pub fn is_fixed_encoding(interp: &mut Artichoke, regexp: Value) -> Result<Value, Exception> {
     let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }.map_err(|err| {
         if let ArtichokeError::UninitializedValue("Regexp") = err {
             Exception::from(TypeError::new(interp, "uninitialized Regexp"))
@@ -139,7 +143,7 @@ pub fn is_fixed_encoding(interp: &Artichoke, regexp: Value) -> Result<Value, Exc
     borrow.is_fixed_encoding(interp)
 }
 
-pub fn hash(interp: &Artichoke, regexp: Value) -> Result<Value, Exception> {
+pub fn hash(interp: &mut Artichoke, regexp: Value) -> Result<Value, Exception> {
     let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }.map_err(|err| {
         if let ArtichokeError::UninitializedValue("Regexp") = err {
             Exception::from(TypeError::new(interp, "uninitialized Regexp"))
@@ -154,7 +158,7 @@ pub fn hash(interp: &Artichoke, regexp: Value) -> Result<Value, Exception> {
     borrow.hash(interp)
 }
 
-pub fn inspect(interp: &Artichoke, regexp: Value) -> Result<Value, Exception> {
+pub fn inspect(interp: &mut Artichoke, regexp: Value) -> Result<Value, Exception> {
     let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }.map_err(|err| {
         if let ArtichokeError::UninitializedValue("Regexp") = err {
             Exception::from(TypeError::new(interp, "uninitialized Regexp"))
@@ -169,7 +173,7 @@ pub fn inspect(interp: &Artichoke, regexp: Value) -> Result<Value, Exception> {
     borrow.inspect(interp)
 }
 
-pub fn named_captures(interp: &Artichoke, regexp: Value) -> Result<Value, Exception> {
+pub fn named_captures(interp: &mut Artichoke, regexp: Value) -> Result<Value, Exception> {
     let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }.map_err(|err| {
         if let ArtichokeError::UninitializedValue("Regexp") = err {
             Exception::from(TypeError::new(interp, "uninitialized Regexp"))
@@ -184,7 +188,7 @@ pub fn named_captures(interp: &Artichoke, regexp: Value) -> Result<Value, Except
     borrow.named_captures(interp)
 }
 
-pub fn names(interp: &Artichoke, regexp: Value) -> Result<Value, Exception> {
+pub fn names(interp: &mut Artichoke, regexp: Value) -> Result<Value, Exception> {
     let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }.map_err(|err| {
         if let ArtichokeError::UninitializedValue("Regexp") = err {
             Exception::from(TypeError::new(interp, "uninitialized Regexp"))
@@ -199,7 +203,7 @@ pub fn names(interp: &Artichoke, regexp: Value) -> Result<Value, Exception> {
     borrow.names(interp)
 }
 
-pub fn options(interp: &Artichoke, regexp: Value) -> Result<Value, Exception> {
+pub fn options(interp: &mut Artichoke, regexp: Value) -> Result<Value, Exception> {
     let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }.map_err(|err| {
         if let ArtichokeError::UninitializedValue("Regexp") = err {
             Exception::from(TypeError::new(interp, "uninitialized Regexp"))
@@ -214,7 +218,7 @@ pub fn options(interp: &Artichoke, regexp: Value) -> Result<Value, Exception> {
     borrow.options(interp)
 }
 
-pub fn source(interp: &Artichoke, regexp: Value) -> Result<Value, Exception> {
+pub fn source(interp: &mut Artichoke, regexp: Value) -> Result<Value, Exception> {
     let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }.map_err(|err| {
         if let ArtichokeError::UninitializedValue("Regexp") = err {
             Exception::from(TypeError::new(interp, "uninitialized Regexp"))
@@ -229,7 +233,7 @@ pub fn source(interp: &Artichoke, regexp: Value) -> Result<Value, Exception> {
     borrow.source(interp)
 }
 
-pub fn to_s(interp: &Artichoke, regexp: Value) -> Result<Value, Exception> {
+pub fn to_s(interp: &mut Artichoke, regexp: Value) -> Result<Value, Exception> {
     let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }.map_err(|err| {
         if let ArtichokeError::UninitializedValue("Regexp") = err {
             Exception::from(TypeError::new(interp, "uninitialized Regexp"))

--- a/artichoke-backend/src/extn/core/string.rs
+++ b/artichoke-backend/src/extn/core/string.rs
@@ -48,7 +48,8 @@ impl RString {
         let (pattern, block) = mrb_get_args!(mrb, required = 1, &block);
         let mut interp = unwrap_interpreter!(mrb);
         let value = Value::new(&interp, slf);
-        let result = scan::method(&mut interp, value, Value::new(&interp, pattern), block);
+        let pattern = Value::new(&interp, pattern);
+        let result = scan::method(&mut interp, value, pattern, block);
         match result {
             Ok(result) => result.inner(),
             Err(exception) => exception::raise(interp, exception),

--- a/artichoke-backend/src/extn/core/string.rs
+++ b/artichoke-backend/src/extn/core/string.rs
@@ -23,7 +23,7 @@ pub struct RString;
 impl RString {
     unsafe extern "C" fn ord(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
         mrb_get_args!(mrb, none);
-        let interp = unwrap_interpreter!(mrb);
+        let mut interp = unwrap_interpreter!(mrb);
         let value = Value::new(&interp, slf);
         if let Ok(s) = value.try_into::<&str>(&mut interp) {
             if let Some(first) = s.chars().next() {
@@ -46,7 +46,7 @@ impl RString {
 
     unsafe extern "C" fn scan(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
         let (pattern, block) = mrb_get_args!(mrb, required = 1, &block);
-        let interp = unwrap_interpreter!(mrb);
+        let mut interp = unwrap_interpreter!(mrb);
         let value = Value::new(&interp, slf);
         let result = scan::method(&mut interp, value, Value::new(&interp, pattern), block);
         match result {

--- a/artichoke-backend/src/extn/core/string.rs
+++ b/artichoke-backend/src/extn/core/string.rs
@@ -51,7 +51,7 @@ impl RString {
         let pattern = Value::new(&interp, pattern);
         let result = scan::method(&mut interp, value, pattern, block);
         match result {
-            Ok(result) => result.inner(),
+            Ok(result) => ffi::return_into_vm(interp, result),
             Err(exception) => exception::raise(interp, exception),
         }
     }

--- a/artichoke-backend/src/extn/core/symbol/mod.rs
+++ b/artichoke-backend/src/extn/core/symbol/mod.rs
@@ -1,11 +1,11 @@
 use crate::extn::prelude::*;
 
-pub fn init(interp: &Artichoke) -> InitializeResult<()> {
-    if interp.0.borrow().class_spec::<Symbol>().is_some() {
+pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
+    if interp.state().class_spec::<Symbol>().is_some() {
         return Ok(());
     }
     let spec = class::Spec::new("Symbol", None, None)?;
-    interp.0.borrow_mut().def_class::<Symbol>(spec);
+    interp.state_mut().def_class::<Symbol>(spec);
     let _ = interp.eval(&include_bytes!("symbol.rb")[..])?;
     trace!("Patched Symbol onto interpreter");
     Ok(())

--- a/artichoke-backend/src/extn/core/thread.rs
+++ b/artichoke-backend/src/extn/core/thread.rs
@@ -1,16 +1,16 @@
 use crate::extn::prelude::*;
 
-pub fn init(interp: &Artichoke) -> InitializeResult<()> {
-    if interp.0.borrow().class_spec::<Thread>().is_some() {
+pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
+    if interp.state().class_spec::<Thread>().is_some() {
         return Ok(());
     }
-    if interp.0.borrow().class_spec::<Mutex>().is_some() {
+    if interp.state().class_spec::<Mutex>().is_some() {
         return Ok(());
     }
     let spec = class::Spec::new("Thread", None, None)?;
-    interp.0.borrow_mut().def_class::<Thread>(spec);
+    interp.state_mut().def_class::<Thread>(spec);
     let spec = class::Spec::new("Mutex", None, None)?;
-    interp.0.borrow_mut().def_class::<Mutex>(spec);
+    interp.state_mut().def_class::<Mutex>(spec);
     interp.def_rb_source_file(b"thread.rb", &include_bytes!("thread.rb")[..])?;
     // Thread is loaded by default, so eval it on interpreter initialization
     // https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/UnneededRequireStatement

--- a/artichoke-backend/src/extn/core/time/mruby.rs
+++ b/artichoke-backend/src/extn/core/time/mruby.rs
@@ -1,8 +1,8 @@
 use crate::extn::core::time::{self, trampoline};
 use crate::extn::prelude::*;
 
-pub fn init(interp: &Artichoke) -> InitializeResult<()> {
-    if interp.0.borrow().class_spec::<time::Time>().is_some() {
+pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
+    if interp.state().class_spec::<time::Time>().is_some() {
         return Ok(());
     }
     let spec = class::Spec::new("Time", None, Some(def::rust_data_free::<time::Time>))?;
@@ -24,7 +24,7 @@ pub fn init(interp: &Artichoke) -> InitializeResult<()> {
         .add_method("yday", artichoke_time_year_day, sys::mrb_args_none())?
         .add_method("year", artichoke_time_year, sys::mrb_args_none())?
         .define()?;
-    interp.0.borrow_mut().def_class::<time::Time>(spec);
+    interp.state_mut().def_class::<time::Time>(spec);
 
     let _ = interp.eval(&include_bytes!("time.rb")[..])?;
     trace!("Patched Random onto interpreter");

--- a/artichoke-backend/src/extn/core/time/mruby.rs
+++ b/artichoke-backend/src/extn/core/time/mruby.rs
@@ -40,7 +40,7 @@ unsafe extern "C" fn artichoke_time_self_now(
     let mut interp = unwrap_interpreter!(mrb);
     let result = trampoline::now(&mut interp);
     match result {
-        Ok(value) => value.inner(),
+        Ok(value) => ffi::return_into_vm(interp, value),
         Err(exception) => exception::raise(interp, exception),
     }
 }
@@ -55,7 +55,7 @@ unsafe extern "C" fn artichoke_time_day(
     let time = Value::new(&interp, slf);
     let result = trampoline::day(&mut interp, time);
     match result {
-        Ok(value) => value.inner(),
+        Ok(value) => ffi::return_into_vm(interp, value),
         Err(exception) => exception::raise(interp, exception),
     }
 }
@@ -70,7 +70,7 @@ unsafe extern "C" fn artichoke_time_hour(
     let time = Value::new(&interp, slf);
     let result = trampoline::hour(&mut interp, time);
     match result {
-        Ok(value) => value.inner(),
+        Ok(value) => ffi::return_into_vm(interp, value),
         Err(exception) => exception::raise(interp, exception),
     }
 }
@@ -85,7 +85,7 @@ unsafe extern "C" fn artichoke_time_minute(
     let time = Value::new(&interp, slf);
     let result = trampoline::minute(&mut interp, time);
     match result {
-        Ok(value) => value.inner(),
+        Ok(value) => ffi::return_into_vm(interp, value),
         Err(exception) => exception::raise(interp, exception),
     }
 }
@@ -100,7 +100,7 @@ unsafe extern "C" fn artichoke_time_month(
     let time = Value::new(&interp, slf);
     let result = trampoline::month(&mut interp, time);
     match result {
-        Ok(value) => value.inner(),
+        Ok(value) => ffi::return_into_vm(interp, value),
         Err(exception) => exception::raise(interp, exception),
     }
 }
@@ -115,7 +115,7 @@ unsafe extern "C" fn artichoke_time_nanosecond(
     let time = Value::new(&interp, slf);
     let result = trampoline::nanosecond(&mut interp, time);
     match result {
-        Ok(value) => value.inner(),
+        Ok(value) => ffi::return_into_vm(interp, value),
         Err(exception) => exception::raise(interp, exception),
     }
 }
@@ -130,7 +130,7 @@ unsafe extern "C" fn artichoke_time_second(
     let time = Value::new(&interp, slf);
     let result = trampoline::second(&mut interp, time);
     match result {
-        Ok(value) => value.inner(),
+        Ok(value) => ffi::return_into_vm(interp, value),
         Err(exception) => exception::raise(interp, exception),
     }
 }
@@ -145,7 +145,7 @@ unsafe extern "C" fn artichoke_time_microsecond(
     let time = Value::new(&interp, slf);
     let result = trampoline::microsecond(&mut interp, time);
     match result {
-        Ok(value) => value.inner(),
+        Ok(value) => ffi::return_into_vm(interp, value),
         Err(exception) => exception::raise(interp, exception),
     }
 }
@@ -160,7 +160,7 @@ unsafe extern "C" fn artichoke_time_weekday(
     let time = Value::new(&interp, slf);
     let result = trampoline::weekday(&mut interp, time);
     match result {
-        Ok(value) => value.inner(),
+        Ok(value) => ffi::return_into_vm(interp, value),
         Err(exception) => exception::raise(interp, exception),
     }
 }
@@ -175,7 +175,7 @@ unsafe extern "C" fn artichoke_time_year_day(
     let time = Value::new(&interp, slf);
     let result = trampoline::year_day(&mut interp, time);
     match result {
-        Ok(value) => value.inner(),
+        Ok(value) => ffi::return_into_vm(interp, value),
         Err(exception) => exception::raise(interp, exception),
     }
 }
@@ -190,7 +190,7 @@ unsafe extern "C" fn artichoke_time_year(
     let time = Value::new(&interp, slf);
     let result = trampoline::year(&mut interp, time);
     match result {
-        Ok(value) => value.inner(),
+        Ok(value) => ffi::return_into_vm(interp, value),
         Err(exception) => exception::raise(interp, exception),
     }
 }

--- a/artichoke-backend/src/extn/core/time/mruby.rs
+++ b/artichoke-backend/src/extn/core/time/mruby.rs
@@ -37,7 +37,7 @@ unsafe extern "C" fn artichoke_time_self_now(
     _slf: sys::mrb_value,
 ) -> sys::mrb_value {
     mrb_get_args!(mrb, none);
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let result = trampoline::now(&mut interp);
     match result {
         Ok(value) => value.inner(),
@@ -51,7 +51,7 @@ unsafe extern "C" fn artichoke_time_day(
     slf: sys::mrb_value,
 ) -> sys::mrb_value {
     mrb_get_args!(mrb, none);
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let time = Value::new(&interp, slf);
     let result = trampoline::day(&mut interp, time);
     match result {
@@ -66,7 +66,7 @@ unsafe extern "C" fn artichoke_time_hour(
     slf: sys::mrb_value,
 ) -> sys::mrb_value {
     mrb_get_args!(mrb, none);
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let time = Value::new(&interp, slf);
     let result = trampoline::hour(&mut interp, time);
     match result {
@@ -81,7 +81,7 @@ unsafe extern "C" fn artichoke_time_minute(
     slf: sys::mrb_value,
 ) -> sys::mrb_value {
     mrb_get_args!(mrb, none);
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let time = Value::new(&interp, slf);
     let result = trampoline::minute(&mut interp, time);
     match result {
@@ -96,7 +96,7 @@ unsafe extern "C" fn artichoke_time_month(
     slf: sys::mrb_value,
 ) -> sys::mrb_value {
     mrb_get_args!(mrb, none);
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let time = Value::new(&interp, slf);
     let result = trampoline::month(&mut interp, time);
     match result {
@@ -111,7 +111,7 @@ unsafe extern "C" fn artichoke_time_nanosecond(
     slf: sys::mrb_value,
 ) -> sys::mrb_value {
     mrb_get_args!(mrb, none);
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let time = Value::new(&interp, slf);
     let result = trampoline::nanosecond(&mut interp, time);
     match result {
@@ -126,7 +126,7 @@ unsafe extern "C" fn artichoke_time_second(
     slf: sys::mrb_value,
 ) -> sys::mrb_value {
     mrb_get_args!(mrb, none);
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let time = Value::new(&interp, slf);
     let result = trampoline::second(&mut interp, time);
     match result {
@@ -141,7 +141,7 @@ unsafe extern "C" fn artichoke_time_microsecond(
     slf: sys::mrb_value,
 ) -> sys::mrb_value {
     mrb_get_args!(mrb, none);
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let time = Value::new(&interp, slf);
     let result = trampoline::microsecond(&mut interp, time);
     match result {
@@ -156,7 +156,7 @@ unsafe extern "C" fn artichoke_time_weekday(
     slf: sys::mrb_value,
 ) -> sys::mrb_value {
     mrb_get_args!(mrb, none);
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let time = Value::new(&interp, slf);
     let result = trampoline::weekday(&mut interp, time);
     match result {
@@ -171,7 +171,7 @@ unsafe extern "C" fn artichoke_time_year_day(
     slf: sys::mrb_value,
 ) -> sys::mrb_value {
     mrb_get_args!(mrb, none);
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let time = Value::new(&interp, slf);
     let result = trampoline::year_day(&mut interp, time);
     match result {
@@ -186,7 +186,7 @@ unsafe extern "C" fn artichoke_time_year(
     slf: sys::mrb_value,
 ) -> sys::mrb_value {
     mrb_get_args!(mrb, none);
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let time = Value::new(&interp, slf);
     let result = trampoline::year(&mut interp, time);
     match result {

--- a/artichoke-backend/src/extn/core/time/mruby.rs
+++ b/artichoke-backend/src/extn/core/time/mruby.rs
@@ -38,7 +38,7 @@ unsafe extern "C" fn artichoke_time_self_now(
 ) -> sys::mrb_value {
     mrb_get_args!(mrb, none);
     let interp = unwrap_interpreter!(mrb);
-    let result = trampoline::now(&interp);
+    let result = trampoline::now(&mut interp);
     match result {
         Ok(value) => value.inner(),
         Err(exception) => exception::raise(interp, exception),
@@ -53,7 +53,7 @@ unsafe extern "C" fn artichoke_time_day(
     mrb_get_args!(mrb, none);
     let interp = unwrap_interpreter!(mrb);
     let time = Value::new(&interp, slf);
-    let result = trampoline::day(&interp, time);
+    let result = trampoline::day(&mut interp, time);
     match result {
         Ok(value) => value.inner(),
         Err(exception) => exception::raise(interp, exception),
@@ -68,7 +68,7 @@ unsafe extern "C" fn artichoke_time_hour(
     mrb_get_args!(mrb, none);
     let interp = unwrap_interpreter!(mrb);
     let time = Value::new(&interp, slf);
-    let result = trampoline::hour(&interp, time);
+    let result = trampoline::hour(&mut interp, time);
     match result {
         Ok(value) => value.inner(),
         Err(exception) => exception::raise(interp, exception),
@@ -83,7 +83,7 @@ unsafe extern "C" fn artichoke_time_minute(
     mrb_get_args!(mrb, none);
     let interp = unwrap_interpreter!(mrb);
     let time = Value::new(&interp, slf);
-    let result = trampoline::minute(&interp, time);
+    let result = trampoline::minute(&mut interp, time);
     match result {
         Ok(value) => value.inner(),
         Err(exception) => exception::raise(interp, exception),
@@ -98,7 +98,7 @@ unsafe extern "C" fn artichoke_time_month(
     mrb_get_args!(mrb, none);
     let interp = unwrap_interpreter!(mrb);
     let time = Value::new(&interp, slf);
-    let result = trampoline::month(&interp, time);
+    let result = trampoline::month(&mut interp, time);
     match result {
         Ok(value) => value.inner(),
         Err(exception) => exception::raise(interp, exception),
@@ -113,7 +113,7 @@ unsafe extern "C" fn artichoke_time_nanosecond(
     mrb_get_args!(mrb, none);
     let interp = unwrap_interpreter!(mrb);
     let time = Value::new(&interp, slf);
-    let result = trampoline::nanosecond(&interp, time);
+    let result = trampoline::nanosecond(&mut interp, time);
     match result {
         Ok(value) => value.inner(),
         Err(exception) => exception::raise(interp, exception),
@@ -128,7 +128,7 @@ unsafe extern "C" fn artichoke_time_second(
     mrb_get_args!(mrb, none);
     let interp = unwrap_interpreter!(mrb);
     let time = Value::new(&interp, slf);
-    let result = trampoline::second(&interp, time);
+    let result = trampoline::second(&mut interp, time);
     match result {
         Ok(value) => value.inner(),
         Err(exception) => exception::raise(interp, exception),
@@ -143,7 +143,7 @@ unsafe extern "C" fn artichoke_time_microsecond(
     mrb_get_args!(mrb, none);
     let interp = unwrap_interpreter!(mrb);
     let time = Value::new(&interp, slf);
-    let result = trampoline::microsecond(&interp, time);
+    let result = trampoline::microsecond(&mut interp, time);
     match result {
         Ok(value) => value.inner(),
         Err(exception) => exception::raise(interp, exception),
@@ -158,7 +158,7 @@ unsafe extern "C" fn artichoke_time_weekday(
     mrb_get_args!(mrb, none);
     let interp = unwrap_interpreter!(mrb);
     let time = Value::new(&interp, slf);
-    let result = trampoline::weekday(&interp, time);
+    let result = trampoline::weekday(&mut interp, time);
     match result {
         Ok(value) => value.inner(),
         Err(exception) => exception::raise(interp, exception),
@@ -173,7 +173,7 @@ unsafe extern "C" fn artichoke_time_year_day(
     mrb_get_args!(mrb, none);
     let interp = unwrap_interpreter!(mrb);
     let time = Value::new(&interp, slf);
-    let result = trampoline::year_day(&interp, time);
+    let result = trampoline::year_day(&mut interp, time);
     match result {
         Ok(value) => value.inner(),
         Err(exception) => exception::raise(interp, exception),
@@ -188,7 +188,7 @@ unsafe extern "C" fn artichoke_time_year(
     mrb_get_args!(mrb, none);
     let interp = unwrap_interpreter!(mrb);
     let time = Value::new(&interp, slf);
-    let result = trampoline::year(&interp, time);
+    let result = trampoline::year(&mut interp, time);
     match result {
         Ok(value) => value.inner(),
         Err(exception) => exception::raise(interp, exception),

--- a/artichoke-backend/src/extn/core/time/trampoline.rs
+++ b/artichoke-backend/src/extn/core/time/trampoline.rs
@@ -2,15 +2,15 @@ use crate::extn::core::time::backend::MakeTime;
 use crate::extn::core::time::{self, Time};
 use crate::extn::prelude::*;
 
-pub fn now(interp: &Artichoke) -> Result<Value, Exception> {
+pub fn now(interp: &mut Artichoke) -> Result<Value, Exception> {
     let now = Time(time::factory().now(interp));
     let result = now
-        .try_into_ruby(&interp, None)
+        .try_into_ruby(interp, None)
         .map_err(|_| Fatal::new(interp, "Unable to initialize Ruby Time with Rust Time"))?;
     Ok(result)
 }
 
-pub fn day(interp: &Artichoke, time: Value) -> Result<Value, Exception> {
+pub fn day(interp: &mut Artichoke, time: Value) -> Result<Value, Exception> {
     let time = unsafe { Time::try_from_ruby(interp, &time) }.map_err(|_| {
         Fatal::new(
             interp,
@@ -24,7 +24,7 @@ pub fn day(interp: &Artichoke, time: Value) -> Result<Value, Exception> {
     Ok(result)
 }
 
-pub fn hour(interp: &Artichoke, time: Value) -> Result<Value, Exception> {
+pub fn hour(interp: &mut Artichoke, time: Value) -> Result<Value, Exception> {
     let time = unsafe { Time::try_from_ruby(interp, &time) }.map_err(|_| {
         Fatal::new(
             interp,
@@ -38,7 +38,7 @@ pub fn hour(interp: &Artichoke, time: Value) -> Result<Value, Exception> {
     Ok(result)
 }
 
-pub fn minute(interp: &Artichoke, time: Value) -> Result<Value, Exception> {
+pub fn minute(interp: &mut Artichoke, time: Value) -> Result<Value, Exception> {
     let time = unsafe { Time::try_from_ruby(interp, &time) }.map_err(|_| {
         Fatal::new(
             interp,
@@ -52,7 +52,7 @@ pub fn minute(interp: &Artichoke, time: Value) -> Result<Value, Exception> {
     Ok(result)
 }
 
-pub fn month(interp: &Artichoke, time: Value) -> Result<Value, Exception> {
+pub fn month(interp: &mut Artichoke, time: Value) -> Result<Value, Exception> {
     let time = unsafe { Time::try_from_ruby(interp, &time) }.map_err(|_| {
         Fatal::new(
             interp,
@@ -66,7 +66,7 @@ pub fn month(interp: &Artichoke, time: Value) -> Result<Value, Exception> {
     Ok(result)
 }
 
-pub fn nanosecond(interp: &Artichoke, time: Value) -> Result<Value, Exception> {
+pub fn nanosecond(interp: &mut Artichoke, time: Value) -> Result<Value, Exception> {
     let time = unsafe { Time::try_from_ruby(interp, &time) }.map_err(|_| {
         Fatal::new(
             interp,
@@ -80,7 +80,7 @@ pub fn nanosecond(interp: &Artichoke, time: Value) -> Result<Value, Exception> {
     Ok(result)
 }
 
-pub fn second(interp: &Artichoke, time: Value) -> Result<Value, Exception> {
+pub fn second(interp: &mut Artichoke, time: Value) -> Result<Value, Exception> {
     let time = unsafe { Time::try_from_ruby(interp, &time) }.map_err(|_| {
         Fatal::new(
             interp,
@@ -94,7 +94,7 @@ pub fn second(interp: &Artichoke, time: Value) -> Result<Value, Exception> {
     Ok(result)
 }
 
-pub fn microsecond(interp: &Artichoke, time: Value) -> Result<Value, Exception> {
+pub fn microsecond(interp: &mut Artichoke, time: Value) -> Result<Value, Exception> {
     let time = unsafe { Time::try_from_ruby(interp, &time) }.map_err(|_| {
         Fatal::new(
             interp,
@@ -108,7 +108,7 @@ pub fn microsecond(interp: &Artichoke, time: Value) -> Result<Value, Exception> 
     Ok(result)
 }
 
-pub fn weekday(interp: &Artichoke, time: Value) -> Result<Value, Exception> {
+pub fn weekday(interp: &mut Artichoke, time: Value) -> Result<Value, Exception> {
     let time = unsafe { Time::try_from_ruby(interp, &time) }.map_err(|_| {
         Fatal::new(
             interp,
@@ -122,7 +122,7 @@ pub fn weekday(interp: &Artichoke, time: Value) -> Result<Value, Exception> {
     Ok(result)
 }
 
-pub fn year_day(interp: &Artichoke, time: Value) -> Result<Value, Exception> {
+pub fn year_day(interp: &mut Artichoke, time: Value) -> Result<Value, Exception> {
     let time = unsafe { Time::try_from_ruby(interp, &time) }.map_err(|_| {
         Fatal::new(
             interp,
@@ -136,7 +136,7 @@ pub fn year_day(interp: &Artichoke, time: Value) -> Result<Value, Exception> {
     Ok(result)
 }
 
-pub fn year(interp: &Artichoke, time: Value) -> Result<Value, Exception> {
+pub fn year(interp: &mut Artichoke, time: Value) -> Result<Value, Exception> {
     let time = unsafe { Time::try_from_ruby(interp, &time) }.map_err(|_| {
         Fatal::new(
             interp,

--- a/artichoke-backend/src/extn/core/warning/mod.rs
+++ b/artichoke-backend/src/extn/core/warning/mod.rs
@@ -1,12 +1,12 @@
 use crate::extn::prelude::*;
 
-pub fn init(interp: &Artichoke) -> InitializeResult<()> {
-    if interp.0.borrow().module_spec::<Warning>().is_some() {
+pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
+    if interp.state().module_spec::<Warning>().is_some() {
         return Ok(());
     }
     let spec = module::Spec::new("Warning", None)?;
     module::Builder::for_spec(interp, &spec).define()?;
-    interp.0.borrow_mut().def_module::<Warning>(spec);
+    interp.state_mut().def_module::<Warning>(spec);
     let _ = interp.eval(&include_bytes!("warning.rb")[..])?;
     trace!("Patched Warning onto interpreter");
     Ok(())

--- a/artichoke-backend/src/extn/core/warning/mod.rs
+++ b/artichoke-backend/src/extn/core/warning/mod.rs
@@ -4,7 +4,7 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     if interp.state().module_spec::<Warning>().is_some() {
         return Ok(());
     }
-    let spec = module::Spec::new("Warning", None)?;
+    let spec = module::Spec::new(interp, "Warning", None)?;
     module::Builder::for_spec(interp, &spec).define()?;
     interp.state_mut().def_module::<Warning>(spec);
     let _ = interp.eval(&include_bytes!("warning.rb")[..])?;

--- a/artichoke-backend/src/extn/mod.rs
+++ b/artichoke-backend/src/extn/mod.rs
@@ -22,7 +22,7 @@ pub const INPUT_RECORD_SEPARATOR: &str = "\n";
 
 macro_rules! global_const {
     ($interp:expr, $constant:ident) => {{
-        let mrb = $interp.0.borrow().mrb;
+        let mrb = $interp.mrb_mut();
         unsafe {
             sys::mrb_define_global_const(
                 mrb,
@@ -32,7 +32,7 @@ macro_rules! global_const {
         }
     }};
     ($interp:expr, $constant:ident, $value:expr) => {{
-        let mrb = $interp.0.borrow().mrb;
+        let mrb = $interp.mrb_mut();
         unsafe {
             sys::mrb_define_global_const(
                 mrb,
@@ -42,7 +42,7 @@ macro_rules! global_const {
         }
     }};
     ($interp:expr, $constant:ident as Int) => {{
-        let mrb = $interp.0.borrow().mrb;
+        let mrb = $interp.mrb_mut();
         let constant = $constant.parse::<Int>().map_err(|_| ArtichokeError::New)?;
         unsafe {
             sys::mrb_define_global_const(
@@ -54,7 +54,7 @@ macro_rules! global_const {
     }};
 }
 
-pub fn init(interp: &Artichoke, backend_name: &str) -> InitializeResult<()> {
+pub fn init(interp: &mut Artichoke, backend_name: &str) -> InitializeResult<()> {
     let engine_name = format!("{}-{}", interp.convert(RUBY_ENGINE), backend_name);
     global_const!(interp, RUBY_COPYRIGHT);
     global_const!(interp, RUBY_DESCRIPTION);

--- a/artichoke-backend/src/extn/mod.rs
+++ b/artichoke-backend/src/extn/mod.rs
@@ -55,7 +55,7 @@ macro_rules! global_const {
 }
 
 pub fn init(interp: &mut Artichoke, backend_name: &str) -> InitializeResult<()> {
-    let engine_name = format!("{}-{}", interp.convert(RUBY_ENGINE), backend_name);
+    let engine_name = format!("{}-{}", RUBY_ENGINE, backend_name);
     global_const!(interp, RUBY_COPYRIGHT);
     global_const!(interp, RUBY_DESCRIPTION);
     global_const!(interp, RUBY_ENGINE, engine_name);

--- a/artichoke-backend/src/extn/prelude.rs
+++ b/artichoke-backend/src/extn/prelude.rs
@@ -16,6 +16,7 @@ pub use crate::convert::{Convert, RustBackedValue, TryConvert};
 pub use crate::def::{self, EnclosingRubyScope};
 pub use crate::exception::{self, Exception, RubyException};
 pub use crate::extn::core::exception::*;
+pub use crate::ffi;
 pub use crate::module;
 pub use crate::sys;
 pub use crate::types::{Float, Int, Ruby};

--- a/artichoke-backend/src/extn/stdlib/abbrev.rs
+++ b/artichoke-backend/src/extn/stdlib/abbrev.rs
@@ -1,8 +1,8 @@
 use crate::extn::prelude::*;
 
-pub fn init(interp: &Artichoke) -> InitializeResult<()> {
+pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     let spec = module::Spec::new("Abbrev", None)?;
-    interp.0.borrow_mut().def_module::<Abbrev>(spec);
+    interp.state_mut().def_module::<Abbrev>(spec);
     interp.def_rb_source_file(b"abbrev.rb", &include_bytes!("abbrev.rb")[..])?;
     Ok(())
 }

--- a/artichoke-backend/src/extn/stdlib/abbrev.rs
+++ b/artichoke-backend/src/extn/stdlib/abbrev.rs
@@ -1,7 +1,7 @@
 use crate::extn::prelude::*;
 
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
-    let spec = module::Spec::new("Abbrev", None)?;
+    let spec = module::Spec::new(interp, "Abbrev", None)?;
     interp.state_mut().def_module::<Abbrev>(spec);
     interp.def_rb_source_file(b"abbrev.rb", &include_bytes!("abbrev.rb")[..])?;
     Ok(())

--- a/artichoke-backend/src/extn/stdlib/delegate.rs
+++ b/artichoke-backend/src/extn/stdlib/delegate.rs
@@ -1,10 +1,10 @@
 use crate::extn::prelude::*;
 
-pub fn init(interp: &Artichoke) -> InitializeResult<()> {
+pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     let spec = class::Spec::new("Delegator", None, None)?;
-    interp.0.borrow_mut().def_class::<Delegator>(spec);
+    interp.state_mut().def_class::<Delegator>(spec);
     let spec = class::Spec::new("SimpleDelegator", None, None)?;
-    interp.0.borrow_mut().def_class::<SimpleDelegator>(spec);
+    interp.state_mut().def_class::<SimpleDelegator>(spec);
     interp.def_rb_source_file(b"delegate.rb", &include_bytes!("delegate.rb")[..])?;
     Ok(())
 }

--- a/artichoke-backend/src/extn/stdlib/forwardable.rs
+++ b/artichoke-backend/src/extn/stdlib/forwardable.rs
@@ -1,7 +1,7 @@
 use crate::extn::prelude::*;
 
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
-    let spec = module::Spec::new("Forwardable", None)?;
+    let spec = module::Spec::new(interp, "Forwardable", None)?;
     interp.state_mut().def_module::<Forwardable>(spec);
     interp.def_rb_source_file(b"forwardable.rb", &include_bytes!("forwardable.rb")[..])?;
     interp.def_rb_source_file(

--- a/artichoke-backend/src/extn/stdlib/forwardable.rs
+++ b/artichoke-backend/src/extn/stdlib/forwardable.rs
@@ -1,8 +1,8 @@
 use crate::extn::prelude::*;
 
-pub fn init(interp: &Artichoke) -> InitializeResult<()> {
+pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     let spec = module::Spec::new("Forwardable", None)?;
-    interp.0.borrow_mut().def_module::<Forwardable>(spec);
+    interp.state_mut().def_module::<Forwardable>(spec);
     interp.def_rb_source_file(b"forwardable.rb", &include_bytes!("forwardable.rb")[..])?;
     interp.def_rb_source_file(
         b"forwardable/impl.rb",

--- a/artichoke-backend/src/extn/stdlib/json.rs
+++ b/artichoke-backend/src/extn/stdlib/json.rs
@@ -1,6 +1,6 @@
 use crate::extn::prelude::*;
 
-pub fn init(interp: &Artichoke) -> InitializeResult<()> {
+pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     interp.def_rb_source_file(b"json.rb", &include_bytes!("json.rb")[..])?;
     interp.def_rb_source_file(b"json/common.rb", &include_bytes!("json/common.rb")[..])?;
     interp.def_rb_source_file(

--- a/artichoke-backend/src/extn/stdlib/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/mod.rs
@@ -9,7 +9,7 @@ pub mod ostruct;
 pub mod set;
 pub mod strscan;
 
-pub fn init(interp: &Artichoke) -> InitializeResult<()> {
+pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     abbrev::init(interp)?;
     delegate::init(interp)?;
     forwardable::init(interp)?;

--- a/artichoke-backend/src/extn/stdlib/monitor.rs
+++ b/artichoke-backend/src/extn/stdlib/monitor.rs
@@ -1,8 +1,8 @@
 use crate::extn::prelude::*;
 
-pub fn init(interp: &Artichoke) -> InitializeResult<()> {
+pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     let spec = class::Spec::new("Monitor", None, None)?;
-    interp.0.borrow_mut().def_class::<Monitor>(spec);
+    interp.state_mut().def_class::<Monitor>(spec);
     interp.def_rb_source_file(b"monitor.rb", &include_bytes!("monitor.rb")[..])?;
     Ok(())
 }

--- a/artichoke-backend/src/extn/stdlib/ostruct.rs
+++ b/artichoke-backend/src/extn/stdlib/ostruct.rs
@@ -1,8 +1,8 @@
 use crate::extn::prelude::*;
 
-pub fn init(interp: &Artichoke) -> InitializeResult<()> {
+pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     let spec = class::Spec::new("OpenStruct", None, None)?;
-    interp.0.borrow_mut().def_class::<OpenStruct>(spec);
+    interp.state_mut().def_class::<OpenStruct>(spec);
     interp.def_rb_source_file(b"ostruct.rb", &include_bytes!("ostruct.rb")[..])?;
     Ok(())
 }

--- a/artichoke-backend/src/extn/stdlib/set.rs
+++ b/artichoke-backend/src/extn/stdlib/set.rs
@@ -1,10 +1,10 @@
 use crate::extn::prelude::*;
 
-pub fn init(interp: &Artichoke) -> InitializeResult<()> {
+pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     let spec = class::Spec::new("Set", None, None)?;
-    interp.0.borrow_mut().def_class::<Set>(spec);
+    interp.state_mut().def_class::<Set>(spec);
     let spec = class::Spec::new("SortedSet", None, None)?;
-    interp.0.borrow_mut().def_class::<SortedSet>(spec);
+    interp.state_mut().def_class::<SortedSet>(spec);
     interp.def_rb_source_file(b"set.rb", &include_bytes!("set.rb")[..])?;
     Ok(())
 }

--- a/artichoke-backend/src/extn/stdlib/strscan.rs
+++ b/artichoke-backend/src/extn/stdlib/strscan.rs
@@ -1,8 +1,8 @@
 use crate::extn::prelude::*;
 
-pub fn init(interp: &Artichoke) -> InitializeResult<()> {
+pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     let spec = class::Spec::new("StringScanner", None, None)?;
-    interp.0.borrow_mut().def_class::<StringScanner>(spec);
+    interp.state_mut().def_class::<StringScanner>(spec);
     interp.def_rb_source_file(b"strscan.rb", &include_bytes!("strscan.rb")[..])?;
     Ok(())
 }

--- a/artichoke-backend/src/ffi.rs
+++ b/artichoke-backend/src/ffi.rs
@@ -7,6 +7,7 @@ use std::ptr::{self, NonNull};
 
 use crate::state::State;
 use crate::sys::{self, DescribeState};
+use crate::value::Value;
 use crate::{Artichoke, ArtichokeError};
 
 /// Extract an [`Artichoke`] interpreter from the user data pointer on a
@@ -45,6 +46,11 @@ pub fn from_user_data(mrb: *mut sys::mrb_state) -> Result<Artichoke, ArtichokeEr
         unsafe { mrb.as_ref().debug() }
     );
     Ok(Artichoke { state, mrb })
+}
+
+pub unsafe fn return_into_vm(interp: Artichoke, value: Value) -> sys::mrb_value {
+    interp.into_user_data();
+    value.inner()
 }
 
 #[cfg(test)]

--- a/artichoke-backend/src/ffi.rs
+++ b/artichoke-backend/src/ffi.rs
@@ -2,7 +2,7 @@
 //!
 //! These functions are unsafe. Use them carefully.
 
-use std::mem::{self, ManuallyDrop};
+use std::mem;
 use std::ptr::{self, NonNull};
 
 use crate::state::State;
@@ -40,12 +40,12 @@ pub fn from_user_data(mrb: *mut sys::mrb_state) -> Result<Artichoke, ArtichokeEr
     // Extract the boxed `State` that wraps the API from the user data on the
     // `mrb_state`. This moves ownership of the user data pointer out of the
     // `mrb_state` into the returned `Artichoke`.
-    let state = ManuallyDrop::new(unsafe { Box::from_raw(userdata.as_ptr()) });
+    let state = unsafe { Box::from_raw(userdata.as_ptr()) };
     trace!(
         "Extracted Artichoke State from user data pointer on {}",
         unsafe { mrb.as_ref().debug() }
     );
-    Ok(Artichoke { state, mrb })
+    Ok(Artichoke::new(mrb, state))
 }
 
 pub unsafe fn return_into_vm(interp: Artichoke, value: Value) -> sys::mrb_value {

--- a/artichoke-backend/src/interpreter.rs
+++ b/artichoke-backend/src/interpreter.rs
@@ -1,5 +1,4 @@
 use artichoke_core::eval::Eval;
-use std::mem::ManuallyDrop;
 use std::ptr::NonNull;
 
 use crate::extn;
@@ -24,9 +23,9 @@ pub fn interpreter() -> Result<Artichoke, BootError> {
     };
 
     let context = unsafe { sys::mrbc_context_new(mrb.as_mut()) };
-    let state = ManuallyDrop::new(Box::new(State::new(context, vfs)));
+    let state = Box::new(State::new(context, vfs));
 
-    let mut interp = Artichoke { state, mrb };
+    let mut interp = Artichoke::new(mrb, state);
 
     // mruby garbage collection relies on a fully initialized Array, which we
     // won't have until after `extn::core` is initialized. Disable GC before

--- a/artichoke-backend/src/lib.rs
+++ b/artichoke-backend/src/lib.rs
@@ -171,6 +171,10 @@ impl Artichoke {
         self.state.vfs_mut()
     }
 
+    pub fn regexp_last_evaluation_captures_mut(&mut self) -> &mut usize {
+        self.state.regexp_last_evaluation_captures_mut()
+    }
+
     pub fn mrb_mut(&mut self) -> &mut sys::mrb_state {
         self.mrb.as_mut()
     }

--- a/artichoke-backend/src/lib.rs
+++ b/artichoke-backend/src/lib.rs
@@ -184,6 +184,21 @@ impl Artichoke {
         }
     }
 
+    pub fn try_get_value_from_data<T, R>(
+        &mut self,
+        value: sys::mrb_value,
+    ) -> Result<*const R, ArtichokeError>
+    where
+        T: RustBackedValue,
+    {
+        if let Some(ref mut state) = self.state {
+            let mrb = unsafe { self.mrb.as_mut() };
+            state.try_get_value_from_data::<T, R>(mrb, value)
+        } else {
+            panic!("Artichoke::alloc called with uninitialized State");
+        }
+    }
+
     pub fn state(&self) -> &State {
         if let Some(ref state) = self.state {
             state.as_ref()

--- a/artichoke-backend/src/lib.rs
+++ b/artichoke-backend/src/lib.rs
@@ -138,7 +138,7 @@ use crate::exception::Exception;
 ///
 /// Functionality is added to the interpreter via traits, for example,
 /// [garbage collection](gc::MrbGarbageCollection) or [eval](eval::Eval).
-#[derive(Debug, Clone)]
+// TODO: impl Debug
 pub struct Artichoke {
     state: Box<State>,
     mrb: NonNull<sys::mrb_state>,

--- a/artichoke-backend/src/lib.rs
+++ b/artichoke-backend/src/lib.rs
@@ -184,20 +184,14 @@ impl Artichoke {
     where
         T: Into<Cow<'static, [u8]>>,
     {
-        self.state.sym_intern(self, sym)
+        let mrb = unsafe { self.mrb.as_mut() };
+        self.state.sym_intern(mrb, sym)
     }
 
     pub unsafe fn into_user_data(mut self) -> *mut sys::mrb_state {
+        let state = Box::into_raw(ManuallyDrop::into_inner(self.state));
+        self.mrb.as_mut().ud = state as *mut std::ffi::c_void;
         self.mrb.as_ptr()
-    }
-}
-
-impl Drop for Artichoke {
-    fn drop(&mut self) {
-        let state = Box::into_raw(*self.state);
-        unsafe {
-            self.mrb.as_mut().ud = state as *mut std::ffi::c_void;
-        }
     }
 }
 

--- a/artichoke-backend/src/method.rs
+++ b/artichoke-backend/src/method.rs
@@ -72,10 +72,10 @@ impl Spec {
     /// object.
     pub unsafe fn define(
         &self,
-        interp: &Artichoke,
+        interp: &mut Artichoke,
         into: *mut sys::RClass,
     ) -> Result<(), ArtichokeError> {
-        let mrb = interp.0.borrow().mrb;
+        let mrb = interp.mrb_mut();
         match self.method_type {
             Type::Class => sys::mrb_define_class_method(
                 mrb,

--- a/artichoke-backend/src/module.rs
+++ b/artichoke-backend/src/module.rs
@@ -12,15 +12,14 @@ use crate::sys;
 use crate::value::Value;
 use crate::{Artichoke, ArtichokeError};
 
-#[derive(Clone)]
 pub struct Builder<'a> {
-    interp: &'a Artichoke,
+    interp: &'a mut Artichoke,
     spec: &'a Spec,
     methods: HashSet<method::Spec>,
 }
 
 impl<'a> Builder<'a> {
-    pub fn for_spec(interp: &'a Artichoke, spec: &'a Spec) -> Self {
+    pub fn for_spec(interp: &'a mut Artichoke, spec: &'a Spec) -> Self {
         Self {
             interp,
             spec,

--- a/artichoke-backend/src/state.rs
+++ b/artichoke-backend/src/state.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "artichoke-random")]
+use rand::rngs::SmallRng;
 use std::any::{Any, TypeId};
 use std::borrow::Cow;
 use std::collections::HashMap;
@@ -7,7 +9,7 @@ use std::ptr::NonNull;
 use crate::class;
 use crate::eval::Context;
 #[cfg(feature = "artichoke-random")]
-use crate::extn::core::random::Random;
+use crate::extn::core::random::backend::rand::Rand;
 use crate::fs::Filesystem;
 use crate::module;
 use crate::sys;
@@ -24,7 +26,7 @@ pub struct State {
     symbol_cache: HashMap<Cow<'static, [u8]>, sys::mrb_sym>,
     captured_output: Option<Vec<u8>>,
     #[cfg(feature = "artichoke-random")]
-    prng: Random,
+    prng: Rand<SmallRng>,
 }
 
 impl State {
@@ -42,18 +44,18 @@ impl State {
             symbol_cache: HashMap::default(),
             captured_output: None,
             #[cfg(feature = "artichoke-random")]
-            prng: Random::default(),
+            prng: Rand::new(None),
         }
     }
 
     #[cfg(feature = "artichoke-random")]
     #[must_use]
-    pub fn prng(&self) -> &Random {
+    pub fn prng(&self) -> &Rand<SmallRng> {
         &self.prng
     }
 
     #[cfg(feature = "artichoke-random")]
-    pub fn prng_mut(&mut self) -> &mut Random {
+    pub fn prng_mut(&mut self) -> &mut Rand<SmallRng> {
         &mut self.prng
     }
 

--- a/artichoke-backend/src/state.rs
+++ b/artichoke-backend/src/state.rs
@@ -17,8 +17,8 @@ pub struct State {
     classes: HashMap<TypeId, Box<class::Spec>>,
     modules: HashMap<TypeId, Box<module::Spec>>,
     vfs: Filesystem,
+    regexp_last_evaluation_captures: usize,
     pub(crate) context_stack: Vec<Context>,
-    pub active_regexp_globals: usize,
     symbol_cache: HashMap<Cow<'static, [u8]>, sys::mrb_sym>,
     captured_output: Option<Vec<u8>>,
     #[cfg(feature = "artichoke-random")]
@@ -35,8 +35,8 @@ impl State {
             classes: HashMap::default(),
             modules: HashMap::default(),
             vfs,
+            regexp_last_evaluation_captures: 0,
             context_stack: vec![],
-            active_regexp_globals: 0,
             symbol_cache: HashMap::default(),
             captured_output: None,
             #[cfg(feature = "artichoke-random")]
@@ -61,6 +61,10 @@ impl State {
 
     pub fn vfs_mut(&mut self) -> &mut Filesystem {
         &mut self.vfs
+    }
+
+    pub fn regexp_last_evaluation_captures_mut(&mut self) -> &mut usize {
+        &mut self.regexp_last_evaluation_captures
     }
 
     pub fn capture_output(&mut self) {

--- a/artichoke-backend/src/state.rs
+++ b/artichoke-backend/src/state.rs
@@ -6,6 +6,8 @@ use std::ptr::NonNull;
 
 use crate::class;
 use crate::eval::Context;
+#[cfg(feature = "artichoke-random")]
+use crate::extn::core::random::Random;
 use crate::fs::Filesystem;
 use crate::module;
 use crate::sys;
@@ -22,7 +24,7 @@ pub struct State {
     symbol_cache: HashMap<Cow<'static, [u8]>, sys::mrb_sym>,
     captured_output: Option<Vec<u8>>,
     #[cfg(feature = "artichoke-random")]
-    prng: crate::extn::core::random::Random,
+    prng: Random,
 }
 
 impl State {
@@ -40,18 +42,18 @@ impl State {
             symbol_cache: HashMap::default(),
             captured_output: None,
             #[cfg(feature = "artichoke-random")]
-            prng: crate::extn::core::random::new(None),
+            prng: Random::default(),
         }
     }
 
     #[cfg(feature = "artichoke-random")]
     #[must_use]
-    pub fn prng(&self) -> &crate::extn::core::random::Random {
+    pub fn prng(&self) -> &Random {
         &self.prng
     }
 
     #[cfg(feature = "artichoke-random")]
-    pub fn prng_mut(&mut self) -> &mut crate::extn::core::random::Random {
+    pub fn prng_mut(&mut self) -> &mut Random {
         &mut self.prng
     }
 

--- a/artichoke-backend/src/state.rs
+++ b/artichoke-backend/src/state.rs
@@ -1,23 +1,22 @@
 use std::any::{Any, TypeId};
 use std::borrow::Cow;
 use std::collections::HashMap;
-use std::fmt;
 use std::io::{self, Write};
+use std::ptr::NonNull;
 
 use crate::class;
 use crate::eval::Context;
 use crate::fs::Filesystem;
 use crate::module;
-use crate::sys::{self, DescribeState};
+use crate::sys;
 
 // NOTE: ArtichokeState assumes that it it is stored in `mrb_state->ud` wrapped in a
 // [`Rc`] with type [`Artichoke`] as created by [`crate::interpreter`].
 pub struct State {
-    pub mrb: *mut sys::mrb_state,
     pub ctx: *mut sys::mrbc_context,
     classes: HashMap<TypeId, Box<class::Spec>>,
     modules: HashMap<TypeId, Box<module::Spec>>,
-    pub vfs: Filesystem,
+    vfs: Filesystem,
     pub(crate) context_stack: Vec<Context>,
     pub active_regexp_globals: usize,
     symbol_cache: HashMap<Cow<'static, [u8]>, sys::mrb_sym>,
@@ -30,9 +29,8 @@ impl State {
     /// Create a new [`State`] from a [`sys::mrb_state`] and
     /// [`sys::mrbc_context`] with an
     /// [in memory virtual filesystem](Filesystem).
-    pub fn new(mrb: *mut sys::mrb_state, ctx: *mut sys::mrbc_context, vfs: Filesystem) -> Self {
+    pub fn new(ctx: *mut sys::mrbc_context, vfs: Filesystem) -> Self {
         Self {
-            mrb,
             ctx,
             classes: HashMap::default(),
             modules: HashMap::default(),
@@ -55,6 +53,14 @@ impl State {
     #[cfg(feature = "artichoke-random")]
     pub fn prng_mut(&mut self) -> &mut crate::extn::core::random::Random {
         &mut self.prng
+    }
+
+    pub fn vfs(&self) -> &Filesystem {
+        &self.vfs
+    }
+
+    pub fn vfs_mut(&mut self) -> &mut Filesystem {
+        &mut self.vfs
     }
 
     pub fn capture_output(&mut self) {
@@ -88,36 +94,10 @@ impl State {
     }
 
     /// Close a [`State`] and free underlying mruby structs and memory.
-    pub fn close(&mut self) {
+    pub fn close(&mut self, mrb: &mut NonNull<sys::mrb_state>) {
         unsafe {
-            // At this point, the only refs to the smart poitner wrapping the
-            // state are stored in the `mrb_state->ud` pointer and any
-            // `MRB_TT_DATA` objects in the mruby heap.
-            //
-            // To clean up:
-            //
-            // - Save the raw pointer to the `Artichoke` from the user data.
-            // - Free the mrb context.
-            // - Close the interpreter which frees every object in the heap and
-            //   drops the strong count on the Rc to 1.
-            // - Rematerialize the `Rc`.
-            // - Drop the `Rc` which drops the strong count to 0 and frees the
-            //   state.
-            // - Set the userdata pointer to null.
-            // - Set context and mrb properties to null.
-            if self.mrb.is_null() {
-                return;
-            }
-            let ptr = (*self.mrb).ud;
-            if ptr.is_null() {
-                return;
-            }
             // Free mrb data structures
-            sys::mrbc_context_free(self.mrb, self.ctx);
-            sys::mrb_close(self.mrb);
-            // Cleanup dangling pointers
-            self.ctx = std::ptr::null_mut();
-            self.mrb = std::ptr::null_mut();
+            sys::mrbc_context_free(mrb.as_mut(), self.ctx);
         };
     }
 
@@ -164,11 +144,10 @@ impl State {
         self.modules.get(&TypeId::of::<T>()).map(Box::as_ref)
     }
 
-    pub fn sym_intern<T>(&mut self, sym: T) -> sys::mrb_sym
+    pub fn sym_intern<T>(&mut self, mrb: &mut sys::mrb_state, sym: T) -> sys::mrb_sym
     where
         T: Into<Cow<'static, [u8]>>,
     {
-        let mrb = self.mrb;
         let sym = sym.into();
         let ptr = sym.as_ref().as_ptr();
         let len = sym.as_ref().len();
@@ -177,17 +156,5 @@ impl State {
             .entry(sym)
             .or_insert_with(|| unsafe { sys::mrb_intern_static(mrb, ptr as *const i8, len) });
         *interned
-    }
-}
-
-impl fmt::Debug for State {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.mrb.debug())
-    }
-}
-
-impl fmt::Display for State {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.mrb.info())
     }
 }

--- a/artichoke-backend/src/state.rs
+++ b/artichoke-backend/src/state.rs
@@ -11,7 +11,6 @@ use crate::extn::core::random::Random;
 use crate::fs::Filesystem;
 use crate::module;
 use crate::sys;
-use crate::Artichoke;
 
 // NOTE: ArtichokeState assumes that it it is stored in `mrb_state->ud` wrapped in a
 // [`Rc`] with type [`Artichoke`] as created by [`crate::interpreter`].
@@ -151,16 +150,17 @@ impl State {
         self.modules.get(&TypeId::of::<T>()).map(Box::as_ref)
     }
 
-    pub fn sym_intern<T>(&mut self, interp: &mut Artichoke, sym: T) -> sys::mrb_sym
+    pub fn sym_intern<T>(&mut self, mrb: &mut sys::mrb_state, sym: T) -> sys::mrb_sym
     where
         T: Into<Cow<'static, [u8]>>,
     {
         let sym = sym.into();
         let ptr = sym.as_ref().as_ptr();
         let len = sym.as_ref().len();
-        let interned = self.symbol_cache.entry(sym).or_insert_with(|| unsafe {
-            sys::mrb_intern_static(interp.mrb_mut(), ptr as *const i8, len)
-        });
+        let interned = self
+            .symbol_cache
+            .entry(sym)
+            .or_insert_with(|| unsafe { sys::mrb_intern_static(mrb, ptr as *const i8, len) });
         *interned
     }
 }

--- a/artichoke-backend/src/sys/mod.rs
+++ b/artichoke-backend/src/sys/mod.rs
@@ -103,6 +103,50 @@ impl DescribeState for *mut mrb_state {
     }
 }
 
+impl DescribeState for &mrb_state {
+    fn info(&self) -> String {
+        format!("{}", unsafe { &**self })
+    }
+
+    fn debug(&self) -> String {
+        format!("{:?}", unsafe { &**self })
+    }
+
+    fn version(&self) -> String {
+        // Using the unchecked function is safe because these values are C constants
+        let version = unsafe { CStr::from_bytes_with_nul_unchecked(MRUBY_RUBY_VERSION) };
+        format!(
+            "{} (v{}.{}.{})",
+            version.to_string_lossy(),
+            MRUBY_RELEASE_MAJOR,
+            MRUBY_RELEASE_MINOR,
+            MRUBY_RELEASE_TEENY,
+        )
+    }
+}
+
+impl DescribeState for &mut mrb_state {
+    fn info(&self) -> String {
+        format!("{}", unsafe { &**self })
+    }
+
+    fn debug(&self) -> String {
+        format!("{:?}", unsafe { &**self })
+    }
+
+    fn version(&self) -> String {
+        // Using the unchecked function is safe because these values are C constants
+        let version = unsafe { CStr::from_bytes_with_nul_unchecked(MRUBY_RUBY_VERSION) };
+        format!(
+            "{} (v{}.{}.{})",
+            version.to_string_lossy(),
+            MRUBY_RELEASE_MAJOR,
+            MRUBY_RELEASE_MINOR,
+            MRUBY_RELEASE_TEENY,
+        )
+    }
+}
+
 impl fmt::Debug for mrb_state {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         // Using the unchecked function is safe because these values are C constants

--- a/artichoke-backend/src/sys/mod.rs
+++ b/artichoke-backend/src/sys/mod.rs
@@ -105,11 +105,11 @@ impl DescribeState for *mut mrb_state {
 
 impl DescribeState for &mrb_state {
     fn info(&self) -> String {
-        format!("{}", unsafe { &**self })
+        format!("{}", &**self)
     }
 
     fn debug(&self) -> String {
-        format!("{:?}", unsafe { &**self })
+        format!("{:?}", &**self)
     }
 
     fn version(&self) -> String {
@@ -127,11 +127,11 @@ impl DescribeState for &mrb_state {
 
 impl DescribeState for &mut mrb_state {
     fn info(&self) -> String {
-        format!("{}", unsafe { &**self })
+        format!("{}", &**self)
     }
 
     fn debug(&self) -> String {
-        format!("{:?}", unsafe { &**self })
+        format!("{:?}", &**self)
     }
 
     fn version(&self) -> String {

--- a/artichoke-backend/src/top_self.rs
+++ b/artichoke-backend/src/top_self.rs
@@ -8,7 +8,7 @@ impl TopSelf for Artichoke {
     type Value = Value;
 
     fn top_self(&mut self) -> Value {
-        let mrb = self.mrb_mut();
-        Value::new(self, unsafe { sys::mrb_top_self(mrb) })
+        let top = unsafe { sys::mrb_top_self(self.mrb_mut()) };
+        Value::new(self, top)
     }
 }

--- a/artichoke-backend/src/top_self.rs
+++ b/artichoke-backend/src/top_self.rs
@@ -7,8 +7,8 @@ use crate::Artichoke;
 impl TopSelf for Artichoke {
     type Value = Value;
 
-    fn top_self(&self) -> Value {
-        let mrb = self.0.borrow().mrb;
+    fn top_self(&mut self) -> Value {
+        let mrb = self.mrb_mut();
         Value::new(self, unsafe { sys::mrb_top_self(mrb) })
     }
 }

--- a/artichoke-backend/src/value.rs
+++ b/artichoke-backend/src/value.rs
@@ -258,12 +258,14 @@ impl ValueLike for Value {
             );
             let mut state = mem::MaybeUninit::<sys::mrb_bool>::uninit();
 
+            interp.deinitialize_to_cross_into_ffi_boundary();
             let value = sys::mrb_protect(
                 interp.mrb_mut(),
                 Some(Protect::run),
                 data,
                 state.as_mut_ptr(),
             );
+            interp.reinitialize_to_return_from_ffi_boundary();
             if state.assume_init() != 0 {
                 interp.mrb_mut().exc = sys::mrb_sys_obj_ptr(value);
             }

--- a/artichoke-backend/src/value.rs
+++ b/artichoke-backend/src/value.rs
@@ -341,7 +341,7 @@ impl ValueLike for Value {
 }
 
 impl Convert<Value, Value> for Artichoke {
-    fn convert(&self, value: Value) -> Value {
+    fn convert(&mut self, value: Value) -> Value {
         value
     }
 }

--- a/artichoke-backend/src/warn.rs
+++ b/artichoke-backend/src/warn.rs
@@ -21,7 +21,8 @@ impl Warn for Artichoke {
                 .ok_or_else(|| {
                     ArtichokeError::NotDefined(Cow::Borrowed("Warn with uninitialized Warning"))
                 })
-                .map_err(|err| RuntimeError::new(self, format!("{}", err)))?;
+                .map_err(|err| RuntimeError::new(self, format!("{}", err)))?
+                .clone();
             spec.value(self)
                 .ok_or_else(|| {
                     ArtichokeError::NotDefined(Cow::Borrowed("Warn with uninitialized Warning"))

--- a/artichoke-backend/src/warn.rs
+++ b/artichoke-backend/src/warn.rs
@@ -28,7 +28,8 @@ impl Warn for Artichoke {
                 })
                 .map_err(|err| RuntimeError::new(self, format!("{}", err)))?
         };
-        let _ = warning.funcall::<Value>(self, "warn", &[self.convert(message)], None)?;
+        let funargs = &[self.convert(message)];
+        let _ = warning.funcall::<Value>(self, "warn", funargs, None)?;
         Ok(())
     }
 }

--- a/artichoke-backend/src/warn.rs
+++ b/artichoke-backend/src/warn.rs
@@ -12,11 +12,11 @@ use crate::{Artichoke, ArtichokeError};
 impl Warn for Artichoke {
     type Error = Exception;
 
-    fn warn(&self, message: &[u8]) -> Result<(), Self::Error> {
+    fn warn(&mut self, message: &[u8]) -> Result<(), Self::Error> {
         warn!("rb warning: {}", String::from_utf8_lossy(message));
         let warning = {
-            let borrow = self.0.borrow();
-            let spec = borrow
+            let spec = self
+                .state()
                 .module_spec::<Warning>()
                 .ok_or_else(|| {
                     ArtichokeError::NotDefined(Cow::Borrowed("Warn with uninitialized Warning"))
@@ -28,7 +28,7 @@ impl Warn for Artichoke {
                 })
                 .map_err(|err| RuntimeError::new(self, format!("{}", err)))?
         };
-        let _ = warning.funcall::<Value>("warn", &[self.convert(message)], None)?;
+        let _ = warning.funcall::<Value>(self, "warn", &[self.convert(message)], None)?;
         Ok(())
     }
 }

--- a/artichoke-core/src/convert.rs
+++ b/artichoke-core/src/convert.rs
@@ -7,7 +7,7 @@ use crate::ArtichokeError;
 /// See [`std::convert::From`].
 pub trait Convert<T, U> {
     /// Performs the infallible conversion.
-    fn convert(&self, from: T) -> U;
+    fn convert(&mut self, from: T) -> U;
 }
 
 /// Fallible conversions between two types.
@@ -16,7 +16,7 @@ pub trait Convert<T, U> {
 #[allow(clippy::module_name_repetitions)]
 pub trait TryConvert<T, U> {
     /// Performs the fallible conversion.
-    fn try_convert(&self, value: T) -> Result<U, ArtichokeError>;
+    fn try_convert(&mut self, value: T) -> Result<U, ArtichokeError>;
 }
 
 /// Provide a fallible converter for types that implement an infallible
@@ -25,7 +25,7 @@ impl<T, U, V> TryConvert<T, U> for V
 where
     V: Convert<T, U>,
 {
-    fn try_convert(&self, value: T) -> Result<U, ArtichokeError> {
+    fn try_convert(&mut self, value: T) -> Result<U, ArtichokeError> {
         Ok(Convert::convert(self, value))
     }
 }

--- a/artichoke-core/src/eval.rs
+++ b/artichoke-core/src/eval.rs
@@ -25,14 +25,14 @@ pub trait Eval {
     const TOP_FILENAME: &'static [u8] = b"(eval)";
 
     /// Eval code on the artichoke interpreter using the current `Context`.
-    fn eval(&self, code: &[u8]) -> Result<Self::Value, Self::Error>;
+    fn eval(&mut self, code: &[u8]) -> Result<Self::Value, Self::Error>;
 
     /// Peek at the top of the [`Context`] stack.
-    fn peek_context(&self) -> Option<Self::Context>;
+    fn peek_context(&self) -> Option<&Self::Context>;
 
     /// Push an `Context` onto the stack.
-    fn push_context(&self, context: Self::Context);
+    fn push_context(&mut self, context: Self::Context);
 
     /// Pop an `Context` from the stack.
-    fn pop_context(&self);
+    fn pop_context(&mut self);
 }

--- a/artichoke-core/src/load.rs
+++ b/artichoke-core/src/load.rs
@@ -20,7 +20,7 @@ pub trait LoadSources {
     /// filesystem relative to `RUBY_LOAD_PATH`. If the path is absolute, the
     /// file is placed directly on the filesystem. Anscestor directories are
     /// created automatically.
-    fn def_file_for_type<T>(&self, filename: &[u8]) -> Result<(), ArtichokeError>
+    fn def_file_for_type<T>(&mut self, filename: &[u8]) -> Result<(), ArtichokeError>
     where
         T: File<Artichoke = Self::Artichoke>;
 
@@ -30,7 +30,7 @@ pub trait LoadSources {
     /// filesystem relative to `RUBY_LOAD_PATH`. If the path is absolute, the
     /// file is placed directly on the filesystem. Anscestor directories are
     /// created automatically.
-    fn def_rb_source_file<T>(&self, filename: &[u8], contents: T) -> Result<(), ArtichokeError>
+    fn def_rb_source_file<T>(&mut self, filename: &[u8], contents: T) -> Result<(), ArtichokeError>
     where
         T: Into<Cow<'static, [u8]>>;
 }

--- a/artichoke-core/src/top_self.rs
+++ b/artichoke-core/src/top_self.rs
@@ -17,5 +17,5 @@ pub trait TopSelf {
     ///
     /// Top self is the root object that evaled code is executed within. Global
     /// methods, classes, and modules are defined in top self.
-    fn top_self(&self) -> Self::Value;
+    fn top_self(&mut self) -> Self::Value;
 }

--- a/artichoke-core/src/value.rs
+++ b/artichoke-core/src/value.rs
@@ -23,6 +23,7 @@ where
     /// Call a method on this [`Value`] with arguments and an optional block.
     fn funcall<T>(
         &self,
+        interp: &mut Self::Artichoke,
         func: &str,
         args: &[Self::Arg],
         block: Option<Self::Block>,
@@ -33,7 +34,7 @@ where
     /// Consume `self` and try to convert `self` to type `T`.
     ///
     /// If you do not want to consume this [`Value`], use [`Value::itself`].
-    fn try_into<T>(self) -> Result<T, ArtichokeError>
+    fn try_into<T>(self, interp: &mut Self::Artichoke) -> Result<T, ArtichokeError>
     where
         Self::Artichoke: TryConvert<Self, T>;
 
@@ -41,15 +42,15 @@ where
     /// `T`.
     ///
     /// If you want to consume this [`Value`], use [`Value::try_into`].
-    fn itself<T>(&self) -> Result<T, ArtichokeError>
+    fn itself<T>(&self, interp: &mut Self::Artichoke) -> Result<T, ArtichokeError>
     where
         Self::Artichoke: TryConvert<Self, T>;
 
     /// Call `#freeze` on this [`Value`].
-    fn freeze(&mut self) -> Result<(), Self::Error>;
+    fn freeze(&mut self, interp: &mut Self::Artichoke) -> Result<(), Self::Error>;
 
     /// Call `#frozen?` on this [`Value`].
-    fn is_frozen(&self) -> bool;
+    fn is_frozen(&self, interp: &mut Self::Artichoke) -> bool;
 
     /// Whether `self` is `nil`
     fn is_nil(&self) -> bool;
@@ -57,15 +58,15 @@ where
     /// Whether `self` responds to a method.
     ///
     /// Equivalent to invoking `#respond_to?` on this [`Value`].
-    fn respond_to(&self, method: &str) -> Result<bool, Self::Error>;
+    fn respond_to(&self, interp: &mut Self::Artichoke, method: &str) -> Result<bool, Self::Error>;
 
     /// Call `#inspect` on this [`Value`].
     ///
     /// This function can never fail.
-    fn inspect(&self) -> Vec<u8>;
+    fn inspect(&self, interp: &mut Self::Artichoke) -> Vec<u8>;
 
     /// Call `#to_s` on this [`Value`].
     ///
     /// This function can never fail.
-    fn to_s(&self) -> Vec<u8>;
+    fn to_s(&self, interp: &mut Self::Artichoke) -> Vec<u8>;
 }

--- a/artichoke-core/src/warn.rs
+++ b/artichoke-core/src/warn.rs
@@ -15,5 +15,5 @@ pub trait Warn {
     /// Emit a warning message using `Warning#warn`.
     ///
     /// This method appends newlines to message if necessary.
-    fn warn(&self, message: &[u8]) -> Result<(), Self::Error>;
+    fn warn(&mut self, message: &[u8]) -> Result<(), Self::Error>;
 }

--- a/artichoke-frontend/src/parser.rs
+++ b/artichoke-frontend/src/parser.rs
@@ -58,6 +58,7 @@ pub enum Error {
 }
 
 /// Wraps a [`artichoke_backend`] mruby parser.
+// TODO: this struct should hold references and be parameterized on a lifetime.
 pub struct Parser {
     parser: *mut sys::mrb_parser_state,
     context: *mut sys::mrbc_context,
@@ -66,10 +67,9 @@ pub struct Parser {
 impl Parser {
     /// Create a new parser from an interpreter instance.
     #[must_use]
-    pub fn new(interp: &Artichoke) -> Option<Self> {
-        let mrb = interp.0.borrow().mrb;
-        let context = interp.0.borrow().ctx;
-        let parser = unsafe { sys::mrb_parser_new(mrb) };
+    pub fn new(interp: &mut Artichoke) -> Option<Self> {
+        let context = interp.state().ctx;
+        let parser = unsafe { sys::mrb_parser_new(interp.mrb_mut()) };
         if parser.is_null() {
             None
         } else {

--- a/spec-runner/src/main.rs
+++ b/spec-runner/src/main.rs
@@ -38,14 +38,14 @@ use std::process;
 mod mspec;
 
 pub fn main() {
-    let interp = match artichoke_backend::interpreter() {
+    let mut interp = match artichoke_backend::interpreter() {
         Ok(interp) => interp,
         Err(err) => {
             eprintln!("{}", err);
             process::exit(1);
         }
     };
-    if let Err(err) = mspec::init(&interp) {
+    if let Err(err) = mspec::init(&mut interp) {
         eprintln!("{}", err);
         process::exit(1);
     };


### PR DESCRIPTION
This PR was an experiment and I do not intend to merge it.

This PR was born out of an attempt to implement a `Symbol` table in Rust and attach it to the inner `State` on the `Artichoke` interpreter. This turned out to be impossible (or at least extremely difficult). Most code that interacts with the `State` does not really pass borrowck, enabled by the State being wrapped in a `RefCell`. The worst offenders are APIs like `Class::rclass` which are accessed via a borrow on the `State` and take an `Artichoke`.

Thus, the goal was to get rid of the `Rc<RefCell<_>>` and get normal borrowing semantics.

To achieve this, the `Artichoke` type was rewritten to have two fields: a `NonNull<mrb_state>` and a `Box<State>`. This was mistake number one because I now had to rewrite all of artichoke-backend to deal with the covariants of the `mrb` member.

The `Box<State>` was moved in and out of the userdata pointer on the `mrb_state` when crossing over FFI boundaries. This mostly worked, but introduced lots of panicking pathways.

Borrowing rules with one big state meant that APIs had to be moved into the state to access local borrows while also using an `&mut mrb_state`. `RustBackedValue` was rewritten to be a veneer over calls to the `State`.

`Regexp` code is awful. It heavily relies on dropping down to the C API level of abstraction which made refactoring super tedious. The layout of the `MatchData` code with one file per trampoline also made refactoring tedious.

Positives include lots of unsafe code disappearing. The `NonNull` abstraction is really great.

All APIs that mutate interpreter state now take an interpreter!. This is much more explicit at the cost of some ergonomics (e.g. `Value::funcall`).

By virtue of touching every file in `extn` I discovered some opportunities to refactor, like using `implicitly_convert_to_int` or redesigning backend APIs to avoid dependencies on the interpreter. I'll try to extract some of these changes.

Ultimately, this PR failed because it tried to do too much. Similarly large PRs in lines of code (GH-311, GH-437) had singular purpose in migrating the error abstraction. This PR redesigned the state, rewrote `extn`, altered FFI semantics, and changed mutability requirements of nearly every API.