### PR TITLE
Rewrite random module to introduce a new state component

### DIFF
--- a/artichoke-backend/src/extn/core/random/backend/default.rs
+++ b/artichoke-backend/src/extn/core/random/backend/default.rs
@@ -1,46 +1,32 @@
-use crate::extn::core::random::backend;
+use crate::extn::core::random::backend::RandType;
 use crate::extn::prelude::*;
-
-#[must_use]
-pub fn new() -> Box<dyn backend::Rand> {
-    Box::new(Default::default())
-}
 
 #[derive(Default, Debug, Clone, Copy)]
 pub struct Default;
 
-impl backend::Rand for Default {
-    fn bytes(&mut self, interp: &Artichoke, buf: &mut [u8]) -> Result<(), Exception> {
+impl RandType for Default {
+    fn bytes(&mut self, interp: &mut Artichoke, buf: &mut [u8]) {
         let mut borrow = interp.0.borrow_mut();
-        let prng = borrow.prng_mut();
-        prng.inner_mut().bytes(interp, buf)?;
-        Ok(())
+        borrow.prng.bytes(buf);
     }
 
-    fn seed(&self, interp: &Artichoke) -> Result<u64, Exception> {
-        let borrow = interp.0.borrow_mut();
-        let prng = borrow.prng();
-        let seed = prng.inner().seed(interp)?;
-        Ok(seed)
+    fn seed(&self, interp: &Artichoke) -> u64 {
+        let borrow = interp.0.borrow();
+        borrow.prng.seed()
     }
 
-    fn has_same_internal_state(&self, interp: &Artichoke, other: &dyn backend::Rand) -> bool {
-        let borrow = interp.0.borrow_mut();
-        let prng = borrow.prng();
-        prng.inner().has_same_internal_state(interp, other)
+    fn has_same_internal_state(&self, interp: &Artichoke, other: &dyn RandType) -> bool {
+        let borrow = interp.0.borrow();
+        borrow.prng.has_same_internal_state(other)
     }
 
-    fn rand_int(&mut self, interp: &Artichoke, max: Int) -> Result<Int, Exception> {
+    fn rand_int(&mut self, interp: &mut Artichoke, max: Int) -> Int {
         let mut borrow = interp.0.borrow_mut();
-        let prng = borrow.prng_mut();
-        let rand = prng.inner_mut().rand_int(interp, max)?;
-        Ok(rand)
+        borrow.prng.rand_int(max)
     }
 
-    fn rand_float(&mut self, interp: &Artichoke, max: Option<Float>) -> Result<Float, Exception> {
+    fn rand_float(&mut self, interp: &mut Artichoke, max: Option<Float>) -> Float {
         let mut borrow = interp.0.borrow_mut();
-        let prng = borrow.prng_mut();
-        let rand = prng.inner_mut().rand_float(interp, max)?;
-        Ok(rand)
+        borrow.prng.rand_float(max)
     }
 }

--- a/artichoke-backend/src/extn/core/random/backend/default.rs
+++ b/artichoke-backend/src/extn/core/random/backend/default.rs
@@ -10,6 +10,7 @@ impl RandType for Default {
         borrow.prng.bytes(buf);
     }
 
+    #[must_use]
     fn seed(&self, interp: &Artichoke) -> u64 {
         let borrow = interp.0.borrow();
         borrow.prng.seed()

--- a/artichoke-backend/src/extn/core/random/backend/mod.rs
+++ b/artichoke-backend/src/extn/core/random/backend/mod.rs
@@ -6,28 +6,28 @@ pub mod default;
 pub mod rand;
 
 /// Common API for [`Random`](crate::extn::core::random::Random) backends.
-pub trait Rand: Any {
+pub trait RandType: Any {
     /// Completely fill a buffer with random bytes.
-    fn bytes(&mut self, interp: &Artichoke, buf: &mut [u8]) -> Result<(), Exception>;
+    fn bytes(&mut self, interp: &mut Artichoke, buf: &mut [u8]);
 
     /// Return the value this backend was seeded with.
-    fn seed(&self, interp: &Artichoke) -> Result<u64, Exception>;
+    fn seed(&self, interp: &Artichoke) -> u64;
 
     /// Return true if this and `other` would return the same sequence of random
     /// data.
-    fn has_same_internal_state(&self, interp: &Artichoke, other: &dyn Rand) -> bool;
+    fn has_same_internal_state(&self, interp: &Artichoke, other: &dyn RandType) -> bool;
 
     /// Return a random `Integer` between 0 and `max` -- `[0, max)`.
-    fn rand_int(&mut self, interp: &Artichoke, max: Int) -> Result<Int, Exception>;
+    fn rand_int(&mut self, interp: &mut Artichoke, max: Int) -> Int;
 
     /// Return a random `Float` between 0 and `max` -- `[0, max)`.
     ///
     /// If `max` is `None`, return a random `Float between 0 and 1.0 --
     /// `[0, 1.0)`.
-    fn rand_float(&mut self, interp: &Artichoke, max: Option<Float>) -> Result<Float, Exception>;
+    fn rand_float(&mut self, interp: &mut Artichoke, max: Option<Float>) -> Float;
 }
 
 #[allow(clippy::missing_safety_doc)]
 mod internal {
-    downcast!(dyn super::Rand);
+    downcast!(dyn super::RandType);
 }

--- a/artichoke-backend/src/extn/core/random/mod.rs
+++ b/artichoke-backend/src/extn/core/random/mod.rs
@@ -4,7 +4,6 @@ use std::convert::TryFrom;
 use std::ptr;
 
 use crate::extn::prelude::*;
-use crate::state::prng::Prng;
 
 pub mod backend;
 pub mod mruby;
@@ -189,7 +188,7 @@ pub fn srand(interp: &Artichoke, number: Option<Value>) -> Result<Value, Excepti
     };
     let mut borrow = interp.0.borrow_mut();
     let old_seed = borrow.prng.seed();
-    borrow.prng = Prng::new(new_seed);
+    borrow.prng.reseed(new_seed);
     #[allow(clippy::cast_possible_wrap)]
     Ok(interp.convert(old_seed as Int))
 }

--- a/artichoke-backend/src/extn/core/random/mruby.rs
+++ b/artichoke-backend/src/extn/core/random/mruby.rs
@@ -31,7 +31,7 @@ pub fn init(interp: &Artichoke) -> InitializeResult<()> {
         .define()?;
     interp.0.borrow_mut().def_class::<random::Random>(spec);
 
-    let default = random::default();
+    let default = random::Random::interpreter_prng_delegate();
     let default = default.try_into_ruby(interp, None)?;
     let borrow = interp.0.borrow();
     let mut rclass = borrow
@@ -93,10 +93,10 @@ unsafe extern "C" fn artichoke_random_bytes(
     slf: sys::mrb_value,
 ) -> sys::mrb_value {
     let size = mrb_get_args!(mrb, required = 1);
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let rand = Value::new(&interp, slf);
     let size = Value::new(&interp, size);
-    let result = random::bytes(&interp, rand, size);
+    let result = random::bytes(&mut interp, rand, size);
     match result {
         Ok(value) => value.inner(),
         Err(exception) => exception::raise(interp, exception),
@@ -109,10 +109,10 @@ unsafe extern "C" fn artichoke_random_rand(
     slf: sys::mrb_value,
 ) -> sys::mrb_value {
     let max = mrb_get_args!(mrb, optional = 1);
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let rand = Value::new(&interp, slf);
     let max = max.map(|max| Value::new(&interp, max));
-    let result = random::rand(&interp, rand, max);
+    let result = random::rand(&mut interp, rand, max);
     match result {
         Ok(value) => value.inner(),
         Err(exception) => exception::raise(interp, exception),

--- a/artichoke-backend/src/state/mod.rs
+++ b/artichoke-backend/src/state/mod.rs
@@ -12,6 +12,8 @@ use crate::module;
 use crate::sys::{self, DescribeState};
 
 pub mod parser;
+#[cfg(feature = "artichoke-random")]
+pub mod prng;
 
 // NOTE: ArtichokeState assumes that it it is stored in `mrb_state->ud` wrapped in a
 // [`Rc`] with type [`Artichoke`] as created by [`crate::interpreter`].
@@ -25,7 +27,7 @@ pub struct State {
     symbol_cache: HashMap<Cow<'static, [u8]>, sys::mrb_sym>,
     captured_output: Option<Vec<u8>>,
     #[cfg(feature = "artichoke-random")]
-    prng: crate::extn::core::random::Random,
+    pub prng: prng::Prng,
 }
 
 impl State {
@@ -44,20 +46,9 @@ impl State {
             symbol_cache: HashMap::default(),
             captured_output: None,
             #[cfg(feature = "artichoke-random")]
-            prng: crate::extn::core::random::new(None),
+            prng: prng::Prng::default(),
         };
         Some(state)
-    }
-
-    #[cfg(feature = "artichoke-random")]
-    #[must_use]
-    pub fn prng(&self) -> &crate::extn::core::random::Random {
-        &self.prng
-    }
-
-    #[cfg(feature = "artichoke-random")]
-    pub fn prng_mut(&mut self) -> &mut crate::extn::core::random::Random {
-        &mut self.prng
     }
 
     pub fn capture_output(&mut self) {

--- a/artichoke-backend/src/state/prng.rs
+++ b/artichoke-backend/src/state/prng.rs
@@ -1,0 +1,43 @@
+use rand::rngs::SmallRng;
+
+use crate::extn::core::random::backend::rand::Rand;
+use crate::extn::core::random::backend::RandType;
+use crate::types::{Float, Int};
+
+pub struct Prng {
+    random: Rand<SmallRng>,
+}
+
+impl Prng {
+    pub fn new(seed: Option<u64>) -> Self {
+        Self {
+            random: Rand::new(seed),
+        }
+    }
+
+    pub fn seed(&self) -> u64 {
+        self.random.seed()
+    }
+
+    pub fn has_same_internal_state(&self, other: &dyn RandType) -> bool {
+        self.random.has_same_internal_state(other)
+    }
+
+    pub fn bytes(&mut self, buf: &mut [u8]) {
+        self.random.bytes(buf);
+    }
+
+    pub fn rand_int(&mut self, max: Int) -> Int {
+        self.random.rand_int(max)
+    }
+
+    pub fn rand_float(&mut self, max: Option<Float>) -> Float {
+        self.random.rand_float(max)
+    }
+}
+
+impl Default for Prng {
+    fn default() -> Self {
+        Self::new(None)
+    }
+}

--- a/artichoke-backend/src/state/prng.rs
+++ b/artichoke-backend/src/state/prng.rs
@@ -9,12 +9,14 @@ pub struct Prng {
 }
 
 impl Prng {
+    #[must_use]
     pub fn new(seed: Option<u64>) -> Self {
         Self {
             random: Rand::new(seed),
         }
     }
 
+    #[must_use]
     pub fn seed(&self) -> u64 {
         self.random.seed()
     }
@@ -41,6 +43,7 @@ impl Prng {
 }
 
 impl Default for Prng {
+    #[must_use]
     fn default() -> Self {
         Self::new(None)
     }

--- a/artichoke-backend/src/state/prng.rs
+++ b/artichoke-backend/src/state/prng.rs
@@ -19,6 +19,10 @@ impl Prng {
         self.random.seed()
     }
 
+    pub fn reseed(&mut self, new_seed: Option<u64>) {
+        self.random = Rand::new(new_seed);
+    }
+
     pub fn has_same_internal_state(&self, other: &dyn RandType) -> bool {
         self.random.has_same_internal_state(other)
     }


### PR DESCRIPTION
This commit renames `random::backend::Rand` trait to `RandType` to match
more closely with other modules. The API has been redefined to remove
fallibility and take mutable references to the interpreter when
required. This approach is part of gradually introducing mutability
requirements that was first rolled out in GH-467.

The previous implementation of the interpreter default PRNG attached a
`Random` instance to the `State`. This approach is not compatible with
an idiomatic borrowing setup, as found in GH-442.

This PR introduces a new `Prng` state component. The `Prng` binds
directly to a `Rand<SmallRng>` instead of a `Random` wrapper around a
`RandType` trait object.

`Rand` random backend has now implemented methods outside of `RandType`
that do not take an interpreter. Since the PRNG on the state binds
directly to a `Rand`, this breaks the circular dependency on the
interpreter.

This PR was extracted from GH-442.