### PR TITLE
Replace unwrap_or_default with semantic error handling

### DIFF
--- a/artichoke-backend/src/class.rs
+++ b/artichoke-backend/src/class.rs
@@ -159,7 +159,7 @@ impl Spec {
         let mrb = interp.0.borrow().mrb;
         let mut rclass = self.rclass(mrb)?;
         let args = args.iter().map(Value::inner).collect::<Vec<_>>();
-        let arglen = Int::try_from(args.len()).unwrap_or_default();
+        let arglen = Int::try_from(args.len()).ok()?;
         let value = unsafe { sys::mrb_obj_new(mrb, rclass.as_mut(), arglen, args.as_ptr()) };
         Some(Value::new(interp, value))
     }

--- a/artichoke-backend/src/exception.rs
+++ b/artichoke-backend/src/exception.rs
@@ -246,9 +246,7 @@ impl RubyException for CaughtException {
 
     fn backtrace(&self, interp: &Artichoke) -> Option<Vec<Vec<u8>>> {
         let _ = interp;
-        self.value
-            .funcall("backtrace", &[], None)
-            .unwrap_or_default()
+        self.value.funcall("backtrace", &[], None).ok()
     }
 
     fn as_mrb_value(&self, interp: &Artichoke) -> Option<sys::mrb_value> {

--- a/artichoke-backend/src/extn/core/regexp/mruby.rs
+++ b/artichoke-backend/src/extn/core/regexp/mruby.rs
@@ -67,12 +67,11 @@ unsafe extern "C" fn compile(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> s
     // Call `mrb_obj_new` instead of allocating an object of class `slf` and
     // delegating to `regexp::trampoline::initialize` to handle cases where
     // subclasses override initialize.
-    sys::mrb_obj_new(
-        mrb,
-        sys::mrb_sys_class_ptr(slf),
-        Int::try_from(args.len()).unwrap_or_default(),
-        args.as_ptr(),
-    )
+    if let Ok(argslen) = Int::try_from(args.len()) {
+        sys::mrb_obj_new(mrb, sys::mrb_sys_class_ptr(slf), argslen, args.as_ptr())
+    } else {
+        sys::mrb_sys_nil_value()
+    }
 }
 
 unsafe extern "C" fn escape(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {

--- a/artichoke-backend/src/value.rs
+++ b/artichoke-backend/src/value.rs
@@ -62,7 +62,11 @@ impl<'a> Protect<'a> {
         // This will always unwrap because we've already checked that we
         // have fewer than `MRB_FUNCALL_ARGC_MAX` args, which is less than
         // i64 max value.
-        let argslen = Int::try_from(args.len()).unwrap_or_default();
+        let argslen = if let Ok(argslen) = Int::try_from(args.len()) {
+            argslen
+        } else {
+            return sys::mrb_sys_nil_value();
+        };
         let block = protect.block;
 
         // Drop the `Box` to ensure it is freed.


### PR DESCRIPTION
- Convert Result to Option with ok().
- Handle failed FFI conversions between usize and mrb_int.

This PR was extracted from GH-442.

See also GH-430.