### PR TITLE
Convert some syntax in converters to preferred style

### DIFF
--- a/artichoke-backend/build.rs
+++ b/artichoke-backend/build.rs
@@ -569,7 +569,7 @@ mod release {
             );
         }
         let birth_date = String::from_utf8(birth_date.stdout).unwrap();
-        <DateTime<Utc>>::from(DateTime::parse_from_rfc2822(birth_date.trim()).expect("birth"))
+        DateTime::<Utc>::from(DateTime::parse_from_rfc2822(birth_date.trim()).expect("birth"))
     }
 
     fn revision_count() -> String {

--- a/artichoke-backend/src/convert/array.rs
+++ b/artichoke-backend/src/convert/array.rs
@@ -71,7 +71,7 @@ impl TryConvert<Value, Vec<Value>> for Artichoke {
                     from: Ruby::Array,
                     to: Rust::Vec,
                 })?;
-                let mut elems = <Vec<Value>>::with_capacity(capa);
+                let mut elems = Vec::<Value>::with_capacity(capa);
                 for idx in 0..size {
                     let elem = Value::new(self, unsafe { sys::mrb_ary_ref(mrb, array, idx) });
                     elems.push(elem);
@@ -118,7 +118,7 @@ macro_rules! ruby_to_array {
         impl<'a> TryConvert<Value, Vec<$elem>> for Artichoke {
             fn try_convert(&self, value: Value) -> Result<Vec<$elem>, ArtichokeError> {
                 let elems: Vec<Value> = self.try_convert(value)?;
-                let mut vec = <Vec<$elem>>::with_capacity(elems.len());
+                let mut vec = Vec::<$elem>::with_capacity(elems.len());
                 for elem in elems.into_iter() {
                     let elem = elem.try_into::<$elem>()?;
                     vec.push(elem);

--- a/artichoke-backend/src/convert/bytes.rs
+++ b/artichoke-backend/src/convert/bytes.rs
@@ -29,8 +29,7 @@ impl Convert<&[u8], Value> for Artichoke {
 
 impl TryConvert<Value, Vec<u8>> for Artichoke {
     fn try_convert(&self, value: Value) -> Result<Vec<u8>, ArtichokeError> {
-        let result: &[u8] = self.try_convert(value)?;
-        Ok(result.to_vec())
+        TryConvert::<_, &[u8]>::try_convert(self, value).map(<[_]>::to_vec)
     }
 }
 

--- a/artichoke-backend/src/convert/hash.rs
+++ b/artichoke-backend/src/convert/hash.rs
@@ -62,7 +62,7 @@ impl TryConvert<Value, Vec<(Value, Value)>> for Artichoke {
                             from: Ruby::Hash,
                             to: Rust::Map,
                         })?;
-                    let mut pairs = <Vec<(Value, Value)>>::with_capacity(capacity);
+                    let mut pairs = Vec::<(Value, Value)>::with_capacity(capacity);
                     for idx in 0..size {
                         // Doing a `hash[key]` access is guaranteed to succeed since
                         // we're iterating over the keys in the hash.

--- a/artichoke-backend/src/convert/string.rs
+++ b/artichoke-backend/src/convert/string.rs
@@ -26,8 +26,7 @@ impl Convert<&str, Value> for Artichoke {
 
 impl TryConvert<Value, String> for Artichoke {
     fn try_convert(&self, value: Value) -> Result<String, ArtichokeError> {
-        let result: Result<&str, _> = self.try_convert(value);
-        result.map(String::from)
+        TryConvert::<_, &str>::try_convert(self, value).map(String::from)
     }
 }
 

--- a/artichoke-backend/src/extn/core/regexp/backend/regex_utf8.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/regex_utf8.rs
@@ -797,7 +797,7 @@ impl RegexpType for RegexUtf8 {
                     unsafe {
                         sys::mrb_gv_set(mrb, last_match_sym, sys::mrb_sys_nil_value());
                     }
-                    return Ok(interp.convert(<Vec<Value>>::new()));
+                    return Ok(interp.convert(Vec::<Value>::new()));
                 }
                 for captures in iter {
                     let mut groups = vec![];
@@ -851,7 +851,7 @@ impl RegexpType for RegexUtf8 {
                     unsafe {
                         sys::mrb_gv_set(mrb, last_match_sym, sys::mrb_sys_nil_value());
                     }
-                    return Ok(interp.convert(<Vec<Value>>::new()));
+                    return Ok(interp.convert(Vec::<Value>::new()));
                 }
                 for pos in iter {
                     let scanned = &haystack[pos.start()..pos.end()];

--- a/artichoke-backend/src/extn/core/string.rs
+++ b/artichoke-backend/src/extn/core/string.rs
@@ -149,7 +149,7 @@ mod tests {
         let result = s
             .funcall::<Vec<&str>>("scan", &[interp.eval(b"'no no no'").expect("eval")], None)
             .expect("funcall");
-        assert_eq!(result, <Vec<&str>>::new());
+        assert_eq!(result, Vec::<&str>::new());
     }
 
     #[test]

--- a/artichoke-backend/tests/manual.rs
+++ b/artichoke-backend/tests/manual.rs
@@ -48,7 +48,7 @@ impl Container {
 
     unsafe extern "C" fn value(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
         let interp = unwrap_interpreter!(mrb);
-        if let Ok(data) = <Box<Self>>::try_from_ruby(&interp, &Value::new(&interp, slf)) {
+        if let Ok(data) = Box::<Self>::try_from_ruby(&interp, &Value::new(&interp, slf)) {
             let borrow = data.borrow();
             interp.convert(borrow.inner).inner()
         } else {


### PR DESCRIPTION
`Vec::<String>::new()` instead of `<Vec<String>>::new()`.