### PR TITLE
Implement a wrapper around BStr's Debug impl

### DIFF
--- a/artichoke-backend/src/extn/core/kernel/integer.rs
+++ b/artichoke-backend/src/extn/core/kernel/integer.rs
@@ -1,4 +1,3 @@
-use bstr::BStr;
 use std::convert::TryFrom;
 use std::iter::Iterator;
 use std::str::{self, FromStr};
@@ -24,18 +23,8 @@ pub fn method(interp: &Artichoke, arg: Value, radix: Option<Value>) -> Result<Va
     };
     let radix = match radix.map(u32::try_from) {
         Some(Ok(radix)) if radix >= 2 && radix <= 36 => Some(radix),
-        Some(Ok(radix)) => {
-            return Err(Exception::from(ArgumentError::new(
-                interp,
-                format!("invalid radix {}", radix),
-            )))
-        }
-        Some(Err(_)) => {
-            return Err(Exception::from(ArgumentError::new(
-                interp,
-                format!("invalid radix {}", radix.unwrap_or_default()),
-            )))
-        }
+        Some(Ok(radix)) => return Err(Exception::from(invalid_radix_error(interp, radix))),
+        Some(Err(_)) => return Err(Exception::from(ArgumentError::new(interp, "invalid radix"))),
         None => None,
     };
     let ruby_type = arg.pretty_name();
@@ -50,18 +39,12 @@ pub fn method(interp: &Artichoke, arg: Value, radix: Option<Value>) -> Result<Va
         )));
     };
     if memchr::memchr(b'\0', arg).is_some() {
-        return Err(Exception::from(ArgumentError::new(
-            interp,
-            format!(r#"invalid value for Integer(): "{}"#, <&BStr>::from(arg)),
-        )));
+        return Err(Exception::from(invalid_value_err(interp, arg)?));
     }
     let arg = if let Ok(arg) = str::from_utf8(arg) {
         arg
     } else {
-        return Err(Exception::from(ArgumentError::new(
-            interp,
-            format!(r#"invalid value for Integer(): "{}"#, <&BStr>::from(arg)),
-        )));
+        return Err(Exception::from(invalid_value_err(interp, arg)?));
     };
 
     let mut state = ParseState::Initial;
@@ -85,10 +68,7 @@ pub fn method(interp: &Artichoke, arg: Value, radix: Option<Value>) -> Result<Va
         }
         if current.is_whitespace() {
             if let Some('+') | Some('-') = prev {
-                return Err(Exception::from(ArgumentError::new(
-                    interp,
-                    format!(r#"invalid value for Integer(): "{}"#, <&BStr>::from(arg)),
-                )));
+                return Err(Exception::from(invalid_value_err(interp, arg.as_bytes())?));
             } else {
                 prev = Some(current);
 
@@ -99,19 +79,13 @@ pub fn method(interp: &Artichoke, arg: Value, radix: Option<Value>) -> Result<Va
         state = match current {
             '+' => {
                 if let ParseState::Sign(_) | ParseState::Accumulate(_, _) = state {
-                    return Err(Exception::from(ArgumentError::new(
-                        interp,
-                        format!(r#"invalid value for Integer(): "{}"#, <&BStr>::from(arg)),
-                    )));
+                    return Err(Exception::from(invalid_value_err(interp, arg.as_bytes())?));
                 }
                 ParseState::Sign(Sign::Pos)
             }
             '-' => {
                 if let ParseState::Sign(_) | ParseState::Accumulate(_, _) = state {
-                    return Err(Exception::from(ArgumentError::new(
-                        interp,
-                        format!(r#"invalid value for Integer(): "{}"#, <&BStr>::from(arg)),
-                    )));
+                    return Err(Exception::from(invalid_value_err(interp, arg.as_bytes())?));
                 }
                 ParseState::Sign(Sign::Neg)
             }
@@ -159,10 +133,7 @@ pub fn method(interp: &Artichoke, arg: Value, radix: Option<Value>) -> Result<Va
                 let next = chars.next();
                 if let Some(next) = next {
                     if !next.is_numeric() && !next.is_alphabetic() {
-                        return Err(Exception::from(ArgumentError::new(
-                            interp,
-                            format!(r#"invalid value for Integer(): "{}"#, <&BStr>::from(arg)),
-                        )));
+                        return Err(Exception::from(invalid_value_err(interp, arg.as_bytes())?));
                     } else if let Some('0') = first {
                         digits.drain(..1);
                         Some(8)
@@ -180,10 +151,7 @@ pub fn method(interp: &Artichoke, arg: Value, radix: Option<Value>) -> Result<Va
         }
         (digits, parsed_radix)
     } else {
-        return Err(Exception::from(ArgumentError::new(
-            interp,
-            format!(r#"invalid value for Integer(): "{}"#, <&BStr>::from(arg)),
-        )));
+        return Err(Exception::from(invalid_value_err(interp, arg.as_bytes())?));
     };
 
     match (radix, parsed_radix) {
@@ -191,39 +159,38 @@ pub fn method(interp: &Artichoke, arg: Value, radix: Option<Value>) -> Result<Va
             if let Ok(integer) = Int::from_str_radix(candidate.as_str(), radix) {
                 Ok(interp.convert(integer))
             } else {
-                Err(Exception::from(ArgumentError::new(
-                    interp,
-                    format!(r#"invalid value for Integer(): "{}"#, <&BStr>::from(arg)),
-                )))
+                Err(Exception::from(invalid_value_err(interp, arg.as_bytes())?))
             }
         }
         (Some(radix), None) | (None, Some(radix)) if radix >= 2 && radix <= 36 => {
             if let Ok(integer) = Int::from_str_radix(candidate.as_str(), radix) {
                 Ok(interp.convert(integer))
             } else {
-                Err(Exception::from(ArgumentError::new(
-                    interp,
-                    format!(r#"invalid value for Integer(): "{}"#, <&BStr>::from(arg)),
-                )))
+                Err(Exception::from(invalid_value_err(interp, arg.as_bytes())?))
             }
         }
         (None, None) => {
             if let Ok(integer) = Int::from_str(candidate.as_str()) {
                 Ok(interp.convert(integer))
             } else {
-                Err(Exception::from(ArgumentError::new(
-                    interp,
-                    format!(r#"invalid value for Integer(): "{}"#, <&BStr>::from(arg)),
-                )))
+                Err(Exception::from(invalid_value_err(interp, arg.as_bytes())?))
             }
         }
-        (Some(_), Some(_)) => Err(Exception::from(ArgumentError::new(
-            interp,
-            format!(r#"invalid value for Integer(): "{}"#, <&BStr>::from(arg)),
-        ))),
-        (Some(radix), None) | (None, Some(radix)) => Err(Exception::from(ArgumentError::new(
-            interp,
-            format!("invalid radix {}", radix),
-        ))),
+        (Some(_), Some(_)) => Err(Exception::from(invalid_value_err(interp, arg.as_bytes())?)),
+        (Some(radix), None) | (None, Some(radix)) => {
+            Err(Exception::from(invalid_radix_error(interp, radix)))
+        }
     }
+}
+
+fn invalid_value_err(interp: &Artichoke, arg: &[u8]) -> Result<ArgumentError, Fatal> {
+    let mut message = String::from(r#"invalid value for Integer(): ""#);
+    string::escape_unicode(&mut message, arg)
+        .map_err(|_| Fatal::new(interp, "Unable to generate ArgumentError"))?;
+    message.push('"');
+    Ok(ArgumentError::new(interp, message))
+}
+
+fn invalid_radix_error(interp: &Artichoke, radix: u32) -> ArgumentError {
+    ArgumentError::new(interp, format!("invalid radix {}", radix))
 }

--- a/artichoke-backend/src/extn/core/kernel/integer.rs
+++ b/artichoke-backend/src/extn/core/kernel/integer.rs
@@ -183,10 +183,9 @@ pub fn method(interp: &Artichoke, arg: Value, radix: Option<Value>) -> Result<Va
     }
 }
 
-fn invalid_value_err(interp: &Artichoke, arg: &[u8]) -> Result<ArgumentError, Fatal> {
+fn invalid_value_err(interp: &Artichoke, arg: &[u8]) -> Result<ArgumentError, Exception> {
     let mut message = String::from(r#"invalid value for Integer(): ""#);
-    string::escape_unicode(&mut message, arg)
-        .map_err(|_| Fatal::new(interp, "Unable to generate ArgumentError"))?;
+    string::escape_unicode(&mut message, arg)?;
     message.push('"');
     Ok(ArgumentError::new(interp, message))
 }

--- a/artichoke-backend/src/extn/core/kernel/require.rs
+++ b/artichoke-backend/src/extn/core/kernel/require.rs
@@ -75,11 +75,7 @@ pub fn load(interp: &mut Artichoke, filename: Value) -> Result<Value, Exception>
     let _ = interp.pop_context();
     let mut logged_filename = String::new();
     string::escape_unicode(&mut logged_filename, filename)?;
-    trace!(
-        r#"Successful require of "{}" at {:?}"#,
-        logged_filename,
-        path,
-    );
+    trace!(r#"Successful load of "{}" at {:?}"#, logged_filename, path,);
     Ok(interp.convert(true))
 }
 

--- a/artichoke-backend/src/extn/core/kernel/require.rs
+++ b/artichoke-backend/src/extn/core/kernel/require.rs
@@ -74,7 +74,7 @@ pub fn load(interp: &mut Artichoke, filename: Value) -> Result<Value, Exception>
     }
     let _ = interp.pop_context();
     let mut logged_filename = String::new();
-    let _ = string::escape_unicode(&mut logged_filename, filename);
+    string::escape_unicode(&mut logged_filename, filename)?;
     trace!(
         r#"Successful require of "{}" at {:?}"#,
         logged_filename,
@@ -169,7 +169,7 @@ pub fn require(
                     )
                 })?;
             let mut logged_filename = String::new();
-            let _ = string::escape_unicode(&mut logged_filename, filename);
+            string::escape_unicode(&mut logged_filename, filename)?;
             trace!(
                 r#"Successful require of "{}" at {:?}"#,
                 logged_filename,
@@ -229,7 +229,7 @@ pub fn require(
                         )
                     })?;
                 let mut logged_filename = String::new();
-                let _ = string::escape_unicode(&mut logged_filename, filename);
+                string::escape_unicode(&mut logged_filename, filename)?;
                 trace!(
                     r#"Successful require of "{}" at {:?}"#,
                     logged_filename,
@@ -301,7 +301,7 @@ pub fn require(
             })?;
     }
     let mut logged_filename = String::new();
-    let _ = string::escape_unicode(&mut logged_filename, filename);
+    string::escape_unicode(&mut logged_filename, filename)?;
     trace!(
         r#"Successful require of "{}" at {:?}"#,
         logged_filename,
@@ -329,9 +329,8 @@ pub fn require_relative(interp: &mut Artichoke, file: Value) -> Result<Value, Ex
     require(interp, file, Some(base))
 }
 
-fn load_error(interp: &Artichoke, filename: &[u8]) -> Result<LoadError, Fatal> {
+fn load_error(interp: &Artichoke, filename: &[u8]) -> Result<LoadError, Exception> {
     let mut message = String::from("cannot load such file -- ");
-    string::escape_unicode(&mut message, filename)
-        .map_err(|_| Fatal::new(interp, "Unable to generate LoadError"))?;
+    string::escape_unicode(&mut message, filename)?;
     Ok(LoadError::new(interp, message))
 }

--- a/artichoke-backend/src/extn/core/matchdata/element_reference.rs
+++ b/artichoke-backend/src/extn/core/matchdata/element_reference.rs
@@ -1,6 +1,5 @@
 //! [`MatchData#[]`](https://ruby-doc.org/core-2.6.3/MatchData.html#method-i-5B-5D)
 
-use bstr::BStr;
 use std::convert::TryFrom;
 use std::mem;
 
@@ -144,14 +143,10 @@ pub fn method(interp: &Artichoke, args: Args, value: &Value) -> Result<Value, Ex
                     .last();
                 Ok(interp.convert(group))
             } else {
-                let groupstr = format!("{:?}", <&BStr>::from(name));
-                Err(Exception::from(IndexError::new(
-                    interp,
-                    format!(
-                        "undefined group name reference: {}",
-                        &groupstr[1..groupstr.len() - 1]
-                    ),
-                )))
+                let mut message = String::from("undefined group name reference: ");
+                string::escape_unicode(&mut message, name)
+                    .map_err(|_| Fatal::new(interp, "Unable to generate IndexError"))?;
+                Err(Exception::from(IndexError::new(interp, message)))
             }
         }
         Args::StartLen(start, len) => {

--- a/artichoke-backend/src/extn/core/matchdata/element_reference.rs
+++ b/artichoke-backend/src/extn/core/matchdata/element_reference.rs
@@ -144,8 +144,7 @@ pub fn method(interp: &Artichoke, args: Args, value: &Value) -> Result<Value, Ex
                 Ok(interp.convert(group))
             } else {
                 let mut message = String::from("undefined group name reference: \"");
-                string::escape_unicode(&mut message, name)
-                    .map_err(|_| Fatal::new(interp, "Unable to generate IndexError"))?;
+                string::escape_unicode(&mut message, name)?;
                 message.push('"');
                 Err(Exception::from(IndexError::new(interp, message)))
             }

--- a/artichoke-backend/src/extn/core/matchdata/element_reference.rs
+++ b/artichoke-backend/src/extn/core/matchdata/element_reference.rs
@@ -143,9 +143,10 @@ pub fn method(interp: &Artichoke, args: Args, value: &Value) -> Result<Value, Ex
                     .last();
                 Ok(interp.convert(group))
             } else {
-                let mut message = String::from("undefined group name reference: ");
+                let mut message = String::from("undefined group name reference: \"");
                 string::escape_unicode(&mut message, name)
                     .map_err(|_| Fatal::new(interp, "Unable to generate IndexError"))?;
+                message.push('"');
                 Err(Exception::from(IndexError::new(interp, message)))
             }
         }

--- a/artichoke-backend/src/extn/prelude.rs
+++ b/artichoke-backend/src/extn/prelude.rs
@@ -17,6 +17,7 @@ pub use crate::def::{self, EnclosingRubyScope};
 pub use crate::exception::{self, Exception, RubyException};
 pub use crate::extn::core::exception::*;
 pub use crate::module;
+pub use crate::string;
 pub use crate::sys;
 pub use crate::types::{Float, Int, Ruby};
 pub use crate::value::{Block, Value};

--- a/artichoke-backend/src/lib.rs
+++ b/artichoke-backend/src/lib.rs
@@ -109,6 +109,7 @@ pub mod method;
 pub mod module;
 pub mod parser;
 pub mod state;
+pub mod string;
 pub mod sys;
 pub mod top_self;
 pub mod types;

--- a/artichoke-backend/src/string.rs
+++ b/artichoke-backend/src/string.rs
@@ -57,6 +57,7 @@ where
 pub struct WriteError(fmt::Error);
 
 impl From<fmt::Error> for WriteError {
+    #[must_use]
     fn from(err: fmt::Error) -> Self {
         Self(err)
     }
@@ -69,33 +70,40 @@ impl fmt::Display for WriteError {
 }
 
 impl error::Error for WriteError {
+    #[must_use]
     fn description(&self) -> &str {
         "Write error"
     }
 
+    #[must_use]
     fn cause(&self) -> Option<&dyn error::Error> {
         Some(&self.0)
     }
 }
 
 impl RubyException for WriteError {
+    #[must_use]
     fn box_clone(&self) -> Box<dyn RubyException> {
         Box::new(self.clone())
     }
 
+    #[must_use]
     fn message(&self) -> &[u8] {
         &b"Unable to escape Unicode message"[..]
     }
 
+    #[must_use]
     fn name(&self) -> String {
         String::from("fatal")
     }
 
+    #[must_use]
     fn backtrace(&self, interp: &Artichoke) -> Option<Vec<Vec<u8>>> {
         let _ = interp;
         None
     }
 
+    #[must_use]
     fn as_mrb_value(&self, interp: &Artichoke) -> Option<sys::mrb_value> {
         let borrow = interp.0.borrow();
         let spec = borrow.class_spec::<Fatal>()?;
@@ -106,18 +114,19 @@ impl RubyException for WriteError {
 
 impl From<WriteError> for Exception {
     #[must_use]
-    fn from(exception: WriteError) -> Exception {
-        Exception::from(Box::<dyn RubyException>::from(exception))
+    fn from(exception: WriteError) -> Self {
+        Self::from(Box::<dyn RubyException>::from(exception))
     }
 }
 
 impl From<Box<WriteError>> for Exception {
     #[must_use]
-    fn from(exception: Box<WriteError>) -> Exception {
-        Exception::from(Box::<dyn RubyException>::from(exception))
+    fn from(exception: Box<WriteError>) -> Self {
+        Self::from(Box::<dyn RubyException>::from(exception))
     }
 }
 
+#[allow(clippy::use_self)]
 impl From<WriteError> for Box<dyn RubyException> {
     #[must_use]
     fn from(exception: WriteError) -> Box<dyn RubyException> {
@@ -125,6 +134,7 @@ impl From<WriteError> for Box<dyn RubyException> {
     }
 }
 
+#[allow(clippy::use_self)]
 impl From<Box<WriteError>> for Box<dyn RubyException> {
     #[must_use]
     fn from(exception: Box<WriteError>) -> Box<dyn RubyException> {

--- a/artichoke-backend/src/string.rs
+++ b/artichoke-backend/src/string.rs
@@ -1,0 +1,49 @@
+use bstr::ByteSlice;
+use std::fmt;
+
+pub fn escape_unicode(mut f: impl fmt::Write, string: &[u8]) -> fmt::Result {
+    let buf = bstr::B(string);
+    for (s, e, ch) in buf.char_indices() {
+        if ch == '\u{FFFD}' {
+            for &b in buf[s..e].as_bytes() {
+                write!(f, r"\x{:X}", b)?;
+            }
+        } else {
+            write!(f, "{}", ch.escape_debug())?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::escape_unicode;
+
+    #[test]
+    fn invalid_utf8() {
+        let mut buf = String::new();
+        escape_unicode(&mut buf, &b"abc\xFF"[..]).unwrap();
+        assert_eq!(r"abc\xFF", buf.as_str());
+    }
+
+    #[test]
+    fn ascii() {
+        let mut buf = String::new();
+        escape_unicode(&mut buf, &b"abc"[..]).unwrap();
+        assert_eq!(r"abc", buf.as_str());
+    }
+
+    #[test]
+    fn emoji() {
+        let mut buf = String::new();
+        escape_unicode(&mut buf, "Ruby 💎".as_bytes()).unwrap();
+        assert_eq!(r"Ruby 💎", buf.as_str());
+    }
+
+    #[test]
+    fn escaped() {
+        let mut buf = String::new();
+        escape_unicode(&mut buf, "\n".as_bytes()).unwrap();
+        assert_eq!(r"\n", buf.as_str());
+    }
+}

--- a/artichoke-frontend/src/repl.rs
+++ b/artichoke-frontend/src/repl.rs
@@ -24,7 +24,7 @@ const REPL_FILENAME: &[u8] = b"(airb)";
 #[cfg(test)]
 mod filename_test {
     #[test]
-    fn repl_filename_has_no_nul_bytes() {
+    fn repl_filename_does_not_contain_nul_byte() {
         let contains_nul_byte = super::REPL_FILENAME
             .iter()
             .copied()

--- a/artichoke-frontend/src/ruby.rs
+++ b/artichoke-frontend/src/ruby.rs
@@ -6,12 +6,13 @@ use artichoke_backend::convert::Convert;
 use artichoke_backend::exception::Exception;
 use artichoke_backend::fs;
 use artichoke_backend::state::parser::Context;
+use artichoke_backend::string;
 use artichoke_backend::sys;
+use artichoke_backend::Artichoke;
 use artichoke_backend::BootError;
 use artichoke_core::eval::Eval as _;
 use artichoke_core::parser::Parser as _;
-use bstr::BStr;
-use std::ffi::OsString;
+use std::ffi::{OsStr, OsString};
 use std::io::{self, Read};
 use std::path::{Path, PathBuf};
 use structopt::StructOpt;
@@ -21,14 +22,13 @@ const INLINE_EVAL_SWITCH_FILENAME: &[u8] = b"-e";
 #[cfg(test)]
 mod filename_test {
     #[test]
-    fn inline_eval_switch_filename_has_no_nul_bytes() {
-        assert_eq!(
-            None,
-            super::INLINE_EVAL_SWITCH_FILENAME
-                .iter()
-                .copied()
-                .position(|b| b == b'\0')
-        );
+    fn inline_eval_switch_filename_does_not_contain_nul_byte() {
+        let contains_nul_byte = super::INLINE_EVAL_SWITCH_FILENAME
+            .iter()
+            .copied()
+            .position(|b| b == b'\0')
+            .is_some();
+        assert!(!contains_nul_byte);
     }
 }
 
@@ -52,6 +52,7 @@ struct Opt {
 }
 
 /// Error from Ruby CLI frontend
+#[derive(Debug)]
 pub enum Error {
     /// Error from Artichoke interpreter initialization.
     Artichoke(BootError),
@@ -101,38 +102,34 @@ pub fn entrypoint() -> Result<(), Error> {
     } else if let Some(programfile) = opt.programfile {
         execute_program_file(programfile.as_path(), opt.fixture.as_ref().map(Path::new))
     } else {
-        let mut program = Vec::new();
-        let result = io::stdin().read_to_end(&mut program);
-        if result.is_ok() {
-            let interp = artichoke_backend::interpreter()?;
-            let _ = interp.eval(program.as_slice())?;
-            Ok(())
-        } else {
-            Err(Error::from("Could not read program from STDIN"))
-        }
+        let mut program = vec![];
+        io::stdin()
+            .read_to_end(&mut program)
+            .map_err(|_| "Could not read program from STDIN")?;
+        let interp = artichoke_backend::interpreter()?;
+        let _ = interp.eval(program.as_slice())?;
+        Ok(())
     }
 }
 
 fn execute_inline_eval(commands: Vec<OsString>, fixture: Option<&Path>) -> Result<(), Error> {
     let mut interp = artichoke_backend::interpreter()?;
     // safety:
-    // Context::new_unchecked requires that INLINE_EVAL_SWITCH_FILENAME have no
-    // NUL bytes.
-    // INLINE_EVAL_SWITCH_FILENAME is controlled by this crate and asserts this
-    // invariant with a test.
+    //
+    // - `Context::new_unchecked` requires that its argument has no NUL bytes.
+    // - `INLINE_EVAL_SWITCH_FILENAME` is controlled by this crate.
+    // - A test asserts that `INLINE_EVAL_SWITCH_FILENAME` has no NUL bytes.
     interp.push_context(unsafe { Context::new_unchecked(INLINE_EVAL_SWITCH_FILENAME) });
     if let Some(ref fixture) = fixture {
-        let data = std::fs::read(fixture).map_err(|_| {
-            if let Ok(file) = fs::osstr_to_bytes(&interp, fixture.as_os_str()) {
-                let file = format!("{:?}", <&BStr>::from(file));
-                format!(
-                    "No such file or directory -- {} (LoadError)",
-                    &file[1..file.len() - 1]
-                )
-            } else {
-                format!("No such file or directory -- {:?} (LoadError)", fixture)
-            }
-        })?;
+        let data = if let Ok(data) = std::fs::read(fixture) {
+            data
+        } else {
+            return Err(Error::from(load_error(
+                &interp,
+                fixture.as_os_str(),
+                "No such file or directory",
+            )?));
+        };
         let sym = interp.0.borrow_mut().sym_intern(b"$fixture".as_ref());
         let mrb = interp.0.borrow().mrb;
         let value = interp.convert(data);
@@ -155,17 +152,15 @@ fn execute_inline_eval(commands: Vec<OsString>, fixture: Option<&Path>) -> Resul
 fn execute_program_file(programfile: &Path, fixture: Option<&Path>) -> Result<(), Error> {
     let interp = artichoke_backend::interpreter()?;
     if let Some(ref fixture) = fixture {
-        let data = std::fs::read(fixture).map_err(|_| {
-            if let Ok(file) = fs::osstr_to_bytes(&interp, fixture.as_os_str()) {
-                let file = format!("{:?}", <&BStr>::from(file));
-                format!(
-                    "No such file or directory -- {} (LoadError)",
-                    &file[1..file.len() - 1]
-                )
-            } else {
-                format!("No such file or directory -- {:?} (LoadError)", fixture)
-            }
-        })?;
+        let data = if let Ok(data) = std::fs::read(fixture) {
+            data
+        } else {
+            return Err(Error::from(load_error(
+                &interp,
+                fixture.as_os_str(),
+                "No such file or directory",
+            )?));
+        };
         let sym = interp.0.borrow_mut().sym_intern(b"$fixture".as_ref());
         let mrb = interp.0.borrow().mrb;
         let value = interp.convert(data);
@@ -173,41 +168,40 @@ fn execute_program_file(programfile: &Path, fixture: Option<&Path>) -> Result<()
             sys::mrb_gv_set(mrb, sym, value.inner());
         }
     }
-    let program = std::fs::read(programfile).map_err(|err| match err.kind() {
-        io::ErrorKind::NotFound => {
-            if let Ok(file) = fs::osstr_to_bytes(&interp, programfile.as_os_str()) {
-                let file = format!("{:?}", <&BStr>::from(file));
-                format!(
-                    "No such file or directory -- {} (LoadError)",
-                    &file[1..file.len() - 1]
-                )
-            } else {
-                format!("No such file or directory -- {:?} (LoadError)", programfile)
+    let program = match std::fs::read(programfile) {
+        Ok(programfile) => programfile,
+        Err(err) => {
+            return match err.kind() {
+                io::ErrorKind::NotFound => Err(Error::from(load_error(
+                    &interp,
+                    programfile.as_os_str(),
+                    "No such file or directory",
+                )?)),
+                io::ErrorKind::PermissionDenied => Err(Error::from(load_error(
+                    &interp,
+                    programfile.as_os_str(),
+                    "Permission denied",
+                )?)),
+                _ => Err(Error::from(load_error(
+                    &interp,
+                    programfile.as_os_str(),
+                    "Could not read file",
+                )?)),
             }
         }
-        io::ErrorKind::PermissionDenied => {
-            if let Ok(file) = fs::osstr_to_bytes(&interp, programfile.as_os_str()) {
-                let file = format!("{:?}", <&BStr>::from(file));
-                format!(
-                    "Permission denied -- {} (LoadError)",
-                    &file[1..file.len() - 1]
-                )
-            } else {
-                format!("Permission denied -- {:?} (LoadError)", programfile)
-            }
-        }
-        _ => {
-            if let Ok(file) = fs::osstr_to_bytes(&interp, programfile.as_os_str()) {
-                let file = format!("{:?}", <&BStr>::from(file));
-                format!(
-                    "Could not read file -- {} (LoadError)",
-                    &file[1..file.len() - 1]
-                )
-            } else {
-                format!("Could not read file -- {:?} (LoadError)", programfile)
-            }
-        }
-    })?;
+    };
     let _ = interp.eval(program.as_slice())?;
     Ok(())
+}
+
+fn load_error(interp: &Artichoke, file: &OsStr, message: &str) -> Result<String, Error> {
+    let mut buf = String::from(message);
+    buf.push_str(" -- ");
+    if let Ok(file) = fs::osstr_to_bytes(interp, file) {
+        string::escape_unicode(&mut buf, file).map_err(|err| err.to_string())?;
+    } else {
+        buf.push_str(format!("{:?}", file).as_str());
+    }
+    buf.push_str(" (LoadError)");
+    Ok(buf)
 }

--- a/artichoke-frontend/src/ruby.rs
+++ b/artichoke-frontend/src/ruby.rs
@@ -13,6 +13,7 @@ use artichoke_backend::BootError;
 use artichoke_core::eval::Eval as _;
 use artichoke_core::parser::Parser as _;
 use std::ffi::{OsStr, OsString};
+use std::fmt::Write;
 use std::io::{self, Read};
 use std::path::{Path, PathBuf};
 use structopt::StructOpt;

--- a/artichoke-frontend/src/ruby.rs
+++ b/artichoke-frontend/src/ruby.rs
@@ -198,9 +198,9 @@ fn load_error(interp: &Artichoke, file: &OsStr, message: &str) -> Result<String,
     let mut buf = String::from(message);
     buf.push_str(" -- ");
     if let Ok(file) = fs::osstr_to_bytes(interp, file) {
-        string::escape_unicode(&mut buf, file).map_err(|err| err.to_string())?;
+        string::escape_unicode(&mut buf, file).map_err(Exception::from)?;
     } else {
-        buf.push_str(format!("{:?}", file).as_str());
+        write!(&mut buf, "{:?}", file).map_err(|err| err.to_string())?;
     }
     buf.push_str(" (LoadError)");
     Ok(buf)


### PR DESCRIPTION
Sometimes (mostly when generating `Exception` messages), Ruby escapes `String` contents so they can be displayed. This mostly means escaping invalid UTF-8 sequences into `\xXX` escape sequences.

`bstr` offers a way to do this with the `fmt::Debug` implementation on the `&BStr` type. Unfortunately this is not quite flexible enough:

- `bstr` by wraps the escaped string in quotes.
- Most of the time Artichoke inserts an escaped string into the context of a larger message.
- Slicing into the debug String and formatting again causes unnecessary and fallible allocations.

This PR inlines the `Debug` implementation minus the quotes into the `string::escape_unicode` method. This method takes a `fmt::Write` to write the escaped string into and returns a specific, but `RubyException` compatible error to propagate write failures.

This PR removes all debug printing of `&BStr` from Artichoke.
This PR unifies exception construction in some `extn` modules.
This PR cleans up the error handling in `artichoke_frontend::ruby`.

TODO: eliminate calls to `format!` which can panic and use the fallible `write!` instead.