### PR TITLE
Return Option<NonNull<sys::rclass>> from rclass APIs.

### DIFF
--- a/artichoke-backend/scripts/auto_import/rust_glue.rs.erb
+++ b/artichoke-backend/scripts/auto_import/rust_glue.rs.erb
@@ -6,7 +6,7 @@ pub fn init(interp: &Artichoke) -> InitializeResult<()> {
     let spec = crate::class::Spec::new("<%= constant %>", None, None)?;
     interp.0.borrow_mut().def_class::<<%= constant %>>(spec);
     <% elsif klass == "Module" %>
-    let spec = crate::module::Spec::new("<%= constant %>", None)?;
+    let spec = crate::module::Spec::new(interp, "<%= constant %>", None)?;
     interp.0.borrow_mut().def_module::<<%= constant %>>(spec);
     <% else %>
     // Skipping constant <%= constant %> with class <%= klass %>

--- a/artichoke-backend/src/class.rs
+++ b/artichoke-backend/src/class.rs
@@ -4,6 +4,7 @@ use std::convert::TryFrom;
 use std::ffi::{CStr, CString};
 use std::fmt;
 use std::hash::{Hash, Hasher};
+use std::ptr::NonNull;
 
 use crate::def::{EnclosingRubyScope, Free, Method};
 use crate::method;
@@ -73,39 +74,48 @@ impl<'a> Builder<'a> {
 
     pub fn define(self) -> Result<(), ArtichokeError> {
         let mrb = self.interp.0.borrow().mrb;
-        let super_class = if let Some(spec) = self.super_class {
-            spec.rclass(self.interp)
-                .ok_or_else(|| ArtichokeError::NotDefined(Cow::Owned(spec.fqname().into_owned())))?
+        let mut super_class = if let Some(spec) = self.super_class {
+            spec.rclass(mrb)
+                .ok_or_else(|| ArtichokeError::NotDefined(spec.fqname().into_owned().into()))?
         } else {
-            unsafe { (*mrb).object_class }
+            let rclass = unsafe { (*mrb).object_class };
+            NonNull::new(rclass).ok_or_else(|| ArtichokeError::NotDefined("Object".into()))?
         };
-        let rclass = if let Some(rclass) = self.spec.rclass(self.interp) {
+        let mut rclass = if let Some(rclass) = self.spec.rclass(mrb) {
             rclass
         } else if let Some(scope) = self.spec.enclosing_scope() {
-            let scope = scope.rclass(self.interp).ok_or_else(|| {
-                ArtichokeError::NotDefined(Cow::Owned(scope.fqname().into_owned()))
-            })?;
-            unsafe {
+            let mut scope_rclass = scope
+                .rclass(mrb)
+                .ok_or_else(|| ArtichokeError::NotDefined(scope.fqname().into_owned().into()))?;
+            let rclass = unsafe {
                 sys::mrb_define_class_under(
                     mrb,
-                    scope,
+                    scope_rclass.as_mut(),
                     self.spec.name_c_str().as_ptr(),
-                    super_class,
+                    super_class.as_mut(),
                 )
-            }
+            };
+            NonNull::new(rclass).ok_or_else(|| {
+                ArtichokeError::NotDefined(self.spec.name.as_ref().to_owned().into())
+            })?
         } else {
-            unsafe { sys::mrb_define_class(mrb, self.spec.name_c_str().as_ptr(), super_class) }
+            let rclass = unsafe {
+                sys::mrb_define_class(mrb, self.spec.name_c_str().as_ptr(), super_class.as_mut())
+            };
+            NonNull::new(rclass).ok_or_else(|| {
+                ArtichokeError::NotDefined(self.spec.name.as_ref().to_owned().into())
+            })?
         };
         for method in &self.methods {
             unsafe {
-                method.define(self.interp, rclass)?;
+                method.define(self.interp, rclass.as_mut())?;
             }
         }
         // If a `Spec` defines a `Class` whose isntances own a pointer to a
         // Rust object, mark them as `MRB_TT_DATA`.
         if self.is_mrb_tt_data {
             unsafe {
-                sys::mrb_sys_set_instance_tt(rclass, sys::mrb_vtype::MRB_TT_DATA);
+                sys::mrb_sys_set_instance_tt(rclass.as_mut(), sys::mrb_vtype::MRB_TT_DATA);
             }
         }
         Ok(())
@@ -147,19 +157,17 @@ impl Spec {
     #[must_use]
     pub fn new_instance(&self, interp: &Artichoke, args: &[Value]) -> Option<Value> {
         let mrb = interp.0.borrow().mrb;
-        let rclass = self.rclass(interp)?;
+        let mut rclass = self.rclass(mrb)?;
         let args = args.iter().map(Value::inner).collect::<Vec<_>>();
         let arglen = Int::try_from(args.len()).unwrap_or_default();
-        let value = unsafe {
-            sys::mrb_obj_new(mrb, rclass, arglen, args.as_ptr() as *const sys::mrb_value)
-        };
+        let value = unsafe { sys::mrb_obj_new(mrb, rclass.as_mut(), arglen, args.as_ptr()) };
         Some(Value::new(interp, value))
     }
 
     #[must_use]
     pub fn value(&self, interp: &Artichoke) -> Option<Value> {
-        let rclass = self.rclass(interp)?;
-        let module = unsafe { sys::mrb_sys_class_value(rclass) };
+        let mut rclass = self.rclass(interp.0.borrow().mrb)?;
+        let module = unsafe { sys::mrb_sys_class_value(rclass.as_mut()) };
         Some(Value::new(interp, module))
     }
 
@@ -196,21 +204,21 @@ impl Spec {
     }
 
     #[must_use]
-    pub fn rclass(&self, interp: &Artichoke) -> Option<*mut sys::RClass> {
-        let mrb = interp.0.borrow().mrb;
+    pub fn rclass(&self, mrb: *mut sys::mrb_state) -> Option<NonNull<sys::RClass>> {
         if let Some(ref scope) = self.enclosing_scope {
-            if let Some(scope) = scope.rclass(interp) {
-                if unsafe { sys::mrb_class_defined_under(mrb, scope, self.name_c_str().as_ptr()) }
-                    == 0
-                {
+            if let Some(mut scope) = scope.rclass(mrb) {
+                let defined_under = unsafe {
+                    sys::mrb_class_defined_under(mrb, scope.as_mut(), self.name_c_str().as_ptr())
+                };
+                if defined_under == 0 {
                     // Enclosing scope exists.
                     // Class is not defined under the enclosing scope.
                     None
                 } else {
                     // Enclosing scope exists.
                     // Class is defined under the enclosing scope.
-                    Some(unsafe {
-                        sys::mrb_class_get_under(mrb, scope, self.name_c_str().as_ptr())
+                    NonNull::new(unsafe {
+                        sys::mrb_class_get_under(mrb, scope.as_mut(), self.name_c_str().as_ptr())
                     })
                 }
             } else {
@@ -222,7 +230,7 @@ impl Spec {
             None
         } else {
             // Class exists in root scope.
-            Some(unsafe { sys::mrb_class_get(mrb, self.name_c_str().as_ptr()) })
+            NonNull::new(unsafe { sys::mrb_class_get(mrb, self.name_c_str().as_ptr()) })
         }
     }
 }
@@ -299,7 +307,7 @@ mod tests {
     fn rclass_for_undef_root_class() {
         let interp = crate::interpreter().expect("init");
         let spec = class::Spec::new("Foo", None, None).unwrap();
-        assert!(spec.rclass(&interp).is_none());
+        assert!(spec.rclass(interp.0.borrow().mrb).is_none());
     }
 
     #[test]
@@ -309,7 +317,7 @@ mod tests {
         let scope = borrow.module_spec::<Kernel>().unwrap();
         let spec = class::Spec::new("Foo", Some(EnclosingRubyScope::module(scope)), None).unwrap();
         drop(borrow);
-        assert!(spec.rclass(&interp).is_none());
+        assert!(spec.rclass(interp.0.borrow().mrb).is_none());
     }
 
     #[test]
@@ -317,7 +325,7 @@ mod tests {
         let interp = crate::interpreter().expect("init");
         let borrow = interp.0.borrow();
         let spec = borrow.class_spec::<StandardError>().unwrap();
-        assert!(spec.rclass(&interp).is_some());
+        assert!(spec.rclass(interp.0.borrow().mrb).is_some());
     }
 
     #[test]
@@ -326,9 +334,9 @@ mod tests {
         let _ = interp
             .eval(b"module Foo; class Bar; end; end")
             .expect("eval");
-        let spec = module::Spec::new("Foo", None).unwrap();
+        let spec = module::Spec::new(&interp, "Foo", None).unwrap();
         let spec = class::Spec::new("Bar", Some(EnclosingRubyScope::module(&spec)), None).unwrap();
-        assert!(spec.rclass(&interp).is_some());
+        assert!(spec.rclass(interp.0.borrow().mrb).is_some());
     }
 
     #[test]
@@ -339,6 +347,6 @@ mod tests {
             .expect("eval");
         let spec = class::Spec::new("Foo", None, None).unwrap();
         let spec = class::Spec::new("Bar", Some(EnclosingRubyScope::class(&spec)), None).unwrap();
-        assert!(spec.rclass(&interp).is_some());
+        assert!(spec.rclass(interp.0.borrow().mrb).is_some());
     }
 }

--- a/artichoke-backend/src/class.rs
+++ b/artichoke-backend/src/class.rs
@@ -203,6 +203,7 @@ impl Spec {
         }
     }
 
+    #[allow(clippy::not_unsafe_ptr_arg_deref)]
     #[must_use]
     pub fn rclass(&self, mrb: *mut sys::mrb_state) -> Option<NonNull<sys::RClass>> {
         if let Some(ref scope) = self.enclosing_scope {

--- a/artichoke-backend/src/def.rs
+++ b/artichoke-backend/src/def.rs
@@ -159,6 +159,7 @@ impl EnclosingRubyScope {
     ///
     /// The current implemention results in recursive calls to this function
     /// for each enclosing scope.
+    #[must_use]
     pub fn fqname(&self) -> Cow<'_, str> {
         match self {
             Self::Class { spec } => spec.fqname(),
@@ -170,6 +171,7 @@ impl EnclosingRubyScope {
 impl Eq for EnclosingRubyScope {}
 
 impl PartialEq for EnclosingRubyScope {
+    #[must_use]
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
             (Self::Class { spec: this }, Self::Class { spec: other }) => this == other,

--- a/artichoke-backend/src/def.rs
+++ b/artichoke-backend/src/def.rs
@@ -2,13 +2,13 @@ use std::borrow::Cow;
 use std::cell::RefCell;
 use std::ffi::c_void;
 use std::hash::{Hash, Hasher};
+use std::ptr::NonNull;
 use std::rc::Rc;
 
 use crate::class;
 use crate::convert::RustBackedValue;
 use crate::module;
 use crate::sys;
-use crate::Artichoke;
 
 /// Typedef for an mruby free function for an [`mrb_value`](sys::mrb_value) with
 /// `tt` [`MRB_TT_DATA`](sys::mrb_vtype::MRB_TT_DATA).
@@ -136,10 +136,10 @@ impl EnclosingRubyScope {
     ///
     /// The current implemention results in recursive calls to this function
     /// for each enclosing scope.
-    pub fn rclass(&self, interp: &Artichoke) -> Option<*mut sys::RClass> {
+    pub fn rclass(&self, mrb: *mut sys::mrb_state) -> Option<NonNull<sys::RClass>> {
         match self {
-            Self::Class { spec } => spec.rclass(interp),
-            Self::Module { spec } => spec.rclass(interp),
+            Self::Class { spec } => spec.rclass(mrb),
+            Self::Module { spec } => spec.rclass(mrb),
         }
     }
 
@@ -203,15 +203,19 @@ mod tests {
 
         // Setup: define module and class hierarchy
         let interp = crate::interpreter().expect("init");
-        let root = module::Spec::new("A", None).unwrap();
+        let root = module::Spec::new(&interp, "A", None).unwrap();
         let mod_under_root =
-            module::Spec::new("B", Some(EnclosingRubyScope::module(&root))).unwrap();
+            module::Spec::new(&interp, "B", Some(EnclosingRubyScope::module(&root))).unwrap();
         let cls_under_root =
             class::Spec::new("C", Some(EnclosingRubyScope::module(&root)), None).unwrap();
         let cls_under_mod =
             class::Spec::new("D", Some(EnclosingRubyScope::module(&mod_under_root)), None).unwrap();
-        let mod_under_cls =
-            module::Spec::new("E", Some(EnclosingRubyScope::class(&cls_under_root))).unwrap();
+        let mod_under_cls = module::Spec::new(
+            &interp,
+            "E",
+            Some(EnclosingRubyScope::class(&cls_under_root)),
+        )
+        .unwrap();
         let cls_under_cls =
             class::Spec::new("F", Some(EnclosingRubyScope::class(&cls_under_root)), None).unwrap();
         module::Builder::for_spec(&interp, &root).define().unwrap();
@@ -316,7 +320,7 @@ mod tests {
                 .define()
                 .unwrap();
             interp.0.borrow_mut().def_class::<Class>(class);
-            let module = module::Spec::new("DefineMethodTestModule", None).unwrap();
+            let module = module::Spec::new(&interp, "DefineMethodTestModule", None).unwrap();
             module::Builder::for_spec(&interp, &module)
                 .add_method("value", value, sys::mrb_args_none())
                 .unwrap()

--- a/artichoke-backend/src/eval.rs
+++ b/artichoke-backend/src/eval.rs
@@ -279,7 +279,7 @@ mod tests {
             type Artichoke = Artichoke;
 
             fn require(interp: &Artichoke) -> Result<(), ArtichokeError> {
-                let spec = module::Spec::new("NestedEval", None)?;
+                let spec = module::Spec::new(interp, "NestedEval", None)?;
                 module::Builder::for_spec(interp, &spec)
                     .add_self_method("file", Self::nested_eval, sys::mrb_args_none())?
                     .define()?;

--- a/artichoke-backend/src/extn/core/artichoke/mod.rs
+++ b/artichoke-backend/src/extn/core/artichoke/mod.rs
@@ -4,7 +4,7 @@ pub fn init(interp: &crate::Artichoke) -> InitializeResult<()> {
     if interp.0.borrow().module_spec::<Artichoke>().is_some() {
         return Ok(());
     }
-    let spec = module::Spec::new("Artichoke", None)?;
+    let spec = module::Spec::new(interp, "Artichoke", None)?;
     module::Builder::for_spec(interp, &spec).define()?;
     interp.0.borrow_mut().def_module::<Artichoke>(spec);
     trace!("Patched Artichoke onto interpreter");

--- a/artichoke-backend/src/extn/core/comparable/mod.rs
+++ b/artichoke-backend/src/extn/core/comparable/mod.rs
@@ -4,7 +4,7 @@ pub fn init(interp: &Artichoke) -> InitializeResult<()> {
     if interp.0.borrow().module_spec::<Comparable>().is_some() {
         return Ok(());
     }
-    let spec = module::Spec::new("Comparable", None)?;
+    let spec = module::Spec::new(interp, "Comparable", None)?;
     module::Builder::for_spec(interp, &spec).define()?;
     interp.0.borrow_mut().def_module::<Comparable>(spec);
     let _ = interp.eval(&include_bytes!("comparable.rb")[..])?;

--- a/artichoke-backend/src/extn/core/enumerable/mod.rs
+++ b/artichoke-backend/src/extn/core/enumerable/mod.rs
@@ -4,7 +4,7 @@ pub fn init(interp: &Artichoke) -> InitializeResult<()> {
     if interp.0.borrow().module_spec::<Enumerable>().is_some() {
         return Ok(());
     }
-    let spec = module::Spec::new("Enumerable", None)?;
+    let spec = module::Spec::new(interp, "Enumerable", None)?;
     module::Builder::for_spec(interp, &spec).define()?;
     interp.0.borrow_mut().def_module::<Enumerable>(spec);
     let _ = interp.eval(&include_bytes!("enumerable.rb")[..])?;

--- a/artichoke-backend/src/extn/core/kernel/mod.rs
+++ b/artichoke-backend/src/extn/core/kernel/mod.rs
@@ -8,7 +8,7 @@ pub fn init(interp: &Artichoke) -> InitializeResult<()> {
     if interp.0.borrow().module_spec::<Kernel>().is_some() {
         return Ok(());
     }
-    let spec = module::Spec::new("Kernel", None)?;
+    let spec = module::Spec::new(interp, "Kernel", None)?;
     module::Builder::for_spec(interp, &spec)
         .add_method("require", Kernel::require, sys::mrb_args_rest())?
         .add_method(
@@ -29,7 +29,7 @@ pub fn init(interp: &Artichoke) -> InitializeResult<()> {
         .module_spec::<artichoke::Artichoke>()
         .map(EnclosingRubyScope::module)
         .ok_or(ArtichokeError::New)?;
-    let spec = module::Spec::new("Kernel", Some(scope))?;
+    let spec = module::Spec::new(interp, "Kernel", Some(scope))?;
     module::Builder::for_spec(interp, &spec)
         .add_method("Integer", Kernel::integer, sys::mrb_args_req_and_opt(1, 1))?
         .add_self_method("Integer", Kernel::integer, sys::mrb_args_req_and_opt(1, 1))?

--- a/artichoke-backend/src/extn/core/random/mruby.rs
+++ b/artichoke-backend/src/extn/core/random/mruby.rs
@@ -34,15 +34,15 @@ pub fn init(interp: &Artichoke) -> InitializeResult<()> {
     let default = random::default();
     let default = default.try_into_ruby(interp, None)?;
     let borrow = interp.0.borrow();
-    let rclass = borrow
+    let mut rclass = borrow
         .class_spec::<random::Random>()
-        .and_then(|spec| spec.rclass(interp))
+        .and_then(|spec| spec.rclass(interp.0.borrow().mrb))
         .ok_or(ArtichokeError::New)?;
     let mrb = borrow.mrb;
     unsafe {
         sys::mrb_define_const(
             mrb,
-            rclass,
+            rclass.as_mut(),
             b"DEFAULT\0".as_ptr() as *const i8,
             default.inner(),
         );

--- a/artichoke-backend/src/extn/core/warning/mod.rs
+++ b/artichoke-backend/src/extn/core/warning/mod.rs
@@ -4,7 +4,7 @@ pub fn init(interp: &Artichoke) -> InitializeResult<()> {
     if interp.0.borrow().module_spec::<Warning>().is_some() {
         return Ok(());
     }
-    let spec = module::Spec::new("Warning", None)?;
+    let spec = module::Spec::new(interp, "Warning", None)?;
     module::Builder::for_spec(interp, &spec).define()?;
     interp.0.borrow_mut().def_module::<Warning>(spec);
     let _ = interp.eval(&include_bytes!("warning.rb")[..])?;

--- a/artichoke-backend/src/extn/stdlib/abbrev.rs
+++ b/artichoke-backend/src/extn/stdlib/abbrev.rs
@@ -1,7 +1,7 @@
 use crate::extn::prelude::*;
 
 pub fn init(interp: &Artichoke) -> InitializeResult<()> {
-    let spec = module::Spec::new("Abbrev", None)?;
+    let spec = module::Spec::new(interp, "Abbrev", None)?;
     interp.0.borrow_mut().def_module::<Abbrev>(spec);
     interp.def_rb_source_file(b"abbrev.rb", &include_bytes!("abbrev.rb")[..])?;
     Ok(())

--- a/artichoke-backend/src/extn/stdlib/forwardable.rs
+++ b/artichoke-backend/src/extn/stdlib/forwardable.rs
@@ -1,7 +1,7 @@
 use crate::extn::prelude::*;
 
 pub fn init(interp: &Artichoke) -> InitializeResult<()> {
-    let spec = module::Spec::new("Forwardable", None)?;
+    let spec = module::Spec::new(interp, "Forwardable", None)?;
     interp.0.borrow_mut().def_module::<Forwardable>(spec);
     interp.def_rb_source_file(b"forwardable.rb", &include_bytes!("forwardable.rb")[..])?;
     interp.def_rb_source_file(

--- a/artichoke-backend/src/method.rs
+++ b/artichoke-backend/src/method.rs
@@ -73,7 +73,7 @@ impl Spec {
     pub unsafe fn define(
         &self,
         interp: &Artichoke,
-        into: *mut sys::RClass,
+        into: &mut sys::RClass,
     ) -> Result<(), ArtichokeError> {
         let mrb = interp.0.borrow().mrb;
         match self.method_type {

--- a/artichoke-backend/src/module.rs
+++ b/artichoke-backend/src/module.rs
@@ -20,6 +20,7 @@ pub struct Builder<'a> {
 }
 
 impl<'a> Builder<'a> {
+    #[must_use]
     pub fn for_spec(interp: &'a Artichoke, spec: &'a Spec) -> Self {
         Self {
             interp,
@@ -135,24 +136,29 @@ impl Spec {
         })
     }
 
+    #[must_use]
     pub fn value(&self, interp: &Artichoke) -> Option<Value> {
         let mut rclass = self.rclass(interp.0.borrow().mrb)?;
         let module = unsafe { sys::mrb_sys_module_value(rclass.as_mut()) };
         Some(Value::new(interp, module))
     }
 
+    #[must_use]
     pub fn name(&self) -> &str {
         self.name.as_ref()
     }
 
+    #[must_use]
     pub fn name_c_str(&self) -> &CStr {
         self.cstring.as_c_str()
     }
 
+    #[must_use]
     pub fn enclosing_scope(&self) -> Option<&EnclosingRubyScope> {
         self.enclosing_scope.as_deref()
     }
 
+    #[must_use]
     pub fn fqname(&self) -> Cow<'_, str> {
         if let Some(scope) = self.enclosing_scope() {
             Cow::Owned(format!("{}::{}", scope.fqname(), self.name()))
@@ -164,6 +170,7 @@ impl Spec {
         }
     }
 
+    #[allow(clippy::not_unsafe_ptr_arg_deref)]
     pub fn rclass(&self, mrb: *mut sys::mrb_state) -> Option<NonNull<sys::RClass>> {
         if let Some(ref scope) = self.enclosing_scope {
             if let Some(mut scope) = scope.rclass(mrb) {
@@ -230,6 +237,7 @@ impl Hash for Spec {
 impl Eq for Spec {}
 
 impl PartialEq for Spec {
+    #[must_use]
     fn eq(&self, other: &Self) -> bool {
         self.name == other.name
     }

--- a/artichoke-backend/src/module.rs
+++ b/artichoke-backend/src/module.rs
@@ -1,10 +1,10 @@
 use std::borrow::Cow;
-use std::cell::Cell;
 use std::collections::HashSet;
 use std::convert::AsRef;
 use std::ffi::{c_void, CStr, CString};
 use std::fmt;
 use std::hash::{Hash, Hasher};
+use std::ptr::NonNull;
 
 use crate::def::{EnclosingRubyScope, Method};
 use crate::method;
@@ -72,19 +72,31 @@ impl<'a> Builder<'a> {
 
     pub fn define(self) -> Result<(), ArtichokeError> {
         let mrb = self.interp.0.borrow().mrb;
-        let rclass = if let Some(rclass) = self.spec.rclass(self.interp) {
+        let mut rclass = if let Some(rclass) = self.spec.rclass(mrb) {
             rclass
         } else if let Some(scope) = self.spec.enclosing_scope() {
-            let scope = scope.rclass(self.interp).ok_or_else(|| {
-                ArtichokeError::NotDefined(Cow::Owned(scope.fqname().into_owned()))
-            })?;
-            unsafe { sys::mrb_define_module_under(mrb, scope, self.spec.name_c_str().as_ptr()) }
+            let mut scope_rclass = scope
+                .rclass(mrb)
+                .ok_or_else(|| ArtichokeError::NotDefined(scope.fqname().into_owned().into()))?;
+            let rclass = unsafe {
+                sys::mrb_define_module_under(
+                    mrb,
+                    scope_rclass.as_mut(),
+                    self.spec.name_c_str().as_ptr(),
+                )
+            };
+            NonNull::new(rclass).ok_or_else(|| {
+                ArtichokeError::NotDefined(self.spec.name.as_ref().to_owned().into())
+            })?
         } else {
-            unsafe { sys::mrb_define_module(mrb, self.spec.name_c_str().as_ptr()) }
+            let rclass = unsafe { sys::mrb_define_module(mrb, self.spec.name_c_str().as_ptr()) };
+            NonNull::new(rclass).ok_or_else(|| {
+                ArtichokeError::NotDefined(self.spec.name.as_ref().to_owned().into())
+            })?
         };
         for method in self.methods {
             unsafe {
-                method.define(self.interp, rclass)?;
+                method.define(self.interp, rclass.as_mut())?;
             }
         }
         Ok(())
@@ -94,13 +106,14 @@ impl<'a> Builder<'a> {
 #[derive(Clone)]
 pub struct Spec {
     name: Cow<'static, str>,
-    sym: Cell<sys::mrb_sym>,
+    sym: sys::mrb_sym,
     cstring: CString,
     enclosing_scope: Option<Box<EnclosingRubyScope>>,
 }
 
 impl Spec {
     pub fn new<T>(
+        interp: &Artichoke,
         name: T,
         enclosing_scope: Option<EnclosingRubyScope>,
     ) -> Result<Self, ArtichokeError>
@@ -110,17 +123,21 @@ impl Spec {
         let name = name.into();
         let cstring =
             CString::new(name.as_ref()).map_err(|_| ArtichokeError::InvalidConstantName)?;
+        let sym = interp
+            .0
+            .borrow_mut()
+            .sym_intern(name.as_ref().to_owned().into_bytes());
         Ok(Self {
             name,
             cstring,
-            sym: Cell::default(),
+            sym,
             enclosing_scope: enclosing_scope.map(Box::new),
         })
     }
 
     pub fn value(&self, interp: &Artichoke) -> Option<Value> {
-        let rclass = self.rclass(interp)?;
-        let module = unsafe { sys::mrb_sys_module_value(rclass) };
+        let mut rclass = self.rclass(interp.0.borrow().mrb)?;
+        let module = unsafe { sys::mrb_sys_module_value(rclass.as_mut()) };
         Some(Value::new(interp, module))
     }
 
@@ -147,22 +164,14 @@ impl Spec {
         }
     }
 
-    pub fn rclass(&self, interp: &Artichoke) -> Option<*mut sys::RClass> {
-        let mrb = interp.0.borrow().mrb;
-        if self.sym.get() == 0 {
-            let sym = interp
-                .0
-                .borrow_mut()
-                .sym_intern(self.name.as_bytes().to_vec());
-            self.sym.set(sym);
-        }
+    pub fn rclass(&self, mrb: *mut sys::mrb_state) -> Option<NonNull<sys::RClass>> {
         if let Some(ref scope) = self.enclosing_scope {
-            if let Some(scope) = scope.rclass(interp) {
+            if let Some(mut scope) = scope.rclass(mrb) {
                 let defined = unsafe {
                     sys::mrb_const_defined_at(
                         mrb,
-                        sys::mrb_sys_obj_value(scope as *mut c_void),
-                        self.sym.get(),
+                        sys::mrb_sys_obj_value(scope.cast::<c_void>().as_mut()),
+                        self.sym,
                     )
                 };
                 if defined == 0 {
@@ -172,8 +181,8 @@ impl Spec {
                 } else {
                     // Enclosing scope exists module IS defined under the
                     // enclosing scope.
-                    Some(unsafe {
-                        sys::mrb_module_get_under(mrb, scope, self.name_c_str().as_ptr())
+                    NonNull::new(unsafe {
+                        sys::mrb_module_get_under(mrb, scope.as_mut(), self.name_c_str().as_ptr())
                     })
                 }
             } else {
@@ -185,7 +194,7 @@ impl Spec {
                 sys::mrb_const_defined_at(
                     mrb,
                     sys::mrb_sys_obj_value((*mrb).object_class as *mut c_void),
-                    self.sym.get(),
+                    self.sym,
                 )
             };
             if defined == 0 {
@@ -193,7 +202,7 @@ impl Spec {
                 None
             } else {
                 // Module exists in root scope.
-                Some(unsafe { sys::mrb_module_get(mrb, self.name_c_str().as_ptr()) })
+                NonNull::new(unsafe { sys::mrb_module_get(mrb, self.name_c_str().as_ptr()) })
             }
         }
     }
@@ -237,24 +246,24 @@ mod tests {
     #[test]
     fn rclass_for_undef_root_module() {
         let interp = crate::interpreter().expect("init");
-        let spec = Spec::new("Foo", None).unwrap();
-        assert!(spec.rclass(&interp).is_none());
+        let spec = Spec::new(&interp, "Foo", None).unwrap();
+        assert!(spec.rclass(interp.0.borrow().mrb).is_none());
     }
 
     #[test]
     fn rclass_for_undef_nested_module() {
         let interp = crate::interpreter().expect("init");
-        let scope = Spec::new("Kernel", None).unwrap();
+        let scope = Spec::new(&interp, "Kernel", None).unwrap();
         let scope = EnclosingRubyScope::module(&scope);
-        let spec = Spec::new("Foo", Some(scope)).unwrap();
-        assert!(spec.rclass(&interp).is_none());
+        let spec = Spec::new(&interp, "Foo", Some(scope)).unwrap();
+        assert!(spec.rclass(interp.0.borrow().mrb).is_none());
     }
 
     #[test]
     fn rclass_for_root_module() {
         let interp = crate::interpreter().expect("init");
-        let spec = Spec::new("Kernel", None).unwrap();
-        assert!(spec.rclass(&interp).is_some());
+        let spec = Spec::new(&interp, "Kernel", None).unwrap();
+        assert!(spec.rclass(interp.0.borrow().mrb).is_some());
     }
 
     #[test]
@@ -263,10 +272,10 @@ mod tests {
         let _ = interp
             .eval(b"module Foo; module Bar; end; end")
             .expect("eval");
-        let scope = Spec::new("Foo", None).unwrap();
+        let scope = Spec::new(&interp, "Foo", None).unwrap();
         let scope = EnclosingRubyScope::module(&scope);
-        let spec = Spec::new("Bar", Some(scope)).unwrap();
-        assert!(spec.rclass(&interp).is_some());
+        let spec = Spec::new(&interp, "Bar", Some(scope)).unwrap();
+        assert!(spec.rclass(interp.0.borrow().mrb).is_some());
     }
 
     #[test]
@@ -277,7 +286,7 @@ mod tests {
             .expect("eval");
         let scope = class::Spec::new("Foo", None, None).unwrap();
         let scope = EnclosingRubyScope::class(&scope);
-        let spec = Spec::new("Bar", Some(scope)).unwrap();
-        assert!(spec.rclass(&interp).is_some());
+        let spec = Spec::new(&interp, "Bar", Some(scope)).unwrap();
+        assert!(spec.rclass(interp.0.borrow().mrb).is_some());
     }
 }


### PR DESCRIPTION
This commit breaks the dependency of `def` module on the Artichoke
interpreter. `def` is predominantly glue between Rust and FFI and only
needs a reference to the `mrb_state`.

`class::Spec::rclass` and `module::Spec::rclass` now take an
`mrb_state`.

`module::Spec::new` takes an `Artichoke` and eagerly generates the
`Symbol` ID for the class name, which removes the `Cell` member and
enables `module::Spec::rclass` to take only an `mrb_state`.

This PR was extracted from GH-442.