### PR TITLE
Remove artichoke-array feature

### DIFF
--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -51,8 +51,7 @@ version = "0.51.1"
 default-features = false
 
 [features]
-default = ["artichoke-array", "artichoke-random", "artichoke-system-environ"]
+default = ["artichoke-random", "artichoke-system-environ"]
 artichoke-all-converters = []
-artichoke-array = []
 artichoke-random = ["rand"]
 artichoke-system-environ = []

--- a/artichoke-backend/build.rs
+++ b/artichoke-backend/build.rs
@@ -254,12 +254,8 @@ mod libmruby {
             .define("MRB_DISABLE_STDIO", None)
             .define("MRB_UTF8_STRING", None)
             .define(mrb_int, None)
-            .define("DISABLE_GEMS", None);
-
-        // Detect crate feature: artichoke-array
-        if env::var("CARGO_FEATURE_ARTICHOKE_ARRAY").is_ok() {
-            build.define("ARTICHOKE", None);
-        }
+            .define("DISABLE_GEMS", None)
+            .define("ARTICHOKE", None);
 
         for gem in gems() {
             let dir = if gem == "mruby-compiler" {

--- a/artichoke-backend/src/convert/hash.rs
+++ b/artichoke-backend/src/convert/hash.rs
@@ -2,8 +2,7 @@ use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::hash::BuildHasher;
 
-use crate::convert::{Convert, TryConvert};
-#[cfg(feature = "artichoke-array")]
+use crate::convert::{Convert, RustBackedValue, TryConvert};
 use crate::extn::core::array;
 use crate::sys;
 use crate::types::{Float, Int, Ruby, Rust};
@@ -35,42 +34,20 @@ impl TryConvert<Value, Vec<(Value, Value)>> for Artichoke {
             Ruby::Hash => {
                 let hash = value.inner();
                 let keys = unsafe { sys::mrb_hash_keys(mrb, hash) };
-                #[cfg(feature = "artichoke-array")]
-                {
-                    use crate::convert::RustBackedValue;
 
-                    let keys = Value::new(self, keys);
-                    let ary = unsafe { array::Array::try_from_ruby(self, &keys) }?;
-                    let borrow = ary.borrow();
+                let keys = Value::new(self, keys);
+                let ary = unsafe { array::Array::try_from_ruby(self, &keys) }?;
+                let borrow = ary.borrow();
 
-                    let pairs = borrow
-                        .as_vec(self)
-                        .into_iter()
-                        .map(|key| {
-                            let value = unsafe { sys::mrb_hash_get(mrb, hash, key.inner()) };
-                            (key, Value::new(self, value))
-                        })
-                        .collect::<Vec<_>>();
-                    Ok(pairs)
-                }
-                #[cfg(not(feature = "artichoke-array"))]
-                {
-                    let size = unsafe { sys::mrb_hash_size(mrb, hash) };
-                    let capacity =
-                        usize::try_from(size).map_err(|_| ArtichokeError::ConvertToRust {
-                            from: Ruby::Hash,
-                            to: Rust::Map,
-                        })?;
-                    let mut pairs = Vec::<(Value, Value)>::with_capacity(capacity);
-                    for idx in 0..size {
-                        // Doing a `hash[key]` access is guaranteed to succeed since
-                        // we're iterating over the keys in the hash.
-                        let key = unsafe { sys::mrb_ary_ref(mrb, keys, idx) };
-                        let value = unsafe { sys::mrb_hash_get(mrb, hash, key) };
-                        pairs.push((Value::new(self, key), Value::new(self, value)));
-                    }
-                    Ok(pairs)
-                }
+                let pairs = borrow
+                    .as_vec(self)
+                    .into_iter()
+                    .map(|key| {
+                        let value = unsafe { sys::mrb_hash_get(mrb, hash, key.inner()) };
+                        (key, Value::new(self, value))
+                    })
+                    .collect::<Vec<_>>();
+                Ok(pairs)
             }
             type_tag => Err(ArtichokeError::ConvertToRust {
                 from: type_tag,

--- a/artichoke-backend/src/extn/core/array/mruby.rs
+++ b/artichoke-backend/src/extn/core/array/mruby.rs
@@ -1,11 +1,8 @@
-#[cfg(feature = "artichoke-array")]
 use std::convert::TryFrom;
 
-#[cfg(feature = "artichoke-array")]
 use crate::extn::core::array;
 use crate::extn::prelude::*;
 
-#[cfg(feature = "artichoke-array")]
 pub fn init(interp: &Artichoke) -> InitializeResult<()> {
     if interp.0.borrow().class_spec::<array::Array>().is_some() {
         return Ok(());
@@ -37,14 +34,6 @@ pub fn init(interp: &Artichoke) -> InitializeResult<()> {
     Ok(())
 }
 
-#[cfg(not(feature = "artichoke-array"))]
-pub fn init(interp: &Artichoke) -> InitializeResult<()> {
-    let _ = interp.eval(&include_bytes!("array.rb")[..])?;
-    trace!("Patched Array onto interpreter");
-    Ok(())
-}
-
-#[cfg(feature = "artichoke-array")]
 unsafe extern "C" fn ary_pop(mrb: *mut sys::mrb_state, ary: sys::mrb_value) -> sys::mrb_value {
     let interp = unwrap_interpreter!(mrb);
     let array = Value::new(&interp, ary);
@@ -59,7 +48,6 @@ unsafe extern "C" fn ary_pop(mrb: *mut sys::mrb_state, ary: sys::mrb_value) -> s
     }
 }
 
-#[cfg(feature = "artichoke-array")]
 unsafe extern "C" fn ary_len(mrb: *mut sys::mrb_state, ary: sys::mrb_value) -> sys::mrb_value {
     mrb_get_args!(mrb, none);
     let interp = unwrap_interpreter!(mrb);
@@ -78,7 +66,6 @@ unsafe extern "C" fn ary_len(mrb: *mut sys::mrb_state, ary: sys::mrb_value) -> s
     }
 }
 
-#[cfg(feature = "artichoke-array")]
 unsafe extern "C" fn ary_concat(mrb: *mut sys::mrb_state, ary: sys::mrb_value) -> sys::mrb_value {
     println!("ary concat C");
     let other = mrb_get_args!(mrb, optional = 1);
@@ -96,7 +83,6 @@ unsafe extern "C" fn ary_concat(mrb: *mut sys::mrb_state, ary: sys::mrb_value) -
     }
 }
 
-#[cfg(feature = "artichoke-array")]
 unsafe extern "C" fn ary_initialize(
     mrb: *mut sys::mrb_state,
     ary: sys::mrb_value,
@@ -117,7 +103,6 @@ unsafe extern "C" fn ary_initialize(
     }
 }
 
-#[cfg(feature = "artichoke-array")]
 unsafe extern "C" fn ary_initialize_copy(
     mrb: *mut sys::mrb_state,
     ary: sys::mrb_value,
@@ -137,7 +122,6 @@ unsafe extern "C" fn ary_initialize_copy(
     }
 }
 
-#[cfg(feature = "artichoke-array")]
 unsafe extern "C" fn ary_reverse_bang(
     mrb: *mut sys::mrb_state,
     ary: sys::mrb_value,
@@ -156,7 +140,6 @@ unsafe extern "C" fn ary_reverse_bang(
     }
 }
 
-#[cfg(feature = "artichoke-array")]
 unsafe extern "C" fn ary_element_reference(
     mrb: *mut sys::mrb_state,
     ary: sys::mrb_value,
@@ -173,7 +156,6 @@ unsafe extern "C" fn ary_element_reference(
     }
 }
 
-#[cfg(feature = "artichoke-array")]
 unsafe extern "C" fn ary_element_assignment(
     mrb: *mut sys::mrb_state,
     ary: sys::mrb_value,


### PR DESCRIPTION
The `artichoke-array` feature was added to enable a temporary rollout of
the Artichoke-native `Array` to the playground as the implementation
evolved and shook off all of the segfaults.

As of GH-382, these segfaults are fixed since the Array type is
implemented with a contiguous buffer.

This commit removes the legacy code, makes the Artichoke Array the
default, and removes the feature.

As of this commit, mruby is always built with `-DARTICHOKE`. This change
was required as I think about implementing more core types, like
`Symbol`.