### PR TITLE
Implement default fill branches of Array#initialize constructor

### DIFF
--- a/artichoke-backend/src/extn/core/array/mod.rs
+++ b/artichoke-backend/src/extn/core/array/mod.rs
@@ -92,17 +92,17 @@ impl Array {
                             RangeError::new(interp, "bignum too big to convert into `long'")
                         })?;
                         let idx = interp.convert(idx);
-                        // TODO: propagate exceptions from block call.
                         let elem = block.yield_arg::<Value>(interp, &idx)?;
-                        buffer.push(elem);
+                        buffer.push(elem.inner());
                     }
                     InlineBuffer::from(buffer)
-                } else if let Some(_default) = second {
-                    // backend::repeated::value(default, len)
-                    unimplemented!();
                 } else {
-                    // backend::fixed::hole(len)
-                    unimplemented!();
+                    let default = second.unwrap_or_else(|| interp.convert(None::<Value>));
+                    let mut buffer = Vec::with_capacity(len);
+                    for _ in 0..len {
+                        buffer.push(default.inner());
+                    }
+                    InlineBuffer::from(buffer)
                 }
             }
         } else if second.is_some() {


### PR DESCRIPTION
When InlineBuffer was introduced, the branches in Array::initialize that
were previously implemented with `backend::repeated::value` and
`backend::fixed::hole` were replaced with a call to `unimplemented`.

This commit implements these cases and does so by unifying them into one
branch. This branch and the one above for block initializations are
modified to build a buffer of `sys::mrb_value` instead of `Value` to
reduce an allocation while constructing the `SmallVec`.

This PR is inspired by GH-442.