### PR TITLE
Push nil-value coercion to the edge of Array API

### DIFF
--- a/artichoke-backend/src/extn/core/array/backend/mod.rs
+++ b/artichoke-backend/src/extn/core/array/backend/mod.rs
@@ -13,7 +13,7 @@ pub trait ArrayType: Any {
 
     fn is_empty(&self) -> bool;
 
-    fn get(&self, interp: &Artichoke, index: usize) -> Result<Value, Exception>;
+    fn get(&self, interp: &Artichoke, index: usize) -> Result<Option<Value>, Exception>;
 
     fn slice(
         &self,

--- a/artichoke-backend/src/extn/core/array/ffi.rs
+++ b/artichoke-backend/src/extn/core/array/ffi.rs
@@ -191,7 +191,7 @@ unsafe extern "C" fn artichoke_ary_ref(
     let result = if let Ok(array) = Array::try_from_ruby(&interp, &ary) {
         let borrow = array.borrow();
         let gc_was_enabled = interp.disable_gc();
-        let result = borrow.0.get(&interp, offset);
+        let result = borrow.get(&interp, offset);
         if gc_was_enabled {
             interp.enable_gc();
         }

--- a/artichoke-backend/src/extn/core/array/inline_buffer.rs
+++ b/artichoke-backend/src/extn/core/array/inline_buffer.rs
@@ -67,7 +67,7 @@ impl ArrayType for InlineBuffer {
         self.0.is_empty()
     }
 
-    fn get(&self, interp: &Artichoke, index: usize) -> Result<Value, Exception> {
+    fn get(&self, interp: &Artichoke, index: usize) -> Result<Option<Value>, Exception> {
         Self::get(self, interp, index)
     }
 
@@ -198,10 +198,9 @@ impl InlineBuffer {
         self.0.clear();
     }
 
-    pub fn get(&self, interp: &Artichoke, index: usize) -> Result<Value, Exception> {
+    pub fn get(&self, interp: &Artichoke, index: usize) -> Result<Option<Value>, Exception> {
         let elem = self.0.get(index);
-        let elem = elem.copied().map(|elem| Value::new(interp, elem));
-        Ok(interp.convert(elem))
+        Ok(elem.copied().map(|elem| Value::new(interp, elem)))
     }
 
     pub fn slice(&self, interp: &Artichoke, start: usize, len: usize) -> Result<Self, Exception> {

--- a/artichoke-backend/src/extn/core/array/mod.rs
+++ b/artichoke-backend/src/extn/core/array/mod.rs
@@ -152,7 +152,8 @@ impl Array {
             })?;
             Ok(result)
         } else {
-            self.0.get(interp, start)
+            let result = self.0.get(interp, start)?;
+            Ok(interp.convert(result))
         }
     }
 
@@ -200,7 +201,8 @@ impl Array {
     }
 
     pub fn get(&self, interp: &Artichoke, index: usize) -> Result<Value, Exception> {
-        self.0.get(interp, index)
+        let result = self.0.get(interp, index)?;
+        Ok(interp.convert(result))
     }
 
     pub fn slice(


### PR DESCRIPTION
Change the return type on ArrayType::get to return Option<Value> in
the success case. This makes the type more closely align with std
collections and may eliminate the need for an ArrayType to use the
converter APIs.

This pushes conversion of None valued options into a nil Value to
the public API of Array.

This is part of a push to push interpreter glue to out of core type
backends.

This PR was inspired by GH-442.