### PR TITLE
Make Eval::eval take &mut self

### DIFF
--- a/artichoke-backend/README.md
+++ b/artichoke-backend/README.md
@@ -23,7 +23,7 @@ effects from eval are persisted across invocations.
 ```rust
 use artichoke_backend::{Eval, ValueLike};
 
-let interp = artichoke_backend::interpreter().unwrap();
+let mut interp = artichoke_backend::interpreter().unwrap();
 let result = interp.eval(b"10 * 10").unwrap();
 let result = result.try_into::<i64>();
 assert_eq!(result, Ok(100));

--- a/artichoke-backend/src/class.rs
+++ b/artichoke-backend/src/class.rs
@@ -278,7 +278,7 @@ mod tests {
     fn super_class() {
         struct RustError;
 
-        let interp = crate::interpreter().expect("init");
+        let mut interp = crate::interpreter().expect("init");
         let borrow = interp.0.borrow();
         let standard_error = borrow.class_spec::<StandardError>().unwrap();
         let spec = class::Spec::new("RustError", None, None).unwrap();
@@ -326,7 +326,7 @@ mod tests {
 
     #[test]
     fn rclass_for_nested_class() {
-        let interp = crate::interpreter().expect("init");
+        let mut interp = crate::interpreter().expect("init");
         let _ = interp
             .eval(b"module Foo; class Bar; end; end")
             .expect("eval");
@@ -337,7 +337,7 @@ mod tests {
 
     #[test]
     fn rclass_for_nested_class_under_class() {
-        let interp = crate::interpreter().expect("init");
+        let mut interp = crate::interpreter().expect("init");
         let _ = interp
             .eval(b"class Foo; class Bar; end; end")
             .expect("eval");

--- a/artichoke-backend/src/convert/boolean.rs
+++ b/artichoke-backend/src/convert/boolean.rs
@@ -47,7 +47,7 @@ mod tests {
 
     #[test]
     fn fail_convert() {
-        let interp = crate::interpreter().expect("init");
+        let mut interp = crate::interpreter().expect("init");
         // get a mrb_value that can't be converted to a primitive type.
         let value = interp.eval(b"Object.new").expect("eval");
         let expected = Err(ArtichokeError::ConvertToRust {

--- a/artichoke-backend/src/convert/bytes.rs
+++ b/artichoke-backend/src/convert/bytes.rs
@@ -80,7 +80,7 @@ mod tests {
 
     #[test]
     fn fail_convert() {
-        let interp = crate::interpreter().expect("init");
+        let mut interp = crate::interpreter().expect("init");
         // get a mrb_value that can't be converted to a primitive type.
         let value = interp.eval(b"Object.new").expect("eval");
         let expected = Err(ArtichokeError::ConvertToRust {

--- a/artichoke-backend/src/convert/fixnum.rs
+++ b/artichoke-backend/src/convert/fixnum.rs
@@ -132,7 +132,7 @@ mod tests {
 
     #[test]
     fn fail_convert() {
-        let interp = crate::interpreter().expect("init");
+        let mut interp = crate::interpreter().expect("init");
         // get a mrb_value that can't be converted to a primitive type.
         let value = interp.eval(b"Object.new").expect("eval");
         let expected = Err(ArtichokeError::ConvertToRust {

--- a/artichoke-backend/src/convert/float.rs
+++ b/artichoke-backend/src/convert/float.rs
@@ -34,7 +34,7 @@ mod tests {
 
     #[test]
     fn fail_convert() {
-        let interp = crate::interpreter().expect("init");
+        let mut interp = crate::interpreter().expect("init");
         // get a mrb_value that can't be converted to a primitive type.
         let value = interp.eval(b"Object.new").expect("eval");
         let expected = Err(ArtichokeError::ConvertToRust {

--- a/artichoke-backend/src/convert/string.rs
+++ b/artichoke-backend/src/convert/string.rs
@@ -56,7 +56,7 @@ mod tests {
 
     #[test]
     fn fail_convert() {
-        let interp = crate::interpreter().expect("init");
+        let mut interp = crate::interpreter().expect("init");
         // get a mrb_value that can't be converted to a primitive type.
         let value = interp.eval(b"Object.new").expect("eval");
         let expected = Err(ArtichokeError::ConvertToRust {
@@ -111,7 +111,7 @@ mod tests {
 
     #[test]
     fn symbol_to_string() {
-        let interp = crate::interpreter().expect("init");
+        let mut interp = crate::interpreter().expect("init");
         let value = interp.eval(b":sym").expect("eval");
         let value = value.try_into::<String>().expect("convert");
         assert_eq!(&value, "sym");

--- a/artichoke-backend/src/def.rs
+++ b/artichoke-backend/src/def.rs
@@ -312,7 +312,7 @@ mod tests {
                     }
                 }
             }
-            let interp = crate::interpreter().expect("init");
+            let mut interp = crate::interpreter().expect("init");
             let class = class::Spec::new("DefineMethodTestClass", None, None).unwrap();
             class::Builder::for_spec(&interp, &class)
                 .add_method("value", value, sys::mrb_args_none())

--- a/artichoke-backend/src/eval.rs
+++ b/artichoke-backend/src/eval.rs
@@ -96,7 +96,7 @@ mod tests {
         impl File for NestedEval {
             type Artichoke = Artichoke;
 
-            fn require(interp: &Artichoke) -> Result<(), ArtichokeError> {
+            fn require(interp: &mut Artichoke) -> Result<(), ArtichokeError> {
                 let spec = module::Spec::new(interp, "NestedEval", None)?;
                 module::Builder::for_spec(interp, &spec)
                     .add_self_method("file", Self::nested_eval, sys::mrb_args_none())?

--- a/artichoke-backend/src/exception_handler.rs
+++ b/artichoke-backend/src/exception_handler.rs
@@ -59,7 +59,7 @@ mod tests {
 
     #[test]
     fn return_exception() {
-        let interp = crate::interpreter().expect("init");
+        let mut interp = crate::interpreter().expect("init");
         let err = interp
             .eval(b"raise ArgumentError.new('waffles')")
             .unwrap_err();
@@ -73,7 +73,7 @@ mod tests {
 
     #[test]
     fn return_exception_with_no_backtrace() {
-        let interp = crate::interpreter().expect("init");
+        let mut interp = crate::interpreter().expect("init");
         let err = interp.eval(b"def bad; (; end").unwrap_err();
         assert_eq!("SyntaxError", err.name().as_str());
         assert_eq!(&b"syntax error"[..], err.message());
@@ -82,7 +82,7 @@ mod tests {
 
     #[test]
     fn raise_does_not_panic_or_segfault() {
-        let interp = crate::interpreter().expect("init");
+        let mut interp = crate::interpreter().expect("init");
         let _ = interp.eval(br#"raise 'foo'"#);
         let _ = interp.eval(br#"raise 'foo'"#);
         let _ = interp.eval(br#"eval(b"raise 'foo'""#);

--- a/artichoke-backend/src/extn/core/array/inline_buffer.rs
+++ b/artichoke-backend/src/extn/core/array/inline_buffer.rs
@@ -337,7 +337,7 @@ mod tests {
 
     #[test]
     fn integration_test() {
-        let interp = crate::interpreter().unwrap();
+        let mut interp = crate::interpreter().unwrap();
         let _ = interp
             .eval(&include_bytes!("inline_buffer_test.rb")[..])
             .unwrap();

--- a/artichoke-backend/src/extn/core/array/mruby.rs
+++ b/artichoke-backend/src/extn/core/array/mruby.rs
@@ -3,7 +3,7 @@ use std::convert::TryFrom;
 use crate::extn::core::array;
 use crate::extn::prelude::*;
 
-pub fn init(interp: &Artichoke) -> InitializeResult<()> {
+pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     if interp.0.borrow().class_spec::<array::Array>().is_some() {
         return Ok(());
     }

--- a/artichoke-backend/src/extn/core/comparable/mod.rs
+++ b/artichoke-backend/src/extn/core/comparable/mod.rs
@@ -1,6 +1,6 @@
 use crate::extn::prelude::*;
 
-pub fn init(interp: &Artichoke) -> InitializeResult<()> {
+pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     if interp.0.borrow().module_spec::<Comparable>().is_some() {
         return Ok(());
     }

--- a/artichoke-backend/src/extn/core/enumerable/mod.rs
+++ b/artichoke-backend/src/extn/core/enumerable/mod.rs
@@ -1,6 +1,6 @@
 use crate::extn::prelude::*;
 
-pub fn init(interp: &Artichoke) -> InitializeResult<()> {
+pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     if interp.0.borrow().module_spec::<Enumerable>().is_some() {
         return Ok(());
     }

--- a/artichoke-backend/src/extn/core/enumerator/mod.rs
+++ b/artichoke-backend/src/extn/core/enumerator/mod.rs
@@ -1,6 +1,6 @@
 use crate::extn::prelude::*;
 
-pub fn init(interp: &Artichoke) -> InitializeResult<()> {
+pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     if interp.0.borrow().class_spec::<Enumerator>().is_some() {
         return Ok(());
     }

--- a/artichoke-backend/src/extn/core/env/mruby.rs
+++ b/artichoke-backend/src/extn/core/env/mruby.rs
@@ -2,7 +2,7 @@ use crate::extn::core::artichoke;
 use crate::extn::core::env;
 use crate::extn::prelude::*;
 
-pub fn init(interp: &Artichoke) -> InitializeResult<()> {
+pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     if interp.0.borrow().class_spec::<env::Environ>().is_some() {
         return Ok(());
     }

--- a/artichoke-backend/src/extn/core/exception/mod.rs
+++ b/artichoke-backend/src/extn/core/exception/mod.rs
@@ -462,7 +462,7 @@ mod tests {
     impl File for Run {
         type Artichoke = Artichoke;
 
-        fn require(interp: &Artichoke) -> Result<(), ArtichokeError> {
+        fn require(interp: &mut Artichoke) -> Result<(), ArtichokeError> {
             let spec = class::Spec::new("Run", None, None).unwrap();
             class::Builder::for_spec(interp, &spec)
                 .add_self_method("run", Self::run, sys::mrb_args_none())?
@@ -475,7 +475,7 @@ mod tests {
     #[test]
     fn raise() {
         let mut interp = crate::interpreter().expect("init");
-        Run::require(&interp).unwrap();
+        Run::require(&mut interp).unwrap();
         let err = interp.eval(b"Run.run").unwrap_err();
         assert_eq!("RuntimeError", err.name().as_str());
         assert_eq!(Vec::from(&b"something went wrong"[..]), err.message());

--- a/artichoke-backend/src/extn/core/exception/mod.rs
+++ b/artichoke-backend/src/extn/core/exception/mod.rs
@@ -44,7 +44,7 @@ use std::fmt;
 
 use crate::extn::prelude::*;
 
-pub fn init(interp: &Artichoke) -> InitializeResult<()> {
+pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     let borrow = interp.0.borrow();
 
     let exception_spec = class::Spec::new("Exception", None, None)?;
@@ -474,7 +474,7 @@ mod tests {
 
     #[test]
     fn raise() {
-        let interp = crate::interpreter().expect("init");
+        let mut interp = crate::interpreter().expect("init");
         Run::require(&interp).unwrap();
         let err = interp.eval(b"Run.run").unwrap_err();
         assert_eq!("RuntimeError", err.name().as_str());

--- a/artichoke-backend/src/extn/core/float/mod.rs
+++ b/artichoke-backend/src/extn/core/float/mod.rs
@@ -1,7 +1,7 @@
 use crate::extn::prelude::*;
 use crate::types;
 
-pub fn init(interp: &Artichoke) -> InitializeResult<()> {
+pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     if interp.0.borrow().class_spec::<Float>().is_some() {
         return Ok(());
     }

--- a/artichoke-backend/src/extn/core/hash/mod.rs
+++ b/artichoke-backend/src/extn/core/hash/mod.rs
@@ -1,6 +1,6 @@
 use crate::extn::prelude::*;
 
-pub fn init(interp: &Artichoke) -> InitializeResult<()> {
+pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     if interp.0.borrow().class_spec::<Hash>().is_some() {
         return Ok(());
     }

--- a/artichoke-backend/src/extn/core/integer/div.rs
+++ b/artichoke-backend/src/extn/core/integer/div.rs
@@ -46,7 +46,7 @@ mod tests {
 
     #[quickcheck]
     fn integer_division_vm_opcode(x: Int, y: Int) -> bool {
-        let interp = crate::interpreter().expect("init");
+        let mut interp = crate::interpreter().expect("init");
         let mut result = true;
         match (x, y) {
             (0, 0) => result &= interp.eval(b"0 / 0").is_err(),
@@ -76,7 +76,7 @@ mod tests {
 
     #[quickcheck]
     fn integer_division_send(x: Int, y: Int) -> bool {
-        let interp = crate::interpreter().expect("init");
+        let mut interp = crate::interpreter().expect("init");
         let mut result = true;
         match (x, y) {
             (0, 0) => result &= interp.eval(b"0.send('/', 0)").is_err(),

--- a/artichoke-backend/src/extn/core/integer/mod.rs
+++ b/artichoke-backend/src/extn/core/integer/mod.rs
@@ -5,7 +5,7 @@ use crate::extn::prelude::*;
 
 pub mod div;
 
-pub fn init(interp: &Artichoke) -> InitializeResult<()> {
+pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     if interp.0.borrow().class_spec::<Integer>().is_some() {
         return Ok(());
     }

--- a/artichoke-backend/src/extn/core/kernel/mod.rs
+++ b/artichoke-backend/src/extn/core/kernel/mod.rs
@@ -4,7 +4,7 @@ use crate::extn::prelude::*;
 pub mod integer;
 pub mod require;
 
-pub fn init(interp: &Artichoke) -> InitializeResult<()> {
+pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     if interp.0.borrow().module_spec::<Kernel>().is_some() {
         return Ok(());
     }
@@ -156,7 +156,7 @@ mod tests {
             }
         }
 
-        let interp = crate::interpreter().expect("init");
+        let mut interp = crate::interpreter().expect("init");
         interp
             .def_file_for_type::<TestFile>(b"file.rb")
             .expect("def file");
@@ -183,7 +183,7 @@ mod tests {
 
     #[test]
     fn require_absolute_path() {
-        let interp = crate::interpreter().expect("init");
+        let mut interp = crate::interpreter().expect("init");
         interp
             .def_rb_source_file(b"/foo/bar/source.rb", &b"# a source file"[..])
             .expect("def file");
@@ -195,7 +195,7 @@ mod tests {
 
     #[test]
     fn require_relative_with_dotted_path() {
-        let interp = crate::interpreter().expect("init");
+        let mut interp = crate::interpreter().expect("init");
         interp
             .def_rb_source_file(b"/foo/bar/source.rb", &b"require_relative '../bar.rb'"[..])
             .expect("def file");
@@ -208,7 +208,7 @@ mod tests {
 
     #[test]
     fn require_directory() {
-        let interp = crate::interpreter().expect("init");
+        let mut interp = crate::interpreter().expect("init");
         let err = interp.eval(b"require '/src'").unwrap_err();
         assert_eq!(&b"cannot load such file -- /src"[..], err.message());
         let expected = vec![Vec::from(&b"(eval):1"[..])];
@@ -227,7 +227,7 @@ mod tests {
                 Ok(())
             }
         }
-        let interp = crate::interpreter().expect("init");
+        let mut interp = crate::interpreter().expect("init");
         interp
             .def_rb_source_file(b"foo.rb", &b"module Foo; RUBY = 3; end"[..])
             .expect("def");
@@ -255,7 +255,7 @@ mod tests {
                 Ok(())
             }
         }
-        let interp = crate::interpreter().expect("init");
+        let mut interp = crate::interpreter().expect("init");
         interp.def_file_for_type::<Foo>(b"foo.rb").expect("def");
         interp
             .def_rb_source_file(b"foo.rb", &b"module Foo; RUBY = 3; end"[..])
@@ -275,7 +275,7 @@ mod tests {
     #[allow(clippy::shadow_unrelated)]
     fn kernel_throw_catch() {
         // https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-catch
-        let interp = crate::interpreter().expect("init");
+        let mut interp = crate::interpreter().expect("init");
         let result = interp
             .eval(b"catch(1) { 123 }")
             .unwrap()

--- a/artichoke-backend/src/extn/core/kernel/mod.rs
+++ b/artichoke-backend/src/extn/core/kernel/mod.rs
@@ -150,7 +150,7 @@ mod tests {
         impl File for TestFile {
             type Artichoke = Artichoke;
 
-            fn require(interp: &Artichoke) -> Result<(), ArtichokeError> {
+            fn require(interp: &mut Artichoke) -> Result<(), ArtichokeError> {
                 let _ = interp.eval(b"@i = 255").unwrap();
                 Ok(())
             }
@@ -222,7 +222,7 @@ mod tests {
         impl File for Foo {
             type Artichoke = Artichoke;
 
-            fn require(interp: &Artichoke) -> Result<(), ArtichokeError> {
+            fn require(interp: &mut Artichoke) -> Result<(), ArtichokeError> {
                 let _ = interp.eval(b"module Foo; RUST = 7; end").unwrap();
                 Ok(())
             }
@@ -250,7 +250,7 @@ mod tests {
         impl File for Foo {
             type Artichoke = Artichoke;
 
-            fn require(interp: &Artichoke) -> Result<(), ArtichokeError> {
+            fn require(interp: &mut Artichoke) -> Result<(), ArtichokeError> {
                 let _ = interp.eval(b"module Foo; RUST = 7; end").unwrap();
                 Ok(())
             }

--- a/artichoke-backend/src/extn/core/matchdata/mod.rs
+++ b/artichoke-backend/src/extn/core/matchdata/mod.rs
@@ -30,7 +30,7 @@ pub mod string;
 pub mod to_a;
 pub mod to_s;
 
-pub fn init(interp: &Artichoke) -> InitializeResult<()> {
+pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     if interp.0.borrow().class_spec::<MatchData>().is_some() {
         return Ok(());
     }

--- a/artichoke-backend/src/extn/core/method/mod.rs
+++ b/artichoke-backend/src/extn/core/method/mod.rs
@@ -1,6 +1,6 @@
 use crate::extn::prelude::*;
 
-pub fn init(interp: &Artichoke) -> InitializeResult<()> {
+pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     if interp.0.borrow().class_spec::<Method>().is_some() {
         return Ok(());
     }

--- a/artichoke-backend/src/extn/core/mod.rs
+++ b/artichoke-backend/src/extn/core/mod.rs
@@ -29,7 +29,7 @@ pub mod thread;
 pub mod time;
 pub mod warning;
 
-pub fn init(interp: &Artichoke) -> InitializeResult<()> {
+pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     // These core classes are ordered according to the dependency DAG between
     // them.
     let _ = interp.eval(&include_bytes!("object.rb")[..])?;

--- a/artichoke-backend/src/extn/core/module/mod.rs
+++ b/artichoke-backend/src/extn/core/module/mod.rs
@@ -1,6 +1,6 @@
 use crate::extn::prelude::*;
 
-pub fn init(interp: &Artichoke) -> InitializeResult<()> {
+pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     if interp.0.borrow().class_spec::<Module>().is_some() {
         return Ok(());
     }

--- a/artichoke-backend/src/extn/core/numeric/mod.rs
+++ b/artichoke-backend/src/extn/core/numeric/mod.rs
@@ -1,6 +1,6 @@
 use crate::extn::prelude::*;
 
-pub fn init(interp: &Artichoke) -> InitializeResult<()> {
+pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     if interp.0.borrow().class_spec::<Numeric>().is_some() {
         return Ok(());
     }

--- a/artichoke-backend/src/extn/core/object/mod.rs
+++ b/artichoke-backend/src/extn/core/object/mod.rs
@@ -1,6 +1,6 @@
 use crate::extn::prelude::*;
 
-pub fn init(interp: &Artichoke) -> InitializeResult<()> {
+pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     if interp.0.borrow().class_spec::<Object>().is_some() {
         return Ok(());
     }

--- a/artichoke-backend/src/extn/core/proc/mod.rs
+++ b/artichoke-backend/src/extn/core/proc/mod.rs
@@ -1,6 +1,6 @@
 use crate::extn::prelude::*;
 
-pub fn init(interp: &Artichoke) -> InitializeResult<()> {
+pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     if interp.0.borrow().class_spec::<Proc>().is_some() {
         return Ok(());
     }

--- a/artichoke-backend/src/extn/core/random/mruby.rs
+++ b/artichoke-backend/src/extn/core/random/mruby.rs
@@ -1,7 +1,7 @@
 use crate::extn::core::random;
 use crate::extn::prelude::*;
 
-pub fn init(interp: &Artichoke) -> InitializeResult<()> {
+pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     if interp.0.borrow().class_spec::<random::Random>().is_some() {
         return Ok(());
     }

--- a/artichoke-backend/src/extn/core/range/mod.rs
+++ b/artichoke-backend/src/extn/core/range/mod.rs
@@ -1,6 +1,6 @@
 use crate::extn::prelude::*;
 
-pub fn init(interp: &Artichoke) -> InitializeResult<()> {
+pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     if interp.0.borrow().class_spec::<Range>().is_some() {
         return Ok(());
     }

--- a/artichoke-backend/src/extn/core/regexp/mruby.rs
+++ b/artichoke-backend/src/extn/core/regexp/mruby.rs
@@ -3,7 +3,7 @@ use std::convert::TryFrom;
 use crate::extn::core::regexp;
 use crate::extn::prelude::*;
 
-pub fn init(interp: &Artichoke) -> InitializeResult<()> {
+pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     if interp.0.borrow().class_spec::<regexp::Regexp>().is_some() {
         return Ok(());
     }

--- a/artichoke-backend/src/extn/core/string.rs
+++ b/artichoke-backend/src/extn/core/string.rs
@@ -2,7 +2,7 @@ use crate::extn::prelude::*;
 
 mod scan;
 
-pub fn init(interp: &Artichoke) -> InitializeResult<()> {
+pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     if interp.0.borrow().class_spec::<RString>().is_some() {
         return Ok(());
     }
@@ -59,13 +59,11 @@ impl RString {
 // https://ruby-doc.org/core-2.6.3/String.html
 #[cfg(test)]
 mod tests {
-    use crate::extn::core::string;
     use crate::test::prelude::*;
 
     #[test]
     fn string_equal_squiggle() {
-        let interp = crate::interpreter().expect("init");
-        string::init(&interp).expect("string init");
+        let mut interp = crate::interpreter().expect("init");
 
         let value = interp.eval(br#""cat o' 9 tails" =~ /\d/"#).unwrap();
         assert_eq!(value.try_into::<Option<i64>>(), Ok(Some(7)));
@@ -75,8 +73,7 @@ mod tests {
 
     #[test]
     fn string_idx() {
-        let interp = crate::interpreter().expect("init");
-        string::init(&interp).expect("string init");
+        let mut interp = crate::interpreter().expect("init");
 
         assert_eq!(
             &interp
@@ -130,8 +127,7 @@ mod tests {
 
     #[test]
     fn string_scan() {
-        let interp = crate::interpreter().expect("init");
-        string::init(&interp).expect("string init");
+        let mut interp = crate::interpreter().expect("init");
 
         let s = interp.convert("abababa");
         let result = s
@@ -154,8 +150,7 @@ mod tests {
 
     #[test]
     fn string_unary_minus() {
-        let interp = crate::interpreter().expect("init");
-        string::init(&interp).expect("string init");
+        let mut interp = crate::interpreter().expect("init");
 
         let s = interp.eval(b"-'abababa'").expect("eval");
         let result = s.funcall::<bool>("frozen?", &[], None).unwrap();

--- a/artichoke-backend/src/extn/core/symbol/mod.rs
+++ b/artichoke-backend/src/extn/core/symbol/mod.rs
@@ -1,6 +1,6 @@
 use crate::extn::prelude::*;
 
-pub fn init(interp: &Artichoke) -> InitializeResult<()> {
+pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     if interp.0.borrow().class_spec::<Symbol>().is_some() {
         return Ok(());
     }

--- a/artichoke-backend/src/extn/core/thread.rs
+++ b/artichoke-backend/src/extn/core/thread.rs
@@ -1,6 +1,6 @@
 use crate::extn::prelude::*;
 
-pub fn init(interp: &Artichoke) -> InitializeResult<()> {
+pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     if interp.0.borrow().class_spec::<Thread>().is_some() {
         return Ok(());
     }
@@ -30,7 +30,7 @@ mod tests {
 
     #[test]
     fn thread_required_by_default() {
-        let interp = crate::interpreter().expect("init");
+        let mut interp = crate::interpreter().expect("init");
         let result = interp
             .eval(b"Object.const_defined?(:Thread)")
             .expect("thread");
@@ -39,7 +39,7 @@ mod tests {
 
     #[test]
     fn thread_current_is_main() {
-        let interp = crate::interpreter().expect("init");
+        let mut interp = crate::interpreter().expect("init");
         let spec = b"Thread.current == Thread.main";
         let result = interp.eval(spec).expect("spec");
         assert!(result.try_into::<bool>().expect("convert"));
@@ -50,7 +50,7 @@ mod tests {
 
     #[test]
     fn thread_join_value() {
-        let interp = crate::interpreter().expect("init");
+        let mut interp = crate::interpreter().expect("init");
         let spec = b"Thread.new { 2 + 3 }.join.value == 5";
         let result = interp.eval(spec).expect("spec");
         assert!(result.try_into::<bool>().expect("convert"));
@@ -61,7 +61,7 @@ mod tests {
 
     #[test]
     fn thread_main_is_running() {
-        let interp = crate::interpreter().expect("init");
+        let mut interp = crate::interpreter().expect("init");
         let spec = b"Thread.current.status == 'run'";
         let result = interp.eval(spec).expect("spec");
         assert!(result.try_into::<bool>().expect("convert"));
@@ -72,7 +72,7 @@ mod tests {
 
     #[test]
     fn thread_spawn() {
-        let interp = crate::interpreter().expect("init");
+        let mut interp = crate::interpreter().expect("init");
         let spec = b"Thread.new { Thread.current }.join.value != Thread.current";
         let result = interp.eval(spec).expect("spec");
         assert!(result.try_into::<bool>().expect("convert"));
@@ -89,7 +89,7 @@ mod tests {
 
     #[test]
     fn thread_locals() {
-        let interp = crate::interpreter().expect("init");
+        let mut interp = crate::interpreter().expect("init");
         let spec = br#"
 Thread.current[:local] = 42
 Thread.new { Thread.current.keys.empty? }.join.value
@@ -120,7 +120,7 @@ Thread.current.thread_variable_get(:local) == 42
 
     #[test]
     fn thread_abort_on_exception() {
-        let interp = crate::interpreter().expect("init");
+        let mut interp = crate::interpreter().expect("init");
         let spec = br#"
 Thread.abort_on_exception = true
 Thread.new { raise 'failboat' }.join

--- a/artichoke-backend/src/extn/core/time/mruby.rs
+++ b/artichoke-backend/src/extn/core/time/mruby.rs
@@ -1,7 +1,7 @@
 use crate::extn::core::time::{self, trampoline};
 use crate::extn::prelude::*;
 
-pub fn init(interp: &Artichoke) -> InitializeResult<()> {
+pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     if interp.0.borrow().class_spec::<time::Time>().is_some() {
         return Ok(());
     }

--- a/artichoke-backend/src/extn/core/warning/mod.rs
+++ b/artichoke-backend/src/extn/core/warning/mod.rs
@@ -1,6 +1,6 @@
 use crate::extn::prelude::*;
 
-pub fn init(interp: &Artichoke) -> InitializeResult<()> {
+pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     if interp.0.borrow().module_spec::<Warning>().is_some() {
         return Ok(());
     }

--- a/artichoke-backend/src/extn/mod.rs
+++ b/artichoke-backend/src/extn/mod.rs
@@ -54,7 +54,7 @@ macro_rules! global_const {
     }};
 }
 
-pub fn init(interp: &Artichoke, backend_name: &str) -> InitializeResult<()> {
+pub fn init(interp: &mut Artichoke, backend_name: &str) -> InitializeResult<()> {
     let mut engine = String::from(RUBY_ENGINE);
     engine.push('-');
     engine.push_str(backend_name);

--- a/artichoke-backend/src/extn/stdlib/abbrev.rs
+++ b/artichoke-backend/src/extn/stdlib/abbrev.rs
@@ -27,7 +27,7 @@ expect = {
 result = Abbrev.abbrev(['ruby'])
 expect == result
 "#;
-        let interp = crate::interpreter().expect("init");
+        let mut interp = crate::interpreter().expect("init");
         let _ = interp.eval(b"require 'abbrev'").expect("require");
         let result = interp.eval(spec).expect("spec");
         assert!(result.try_into::<bool>().expect("convert"));
@@ -46,7 +46,7 @@ expect = {
 result = Abbrev.abbrev(%w{ ruby rules })
 expect == result
 "#;
-        let interp = crate::interpreter().expect("init");
+        let mut interp = crate::interpreter().expect("init");
         let _ = interp.eval(b"require 'abbrev'").expect("require");
         let result = interp.eval(spec).expect("spec");
         assert!(result.try_into::<bool>().expect("convert"));
@@ -72,7 +72,7 @@ expect = {
 result = %w{ summer winter }.abbrev
 expect == result
 "#;
-        let interp = crate::interpreter().expect("init");
+        let mut interp = crate::interpreter().expect("init");
         let _ = interp.eval(b"require 'abbrev'").expect("require");
         let result = interp.eval(spec).expect("spec");
         assert!(result.try_into::<bool>().expect("convert"));

--- a/artichoke-backend/src/extn/stdlib/forwardable.rs
+++ b/artichoke-backend/src/extn/stdlib/forwardable.rs
@@ -22,7 +22,7 @@ mod tests {
     #[test]
     #[allow(clippy::shadow_unrelated)]
     fn forwardable() {
-        let interp = crate::interpreter().expect("init");
+        let mut interp = crate::interpreter().expect("init");
         let _ = interp
             .eval(
                 br#"
@@ -87,7 +87,7 @@ r.record_number(0)
 
     #[test]
     fn forwardable_another_example() {
-        let interp = crate::interpreter().expect("init");
+        let mut interp = crate::interpreter().expect("init");
         let result = interp
             .eval(
                 br#"
@@ -144,7 +144,7 @@ out << q.first
 
     #[test]
     fn forwardable_def_instance_delegator() {
-        let interp = crate::interpreter().expect("init");
+        let mut interp = crate::interpreter().expect("init");
         let result = interp
             .eval(
                 br#"

--- a/artichoke-backend/src/extn/stdlib/monitor.rs
+++ b/artichoke-backend/src/extn/stdlib/monitor.rs
@@ -46,7 +46,7 @@ copy != instance
 # The below requires mspec
 # copy.should_not equal(instance)
 "#;
-        let interp = crate::interpreter().expect("init");
+        let mut interp = crate::interpreter().expect("init");
         let _ = interp.eval(b"require 'monitor'").expect("require");
         let result = interp.eval(spec).expect("spec");
         assert!(result.try_into::<bool>().expect("convert"));

--- a/artichoke-backend/src/extn/stdlib/strscan.rs
+++ b/artichoke-backend/src/extn/stdlib/strscan.rs
@@ -17,7 +17,7 @@ mod tests {
 
     #[test]
     fn strscan_spec() {
-        let interp = crate::interpreter().expect("init");
+        let mut interp = crate::interpreter().expect("init");
         interp
             .def_rb_source_file(
                 b"/src/test/strscan_test.rb",

--- a/artichoke-backend/src/fs.rs
+++ b/artichoke-backend/src/fs.rs
@@ -9,7 +9,7 @@ use crate::{Artichoke, ArtichokeError};
 
 pub const RUBY_LOAD_PATH: &str = "/src/lib";
 
-pub type RequireFunc = fn(&Artichoke) -> Result<(), ArtichokeError>;
+pub type RequireFunc = fn(&mut Artichoke) -> Result<(), ArtichokeError>;
 
 /// Virtual filesystem that wraps a [`artichoke_vfs`] [`FakeFileSystem`].
 pub struct Filesystem {

--- a/artichoke-backend/src/gc.rs
+++ b/artichoke-backend/src/gc.rs
@@ -134,7 +134,7 @@ mod tests {
 
     #[test]
     fn arena_restore_on_explicit_restore() {
-        let interp = crate::interpreter().expect("init");
+        let mut interp = crate::interpreter().expect("init");
         let baseline_object_count = interp.live_object_count();
         let arena = interp.create_arena_savepoint();
         for _ in 0..2000 {
@@ -154,7 +154,7 @@ mod tests {
 
     #[test]
     fn arena_restore_on_drop() {
-        let interp = crate::interpreter().expect("init");
+        let mut interp = crate::interpreter().expect("init");
         let baseline_object_count = interp.live_object_count();
         {
             let _arena = interp.create_arena_savepoint();
@@ -175,7 +175,7 @@ mod tests {
 
     #[test]
     fn arena_clone() {
-        let interp = crate::interpreter().expect("init");
+        let mut interp = crate::interpreter().expect("init");
         let baseline_object_count = interp.live_object_count();
         let arena = interp.create_arena_savepoint();
         let arena_clone = arena.clone();
@@ -197,7 +197,7 @@ mod tests {
     }
     #[test]
     fn enable_disable_gc() {
-        let interp = crate::interpreter().expect("init");
+        let mut interp = crate::interpreter().expect("init");
         interp.disable_gc();
         let arena = interp.create_arena_savepoint();
         let _ = interp
@@ -237,7 +237,7 @@ mod tests {
 
     #[test]
     fn gc_after_empty_eval() {
-        let interp = crate::interpreter().expect("init");
+        let mut interp = crate::interpreter().expect("init");
         let arena = interp.create_arena_savepoint();
         let baseline_object_count = interp.live_object_count();
         drop(interp.eval(b"").expect("eval"));
@@ -248,7 +248,7 @@ mod tests {
 
     #[test]
     fn gc_functional_test() {
-        let interp = crate::interpreter().expect("init");
+        let mut interp = crate::interpreter().expect("init");
         let baseline_object_count = interp.live_object_count();
         let initial_arena = interp.create_arena_savepoint();
         for _ in 0..2000 {

--- a/artichoke-backend/src/interpreter.rs
+++ b/artichoke-backend/src/interpreter.rs
@@ -39,7 +39,7 @@ pub fn interpreter() -> Result<Artichoke, BootError> {
     // operation `Rc::strong_count` will still be 1. This dance is required to
     // avoid leaking Artichoke objects, which will let the `Drop` impl close the mrb
     // context and interpreter.
-    let interp = Artichoke(unsafe { Rc::from_raw(userdata) });
+    let mut interp = Artichoke(unsafe { Rc::from_raw(userdata) });
 
     // mruby garbage collection relies on a fully initialized Array, which we
     // won't have until after `extn::core` is initialized. Disable GC before
@@ -47,7 +47,7 @@ pub fn interpreter() -> Result<Artichoke, BootError> {
     interp.disable_gc();
 
     // Initialize Artichoke Core and Standard Library runtime
-    extn::init(&interp, "mruby")?;
+    extn::init(&mut interp, "mruby")?;
 
     // Load mrbgems
     let arena = interp.create_arena_savepoint();

--- a/artichoke-backend/src/lib.rs
+++ b/artichoke-backend/src/lib.rs
@@ -22,7 +22,7 @@
 //! ```rust
 //! use artichoke_backend::{Eval, ValueLike};
 //!
-//! let interp = artichoke_backend::interpreter().unwrap();
+//! let mut interp = artichoke_backend::interpreter().unwrap();
 //! let result = interp.eval(b"10 * 10").unwrap();
 //! let result = result.try_into::<i64>();
 //! assert_eq!(result, Ok(100));

--- a/artichoke-backend/src/module.rs
+++ b/artichoke-backend/src/module.rs
@@ -273,7 +273,7 @@ mod tests {
 
     #[test]
     fn rclass_for_nested_module() {
-        let interp = crate::interpreter().expect("init");
+        let mut interp = crate::interpreter().expect("init");
         let _ = interp
             .eval(b"module Foo; module Bar; end; end")
             .expect("eval");
@@ -285,7 +285,7 @@ mod tests {
 
     #[test]
     fn rclass_for_nested_module_under_class() {
-        let interp = crate::interpreter().expect("init");
+        let mut interp = crate::interpreter().expect("init");
         let _ = interp
             .eval(b"class Foo; module Bar; end; end")
             .expect("eval");

--- a/artichoke-backend/src/value.rs
+++ b/artichoke-backend/src/value.rs
@@ -537,7 +537,7 @@ mod tests {
 
     #[test]
     fn is_dead() {
-        let interp = crate::interpreter().expect("init");
+        let mut interp = crate::interpreter().expect("init");
         let arena = interp.create_arena_savepoint();
         let live = interp.eval(b"'dead'").expect("value");
         assert!(!live.is_dead());
@@ -554,7 +554,7 @@ mod tests {
 
     #[test]
     fn immediate_is_dead() {
-        let interp = crate::interpreter().expect("init");
+        let mut interp = crate::interpreter().expect("init");
         let arena = interp.create_arena_savepoint();
         let live = interp.eval(b"27").expect("value");
         assert!(!live.is_dead());

--- a/artichoke-backend/tests/leak_mrb_tt_data_rc.rs
+++ b/artichoke-backend/tests/leak_mrb_tt_data_rc.rs
@@ -87,7 +87,7 @@ impl File for Container {
 #[test]
 fn rust_backed_mrb_value_smart_pointer_leak() {
     leak::Detector::new("smart pointer", ITERATIONS, LEAK_TOLERANCE).check_leaks(|_| {
-        let interp = artichoke_backend::interpreter().expect("init");
+        let mut interp = artichoke_backend::interpreter().expect("init");
         interp
             .def_file_for_type::<Container>(b"container")
             .expect("def file");

--- a/artichoke-backend/tests/leak_mrb_tt_data_rc.rs
+++ b/artichoke-backend/tests/leak_mrb_tt_data_rc.rs
@@ -73,7 +73,7 @@ impl Container {
 impl File for Container {
     type Artichoke = Artichoke;
 
-    fn require(interp: &Artichoke) -> Result<(), ArtichokeError> {
+    fn require(interp: &mut Artichoke) -> Result<(), ArtichokeError> {
         let spec = class::Spec::new("Container", None, Some(def::rust_data_free::<Self>))?;
         class::Builder::for_spec(interp, &spec)
             .value_is_rust_object()

--- a/artichoke-backend/tests/leak_unbounded_arena_growth.rs
+++ b/artichoke-backend/tests/leak_unbounded_arena_growth.rs
@@ -32,7 +32,7 @@ const LEAK_TOLERANCE: i64 = 1024 * 1024 * 15;
 #[test]
 fn unbounded_arena_growth() {
     // ArtichokeApi::current_exception
-    let interp = artichoke_backend::interpreter().expect("init");
+    let mut interp = artichoke_backend::interpreter().expect("init");
     let code = r#"
 def bad_code
   raise ArgumentError.new("n" * 1024 * 1024)
@@ -44,7 +44,7 @@ end
         Vec::from(&b"(eval):1"[..]),
     ]);
     leak::Detector::new("current exception", ITERATIONS, LEAK_TOLERANCE).check_leaks(|_| {
-        let interp = interp.clone();
+        let mut interp = interp.clone();
         let code = b"bad_code";
         let arena = interp.create_arena_savepoint();
         let result = interp.eval(code).unwrap_err();
@@ -59,7 +59,7 @@ end
     let expected = "a".repeat(1024 * 1024);
     leak::Detector::new("to_s", ITERATIONS, LEAK_TOLERANCE).check_leaks_with_finalizer(
         |_| {
-            let interp = interp.clone();
+            let mut interp = interp.clone();
             let arena = interp.create_arena_savepoint();
             let result = interp.eval(b"'a' * 1024 * 1024").expect("eval");
             arena.restore();
@@ -75,7 +75,7 @@ end
     let expected = format!(r#"String<"{}">"#, "a".repeat(1024 * 1024));
     leak::Detector::new("to_s_debug", ITERATIONS, 3 * LEAK_TOLERANCE).check_leaks_with_finalizer(
         |_| {
-            let interp = interp.clone();
+            let mut interp = interp.clone();
             let arena = interp.create_arena_savepoint();
             let result = interp.eval(b"'a' * 1024 * 1024").expect("eval");
             arena.restore();

--- a/artichoke-backend/tests/manual.rs
+++ b/artichoke-backend/tests/manual.rs
@@ -56,7 +56,7 @@ impl Container {
 impl File for Container {
     type Artichoke = Artichoke;
 
-    fn require(interp: &Artichoke) -> Result<(), ArtichokeError> {
+    fn require(interp: &mut Artichoke) -> Result<(), ArtichokeError> {
         let spec = class::Spec::new("Container", None, Some(def::rust_data_free::<Box<Self>>))?;
         class::Builder::for_spec(interp, &spec)
             .value_is_rust_object()

--- a/artichoke-backend/tests/manual.rs
+++ b/artichoke-backend/tests/manual.rs
@@ -70,7 +70,7 @@ impl File for Container {
 
 #[test]
 fn define_rust_backed_ruby_class() {
-    let interp = artichoke_backend::interpreter().expect("init");
+    let mut interp = artichoke_backend::interpreter().expect("init");
     interp
         .def_file_for_type::<Container>(b"container.rb")
         .expect("def file");

--- a/artichoke-core/src/eval.rs
+++ b/artichoke-core/src/eval.rs
@@ -16,5 +16,5 @@ pub trait Eval {
     type Error: std::error::Error;
 
     /// Eval code on the artichoke interpreter using the current `Context`.
-    fn eval(&self, code: &[u8]) -> Result<Self::Value, Self::Error>;
+    fn eval(&mut self, code: &[u8]) -> Result<Self::Value, Self::Error>;
 }

--- a/artichoke-core/src/file.rs
+++ b/artichoke-core/src/file.rs
@@ -13,5 +13,5 @@ pub trait File {
     /// This function can mutate interpreter state, such as defining classes and
     /// modules. This function is equivalent to the "init" methods of
     /// C-implemented Rubygems.
-    fn require(interp: &Self::Artichoke) -> Result<(), ArtichokeError>;
+    fn require(interp: &mut Self::Artichoke) -> Result<(), ArtichokeError>;
 }

--- a/artichoke-frontend/src/repl.rs
+++ b/artichoke-frontend/src/repl.rs
@@ -98,7 +98,7 @@ impl Default for PromptConfig {
     }
 }
 
-fn preamble(interp: &Artichoke) -> Result<String, Error> {
+fn preamble(interp: &mut Artichoke) -> Result<String, Error> {
     let description = interp
         .eval(b"RUBY_DESCRIPTION")?
         .try_into::<&str>()
@@ -124,7 +124,7 @@ pub fn run(
 ) -> Result<(), Error> {
     let config = config.unwrap_or_default();
     let mut interp = artichoke_backend::interpreter()?;
-    writeln!(output, "{}", preamble(&interp)?)?;
+    writeln!(output, "{}", preamble(&mut interp)?)?;
 
     interp.reset_parser();
     // safety:

--- a/artichoke-frontend/src/ruby.rs
+++ b/artichoke-frontend/src/ruby.rs
@@ -92,7 +92,7 @@ impl From<&'static str> for Error {
 pub fn entrypoint() -> Result<(), Error> {
     let opt = Opt::from_args();
     if opt.copyright {
-        let interp = artichoke_backend::interpreter()?;
+        let mut interp = artichoke_backend::interpreter()?;
         let _ = interp.eval(b"puts RUBY_COPYRIGHT")?;
         Ok(())
     } else if !opt.commands.is_empty() {
@@ -104,7 +104,7 @@ pub fn entrypoint() -> Result<(), Error> {
         io::stdin()
             .read_to_end(&mut program)
             .map_err(|_| "Could not read program from STDIN")?;
-        let interp = artichoke_backend::interpreter()?;
+        let mut interp = artichoke_backend::interpreter()?;
         let _ = interp.eval(program.as_slice())?;
         Ok(())
     }
@@ -148,7 +148,7 @@ fn execute_inline_eval(commands: Vec<OsString>, fixture: Option<&Path>) -> Resul
 }
 
 fn execute_program_file(programfile: &Path, fixture: Option<&Path>) -> Result<(), Error> {
-    let interp = artichoke_backend::interpreter()?;
+    let mut interp = artichoke_backend::interpreter()?;
     if let Some(ref fixture) = fixture {
         let data = if let Ok(data) = std::fs::read(fixture) {
             data

--- a/spec-runner/src/mspec.rs
+++ b/spec-runner/src/mspec.rs
@@ -41,7 +41,7 @@ impl Runner {
         Ok(())
     }
 
-    pub fn run(self) -> Result<bool, BootError> {
+    pub fn run(mut self) -> Result<bool, BootError> {
         init(&self.interp).unwrap();
         self.interp
             .def_rb_source_file(b"/src/spec_helper.rb", &b""[..])?;


### PR DESCRIPTION
This PR is part of the series related to GH-442 to remove interior mutability in Artichoke.

This change adds a `&mut self` bound on `Eval::eval` and also a `&mut Artichoke` bound on `File::require`. These APIs require unique access to the interpreter because they are manipulating interpreter state.