### PR TITLE
Parse raw mrb pointers into NonNull for added safety

### DIFF
--- a/artichoke-backend/src/state.rs
+++ b/artichoke-backend/src/state.rs
@@ -3,6 +3,7 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fmt;
 use std::io::{self, Write};
+use std::ptr::{self, NonNull};
 
 use crate::class;
 use crate::eval::Context;
@@ -89,36 +90,33 @@ impl State {
 
     /// Close a [`State`] and free underlying mruby structs and memory.
     pub fn close(&mut self) {
-        unsafe {
-            // At this point, the only refs to the smart poitner wrapping the
-            // state are stored in the `mrb_state->ud` pointer and any
-            // `MRB_TT_DATA` objects in the mruby heap.
-            //
-            // To clean up:
-            //
-            // - Save the raw pointer to the `Artichoke` from the user data.
-            // - Free the mrb context.
-            // - Close the interpreter which frees every object in the heap and
-            //   drops the strong count on the Rc to 1.
-            // - Rematerialize the `Rc`.
-            // - Drop the `Rc` which drops the strong count to 0 and frees the
-            //   state.
-            // - Set the userdata pointer to null.
-            // - Set context and mrb properties to null.
-            if self.mrb.is_null() {
-                return;
+        // At this point, the only refs to the smart poitner wrapping the state
+        // are stored in the `mrb_state->ud` pointer and any `MRB_TT_DATA`
+        // objects in the mruby heap.
+        //
+        // To clean up:
+        //
+        // - Save the raw pointer to the `Artichoke` from the user data.
+        // - Free the mrb context.
+        // - Close the interpreter which frees every object in the heap and
+        // drops the strong count on the Rc to 1.
+        // - Rematerialize the `Rc`.
+        // - Drop the `Rc` which drops the strong count to 0 and frees the
+        //   state.
+        // - Set the userdata pointer to null.
+        // - Set context and mrb properties to null.
+        if let Some(mut mrb) = NonNull::new(self.mrb) {
+            if let Some(_userdata) = NonNull::new(unsafe { mrb.as_ref().ud }) {
+                unsafe {
+                    // Free mrb data structures
+                    sys::mrbc_context_free(mrb.as_mut(), self.ctx);
+                    sys::mrb_close(mrb.as_mut());
+                }
             }
-            let ptr = (*self.mrb).ud;
-            if ptr.is_null() {
-                return;
-            }
-            // Free mrb data structures
-            sys::mrbc_context_free(self.mrb, self.ctx);
-            sys::mrb_close(self.mrb);
-            // Cleanup dangling pointers
-            self.ctx = std::ptr::null_mut();
-            self.mrb = std::ptr::null_mut();
-        };
+        }
+        // Cleanup dangling pointers
+        self.ctx = ptr::null_mut();
+        self.mrb = ptr::null_mut();
     }
 
     /// Create a class definition bound to a Rust type `T`. Class definitions

--- a/artichoke-backend/src/sys/mod.rs
+++ b/artichoke-backend/src/sys/mod.rs
@@ -78,14 +78,17 @@ pub trait DescribeState {
 }
 
 impl DescribeState for mrb_state {
+    #[must_use]
     fn info(&self) -> String {
         format!("{}", self)
     }
 
+    #[must_use]
     fn debug(&self) -> String {
         format!("{:?}", self)
     }
 
+    #[must_use]
     fn version(&self) -> String {
         // Safety:
         //
@@ -134,48 +137,58 @@ impl fmt::Display for mrb_state {
 }
 
 impl DescribeState for &mut mrb_state {
+    #[must_use]
     fn info(&self) -> String {
         format!("{}", **self)
     }
 
+    #[must_use]
     fn debug(&self) -> String {
         format!("{:?}", **self)
     }
 
+    #[must_use]
     fn version(&self) -> String {
         (**self).version()
     }
 }
 
 impl DescribeState for &mrb_state {
+    #[must_use]
     fn info(&self) -> String {
         format!("{}", **self)
     }
 
+    #[must_use]
     fn debug(&self) -> String {
         format!("{:?}", **self)
     }
 
+    #[must_use]
     fn version(&self) -> String {
         (**self).version()
     }
 }
 
 impl DescribeState for NonNull<mrb_state> {
+    #[must_use]
     fn info(&self) -> String {
         format!("{}", unsafe { self.as_ref() })
     }
 
+    #[must_use]
     fn debug(&self) -> String {
         format!("{:?}", unsafe { self.as_ref() })
     }
 
+    #[must_use]
     fn version(&self) -> String {
         unsafe { self.as_ref() }.version()
     }
 }
 
 impl DescribeState for *mut mrb_state {
+    #[must_use]
     fn info(&self) -> String {
         NonNull::new(unsafe { &mut **self })
             .as_ref()
@@ -183,6 +196,7 @@ impl DescribeState for *mut mrb_state {
             .unwrap_or_default()
     }
 
+    #[must_use]
     fn debug(&self) -> String {
         NonNull::new(unsafe { &mut **self })
             .as_ref()
@@ -190,6 +204,7 @@ impl DescribeState for *mut mrb_state {
             .unwrap_or_default()
     }
 
+    #[must_use]
     fn version(&self) -> String {
         NonNull::new(unsafe { &mut **self })
             .as_ref()

--- a/artichoke-backend/src/value.rs
+++ b/artichoke-backend/src/value.rs
@@ -3,6 +3,7 @@ use std::convert::TryFrom;
 use std::ffi::c_void;
 use std::fmt;
 use std::mem;
+use std::ptr;
 
 use crate::convert::{Convert, TryConvert};
 use crate::exception::Exception;
@@ -381,9 +382,9 @@ impl Clone for Value {
 impl PartialEq for Value {
     #[must_use]
     fn eq(&self, other: &Self) -> bool {
-        std::ptr::eq(unsafe { sys::mrb_sys_basic_ptr(self.inner()) }, unsafe {
-            sys::mrb_sys_basic_ptr(other.inner())
-        })
+        let this = unsafe { sys::mrb_sys_basic_ptr(self.inner()) };
+        let other = unsafe { sys::mrb_sys_basic_ptr(other.inner()) };
+        ptr::eq(this, other)
     }
 }
 


### PR DESCRIPTION
This commit was extracted from GH-442.

This commit is a step toward storing `NonNull<sys::mrb_state>` on
the Artichoke struct directly.