### PR TITLE
Propagate Exception errors from Warn::warn in extn

### DIFF
--- a/artichoke-backend/src/extn/core/array/mod.rs
+++ b/artichoke-backend/src/extn/core/array/mod.rs
@@ -75,9 +75,7 @@ impl Array {
                     .map_err(|_| ArgumentError::new(interp, "negative array size"))?;
                 if let Some(block) = block {
                     if second.is_some() {
-                        interp
-                            .warn(&b"warning: block supersedes default value argument"[..])
-                            .map_err(|_| Fatal::new(interp, "Could not emit warning"))?;
+                        interp.warn(&b"warning: block supersedes default value argument"[..])?;
                     }
                     let mut buffer = Vec::with_capacity(len);
                     for idx in 0..len {

--- a/artichoke-backend/src/extn/core/regexp/mod.rs
+++ b/artichoke-backend/src/extn/core/regexp/mod.rs
@@ -133,9 +133,7 @@ impl Regexp {
                     let encoding_bytes = encoding.to_s();
                     let encoding_string = String::from_utf8_lossy(encoding_bytes.as_slice());
                     let warning = format!("encoding option is ignored -- {}", encoding_string);
-                    interp
-                        .warn(warning.as_bytes())
-                        .map_err(|_| Fatal::new(interp, "Warn for ignored encoding failed"))?;
+                    interp.warn(warning.as_bytes())?;
                     None
                 }
             };
@@ -148,9 +146,7 @@ impl Regexp {
                     let options_bytes = options.to_s();
                     let options_string = String::from_utf8_lossy(options_bytes.as_slice());
                     let warning = format!("encoding option is ignored -- {}", options_string);
-                    interp
-                        .warn(warning.as_bytes())
-                        .map_err(|_| Fatal::new(interp, "Warn for ignored encoding failed"))?;
+                    interp.warn(warning.as_bytes())?;
                     None
                 }
             };
@@ -161,9 +157,7 @@ impl Regexp {
         };
         let literal_config = if let Ok(regexp) = unsafe { Self::try_from_ruby(interp, &pattern) } {
             if options.is_some() || encoding.is_some() {
-                interp
-                    .warn(&b"flags ignored when initializing from Regexp"[..])
-                    .map_err(|_| Fatal::new(interp, "Warn for ignored encoding failed"))?;
+                interp.warn(&b"flags ignored when initializing from Regexp"[..])?;
             }
             let borrow = regexp.borrow();
             let options = borrow.0.literal_config().options;


### PR DESCRIPTION
When `Warn::warn` used to return `ArtichokeError` in the error case, it was necessary to mask these errors into a `RubyException`. `Warn::warn` now returns a `RubyException` compatible error, so these masks are no longer necessary.

This means underlying errors from the funcall on `Warning::warn` in Ruby will be propagated.

This PR was inspired by GH-442 and the bug discovered when reviewing GH-462.