### PR TITLE
Remove env_logger and backtrace from artichoke-backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,7 +46,6 @@ dependencies = [
  "cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "downcast 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs_extra 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -359,11 +358,8 @@ name = "env_logger"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "humantime 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "termcolor 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,7 +40,6 @@ version = "0.1.0"
 dependencies = [
  "artichoke-core 0.1.0",
  "artichoke-vfs 0.5.0-alpha",
- "backtrace 0.3.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "bindgen 0.51.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bstr 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -10,7 +10,6 @@ license = "MIT"
 keywords = ["artichoke", "artichoke-ruby", "ruby"]
 
 [dependencies]
-backtrace = { version = "0.3", optional = true }
 bstr = "0.2"
 chrono = "0.4"
 downcast = "0.10"
@@ -55,6 +54,5 @@ default-features = false
 default = ["artichoke-array", "artichoke-random", "artichoke-system-environ"]
 artichoke-all-converters = []
 artichoke-array = []
-artichoke-debug = ["backtrace"]
 artichoke-random = ["rand"]
 artichoke-system-environ = []

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -33,7 +33,6 @@ optional = true
 features = ["small_rng"]
 
 [dev-dependencies]
-env_logger = "0.7"
 libc = "0.2"
 quickcheck = "0.9"
 quickcheck_macros = "0.9"

--- a/artichoke-backend/src/extn/core/exception/mod.rs
+++ b/artichoke-backend/src/extn/core/exception/mod.rs
@@ -38,8 +38,6 @@
 //! - `SystemStackError`
 //! - `fatal` -- impossible to rescue
 
-#[cfg(feature = "artichoke-debug")]
-use backtrace::Backtrace;
 use std::borrow::Cow;
 use std::error;
 use std::fmt;
@@ -271,8 +269,6 @@ macro_rules! ruby_exception_impl {
         #[must_use]
         pub struct $exception {
             message: Cow<'static, [u8]>,
-            #[cfg(feature = "artichoke-debug")]
-            backtrace: Backtrace,
         }
 
         impl $exception {
@@ -285,11 +281,7 @@ macro_rules! ruby_exception_impl {
                     Cow::Borrowed(s) => Cow::Borrowed(s.as_bytes()),
                     Cow::Owned(s) => Cow::Owned(s.into_bytes()),
                 };
-                Self {
-                    message,
-                    #[cfg(feature = "artichoke-debug")]
-                    backtrace: Backtrace::new(),
-                }
+                Self { message }
             }
 
             pub fn new_raw<S>(interp: &Artichoke, message: S) -> Self
@@ -299,8 +291,6 @@ macro_rules! ruby_exception_impl {
                 let _ = interp;
                 Self {
                     message: message.into(),
-                    #[cfg(feature = "artichoke-debug")]
-                    backtrace: Backtrace::new(),
                 }
             }
         }
@@ -384,15 +374,6 @@ macro_rules! ruby_exception_impl {
         where
             $exception: RubyException,
         {
-            #[cfg(feature = "artichoke-debug")]
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                let classname = self.name();
-                let message = String::from_utf8_lossy(self.message());
-                write!(f, "{} ({})", classname, message)?;
-                write!(f, "\n{:?}", self.backtrace)
-            }
-
-            #[cfg(not(feature = "artichoke-debug"))]
             fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 let classname = self.name();
                 let message = String::from_utf8_lossy(self.message());


### PR DESCRIPTION
`env_logger` dev-dependency is a relic from when cactusref was part of this repo I
think and is not used in tests.

I added backtraces to RubyExceptions because I thought it was cool and then added
a feature to turn them off because they are slow. This was functionality without
a concrete use case. Time to purge this dep and code. This commit also removes the
`artichoke-debug` feature.