### PR TITLE
Remove macro-generated converter implementations

### DIFF
--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -55,6 +55,5 @@ default-features = false
 
 [features]
 default = ["artichoke-random", "artichoke-system-environ"]
-artichoke-all-converters = []
 artichoke-random = ["rand"]
 artichoke-system-environ = []

--- a/artichoke-backend/src/convert/array.rs
+++ b/artichoke-backend/src/convert/array.rs
@@ -1,6 +1,7 @@
+use std::iter::FromIterator;
+
 use crate::convert::{Convert, RustBackedValue, TryConvert};
 use crate::extn::core::array::{Array, InlineBuffer};
-use crate::sys;
 use crate::types::{Int, Ruby, Rust};
 use crate::value::Value;
 use crate::{Artichoke, ArtichokeError};
@@ -21,160 +22,111 @@ impl Convert<Vec<Value>, Value> for Artichoke {
 
 impl Convert<&[Option<Value>], Value> for Artichoke {
     fn convert(&self, value: &[Option<Value>]) -> Value {
-        let buf = value
-            .iter()
-            .map(|item| {
-                item.as_ref()
-                    .map_or_else(|| unsafe { sys::mrb_sys_nil_value() }, Value::inner)
-            })
-            .collect::<Vec<_>>();
-        let ary = Array::new(InlineBuffer::from(buf));
+        let ary = Array::new(InlineBuffer::from_iter(value));
         ary.try_into_ruby(self, None).expect("Array into Value")
     }
 }
 
 impl Convert<Vec<Vec<u8>>, Value> for Artichoke {
     fn convert(&self, value: Vec<Vec<u8>>) -> Value {
-        let buf = value
-            .into_iter()
-            .map(|item| self.convert(item).inner())
-            .collect::<Vec<_>>();
-        let ary = Array::new(InlineBuffer::from(buf));
+        let iter = value.into_iter().map(|item| self.convert(item));
+        let ary = Array::new(InlineBuffer::from_iter(iter));
         ary.try_into_ruby(self, None).expect("Array into Value")
     }
 }
 
 impl Convert<Vec<&[u8]>, Value> for Artichoke {
     fn convert(&self, value: Vec<&[u8]>) -> Value {
-        let buf = value
-            .into_iter()
-            .map(|item| self.convert(item).inner())
-            .collect::<Vec<_>>();
-        let ary = Array::new(InlineBuffer::from(buf));
+        let iter = value.into_iter().map(|item| self.convert(item));
+        let ary = Array::new(InlineBuffer::from_iter(iter));
         ary.try_into_ruby(self, None).expect("Array into Value")
     }
 }
 
 impl Convert<Vec<String>, Value> for Artichoke {
     fn convert(&self, value: Vec<String>) -> Value {
-        let buf = value
-            .into_iter()
-            .map(|item| self.convert(item).inner())
-            .collect::<Vec<_>>();
-        let ary = Array::new(InlineBuffer::from(buf));
+        let iter = value.into_iter().map(|item| self.convert(item));
+        let ary = Array::new(InlineBuffer::from_iter(iter));
         ary.try_into_ruby(self, None).expect("Array into Value")
     }
 }
 
 impl Convert<Vec<&str>, Value> for Artichoke {
     fn convert(&self, value: Vec<&str>) -> Value {
-        let buf = value
-            .into_iter()
-            .map(|item| self.convert(item).inner())
-            .collect::<Vec<_>>();
-        let ary = Array::new(InlineBuffer::from(buf));
+        let iter = value.into_iter().map(|item| self.convert(item));
+        let ary = Array::new(InlineBuffer::from_iter(iter));
         ary.try_into_ruby(self, None).expect("Array into Value")
     }
 }
 
 impl Convert<Vec<Int>, Value> for Artichoke {
     fn convert(&self, value: Vec<Int>) -> Value {
-        let buf = value
-            .into_iter()
-            .map(|item| self.convert(item).inner())
-            .collect::<Vec<_>>();
-        let ary = Array::new(InlineBuffer::from(buf));
+        let iter = value.into_iter().map(|item| self.convert(item));
+        let ary = Array::new(InlineBuffer::from_iter(iter));
         ary.try_into_ruby(self, None).expect("Array into Value")
     }
 }
 
 impl Convert<&[Int], Value> for Artichoke {
     fn convert(&self, value: &[Int]) -> Value {
-        let buf = value
-            .iter()
-            .copied()
-            .map(|item| self.convert(item).inner())
-            .collect::<Vec<_>>();
-        let ary = Array::new(InlineBuffer::from(buf));
+        let iter = value.iter().copied().map(|item| self.convert(item));
+        let ary = Array::new(InlineBuffer::from_iter(iter));
         ary.try_into_ruby(self, None).expect("Array into Value")
     }
 }
 
 impl Convert<Vec<Option<Vec<u8>>>, Value> for Artichoke {
     fn convert(&self, value: Vec<Option<Vec<u8>>>) -> Value {
-        let buf = value
-            .into_iter()
-            .map(|item| self.convert(item).inner())
-            .collect::<Vec<_>>();
-        let ary = Array::new(InlineBuffer::from(buf));
+        let iter = value.into_iter().map(|item| self.convert(item));
+        let ary = Array::new(InlineBuffer::from_iter(iter));
         ary.try_into_ruby(self, None).expect("Array into Value")
     }
 }
 
 impl Convert<&[Option<&[u8]>], Value> for Artichoke {
     fn convert(&self, value: &[Option<&[u8]>]) -> Value {
-        let buf = value
-            .iter()
-            .copied()
-            .map(|item| self.convert(item).inner())
-            .collect::<Vec<_>>();
-        let ary = Array::new(InlineBuffer::from(buf));
+        let iter = value.iter().copied().map(|item| self.convert(item));
+        let ary = Array::new(InlineBuffer::from_iter(iter));
         ary.try_into_ruby(self, None).expect("Array into Value")
     }
 }
 
 impl Convert<Vec<Option<&[u8]>>, Value> for Artichoke {
     fn convert(&self, value: Vec<Option<&[u8]>>) -> Value {
-        let buf = value
-            .into_iter()
-            .map(|item| self.convert(item).inner())
-            .collect::<Vec<_>>();
-        let ary = Array::new(InlineBuffer::from(buf));
+        let iter = value.into_iter().map(|item| self.convert(item));
+        let ary = Array::new(InlineBuffer::from_iter(iter));
         ary.try_into_ruby(self, None).expect("Array into Value")
     }
 }
 
 impl Convert<Vec<Vec<Option<&[u8]>>>, Value> for Artichoke {
     fn convert(&self, value: Vec<Vec<Option<&[u8]>>>) -> Value {
-        let buf = value
-            .into_iter()
-            .map(|item| self.convert(item).inner())
-            .collect::<Vec<_>>();
-        let ary = Array::new(InlineBuffer::from(buf));
+        let iter = value.into_iter().map(|item| self.convert(item));
+        let ary = Array::new(InlineBuffer::from_iter(iter));
         ary.try_into_ruby(self, None).expect("Array into Value")
     }
 }
 
 impl Convert<&[Option<&str>], Value> for Artichoke {
     fn convert(&self, value: &[Option<&str>]) -> Value {
-        let buf = value
-            .iter()
-            .copied()
-            .map(|item| self.convert(item).inner())
-            .collect::<Vec<_>>();
-        let ary = Array::new(InlineBuffer::from(buf));
+        let iter = value.iter().copied().map(|item| self.convert(item));
+        let ary = Array::new(InlineBuffer::from_iter(iter));
         ary.try_into_ruby(self, None).expect("Array into Value")
     }
 }
 
 impl Convert<Vec<Option<&str>>, Value> for Artichoke {
     fn convert(&self, value: Vec<Option<&str>>) -> Value {
-        let buf = value
-            .into_iter()
-            .map(|item| self.convert(item).inner())
-            .collect::<Vec<_>>();
-        let ary = Array::new(InlineBuffer::from(buf));
+        let iter = value.into_iter().map(|item| self.convert(item));
+        let ary = Array::new(InlineBuffer::from_iter(iter));
         ary.try_into_ruby(self, None).expect("Array into Value")
     }
 }
 
 impl Convert<Vec<Vec<Option<&str>>>, Value> for Artichoke {
     fn convert(&self, value: Vec<Vec<Option<&str>>>) -> Value {
-        let buf = value
-            .into_iter()
-            .map(|item| self.convert(item).inner())
-            .collect::<Vec<_>>();
-        let ary = Array::new(InlineBuffer::from(buf));
+        let iter = value.into_iter().map(|item| self.convert(item));
+        let ary = Array::new(InlineBuffer::from_iter(iter));
         ary.try_into_ruby(self, None).expect("Array into Value")
     }
 }

--- a/artichoke-backend/src/convert/array.rs
+++ b/artichoke-backend/src/convert/array.rs
@@ -1,13 +1,9 @@
-use std::convert::TryFrom;
-
 use crate::convert::{Convert, RustBackedValue, TryConvert};
 use crate::extn::core::array::{Array, InlineBuffer};
-use crate::sys;
-use crate::types::{Float, Int, Ruby, Rust};
+use crate::types::{Int, Ruby, Rust};
 use crate::value::Value;
 use crate::{Artichoke, ArtichokeError};
 
-// bail out implementation for mixed-type collections
 impl Convert<&[Value], Value> for Artichoke {
     fn convert(&self, value: &[Value]) -> Value {
         let ary = Array::new(InlineBuffer::from(value));
@@ -22,23 +18,168 @@ impl Convert<Vec<Value>, Value> for Artichoke {
     }
 }
 
+impl Convert<&[Option<Value>], Value> for Artichoke {
+    fn convert(&self, value: &[Option<Value>]) -> Value {
+        let buf = value
+            .iter()
+            .map(|item| self.convert(item))
+            .collect::<Vec<Value>>();
+        let ary = Array::new(InlineBuffer::from(buf));
+        ary.try_into_ruby(self, None).expect("Array into Value")
+    }
+}
+
+impl Convert<Vec<Vec<u8>>, Value> for Artichoke {
+    fn convert(&self, value: Vec<Vec<u8>>) -> Value {
+        let buf = value
+            .into_iter()
+            .map(|item| self.convert(item))
+            .collect::<Vec<Value>>();
+        let ary = Array::new(InlineBuffer::from(buf));
+        ary.try_into_ruby(self, None).expect("Array into Value")
+    }
+}
+
+impl Convert<Vec<&[u8]>, Value> for Artichoke {
+    fn convert(&self, value: Vec<&[u8]>) -> Value {
+        let buf = value
+            .into_iter()
+            .map(|item| self.convert(item))
+            .collect::<Vec<Value>>();
+        let ary = Array::new(InlineBuffer::from(buf));
+        ary.try_into_ruby(self, None).expect("Array into Value")
+    }
+}
+
+impl Convert<Vec<String>, Value> for Artichoke {
+    fn convert(&self, value: Vec<String>) -> Value {
+        let buf = value
+            .into_iter()
+            .map(|item| self.convert(item))
+            .collect::<Vec<Value>>();
+        let ary = Array::new(InlineBuffer::from(buf));
+        ary.try_into_ruby(self, None).expect("Array into Value")
+    }
+}
+
+impl Convert<Vec<&str>, Value> for Artichoke {
+    fn convert(&self, value: Vec<&str>) -> Value {
+        let buf = value
+            .into_iter()
+            .map(|item| self.convert(item))
+            .collect::<Vec<Value>>();
+        let ary = Array::new(InlineBuffer::from(buf));
+        ary.try_into_ruby(self, None).expect("Array into Value")
+    }
+}
+
+impl Convert<Vec<Int>, Value> for Artichoke {
+    fn convert(&self, value: Vec<Int>) -> Value {
+        let buf = value
+            .into_iter()
+            .map(|item| self.convert(item))
+            .collect::<Vec<Value>>();
+        let ary = Array::new(InlineBuffer::from(buf));
+        ary.try_into_ruby(self, None).expect("Array into Value")
+    }
+}
+
+impl Convert<&[Int], Value> for Artichoke {
+    fn convert(&self, value: &[Int]) -> Value {
+        let buf = value
+            .iter()
+            .copied()
+            .map(|item| self.convert(item))
+            .collect::<Vec<Value>>();
+        let ary = Array::new(InlineBuffer::from(buf));
+        ary.try_into_ruby(self, None).expect("Array into Value")
+    }
+}
+
+impl Convert<Vec<Option<Vec<u8>>>, Value> for Artichoke {
+    fn convert(&self, value: Vec<Option<Vec<u8>>>) -> Value {
+        let buf = value
+            .into_iter()
+            .map(|item| self.convert(item))
+            .collect::<Vec<Value>>();
+        let ary = Array::new(InlineBuffer::from(buf));
+        ary.try_into_ruby(self, None).expect("Array into Value")
+    }
+}
+
+impl Convert<&[Option<&[u8]>], Value> for Artichoke {
+    fn convert(&self, value: &[Option<&[u8]>]) -> Value {
+        let buf = value
+            .iter()
+            .copied()
+            .map(|item| self.convert(item))
+            .collect::<Vec<Value>>();
+        let ary = Array::new(InlineBuffer::from(buf));
+        ary.try_into_ruby(self, None).expect("Array into Value")
+    }
+}
+
+impl Convert<Vec<Option<&[u8]>>, Value> for Artichoke {
+    fn convert(&self, value: Vec<Option<&[u8]>>) -> Value {
+        let buf = value
+            .into_iter()
+            .map(|item| self.convert(item))
+            .collect::<Vec<Value>>();
+        let ary = Array::new(InlineBuffer::from(buf));
+        ary.try_into_ruby(self, None).expect("Array into Value")
+    }
+}
+
+impl Convert<Vec<Vec<Option<&[u8]>>>, Value> for Artichoke {
+    fn convert(&self, value: Vec<Vec<Option<&[u8]>>>) -> Value {
+        let buf = value
+            .into_iter()
+            .map(|item| self.convert(item))
+            .collect::<Vec<Value>>();
+        let ary = Array::new(InlineBuffer::from(buf));
+        ary.try_into_ruby(self, None).expect("Array into Value")
+    }
+}
+
+impl Convert<&[Option<&str>], Value> for Artichoke {
+    fn convert(&self, value: &[Option<&str>]) -> Value {
+        let buf = value
+            .iter()
+            .copied()
+            .map(|item| self.convert(item))
+            .collect::<Vec<Value>>();
+        let ary = Array::new(InlineBuffer::from(buf));
+        ary.try_into_ruby(self, None).expect("Array into Value")
+    }
+}
+
+impl Convert<Vec<Option<&str>>, Value> for Artichoke {
+    fn convert(&self, value: Vec<Option<&str>>) -> Value {
+        let buf = value
+            .into_iter()
+            .map(|item| self.convert(item))
+            .collect::<Vec<Value>>();
+        let ary = Array::new(InlineBuffer::from(buf));
+        ary.try_into_ruby(self, None).expect("Array into Value")
+    }
+}
+
+impl Convert<Vec<Vec<Option<&str>>>, Value> for Artichoke {
+    fn convert(&self, value: Vec<Vec<Option<&str>>>) -> Value {
+        let buf = value
+            .into_iter()
+            .map(|item| self.convert(item))
+            .collect::<Vec<Value>>();
+        let ary = Array::new(InlineBuffer::from(buf));
+        ary.try_into_ruby(self, None).expect("Array into Value")
+    }
+}
+
 impl TryConvert<Value, Vec<Value>> for Artichoke {
     fn try_convert(&self, value: Value) -> Result<Vec<Value>, ArtichokeError> {
-        let mrb = self.0.borrow().mrb;
         match value.ruby_type() {
             Ruby::Array => {
-                let array = value.inner();
-                let size = unsafe { sys::mrb_sys_ary_len(array) };
-                let capa = usize::try_from(size).map_err(|_| ArtichokeError::ConvertToRust {
-                    from: Ruby::Array,
-                    to: Rust::Vec,
-                })?;
-                let mut elems = Vec::<Value>::with_capacity(capa);
-                for idx in 0..size {
-                    let elem = Value::new(self, unsafe { sys::mrb_ary_ref(mrb, array, idx) });
-                    elems.push(elem);
-                }
-                Ok(elems)
+                unreachable!("mrb_array implementation is obsoleted by extn::core::array")
             }
             Ruby::Data => {
                 let array = unsafe { Array::try_from_ruby(self, &value)? };
@@ -53,433 +194,218 @@ impl TryConvert<Value, Vec<Value>> for Artichoke {
     }
 }
 
-macro_rules! array_to_ruby {
-    ($elem:ty) => {
-        impl<'a> Convert<&[$elem], Value> for Artichoke {
-            fn convert(&self, value: &[$elem]) -> Value {
-                self.convert(value.to_vec())
+impl TryConvert<Value, Vec<Vec<u8>>> for Artichoke {
+    fn try_convert(&self, value: Value) -> Result<Vec<Vec<u8>>, ArtichokeError> {
+        match value.ruby_type() {
+            Ruby::Array => {
+                unreachable!("mrb_array implementation is obsoleted by extn::core::array")
             }
-        }
-
-        impl<'a> Convert<Vec<$elem>, Value> for Artichoke {
-            fn convert(&self, value: Vec<$elem>) -> Value {
-                let elems = value
-                    .into_iter()
-                    .map(|elem| self.convert(elem))
-                    .collect::<Vec<Value>>();
-                self.convert(elems)
-            }
-        }
-    };
-}
-
-macro_rules! ruby_to_array {
-    ($elem:ty) => {
-        impl<'a> TryConvert<Value, Vec<$elem>> for Artichoke {
-            fn try_convert(&self, value: Value) -> Result<Vec<$elem>, ArtichokeError> {
-                let elems = TryConvert::<_, Vec<Value>>::try_convert(self, value)?;
-                let mut vec = Vec::<$elem>::with_capacity(elems.len());
-                for elem in elems.into_iter() {
-                    vec.push(self.try_convert(elem)?);
+            Ruby::Data => {
+                let array = unsafe { Array::try_from_ruby(self, &value)? };
+                let borrow = array.borrow();
+                let array = borrow.as_vec(self);
+                let mut buf = Vec::with_capacity(array.len());
+                for elem in array {
+                    buf.push(self.try_convert(elem)?);
                 }
-                Ok(vec)
+                Ok(buf)
             }
+            type_tag => Err(ArtichokeError::ConvertToRust {
+                from: type_tag,
+                to: Rust::Vec,
+            }),
         }
-    };
+    }
 }
 
-// Primitives
-array_to_ruby!(bool);
-array_to_ruby!(Vec<u8>);
-array_to_ruby!(&'a [u8]);
-array_to_ruby!(Int);
-array_to_ruby!(Float);
-array_to_ruby!(String);
-array_to_ruby!(&'a str);
-
-// Optional primitives
-array_to_ruby!(Option<Value>);
-array_to_ruby!(Option<bool>);
-array_to_ruby!(Option<Vec<u8>>);
-array_to_ruby!(Option<&'a [u8]>);
-array_to_ruby!(Option<Int>);
-array_to_ruby!(Option<Float>);
-array_to_ruby!(Option<String>);
-array_to_ruby!(Option<&'a str>);
-
-// Array of primitives
-array_to_ruby!(Vec<Value>);
-array_to_ruby!(Vec<bool>);
-array_to_ruby!(Vec<Vec<u8>>);
-array_to_ruby!(Vec<&'a [u8]>);
-array_to_ruby!(Vec<Int>);
-array_to_ruby!(Vec<Float>);
-array_to_ruby!(Vec<String>);
-array_to_ruby!(Vec<&'a str>);
-array_to_ruby!(&'a [Value]);
-array_to_ruby!(&'a [bool]);
-array_to_ruby!(&'a [Vec<u8>]);
-array_to_ruby!(&'a [&'a [u8]]);
-array_to_ruby!(&'a [Int]);
-array_to_ruby!(&'a [Float]);
-array_to_ruby!(&'a [String]);
-array_to_ruby!(&'a [&'a str]);
-
-// Array of optional primitives
-array_to_ruby!(Vec<Option<Value>>);
-array_to_ruby!(Vec<Option<bool>>);
-array_to_ruby!(Vec<Option<Vec<u8>>>);
-array_to_ruby!(Vec<Option<&'a [u8]>>);
-array_to_ruby!(Vec<Option<Int>>);
-array_to_ruby!(Vec<Option<Float>>);
-array_to_ruby!(Vec<Option<String>>);
-array_to_ruby!(Vec<Option<&'a str>>);
-array_to_ruby!(&'a [Option<Value>]);
-array_to_ruby!(&'a [Option<bool>]);
-array_to_ruby!(&'a [Option<Vec<u8>>]);
-array_to_ruby!(&'a [Option<&'a [u8]>]);
-array_to_ruby!(&'a [Option<Int>]);
-array_to_ruby!(&'a [Option<Float>]);
-array_to_ruby!(&'a [Option<String>]);
-array_to_ruby!(&'a [Option<&'a str>]);
-
-#[cfg(feature = "artichoke-all-converters")]
-mod optional {
-    use super::*;
-    use std::collections::HashMap;
-
-    // Hash of primitive keys to values
-    array_to_ruby!(HashMap<bool, Value>);
-    array_to_ruby!(HashMap<bool, bool>);
-    array_to_ruby!(HashMap<bool, Vec<u8>>);
-    array_to_ruby!(HashMap<bool, Int>);
-    array_to_ruby!(HashMap<bool, Float>);
-    array_to_ruby!(HashMap<bool, String>);
-    array_to_ruby!(HashMap<bool, &'a str>);
-    array_to_ruby!(HashMap<Vec<u8>, Value>);
-    array_to_ruby!(HashMap<Vec<u8>, bool>);
-    array_to_ruby!(HashMap<Vec<u8>, Vec<u8>>);
-    array_to_ruby!(HashMap<Vec<u8>, Int>);
-    array_to_ruby!(HashMap<Vec<u8>, Float>);
-    array_to_ruby!(HashMap<Vec<u8>, String>);
-    array_to_ruby!(HashMap<Vec<u8>, &'a str>);
-    array_to_ruby!(HashMap<Int, Value>);
-    array_to_ruby!(HashMap<Int, bool>);
-    array_to_ruby!(HashMap<Int, Vec<u8>>);
-    array_to_ruby!(HashMap<Int, Int>);
-    array_to_ruby!(HashMap<Int, Float>);
-    array_to_ruby!(HashMap<Int, String>);
-    array_to_ruby!(HashMap<Int, &'a str>);
-    array_to_ruby!(HashMap<String, Value>);
-    array_to_ruby!(HashMap<String, bool>);
-    array_to_ruby!(HashMap<String, Vec<u8>>);
-    array_to_ruby!(HashMap<String, Int>);
-    array_to_ruby!(HashMap<String, Float>);
-    array_to_ruby!(HashMap<String, String>);
-    array_to_ruby!(HashMap<String, &'a str>);
-    array_to_ruby!(HashMap<&'a str, Value>);
-    array_to_ruby!(HashMap<&'a str, bool>);
-    array_to_ruby!(HashMap<&'a str, Vec<u8>>);
-    array_to_ruby!(HashMap<&'a str, Int>);
-    array_to_ruby!(HashMap<&'a str, Float>);
-    array_to_ruby!(HashMap<&'a str, String>);
-    array_to_ruby!(HashMap<&'a str, &'a str>);
-
-    // Hash of optional keys to values
-    array_to_ruby!(HashMap<Option<bool>, Value>);
-    array_to_ruby!(HashMap<Option<bool>, bool>);
-    array_to_ruby!(HashMap<Option<bool>, Vec<u8>>);
-    array_to_ruby!(HashMap<Option<bool>, Int>);
-    array_to_ruby!(HashMap<Option<bool>, Float>);
-    array_to_ruby!(HashMap<Option<bool>, String>);
-    array_to_ruby!(HashMap<Option<bool>, &'a str>);
-    array_to_ruby!(HashMap<Option<Vec<u8>>, Value>);
-    array_to_ruby!(HashMap<Option<Vec<u8>>, bool>);
-    array_to_ruby!(HashMap<Option<Vec<u8>>, Vec<u8>>);
-    array_to_ruby!(HashMap<Option<Vec<u8>>, Int>);
-    array_to_ruby!(HashMap<Option<Vec<u8>>, Float>);
-    array_to_ruby!(HashMap<Option<Vec<u8>>, String>);
-    array_to_ruby!(HashMap<Option<Vec<u8>>, &'a str>);
-    array_to_ruby!(HashMap<Option<Int>, Value>);
-    array_to_ruby!(HashMap<Option<Int>, bool>);
-    array_to_ruby!(HashMap<Option<Int>, Vec<u8>>);
-    array_to_ruby!(HashMap<Option<Int>, Int>);
-    array_to_ruby!(HashMap<Option<Int>, Float>);
-    array_to_ruby!(HashMap<Option<Int>, String>);
-    array_to_ruby!(HashMap<Option<Int>, &'a str>);
-    array_to_ruby!(HashMap<Option<String>, Value>);
-    array_to_ruby!(HashMap<Option<String>, bool>);
-    array_to_ruby!(HashMap<Option<String>, Vec<u8>>);
-    array_to_ruby!(HashMap<Option<String>, Int>);
-    array_to_ruby!(HashMap<Option<String>, Float>);
-    array_to_ruby!(HashMap<Option<String>, String>);
-    array_to_ruby!(HashMap<Option<String>, &'a str>);
-    array_to_ruby!(HashMap<Option<&'a str>, Value>);
-    array_to_ruby!(HashMap<Option<&'a str>, bool>);
-    array_to_ruby!(HashMap<Option<&'a str>, Vec<u8>>);
-    array_to_ruby!(HashMap<Option<&'a str>, Int>);
-    array_to_ruby!(HashMap<Option<&'a str>, Float>);
-    array_to_ruby!(HashMap<Option<&'a str>, String>);
-    array_to_ruby!(HashMap<Option<&'a str>, &'a str>);
-
-    // Hash of primitive keys to optional values
-    array_to_ruby!(HashMap<bool, Option<Value>>);
-    array_to_ruby!(HashMap<bool, Option<bool>>);
-    array_to_ruby!(HashMap<bool, Option<Vec<u8>>>);
-    array_to_ruby!(HashMap<bool, Option<Int>>);
-    array_to_ruby!(HashMap<bool, Option<Float>>);
-    array_to_ruby!(HashMap<bool, Option<String>>);
-    array_to_ruby!(HashMap<bool, Option<&'a str>>);
-    array_to_ruby!(HashMap<Vec<u8>, Option<Value>>);
-    array_to_ruby!(HashMap<Vec<u8>, Option<bool>>);
-    array_to_ruby!(HashMap<Vec<u8>, Option<Vec<u8>>>);
-    array_to_ruby!(HashMap<Vec<u8>, Option<Int>>);
-    array_to_ruby!(HashMap<Vec<u8>, Option<Float>>);
-    array_to_ruby!(HashMap<Vec<u8>, Option<String>>);
-    array_to_ruby!(HashMap<Vec<u8>, Option<&'a str>>);
-    array_to_ruby!(HashMap<Int, Option<Value>>);
-    array_to_ruby!(HashMap<Int, Option<bool>>);
-    array_to_ruby!(HashMap<Int, Option<Vec<u8>>>);
-    array_to_ruby!(HashMap<Int, Option<Int>>);
-    array_to_ruby!(HashMap<Int, Option<Float>>);
-    array_to_ruby!(HashMap<Int, Option<String>>);
-    array_to_ruby!(HashMap<Int, Option<&'a str>>);
-    array_to_ruby!(HashMap<String, Option<Value>>);
-    array_to_ruby!(HashMap<String, Option<bool>>);
-    array_to_ruby!(HashMap<String, Option<Vec<u8>>>);
-    array_to_ruby!(HashMap<String, Option<Int>>);
-    array_to_ruby!(HashMap<String, Option<Float>>);
-    array_to_ruby!(HashMap<String, Option<String>>);
-    array_to_ruby!(HashMap<String, Option<&'a str>>);
-    array_to_ruby!(HashMap<&'a str, Option<Value>>);
-    array_to_ruby!(HashMap<&'a str, Option<bool>>);
-    array_to_ruby!(HashMap<&'a str, Option<Vec<u8>>>);
-    array_to_ruby!(HashMap<&'a str, Option<Int>>);
-    array_to_ruby!(HashMap<&'a str, Option<Float>>);
-    array_to_ruby!(HashMap<&'a str, Option<String>>);
-    array_to_ruby!(HashMap<&'a str, Option<&'a str>>);
-
-    // Hash of primitive optional keys to optional values
-    array_to_ruby!(HashMap<Option<bool>, Option<Value>>);
-    array_to_ruby!(HashMap<Option<bool>, Option<bool>>);
-    array_to_ruby!(HashMap<Option<bool>, Option<Vec<u8>>>);
-    array_to_ruby!(HashMap<Option<bool>, Option<Int>>);
-    array_to_ruby!(HashMap<Option<bool>, Option<Float>>);
-    array_to_ruby!(HashMap<Option<bool>, Option<String>>);
-    array_to_ruby!(HashMap<Option<bool>, Option<&'a str>>);
-    array_to_ruby!(HashMap<Option<Vec<u8>>, Option<Value>>);
-    array_to_ruby!(HashMap<Option<Vec<u8>>, Option<bool>>);
-    array_to_ruby!(HashMap<Option<Vec<u8>>, Option<Vec<u8>>>);
-    array_to_ruby!(HashMap<Option<Vec<u8>>, Option<Int>>);
-    array_to_ruby!(HashMap<Option<Vec<u8>>, Option<Float>>);
-    array_to_ruby!(HashMap<Option<Vec<u8>>, Option<String>>);
-    array_to_ruby!(HashMap<Option<Vec<u8>>, Option<&'a str>>);
-    array_to_ruby!(HashMap<Option<Int>, Option<Value>>);
-    array_to_ruby!(HashMap<Option<Int>, Option<bool>>);
-    array_to_ruby!(HashMap<Option<Int>, Option<Vec<u8>>>);
-    array_to_ruby!(HashMap<Option<Int>, Option<Int>>);
-    array_to_ruby!(HashMap<Option<Int>, Option<Float>>);
-    array_to_ruby!(HashMap<Option<Int>, Option<String>>);
-    array_to_ruby!(HashMap<Option<Int>, Option<&'a str>>);
-    array_to_ruby!(HashMap<Option<String>, Option<Value>>);
-    array_to_ruby!(HashMap<Option<String>, Option<bool>>);
-    array_to_ruby!(HashMap<Option<String>, Option<Vec<u8>>>);
-    array_to_ruby!(HashMap<Option<String>, Option<Int>>);
-    array_to_ruby!(HashMap<Option<String>, Option<Float>>);
-    array_to_ruby!(HashMap<Option<String>, Option<String>>);
-    array_to_ruby!(HashMap<Option<String>, Option<&'a str>>);
-    array_to_ruby!(HashMap<Option<&'a str>, Option<Value>>);
-    array_to_ruby!(HashMap<Option<&'a str>, Option<bool>>);
-    array_to_ruby!(HashMap<Option<&'a str>, Option<Vec<u8>>>);
-    array_to_ruby!(HashMap<Option<&'a str>, Option<Int>>);
-    array_to_ruby!(HashMap<Option<&'a str>, Option<Float>>);
-    array_to_ruby!(HashMap<Option<&'a str>, Option<String>>);
-    array_to_ruby!(HashMap<Option<&'a str>, Option<&'a str>>);
-
-    // Hash of primitive keys to values
-    ruby_to_array!(HashMap<bool, Value>);
-    ruby_to_array!(HashMap<bool, bool>);
-    ruby_to_array!(HashMap<bool, Vec<u8>>);
-    ruby_to_array!(HashMap<bool, Int>);
-    ruby_to_array!(HashMap<bool, Float>);
-    ruby_to_array!(HashMap<bool, String>);
-    ruby_to_array!(HashMap<bool, &'a str>);
-    ruby_to_array!(HashMap<Vec<u8>, Value>);
-    ruby_to_array!(HashMap<Vec<u8>, bool>);
-    ruby_to_array!(HashMap<Vec<u8>, Vec<u8>>);
-    ruby_to_array!(HashMap<Vec<u8>, Int>);
-    ruby_to_array!(HashMap<Vec<u8>, Float>);
-    ruby_to_array!(HashMap<Vec<u8>, String>);
-    ruby_to_array!(HashMap<Vec<u8>, &'a str>);
-    ruby_to_array!(HashMap<Int, Value>);
-    ruby_to_array!(HashMap<Int, bool>);
-    ruby_to_array!(HashMap<Int, Vec<u8>>);
-    ruby_to_array!(HashMap<Int, Int>);
-    ruby_to_array!(HashMap<Int, Float>);
-    ruby_to_array!(HashMap<Int, String>);
-    ruby_to_array!(HashMap<Int, &'a str>);
-    ruby_to_array!(HashMap<String, Value>);
-    ruby_to_array!(HashMap<String, bool>);
-    ruby_to_array!(HashMap<String, Vec<u8>>);
-    ruby_to_array!(HashMap<String, Int>);
-    ruby_to_array!(HashMap<String, Float>);
-    ruby_to_array!(HashMap<String, String>);
-    ruby_to_array!(HashMap<String, &'a str>);
-    ruby_to_array!(HashMap<&'a str, Value>);
-    ruby_to_array!(HashMap<&'a str, bool>);
-    ruby_to_array!(HashMap<&'a str, Vec<u8>>);
-    ruby_to_array!(HashMap<&'a str, Int>);
-    ruby_to_array!(HashMap<&'a str, Float>);
-    ruby_to_array!(HashMap<&'a str, String>);
-    ruby_to_array!(HashMap<&'a str, &'a str>);
-
-    // Hash of optional keys to values
-    ruby_to_array!(HashMap<Option<bool>, Value>);
-    ruby_to_array!(HashMap<Option<bool>, bool>);
-    ruby_to_array!(HashMap<Option<bool>, Vec<u8>>);
-    ruby_to_array!(HashMap<Option<bool>, Int>);
-    ruby_to_array!(HashMap<Option<bool>, Float>);
-    ruby_to_array!(HashMap<Option<bool>, String>);
-    ruby_to_array!(HashMap<Option<bool>, &'a str>);
-    ruby_to_array!(HashMap<Option<Vec<u8>>, Value>);
-    ruby_to_array!(HashMap<Option<Vec<u8>>, bool>);
-    ruby_to_array!(HashMap<Option<Vec<u8>>, Vec<u8>>);
-    ruby_to_array!(HashMap<Option<Vec<u8>>, Int>);
-    ruby_to_array!(HashMap<Option<Vec<u8>>, Float>);
-    ruby_to_array!(HashMap<Option<Vec<u8>>, String>);
-    ruby_to_array!(HashMap<Option<Vec<u8>>, &'a str>);
-    ruby_to_array!(HashMap<Option<Int>, Value>);
-    ruby_to_array!(HashMap<Option<Int>, bool>);
-    ruby_to_array!(HashMap<Option<Int>, Vec<u8>>);
-    ruby_to_array!(HashMap<Option<Int>, Int>);
-    ruby_to_array!(HashMap<Option<Int>, Float>);
-    ruby_to_array!(HashMap<Option<Int>, String>);
-    ruby_to_array!(HashMap<Option<Int>, &'a str>);
-    ruby_to_array!(HashMap<Option<String>, Value>);
-    ruby_to_array!(HashMap<Option<String>, bool>);
-    ruby_to_array!(HashMap<Option<String>, Vec<u8>>);
-    ruby_to_array!(HashMap<Option<String>, Int>);
-    ruby_to_array!(HashMap<Option<String>, Float>);
-    ruby_to_array!(HashMap<Option<String>, String>);
-    ruby_to_array!(HashMap<Option<String>, &'a str>);
-    ruby_to_array!(HashMap<Option<&'a str>, Value>);
-    ruby_to_array!(HashMap<Option<&'a str>, bool>);
-    ruby_to_array!(HashMap<Option<&'a str>, Vec<u8>>);
-    ruby_to_array!(HashMap<Option<&'a str>, Int>);
-    ruby_to_array!(HashMap<Option<&'a str>, Float>);
-    ruby_to_array!(HashMap<Option<&'a str>, String>);
-    ruby_to_array!(HashMap<Option<&'a str>, &'a str>);
-
-    // Hash of primitive keys to optional values
-    ruby_to_array!(HashMap<bool, Option<Value>>);
-    ruby_to_array!(HashMap<bool, Option<bool>>);
-    ruby_to_array!(HashMap<bool, Option<Vec<u8>>>);
-    ruby_to_array!(HashMap<bool, Option<Int>>);
-    ruby_to_array!(HashMap<bool, Option<Float>>);
-    ruby_to_array!(HashMap<bool, Option<String>>);
-    ruby_to_array!(HashMap<bool, Option<&'a str>>);
-    ruby_to_array!(HashMap<Vec<u8>, Option<Value>>);
-    ruby_to_array!(HashMap<Vec<u8>, Option<bool>>);
-    ruby_to_array!(HashMap<Vec<u8>, Option<Vec<u8>>>);
-    ruby_to_array!(HashMap<Vec<u8>, Option<Int>>);
-    ruby_to_array!(HashMap<Vec<u8>, Option<Float>>);
-    ruby_to_array!(HashMap<Vec<u8>, Option<String>>);
-    ruby_to_array!(HashMap<Vec<u8>, Option<&'a str>>);
-    ruby_to_array!(HashMap<Int, Option<Value>>);
-    ruby_to_array!(HashMap<Int, Option<bool>>);
-    ruby_to_array!(HashMap<Int, Option<Vec<u8>>>);
-    ruby_to_array!(HashMap<Int, Option<Int>>);
-    ruby_to_array!(HashMap<Int, Option<Float>>);
-    ruby_to_array!(HashMap<Int, Option<String>>);
-    ruby_to_array!(HashMap<Int, Option<&'a str>>);
-    ruby_to_array!(HashMap<String, Option<Value>>);
-    ruby_to_array!(HashMap<String, Option<bool>>);
-    ruby_to_array!(HashMap<String, Option<Vec<u8>>>);
-    ruby_to_array!(HashMap<String, Option<Int>>);
-    ruby_to_array!(HashMap<String, Option<Float>>);
-    ruby_to_array!(HashMap<String, Option<String>>);
-    ruby_to_array!(HashMap<String, Option<&'a str>>);
-    ruby_to_array!(HashMap<&'a str, Option<Value>>);
-    ruby_to_array!(HashMap<&'a str, Option<bool>>);
-    ruby_to_array!(HashMap<&'a str, Option<Vec<u8>>>);
-    ruby_to_array!(HashMap<&'a str, Option<Int>>);
-    ruby_to_array!(HashMap<&'a str, Option<Float>>);
-    ruby_to_array!(HashMap<&'a str, Option<String>>);
-    ruby_to_array!(HashMap<&'a str, Option<&'a str>>);
-
-    // Hash of primitive optional keys to optional values
-    ruby_to_array!(HashMap<Option<bool>, Option<Value>>);
-    ruby_to_array!(HashMap<Option<bool>, Option<bool>>);
-    ruby_to_array!(HashMap<Option<bool>, Option<Vec<u8>>>);
-    ruby_to_array!(HashMap<Option<bool>, Option<Int>>);
-    ruby_to_array!(HashMap<Option<bool>, Option<Float>>);
-    ruby_to_array!(HashMap<Option<bool>, Option<String>>);
-    ruby_to_array!(HashMap<Option<bool>, Option<&'a str>>);
-    ruby_to_array!(HashMap<Option<Vec<u8>>, Option<Value>>);
-    ruby_to_array!(HashMap<Option<Vec<u8>>, Option<bool>>);
-    ruby_to_array!(HashMap<Option<Vec<u8>>, Option<Vec<u8>>>);
-    ruby_to_array!(HashMap<Option<Vec<u8>>, Option<Int>>);
-    ruby_to_array!(HashMap<Option<Vec<u8>>, Option<Float>>);
-    ruby_to_array!(HashMap<Option<Vec<u8>>, Option<String>>);
-    ruby_to_array!(HashMap<Option<Vec<u8>>, Option<&'a str>>);
-    ruby_to_array!(HashMap<Option<Int>, Option<Value>>);
-    ruby_to_array!(HashMap<Option<Int>, Option<bool>>);
-    ruby_to_array!(HashMap<Option<Int>, Option<Vec<u8>>>);
-    ruby_to_array!(HashMap<Option<Int>, Option<Int>>);
-    ruby_to_array!(HashMap<Option<Int>, Option<Float>>);
-    ruby_to_array!(HashMap<Option<Int>, Option<String>>);
-    ruby_to_array!(HashMap<Option<Int>, Option<&'a str>>);
-    ruby_to_array!(HashMap<Option<String>, Option<Value>>);
-    ruby_to_array!(HashMap<Option<String>, Option<bool>>);
-    ruby_to_array!(HashMap<Option<String>, Option<Vec<u8>>>);
-    ruby_to_array!(HashMap<Option<String>, Option<Int>>);
-    ruby_to_array!(HashMap<Option<String>, Option<Float>>);
-    ruby_to_array!(HashMap<Option<String>, Option<String>>);
-    ruby_to_array!(HashMap<Option<String>, Option<&'a str>>);
-    ruby_to_array!(HashMap<Option<&'a str>, Option<Value>>);
-    ruby_to_array!(HashMap<Option<&'a str>, Option<bool>>);
-    ruby_to_array!(HashMap<Option<&'a str>, Option<Vec<u8>>>);
-    ruby_to_array!(HashMap<Option<&'a str>, Option<Int>>);
-    ruby_to_array!(HashMap<Option<&'a str>, Option<Float>>);
-    ruby_to_array!(HashMap<Option<&'a str>, Option<String>>);
-    ruby_to_array!(HashMap<Option<&'a str>, Option<&'a str>>);
+impl TryConvert<Value, Vec<Option<Vec<u8>>>> for Artichoke {
+    fn try_convert(&self, value: Value) -> Result<Vec<Option<Vec<u8>>>, ArtichokeError> {
+        match value.ruby_type() {
+            Ruby::Array => {
+                unreachable!("mrb_array implementation is obsoleted by extn::core::array")
+            }
+            Ruby::Data => {
+                let array = unsafe { Array::try_from_ruby(self, &value)? };
+                let borrow = array.borrow();
+                let array = borrow.as_vec(self);
+                let mut buf = Vec::with_capacity(array.len());
+                for elem in array {
+                    buf.push(self.try_convert(elem)?);
+                }
+                Ok(buf)
+            }
+            type_tag => Err(ArtichokeError::ConvertToRust {
+                from: type_tag,
+                to: Rust::Vec,
+            }),
+        }
+    }
 }
 
-// Primitives
-ruby_to_array!(bool);
-ruby_to_array!(Vec<u8>);
-ruby_to_array!(&'a [u8]);
-ruby_to_array!(Int);
-ruby_to_array!(Float);
-ruby_to_array!(String);
-ruby_to_array!(&'a str);
+impl<'a> TryConvert<Value, Vec<&'a [u8]>> for Artichoke {
+    fn try_convert(&self, value: Value) -> Result<Vec<&'a [u8]>, ArtichokeError> {
+        match value.ruby_type() {
+            Ruby::Array => {
+                unreachable!("mrb_array implementation is obsoleted by extn::core::array")
+            }
+            Ruby::Data => {
+                let array = unsafe { Array::try_from_ruby(self, &value)? };
+                let borrow = array.borrow();
+                let array = borrow.as_vec(self);
+                let mut buf = Vec::with_capacity(array.len());
+                for elem in array {
+                    buf.push(self.try_convert(elem)?);
+                }
+                Ok(buf)
+            }
+            type_tag => Err(ArtichokeError::ConvertToRust {
+                from: type_tag,
+                to: Rust::Vec,
+            }),
+        }
+    }
+}
 
-// Optional primitives
-ruby_to_array!(Option<Value>);
-ruby_to_array!(Option<bool>);
-ruby_to_array!(Option<Vec<u8>>);
-ruby_to_array!(Option<&'a [u8]>);
-ruby_to_array!(Option<Int>);
-ruby_to_array!(Option<Float>);
-ruby_to_array!(Option<String>);
-ruby_to_array!(Option<&'a str>);
+impl<'a> TryConvert<Value, Vec<Option<&'a [u8]>>> for Artichoke {
+    fn try_convert(&self, value: Value) -> Result<Vec<Option<&'a [u8]>>, ArtichokeError> {
+        match value.ruby_type() {
+            Ruby::Array => {
+                unreachable!("mrb_array implementation is obsoleted by extn::core::array")
+            }
+            Ruby::Data => {
+                let array = unsafe { Array::try_from_ruby(self, &value)? };
+                let borrow = array.borrow();
+                let array = borrow.as_vec(self);
+                let mut buf = Vec::with_capacity(array.len());
+                for elem in array {
+                    buf.push(self.try_convert(elem)?);
+                }
+                Ok(buf)
+            }
+            type_tag => Err(ArtichokeError::ConvertToRust {
+                from: type_tag,
+                to: Rust::Vec,
+            }),
+        }
+    }
+}
 
-// Array of primitives
-ruby_to_array!(Vec<Value>);
-ruby_to_array!(Vec<bool>);
-ruby_to_array!(Vec<Vec<u8>>);
-ruby_to_array!(Vec<&'a [u8]>);
-ruby_to_array!(Vec<Int>);
-ruby_to_array!(Vec<Float>);
-ruby_to_array!(Vec<String>);
-ruby_to_array!(Vec<&'a str>);
+impl TryConvert<Value, Vec<String>> for Artichoke {
+    fn try_convert(&self, value: Value) -> Result<Vec<String>, ArtichokeError> {
+        match value.ruby_type() {
+            Ruby::Array => {
+                unreachable!("mrb_array implementation is obsoleted by extn::core::array")
+            }
+            Ruby::Data => {
+                let array = unsafe { Array::try_from_ruby(self, &value)? };
+                let borrow = array.borrow();
+                let array = borrow.as_vec(self);
+                let mut buf = Vec::with_capacity(array.len());
+                for elem in array {
+                    buf.push(self.try_convert(elem)?);
+                }
+                Ok(buf)
+            }
+            type_tag => Err(ArtichokeError::ConvertToRust {
+                from: type_tag,
+                to: Rust::Vec,
+            }),
+        }
+    }
+}
 
-// Array of optional primitives
-ruby_to_array!(Vec<Option<Value>>);
-ruby_to_array!(Vec<Option<bool>>);
-ruby_to_array!(Vec<Option<Vec<u8>>>);
-ruby_to_array!(Vec<Option<&'a [u8]>>);
-ruby_to_array!(Vec<Option<Int>>);
-ruby_to_array!(Vec<Option<Float>>);
-ruby_to_array!(Vec<Option<String>>);
-ruby_to_array!(Vec<Option<&'a str>>);
+impl TryConvert<Value, Vec<Option<String>>> for Artichoke {
+    fn try_convert(&self, value: Value) -> Result<Vec<Option<String>>, ArtichokeError> {
+        match value.ruby_type() {
+            Ruby::Array => {
+                unreachable!("mrb_array implementation is obsoleted by extn::core::array")
+            }
+            Ruby::Data => {
+                let array = unsafe { Array::try_from_ruby(self, &value)? };
+                let borrow = array.borrow();
+                let array = borrow.as_vec(self);
+                let mut buf = Vec::with_capacity(array.len());
+                for elem in array {
+                    buf.push(self.try_convert(elem)?);
+                }
+                Ok(buf)
+            }
+            type_tag => Err(ArtichokeError::ConvertToRust {
+                from: type_tag,
+                to: Rust::Vec,
+            }),
+        }
+    }
+}
+
+impl<'a> TryConvert<Value, Vec<&'a str>> for Artichoke {
+    fn try_convert(&self, value: Value) -> Result<Vec<&'a str>, ArtichokeError> {
+        match value.ruby_type() {
+            Ruby::Array => {
+                unreachable!("mrb_array implementation is obsoleted by extn::core::array")
+            }
+            Ruby::Data => {
+                let array = unsafe { Array::try_from_ruby(self, &value)? };
+                let borrow = array.borrow();
+                let array = borrow.as_vec(self);
+                let mut buf = Vec::with_capacity(array.len());
+                for elem in array {
+                    buf.push(self.try_convert(elem)?);
+                }
+                Ok(buf)
+            }
+            type_tag => Err(ArtichokeError::ConvertToRust {
+                from: type_tag,
+                to: Rust::Vec,
+            }),
+        }
+    }
+}
+
+impl<'a> TryConvert<Value, Vec<Option<&'a str>>> for Artichoke {
+    fn try_convert(&self, value: Value) -> Result<Vec<Option<&'a str>>, ArtichokeError> {
+        match value.ruby_type() {
+            Ruby::Array => {
+                unreachable!("mrb_array implementation is obsoleted by extn::core::array")
+            }
+            Ruby::Data => {
+                let array = unsafe { Array::try_from_ruby(self, &value)? };
+                let borrow = array.borrow();
+                let array = borrow.as_vec(self);
+                let mut buf = Vec::with_capacity(array.len());
+                for elem in array {
+                    buf.push(self.try_convert(elem)?);
+                }
+                Ok(buf)
+            }
+            type_tag => Err(ArtichokeError::ConvertToRust {
+                from: type_tag,
+                to: Rust::Vec,
+            }),
+        }
+    }
+}
+
+impl TryConvert<Value, Vec<Int>> for Artichoke {
+    fn try_convert(&self, value: Value) -> Result<Vec<Int>, ArtichokeError> {
+        match value.ruby_type() {
+            Ruby::Array => {
+                unreachable!("mrb_array implementation is obsoleted by extn::core::array")
+            }
+            Ruby::Data => {
+                let array = unsafe { Array::try_from_ruby(self, &value)? };
+                let borrow = array.borrow();
+                let array = borrow.as_vec(self);
+                let mut buf = Vec::with_capacity(array.len());
+                for elem in array {
+                    buf.push(self.try_convert(elem)?);
+                }
+                Ok(buf)
+            }
+            type_tag => Err(ArtichokeError::ConvertToRust {
+                from: type_tag,
+                to: Rust::Vec,
+            }),
+        }
+    }
+}

--- a/artichoke-backend/src/convert/array.rs
+++ b/artichoke-backend/src/convert/array.rs
@@ -25,8 +25,7 @@ impl Convert<&[Option<Value>], Value> for Artichoke {
             .iter()
             .map(|item| {
                 item.as_ref()
-                    .map(Value::inner)
-                    .unwrap_or_else(|| unsafe { sys::mrb_sys_nil_value() })
+                    .map_or_else(|| unsafe { sys::mrb_sys_nil_value() }, Value::inner)
             })
             .collect::<Vec<_>>();
         let ary = Array::new(InlineBuffer::from(buf));

--- a/artichoke-backend/src/convert/array.rs
+++ b/artichoke-backend/src/convert/array.rs
@@ -1,5 +1,6 @@
 use crate::convert::{Convert, RustBackedValue, TryConvert};
 use crate::extn::core::array::{Array, InlineBuffer};
+use crate::sys;
 use crate::types::{Int, Ruby, Rust};
 use crate::value::Value;
 use crate::{Artichoke, ArtichokeError};
@@ -22,8 +23,12 @@ impl Convert<&[Option<Value>], Value> for Artichoke {
     fn convert(&self, value: &[Option<Value>]) -> Value {
         let buf = value
             .iter()
-            .map(|item| self.convert(item))
-            .collect::<Vec<Value>>();
+            .map(|item| {
+                item.as_ref()
+                    .map(Value::inner)
+                    .unwrap_or_else(|| unsafe { sys::mrb_sys_nil_value() })
+            })
+            .collect::<Vec<_>>();
         let ary = Array::new(InlineBuffer::from(buf));
         ary.try_into_ruby(self, None).expect("Array into Value")
     }
@@ -33,8 +38,8 @@ impl Convert<Vec<Vec<u8>>, Value> for Artichoke {
     fn convert(&self, value: Vec<Vec<u8>>) -> Value {
         let buf = value
             .into_iter()
-            .map(|item| self.convert(item))
-            .collect::<Vec<Value>>();
+            .map(|item| self.convert(item).inner())
+            .collect::<Vec<_>>();
         let ary = Array::new(InlineBuffer::from(buf));
         ary.try_into_ruby(self, None).expect("Array into Value")
     }
@@ -44,8 +49,8 @@ impl Convert<Vec<&[u8]>, Value> for Artichoke {
     fn convert(&self, value: Vec<&[u8]>) -> Value {
         let buf = value
             .into_iter()
-            .map(|item| self.convert(item))
-            .collect::<Vec<Value>>();
+            .map(|item| self.convert(item).inner())
+            .collect::<Vec<_>>();
         let ary = Array::new(InlineBuffer::from(buf));
         ary.try_into_ruby(self, None).expect("Array into Value")
     }
@@ -55,8 +60,8 @@ impl Convert<Vec<String>, Value> for Artichoke {
     fn convert(&self, value: Vec<String>) -> Value {
         let buf = value
             .into_iter()
-            .map(|item| self.convert(item))
-            .collect::<Vec<Value>>();
+            .map(|item| self.convert(item).inner())
+            .collect::<Vec<_>>();
         let ary = Array::new(InlineBuffer::from(buf));
         ary.try_into_ruby(self, None).expect("Array into Value")
     }
@@ -66,8 +71,8 @@ impl Convert<Vec<&str>, Value> for Artichoke {
     fn convert(&self, value: Vec<&str>) -> Value {
         let buf = value
             .into_iter()
-            .map(|item| self.convert(item))
-            .collect::<Vec<Value>>();
+            .map(|item| self.convert(item).inner())
+            .collect::<Vec<_>>();
         let ary = Array::new(InlineBuffer::from(buf));
         ary.try_into_ruby(self, None).expect("Array into Value")
     }
@@ -77,8 +82,8 @@ impl Convert<Vec<Int>, Value> for Artichoke {
     fn convert(&self, value: Vec<Int>) -> Value {
         let buf = value
             .into_iter()
-            .map(|item| self.convert(item))
-            .collect::<Vec<Value>>();
+            .map(|item| self.convert(item).inner())
+            .collect::<Vec<_>>();
         let ary = Array::new(InlineBuffer::from(buf));
         ary.try_into_ruby(self, None).expect("Array into Value")
     }
@@ -89,8 +94,8 @@ impl Convert<&[Int], Value> for Artichoke {
         let buf = value
             .iter()
             .copied()
-            .map(|item| self.convert(item))
-            .collect::<Vec<Value>>();
+            .map(|item| self.convert(item).inner())
+            .collect::<Vec<_>>();
         let ary = Array::new(InlineBuffer::from(buf));
         ary.try_into_ruby(self, None).expect("Array into Value")
     }
@@ -100,8 +105,8 @@ impl Convert<Vec<Option<Vec<u8>>>, Value> for Artichoke {
     fn convert(&self, value: Vec<Option<Vec<u8>>>) -> Value {
         let buf = value
             .into_iter()
-            .map(|item| self.convert(item))
-            .collect::<Vec<Value>>();
+            .map(|item| self.convert(item).inner())
+            .collect::<Vec<_>>();
         let ary = Array::new(InlineBuffer::from(buf));
         ary.try_into_ruby(self, None).expect("Array into Value")
     }
@@ -112,8 +117,8 @@ impl Convert<&[Option<&[u8]>], Value> for Artichoke {
         let buf = value
             .iter()
             .copied()
-            .map(|item| self.convert(item))
-            .collect::<Vec<Value>>();
+            .map(|item| self.convert(item).inner())
+            .collect::<Vec<_>>();
         let ary = Array::new(InlineBuffer::from(buf));
         ary.try_into_ruby(self, None).expect("Array into Value")
     }
@@ -123,8 +128,8 @@ impl Convert<Vec<Option<&[u8]>>, Value> for Artichoke {
     fn convert(&self, value: Vec<Option<&[u8]>>) -> Value {
         let buf = value
             .into_iter()
-            .map(|item| self.convert(item))
-            .collect::<Vec<Value>>();
+            .map(|item| self.convert(item).inner())
+            .collect::<Vec<_>>();
         let ary = Array::new(InlineBuffer::from(buf));
         ary.try_into_ruby(self, None).expect("Array into Value")
     }
@@ -134,8 +139,8 @@ impl Convert<Vec<Vec<Option<&[u8]>>>, Value> for Artichoke {
     fn convert(&self, value: Vec<Vec<Option<&[u8]>>>) -> Value {
         let buf = value
             .into_iter()
-            .map(|item| self.convert(item))
-            .collect::<Vec<Value>>();
+            .map(|item| self.convert(item).inner())
+            .collect::<Vec<_>>();
         let ary = Array::new(InlineBuffer::from(buf));
         ary.try_into_ruby(self, None).expect("Array into Value")
     }
@@ -146,8 +151,8 @@ impl Convert<&[Option<&str>], Value> for Artichoke {
         let buf = value
             .iter()
             .copied()
-            .map(|item| self.convert(item))
-            .collect::<Vec<Value>>();
+            .map(|item| self.convert(item).inner())
+            .collect::<Vec<_>>();
         let ary = Array::new(InlineBuffer::from(buf));
         ary.try_into_ruby(self, None).expect("Array into Value")
     }
@@ -157,8 +162,8 @@ impl Convert<Vec<Option<&str>>, Value> for Artichoke {
     fn convert(&self, value: Vec<Option<&str>>) -> Value {
         let buf = value
             .into_iter()
-            .map(|item| self.convert(item))
-            .collect::<Vec<Value>>();
+            .map(|item| self.convert(item).inner())
+            .collect::<Vec<_>>();
         let ary = Array::new(InlineBuffer::from(buf));
         ary.try_into_ruby(self, None).expect("Array into Value")
     }
@@ -168,8 +173,8 @@ impl Convert<Vec<Vec<Option<&str>>>, Value> for Artichoke {
     fn convert(&self, value: Vec<Vec<Option<&str>>>) -> Value {
         let buf = value
             .into_iter()
-            .map(|item| self.convert(item))
-            .collect::<Vec<Value>>();
+            .map(|item| self.convert(item).inner())
+            .collect::<Vec<_>>();
         let ary = Array::new(InlineBuffer::from(buf));
         ary.try_into_ruby(self, None).expect("Array into Value")
     }

--- a/artichoke-backend/src/convert/hash.rs
+++ b/artichoke-backend/src/convert/hash.rs
@@ -1,18 +1,16 @@
 use std::collections::HashMap;
 use std::convert::TryFrom;
-use std::hash::BuildHasher;
 
 use crate::convert::{Convert, RustBackedValue, TryConvert};
 use crate::extn::core::array;
 use crate::sys;
-use crate::types::{Float, Int, Ruby, Rust};
+use crate::types::{Int, Ruby, Rust};
 use crate::value::Value;
 use crate::{Artichoke, ArtichokeError};
 
 // TODO: implement `PartialEq`, `Eq`, and `Hash` on `Value`, see GH-159.
 // TODO: implement `Convert<HashMap<Value, Value>>`, see GH-160.
 
-// bail out implementation for mixed-type collections
 impl Convert<Vec<(Value, Value)>, Value> for Artichoke {
     fn convert(&self, value: Vec<(Value, Value)>) -> Value {
         let mrb = self.0.borrow().mrb;
@@ -24,6 +22,52 @@ impl Convert<Vec<(Value, Value)>, Value> for Artichoke {
             unsafe { sys::mrb_hash_set(mrb, hash, key, val) };
         }
         Value::new(self, hash)
+    }
+}
+
+impl Convert<Vec<(Vec<u8>, Vec<Int>)>, Value> for Artichoke {
+    fn convert(&self, value: Vec<(Vec<u8>, Vec<Int>)>) -> Value {
+        let mrb = self.0.borrow().mrb;
+        let capa = Int::try_from(value.len()).unwrap_or_default();
+        let hash = unsafe { sys::mrb_hash_new_capa(mrb, capa) };
+        for (key, val) in value {
+            let key = self.convert(key).inner();
+            let val = self.convert(val).inner();
+            unsafe { sys::mrb_hash_set(mrb, hash, key, val) };
+        }
+        Value::new(self, hash)
+    }
+}
+
+impl Convert<HashMap<Vec<u8>, Vec<u8>>, Value> for Artichoke {
+    fn convert(&self, value: HashMap<Vec<u8>, Vec<u8>>) -> Value {
+        let mrb = self.0.borrow().mrb;
+        let capa = Int::try_from(value.len()).unwrap_or_default();
+        let hash = unsafe { sys::mrb_hash_new_capa(mrb, capa) };
+        for (key, val) in value {
+            let key = self.convert(key).inner();
+            let val = self.convert(val).inner();
+            unsafe { sys::mrb_hash_set(mrb, hash, key, val) };
+        }
+        Value::new(self, hash)
+    }
+}
+
+impl Convert<Option<HashMap<Vec<u8>, Option<Vec<u8>>>>, Value> for Artichoke {
+    fn convert(&self, value: Option<HashMap<Vec<u8>, Option<Vec<u8>>>>) -> Value {
+        if let Some(value) = value {
+            let mrb = self.0.borrow().mrb;
+            let capa = Int::try_from(value.len()).unwrap_or_default();
+            let hash = unsafe { sys::mrb_hash_new_capa(mrb, capa) };
+            for (key, val) in value {
+                let key = self.convert(key).inner();
+                let val = self.convert(val).inner();
+                unsafe { sys::mrb_hash_set(mrb, hash, key, val) };
+            }
+            Value::new(self, hash)
+        } else {
+            Value::new(self, unsafe { sys::mrb_sys_nil_value() })
+        }
     }
 }
 
@@ -55,486 +99,6 @@ impl TryConvert<Value, Vec<(Value, Value)>> for Artichoke {
             }),
         }
     }
-}
-
-macro_rules! hash_to_ruby {
-    ($key:ty => $value:ty) => {
-        impl<'a> Convert<Vec<($key, $value)>, Value> for Artichoke {
-            fn convert(&self, value: Vec<($key, $value)>) -> Value {
-                let pairs = value
-                    .into_iter()
-                    .map(|(key, value)| {
-                        let key = self.convert(key);
-                        let value = self.convert(value);
-                        (key, value)
-                    })
-                    .collect::<Vec<(Value, Value)>>();
-                self.convert(pairs)
-            }
-        }
-
-        impl<'a> Convert<HashMap<$key, $value>, Value> for Artichoke {
-            fn convert(&self, value: HashMap<$key, $value>) -> Value {
-                let pairs = value.into_iter().collect::<Vec<($key, $value)>>();
-                self.convert(pairs)
-            }
-        }
-    };
-    (no_hash_map | $key:ty => $value:ty) => {
-        impl<'a> Convert<Vec<($key, $value)>, Value> for Artichoke {
-            fn convert(&self, value: Vec<($key, $value)>) -> Value {
-                let pairs = value
-                    .into_iter()
-                    .map(|(key, value)| {
-                        let key = self.convert(key);
-                        let value = self.convert(value);
-                        (key, value)
-                    })
-                    .collect::<Vec<(Value, Value)>>();
-                self.convert(pairs)
-            }
-        }
-    };
-}
-
-macro_rules! ruby_to_hash {
-    ($key:ty => $value:ty) => {
-        impl<'a> TryConvert<Value, Vec<($key, $value)>> for Artichoke {
-            fn try_convert(&self, value: Value) -> Result<Vec<($key, $value)>, ArtichokeError> {
-                let pairs = TryConvert::<_, Vec<(Value, Value)>>::try_convert(self, value)?;
-                let mut vec = Vec::with_capacity(pairs.len());
-                for (key, value) in pairs.into_iter() {
-                    let key = self.try_convert(key)?;
-                    let value = self.try_convert(value)?;
-                    vec.push((key, value));
-                }
-                Ok(vec)
-            }
-        }
-
-        impl<'a, S: BuildHasher + Default> TryConvert<Value, HashMap<$key, $value, S>>
-            for Artichoke
-        {
-            fn try_convert(
-                &self,
-                value: Value,
-            ) -> Result<HashMap<$key, $value, S>, ArtichokeError> {
-                let pairs = TryConvert::<_, Vec<($key, $value)>>::try_convert(self, value)?;
-                // we can't set capacity since we are paratemterized on hasher.
-                let mut hash = HashMap::default();
-                for (key, value) in pairs {
-                    hash.insert(key, value);
-                }
-                Ok(hash)
-            }
-        }
-    };
-    (no_hash_map | $key:ty => $value:ty) => {
-        impl<'a> TryConvert<Value, Vec<($key, $value)>> for Artichoke {
-            fn try_convert(&self, value: Value) -> Result<Vec<($key, $value)>, ArtichokeError> {
-                let pairs = TryConvert::<_, Vec<(Value, Value)>>::try_convert(self, value)?;
-                let mut vec = Vec::<($key, $value)>::with_capacity(pairs.len());
-                for (key, value) in pairs.into_iter() {
-                    let key = self.try_convert(key)?;
-                    let value = self.try_convert(value)?;
-                    vec.push((key, value));
-                }
-                Ok(vec)
-            }
-        }
-    };
-}
-
-macro_rules! hash_impl {
-    (Value) => {
-        // non nilable
-        hash_to_ruby!(no_hash_map | Value => bool);
-        hash_to_ruby!(no_hash_map | Value => Vec<u8>);
-        hash_to_ruby!(no_hash_map | Value => Int);
-        hash_to_ruby!(no_hash_map | Value => Float);
-        hash_to_ruby!(no_hash_map | Value => String);
-        hash_to_ruby!(no_hash_map | Value => &'a str);
-        hash_to_ruby!(no_hash_map | Value => Option<bool>);
-        hash_to_ruby!(no_hash_map | Value => Option<Vec<u8>>);
-        hash_to_ruby!(no_hash_map | Value => Option<Int>);
-        hash_to_ruby!(no_hash_map | Value => Option<Float>);
-        hash_to_ruby!(no_hash_map | Value => Option<String>);
-        hash_to_ruby!(no_hash_map | Value => Option<&'a str>);
-        hash_to_ruby!(no_hash_map | Value => Vec<bool>);
-        hash_to_ruby!(no_hash_map | Value => Vec<Vec<u8>>);
-        hash_to_ruby!(no_hash_map | Value => Vec<Int>);
-        hash_to_ruby!(no_hash_map | Value => Vec<Float>);
-        hash_to_ruby!(no_hash_map | Value => Vec<String>);
-        hash_to_ruby!(no_hash_map | Value => Vec<&'a str>);
-        hash_to_ruby!(no_hash_map | Value => Vec<Option<bool>>);
-        hash_to_ruby!(no_hash_map | Value => Vec<Option<Vec<u8>>>);
-        hash_to_ruby!(no_hash_map | Value => Vec<Option<Int>>);
-        hash_to_ruby!(no_hash_map | Value => Vec<Option<Float>>);
-        hash_to_ruby!(no_hash_map | Value => Vec<Option<String>>);
-        hash_to_ruby!(no_hash_map | Value => Vec<Option<&'a str>>);
-
-        // nilable
-        hash_to_ruby!(no_hash_map | Option<Value> => bool);
-        hash_to_ruby!(no_hash_map | Option<Value> => Vec<u8>);
-        hash_to_ruby!(no_hash_map | Option<Value> => Int);
-        hash_to_ruby!(no_hash_map | Option<Value> => Float);
-        hash_to_ruby!(no_hash_map | Option<Value> => String);
-        hash_to_ruby!(no_hash_map | Option<Value> => &'a str);
-        hash_to_ruby!(no_hash_map | Option<Value> => Option<bool>);
-        hash_to_ruby!(no_hash_map | Option<Value> => Option<Vec<u8>>);
-        hash_to_ruby!(no_hash_map | Option<Value> => Option<Int>);
-        hash_to_ruby!(no_hash_map | Option<Value> => Option<Float>);
-        hash_to_ruby!(no_hash_map | Option<Value> => Option<String>);
-        hash_to_ruby!(no_hash_map | Option<Value> => Option<&'a str>);
-        hash_to_ruby!(no_hash_map | Option<Value> => Vec<bool>);
-        hash_to_ruby!(no_hash_map | Option<Value> => Vec<Vec<u8>>);
-        hash_to_ruby!(no_hash_map | Option<Value> => Vec<Int>);
-        hash_to_ruby!(no_hash_map | Option<Value> => Vec<Float>);
-        hash_to_ruby!(no_hash_map | Option<Value> => Vec<String>);
-        hash_to_ruby!(no_hash_map | Option<Value> => Vec<&'a str>);
-        hash_to_ruby!(no_hash_map | Option<Value> => Vec<Option<bool>>);
-        hash_to_ruby!(no_hash_map | Option<Value> => Vec<Option<Vec<u8>>>);
-        hash_to_ruby!(no_hash_map | Option<Value> => Vec<Option<Int>>);
-        hash_to_ruby!(no_hash_map | Option<Value> => Vec<Option<Float>>);
-        hash_to_ruby!(no_hash_map | Option<Value> => Vec<Option<String>>);
-        hash_to_ruby!(no_hash_map | Option<Value> => Vec<Option<&'a str>>);
-
-        // nested hash
-        // already implemented by hand -> hash_to_ruby!(no_hash_map | Value => Vec<(Value, Value)>);
-        hash_to_ruby!(no_hash_map | Option<Value> => Vec<(Value, Value)>);
-
-        // bail out
-        // already implemented by hand -> hash_to_ruby!(no_hash_map | $key => Value);
-        hash_to_ruby!(no_hash_map | Value => Option<Value>);
-        hash_to_ruby!(no_hash_map | Option<Value> => Value);
-        hash_to_ruby!(no_hash_map | Option<Value> => Option<Value>);
-
-        // non nilable
-        ruby_to_hash!(no_hash_map | Value => bool);
-        ruby_to_hash!(no_hash_map | Value => Vec<u8>);
-        ruby_to_hash!(no_hash_map | Value => Int);
-        ruby_to_hash!(no_hash_map | Value => Float);
-        ruby_to_hash!(no_hash_map | Value => String);
-        ruby_to_hash!(no_hash_map | Value => &'a str);
-        ruby_to_hash!(no_hash_map | Value => Option<bool>);
-        ruby_to_hash!(no_hash_map | Value => Option<Vec<u8>>);
-        ruby_to_hash!(no_hash_map | Value => Option<Int>);
-        ruby_to_hash!(no_hash_map | Value => Option<Float>);
-        ruby_to_hash!(no_hash_map | Value => Option<String>);
-        ruby_to_hash!(no_hash_map | Value => Option<&'a str>);
-        ruby_to_hash!(no_hash_map | Value => Vec<bool>);
-        ruby_to_hash!(no_hash_map | Value => Vec<Vec<u8>>);
-        ruby_to_hash!(no_hash_map | Value => Vec<Int>);
-        ruby_to_hash!(no_hash_map | Value => Vec<Float>);
-        ruby_to_hash!(no_hash_map | Value => Vec<String>);
-        ruby_to_hash!(no_hash_map | Value => Vec<&'a str>);
-        ruby_to_hash!(no_hash_map | Value => Vec<Option<bool>>);
-        ruby_to_hash!(no_hash_map | Value => Vec<Option<Vec<u8>>>);
-        ruby_to_hash!(no_hash_map | Value => Vec<Option<Int>>);
-        ruby_to_hash!(no_hash_map | Value => Vec<Option<Float>>);
-        ruby_to_hash!(no_hash_map | Value => Vec<Option<String>>);
-        ruby_to_hash!(no_hash_map | Value => Vec<Option<&'a str>>);
-
-        // nilable
-        ruby_to_hash!(no_hash_map | Option<Value> => bool);
-        ruby_to_hash!(no_hash_map | Option<Value> => Vec<u8>);
-        ruby_to_hash!(no_hash_map | Option<Value> => Int);
-        ruby_to_hash!(no_hash_map | Option<Value> => Float);
-        ruby_to_hash!(no_hash_map | Option<Value> => String);
-        ruby_to_hash!(no_hash_map | Option<Value> => &'a str);
-        ruby_to_hash!(no_hash_map | Option<Value> => Option<bool>);
-        ruby_to_hash!(no_hash_map | Option<Value> => Option<Vec<u8>>);
-        ruby_to_hash!(no_hash_map | Option<Value> => Option<Int>);
-        ruby_to_hash!(no_hash_map | Option<Value> => Option<Float>);
-        ruby_to_hash!(no_hash_map | Option<Value> => Option<String>);
-        ruby_to_hash!(no_hash_map | Option<Value> => Option<&'a str>);
-        ruby_to_hash!(no_hash_map | Option<Value> => Vec<bool>);
-        ruby_to_hash!(no_hash_map | Option<Value> => Vec<Vec<u8>>);
-        ruby_to_hash!(no_hash_map | Option<Value> => Vec<Int>);
-        ruby_to_hash!(no_hash_map | Option<Value> => Vec<Float>);
-        ruby_to_hash!(no_hash_map | Option<Value> => Vec<String>);
-        ruby_to_hash!(no_hash_map | Option<Value> => Vec<&'a str>);
-        ruby_to_hash!(no_hash_map | Option<Value> => Vec<Option<bool>>);
-        ruby_to_hash!(no_hash_map | Option<Value> => Vec<Option<Vec<u8>>>);
-        ruby_to_hash!(no_hash_map | Option<Value> => Vec<Option<Int>>);
-        ruby_to_hash!(no_hash_map | Option<Value> => Vec<Option<Float>>);
-        ruby_to_hash!(no_hash_map | Option<Value> => Vec<Option<String>>);
-        ruby_to_hash!(no_hash_map | Option<Value> => Vec<Option<&'a str>>);
-
-        // nested hash
-        // already implemented by hand -> ruby_to_hash!(no_hash_map | Value => Vec<(Value, Value)>);
-        ruby_to_hash!(no_hash_map | Option<Value> => Vec<(Value, Value)>);
-
-        // bail out
-        // already implemented by hand -> ruby_to_hash!(no_hash_map | $key => Value);
-        ruby_to_hash!(no_hash_map | Value => Option<Value>);
-        ruby_to_hash!(no_hash_map | Option<Value> => Value);
-        ruby_to_hash!(no_hash_map | Option<Value> => Option<Value>);
-    };
-    (no_hash_map | $key:tt) => {
-        // non nilable
-        hash_to_ruby!(no_hash_map | $key => bool);
-        hash_to_ruby!(no_hash_map | $key => Vec<u8>);
-        hash_to_ruby!(no_hash_map | $key => Int);
-        hash_to_ruby!(no_hash_map | $key => Float);
-        hash_to_ruby!(no_hash_map | $key => String);
-        hash_to_ruby!(no_hash_map | $key => &'a str);
-        hash_to_ruby!(no_hash_map | $key => Option<bool>);
-        hash_to_ruby!(no_hash_map | $key => Option<Vec<u8>>);
-        hash_to_ruby!(no_hash_map | $key => Option<Int>);
-        hash_to_ruby!(no_hash_map | $key => Option<Float>);
-        hash_to_ruby!(no_hash_map | $key => Option<String>);
-        hash_to_ruby!(no_hash_map | $key => Option<&'a str>);
-        hash_to_ruby!(no_hash_map | $key => Vec<bool>);
-        hash_to_ruby!(no_hash_map | $key => Vec<Vec<u8>>);
-        hash_to_ruby!(no_hash_map | $key => Vec<Int>);
-        hash_to_ruby!(no_hash_map | $key => Vec<Float>);
-        hash_to_ruby!(no_hash_map | $key => Vec<String>);
-        hash_to_ruby!(no_hash_map | $key => Vec<&'a str>);
-        hash_to_ruby!(no_hash_map | $key => Vec<Option<bool>>);
-        hash_to_ruby!(no_hash_map | $key => Vec<Option<Vec<u8>>>);
-        hash_to_ruby!(no_hash_map | $key => Vec<Option<Int>>);
-        hash_to_ruby!(no_hash_map | $key => Vec<Option<Float>>);
-        hash_to_ruby!(no_hash_map | $key => Vec<Option<String>>);
-        hash_to_ruby!(no_hash_map | $key => Vec<Option<&'a str>>);
-
-        // nilable
-        hash_to_ruby!(no_hash_map | Option<$key> => bool);
-        hash_to_ruby!(no_hash_map | Option<$key> => Vec<u8>);
-        hash_to_ruby!(no_hash_map | Option<$key> => Int);
-        hash_to_ruby!(no_hash_map | Option<$key> => Float);
-        hash_to_ruby!(no_hash_map | Option<$key> => String);
-        hash_to_ruby!(no_hash_map | Option<$key> => &'a str);
-        hash_to_ruby!(no_hash_map | Option<$key> => Option<bool>);
-        hash_to_ruby!(no_hash_map | Option<$key> => Option<Vec<u8>>);
-        hash_to_ruby!(no_hash_map | Option<$key> => Option<Int>);
-        hash_to_ruby!(no_hash_map | Option<$key> => Option<Float>);
-        hash_to_ruby!(no_hash_map | Option<$key> => Option<String>);
-        hash_to_ruby!(no_hash_map | Option<$key> => Option<&'a str>);
-        hash_to_ruby!(no_hash_map | Option<$key> => Vec<bool>);
-        hash_to_ruby!(no_hash_map | Option<$key> => Vec<Vec<u8>>);
-        hash_to_ruby!(no_hash_map | Option<$key> => Vec<Int>);
-        hash_to_ruby!(no_hash_map | Option<$key> => Vec<Float>);
-        hash_to_ruby!(no_hash_map | Option<$key> => Vec<String>);
-        hash_to_ruby!(no_hash_map | Option<$key> => Vec<&'a str>);
-        hash_to_ruby!(no_hash_map | Option<$key> => Vec<Option<bool>>);
-        hash_to_ruby!(no_hash_map | Option<$key> => Vec<Option<Vec<u8>>>);
-        hash_to_ruby!(no_hash_map | Option<$key> => Vec<Option<Int>>);
-        hash_to_ruby!(no_hash_map | Option<$key> => Vec<Option<Float>>);
-        hash_to_ruby!(no_hash_map | Option<$key> => Vec<Option<String>>);
-        hash_to_ruby!(no_hash_map | Option<$key> => Vec<Option<&'a str>>);
-
-        // nested hash
-        hash_to_ruby!(no_hash_map | $key => Vec<(Value, Value)>);
-        hash_to_ruby!(no_hash_map | Option<$key> => Vec<(Value, Value)>);
-
-        // bail out
-        // already implemented by hand -> hash_to_ruby!(no_hash_map | $key => Value);
-        hash_to_ruby!(no_hash_map | $key => Option<Value>);
-        hash_to_ruby!(no_hash_map | Option<$key> => Value);
-        hash_to_ruby!(no_hash_map | Option<$key> => Option<Value>);
-
-        // non nilable
-        ruby_to_hash!(no_hash_map | $key => bool);
-        ruby_to_hash!(no_hash_map | $key => Vec<u8>);
-        ruby_to_hash!(no_hash_map | $key => Int);
-        ruby_to_hash!(no_hash_map | $key => Float);
-        ruby_to_hash!(no_hash_map | $key => String);
-        ruby_to_hash!(no_hash_map | $key => &'a str);
-        ruby_to_hash!(no_hash_map | $key => Option<bool>);
-        ruby_to_hash!(no_hash_map | $key => Option<Vec<u8>>);
-        ruby_to_hash!(no_hash_map | $key => Option<Int>);
-        ruby_to_hash!(no_hash_map | $key => Option<Float>);
-        ruby_to_hash!(no_hash_map | $key => Option<String>);
-        ruby_to_hash!(no_hash_map | $key => Option<&'a str>);
-        ruby_to_hash!(no_hash_map | $key => Vec<bool>);
-        ruby_to_hash!(no_hash_map | $key => Vec<Vec<u8>>);
-        ruby_to_hash!(no_hash_map | $key => Vec<Int>);
-        ruby_to_hash!(no_hash_map | $key => Vec<Float>);
-        ruby_to_hash!(no_hash_map | $key => Vec<String>);
-        ruby_to_hash!(no_hash_map | $key => Vec<&'a str>);
-        ruby_to_hash!(no_hash_map | $key => Vec<Option<bool>>);
-        ruby_to_hash!(no_hash_map | $key => Vec<Option<Vec<u8>>>);
-        ruby_to_hash!(no_hash_map | $key => Vec<Option<Int>>);
-        ruby_to_hash!(no_hash_map | $key => Vec<Option<Float>>);
-        ruby_to_hash!(no_hash_map | $key => Vec<Option<String>>);
-        ruby_to_hash!(no_hash_map | $key => Vec<Option<&'a str>>);
-
-        // nilable
-        ruby_to_hash!(no_hash_map | Option<$key> => bool);
-        ruby_to_hash!(no_hash_map | Option<$key> => Vec<u8>);
-        ruby_to_hash!(no_hash_map | Option<$key> => Int);
-        ruby_to_hash!(no_hash_map | Option<$key> => Float);
-        ruby_to_hash!(no_hash_map | Option<$key> => String);
-        ruby_to_hash!(no_hash_map | Option<$key> => &'a str);
-        ruby_to_hash!(no_hash_map | Option<$key> => Option<bool>);
-        ruby_to_hash!(no_hash_map | Option<$key> => Option<Vec<u8>>);
-        ruby_to_hash!(no_hash_map | Option<$key> => Option<Int>);
-        ruby_to_hash!(no_hash_map | Option<$key> => Option<Float>);
-        ruby_to_hash!(no_hash_map | Option<$key> => Option<String>);
-        ruby_to_hash!(no_hash_map | Option<$key> => Option<&'a str>);
-        ruby_to_hash!(no_hash_map | Option<$key> => Vec<bool>);
-        ruby_to_hash!(no_hash_map | Option<$key> => Vec<Vec<u8>>);
-        ruby_to_hash!(no_hash_map | Option<$key> => Vec<Int>);
-        ruby_to_hash!(no_hash_map | Option<$key> => Vec<Float>);
-        ruby_to_hash!(no_hash_map | Option<$key> => Vec<String>);
-        ruby_to_hash!(no_hash_map | Option<$key> => Vec<&'a str>);
-        ruby_to_hash!(no_hash_map | Option<$key> => Vec<Option<bool>>);
-        ruby_to_hash!(no_hash_map | Option<$key> => Vec<Option<Vec<u8>>>);
-        ruby_to_hash!(no_hash_map | Option<$key> => Vec<Option<Int>>);
-        ruby_to_hash!(no_hash_map | Option<$key> => Vec<Option<Float>>);
-        ruby_to_hash!(no_hash_map | Option<$key> => Vec<Option<String>>);
-        ruby_to_hash!(no_hash_map | Option<$key> => Vec<Option<&'a str>>);
-
-        // nested hash
-        ruby_to_hash!(no_hash_map | $key => Vec<(Value, Value)>);
-        ruby_to_hash!(no_hash_map | Option<$key> => Vec<(Value, Value)>);
-
-        // bail out
-        // already implemented by hand -> ruby_to_hash!(no_hash_map | $key => Value);
-        ruby_to_hash!(no_hash_map | $key => Option<Value>);
-        ruby_to_hash!(no_hash_map | Option<$key> => Value);
-        ruby_to_hash!(no_hash_map | Option<$key> => Option<Value>);
-    };
-    ($key:ty) => {
-        // non nilable
-        hash_to_ruby!($key => bool);
-        hash_to_ruby!($key => Vec<u8>);
-        hash_to_ruby!($key => Int);
-        hash_to_ruby!($key => Float);
-        hash_to_ruby!($key => String);
-        hash_to_ruby!($key => &'a str);
-        hash_to_ruby!($key => Option<bool>);
-        hash_to_ruby!($key => Option<Vec<u8>>);
-        hash_to_ruby!($key => Option<Int>);
-        hash_to_ruby!($key => Option<Float>);
-        hash_to_ruby!($key => Option<String>);
-        hash_to_ruby!($key => Option<&'a str>);
-        hash_to_ruby!($key => Vec<bool>);
-        hash_to_ruby!($key => Vec<Vec<u8>>);
-        hash_to_ruby!($key => Vec<Int>);
-        hash_to_ruby!($key => Vec<Float>);
-        hash_to_ruby!($key => Vec<String>);
-        hash_to_ruby!($key => Vec<&'a str>);
-        hash_to_ruby!($key => Vec<Option<bool>>);
-        hash_to_ruby!($key => Vec<Option<Vec<u8>>>);
-        hash_to_ruby!($key => Vec<Option<Int>>);
-        hash_to_ruby!($key => Vec<Option<Float>>);
-        hash_to_ruby!($key => Vec<Option<String>>);
-        hash_to_ruby!($key => Vec<Option<&'a str>>);
-
-        // nilable
-        hash_to_ruby!(Option<$key> => bool);
-        hash_to_ruby!(Option<$key> => Vec<u8>);
-        hash_to_ruby!(Option<$key> => Int);
-        hash_to_ruby!(Option<$key> => Float);
-        hash_to_ruby!(Option<$key> => String);
-        hash_to_ruby!(Option<$key> => &'a str);
-        hash_to_ruby!(Option<$key> => Option<bool>);
-        hash_to_ruby!(Option<$key> => Option<Vec<u8>>);
-        hash_to_ruby!(Option<$key> => Option<Int>);
-        hash_to_ruby!(Option<$key> => Option<Float>);
-        hash_to_ruby!(Option<$key> => Option<String>);
-        hash_to_ruby!(Option<$key> => Option<&'a str>);
-        hash_to_ruby!(Option<$key> => Vec<bool>);
-        hash_to_ruby!(Option<$key> => Vec<Vec<u8>>);
-        hash_to_ruby!(Option<$key> => Vec<Int>);
-        hash_to_ruby!(Option<$key> => Vec<Float>);
-        hash_to_ruby!(Option<$key> => Vec<String>);
-        hash_to_ruby!(Option<$key> => Vec<&'a str>);
-        hash_to_ruby!(Option<$key> => Vec<Option<bool>>);
-        hash_to_ruby!(Option<$key> => Vec<Option<Vec<u8>>>);
-        hash_to_ruby!(Option<$key> => Vec<Option<Int>>);
-        hash_to_ruby!(Option<$key> => Vec<Option<Float>>);
-        hash_to_ruby!(Option<$key> => Vec<Option<String>>);
-        hash_to_ruby!(Option<$key> => Vec<Option<&'a str>>);
-
-        // nested hash
-        hash_to_ruby!($key => Vec<(Value, Value)>);
-        hash_to_ruby!(Option<$key> => Vec<(Value, Value)>);
-
-        // bail out
-        hash_to_ruby!($key => Value);
-        hash_to_ruby!($key => Option<Value>);
-        hash_to_ruby!(Option<$key> => Value);
-        hash_to_ruby!(Option<$key> => Option<Value>);
-
-        // non nilable
-        ruby_to_hash!($key => bool);
-        ruby_to_hash!($key => Vec<u8>);
-        ruby_to_hash!($key => Int);
-        ruby_to_hash!($key => Float);
-        ruby_to_hash!($key => String);
-        ruby_to_hash!($key => &'a str);
-        ruby_to_hash!($key => Option<bool>);
-        ruby_to_hash!($key => Option<Vec<u8>>);
-        ruby_to_hash!($key => Option<Int>);
-        ruby_to_hash!($key => Option<Float>);
-        ruby_to_hash!($key => Option<String>);
-        ruby_to_hash!($key => Option<&'a str>);
-        ruby_to_hash!($key => Vec<bool>);
-        ruby_to_hash!($key => Vec<Vec<u8>>);
-        ruby_to_hash!($key => Vec<Int>);
-        ruby_to_hash!($key => Vec<Float>);
-        ruby_to_hash!($key => Vec<String>);
-        ruby_to_hash!($key => Vec<&'a str>);
-        ruby_to_hash!($key => Vec<Option<bool>>);
-        ruby_to_hash!($key => Vec<Option<Vec<u8>>>);
-        ruby_to_hash!($key => Vec<Option<Int>>);
-        ruby_to_hash!($key => Vec<Option<Float>>);
-        ruby_to_hash!($key => Vec<Option<String>>);
-        ruby_to_hash!($key => Vec<Option<&'a str>>);
-
-        // nilable
-        ruby_to_hash!(Option<$key> => bool);
-        ruby_to_hash!(Option<$key> => Vec<u8>);
-        ruby_to_hash!(Option<$key> => Int);
-        ruby_to_hash!(Option<$key> => Float);
-        ruby_to_hash!(Option<$key> => String);
-        ruby_to_hash!(Option<$key> => &'a str);
-        ruby_to_hash!(Option<$key> => Option<bool>);
-        ruby_to_hash!(Option<$key> => Option<Vec<u8>>);
-        ruby_to_hash!(Option<$key> => Option<Int>);
-        ruby_to_hash!(Option<$key> => Option<Float>);
-        ruby_to_hash!(Option<$key> => Option<String>);
-        ruby_to_hash!(Option<$key> => Option<&'a str>);
-        ruby_to_hash!(Option<$key> => Vec<bool>);
-        ruby_to_hash!(Option<$key> => Vec<Vec<u8>>);
-        ruby_to_hash!(Option<$key> => Vec<Int>);
-        ruby_to_hash!(Option<$key> => Vec<Float>);
-        ruby_to_hash!(Option<$key> => Vec<String>);
-        ruby_to_hash!(Option<$key> => Vec<&'a str>);
-        ruby_to_hash!(Option<$key> => Vec<Option<bool>>);
-        ruby_to_hash!(Option<$key> => Vec<Option<Vec<u8>>>);
-        ruby_to_hash!(Option<$key> => Vec<Option<Int>>);
-        ruby_to_hash!(Option<$key> => Vec<Option<Float>>);
-        ruby_to_hash!(Option<$key> => Vec<Option<String>>);
-        ruby_to_hash!(Option<$key> => Vec<Option<&'a str>>);
-
-        // nested hash
-        ruby_to_hash!($key => Vec<(Value, Value)>);
-        ruby_to_hash!(Option<$key> => Vec<(Value, Value)>);
-
-        // bail out
-        ruby_to_hash!($key => Value);
-        ruby_to_hash!($key => Option<Value>);
-        ruby_to_hash!(Option<$key> => Value);
-        ruby_to_hash!(Option<$key> => Option<Value>);
-    };
-}
-
-hash_impl!(Vec<u8>);
-
-#[cfg(feature = "artichoke-all-converters")]
-mod optional {
-    use super::*;
-
-    hash_impl!(Value);
-    hash_impl!(bool);
-    hash_impl!(no_hash_map | Float);
-    hash_impl!(Int);
-    hash_impl!(String);
-    hash_impl!(&'a str);
 }
 
 #[cfg(test)]

--- a/artichoke-backend/src/convert/nilable.rs
+++ b/artichoke-backend/src/convert/nilable.rs
@@ -17,16 +17,6 @@ impl Convert<Option<Value>, Value> for Artichoke {
     }
 }
 
-impl Convert<&Option<Value>, Value> for Artichoke {
-    fn convert(&self, value: &Option<Value>) -> Value {
-        if let Some(value) = value {
-            value.clone()
-        } else {
-            Value::new(self, unsafe { sys::mrb_sys_nil_value() })
-        }
-    }
-}
-
 impl Convert<Option<Int>, Value> for Artichoke {
     fn convert(&self, value: Option<Int>) -> Value {
         if let Some(value) = value {

--- a/artichoke-backend/src/convert/nilable.rs
+++ b/artichoke-backend/src/convert/nilable.rs
@@ -1,15 +1,12 @@
 //! Converters for nilable primitive Ruby types. Excludes collection types
 //! Array and Hash.
 
-use std::collections::HashMap;
-
 use crate::convert::{Convert, TryConvert};
 use crate::sys;
-use crate::types::{Float, Int, Ruby};
+use crate::types::{Int, Ruby};
 use crate::value::Value;
 use crate::{Artichoke, ArtichokeError};
 
-// bail out implementation for mixed-type collections
 impl Convert<Option<Value>, Value> for Artichoke {
     fn convert(&self, value: Option<Value>) -> Value {
         if let Some(value) = value {
@@ -20,9 +17,53 @@ impl Convert<Option<Value>, Value> for Artichoke {
     }
 }
 
-impl Convert<Option<&Value>, Value> for Artichoke {
-    fn convert(&self, value: Option<&Value>) -> Value {
-        self.convert(value.cloned())
+impl Convert<&Option<Value>, Value> for Artichoke {
+    fn convert(&self, value: &Option<Value>) -> Value {
+        if let Some(value) = value {
+            value.clone()
+        } else {
+            Value::new(self, unsafe { sys::mrb_sys_nil_value() })
+        }
+    }
+}
+
+impl Convert<Option<Int>, Value> for Artichoke {
+    fn convert(&self, value: Option<Int>) -> Value {
+        if let Some(value) = value {
+            self.convert(value)
+        } else {
+            Value::new(self, unsafe { sys::mrb_sys_nil_value() })
+        }
+    }
+}
+
+impl Convert<Option<Vec<u8>>, Value> for Artichoke {
+    fn convert(&self, value: Option<Vec<u8>>) -> Value {
+        if let Some(value) = value {
+            self.convert(value)
+        } else {
+            Value::new(self, unsafe { sys::mrb_sys_nil_value() })
+        }
+    }
+}
+
+impl Convert<Option<&[u8]>, Value> for Artichoke {
+    fn convert(&self, value: Option<&[u8]>) -> Value {
+        if let Some(value) = value {
+            self.convert(value)
+        } else {
+            Value::new(self, unsafe { sys::mrb_sys_nil_value() })
+        }
+    }
+}
+
+impl Convert<Option<&str>, Value> for Artichoke {
+    fn convert(&self, value: Option<&str>) -> Value {
+        if let Some(value) = value {
+            self.convert(value)
+        } else {
+            Value::new(self, unsafe { sys::mrb_sys_nil_value() })
+        }
     }
 }
 
@@ -36,389 +77,62 @@ impl Convert<Value, Option<Value>> for Artichoke {
     }
 }
 
-macro_rules! option_to_ruby {
-    ($elem:ty) => {
-        impl<'a> Convert<Option<$elem>, Value> for Artichoke {
-            fn convert(&self, value: Option<$elem>) -> Value {
-                if let Some(value) = value {
-                    self.convert(value)
-                } else {
-                    Value::new(self, unsafe { sys::mrb_sys_nil_value() })
-                }
-            }
+impl<'a> TryConvert<Value, Option<bool>> for Artichoke {
+    fn try_convert(&self, value: Value) -> Result<Option<bool>, ArtichokeError> {
+        if let Ruby::Nil = value.ruby_type() {
+            Ok(None)
+        } else {
+            self.try_convert(value).map(Some)
         }
-    };
+    }
 }
 
-macro_rules! ruby_to_option {
-    ($elem:ty) => {
-        impl<'a> TryConvert<Value, Option<$elem>> for Artichoke {
-            fn try_convert(&self, value: Value) -> Result<Option<$elem>, ArtichokeError> {
-                if let Some(value) = self.convert(value) {
-                    self.try_convert(value).map(Some)
-                } else {
-                    Ok(None)
-                }
-            }
+impl<'a> TryConvert<Value, Option<Vec<u8>>> for Artichoke {
+    fn try_convert(&self, value: Value) -> Result<Option<Vec<u8>>, ArtichokeError> {
+        if let Ruby::Nil = value.ruby_type() {
+            Ok(None)
+        } else {
+            self.try_convert(value).map(Some)
         }
-    };
+    }
 }
 
-// Primitives
-option_to_ruby!(bool);
-option_to_ruby!(Vec<u8>);
-option_to_ruby!(&'a [u8]);
-option_to_ruby!(Int);
-option_to_ruby!(Float);
-option_to_ruby!(String);
-option_to_ruby!(&'a str);
-
-// Array of primitives
-option_to_ruby!(Vec<Value>);
-option_to_ruby!(Vec<bool>);
-option_to_ruby!(Vec<Vec<u8>>);
-option_to_ruby!(Vec<&'a [u8]>);
-option_to_ruby!(Vec<Int>);
-option_to_ruby!(Vec<Float>);
-option_to_ruby!(Vec<String>);
-option_to_ruby!(Vec<&'a str>);
-
-// Array of optional primitives
-option_to_ruby!(Vec<Option<Value>>);
-option_to_ruby!(Vec<Option<bool>>);
-option_to_ruby!(Vec<Option<Vec<u8>>>);
-option_to_ruby!(Vec<Option<Int>>);
-option_to_ruby!(Vec<Option<Float>>);
-option_to_ruby!(Vec<Option<String>>);
-option_to_ruby!(Vec<Option<&'a str>>);
-
-option_to_ruby!(HashMap<Vec<u8>, Option<Vec<u8>>>);
-
-#[cfg(feature = "artichoke-all-converters")]
-mod optional {
-    use super::*;
-
-    // Hash of primitive keys to values
-    option_to_ruby!(HashMap<bool, Value>);
-    option_to_ruby!(HashMap<bool, bool>);
-    option_to_ruby!(HashMap<bool, Vec<u8>>);
-    option_to_ruby!(HashMap<bool, Int>);
-    option_to_ruby!(HashMap<bool, Float>);
-    option_to_ruby!(HashMap<bool, String>);
-    option_to_ruby!(HashMap<bool, &'a str>);
-    option_to_ruby!(HashMap<Vec<u8>, Value>);
-    option_to_ruby!(HashMap<Vec<u8>, bool>);
-    option_to_ruby!(HashMap<Vec<u8>, Vec<u8>>);
-    option_to_ruby!(HashMap<Vec<u8>, Int>);
-    option_to_ruby!(HashMap<Vec<u8>, Float>);
-    option_to_ruby!(HashMap<Vec<u8>, String>);
-    option_to_ruby!(HashMap<Vec<u8>, &'a str>);
-    option_to_ruby!(HashMap<Int, Value>);
-    option_to_ruby!(HashMap<Int, bool>);
-    option_to_ruby!(HashMap<Int, Vec<u8>>);
-    option_to_ruby!(HashMap<Int, Int>);
-    option_to_ruby!(HashMap<Int, Float>);
-    option_to_ruby!(HashMap<Int, String>);
-    option_to_ruby!(HashMap<Int, &'a str>);
-    option_to_ruby!(HashMap<String, Value>);
-    option_to_ruby!(HashMap<String, bool>);
-    option_to_ruby!(HashMap<String, Vec<u8>>);
-    option_to_ruby!(HashMap<String, Int>);
-    option_to_ruby!(HashMap<String, Float>);
-    option_to_ruby!(HashMap<String, String>);
-    option_to_ruby!(HashMap<String, &'a str>);
-    option_to_ruby!(HashMap<&'a str, Value>);
-    option_to_ruby!(HashMap<&'a str, bool>);
-    option_to_ruby!(HashMap<&'a str, Vec<u8>>);
-    option_to_ruby!(HashMap<&'a str, Int>);
-    option_to_ruby!(HashMap<&'a str, Float>);
-    option_to_ruby!(HashMap<&'a str, String>);
-    option_to_ruby!(HashMap<&'a str, &'a str>);
-
-    // Hash of optional keys to values
-    option_to_ruby!(HashMap<Option<bool>, Value>);
-    option_to_ruby!(HashMap<Option<bool>, bool>);
-    option_to_ruby!(HashMap<Option<bool>, Vec<u8>>);
-    option_to_ruby!(HashMap<Option<bool>, Int>);
-    option_to_ruby!(HashMap<Option<bool>, Float>);
-    option_to_ruby!(HashMap<Option<bool>, String>);
-    option_to_ruby!(HashMap<Option<bool>, &'a str>);
-    option_to_ruby!(HashMap<Option<Vec<u8>>, Value>);
-    option_to_ruby!(HashMap<Option<Vec<u8>>, bool>);
-    option_to_ruby!(HashMap<Option<Vec<u8>>, Vec<u8>>);
-    option_to_ruby!(HashMap<Option<Vec<u8>>, Int>);
-    option_to_ruby!(HashMap<Option<Vec<u8>>, Float>);
-    option_to_ruby!(HashMap<Option<Vec<u8>>, String>);
-    option_to_ruby!(HashMap<Option<Vec<u8>>, &'a str>);
-    option_to_ruby!(HashMap<Option<Int>, Value>);
-    option_to_ruby!(HashMap<Option<Int>, bool>);
-    option_to_ruby!(HashMap<Option<Int>, Vec<u8>>);
-    option_to_ruby!(HashMap<Option<Int>, Int>);
-    option_to_ruby!(HashMap<Option<Int>, Float>);
-    option_to_ruby!(HashMap<Option<Int>, String>);
-    option_to_ruby!(HashMap<Option<Int>, &'a str>);
-    option_to_ruby!(HashMap<Option<String>, Value>);
-    option_to_ruby!(HashMap<Option<String>, bool>);
-    option_to_ruby!(HashMap<Option<String>, Vec<u8>>);
-    option_to_ruby!(HashMap<Option<String>, Int>);
-    option_to_ruby!(HashMap<Option<String>, Float>);
-    option_to_ruby!(HashMap<Option<String>, String>);
-    option_to_ruby!(HashMap<Option<String>, &'a str>);
-    option_to_ruby!(HashMap<Option<&'a str>, Value>);
-    option_to_ruby!(HashMap<Option<&'a str>, bool>);
-    option_to_ruby!(HashMap<Option<&'a str>, Vec<u8>>);
-    option_to_ruby!(HashMap<Option<&'a str>, Int>);
-    option_to_ruby!(HashMap<Option<&'a str>, Float>);
-    option_to_ruby!(HashMap<Option<&'a str>, String>);
-    option_to_ruby!(HashMap<Option<&'a str>, &'a str>);
-
-    // Hash of primitive keys to optional values
-    option_to_ruby!(HashMap<bool, Option<Value>>);
-    option_to_ruby!(HashMap<bool, Option<bool>>);
-    option_to_ruby!(HashMap<bool, Option<Vec<u8>>>);
-    option_to_ruby!(HashMap<bool, Option<Int>>);
-    option_to_ruby!(HashMap<bool, Option<Float>>);
-    option_to_ruby!(HashMap<bool, Option<String>>);
-    option_to_ruby!(HashMap<bool, Option<&'a str>>);
-    option_to_ruby!(HashMap<Vec<u8>, Option<Value>>);
-    option_to_ruby!(HashMap<Vec<u8>, Option<bool>>);
-    option_to_ruby!(HashMap<Vec<u8>, Option<Int>>);
-    option_to_ruby!(HashMap<Vec<u8>, Option<Float>>);
-    option_to_ruby!(HashMap<Vec<u8>, Option<String>>);
-    option_to_ruby!(HashMap<Vec<u8>, Option<&'a str>>);
-    option_to_ruby!(HashMap<Int, Option<Value>>);
-    option_to_ruby!(HashMap<Int, Option<bool>>);
-    option_to_ruby!(HashMap<Int, Option<Vec<u8>>>);
-    option_to_ruby!(HashMap<Int, Option<Int>>);
-    option_to_ruby!(HashMap<Int, Option<Float>>);
-    option_to_ruby!(HashMap<Int, Option<String>>);
-    option_to_ruby!(HashMap<Int, Option<&'a str>>);
-    option_to_ruby!(HashMap<String, Option<Value>>);
-    option_to_ruby!(HashMap<String, Option<bool>>);
-    option_to_ruby!(HashMap<String, Option<Vec<u8>>>);
-    option_to_ruby!(HashMap<String, Option<Int>>);
-    option_to_ruby!(HashMap<String, Option<Float>>);
-    option_to_ruby!(HashMap<String, Option<String>>);
-    option_to_ruby!(HashMap<String, Option<&'a str>>);
-    option_to_ruby!(HashMap<&'a str, Option<Value>>);
-    option_to_ruby!(HashMap<&'a str, Option<bool>>);
-    option_to_ruby!(HashMap<&'a str, Option<Vec<u8>>>);
-    option_to_ruby!(HashMap<&'a str, Option<Int>>);
-    option_to_ruby!(HashMap<&'a str, Option<Float>>);
-    option_to_ruby!(HashMap<&'a str, Option<String>>);
-    option_to_ruby!(HashMap<&'a str, Option<&'a str>>);
-
-    // Hash of primitive optional keys to optional values
-    option_to_ruby!(HashMap<Option<bool>, Option<Value>>);
-    option_to_ruby!(HashMap<Option<bool>, Option<bool>>);
-    option_to_ruby!(HashMap<Option<bool>, Option<Vec<u8>>>);
-    option_to_ruby!(HashMap<Option<bool>, Option<Int>>);
-    option_to_ruby!(HashMap<Option<bool>, Option<Float>>);
-    option_to_ruby!(HashMap<Option<bool>, Option<String>>);
-    option_to_ruby!(HashMap<Option<bool>, Option<&'a str>>);
-    option_to_ruby!(HashMap<Option<Vec<u8>>, Option<Value>>);
-    option_to_ruby!(HashMap<Option<Vec<u8>>, Option<bool>>);
-    option_to_ruby!(HashMap<Option<Vec<u8>>, Option<Vec<u8>>>);
-    option_to_ruby!(HashMap<Option<Vec<u8>>, Option<Int>>);
-    option_to_ruby!(HashMap<Option<Vec<u8>>, Option<Float>>);
-    option_to_ruby!(HashMap<Option<Vec<u8>>, Option<String>>);
-    option_to_ruby!(HashMap<Option<Vec<u8>>, Option<&'a str>>);
-    option_to_ruby!(HashMap<Option<Int>, Option<Value>>);
-    option_to_ruby!(HashMap<Option<Int>, Option<bool>>);
-    option_to_ruby!(HashMap<Option<Int>, Option<Vec<u8>>>);
-    option_to_ruby!(HashMap<Option<Int>, Option<Int>>);
-    option_to_ruby!(HashMap<Option<Int>, Option<Float>>);
-    option_to_ruby!(HashMap<Option<Int>, Option<String>>);
-    option_to_ruby!(HashMap<Option<Int>, Option<&'a str>>);
-    option_to_ruby!(HashMap<Option<String>, Option<Value>>);
-    option_to_ruby!(HashMap<Option<String>, Option<bool>>);
-    option_to_ruby!(HashMap<Option<String>, Option<Vec<u8>>>);
-    option_to_ruby!(HashMap<Option<String>, Option<Int>>);
-    option_to_ruby!(HashMap<Option<String>, Option<Float>>);
-    option_to_ruby!(HashMap<Option<String>, Option<String>>);
-    option_to_ruby!(HashMap<Option<String>, Option<&'a str>>);
-    option_to_ruby!(HashMap<Option<&'a str>, Option<Value>>);
-    option_to_ruby!(HashMap<Option<&'a str>, Option<bool>>);
-    option_to_ruby!(HashMap<Option<&'a str>, Option<Vec<u8>>>);
-    option_to_ruby!(HashMap<Option<&'a str>, Option<Int>>);
-    option_to_ruby!(HashMap<Option<&'a str>, Option<Float>>);
-    option_to_ruby!(HashMap<Option<&'a str>, Option<String>>);
-    option_to_ruby!(HashMap<Option<&'a str>, Option<&'a str>>);
-
-    // Hash of primitive keys to values
-    ruby_to_option!(HashMap<bool, Value>);
-    ruby_to_option!(HashMap<bool, bool>);
-    ruby_to_option!(HashMap<bool, Vec<u8>>);
-    ruby_to_option!(HashMap<bool, Int>);
-    ruby_to_option!(HashMap<bool, Float>);
-    ruby_to_option!(HashMap<bool, String>);
-    ruby_to_option!(HashMap<bool, &'a str>);
-    ruby_to_option!(HashMap<Vec<u8>, Value>);
-    ruby_to_option!(HashMap<Vec<u8>, bool>);
-    ruby_to_option!(HashMap<Vec<u8>, Vec<u8>>);
-    ruby_to_option!(HashMap<Vec<u8>, Int>);
-    ruby_to_option!(HashMap<Vec<u8>, Float>);
-    ruby_to_option!(HashMap<Vec<u8>, String>);
-    ruby_to_option!(HashMap<Vec<u8>, &'a str>);
-    ruby_to_option!(HashMap<Int, Value>);
-    ruby_to_option!(HashMap<Int, bool>);
-    ruby_to_option!(HashMap<Int, Vec<u8>>);
-    ruby_to_option!(HashMap<Int, Int>);
-    ruby_to_option!(HashMap<Int, Float>);
-    ruby_to_option!(HashMap<Int, String>);
-    ruby_to_option!(HashMap<Int, &'a str>);
-    ruby_to_option!(HashMap<String, Value>);
-    ruby_to_option!(HashMap<String, bool>);
-    ruby_to_option!(HashMap<String, Vec<u8>>);
-    ruby_to_option!(HashMap<String, Int>);
-    ruby_to_option!(HashMap<String, Float>);
-    ruby_to_option!(HashMap<String, String>);
-    ruby_to_option!(HashMap<String, &'a str>);
-    ruby_to_option!(HashMap<&'a str, Value>);
-    ruby_to_option!(HashMap<&'a str, bool>);
-    ruby_to_option!(HashMap<&'a str, Vec<u8>>);
-    ruby_to_option!(HashMap<&'a str, Int>);
-    ruby_to_option!(HashMap<&'a str, Float>);
-    ruby_to_option!(HashMap<&'a str, String>);
-    ruby_to_option!(HashMap<&'a str, &'a str>);
-
-    // Hash of optional keys to values
-    ruby_to_option!(HashMap<Option<bool>, Value>);
-    ruby_to_option!(HashMap<Option<bool>, bool>);
-    ruby_to_option!(HashMap<Option<bool>, Vec<u8>>);
-    ruby_to_option!(HashMap<Option<bool>, Int>);
-    ruby_to_option!(HashMap<Option<bool>, Float>);
-    ruby_to_option!(HashMap<Option<bool>, String>);
-    ruby_to_option!(HashMap<Option<bool>, &'a str>);
-    ruby_to_option!(HashMap<Option<Vec<u8>>, Value>);
-    ruby_to_option!(HashMap<Option<Vec<u8>>, bool>);
-    ruby_to_option!(HashMap<Option<Vec<u8>>, Vec<u8>>);
-    ruby_to_option!(HashMap<Option<Vec<u8>>, Int>);
-    ruby_to_option!(HashMap<Option<Vec<u8>>, Float>);
-    ruby_to_option!(HashMap<Option<Vec<u8>>, String>);
-    ruby_to_option!(HashMap<Option<Vec<u8>>, &'a str>);
-    ruby_to_option!(HashMap<Option<Int>, Value>);
-    ruby_to_option!(HashMap<Option<Int>, bool>);
-    ruby_to_option!(HashMap<Option<Int>, Vec<u8>>);
-    ruby_to_option!(HashMap<Option<Int>, Int>);
-    ruby_to_option!(HashMap<Option<Int>, Float>);
-    ruby_to_option!(HashMap<Option<Int>, String>);
-    ruby_to_option!(HashMap<Option<Int>, &'a str>);
-    ruby_to_option!(HashMap<Option<String>, Value>);
-    ruby_to_option!(HashMap<Option<String>, bool>);
-    ruby_to_option!(HashMap<Option<String>, Vec<u8>>);
-    ruby_to_option!(HashMap<Option<String>, Int>);
-    ruby_to_option!(HashMap<Option<String>, Float>);
-    ruby_to_option!(HashMap<Option<String>, String>);
-    ruby_to_option!(HashMap<Option<String>, &'a str>);
-    ruby_to_option!(HashMap<Option<&'a str>, Value>);
-    ruby_to_option!(HashMap<Option<&'a str>, bool>);
-    ruby_to_option!(HashMap<Option<&'a str>, Vec<u8>>);
-    ruby_to_option!(HashMap<Option<&'a str>, Int>);
-    ruby_to_option!(HashMap<Option<&'a str>, Float>);
-    ruby_to_option!(HashMap<Option<&'a str>, String>);
-    ruby_to_option!(HashMap<Option<&'a str>, &'a str>);
-
-    // Hash of primitive keys to optional values
-    ruby_to_option!(HashMap<bool, Option<Value>>);
-    ruby_to_option!(HashMap<bool, Option<bool>>);
-    ruby_to_option!(HashMap<bool, Option<Vec<u8>>>);
-    ruby_to_option!(HashMap<bool, Option<Int>>);
-    ruby_to_option!(HashMap<bool, Option<Float>>);
-    ruby_to_option!(HashMap<bool, Option<String>>);
-    ruby_to_option!(HashMap<bool, Option<&'a str>>);
-    ruby_to_option!(HashMap<Vec<u8>, Option<Value>>);
-    ruby_to_option!(HashMap<Vec<u8>, Option<bool>>);
-    ruby_to_option!(HashMap<Vec<u8>, Option<Int>>);
-    ruby_to_option!(HashMap<Vec<u8>, Option<Float>>);
-    ruby_to_option!(HashMap<Vec<u8>, Option<String>>);
-    ruby_to_option!(HashMap<Vec<u8>, Option<&'a str>>);
-    ruby_to_option!(HashMap<Int, Option<Value>>);
-    ruby_to_option!(HashMap<Int, Option<bool>>);
-    ruby_to_option!(HashMap<Int, Option<Vec<u8>>>);
-    ruby_to_option!(HashMap<Int, Option<Int>>);
-    ruby_to_option!(HashMap<Int, Option<Float>>);
-    ruby_to_option!(HashMap<Int, Option<String>>);
-    ruby_to_option!(HashMap<Int, Option<&'a str>>);
-    ruby_to_option!(HashMap<String, Option<Value>>);
-    ruby_to_option!(HashMap<String, Option<bool>>);
-    ruby_to_option!(HashMap<String, Option<Vec<u8>>>);
-    ruby_to_option!(HashMap<String, Option<Int>>);
-    ruby_to_option!(HashMap<String, Option<Float>>);
-    ruby_to_option!(HashMap<String, Option<String>>);
-    ruby_to_option!(HashMap<String, Option<&'a str>>);
-    ruby_to_option!(HashMap<&'a str, Option<Value>>);
-    ruby_to_option!(HashMap<&'a str, Option<bool>>);
-    ruby_to_option!(HashMap<&'a str, Option<Vec<u8>>>);
-    ruby_to_option!(HashMap<&'a str, Option<Int>>);
-    ruby_to_option!(HashMap<&'a str, Option<Float>>);
-    ruby_to_option!(HashMap<&'a str, Option<String>>);
-    ruby_to_option!(HashMap<&'a str, Option<&'a str>>);
-
-    // Hash of primitive optional keys to optional values
-    ruby_to_option!(HashMap<Option<bool>, Option<Value>>);
-    ruby_to_option!(HashMap<Option<bool>, Option<bool>>);
-    ruby_to_option!(HashMap<Option<bool>, Option<Vec<u8>>>);
-    ruby_to_option!(HashMap<Option<bool>, Option<Int>>);
-    ruby_to_option!(HashMap<Option<bool>, Option<Float>>);
-    ruby_to_option!(HashMap<Option<bool>, Option<String>>);
-    ruby_to_option!(HashMap<Option<bool>, Option<&'a str>>);
-    ruby_to_option!(HashMap<Option<Vec<u8>>, Option<Value>>);
-    ruby_to_option!(HashMap<Option<Vec<u8>>, Option<bool>>);
-    ruby_to_option!(HashMap<Option<Vec<u8>>, Option<Vec<u8>>>);
-    ruby_to_option!(HashMap<Option<Vec<u8>>, Option<Int>>);
-    ruby_to_option!(HashMap<Option<Vec<u8>>, Option<Float>>);
-    ruby_to_option!(HashMap<Option<Vec<u8>>, Option<String>>);
-    ruby_to_option!(HashMap<Option<Vec<u8>>, Option<&'a str>>);
-    ruby_to_option!(HashMap<Option<Int>, Option<Value>>);
-    ruby_to_option!(HashMap<Option<Int>, Option<bool>>);
-    ruby_to_option!(HashMap<Option<Int>, Option<Vec<u8>>>);
-    ruby_to_option!(HashMap<Option<Int>, Option<Int>>);
-    ruby_to_option!(HashMap<Option<Int>, Option<Float>>);
-    ruby_to_option!(HashMap<Option<Int>, Option<String>>);
-    ruby_to_option!(HashMap<Option<Int>, Option<&'a str>>);
-    ruby_to_option!(HashMap<Option<String>, Option<Value>>);
-    ruby_to_option!(HashMap<Option<String>, Option<bool>>);
-    ruby_to_option!(HashMap<Option<String>, Option<Vec<u8>>>);
-    ruby_to_option!(HashMap<Option<String>, Option<Int>>);
-    ruby_to_option!(HashMap<Option<String>, Option<Float>>);
-    ruby_to_option!(HashMap<Option<String>, Option<String>>);
-    ruby_to_option!(HashMap<Option<String>, Option<&'a str>>);
-    ruby_to_option!(HashMap<Option<&'a str>, Option<Value>>);
-    ruby_to_option!(HashMap<Option<&'a str>, Option<bool>>);
-    ruby_to_option!(HashMap<Option<&'a str>, Option<Vec<u8>>>);
-    ruby_to_option!(HashMap<Option<&'a str>, Option<Int>>);
-    ruby_to_option!(HashMap<Option<&'a str>, Option<Float>>);
-    ruby_to_option!(HashMap<Option<&'a str>, Option<String>>);
-    ruby_to_option!(HashMap<Option<&'a str>, Option<&'a str>>);
+impl<'a> TryConvert<Value, Option<&'a [u8]>> for Artichoke {
+    fn try_convert(&self, value: Value) -> Result<Option<&'a [u8]>, ArtichokeError> {
+        if let Ruby::Nil = value.ruby_type() {
+            Ok(None)
+        } else {
+            self.try_convert(value).map(Some)
+        }
+    }
 }
 
-// Primitives
-ruby_to_option!(bool);
-ruby_to_option!(Vec<u8>);
-ruby_to_option!(&'a [u8]);
-ruby_to_option!(Int);
-ruby_to_option!(Float);
-ruby_to_option!(String);
-ruby_to_option!(&'a str);
+impl<'a> TryConvert<Value, Option<String>> for Artichoke {
+    fn try_convert(&self, value: Value) -> Result<Option<String>, ArtichokeError> {
+        if let Ruby::Nil = value.ruby_type() {
+            Ok(None)
+        } else {
+            self.try_convert(value).map(Some)
+        }
+    }
+}
 
-// Array of primitives
-ruby_to_option!(Vec<Value>);
-ruby_to_option!(Vec<bool>);
-ruby_to_option!(Vec<Vec<u8>>);
-ruby_to_option!(Vec<&'a [u8]>);
-ruby_to_option!(Vec<Int>);
-ruby_to_option!(Vec<Float>);
-ruby_to_option!(Vec<String>);
-ruby_to_option!(Vec<&'a str>);
+impl<'a> TryConvert<Value, Option<&'a str>> for Artichoke {
+    fn try_convert(&self, value: Value) -> Result<Option<&'a str>, ArtichokeError> {
+        if let Ruby::Nil = value.ruby_type() {
+            Ok(None)
+        } else {
+            self.try_convert(value).map(Some)
+        }
+    }
+}
 
-// Array of optional primitives
-ruby_to_option!(Vec<Option<Value>>);
-ruby_to_option!(Vec<Option<bool>>);
-ruby_to_option!(Vec<Option<Vec<u8>>>);
-ruby_to_option!(Vec<Option<Int>>);
-ruby_to_option!(Vec<Option<Float>>);
-ruby_to_option!(Vec<Option<String>>);
-ruby_to_option!(Vec<Option<&'a str>>);
-
-ruby_to_option!(HashMap<Vec<u8>, Option<Vec<u8>>>);
+impl<'a> TryConvert<Value, Option<Int>> for Artichoke {
+    fn try_convert(&self, value: Value) -> Result<Option<Int>, ArtichokeError> {
+        if let Ruby::Nil = value.ruby_type() {
+            Ok(None)
+        } else {
+            self.try_convert(value).map(Some)
+        }
+    }
+}

--- a/artichoke-backend/src/extn/core/array/inline_buffer.rs
+++ b/artichoke-backend/src/extn/core/array/inline_buffer.rs
@@ -19,7 +19,7 @@ impl From<Vec<sys::mrb_value>> for InlineBuffer {
 
 impl From<Vec<Value>> for InlineBuffer {
     fn from(values: Vec<Value>) -> Self {
-        Self::from(values.as_slice())
+        Self(SmallVec::from_iter(values.iter().map(Value::inner)))
     }
 }
 

--- a/artichoke-backend/src/extn/core/string.rs
+++ b/artichoke-backend/src/extn/core/string.rs
@@ -77,26 +77,26 @@ mod tests {
         let mut interp = crate::interpreter().expect("init");
 
         assert_eq!(
-            &interp
+            interp
                 .eval(br"'hello there'[/[aeiou](.)\1/]")
                 .unwrap()
-                .try_into::<String>()
+                .try_into::<&str>()
                 .unwrap(),
             "ell"
         );
         assert_eq!(
-            &interp
+            interp
                 .eval(br"'hello there'[/[aeiou](.)\1/, 0]")
                 .unwrap()
-                .try_into::<String>()
+                .try_into::<&str>()
                 .unwrap(),
             "ell"
         );
         assert_eq!(
-            &interp
+            interp
                 .eval(br"'hello there'[/[aeiou](.)\1/, 1]")
                 .unwrap()
-                .try_into::<String>()
+                .try_into::<&str>()
                 .unwrap(),
             "l"
         );
@@ -104,23 +104,23 @@ mod tests {
             interp
                 .eval(br"'hello there'[/[aeiou](.)\1/, 2]")
                 .unwrap()
-                .try_into::<Option<String>>()
+                .try_into::<Option<&str>>()
                 .unwrap(),
             None
         );
         assert_eq!(
-            &interp
+            interp
                 .eval(br"'hello there'[/(?<vowel>[aeiou])(?<non_vowel>[^aeiou])/, 'non_vowel']")
                 .unwrap()
-                .try_into::<String>()
+                .try_into::<&str>()
                 .unwrap(),
             "l"
         );
         assert_eq!(
-            &interp
+            interp
                 .eval(br"'hello there'[/(?<vowel>[aeiou])(?<non_vowel>[^aeiou])/, 'vowel']")
                 .unwrap()
-                .try_into::<String>()
+                .try_into::<&str>()
                 .unwrap(),
             "e"
         );

--- a/artichoke-backend/src/extn/stdlib/forwardable.rs
+++ b/artichoke-backend/src/extn/stdlib/forwardable.rs
@@ -126,17 +126,17 @@ out << q.first
                 "#,
             )
             .unwrap()
-            .try_into::<Vec<Option<String>>>()
+            .try_into::<Vec<Option<&str>>>()
             .unwrap();
         assert_eq!(
             result,
             vec![
-                Some("2".to_owned()),
-                Some("3".to_owned()),
-                Some("4".to_owned()),
-                Some("5".to_owned()),
-                Some("6".to_owned()),
-                Some("Ruby".to_owned()),
+                Some("2"),
+                Some("3"),
+                Some("4"),
+                Some("5"),
+                Some("6"),
+                Some("Ruby"),
                 None
             ]
         );


### PR DESCRIPTION
Remove the 1000+ Convert and TryConvert implementations. Remove the
`artichoke-all-converters` feature.

Manually implement all converters required by the current application.

Converters are specialized for each type and do not funnel through the
base `Value` converter for collections.

This change is in preparation for converter work falling out of GH-442
which will require converters that allocate on the interpreter heap as
`&mut self`.

This patch removes a bunch of code and speeds up compile times. (Shaves
5s or 10% off a clean build on my machine.)

Fixes GH-486.