### PR TITLE
Write warnings to stderr instead of using the log crate

### DIFF
--- a/artichoke-backend/src/warn.rs
+++ b/artichoke-backend/src/warn.rs
@@ -1,6 +1,7 @@
 use artichoke_core::value::Value as _;
 use artichoke_core::warn::Warn;
 use std::borrow::Cow;
+use std::io::{self, Write};
 
 use crate::convert::Convert;
 use crate::exception::Exception;
@@ -13,7 +14,9 @@ impl Warn for Artichoke {
     type Error = Exception;
 
     fn warn(&self, message: &[u8]) -> Result<(), Self::Error> {
-        warn!("rb warning: {}", String::from_utf8_lossy(message));
+        let _ = io::stderr().write_all(b"rb warning: ");
+        let _ = io::stderr().write_all(message);
+        let _ = io::stderr().write_all(b"\n");
         let warning = {
             let borrow = self.0.borrow();
             let spec = borrow


### PR DESCRIPTION
Discovered when working on GH-442.