### PR TITLE
Move low-level protect code into sys::protect module

### DIFF
--- a/artichoke-backend/src/exception_handler.rs
+++ b/artichoke-backend/src/exception_handler.rs
@@ -1,81 +1,57 @@
 use artichoke_core::value::Value as _;
-use std::ffi::c_void;
-use std::mem;
-use std::ptr::{self, NonNull};
+use std::ptr;
 
 use crate::exception::{CaughtException, Exception};
 use crate::gc::MrbGarbageCollection;
-use crate::sys;
 use crate::value::Value;
 use crate::Artichoke;
 
-/// Extract the last exception thrown on the interpreter.
-pub trait ExceptionHandler {
-    /// Extract the last thrown exception on the artichoke interpreter if there
-    /// is one.
-    ///
-    /// If there is an error, return an [`Exception`], which contains the
-    /// exception class name, message, and optional backtrace.
-    fn last_error(&self) -> Result<Option<Exception>, Exception>;
-}
+/// Transform a `Exception` Ruby `Value` into an [`Exception`].
+///
+/// # Errors
+///
+/// This function makes funcalls on the interpreter which are fallible.
+pub fn last_error(interp: &Artichoke, exception: Value) -> Result<Exception, Exception> {
+    let _arena = interp.create_arena_savepoint();
+    // Clear the current exception from the mruby interpreter so subsequent
+    // calls to the mruby VM are not tainted by an error they did not
+    // generate.
+    //
+    // We must clear the pointer at the beginning of this function so we can
+    // use the mruby VM to inspect the exception once we turn it into an
+    // `mrb_value`. `Value::funcall` handles errors by calling this
+    // function, so not clearing the exception results in a stack overflow.
 
-impl ExceptionHandler for Artichoke {
-    fn last_error(&self) -> Result<Option<Exception>, Exception> {
-        let _arena = self.create_arena_savepoint();
-        // Clear the current exception from the mruby interpreter so subsequent
-        // calls to the mruby VM are not tainted by an error they did not
-        // generate.
-        //
-        // We must clear the pointer at the beginning of this function so we can
-        // use the mruby VM to inspect the exception once we turn it into an
-        // `mrb_value`. `Value::funcall` handles errors by calling this
-        // function, so not clearing the exception results in a stack overflow.
-
-        // Safety:
-        //
-        // - Artichoke is guaranteed to be constructed with a non-null `mrb`
-        //   pointer by `ffi::from_user_data` and `interpreter::interpreter`.
-        let exc = mem::replace(unsafe { &mut (*self.0.borrow().mrb).exc }, ptr::null_mut());
-        if let Some(exc) = NonNull::new(exc) {
-            // Generate exception metadata in by executing the Ruby code:
-            //
-            // ```ruby
-            // clazz = exception.class.name
-            // message = exception.message
-            // ```
-
-            // Safety:
-            //
-            // - mruby guarantees the `exc` field is either null or a pointer to
-            //   a `sys::RBasic`.
-            // - `sys::mrb_sys_obj_value` takes a pointer to a
-            //   `sys::RBasic`-compatible struct.
-            // - The only write Artichoke makes to this field is a null pointer
-            //   above.
-            // - `exc` is guaranteed to be non-null by `NonNull::new`.
-            let exc = unsafe { sys::mrb_sys_obj_value(exc.cast::<c_void>().as_ptr()) };
-            let exception = Value::new(self, exc);
-
-            // Sometimes when hacking on extn/core it is possible to enter a
-            // crash loop where an exception is captured by this handler, but
-            // extracting the exception name or backtrace throws again.
-            // Uncommenting the folllowing print statement will at least get you
-            // the exception class and message, which should help debugging.
-            //
-            // println!("{:?}", exception);
-
-            let class = exception.funcall::<Value>("class", &[], None)?;
-            let classname = class.funcall::<&str>("name", &[], None)?;
-            let message = exception.funcall::<&[u8]>("message", &[], None)?;
-
-            let exception = CaughtException::new(exception, classname, message);
-            debug!("Extracted exception from interpreter: {}", exception);
-            Ok(Some(Exception::from(exception)))
-        } else {
-            trace!("No last error present");
-            Ok(None)
-        }
+    // Safety:
+    //
+    // - Artichoke is guaranteed to be constructed with a non-null `mrb`
+    //   pointer by `ffi::from_user_data` and `interpreter::interpreter`.
+    unsafe {
+        let mrb = interp.0.borrow().mrb;
+        (*mrb).exc = ptr::null_mut();
     }
+    // Generate exception metadata in by executing the Ruby code:
+    //
+    // ```ruby
+    // clazz = exception.class.name
+    // message = exception.message
+    // ```
+
+    // Sometimes when hacking on extn/core it is possible to enter a
+    // crash loop where an exception is captured by this handler, but
+    // extracting the exception name or backtrace throws again.
+    // Uncommenting the folllowing print statement will at least get you
+    // the exception class and message, which should help debugging.
+    //
+    // println!("{:?}", exception);
+
+    let class = exception.funcall::<Value>("class", &[], None)?;
+    let classname = class.funcall::<&str>("name", &[], None)?;
+    let message = exception.funcall::<&[u8]>("message", &[], None)?;
+
+    let exception = CaughtException::new(exception, classname, message);
+    debug!("Extracted exception from interpreter: {}", exception);
+    Ok(Exception::from(exception))
 }
 
 #[cfg(test)]

--- a/artichoke-backend/src/sys/mod.rs
+++ b/artichoke-backend/src/sys/mod.rs
@@ -20,6 +20,7 @@ mod args;
 mod ffi {
     include!(concat!(env!("OUT_DIR"), "/ffi.rs"));
 }
+pub(crate) mod protect;
 
 #[path = "ffi_tests.rs"]
 #[cfg(test)]

--- a/artichoke-backend/src/sys/protect.rs
+++ b/artichoke-backend/src/sys/protect.rs
@@ -5,29 +5,29 @@ use std::ptr::NonNull;
 use crate::sys;
 use crate::types::Int;
 
-pub unsafe fn funcall<'a>(
+pub unsafe fn funcall(
     mrb: *mut sys::mrb_state,
     slf: sys::mrb_value,
     func: sys::mrb_sym,
-    args: &'a [sys::mrb_value],
+    args: &[sys::mrb_value],
     block: Option<sys::mrb_value>,
 ) -> Result<sys::mrb_value, sys::mrb_value> {
-    let cdata = Funcall {
+    let data = Funcall {
         slf,
         func,
         args,
         block,
     };
-    protect(mrb, cdata)
+    protect(mrb, data)
 }
 
-pub unsafe fn eval<'a>(
+pub unsafe fn eval(
     mrb: *mut sys::mrb_state,
     context: *mut sys::mrbc_context,
-    code: &'a [u8],
+    code: &[u8],
 ) -> Result<sys::mrb_value, sys::mrb_value> {
-    let cdata = Eval { context, code };
-    protect(mrb, cdata)
+    let data = Eval { context, code };
+    protect(mrb, data)
 }
 
 pub unsafe fn block_yield(
@@ -35,17 +35,17 @@ pub unsafe fn block_yield(
     block: sys::mrb_value,
     arg: sys::mrb_value,
 ) -> Result<sys::mrb_value, sys::mrb_value> {
-    let cdata = BlockYield { block, arg };
-    protect(mrb, cdata)
+    let data = BlockYield { block, arg };
+    protect(mrb, data)
 }
 
 unsafe fn protect<T: Protect>(
     mrb: *mut sys::mrb_state,
-    cdata: T,
+    data: T,
 ) -> Result<sys::mrb_value, sys::mrb_value> {
-    let cdata = Box::new(cdata);
-    let cdata = Box::into_raw(cdata);
-    let data = sys::mrb_sys_cptr_value(mrb, cdata as *mut c_void);
+    let data = Box::new(data);
+    let data = Box::into_raw(data);
+    let data = sys::mrb_sys_cptr_value(mrb, data as *mut c_void);
     let mut state = 0;
 
     let value = sys::mrb_protect(mrb, Some(T::run), data, &mut state);

--- a/artichoke-backend/src/sys/protect.rs
+++ b/artichoke-backend/src/sys/protect.rs
@@ -1,0 +1,142 @@
+use std::convert::TryFrom;
+use std::ffi::c_void;
+use std::ptr::NonNull;
+
+use crate::sys;
+use crate::types::Int;
+
+pub unsafe fn funcall<'a>(
+    mrb: *mut sys::mrb_state,
+    slf: sys::mrb_value,
+    func: sys::mrb_sym,
+    args: &'a [sys::mrb_value],
+    block: Option<sys::mrb_value>,
+) -> Result<sys::mrb_value, sys::mrb_value> {
+    let cdata = Funcall {
+        slf,
+        func,
+        args,
+        block,
+    };
+    protect(mrb, cdata)
+}
+
+pub unsafe fn eval<'a>(
+    mrb: *mut sys::mrb_state,
+    context: *mut sys::mrbc_context,
+    code: &'a [u8],
+) -> Result<sys::mrb_value, sys::mrb_value> {
+    let cdata = Eval { context, code };
+    protect(mrb, cdata)
+}
+
+pub unsafe fn block_yield(
+    mrb: *mut sys::mrb_state,
+    block: sys::mrb_value,
+    arg: sys::mrb_value,
+) -> Result<sys::mrb_value, sys::mrb_value> {
+    let cdata = BlockYield { block, arg };
+    protect(mrb, cdata)
+}
+
+unsafe fn protect<T: Protect>(
+    mrb: *mut sys::mrb_state,
+    cdata: T,
+) -> Result<sys::mrb_value, sys::mrb_value> {
+    let cdata = Box::new(cdata);
+    let cdata = Box::into_raw(cdata);
+    let data = sys::mrb_sys_cptr_value(mrb, cdata as *mut c_void);
+    let mut state = 0;
+
+    let value = sys::mrb_protect(mrb, Some(T::run), data, &mut state);
+    if let Some(exc) = NonNull::new((*mrb).exc) {
+        Err(sys::mrb_sys_obj_value(exc.cast::<c_void>().as_ptr()))
+    } else if state == 0 {
+        Ok(value)
+    } else {
+        Err(value)
+    }
+}
+
+trait Protect {
+    unsafe extern "C" fn run(mrb: *mut sys::mrb_state, data: sys::mrb_value) -> sys::mrb_value;
+}
+
+// `Funcall` must be `Copy` because the we may unwind past the frames in which
+// it is used with `longjmp` which does not allow Rust  to run destructors.
+#[derive(Clone, Copy)]
+struct Funcall<'a> {
+    slf: sys::mrb_value,
+    func: u32,
+    args: &'a [sys::mrb_value],
+    block: Option<sys::mrb_value>,
+}
+
+impl<'a> Protect for Funcall<'a> {
+    unsafe extern "C" fn run(mrb: *mut sys::mrb_state, data: sys::mrb_value) -> sys::mrb_value {
+        let ptr = sys::mrb_sys_cptr_ptr(data);
+        // `protect` must be `Copy` because the call to a function in the
+        // `mrb_funcall...` family can unwind with `longjmp` which does not
+        // allow Rust to run destructors.
+        let Self {
+            slf,
+            func,
+            args,
+            block,
+        } = *Box::from_raw(ptr as *mut Self);
+
+        // This will always unwrap because we've already checked that we
+        // have fewer than `MRB_FUNCALL_ARGC_MAX` args, which is less than
+        // i64 max value.
+        let argslen = if let Ok(argslen) = Int::try_from(args.len()) {
+            argslen
+        } else {
+            return sys::mrb_sys_nil_value();
+        };
+
+        if let Some(block) = block {
+            sys::mrb_funcall_with_block(mrb, slf, func, argslen, args.as_ptr(), block)
+        } else {
+            sys::mrb_funcall_argv(mrb, slf, func, argslen, args.as_ptr())
+        }
+    }
+}
+
+// `Eval` must be `Copy` because the we may unwind past the frames in which
+// it is used with `longjmp` which does not allow Rust  to run destructors.
+#[derive(Clone, Copy)]
+struct Eval<'a> {
+    context: *mut sys::mrbc_context,
+    code: &'a [u8],
+}
+
+impl<'a> Protect for Eval<'a> {
+    unsafe extern "C" fn run(mrb: *mut sys::mrb_state, data: sys::mrb_value) -> sys::mrb_value {
+        let ptr = sys::mrb_sys_cptr_ptr(data);
+        let Self { context, code } = *Box::from_raw(ptr as *mut Self);
+
+        // Execute arbitrary ruby code, which may generate objects with C APIs
+        // if backed by Rust functions.
+        //
+        // `mrb_load_nstring_ctx` sets the "stack keep" field on the context
+        // which means the most recent value returned by eval will always be
+        // considered live by the GC.
+        sys::mrb_load_nstring_cxt(mrb, code.as_ptr() as *const i8, code.len(), context)
+    }
+}
+
+// `BlockYield` must be `Copy` because the we may unwind past the frames in which
+// it is used with `longjmp` which does not allow Rust  to run destructors.
+#[derive(Clone, Copy)]
+struct BlockYield {
+    block: sys::mrb_value,
+    arg: sys::mrb_value,
+}
+
+impl Protect for BlockYield {
+    unsafe extern "C" fn run(mrb: *mut sys::mrb_state, data: sys::mrb_value) -> sys::mrb_value {
+        let ptr = sys::mrb_sys_cptr_ptr(data);
+        let Self { block, arg } = *Box::from_raw(ptr as *mut Self);
+        sys::mrb_yield(mrb, block, arg)
+    }
+}


### PR DESCRIPTION
This commit extracts the low-level `mrb_protect` API out of
`Value::funcall`, `Eval::eval`, and `Block::yield_arg`. Module
`sys::protect` exposes functions for each use case that call the
appropriate mruby APIs and wrap each interpreter call in `mrb_protect`
to prevent `longjmp` unwinds from unwinding Rust frames.

This fixes a bug where `mrb_protect` was not present for block yields.

The `sys::protect` family of functions properly extract exceptions from
the interpreter and return `Result<sys::mrb_value, sys::mrb_value>`.
This signigifcantly simplifies the exception handler which has been
refactored into a function instead of a trait.

This change makes explicit an exception handling step that worked by
accident before: some errors like `SyntaxError` do not get returned out
of `mrb_protect` and are only present on the `exc` property of the
`mrb_state`.

This commit makes use of a "move out of `Box` and destructure" pattern I recently learned about.

This change significantly reduces the amount of unsafe.