### PR TITLE
Rewrite ENV module

### DIFF
--- a/artichoke-backend/src/extn/core/env/backend/memory.rs
+++ b/artichoke-backend/src/extn/core/env/backend/memory.rs
@@ -35,10 +35,10 @@ impl EnvType for Memory {
             return Ok(None);
         }
         if memchr::memchr(b'\0', name).is_some() {
-            Err(ArgumentError::new(
+            return Err(Exception::from(ArgumentError::new(
                 interp,
                 "bad environment variable name: contains null byte",
-            ))?
+            )));
         }
         if memchr::memchr(b'=', name).is_some() {
             // MRI accepts names containing '=' on get and should always return
@@ -64,27 +64,30 @@ impl EnvType for Memory {
         // NUL character.
         if name.is_empty() {
             // TODO: This should raise `Errno::EINVAL`.
-            Err(ArgumentError::new(interp, "Invalid argument - setenv()"))?
+            return Err(Exception::from(ArgumentError::new(
+                interp,
+                "Invalid argument - setenv()",
+            )));
         }
         if memchr::memchr(b'\0', name).is_some() {
-            Err(ArgumentError::new(
+            return Err(Exception::from(ArgumentError::new(
                 interp,
                 "bad environment variable name: contains null byte",
-            ))?
+            )));
         }
         if memchr::memchr(b'=', name).is_some() {
             let mut message = b"Invalid argumen - setenv(".to_vec();
             message.extend(name.to_vec());
             message.push(b')');
             // TODO: This should raise `Errno::EINVAL`.
-            Err(ArgumentError::new_raw(interp, message))?
+            return Err(Exception::from(ArgumentError::new_raw(interp, message)));
         }
         if let Some(value) = value {
             if memchr::memchr(b'\0', value).is_some() {
-                Err(ArgumentError::new(
+                return Err(Exception::from(ArgumentError::new(
                     interp,
                     "bad environment variable value: contains null byte",
-                ))?
+                )));
             }
             self.store.insert(name.to_vec(), value.to_vec());
             Ok(())

--- a/artichoke-backend/src/extn/core/env/backend/mod.rs
+++ b/artichoke-backend/src/extn/core/env/backend/mod.rs
@@ -1,2 +1,24 @@
+use std::borrow::Cow;
+use std::collections::HashMap;
+
+use crate::extn::prelude::*;
+
 pub mod memory;
 pub mod system;
+
+pub trait EnvType {
+    fn get<'a>(
+        &'a self,
+        interp: &Artichoke,
+        name: &[u8],
+    ) -> Result<Option<Cow<'a, [u8]>>, Exception>;
+
+    fn put(
+        &mut self,
+        interp: &Artichoke,
+        name: &[u8],
+        value: Option<&[u8]>,
+    ) -> Result<(), Exception>;
+
+    fn as_map(&self, interp: &Artichoke) -> Result<HashMap<Vec<u8>, Vec<u8>>, Exception>;
+}

--- a/artichoke-backend/src/extn/core/env/backend/system.rs
+++ b/artichoke-backend/src/extn/core/env/backend/system.rs
@@ -34,10 +34,10 @@ impl EnvType for System {
             return Ok(None);
         }
         if memchr::memchr(b'\0', name).is_some() {
-            Err(ArgumentError::new(
+            return Err(Exception::from(ArgumentError::new(
                 interp,
                 "bad environment variable name: contains null byte",
-            ))?
+            )));
         }
         if memchr::memchr(b'=', name).is_some() {
             // MRI accepts names containing '=' on get and should always return
@@ -71,27 +71,30 @@ impl EnvType for System {
         // NUL character.
         if name.is_empty() {
             // TODO: This should raise `Errno::EINVAL`.
-            Err(ArgumentError::new(interp, "Invalid argument - setenv()"))?
+            return Err(Exception::from(ArgumentError::new(
+                interp,
+                "Invalid argument - setenv()",
+            )));
         }
         if memchr::memchr(b'\0', name).is_some() {
-            Err(ArgumentError::new(
+            return Err(Exception::from(ArgumentError::new(
                 interp,
                 "bad environment variable name: contains null byte",
-            ))?
+            )));
         }
         if memchr::memchr(b'=', name).is_some() {
             let mut message = b"Invalid argumen - setenv(".to_vec();
             message.extend(name.to_vec());
             message.push(b')');
             // TODO: This should raise `Errno::EINVAL`.
-            Err(ArgumentError::new_raw(interp, message))?
+            return Err(Exception::from(ArgumentError::new_raw(interp, message)));
         }
         if let Some(value) = value {
             if memchr::memchr(b'\0', value).is_some() {
-                Err(ArgumentError::new(
+                return Err(Exception::from(ArgumentError::new(
                     interp,
                     "bad environment variable value: contains null byte",
-                ))?
+                )));
             }
             std::env::set_var(
                 fs::bytes_to_osstr(interp, name)?,


### PR DESCRIPTION
- Rename `Env` trait to `EnvType` and move it to the `env::backend`
  module to be consistent with Array and other core types.
- Modify return types of `EnvType::get` to return Option<Vec<u8>>. This
  pushes conversions out to the edge. See GH-460.
- Rewrite error handling to use question mark operator for automatic
  `Exception::from` conversions and clearer control flow.
- Return `Cow<'self, [u8]>` in `EnvType::get` to reduce allocations if
  the backend owns the data (as the `Memory` type does).

This PR was extracted from GH-442.