### PR TITLE
Remove dependency on artichoke_core::value::Value in artichoke-backend converters

### DIFF
--- a/artichoke-backend/src/convert/array.rs
+++ b/artichoke-backend/src/convert/array.rs
@@ -1,4 +1,3 @@
-use artichoke_core::value::Value as _;
 use std::convert::TryFrom;
 
 use crate::convert::{Convert, TryConvert};
@@ -117,11 +116,10 @@ macro_rules! ruby_to_array {
     ($elem:ty) => {
         impl<'a> TryConvert<Value, Vec<$elem>> for Artichoke {
             fn try_convert(&self, value: Value) -> Result<Vec<$elem>, ArtichokeError> {
-                let elems: Vec<Value> = self.try_convert(value)?;
+                let elems = TryConvert::<_, Vec<Value>>::try_convert(self, value)?;
                 let mut vec = Vec::<$elem>::with_capacity(elems.len());
                 for elem in elems.into_iter() {
-                    let elem = elem.try_into::<$elem>()?;
-                    vec.push(elem);
+                    vec.push(self.try_convert(elem)?);
                 }
                 Ok(vec)
             }

--- a/artichoke-backend/src/convert/bytes.rs
+++ b/artichoke-backend/src/convert/bytes.rs
@@ -38,7 +38,6 @@ impl<'a> TryConvert<Value, &'a [u8]> for Artichoke {
         let mrb = self.0.borrow().mrb;
         match value.ruby_type() {
             Ruby::Symbol => {
-                let mrb = self.0.borrow().mrb;
                 // mruby does not expose an API to get the raw byte contents of a
                 // `Symbol`. For non-literal symbols and non-ASCII symbols,
                 // `sys::mrb_sys_symbol_name` round trips through a `String`

--- a/artichoke-backend/src/convert/hash.rs
+++ b/artichoke-backend/src/convert/hash.rs
@@ -1,4 +1,3 @@
-use artichoke_core::value::Value as _;
 use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::hash::BuildHasher;
@@ -125,7 +124,7 @@ macro_rules! ruby_to_hash {
     ($key:ty => $value:ty) => {
         impl<'a> TryConvert<Value, Vec<($key, $value)>> for Artichoke {
             fn try_convert(&self, value: Value) -> Result<Vec<($key, $value)>, ArtichokeError> {
-                let pairs = value.try_into::<Vec<(Value, Value)>>()?;
+                let pairs = TryConvert::<_, Vec<(Value, Value)>>::try_convert(self, value)?;
                 let mut vec = Vec::with_capacity(pairs.len());
                 for (key, value) in pairs.into_iter() {
                     let key = self.try_convert(key)?;
@@ -144,6 +143,7 @@ macro_rules! ruby_to_hash {
                 value: Value,
             ) -> Result<HashMap<$key, $value, S>, ArtichokeError> {
                 let pairs = TryConvert::<_, Vec<($key, $value)>>::try_convert(self, value)?;
+                // we can't set capacity since we are paratemterized on hasher.
                 let mut hash = HashMap::default();
                 for (key, value) in pairs {
                     hash.insert(key, value);

--- a/artichoke-backend/src/convert/nilable.rs
+++ b/artichoke-backend/src/convert/nilable.rs
@@ -1,7 +1,6 @@
 //! Converters for nilable primitive Ruby types. Excludes collection types
 //! Array and Hash.
 
-use artichoke_core::value::Value as _;
 use std::collections::HashMap;
 
 use crate::convert::{Convert, TryConvert};
@@ -57,7 +56,7 @@ macro_rules! ruby_to_option {
         impl<'a> TryConvert<Value, Option<$elem>> for Artichoke {
             fn try_convert(&self, value: Value) -> Result<Option<$elem>, ArtichokeError> {
                 if let Some(value) = self.convert(value) {
-                    value.try_into::<$elem>().map(Some)
+                    self.try_convert(value).map(Some)
                 } else {
                     Ok(None)
                 }

--- a/artichoke-backend/src/convert/string.rs
+++ b/artichoke-backend/src/convert/string.rs
@@ -1,4 +1,3 @@
-use artichoke_core::value::Value as _;
 use std::str;
 
 use crate::convert::{Convert, TryConvert};
@@ -31,8 +30,8 @@ impl TryConvert<Value, String> for Artichoke {
 impl<'a> TryConvert<Value, &'a str> for Artichoke {
     fn try_convert(&self, value: Value) -> Result<&'a str, ArtichokeError> {
         let type_tag = value.ruby_type();
-        let bytes = value
-            .try_into::<&[u8]>()
+        let bytes = self
+            .try_convert(value)
             .map_err(|_| ArtichokeError::ConvertToRust {
                 from: type_tag,
                 to: Rust::String,


### PR DESCRIPTION
Remove instances of value.try_into and instead use the TryConverter trait, sometimes
with assisted inference.