### PR TITLE
Minimize unsafe in ExceptionHandler::last_error

### DIFF
--- a/artichoke-backend/src/exception_handler.rs
+++ b/artichoke-backend/src/exception_handler.rs
@@ -35,7 +35,7 @@ impl ExceptionHandler for Artichoke {
         //
         // - Artichoke is guaranteed to be constructed with a non-null `mrb`
         //   pointer by `ffi::from_user_data` and `interpreter::interpreter`.
-        let exc = mem::replace(&mut unsafe { (*self.0.borrow().mrb).exc }, ptr::null_mut());
+        let exc = mem::replace(unsafe { &mut (*self.0.borrow().mrb).exc }, ptr::null_mut());
         if let Some(exc) = NonNull::new(exc) {
             // Generate exception metadata in by executing the Ruby code:
             //

--- a/artichoke-backend/src/exception_handler.rs
+++ b/artichoke-backend/src/exception_handler.rs
@@ -1,5 +1,7 @@
 use artichoke_core::value::Value as _;
 use std::ffi::c_void;
+use std::mem;
+use std::ptr::{self, NonNull};
 
 use crate::exception::{CaughtException, Exception};
 use crate::gc::MrbGarbageCollection;
@@ -20,46 +22,59 @@ pub trait ExceptionHandler {
 impl ExceptionHandler for Artichoke {
     fn last_error(&self) -> Result<Option<Exception>, Exception> {
         let _arena = self.create_arena_savepoint();
-        let mrb = self.0.borrow().mrb;
-        let exc = unsafe {
-            let exc = (*mrb).exc;
-            // Clear the current exception from the mruby interpreter so
-            // subsequent calls to the mruby VM are not tainted by an error they
-            // did not generate.
+        // Clear the current exception from the mruby interpreter so subsequent
+        // calls to the mruby VM are not tainted by an error they did not
+        // generate.
+        //
+        // We must clear the pointer at the beginning of this function so we can
+        // use the mruby VM to inspect the exception once we turn it into an
+        // `mrb_value`. `Value::funcall` handles errors by calling this
+        // function, so not clearing the exception results in a stack overflow.
+
+        // Safety:
+        //
+        // - Artichoke is guaranteed to be constructed with a non-null `mrb`
+        //   pointer by `ffi::from_user_data` and `interpreter::interpreter`.
+        let exc = mem::replace(&mut unsafe { (*self.0.borrow().mrb).exc }, ptr::null_mut());
+        if let Some(exc) = NonNull::new(exc) {
+            // Generate exception metadata in by executing the Ruby code:
             //
-            // We must do this at the beginning of `current_exception` so we can
-            // use the mruby VM to inspect the exception once we turn it into an
-            // `mrb_value`. `Value::funcall` handles errors by calling this
-            // function, so not clearing the exception results in a stack
-            // overflow.
-            (*mrb).exc = std::ptr::null_mut();
-            exc
-        };
-        if exc.is_null() {
+            // ```ruby
+            // clazz = exception.class.name
+            // message = exception.message
+            // ```
+
+            // Safety:
+            //
+            // - mruby guarantees the `exc` field is either null or a pointer to
+            //   a `sys::RBasic`.
+            // - `sys::mrb_sys_obj_value` takes a pointer to a
+            //   `sys::RBasic`-compatible struct.
+            // - The only write Artichoke makes to this field is a null pointer
+            //   above.
+            // - `exc` is guaranteed to be non-null by `NonNull::new`.
+            let exc = unsafe { sys::mrb_sys_obj_value(exc.cast::<c_void>().as_ptr()) };
+            let exception = Value::new(self, exc);
+
+            // Sometimes when hacking on extn/core it is possible to enter a
+            // crash loop where an exception is captured by this handler, but
+            // extracting the exception name or backtrace throws again.
+            // Uncommenting the folllowing print statement will at least get you
+            // the exception class and message, which should help debugging.
+            //
+            // println!("{:?}", exception);
+
+            let class = exception.funcall::<Value>("class", &[], None)?;
+            let classname = class.funcall::<&str>("name", &[], None)?;
+            let message = exception.funcall::<&[u8]>("message", &[], None)?;
+
+            let exception = CaughtException::new(exception, classname, message);
+            debug!("Extracted exception from interpreter: {}", exception);
+            Ok(Some(Exception::from(exception)))
+        } else {
             trace!("No last error present");
-            return Ok(None);
+            Ok(None)
         }
-        // Generate exception metadata in by executing the following Ruby code:
-        //
-        // ```ruby
-        // clazz = exception.class.name
-        // message = exception.message
-        // ```
-        let exception = Value::new(self, unsafe { sys::mrb_sys_obj_value(exc as *mut c_void) });
-        // Sometimes when hacking on extn/core it is possible to enter a crash
-        // loop where an exception is captured by this handler, but extracting
-        // the exception name or backtrace throws again. Uncommenting the
-        // folllowing print statement will at least get you the exception class
-        // and message, which should help debugging.
-        //
-        // println!("{:?}", exception);
-        let classname = exception
-            .funcall::<Value>("class", &[], None)
-            .and_then(|exception| exception.funcall::<&str>("name", &[], None))?;
-        let message = exception.funcall::<&[u8]>("message", &[], None)?;
-        let exception = CaughtException::new(exception, classname, message);
-        debug!("Extracted exception from interpreter: {}", exception);
-        Ok(Some(Exception::from(exception)))
     }
 }
 


### PR DESCRIPTION
Use Rust patterns like mem::replace and NonNull to minimize unsafe in
ExceptionHandler impl to one pointer deref and one FFI funcall.

Add safety proofs.