### PR TITLE
Make Warn::warn take &mut self

### DIFF
--- a/artichoke-backend/src/extn/core/array/mod.rs
+++ b/artichoke-backend/src/extn/core/array/mod.rs
@@ -44,7 +44,7 @@ impl Array {
     }
 
     pub fn initialize(
-        interp: &Artichoke,
+        interp: &mut Artichoke,
         first: Option<Value>,
         second: Option<Value>,
         block: Option<Block>,

--- a/artichoke-backend/src/extn/core/array/mruby.rs
+++ b/artichoke-backend/src/extn/core/array/mruby.rs
@@ -88,11 +88,11 @@ unsafe extern "C" fn ary_initialize(
     ary: sys::mrb_value,
 ) -> sys::mrb_value {
     let (first, second, block) = mrb_get_args!(mrb, optional = 2, &block);
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let array = Value::new(&interp, ary);
     let first = first.map(|first| Value::new(&interp, first));
     let second = second.map(|second| Value::new(&interp, second));
-    let result = array::trampoline::initialize(&interp, array, first, second, block);
+    let result = array::trampoline::initialize(&mut interp, array, first, second, block);
     match result {
         Ok(value) => {
             let basic = sys::mrb_sys_basic_ptr(ary);

--- a/artichoke-backend/src/extn/core/array/trampoline.rs
+++ b/artichoke-backend/src/extn/core/array/trampoline.rs
@@ -171,7 +171,7 @@ pub fn len(interp: &Artichoke, ary: Value) -> Result<usize, Exception> {
 }
 
 pub fn initialize(
-    interp: &Artichoke,
+    interp: &mut Artichoke,
     ary: Value,
     first: Option<Value>,
     second: Option<Value>,

--- a/artichoke-backend/src/extn/core/regexp/mod.rs
+++ b/artichoke-backend/src/extn/core/regexp/mod.rs
@@ -119,7 +119,7 @@ impl Regexp {
     }
 
     pub fn initialize(
-        interp: &Artichoke,
+        interp: &mut Artichoke,
         pattern: Value,
         options: Option<Value>,
         encoding: Option<Value>,

--- a/artichoke-backend/src/extn/core/regexp/mruby.rs
+++ b/artichoke-backend/src/extn/core/regexp/mruby.rs
@@ -48,14 +48,13 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
 
 unsafe extern "C" fn initialize(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
     let (pattern, options, encoding) = mrb_get_args!(mrb, required = 1, optional = 2);
-    let interp = unwrap_interpreter!(mrb);
-    let result = regexp::trampoline::initialize(
-        &interp,
-        Value::new(&interp, pattern),
-        options.map(|options| Value::new(&interp, options)),
-        encoding.map(|encoding| Value::new(&interp, encoding)),
-        Some(Value::new(&interp, slf)),
-    );
+    let mut interp = unwrap_interpreter!(mrb);
+    let into = Value::new(&interp, slf);
+    let pattern = Value::new(&interp, pattern);
+    let options = options.map(|options| Value::new(&interp, options));
+    let encoding = encoding.map(|encoding| Value::new(&interp, encoding));
+    let result =
+        regexp::trampoline::initialize(&mut interp, pattern, options, encoding, Some(into));
     match result {
         Ok(value) => value.inner(),
         Err(exception) => exception::raise(interp, exception),

--- a/artichoke-backend/src/extn/core/regexp/trampoline.rs
+++ b/artichoke-backend/src/extn/core/regexp/trampoline.rs
@@ -2,7 +2,7 @@ use crate::extn::core::regexp::Regexp;
 use crate::extn::prelude::*;
 
 pub fn initialize(
-    interp: &Artichoke,
+    interp: &mut Artichoke,
     pattern: Value,
     options: Option<Value>,
     encoding: Option<Value>,

--- a/artichoke-backend/src/warn.rs
+++ b/artichoke-backend/src/warn.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use std::io::{self, Write};
 
 use crate::convert::Convert;
@@ -11,7 +10,7 @@ use crate::{Artichoke, ArtichokeError, ValueLike, Warn};
 impl Warn for Artichoke {
     type Error = Exception;
 
-    fn warn(&self, message: &[u8]) -> Result<(), Self::Error> {
+    fn warn(&mut self, message: &[u8]) -> Result<(), Self::Error> {
         let _ = io::stderr().write_all(b"rb warning: ");
         let _ = io::stderr().write_all(message);
         let _ = io::stderr().write_all(b"\n");
@@ -19,17 +18,14 @@ impl Warn for Artichoke {
             let borrow = self.0.borrow();
             let spec = borrow
                 .module_spec::<Warning>()
-                .ok_or_else(|| {
-                    ArtichokeError::NotDefined(Cow::Borrowed("Warn with uninitialized Warning"))
-                })
-                .map_err(|err| RuntimeError::new(self, format!("{}", err)))?;
+                .ok_or_else(|| ArtichokeError::NotDefined("Warn with uninitialized Warning".into()))
+                .map_err(|err| RuntimeError::new(self, err.to_string()))?;
             spec.value(self)
-                .ok_or_else(|| {
-                    ArtichokeError::NotDefined(Cow::Borrowed("Warn with uninitialized Warning"))
-                })
-                .map_err(|err| RuntimeError::new(self, format!("{}", err)))?
+                .ok_or_else(|| ArtichokeError::NotDefined("Warn with uninitialized Warning".into()))
+                .map_err(|err| RuntimeError::new(self, err.to_string()))?
         };
-        let _ = warning.funcall::<Value>("warn", &[self.convert(message)], None)?;
+        let message = self.convert(message);
+        let _ = warning.funcall::<Value>("warn", &[message], None)?;
         Ok(())
     }
 }

--- a/artichoke-core/src/warn.rs
+++ b/artichoke-core/src/warn.rs
@@ -22,5 +22,5 @@ pub trait Warn {
     /// `Warning` module.
     ///
     /// If an exception is raised on the interpreter, then an error is returned.
-    fn warn(&self, message: &[u8]) -> Result<(), Self::Error>;
+    fn warn(&mut self, message: &[u8]) -> Result<(), Self::Error>;
 }


### PR DESCRIPTION
Warn::warn allocates on the interpreter heap when sending the message to
the Warning#warn method, so it requires unique access.