### PR TITLE
Simplify implementation of RubyException::as_value

### DIFF
--- a/artichoke-backend/src/extn/core/exception/mod.rs
+++ b/artichoke-backend/src/extn/core/exception/mod.rs
@@ -373,13 +373,10 @@ macro_rules! ruby_exception_impl {
 
             #[must_use]
             fn as_mrb_value(&self, interp: &Artichoke) -> Option<sys::mrb_value> {
-                interp
-                    .0
-                    .borrow()
-                    .class_spec::<Self>()
-                    .and_then(|spec| spec.new_instance(interp, &[interp.convert(self.message())]))
-                    .as_ref()
-                    .map(Value::inner)
+                let borrow = interp.0.borrow();
+                let spec = borrow.class_spec::<Self>()?;
+                let value = spec.new_instance(interp, &[interp.convert(self.message())])?;
+                Some(value.inner())
             }
         }
 


### PR DESCRIPTION
Use ? operator to unpack options.

This PR was extracted from GH-442.