### PR TITLE
Remove explicit type annotations where possible

### DIFF
--- a/artichoke-backend/src/convert/fixnum.rs
+++ b/artichoke-backend/src/convert/fixnum.rs
@@ -182,11 +182,11 @@ mod tests {
     #[test]
     fn fixnum_to_usize() {
         let interp = crate::interpreter().expect("init");
-        let value: Value = interp.convert(100);
+        let value = Convert::<_, Value>::convert(&interp, 100);
         let value = value.try_into::<usize>();
         let expected = Ok(100);
         assert_eq!(value, expected);
-        let value: Value = interp.convert(-100);
+        let value = Convert::<_, Value>::convert(&interp, -100);
         let value = value.try_into::<usize>();
         let expected = Err(ArtichokeError::ConvertToRust {
             from: Ruby::Fixnum,

--- a/artichoke-backend/src/convert/hash.rs
+++ b/artichoke-backend/src/convert/hash.rs
@@ -88,21 +88,19 @@ macro_rules! hash_to_ruby {
                 let pairs = value
                     .into_iter()
                     .map(|(key, value)| {
-                        let key: Value = self.convert(key);
-                        let value: Value = self.convert(value);
+                        let key = self.convert(key);
+                        let value = self.convert(value);
                         (key, value)
                     })
-                    .collect::<Vec<_>>();
-                let result: Value = self.convert(pairs);
-                result
+                    .collect::<Vec<(Value, Value)>>();
+                self.convert(pairs)
             }
         }
 
         impl<'a> Convert<HashMap<$key, $value>, Value> for Artichoke {
             fn convert(&self, value: HashMap<$key, $value>) -> Value {
                 let pairs = value.into_iter().collect::<Vec<($key, $value)>>();
-                let result: Value = self.convert(pairs);
-                result
+                self.convert(pairs)
             }
         }
     };
@@ -112,13 +110,12 @@ macro_rules! hash_to_ruby {
                 let pairs = value
                     .into_iter()
                     .map(|(key, value)| {
-                        let key: Value = self.convert(key);
-                        let value: Value = self.convert(value);
+                        let key = self.convert(key);
+                        let value = self.convert(value);
                         (key, value)
                     })
-                    .collect::<Vec<_>>();
-                let result: Value = self.convert(pairs);
-                result
+                    .collect::<Vec<(Value, Value)>>();
+                self.convert(pairs)
             }
         }
     };
@@ -578,7 +575,7 @@ mod tests {
             (interp.convert(7), interp.convert(8)),
         ];
 
-        let value: Value = interp.convert(map);
+        let value = Convert::<_, Value>::convert(&interp, map);
         assert_eq!(value.to_s(), b"{1=>2, 7=>8}");
 
         let pairs = value.try_into::<Vec<(Value, Value)>>().expect("convert");

--- a/artichoke-backend/src/convert/string.rs
+++ b/artichoke-backend/src/convert/string.rs
@@ -10,8 +10,7 @@ impl Convert<String, Value> for Artichoke {
     fn convert(&self, value: String) -> Value {
         // Ruby `String`s are just bytes, so get a pointer to the underlying
         // `&[u8]` infallibly and convert that to a `Value`.
-        let result: Value = self.convert(value.as_bytes());
-        result
+        self.convert(value.as_bytes())
     }
 }
 
@@ -19,8 +18,7 @@ impl Convert<&str, Value> for Artichoke {
     fn convert(&self, value: &str) -> Value {
         // Ruby `String`s are just bytes, so get a pointer to the underlying
         // `&[u8]` infallibly and convert that to a `Value`.
-        let result: Value = self.convert(value.as_bytes());
-        result
+        self.convert(value.as_bytes())
     }
 }
 

--- a/artichoke-backend/src/value.rs
+++ b/artichoke-backend/src/value.rs
@@ -532,7 +532,7 @@ mod tests {
     fn to_s_fixnum() {
         let interp = crate::interpreter().expect("init");
 
-        let value: Value = interp.convert(255);
+        let value = Convert::<_, Value>::convert(&interp, 255);
         let string = value.to_s();
         assert_eq!(string, b"255");
     }
@@ -541,7 +541,7 @@ mod tests {
     fn debug_fixnum() {
         let interp = crate::interpreter().expect("init");
 
-        let value: Value = interp.convert(255);
+        let value = Convert::<_, Value>::convert(&interp, 255);
         let debug = value.to_s_debug();
         assert_eq!(debug, "Fixnum<255>");
     }
@@ -550,7 +550,7 @@ mod tests {
     fn inspect_fixnum() {
         let interp = crate::interpreter().expect("init");
 
-        let value: Value = interp.convert(255);
+        let value = Convert::<_, Value>::convert(&interp, 255);
         let debug = value.inspect();
         assert_eq!(debug, b"255");
     }
@@ -643,7 +643,7 @@ mod tests {
         assert!(!live.is_dead());
         // Fixnums are immediate even if they are created directly without an
         // interpreter.
-        let fixnum: Value = interp.convert(99);
+        let fixnum = Convert::<_, Value>::convert(&interp, 99);
         assert!(!fixnum.is_dead());
     }
 

--- a/artichoke-backend/tests/leak_funcall.rs
+++ b/artichoke-backend/tests/leak_funcall.rs
@@ -16,7 +16,6 @@
 
 use artichoke_backend::convert::Convert;
 use artichoke_backend::gc::MrbGarbageCollection;
-use artichoke_backend::value::Value;
 use artichoke_core::value::Value as _;
 
 mod leak;
@@ -27,7 +26,7 @@ const LEAK_TOLERANCE: i64 = 1024 * 1024 * 30;
 #[test]
 fn funcall_arena() {
     let interp = artichoke_backend::interpreter().expect("init");
-    let s: Value = interp.convert("a".repeat(1024 * 1024));
+    let s = interp.convert("a".repeat(1024 * 1024));
 
     leak::Detector::new("ValueLike::funcall", ITERATIONS, LEAK_TOLERANCE).check_leaks(|_| {
         let expected = format!(r#""{}""#, "a".repeat(1024 * 1024));


### PR DESCRIPTION
Call convert as an associated function to add the type hints
and specify `Vec` inner types when collecting.

This PR was extracted from GH-442.