### PR TITLE
Add safety and logging to exception::raise

### DIFF
--- a/artichoke-backend/src/exception.rs
+++ b/artichoke-backend/src/exception.rs
@@ -73,12 +73,12 @@ impl From<Box<dyn RubyException>> for Exception {
 /// Because this precondition must hold for all frames between the caller and
 /// the closest [`sys::mrb_protect`] landing pad, this function should only be
 /// called in the entrypoint into Rust from mruby.
-pub unsafe fn raise(interp: Artichoke, exception: impl RubyException) -> ! {
+pub unsafe fn raise(interp: Artichoke, exception: impl RubyException + fmt::Debug) -> ! {
     let exc = if let Some(exc) = exception.as_mrb_value(&interp) {
         exc
     } else {
-        error!("unable to raise {}", exception.name());
-        panic!("unable to raise {}", exception.name());
+        error!("unable to raise {:?}", exception);
+        panic!("unable to raise {:?}", exception);
     };
     // `mrb_sys_raise` will call longjmp which will unwind the stack.
     // Any non-`Copy` objects that we haven't cleaned up at this point will

--- a/artichoke-backend/src/lib.rs
+++ b/artichoke-backend/src/lib.rs
@@ -148,8 +148,18 @@ impl Artichoke {
     ///
     /// This is an associated function and must be called as
     /// `Artichoke::into_raw(interp)`.
+    ///
+    /// # Safety
+    ///
+    /// After calling this function, the caller is responsible for properly
+    /// freeing the memory occupied by the interpreter heap. The easiest way to
+    /// do this is to call `ffi::from_user_data` with the returned pointer and
+    /// then call `Artichoke::close`.
+    #[must_use]
     pub unsafe fn into_raw(interp: Self) -> *mut sys::mrb_state {
-        interp.0.borrow_mut().mrb
+        let mrb = interp.0.borrow_mut().mrb;
+        drop(interp);
+        mrb
     }
 
     /// Consume an interpreter and free all

--- a/artichoke-backend/src/lib.rs
+++ b/artichoke-backend/src/lib.rs
@@ -140,6 +140,18 @@ use crate::exception::Exception;
 pub struct Artichoke(pub Rc<RefCell<state::State>>); // TODO: this should not be pub
 
 impl Artichoke {
+    /// Consume an interpreter and return the pointer to the underlying
+    /// [`sys::mrb_state`].
+    ///
+    /// This function does not free any interpreter resources. Its intended use
+    /// is to prepare the interpreter to cross over an FFI boundary.
+    ///
+    /// This is an associated function and must be called as
+    /// `Artichoke::into_raw(interp)`.
+    pub unsafe fn into_raw(interp: Self) -> *mut sys::mrb_state {
+        interp.0.borrow_mut().mrb
+    }
+
     /// Consume an interpreter and free all
     /// [live](gc::MrbGarbageCollection::live_object_count)
     /// [`Value`](value::Value)s.


### PR DESCRIPTION
- Add `Artichoke::into_raw` associated function analogous to `Box::into_raw` that consumes an interpreter and returns the underlying `*mut mrb_state`.
- Use this new API in `exception::raise`.
- Add a `fmt::Debug` trait bound on the `RubyException` passed into `exception::raise`.
- Use debug formatting of exception in `error` and `panic` messages.

This PR was inspired by GH-442.