### PR TITLE
Replace to_int funcalls in Rust with Value::implicitly_convert_to_int

### DIFF
--- a/artichoke-backend/src/extn/core/array/args.rs
+++ b/artichoke-backend/src/extn/core/array/args.rs
@@ -52,8 +52,7 @@ pub fn element_assignment(
     len: usize,
 ) -> Result<(usize, Option<usize>, Value), Exception> {
     if let Some(elem) = third {
-        let start = first;
-        let start = start.implicitly_convert_to_int()?;
+        let start = first.implicitly_convert_to_int()?;
         let start = if let Ok(start) = usize::try_from(start) {
             start
         } else {
@@ -68,8 +67,7 @@ pub fn element_assignment(
                 )));
             }
         };
-        let len = second;
-        let len = len.implicitly_convert_to_int()?;
+        let len = second.implicitly_convert_to_int()?;
         if let Ok(len) = usize::try_from(len) {
             Ok((start, Some(len), elem))
         } else {

--- a/artichoke-backend/src/extn/core/array/args.rs
+++ b/artichoke-backend/src/extn/core/array/args.rs
@@ -67,13 +67,13 @@ pub fn element_assignment(
                 )));
             }
         };
-        let len = second.implicitly_convert_to_int()?;
-        if let Ok(len) = usize::try_from(len) {
-            Ok((start, Some(len), elem))
+        let slice_len = second.implicitly_convert_to_int()?;
+        if let Ok(slice_len) = usize::try_from(slice_len) {
+            Ok((start, Some(slice_len), elem))
         } else {
             Err(Exception::from(IndexError::new(
                 interp,
-                format!("negative length ({})", len),
+                format!("negative length ({})", slice_len),
             )))
         }
     } else if let Ok(index) = first.implicitly_convert_to_int() {

--- a/artichoke-backend/src/extn/core/array/args.rs
+++ b/artichoke-backend/src/extn/core/array/args.rs
@@ -18,28 +18,8 @@ pub fn element_reference(
     ary_len: usize,
 ) -> Result<ElementReference, Exception> {
     if let Some(len) = len {
-        let start = if let Ok(start) = elem.clone().try_into::<Int>() {
-            start
-        } else if let Ok(start) = elem.funcall::<Int>("to_int", &[], None) {
-            start
-        } else {
-            let elem_type_name = elem.pretty_name();
-            return Err(Exception::from(TypeError::new(
-                interp,
-                format!("no implicit conversion of {} into Integer", elem_type_name),
-            )));
-        };
-        let len = if let Ok(len) = len.clone().try_into::<Int>() {
-            len
-        } else if let Ok(len) = len.funcall::<Int>("to_int", &[], None) {
-            len
-        } else {
-            let len_type_name = len.pretty_name();
-            return Err(Exception::from(TypeError::new(
-                interp,
-                format!("no implicit conversion of {} into Integer", len_type_name),
-            )));
-        };
+        let start = elem.implicitly_convert_to_int()?;
+        let len = len.implicitly_convert_to_int()?;
         if let Ok(len) = usize::try_from(len) {
             Ok(ElementReference::StartLen(start, len))
         } else {
@@ -47,9 +27,7 @@ pub fn element_reference(
         }
     } else {
         let name = elem.pretty_name();
-        if let Ok(index) = elem.clone().try_into::<Int>() {
-            Ok(ElementReference::Index(index))
-        } else if let Ok(index) = elem.funcall::<Int>("to_int", &[], None) {
+        if let Ok(index) = elem.implicitly_convert_to_int() {
             Ok(ElementReference::Index(index))
         } else {
             let rangelen = Int::try_from(ary_len)
@@ -75,17 +53,7 @@ pub fn element_assignment(
 ) -> Result<(usize, Option<usize>, Value), Exception> {
     if let Some(elem) = third {
         let start = first;
-        let start_type_name = start.pretty_name();
-        let start = if let Ok(start) = start.clone().try_into::<Int>() {
-            start
-        } else if let Ok(start) = start.funcall::<Int>("to_int", &[], None) {
-            start
-        } else {
-            return Err(Exception::from(TypeError::new(
-                interp,
-                format!("no implicit conversion of {} into Integer", start_type_name),
-            )));
-        };
+        let start = start.implicitly_convert_to_int()?;
         let start = if let Ok(start) = usize::try_from(start) {
             start
         } else {
@@ -101,17 +69,7 @@ pub fn element_assignment(
             }
         };
         let len = second;
-        let len_type_name = len.pretty_name();
-        let len = if let Ok(len) = len.clone().try_into::<Int>() {
-            len
-        } else if let Ok(len) = len.funcall::<Int>("to_int", &[], None) {
-            len
-        } else {
-            return Err(Exception::from(TypeError::new(
-                interp,
-                format!("no implicit conversion of {} into Integer", len_type_name),
-            )));
-        };
+        let len = len.implicitly_convert_to_int()?;
         if let Ok(len) = usize::try_from(len) {
             Ok((start, Some(len), elem))
         } else {
@@ -120,22 +78,7 @@ pub fn element_assignment(
                 format!("negative length ({})", len),
             )))
         }
-    } else if let Ok(index) = first.clone().try_into::<Int>() {
-        if let Ok(index) = usize::try_from(index) {
-            Ok((index, None, second))
-        } else {
-            let index = usize::try_from(-index)
-                .map_err(|_| Fatal::new(interp, "Positive Int must be usize"))?;
-            if index < len {
-                Ok((len - index, None, second))
-            } else {
-                Err(Exception::from(IndexError::new(
-                    interp,
-                    format!("index {} too small for array; minimum: -{}", index, len),
-                )))
-            }
-        }
-    } else if let Ok(index) = first.funcall::<Int>("to_int", &[], None) {
+    } else if let Ok(index) = first.implicitly_convert_to_int() {
         if let Ok(index) = usize::try_from(index) {
             Ok((index, None, second))
         } else {
@@ -170,19 +113,7 @@ pub fn element_assignment(
                         "Unable to extract first from Range",
                     )));
                 };
-                let start = if let Ok(start) = start.clone().try_into::<Int>() {
-                    start
-                } else if let Ok(start) = start.funcall::<Int>("to_int", &[], None) {
-                    start
-                } else {
-                    return Err(Exception::from(TypeError::new(
-                        interp,
-                        format!(
-                            "no implicit conversion of {} into Integer",
-                            start.pretty_name()
-                        ),
-                    )));
-                };
+                let start = start.implicitly_convert_to_int()?;
                 let end = if let Ok(end) = first.funcall::<Value>("last", &[], None) {
                     end
                 } else {
@@ -191,19 +122,7 @@ pub fn element_assignment(
                         "Unable to extract first from Range",
                     )));
                 };
-                let end = if let Ok(end) = end.clone().try_into::<Int>() {
-                    end
-                } else if let Ok(end) = end.funcall::<Int>("to_int", &[], None) {
-                    end
-                } else {
-                    return Err(Exception::from(TypeError::new(
-                        interp,
-                        format!(
-                            "no implicit conversion of {} into Integer",
-                            end.pretty_name()
-                        ),
-                    )));
-                };
+                let end = end.implicitly_convert_to_int()?;
                 if start + (end - start) < 0 {
                     return Err(Exception::from(RangeError::new(
                         interp,

--- a/artichoke-backend/src/extn/core/kernel/integer.rs
+++ b/artichoke-backend/src/extn/core/kernel/integer.rs
@@ -18,13 +18,7 @@ pub fn method(interp: &Artichoke, arg: Value, radix: Option<Value>) -> Result<Va
         Accumulate(Sign, String),
     }
     let radix = if let Some(radix) = radix {
-        if let Ok(radix) = radix.clone().try_into::<Int>() {
-            Some(radix)
-        } else if let Ok(radix) = radix.funcall::<Int>("to_int", &[], None) {
-            Some(radix)
-        } else {
-            None
-        }
+        radix.implicitly_convert_to_int().ok()
     } else {
         None
     };

--- a/artichoke-backend/src/extn/core/matchdata/begin.rs
+++ b/artichoke-backend/src/extn/core/matchdata/begin.rs
@@ -14,18 +14,12 @@ pub enum Args<'a> {
 
 impl<'a> Args<'a> {
     pub fn extract(interp: &Artichoke, at: Value) -> Result<Self, Exception> {
-        let name = at.pretty_name();
-        if let Ok(index) = at.clone().try_into::<Int>() {
-            Ok(Self::Index(index))
-        } else if let Ok(name) = at.clone().try_into::<&str>() {
+        let _ = interp;
+        if let Ok(name) = at.clone().try_into::<&str>() {
             Ok(Self::Name(name))
-        } else if let Ok(index) = at.funcall::<Int>("to_int", &[], None) {
-            Ok(Self::Index(index))
         } else {
-            Err(Exception::from(TypeError::new(
-                interp,
-                format!("no implicit conversion of {} into Integer", name),
-            )))
+            let index = at.implicitly_convert_to_int()?;
+            Ok(Self::Index(index))
         }
     }
 }

--- a/artichoke-backend/src/extn/core/matchdata/end.rs
+++ b/artichoke-backend/src/extn/core/matchdata/end.rs
@@ -14,18 +14,12 @@ pub enum Args<'a> {
 
 impl<'a> Args<'a> {
     pub fn extract(interp: &Artichoke, at: Value) -> Result<Self, Exception> {
-        let name = at.pretty_name();
-        if let Ok(index) = at.clone().try_into::<Int>() {
-            Ok(Self::Index(index))
-        } else if let Ok(name) = at.clone().try_into::<&str>() {
+        let _ = interp;
+        if let Ok(name) = at.clone().try_into::<&str>() {
             Ok(Self::Name(name))
-        } else if let Ok(index) = at.funcall::<Int>("to_int", &[], None) {
-            Ok(Self::Index(index))
         } else {
-            Err(Exception::from(TypeError::new(
-                interp,
-                format!("no implicit conversion of {} into Integer", name),
-            )))
+            let index = at.implicitly_convert_to_int()?;
+            Ok(Self::Index(index))
         }
     }
 }

--- a/artichoke-backend/src/extn/core/matchdata/offset.rs
+++ b/artichoke-backend/src/extn/core/matchdata/offset.rs
@@ -14,18 +14,12 @@ pub enum Args<'a> {
 
 impl<'a> Args<'a> {
     pub fn extract(interp: &Artichoke, elem: Value) -> Result<Self, Exception> {
-        let name = elem.pretty_name();
-        if let Ok(index) = elem.clone().try_into::<Int>() {
-            Ok(Self::Index(index))
-        } else if let Ok(name) = elem.funcall::<&str>("to_str", &[], None) {
+        let _ = interp;
+        if let Ok(name) = elem.funcall::<&str>("to_str", &[], None) {
             Ok(Self::Name(name))
-        } else if let Ok(index) = elem.funcall::<Int>("to_int", &[], None) {
-            Ok(Self::Index(index))
         } else {
-            Err(Exception::from(TypeError::new(
-                interp,
-                format!("no implicit conversion of {} into Integer", name),
-            )))
+            let index = elem.implicitly_convert_to_int()?;
+            Ok(Self::Index(index))
         }
     }
 }

--- a/artichoke-backend/src/extn/core/regexp/mod.rs
+++ b/artichoke-backend/src/extn/core/regexp/mod.rs
@@ -413,19 +413,7 @@ impl Regexp {
             return Ok(interp.convert(false));
         };
         let pos = if let Some(pos) = pos {
-            if let Ok(pos) = pos.clone().try_into::<Int>() {
-                Some(pos)
-            } else if let Ok(pos) = pos.funcall::<Int>("to_int", &[], None) {
-                Some(pos)
-            } else {
-                return Err(Exception::from(TypeError::new(
-                    interp,
-                    format!(
-                        "no implicit conversion of {} into Integer",
-                        pos.pretty_name()
-                    ),
-                )));
-            }
+            Some(pos.implicitly_convert_to_int()?)
         } else {
             None
         };
@@ -464,19 +452,7 @@ impl Regexp {
             return Ok(matchdata);
         };
         let pos = if let Some(pos) = pos {
-            if let Ok(pos) = pos.clone().try_into::<Int>() {
-                Some(pos)
-            } else if let Ok(pos) = pos.funcall::<Int>("to_int", &[], None) {
-                Some(pos)
-            } else {
-                return Err(Exception::from(TypeError::new(
-                    interp,
-                    format!(
-                        "no implicit conversion of {} into Integer",
-                        pos.pretty_name()
-                    ),
-                )));
-            }
+            Some(pos.implicitly_convert_to_int()?)
         } else {
             None
         };


### PR DESCRIPTION
This PR was extracted from GH-442.