### PR TITLE
Split converter traits by whether they allocate on the interpreter heap

### DIFF
--- a/artichoke-backend/src/convert.rs
+++ b/artichoke-backend/src/convert.rs
@@ -10,7 +10,11 @@ mod string;
 
 /// Re-export from [`artichoke_core`](artichoke_core::convert::Convert).
 pub use crate::core::convert::Convert;
+/// Re-export from [`artichoke_core`](artichoke_core::convert::ConvertMut).
+pub use crate::core::convert::ConvertMut;
 /// Re-export from [`artichoke_core`](artichoke_core::convert::TryConvert).
 pub use crate::core::convert::TryConvert;
+/// Re-export from [`artichoke_core`](artichoke_core::convert::TryConvertMut).
+pub use crate::core::convert::TryConvertMut;
 
 pub use self::object::RustBackedValue;

--- a/artichoke-backend/src/convert/array.rs
+++ b/artichoke-backend/src/convert/array.rs
@@ -77,9 +77,7 @@ impl ConvertMut<&[Int], Value> for Artichoke {
 
 impl ConvertMut<&[Option<Vec<u8>>], Value> for Artichoke {
     fn convert_mut(&mut self, value: &[Option<Vec<u8>>]) -> Value {
-        let iter = value
-            .into_iter()
-            .map(|item| self.convert_mut(item.as_deref()));
+        let iter = value.iter().map(|item| self.convert_mut(item.as_deref()));
         let ary = Array::new(InlineBuffer::from_iter(iter));
         ary.try_into_ruby(self, None).expect("Array into Value")
     }

--- a/artichoke-backend/src/convert/array.rs
+++ b/artichoke-backend/src/convert/array.rs
@@ -1,131 +1,141 @@
 use std::iter::FromIterator;
 
-use crate::convert::{Convert, RustBackedValue, TryConvert};
+use crate::convert::{Convert, ConvertMut, RustBackedValue, TryConvert};
 use crate::extn::core::array::{Array, InlineBuffer};
 use crate::types::{Int, Ruby, Rust};
 use crate::value::Value;
 use crate::{Artichoke, ArtichokeError};
 
-impl Convert<&[Value], Value> for Artichoke {
-    fn convert(&self, value: &[Value]) -> Value {
+impl ConvertMut<&[Value], Value> for Artichoke {
+    fn convert_mut(&mut self, value: &[Value]) -> Value {
         let ary = Array::new(InlineBuffer::from(value));
         ary.try_into_ruby(self, None).expect("Array into Value")
     }
 }
 
-impl Convert<Vec<Value>, Value> for Artichoke {
-    fn convert(&self, value: Vec<Value>) -> Value {
+impl ConvertMut<Vec<Value>, Value> for Artichoke {
+    fn convert_mut(&mut self, value: Vec<Value>) -> Value {
         let ary = Array::new(InlineBuffer::from(value));
         ary.try_into_ruby(self, None).expect("Array into Value")
     }
 }
 
-impl Convert<&[Option<Value>], Value> for Artichoke {
-    fn convert(&self, value: &[Option<Value>]) -> Value {
+impl ConvertMut<&[Option<Value>], Value> for Artichoke {
+    fn convert_mut(&mut self, value: &[Option<Value>]) -> Value {
         let ary = Array::new(InlineBuffer::from_iter(value));
         ary.try_into_ruby(self, None).expect("Array into Value")
     }
 }
 
-impl Convert<Vec<Vec<u8>>, Value> for Artichoke {
-    fn convert(&self, value: Vec<Vec<u8>>) -> Value {
+impl ConvertMut<Vec<Vec<u8>>, Value> for Artichoke {
+    fn convert_mut(&mut self, value: Vec<Vec<u8>>) -> Value {
+        let iter = value.into_iter().map(|item| self.convert_mut(item));
+        let ary = Array::new(InlineBuffer::from_iter(iter));
+        ary.try_into_ruby(self, None).expect("Array into Value")
+    }
+}
+
+impl ConvertMut<Vec<&[u8]>, Value> for Artichoke {
+    fn convert_mut(&mut self, value: Vec<&[u8]>) -> Value {
+        let iter = value.into_iter().map(|item| self.convert_mut(item));
+        let ary = Array::new(InlineBuffer::from_iter(iter));
+        ary.try_into_ruby(self, None).expect("Array into Value")
+    }
+}
+
+impl ConvertMut<Vec<String>, Value> for Artichoke {
+    fn convert_mut(&mut self, value: Vec<String>) -> Value {
+        let iter = value.into_iter().map(|item| self.convert_mut(item));
+        let ary = Array::new(InlineBuffer::from_iter(iter));
+        ary.try_into_ruby(self, None).expect("Array into Value")
+    }
+}
+
+impl ConvertMut<Vec<&str>, Value> for Artichoke {
+    fn convert_mut(&mut self, value: Vec<&str>) -> Value {
+        let iter = value.into_iter().map(|item| self.convert_mut(item));
+        let ary = Array::new(InlineBuffer::from_iter(iter));
+        ary.try_into_ruby(self, None).expect("Array into Value")
+    }
+}
+
+impl ConvertMut<Vec<Int>, Value> for Artichoke {
+    fn convert_mut(&mut self, value: Vec<Int>) -> Value {
         let iter = value.into_iter().map(|item| self.convert(item));
         let ary = Array::new(InlineBuffer::from_iter(iter));
         ary.try_into_ruby(self, None).expect("Array into Value")
     }
 }
 
-impl Convert<Vec<&[u8]>, Value> for Artichoke {
-    fn convert(&self, value: Vec<&[u8]>) -> Value {
-        let iter = value.into_iter().map(|item| self.convert(item));
-        let ary = Array::new(InlineBuffer::from_iter(iter));
-        ary.try_into_ruby(self, None).expect("Array into Value")
-    }
-}
-
-impl Convert<Vec<String>, Value> for Artichoke {
-    fn convert(&self, value: Vec<String>) -> Value {
-        let iter = value.into_iter().map(|item| self.convert(item));
-        let ary = Array::new(InlineBuffer::from_iter(iter));
-        ary.try_into_ruby(self, None).expect("Array into Value")
-    }
-}
-
-impl Convert<Vec<&str>, Value> for Artichoke {
-    fn convert(&self, value: Vec<&str>) -> Value {
-        let iter = value.into_iter().map(|item| self.convert(item));
-        let ary = Array::new(InlineBuffer::from_iter(iter));
-        ary.try_into_ruby(self, None).expect("Array into Value")
-    }
-}
-
-impl Convert<Vec<Int>, Value> for Artichoke {
-    fn convert(&self, value: Vec<Int>) -> Value {
-        let iter = value.into_iter().map(|item| self.convert(item));
-        let ary = Array::new(InlineBuffer::from_iter(iter));
-        ary.try_into_ruby(self, None).expect("Array into Value")
-    }
-}
-
-impl Convert<&[Int], Value> for Artichoke {
-    fn convert(&self, value: &[Int]) -> Value {
+impl ConvertMut<&[Int], Value> for Artichoke {
+    fn convert_mut(&mut self, value: &[Int]) -> Value {
         let iter = value.iter().copied().map(|item| self.convert(item));
         let ary = Array::new(InlineBuffer::from_iter(iter));
         ary.try_into_ruby(self, None).expect("Array into Value")
     }
 }
 
-impl Convert<Vec<Option<Vec<u8>>>, Value> for Artichoke {
-    fn convert(&self, value: Vec<Option<Vec<u8>>>) -> Value {
-        let iter = value.into_iter().map(|item| self.convert(item));
+impl ConvertMut<&[Option<Vec<u8>>], Value> for Artichoke {
+    fn convert_mut(&mut self, value: &[Option<Vec<u8>>]) -> Value {
+        let iter = value
+            .into_iter()
+            .map(|item| self.convert_mut(item.as_deref()));
         let ary = Array::new(InlineBuffer::from_iter(iter));
         ary.try_into_ruby(self, None).expect("Array into Value")
     }
 }
 
-impl Convert<&[Option<&[u8]>], Value> for Artichoke {
-    fn convert(&self, value: &[Option<&[u8]>]) -> Value {
-        let iter = value.iter().copied().map(|item| self.convert(item));
+impl ConvertMut<Vec<Option<Vec<u8>>>, Value> for Artichoke {
+    fn convert_mut(&mut self, value: Vec<Option<Vec<u8>>>) -> Value {
+        let iter = value.into_iter().map(|item| self.convert_mut(item));
         let ary = Array::new(InlineBuffer::from_iter(iter));
         ary.try_into_ruby(self, None).expect("Array into Value")
     }
 }
 
-impl Convert<Vec<Option<&[u8]>>, Value> for Artichoke {
-    fn convert(&self, value: Vec<Option<&[u8]>>) -> Value {
-        let iter = value.into_iter().map(|item| self.convert(item));
+impl ConvertMut<&[Option<&[u8]>], Value> for Artichoke {
+    fn convert_mut(&mut self, value: &[Option<&[u8]>]) -> Value {
+        let iter = value.iter().copied().map(|item| self.convert_mut(item));
         let ary = Array::new(InlineBuffer::from_iter(iter));
         ary.try_into_ruby(self, None).expect("Array into Value")
     }
 }
 
-impl Convert<Vec<Vec<Option<&[u8]>>>, Value> for Artichoke {
-    fn convert(&self, value: Vec<Vec<Option<&[u8]>>>) -> Value {
-        let iter = value.into_iter().map(|item| self.convert(item));
+impl ConvertMut<Vec<Option<&[u8]>>, Value> for Artichoke {
+    fn convert_mut(&mut self, value: Vec<Option<&[u8]>>) -> Value {
+        let iter = value.into_iter().map(|item| self.convert_mut(item));
         let ary = Array::new(InlineBuffer::from_iter(iter));
         ary.try_into_ruby(self, None).expect("Array into Value")
     }
 }
 
-impl Convert<&[Option<&str>], Value> for Artichoke {
-    fn convert(&self, value: &[Option<&str>]) -> Value {
-        let iter = value.iter().copied().map(|item| self.convert(item));
+impl ConvertMut<Vec<Vec<Option<&[u8]>>>, Value> for Artichoke {
+    fn convert_mut(&mut self, value: Vec<Vec<Option<&[u8]>>>) -> Value {
+        let iter = value.into_iter().map(|item| self.convert_mut(item));
         let ary = Array::new(InlineBuffer::from_iter(iter));
         ary.try_into_ruby(self, None).expect("Array into Value")
     }
 }
 
-impl Convert<Vec<Option<&str>>, Value> for Artichoke {
-    fn convert(&self, value: Vec<Option<&str>>) -> Value {
-        let iter = value.into_iter().map(|item| self.convert(item));
+impl ConvertMut<&[Option<&str>], Value> for Artichoke {
+    fn convert_mut(&mut self, value: &[Option<&str>]) -> Value {
+        let iter = value.iter().copied().map(|item| self.convert_mut(item));
         let ary = Array::new(InlineBuffer::from_iter(iter));
         ary.try_into_ruby(self, None).expect("Array into Value")
     }
 }
 
-impl Convert<Vec<Vec<Option<&str>>>, Value> for Artichoke {
-    fn convert(&self, value: Vec<Vec<Option<&str>>>) -> Value {
-        let iter = value.into_iter().map(|item| self.convert(item));
+impl ConvertMut<Vec<Option<&str>>, Value> for Artichoke {
+    fn convert_mut(&mut self, value: Vec<Option<&str>>) -> Value {
+        let iter = value.into_iter().map(|item| self.convert_mut(item));
+        let ary = Array::new(InlineBuffer::from_iter(iter));
+        ary.try_into_ruby(self, None).expect("Array into Value")
+    }
+}
+
+impl ConvertMut<Vec<Vec<Option<&str>>>, Value> for Artichoke {
+    fn convert_mut(&mut self, value: Vec<Vec<Option<&str>>>) -> Value {
+        let iter = value.into_iter().map(|item| self.convert_mut(item));
         let ary = Array::new(InlineBuffer::from_iter(iter));
         ary.try_into_ruby(self, None).expect("Array into Value")
     }

--- a/artichoke-backend/src/convert/bytes.rs
+++ b/artichoke-backend/src/convert/bytes.rs
@@ -2,20 +2,20 @@ use std::convert::TryFrom;
 use std::ffi::CStr;
 use std::slice;
 
-use crate::convert::{Convert, TryConvert};
+use crate::convert::{ConvertMut, TryConvert};
 use crate::sys;
 use crate::types::{Ruby, Rust};
 use crate::value::Value;
 use crate::{Artichoke, ArtichokeError};
 
-impl Convert<Vec<u8>, Value> for Artichoke {
-    fn convert(&self, value: Vec<u8>) -> Value {
-        self.convert(value.as_slice())
+impl ConvertMut<Vec<u8>, Value> for Artichoke {
+    fn convert_mut(&mut self, value: Vec<u8>) -> Value {
+        self.convert_mut(value.as_slice())
     }
 }
 
-impl Convert<&[u8], Value> for Artichoke {
-    fn convert(&self, value: &[u8]) -> Value {
+impl ConvertMut<&[u8], Value> for Artichoke {
+    fn convert_mut(&mut self, value: &[u8]) -> Value {
         let mrb = self.0.borrow().mrb;
         // Ruby strings contain raw bytes, so we can convert from a &[u8] to a
         // `char *` and `size_t`.
@@ -23,7 +23,8 @@ impl Convert<&[u8], Value> for Artichoke {
         let len = value.len();
         // `mrb_str_new` copies the `char *` to the mruby heap so we do not have
         // to worry about the lifetime of the slice passed into this converter.
-        Value::new(self, unsafe { sys::mrb_str_new(mrb, raw, len) })
+        let string = unsafe { sys::mrb_str_new(mrb, raw, len) };
+        Value::new(self, string)
     }
 }
 

--- a/artichoke-backend/src/convert/bytes.rs
+++ b/artichoke-backend/src/convert/bytes.rs
@@ -95,17 +95,17 @@ mod tests {
     #[allow(clippy::needless_pass_by_value)]
     #[quickcheck]
     fn convert_to_vec(v: Vec<u8>) -> bool {
-        let interp = crate::interpreter().expect("init");
-        let value = interp.convert(v.clone());
+        let mut interp = crate::interpreter().expect("init");
+        let value = interp.convert_mut(v.clone());
         value.ruby_type() == Ruby::String
     }
 
     #[allow(clippy::needless_pass_by_value)]
     #[quickcheck]
     fn vec_with_value(v: Vec<u8>) -> bool {
-        let interp = crate::interpreter().expect("init");
+        let mut interp = crate::interpreter().expect("init");
         let mrb = interp.0.borrow().mrb;
-        let value = interp.convert(v.clone());
+        let value = interp.convert_mut(v.clone());
         let inner = value.inner();
         let len = unsafe { sys::mrb_string_value_len(mrb, inner) };
         let len = usize::try_from(len).expect("usize");
@@ -115,8 +115,8 @@ mod tests {
     #[allow(clippy::needless_pass_by_value)]
     #[quickcheck]
     fn roundtrip(v: Vec<u8>) -> bool {
-        let interp = crate::interpreter().expect("init");
-        let value = interp.convert(v.clone());
+        let mut interp = crate::interpreter().expect("init");
+        let value = interp.convert_mut(v.clone());
         let value = value.try_into::<Vec<u8>>().expect("convert");
         value == v
     }

--- a/artichoke-backend/src/convert/fixnum.rs
+++ b/artichoke-backend/src/convert/fixnum.rs
@@ -8,23 +8,20 @@ use crate::{Artichoke, ArtichokeError};
 
 impl Convert<u8, Value> for Artichoke {
     fn convert(&self, value: u8) -> Value {
-        let value = Int::from(value);
-        Value::new(self, unsafe { sys::mrb_sys_fixnum_value(value) })
+        self.convert(Int::from(value))
     }
 }
 
 impl Convert<u16, Value> for Artichoke {
     fn convert(&self, value: u16) -> Value {
-        let value = Int::from(value);
-        Value::new(self, unsafe { sys::mrb_sys_fixnum_value(value) })
+        self.convert(Int::from(value))
     }
 }
 
 #[cfg(not(target_arch = "wasm32"))]
 impl Convert<u32, Value> for Artichoke {
     fn convert(&self, value: u32) -> Value {
-        let value = Int::from(value);
-        Value::new(self, unsafe { sys::mrb_sys_fixnum_value(value) })
+        self.convert(Int::from(value))
     }
 }
 
@@ -35,9 +32,8 @@ impl TryConvert<u32, Value> for Artichoke {
             from: Rust::UnsignedInt,
             to: Ruby::Fixnum,
         })?;
-        Ok(Value::new(self, unsafe {
-            sys::mrb_sys_fixnum_value(value)
-        }))
+        let fixnum = unsafe { sys::mrb_sys_fixnum_value(value) };
+        Ok(Value::new(self, fixnum))
     }
 }
 
@@ -47,37 +43,34 @@ impl TryConvert<u64, Value> for Artichoke {
             from: Rust::UnsignedInt,
             to: Ruby::Fixnum,
         })?;
-        Ok(Value::new(self, unsafe {
-            sys::mrb_sys_fixnum_value(value)
-        }))
+        let fixnum = unsafe { sys::mrb_sys_fixnum_value(value) };
+        Ok(Value::new(self, fixnum))
     }
 }
 
 impl Convert<i8, Value> for Artichoke {
     fn convert(&self, value: i8) -> Value {
-        let value = Int::from(value);
-        Value::new(self, unsafe { sys::mrb_sys_fixnum_value(value) })
+        self.convert(Int::from(value))
     }
 }
 
 impl Convert<i16, Value> for Artichoke {
     fn convert(&self, value: i16) -> Value {
-        let value = Int::from(value);
-        Value::new(self, unsafe { sys::mrb_sys_fixnum_value(value) })
+        self.convert(Int::from(value))
     }
 }
 
 impl Convert<i32, Value> for Artichoke {
     fn convert(&self, value: i32) -> Value {
-        let value = Int::from(value);
-        Value::new(self, unsafe { sys::mrb_sys_fixnum_value(value) })
+        self.convert(Int::from(value))
     }
 }
 
 #[cfg(not(target_arch = "wasm32"))]
 impl Convert<i64, Value> for Artichoke {
     fn convert(&self, value: i64) -> Value {
-        Value::new(self, unsafe { sys::mrb_sys_fixnum_value(value) })
+        let fixnum = unsafe { sys::mrb_sys_fixnum_value(value) };
+        Value::new(self, fixnum)
     }
 }
 
@@ -88,9 +81,8 @@ impl TryConvert<i64, Value> for Artichoke {
             from: Rust::UnsignedInt,
             to: Ruby::Fixnum,
         })?;
-        Ok(Value::new(self, unsafe {
-            sys::mrb_sys_fixnum_value(value)
-        }))
+        let fixnum = unsafe { sys::mrb_sys_fixnum_value(value) };
+        Ok(Value::new(self, fixnum))
     }
 }
 
@@ -111,16 +103,13 @@ impl TryConvert<Value, Int> for Artichoke {
 
 impl TryConvert<Value, usize> for Artichoke {
     fn try_convert(&self, value: Value) -> Result<usize, ArtichokeError> {
-        let value: Int = self
-            .try_convert(value)
-            .map_err(|_| ArtichokeError::ConvertToRust {
+        TryConvert::<_, Int>::try_convert(self, value)
+            .ok()
+            .and_then(|value| usize::try_from(value).ok())
+            .ok_or(ArtichokeError::ConvertToRust {
                 from: Ruby::Fixnum,
                 to: Rust::UnsignedInt,
-            })?;
-        usize::try_from(value).map_err(|_| ArtichokeError::ConvertToRust {
-            from: Ruby::Fixnum,
-            to: Rust::UnsignedInt,
-        })
+            })
     }
 }
 

--- a/artichoke-backend/src/convert/float.rs
+++ b/artichoke-backend/src/convert/float.rs
@@ -1,13 +1,15 @@
-use crate::convert::{Convert, TryConvert};
+use crate::convert::{ConvertMut, TryConvert};
 use crate::sys;
 use crate::types::{Float, Ruby, Rust};
 use crate::value::Value;
 use crate::{Artichoke, ArtichokeError};
 
-impl Convert<Float, Value> for Artichoke {
-    fn convert(&self, value: Float) -> Value {
+// TODO: when ,mruby is gone, float conversion should not allocate.
+impl ConvertMut<Float, Value> for Artichoke {
+    fn convert_mut(&mut self, value: Float) -> Value {
         let mrb = self.0.borrow().mrb;
-        Value::new(self, unsafe { sys::mrb_sys_float_value(mrb, value) })
+        let float = unsafe { sys::mrb_sys_float_value(mrb, value) };
+        Value::new(self, float)
     }
 }
 

--- a/artichoke-backend/src/convert/float.rs
+++ b/artichoke-backend/src/convert/float.rs
@@ -49,15 +49,15 @@ mod tests {
 
     #[quickcheck]
     fn convert_to_float(f: Float) -> bool {
-        let interp = crate::interpreter().expect("init");
-        let value = interp.convert(f);
+        let mut interp = crate::interpreter().expect("init");
+        let value = interp.convert_mut(f);
         value.ruby_type() == Ruby::Float
     }
 
     #[quickcheck]
     fn float_with_value(f: Float) -> bool {
-        let interp = crate::interpreter().expect("init");
-        let value = interp.convert(f);
+        let mut interp = crate::interpreter().expect("init");
+        let value = interp.convert_mut(f);
         let inner = value.inner();
         let cdouble = unsafe { sys::mrb_sys_float_to_cdouble(inner) };
         (cdouble - f).abs() < std::f64::EPSILON
@@ -65,8 +65,8 @@ mod tests {
 
     #[quickcheck]
     fn roundtrip(f: Float) -> bool {
-        let interp = crate::interpreter().expect("init");
-        let value = interp.convert(f);
+        let mut interp = crate::interpreter().expect("init");
+        let value = interp.convert_mut(f);
         let value = value.try_into::<Float>().expect("convert");
         (value - f).abs() < std::f64::EPSILON
     }

--- a/artichoke-backend/src/convert/hash.rs
+++ b/artichoke-backend/src/convert/hash.rs
@@ -109,14 +109,14 @@ mod tests {
 
     #[test]
     fn roundtrip_kv() {
-        let interp = crate::interpreter().expect("init");
+        let mut interp = crate::interpreter().expect("init");
 
         let map = vec![
             (interp.convert(1), interp.convert(2)),
             (interp.convert(7), interp.convert(8)),
         ];
 
-        let value = Convert::<_, Value>::convert(&interp, map);
+        let value = ConvertMut::<_, Value>::convert_mut(&mut interp, map);
         assert_eq!(value.to_s(), b"{1=>2, 7=>8}");
 
         let pairs = value.try_into::<Vec<(Value, Value)>>().expect("convert");

--- a/artichoke-backend/src/convert/hash.rs
+++ b/artichoke-backend/src/convert/hash.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::convert::TryFrom;
 
-use crate::convert::{Convert, RustBackedValue, TryConvert};
+use crate::convert::{ConvertMut, RustBackedValue, TryConvert};
 use crate::extn::core::array;
 use crate::sys;
 use crate::types::{Int, Ruby, Rust};
@@ -11,8 +11,8 @@ use crate::{Artichoke, ArtichokeError};
 // TODO: implement `PartialEq`, `Eq`, and `Hash` on `Value`, see GH-159.
 // TODO: implement `Convert<HashMap<Value, Value>>`, see GH-160.
 
-impl Convert<Vec<(Value, Value)>, Value> for Artichoke {
-    fn convert(&self, value: Vec<(Value, Value)>) -> Value {
+impl ConvertMut<Vec<(Value, Value)>, Value> for Artichoke {
+    fn convert_mut(&mut self, value: Vec<(Value, Value)>) -> Value {
         let mrb = self.0.borrow().mrb;
         let capa = Int::try_from(value.len()).unwrap_or_default();
         let hash = unsafe { sys::mrb_hash_new_capa(mrb, capa) };
@@ -25,43 +25,43 @@ impl Convert<Vec<(Value, Value)>, Value> for Artichoke {
     }
 }
 
-impl Convert<Vec<(Vec<u8>, Vec<Int>)>, Value> for Artichoke {
-    fn convert(&self, value: Vec<(Vec<u8>, Vec<Int>)>) -> Value {
+impl ConvertMut<Vec<(Vec<u8>, Vec<Int>)>, Value> for Artichoke {
+    fn convert_mut(&mut self, value: Vec<(Vec<u8>, Vec<Int>)>) -> Value {
         let mrb = self.0.borrow().mrb;
         let capa = Int::try_from(value.len()).unwrap_or_default();
         let hash = unsafe { sys::mrb_hash_new_capa(mrb, capa) };
         for (key, val) in value {
-            let key = self.convert(key).inner();
-            let val = self.convert(val).inner();
+            let key = self.convert_mut(key).inner();
+            let val = self.convert_mut(val).inner();
             unsafe { sys::mrb_hash_set(mrb, hash, key, val) };
         }
         Value::new(self, hash)
     }
 }
 
-impl Convert<HashMap<Vec<u8>, Vec<u8>>, Value> for Artichoke {
-    fn convert(&self, value: HashMap<Vec<u8>, Vec<u8>>) -> Value {
+impl ConvertMut<HashMap<Vec<u8>, Vec<u8>>, Value> for Artichoke {
+    fn convert_mut(&mut self, value: HashMap<Vec<u8>, Vec<u8>>) -> Value {
         let mrb = self.0.borrow().mrb;
         let capa = Int::try_from(value.len()).unwrap_or_default();
         let hash = unsafe { sys::mrb_hash_new_capa(mrb, capa) };
         for (key, val) in value {
-            let key = self.convert(key).inner();
-            let val = self.convert(val).inner();
+            let key = self.convert_mut(key).inner();
+            let val = self.convert_mut(val).inner();
             unsafe { sys::mrb_hash_set(mrb, hash, key, val) };
         }
         Value::new(self, hash)
     }
 }
 
-impl Convert<Option<HashMap<Vec<u8>, Option<Vec<u8>>>>, Value> for Artichoke {
-    fn convert(&self, value: Option<HashMap<Vec<u8>, Option<Vec<u8>>>>) -> Value {
+impl ConvertMut<Option<HashMap<Vec<u8>, Option<Vec<u8>>>>, Value> for Artichoke {
+    fn convert_mut(&mut self, value: Option<HashMap<Vec<u8>, Option<Vec<u8>>>>) -> Value {
         if let Some(value) = value {
             let mrb = self.0.borrow().mrb;
             let capa = Int::try_from(value.len()).unwrap_or_default();
             let hash = unsafe { sys::mrb_hash_new_capa(mrb, capa) };
             for (key, val) in value {
-                let key = self.convert(key).inner();
-                let val = self.convert(val).inner();
+                let key = self.convert_mut(key).inner();
+                let val = self.convert_mut(val).inner();
                 unsafe { sys::mrb_hash_set(mrb, hash, key, val) };
             }
             Value::new(self, hash)

--- a/artichoke-backend/src/convert/nilable.rs
+++ b/artichoke-backend/src/convert/nilable.rs
@@ -1,7 +1,7 @@
 //! Converters for nilable primitive Ruby types. Excludes collection types
 //! Array and Hash.
 
-use crate::convert::{Convert, TryConvert};
+use crate::convert::{Convert, ConvertMut, TryConvert};
 use crate::sys;
 use crate::types::{Int, Ruby};
 use crate::value::Value;
@@ -27,30 +27,32 @@ impl Convert<Option<Int>, Value> for Artichoke {
     }
 }
 
-impl Convert<Option<Vec<u8>>, Value> for Artichoke {
-    fn convert(&self, value: Option<Vec<u8>>) -> Value {
+impl ConvertMut<Option<Vec<u8>>, Value> for Artichoke {
+    fn convert_mut(&mut self, value: Option<Vec<u8>>) -> Value {
+        self.convert_mut(value.as_deref())
+    }
+}
+
+impl ConvertMut<Option<&[u8]>, Value> for Artichoke {
+    fn convert_mut(&mut self, value: Option<&[u8]>) -> Value {
         if let Some(value) = value {
-            self.convert(value)
+            self.convert_mut(value)
         } else {
             Value::new(self, unsafe { sys::mrb_sys_nil_value() })
         }
     }
 }
 
-impl Convert<Option<&[u8]>, Value> for Artichoke {
-    fn convert(&self, value: Option<&[u8]>) -> Value {
-        if let Some(value) = value {
-            self.convert(value)
-        } else {
-            Value::new(self, unsafe { sys::mrb_sys_nil_value() })
-        }
+impl ConvertMut<Option<String>, Value> for Artichoke {
+    fn convert_mut(&mut self, value: Option<String>) -> Value {
+        self.convert_mut(value.as_deref())
     }
 }
 
-impl Convert<Option<&str>, Value> for Artichoke {
-    fn convert(&self, value: Option<&str>) -> Value {
+impl ConvertMut<Option<&str>, Value> for Artichoke {
+    fn convert_mut(&mut self, value: Option<&str>) -> Value {
         if let Some(value) = value {
-            self.convert(value)
+            self.convert_mut(value)
         } else {
             Value::new(self, unsafe { sys::mrb_sys_nil_value() })
         }

--- a/artichoke-backend/src/convert/object.rs
+++ b/artichoke-backend/src/convert/object.rs
@@ -160,12 +160,12 @@ mod tests {
             mrb: *mut sys::mrb_state,
             slf: sys::mrb_value,
         ) -> sys::mrb_value {
-            let interp = unwrap_interpreter!(mrb);
+            let mut interp = unwrap_interpreter!(mrb);
 
             let value = Value::new(&interp, slf);
             if let Ok(container) = Self::try_from_ruby(&interp, &value) {
                 let borrow = container.borrow();
-                interp.convert(borrow.inner.as_bytes()).inner()
+                interp.convert_mut(borrow.inner.as_bytes()).inner()
             } else {
                 interp.convert(None::<Value>).inner()
             }
@@ -219,7 +219,7 @@ mod tests {
 
     #[test]
     fn convert_obj_not_data() {
-        let interp = crate::interpreter().expect("init");
+        let mut interp = crate::interpreter().expect("init");
         let spec =
             class::Spec::new("Container", None, Some(def::rust_data_free::<Container>)).unwrap();
         class::Builder::for_spec(&interp, &spec)
@@ -236,7 +236,7 @@ mod tests {
             .unwrap();
         interp.0.borrow_mut().def_class::<Box<Other>>(spec);
 
-        let value = interp.convert("string");
+        let value = interp.convert_mut("string");
         let class = value.funcall::<Value>("class", &[], None).expect("funcall");
         assert_eq!(class.to_s(), b"String");
         let data = unsafe { Container::try_from_ruby(&interp, &value) };

--- a/artichoke-backend/src/convert/string.rs
+++ b/artichoke-backend/src/convert/string.rs
@@ -70,9 +70,9 @@ mod tests {
     #[allow(clippy::needless_pass_by_value)]
     #[quickcheck]
     fn convert_to_string(s: String) -> bool {
-        let interp = crate::interpreter().expect("init");
+        let mut interp = crate::interpreter().expect("init");
         let mrb = interp.0.borrow().mrb;
-        let value = interp.convert(s.clone());
+        let value = interp.convert_mut(s.clone());
         let ptr = unsafe { sys::mrb_string_value_ptr(mrb, value.inner()) };
         let len = unsafe { sys::mrb_string_value_len(mrb, value.inner()) };
         let string =
@@ -83,16 +83,16 @@ mod tests {
     #[allow(clippy::needless_pass_by_value)]
     #[quickcheck]
     fn string_with_value(s: String) -> bool {
-        let interp = crate::interpreter().expect("init");
-        let value = interp.convert(s.clone());
+        let mut interp = crate::interpreter().expect("init");
+        let value = interp.convert_mut(s.clone());
         value.to_s() == s.as_bytes()
     }
 
     #[allow(clippy::needless_pass_by_value)]
     #[quickcheck]
     fn roundtrip(s: String) -> bool {
-        let interp = crate::interpreter().expect("init");
-        let value = interp.convert(s.clone());
+        let mut interp = crate::interpreter().expect("init");
+        let value = interp.convert_mut(s.clone());
         let value = value.try_into::<String>().expect("convert");
         value == s
     }

--- a/artichoke-backend/src/convert/string.rs
+++ b/artichoke-backend/src/convert/string.rs
@@ -1,23 +1,23 @@
 use std::str;
 
-use crate::convert::{Convert, TryConvert};
-use crate::types::{Ruby, Rust};
+use crate::convert::{ConvertMut, TryConvert};
+use crate::types::Rust;
 use crate::value::Value;
 use crate::{Artichoke, ArtichokeError};
 
-impl Convert<String, Value> for Artichoke {
-    fn convert(&self, value: String) -> Value {
+impl ConvertMut<String, Value> for Artichoke {
+    fn convert_mut(&mut self, value: String) -> Value {
         // Ruby `String`s are just bytes, so get a pointer to the underlying
         // `&[u8]` infallibly and convert that to a `Value`.
-        self.convert(value.as_bytes())
+        self.convert_mut(value.as_bytes())
     }
 }
 
-impl Convert<&str, Value> for Artichoke {
-    fn convert(&self, value: &str) -> Value {
+impl ConvertMut<&str, Value> for Artichoke {
+    fn convert_mut(&mut self, value: &str) -> Value {
         // Ruby `String`s are just bytes, so get a pointer to the underlying
         // `&[u8]` infallibly and convert that to a `Value`.
-        self.convert(value.as_bytes())
+        self.convert_mut(value.as_bytes())
     }
 }
 
@@ -30,18 +30,18 @@ impl TryConvert<Value, String> for Artichoke {
 impl<'a> TryConvert<Value, &'a str> for Artichoke {
     fn try_convert(&self, value: Value) -> Result<&'a str, ArtichokeError> {
         let type_tag = value.ruby_type();
-        let bytes = self
-            .try_convert(value)
-            .map_err(|_| ArtichokeError::ConvertToRust {
+        self.try_convert(value)
+            .ok()
+            .and_then(|bytes| {
+                // This converter requires that the bytes be valid UTF-8 data.
+                // If the `Value` contains binary data, use the `Vec<u8>` or
+                // `&[u8]` converter.
+                str::from_utf8(bytes).ok()
+            })
+            .ok_or(ArtichokeError::ConvertToRust {
                 from: type_tag,
                 to: Rust::String,
-            })?;
-        // This converter requires that the bytes be valid UTF-8 data. If the
-        // `mrb_value` contains binary data, use the `Vec<u8>` converter.
-        str::from_utf8(bytes).map_err(|_| ArtichokeError::ConvertToRust {
-            from: Ruby::String,
-            to: Rust::String,
-        })
+            })
     }
 }
 

--- a/artichoke-backend/src/extn/core/env/mod.rs
+++ b/artichoke-backend/src/extn/core/env/mod.rs
@@ -33,7 +33,11 @@ pub fn initialize(interp: &Artichoke, into: Option<sys::mrb_value>) -> Result<Va
     Ok(result)
 }
 
-pub fn element_reference(interp: &Artichoke, obj: Value, name: &Value) -> Result<Value, Exception> {
+pub fn element_reference(
+    interp: &mut Artichoke,
+    obj: Value,
+    name: &Value,
+) -> Result<Value, Exception> {
     let obj = unsafe { Environ::try_from_ruby(interp, &obj) }
         .map_err(|_| Fatal::new(interp, "Unable to extract Rust ENV from Ruby ENV receiver"))?;
     let ruby_type = name.pretty_name();
@@ -49,11 +53,11 @@ pub fn element_reference(interp: &Artichoke, obj: Value, name: &Value) -> Result
     };
     let env = obj.borrow();
     let result = env.0.get(interp, name)?;
-    Ok(interp.convert(result.as_ref().map(Cow::as_ref)))
+    Ok(interp.convert_mut(result.as_ref().map(Cow::as_ref)))
 }
 
 pub fn element_assignment(
-    interp: &Artichoke,
+    interp: &mut Artichoke,
     obj: Value,
     name: &Value,
     value: Value,
@@ -84,12 +88,12 @@ pub fn element_assignment(
     };
     obj.borrow_mut().0.put(interp, name, value)?;
     // Return original object, even if we converted it to a `String`.
-    Ok(interp.convert(value))
+    Ok(interp.convert_mut(value))
 }
 
-pub fn to_h(interp: &Artichoke, obj: Value) -> Result<Value, Exception> {
+pub fn to_h(interp: &mut Artichoke, obj: Value) -> Result<Value, Exception> {
     let obj = unsafe { Environ::try_from_ruby(interp, &obj) }
         .map_err(|_| Fatal::new(interp, "Unable to extract Rust ENV from Ruby ENV receiver"))?;
     let result = obj.borrow().0.as_map(interp)?;
-    Ok(interp.convert(result))
+    Ok(interp.convert_mut(result))
 }

--- a/artichoke-backend/src/extn/core/env/mruby.rs
+++ b/artichoke-backend/src/extn/core/env/mruby.rs
@@ -55,10 +55,10 @@ unsafe extern "C" fn artichoke_env_element_reference(
     slf: sys::mrb_value,
 ) -> sys::mrb_value {
     let name = mrb_get_args!(mrb, required = 1);
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let obj = Value::new(&interp, slf);
     let name = Value::new(&interp, name);
-    let result = env::element_reference(&interp, obj, &name);
+    let result = env::element_reference(&mut interp, obj, &name);
     match result {
         Ok(value) => value.inner(),
         Err(exception) => exception::raise(interp, exception),
@@ -71,11 +71,11 @@ unsafe extern "C" fn artichoke_env_element_assignment(
     slf: sys::mrb_value,
 ) -> sys::mrb_value {
     let (name, value) = mrb_get_args!(mrb, required = 2);
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let obj = Value::new(&interp, slf);
     let name = Value::new(&interp, name);
     let value = Value::new(&interp, value);
-    let result = env::element_assignment(&interp, obj, &name, value);
+    let result = env::element_assignment(&mut interp, obj, &name, value);
     match result {
         Ok(value) => value.inner(),
         Err(exception) => exception::raise(interp, exception),
@@ -88,9 +88,9 @@ unsafe extern "C" fn artichoke_env_to_h(
     slf: sys::mrb_value,
 ) -> sys::mrb_value {
     mrb_get_args!(mrb, none);
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let obj = Value::new(&interp, slf);
-    let result = env::to_h(&interp, obj);
+    let result = env::to_h(&mut interp, obj);
     match result {
         Ok(value) => value.inner(),
         Err(exception) => exception::raise(interp, exception),

--- a/artichoke-backend/src/extn/core/exception/mod.rs
+++ b/artichoke-backend/src/extn/core/exception/mod.rs
@@ -352,10 +352,11 @@ macro_rules! ruby_exception_impl {
                 None
             }
 
-            fn as_mrb_value(&self, interp: &Artichoke) -> Option<sys::mrb_value> {
+            fn as_mrb_value(&self, interp: &mut Artichoke) -> Option<sys::mrb_value> {
+                let message = interp.convert_mut(self.message());
                 let borrow = interp.0.borrow();
                 let spec = borrow.class_spec::<Self>()?;
-                let value = spec.new_instance(interp, &[interp.convert(self.message())])?;
+                let value = spec.new_instance(interp, &[message])?;
                 Some(value.inner())
             }
         }

--- a/artichoke-backend/src/extn/core/integer/div.rs
+++ b/artichoke-backend/src/extn/core/integer/div.rs
@@ -2,7 +2,7 @@ use crate::extn::core::float::Float;
 use crate::extn::prelude::*;
 use crate::types;
 
-pub fn method(interp: &Artichoke, value: Value, other: Value) -> Result<Value, Exception> {
+pub fn method(interp: &mut Artichoke, value: Value, other: Value) -> Result<Value, Exception> {
     let x = value.try_into::<Int>().map_err(|_| {
         Fatal::new(
             interp,
@@ -22,13 +22,13 @@ pub fn method(interp: &Artichoke, value: Value, other: Value) -> Result<Value, E
     } else if let Ok(y) = other.try_into::<types::Float>() {
         if y == 0.0 {
             match x {
-                x if x > 0 => Ok(interp.convert(Float::INFINITY)),
-                x if x < 0 => Ok(interp.convert(Float::NEG_INFINITY)),
-                _ => Ok(interp.convert(Float::NAN)),
+                x if x > 0 => Ok(interp.convert_mut(Float::INFINITY)),
+                x if x < 0 => Ok(interp.convert_mut(Float::NEG_INFINITY)),
+                _ => Ok(interp.convert_mut(Float::NAN)),
             }
         } else {
             #[allow(clippy::cast_precision_loss)]
-            Ok(interp.convert(x as types::Float / y))
+            Ok(interp.convert_mut(x as types::Float / y))
         }
     } else {
         Err(Exception::from(TypeError::new(

--- a/artichoke-backend/src/extn/core/matchdata/captures.rs
+++ b/artichoke-backend/src/extn/core/matchdata/captures.rs
@@ -3,7 +3,7 @@
 use crate::extn::core::matchdata::MatchData;
 use crate::extn::prelude::*;
 
-pub fn method(interp: &Artichoke, value: &Value) -> Result<Value, Exception> {
+pub fn method(interp: &mut Artichoke, value: &Value) -> Result<Value, Exception> {
     let data = unsafe { MatchData::try_from_ruby(interp, value) }.map_err(|_| {
         Fatal::new(
             interp,
@@ -13,9 +13,8 @@ pub fn method(interp: &Artichoke, value: &Value) -> Result<Value, Exception> {
     let borrow = data.borrow();
     let haystack = &borrow.string[borrow.region.start..borrow.region.end];
     let captures = borrow.regexp.inner().captures(interp, haystack)?;
-    if let Some(mut captures) = captures {
-        captures.remove(0);
-        Ok(interp.convert(captures))
+    if let Some(captures) = captures {
+        Ok(interp.convert_mut(&captures[1..]))
     } else {
         Ok(interp.convert(None::<Value>))
     }

--- a/artichoke-backend/src/extn/core/matchdata/mod.rs
+++ b/artichoke-backend/src/extn/core/matchdata/mod.rs
@@ -115,9 +115,9 @@ impl MatchData {
 
     unsafe extern "C" fn captures(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
         mrb_get_args!(mrb, none);
-        let interp = unwrap_interpreter!(mrb);
+        let mut interp = unwrap_interpreter!(mrb);
         let value = Value::new(&interp, slf);
-        let result = captures::method(&interp, &value);
+        let result = captures::method(&mut interp, &value);
         match result {
             Ok(result) => result.inner(),
             Err(exception) => exception::raise(interp, exception),
@@ -129,7 +129,7 @@ impl MatchData {
         slf: sys::mrb_value,
     ) -> sys::mrb_value {
         let (elem, len) = mrb_get_args!(mrb, required = 1, optional = 1);
-        let interp = unwrap_interpreter!(mrb);
+        let mut interp = unwrap_interpreter!(mrb);
         let value = Value::new(&interp, slf);
         let result = element_reference::Args::num_captures(&interp, &value)
             .and_then(|num_captures| {
@@ -140,7 +140,7 @@ impl MatchData {
                     num_captures,
                 )
             })
-            .and_then(|args| element_reference::method(&interp, args, &value));
+            .and_then(|args| element_reference::method(&mut interp, args, &value));
         match result {
             Ok(result) => result.inner(),
             Err(exception) => exception::raise(interp, exception),
@@ -176,9 +176,9 @@ impl MatchData {
         slf: sys::mrb_value,
     ) -> sys::mrb_value {
         mrb_get_args!(mrb, none);
-        let interp = unwrap_interpreter!(mrb);
+        let mut interp = unwrap_interpreter!(mrb);
         let value = Value::new(&interp, slf);
-        let result = named_captures::method(&interp, &value);
+        let result = named_captures::method(&mut interp, &value);
         match result {
             Ok(result) => result.inner(),
             Err(exception) => exception::raise(interp, exception),
@@ -187,9 +187,9 @@ impl MatchData {
 
     unsafe extern "C" fn names(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
         mrb_get_args!(mrb, none);
-        let interp = unwrap_interpreter!(mrb);
+        let mut interp = unwrap_interpreter!(mrb);
         let value = Value::new(&interp, slf);
-        let result = names::method(&interp, &value);
+        let result = names::method(&mut interp, &value);
         match result {
             Ok(result) => result.inner(),
             Err(exception) => exception::raise(interp, exception),
@@ -198,10 +198,10 @@ impl MatchData {
 
     unsafe extern "C" fn offset(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
         let elem = mrb_get_args!(mrb, required = 1);
-        let interp = unwrap_interpreter!(mrb);
+        let mut interp = unwrap_interpreter!(mrb);
         let value = Value::new(&interp, slf);
         let result = offset::Args::extract(&interp, Value::new(&interp, elem))
-            .and_then(|args| offset::method(&interp, args, &value));
+            .and_then(|args| offset::method(&mut interp, args, &value));
         match result {
             Ok(result) => result.inner(),
             Err(exception) => exception::raise(interp, exception),
@@ -213,9 +213,9 @@ impl MatchData {
         slf: sys::mrb_value,
     ) -> sys::mrb_value {
         mrb_get_args!(mrb, none);
-        let interp = unwrap_interpreter!(mrb);
+        let mut interp = unwrap_interpreter!(mrb);
         let value = Value::new(&interp, slf);
-        let result = post_match::method(&interp, &value);
+        let result = post_match::method(&mut interp, &value);
         match result {
             Ok(result) => result.inner(),
             Err(exception) => exception::raise(interp, exception),
@@ -227,9 +227,9 @@ impl MatchData {
         slf: sys::mrb_value,
     ) -> sys::mrb_value {
         mrb_get_args!(mrb, none);
-        let interp = unwrap_interpreter!(mrb);
+        let mut interp = unwrap_interpreter!(mrb);
         let value = Value::new(&interp, slf);
-        let result = pre_match::method(&interp, &value);
+        let result = pre_match::method(&mut interp, &value);
         match result {
             Ok(result) => result.inner(),
             Err(exception) => exception::raise(interp, exception),
@@ -249,9 +249,9 @@ impl MatchData {
 
     unsafe extern "C" fn string(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
         mrb_get_args!(mrb, none);
-        let interp = unwrap_interpreter!(mrb);
+        let mut interp = unwrap_interpreter!(mrb);
         let value = Value::new(&interp, slf);
-        let result = string::method(&interp, &value);
+        let result = string::method(&mut interp, &value);
         match result {
             Ok(result) => result.inner(),
             Err(exception) => exception::raise(interp, exception),
@@ -261,9 +261,9 @@ impl MatchData {
     #[allow(clippy::wrong_self_convention)]
     unsafe extern "C" fn to_a(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
         mrb_get_args!(mrb, none);
-        let interp = unwrap_interpreter!(mrb);
+        let mut interp = unwrap_interpreter!(mrb);
         let value = Value::new(&interp, slf);
-        let result = to_a::method(&interp, &value);
+        let result = to_a::method(&mut interp, &value);
         match result {
             Ok(result) => result.inner(),
             Err(exception) => exception::raise(interp, exception),
@@ -273,9 +273,9 @@ impl MatchData {
     #[allow(clippy::wrong_self_convention)]
     unsafe extern "C" fn to_s(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
         mrb_get_args!(mrb, none);
-        let interp = unwrap_interpreter!(mrb);
+        let mut interp = unwrap_interpreter!(mrb);
         let value = Value::new(&interp, slf);
-        let result = to_s::method(&interp, &value);
+        let result = to_s::method(&mut interp, &value);
         match result {
             Ok(result) => result.inner(),
             Err(exception) => exception::raise(interp, exception),

--- a/artichoke-backend/src/extn/core/matchdata/named_captures.rs
+++ b/artichoke-backend/src/extn/core/matchdata/named_captures.rs
@@ -3,7 +3,7 @@
 use crate::extn::core::matchdata::MatchData;
 use crate::extn::prelude::*;
 
-pub fn method(interp: &Artichoke, value: &Value) -> Result<Value, Exception> {
+pub fn method(interp: &mut Artichoke, value: &Value) -> Result<Value, Exception> {
     let data = unsafe { MatchData::try_from_ruby(interp, value) }.map_err(|_| {
         Fatal::new(
             interp,
@@ -16,5 +16,5 @@ pub fn method(interp: &Artichoke, value: &Value) -> Result<Value, Exception> {
         .regexp
         .inner()
         .named_captures_for_haystack(interp, haystack)?;
-    Ok(interp.convert(named_captures))
+    Ok(interp.convert_mut(named_captures))
 }

--- a/artichoke-backend/src/extn/core/matchdata/names.rs
+++ b/artichoke-backend/src/extn/core/matchdata/names.rs
@@ -3,7 +3,7 @@
 use crate::extn::core::matchdata::MatchData;
 use crate::extn::prelude::*;
 
-pub fn method(interp: &Artichoke, value: &Value) -> Result<Value, Exception> {
+pub fn method(interp: &mut Artichoke, value: &Value) -> Result<Value, Exception> {
     let data = unsafe { MatchData::try_from_ruby(interp, value) }.map_err(|_| {
         Fatal::new(
             interp,

--- a/artichoke-backend/src/extn/core/matchdata/offset.rs
+++ b/artichoke-backend/src/extn/core/matchdata/offset.rs
@@ -24,7 +24,7 @@ impl<'a> Args<'a> {
     }
 }
 
-pub fn method(interp: &Artichoke, args: Args, value: &Value) -> Result<Value, Exception> {
+pub fn method(interp: &mut Artichoke, args: Args, value: &Value) -> Result<Value, Exception> {
     let data = unsafe { MatchData::try_from_ruby(interp, value) }.map_err(|_| {
         Fatal::new(
             interp,
@@ -44,14 +44,14 @@ pub fn method(interp: &Artichoke, args: Args, value: &Value) -> Result<Value, Ex
                 if let Some(idx) = captures_len.checked_sub(idx) {
                     idx
                 } else {
-                    return Ok(interp.convert([None::<Value>, None::<Value>].as_ref()));
+                    return Ok(interp.convert_mut(&[None::<Value>, None::<Value>][..]));
                 }
             } else {
                 let idx = usize::try_from(index).map_err(|_| {
                     Fatal::new(interp, "Expected positive position to convert to usize")
                 })?;
                 if idx > captures_len {
-                    return Ok(interp.convert([None::<Value>, None::<Value>].as_ref()));
+                    return Ok(interp.convert_mut(&[None::<Value>, None::<Value>][..]));
                 }
                 idx
             }
@@ -64,12 +64,12 @@ pub fn method(interp: &Artichoke, args: Args, value: &Value) -> Result<Value, Ex
             let indexes = if let Some(indexes) = indexes {
                 indexes
             } else {
-                return Ok(interp.convert([None::<Value>, None::<Value>].as_ref()));
+                return Ok(interp.convert_mut(&[None::<Value>, None::<Value>][..]));
             };
             if let Some(Ok(index)) = indexes.last().copied().map(usize::try_from) {
                 index
             } else {
-                return Ok(interp.convert([None::<Value>, None::<Value>].as_ref()));
+                return Ok(interp.convert_mut(&[None::<Value>, None::<Value>][..]));
             }
         }
     };
@@ -92,8 +92,8 @@ pub fn method(interp: &Artichoke, args: Args, value: &Value) -> Result<Value, Ex
         let end = Int::try_from(end)
             .map_err(|_| Fatal::new(interp, "MatchData end pos does not fit in Integer"))?;
 
-        Ok(interp.convert([begin, end].as_ref()))
+        Ok(interp.convert_mut(&[begin, end][..]))
     } else {
-        Ok(interp.convert([None::<Value>, None::<Value>].as_ref()))
+        Ok(interp.convert_mut(&[None::<Value>, None::<Value>][..]))
     }
 }

--- a/artichoke-backend/src/extn/core/matchdata/post_match.rs
+++ b/artichoke-backend/src/extn/core/matchdata/post_match.rs
@@ -3,7 +3,7 @@
 use crate::extn::core::matchdata::MatchData;
 use crate::extn::prelude::*;
 
-pub fn method(interp: &Artichoke, value: &Value) -> Result<Value, Exception> {
+pub fn method(interp: &mut Artichoke, value: &Value) -> Result<Value, Exception> {
     let data = unsafe { MatchData::try_from_ruby(interp, value) }.map_err(|_| {
         Fatal::new(
             interp,
@@ -12,5 +12,5 @@ pub fn method(interp: &Artichoke, value: &Value) -> Result<Value, Exception> {
     })?;
     let borrow = data.borrow();
     let post_match = &borrow.string[borrow.region.end..];
-    Ok(interp.convert(post_match))
+    Ok(interp.convert_mut(post_match))
 }

--- a/artichoke-backend/src/extn/core/matchdata/pre_match.rs
+++ b/artichoke-backend/src/extn/core/matchdata/pre_match.rs
@@ -3,7 +3,7 @@
 use crate::extn::core::matchdata::MatchData;
 use crate::extn::prelude::*;
 
-pub fn method(interp: &Artichoke, value: &Value) -> Result<Value, Exception> {
+pub fn method(interp: &mut Artichoke, value: &Value) -> Result<Value, Exception> {
     let data = unsafe { MatchData::try_from_ruby(interp, value) }.map_err(|_| {
         Fatal::new(
             interp,
@@ -12,5 +12,5 @@ pub fn method(interp: &Artichoke, value: &Value) -> Result<Value, Exception> {
     })?;
     let borrow = data.borrow();
     let pre_match = &borrow.string[0..borrow.region.start];
-    Ok(interp.convert(pre_match))
+    Ok(interp.convert_mut(pre_match))
 }

--- a/artichoke-backend/src/extn/core/matchdata/string.rs
+++ b/artichoke-backend/src/extn/core/matchdata/string.rs
@@ -3,14 +3,14 @@
 use crate::extn::core::matchdata::MatchData;
 use crate::extn::prelude::*;
 
-pub fn method(interp: &Artichoke, value: &Value) -> Result<Value, Exception> {
+pub fn method(interp: &mut Artichoke, value: &Value) -> Result<Value, Exception> {
     let data = unsafe { MatchData::try_from_ruby(interp, value) }.map_err(|_| {
         Fatal::new(
             interp,
             "Unable to extract Rust MatchData from Ruby MatchData receiver",
         )
     })?;
-    let mut result = interp.convert(data.borrow().string.as_slice());
+    let mut result = interp.convert_mut(data.borrow().string.as_slice());
     result
         .freeze()
         .map_err(|_| Fatal::new(interp, "Unable to freeze MatchData#string result"))?;

--- a/artichoke-backend/src/extn/core/matchdata/to_a.rs
+++ b/artichoke-backend/src/extn/core/matchdata/to_a.rs
@@ -3,7 +3,7 @@
 use crate::extn::core::matchdata::MatchData;
 use crate::extn::prelude::*;
 
-pub fn method(interp: &Artichoke, value: &Value) -> Result<Value, Exception> {
+pub fn method(interp: &mut Artichoke, value: &Value) -> Result<Value, Exception> {
     let data = unsafe { MatchData::try_from_ruby(interp, value) }.map_err(|_| {
         Fatal::new(
             interp,
@@ -13,7 +13,7 @@ pub fn method(interp: &Artichoke, value: &Value) -> Result<Value, Exception> {
     let borrow = data.borrow();
     let haystack = &borrow.string[borrow.region.start..borrow.region.end];
     if let Some(captures) = borrow.regexp.inner().captures(interp, haystack)? {
-        Ok(interp.convert(captures))
+        Ok(interp.convert_mut(captures))
     } else {
         Ok(interp.convert(None::<Value>))
     }

--- a/artichoke-backend/src/extn/core/matchdata/to_s.rs
+++ b/artichoke-backend/src/extn/core/matchdata/to_s.rs
@@ -3,7 +3,7 @@
 use crate::extn::core::matchdata::MatchData;
 use crate::extn::prelude::*;
 
-pub fn method(interp: &Artichoke, value: &Value) -> Result<Value, Exception> {
+pub fn method(interp: &mut Artichoke, value: &Value) -> Result<Value, Exception> {
     let data = unsafe { MatchData::try_from_ruby(interp, value) }.map_err(|_| {
         Fatal::new(
             interp,
@@ -12,5 +12,6 @@ pub fn method(interp: &Artichoke, value: &Value) -> Result<Value, Exception> {
     })?;
     let borrow = data.borrow();
     let haystack = &borrow.string[borrow.region.start..borrow.region.end];
-    Ok(interp.convert(borrow.regexp.inner().capture0(interp, haystack)?))
+    let fullcapture = borrow.regexp.inner().capture0(interp, haystack)?;
+    Ok(interp.convert_mut(fullcapture))
 }

--- a/artichoke-backend/src/extn/core/random/mod.rs
+++ b/artichoke-backend/src/extn/core/random/mod.rs
@@ -88,7 +88,7 @@ pub fn bytes(interp: &mut Artichoke, rand: Value, size: Value) -> Result<Value, 
         let mut buf = vec![0; size];
         let mut borrow = rand.borrow_mut();
         borrow.inner_mut().bytes(interp, buf.as_mut_slice());
-        Ok(interp.convert(buf))
+        Ok(interp.convert_mut(buf))
     } else {
         Err(Exception::from(ArgumentError::new(
             interp,
@@ -131,12 +131,12 @@ pub fn rand(interp: &mut Artichoke, rand: Value, max: Option<Value>) -> Result<V
         Max::Float(max) if max == 0.0 => {
             let mut borrow = rand.borrow_mut();
             let number = borrow.inner_mut().rand_float(interp, None);
-            Ok(interp.convert(number))
+            Ok(interp.convert_mut(number))
         }
         Max::Float(max) => {
             let mut borrow = rand.borrow_mut();
             let number = borrow.inner_mut().rand_float(interp, Some(max));
-            Ok(interp.convert(number))
+            Ok(interp.convert_mut(number))
         }
         Max::Int(max) if max < 1 => Err(Exception::from(ArgumentError::new(
             interp,
@@ -150,7 +150,7 @@ pub fn rand(interp: &mut Artichoke, rand: Value, max: Option<Value>) -> Result<V
         Max::None => {
             let mut borrow = rand.borrow_mut();
             let number = borrow.inner_mut().rand_float(interp, None);
-            Ok(interp.convert(number))
+            Ok(interp.convert_mut(number))
         }
     }
 }
@@ -191,12 +191,12 @@ pub fn srand(interp: &Artichoke, number: Option<Value>) -> Result<Value, Excepti
     Ok(interp.convert(old_seed as Int))
 }
 
-pub fn urandom(interp: &Artichoke, size: Value) -> Result<Value, Exception> {
+pub fn urandom(interp: &mut Artichoke, size: Value) -> Result<Value, Exception> {
     let size = size.implicitly_convert_to_int()?;
     let size = usize::try_from(size)
         .map_err(|_| ArgumentError::new(interp, "negative string size (or size too big)"))?;
     let mut bytes = vec![0; size];
     let mut rng = rand::thread_rng();
     rng.fill_bytes(bytes.as_mut_slice());
-    Ok(interp.convert(bytes))
+    Ok(interp.convert_mut(bytes))
 }

--- a/artichoke-backend/src/extn/core/random/mruby.rs
+++ b/artichoke-backend/src/extn/core/random/mruby.rs
@@ -169,9 +169,9 @@ unsafe extern "C" fn artichoke_random_self_urandom(
     _slf: sys::mrb_value,
 ) -> sys::mrb_value {
     let size = mrb_get_args!(mrb, required = 1);
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let size = Value::new(&interp, size);
-    let result = random::urandom(&interp, size);
+    let result = random::urandom(&mut interp, size);
     match result {
         Ok(value) => value.inner(),
         Err(exception) => exception::raise(interp, exception),

--- a/artichoke-backend/src/extn/core/regexp/backend/onig.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/onig.rs
@@ -209,13 +209,13 @@ impl RegexpType for Onig {
         if let Some(captures) = self.regex.captures(pattern) {
             let globals_to_set = cmp::max(interp.0.borrow().active_regexp_globals, captures.len());
             let sym = interp.intern_symbol(regexp::LAST_MATCHED_STRING);
-            let value = interp.convert(captures.at(0));
+            let value = interp.convert_mut(captures.at(0));
             unsafe {
                 sys::mrb_gv_set(mrb, sym, value.inner());
             }
             for group in 1..=globals_to_set {
                 let sym = interp.intern_symbol(regexp::nth_match_group(group));
-                let value = interp.convert(captures.at(group));
+                let value = interp.convert_mut(captures.at(group));
                 unsafe {
                     sys::mrb_gv_set(mrb, sym, value.inner());
                 }
@@ -223,13 +223,13 @@ impl RegexpType for Onig {
             interp.0.borrow_mut().active_regexp_globals = captures.len();
 
             if let Some(match_pos) = captures.pos(0) {
-                let pre_match = &pattern[..match_pos.0];
-                let post_match = &pattern[match_pos.1..];
+                let pre_match = interp.convert_mut(&pattern[..match_pos.0]);
+                let post_match = interp.convert_mut(&pattern[match_pos.1..]);
                 let pre_match_sym = interp.intern_symbol(regexp::STRING_LEFT_OF_MATCH);
                 let post_match_sym = interp.intern_symbol(regexp::STRING_RIGHT_OF_MATCH);
                 unsafe {
-                    sys::mrb_gv_set(mrb, pre_match_sym, interp.convert(pre_match).inner());
-                    sys::mrb_gv_set(mrb, post_match_sym, interp.convert(post_match).inner());
+                    sys::mrb_gv_set(mrb, pre_match_sym, pre_match.inner());
+                    sys::mrb_gv_set(mrb, post_match_sym, post_match.inner());
                 }
             }
             let matchdata = MatchData::new(
@@ -334,13 +334,13 @@ impl RegexpType for Onig {
         if let Some(captures) = self.regex.captures(match_target) {
             let globals_to_set = cmp::max(interp.0.borrow().active_regexp_globals, captures.len());
             let sym = interp.intern_symbol(regexp::LAST_MATCHED_STRING);
-            let value = interp.convert(captures.at(0));
+            let value = interp.convert_mut(captures.at(0));
             unsafe {
                 sys::mrb_gv_set(mrb, sym, value.inner());
             }
             for group in 1..=globals_to_set {
                 let sym = interp.intern_symbol(regexp::nth_match_group(group));
-                let value = interp.convert(captures.at(group));
+                let value = interp.convert_mut(captures.at(group));
                 unsafe {
                     sys::mrb_gv_set(mrb, sym, value.inner());
                 }
@@ -354,13 +354,13 @@ impl RegexpType for Onig {
                 pattern.len(),
             );
             if let Some(match_pos) = captures.pos(0) {
-                let pre_match = &match_target[..match_pos.0];
-                let post_match = &match_target[match_pos.1..];
+                let pre_match = interp.convert_mut(&match_target[..match_pos.0]);
+                let post_match = interp.convert_mut(&match_target[match_pos.1..]);
                 let pre_match_sym = interp.intern_symbol(regexp::STRING_LEFT_OF_MATCH);
                 let post_match_sym = interp.intern_symbol(regexp::STRING_RIGHT_OF_MATCH);
                 unsafe {
-                    sys::mrb_gv_set(mrb, pre_match_sym, interp.convert(pre_match).inner());
-                    sys::mrb_gv_set(mrb, post_match_sym, interp.convert(post_match).inner());
+                    sys::mrb_gv_set(mrb, pre_match_sym, pre_match.inner());
+                    sys::mrb_gv_set(mrb, post_match_sym, post_match.inner());
                 }
                 matchdata.set_region(byte_offset + match_pos.0, byte_offset + match_pos.1);
             }
@@ -409,13 +409,13 @@ impl RegexpType for Onig {
         if let Some(captures) = self.regex.captures(pattern) {
             let globals_to_set = cmp::max(interp.0.borrow().active_regexp_globals, captures.len());
             let sym = interp.intern_symbol(regexp::LAST_MATCHED_STRING);
-            let value = interp.convert(captures.at(0));
+            let value = interp.convert_mut(captures.at(0));
             unsafe {
                 sys::mrb_gv_set(mrb, sym, value.inner());
             }
             for group in 1..=globals_to_set {
                 let sym = interp.intern_symbol(regexp::nth_match_group(group));
-                let value = interp.convert(captures.at(group));
+                let value = interp.convert_mut(captures.at(group));
                 unsafe {
                     sys::mrb_gv_set(mrb, sym, value.inner());
                 }
@@ -439,8 +439,8 @@ impl RegexpType for Onig {
                 sys::mrb_gv_set(mrb, matchdata_sym, matchdata.inner());
             }
             if let Some(match_pos) = captures.pos(0) {
-                let pre_match = interp.convert(&pattern[..match_pos.0]);
-                let post_match = interp.convert(&pattern[match_pos.1..]);
+                let pre_match = interp.convert_mut(&pattern[..match_pos.0]);
+                let post_match = interp.convert_mut(&pattern[match_pos.1..]);
                 let pre_match_sym = interp.intern_symbol(regexp::STRING_LEFT_OF_MATCH);
                 let post_match_sym = interp.intern_symbol(regexp::STRING_RIGHT_OF_MATCH);
                 unsafe {
@@ -618,21 +618,21 @@ impl RegexpType for Onig {
                 }
                 for captures in iter {
                     let fullmatch = interp.intern_symbol(regexp::LAST_MATCHED_STRING);
-                    let fullcapture = interp.convert(captures.at(0));
+                    let fullcapture = interp.convert_mut(captures.at(0));
                     unsafe {
                         sys::mrb_gv_set(mrb, fullmatch, fullcapture.inner());
                     }
                     let mut groups = vec![];
                     for group in 1..=len {
                         let sym = interp.intern_symbol(regexp::nth_match_group(group));
-                        let capture = interp.convert(captures.at(group));
+                        let capture = interp.convert_mut(captures.at(group));
                         groups.push(captures.at(group));
                         unsafe {
                             sys::mrb_gv_set(mrb, sym, capture.inner());
                         }
                     }
 
-                    let matched = interp.convert(groups);
+                    let matched = interp.convert_mut(groups);
                     if let Some(pos) = captures.pos(0) {
                         matchdata.set_region(pos.0, pos.1);
                     }
@@ -657,7 +657,7 @@ impl RegexpType for Onig {
                 }
                 for pos in iter {
                     let scanned = &haystack[pos.0..pos.1];
-                    let matched = interp.convert(scanned);
+                    let matched = interp.convert_mut(scanned);
                     matchdata.set_region(pos.0, pos.1);
                     let data = matchdata.clone().try_into_ruby(interp, None).map_err(|_| {
                         Fatal::new(interp, "Failed to convert MatchData to Ruby Value")
@@ -691,7 +691,7 @@ impl RegexpType for Onig {
                     unsafe {
                         sys::mrb_gv_set(mrb, last_match_sym, nil);
                     }
-                    return Ok(interp.convert(Vec::<Value>::new()));
+                    return Ok(interp.convert_mut(&[] as &[Value]));
                 }
                 for captures in iter {
                     let mut groups = vec![];
@@ -714,19 +714,19 @@ impl RegexpType for Onig {
                 let mut iter = collected.iter().enumerate();
                 if let Some((_, fullcapture)) = iter.next() {
                     let fullmatch = interp.intern_symbol(regexp::LAST_MATCHED_STRING);
-                    let fullcapture = interp.convert(fullcapture.as_slice());
+                    let fullcapture = interp.convert_mut(fullcapture.as_slice());
                     unsafe {
                         sys::mrb_gv_set(mrb, fullmatch, fullcapture.inner());
                     }
                 }
                 for (group, capture) in iter {
                     let sym = interp.intern_symbol(regexp::nth_match_group(group));
-                    let capture = interp.convert(capture.as_slice());
+                    let capture = interp.convert_mut(capture.as_slice());
                     unsafe {
                         sys::mrb_gv_set(mrb, sym, capture.inner());
                     }
                 }
-                Ok(interp.convert(collected))
+                Ok(interp.convert_mut(collected))
             } else {
                 let mut collected = vec![];
                 let mut iter = self.regex.find_iter(haystack).peekable();
@@ -734,7 +734,7 @@ impl RegexpType for Onig {
                     unsafe {
                         sys::mrb_gv_set(mrb, last_match_sym, interp.convert(None::<Value>).inner());
                     }
-                    return Ok(interp.convert(Vec::<Value>::new()));
+                    return Ok(interp.convert_mut(&[] as &[Value]));
                 }
                 for pos in iter {
                     let scanned = &haystack[pos.0..pos.1];
@@ -750,12 +750,12 @@ impl RegexpType for Onig {
                 }
                 if let Some(fullcapture) = collected.last().copied() {
                     let fullmatch = interp.intern_symbol(regexp::LAST_MATCHED_STRING);
-                    let fullcapture = interp.convert(fullcapture);
+                    let fullcapture = interp.convert_mut(fullcapture);
                     unsafe {
                         sys::mrb_gv_set(mrb, fullmatch, fullcapture.inner());
                     }
                 }
-                Ok(interp.convert(collected))
+                Ok(interp.convert_mut(collected))
             }
         }
     }

--- a/artichoke-backend/src/extn/core/regexp/backend/regex_utf8.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/regex_utf8.rs
@@ -213,25 +213,23 @@ impl RegexpType for RegexUtf8 {
         if let Some(captures) = self.regex.captures(pattern) {
             let globals_to_set = cmp::max(interp.0.borrow().active_regexp_globals, captures.len());
             let sym = interp.intern_symbol(regexp::LAST_MATCHED_STRING);
-            let value = interp.convert(
-                captures
-                    .get(0)
-                    .as_ref()
-                    .map(regex::Match::as_str)
-                    .map(str::as_bytes),
-            );
+            let fullmatch = captures
+                .get(0)
+                .as_ref()
+                .map(regex::Match::as_str)
+                .map(str::as_bytes);
+            let value = interp.convert_mut(fullmatch);
             unsafe {
                 sys::mrb_gv_set(mrb, sym, value.inner());
             }
             for group in 1..=globals_to_set {
                 let sym = interp.intern_symbol(regexp::nth_match_group(group));
-                let value = interp.convert(
-                    captures
-                        .get(0)
-                        .as_ref()
-                        .map(regex::Match::as_str)
-                        .map(str::as_bytes),
-                );
+                let capture = captures
+                    .get(group)
+                    .as_ref()
+                    .map(regex::Match::as_str)
+                    .map(str::as_bytes);
+                let value = interp.convert_mut(capture);
                 unsafe {
                     sys::mrb_gv_set(mrb, sym, value.inner());
                 }
@@ -244,8 +242,8 @@ impl RegexpType for RegexUtf8 {
                 let pre_match_sym = interp.intern_symbol(regexp::STRING_LEFT_OF_MATCH);
                 let post_match_sym = interp.intern_symbol(regexp::STRING_RIGHT_OF_MATCH);
                 unsafe {
-                    sys::mrb_gv_set(mrb, pre_match_sym, interp.convert(pre_match).inner());
-                    sys::mrb_gv_set(mrb, post_match_sym, interp.convert(post_match).inner());
+                    sys::mrb_gv_set(mrb, pre_match_sym, interp.convert_mut(pre_match).inner());
+                    sys::mrb_gv_set(mrb, post_match_sym, interp.convert_mut(post_match).inner());
                 }
             }
             let matchdata = MatchData::new(
@@ -350,25 +348,23 @@ impl RegexpType for RegexUtf8 {
         if let Some(captures) = self.regex.captures(match_target) {
             let globals_to_set = cmp::max(interp.0.borrow().active_regexp_globals, captures.len());
             let sym = interp.intern_symbol(regexp::LAST_MATCHED_STRING);
-            let value = interp.convert(
-                captures
-                    .get(0)
-                    .as_ref()
-                    .map(regex::Match::as_str)
-                    .map(str::as_bytes),
-            );
+            let fullmatch = captures
+                .get(0)
+                .as_ref()
+                .map(regex::Match::as_str)
+                .map(str::as_bytes);
+            let value = interp.convert_mut(fullmatch);
             unsafe {
                 sys::mrb_gv_set(mrb, sym, value.inner());
             }
             for group in 1..=globals_to_set {
                 let sym = interp.intern_symbol(regexp::nth_match_group(group));
-                let value = interp.convert(
-                    captures
-                        .get(0)
-                        .as_ref()
-                        .map(regex::Match::as_str)
-                        .map(str::as_bytes),
-                );
+                let capture = captures
+                    .get(group)
+                    .as_ref()
+                    .map(regex::Match::as_str)
+                    .map(str::as_bytes);
+                let value = interp.convert_mut(capture);
                 unsafe {
                     sys::mrb_gv_set(mrb, sym, value.inner());
                 }
@@ -387,8 +383,8 @@ impl RegexpType for RegexUtf8 {
                 let pre_match_sym = interp.intern_symbol(regexp::STRING_LEFT_OF_MATCH);
                 let post_match_sym = interp.intern_symbol(regexp::STRING_RIGHT_OF_MATCH);
                 unsafe {
-                    sys::mrb_gv_set(mrb, pre_match_sym, interp.convert(pre_match).inner());
-                    sys::mrb_gv_set(mrb, post_match_sym, interp.convert(post_match).inner());
+                    sys::mrb_gv_set(mrb, pre_match_sym, interp.convert_mut(pre_match).inner());
+                    sys::mrb_gv_set(mrb, post_match_sym, interp.convert_mut(post_match).inner());
                 }
                 matchdata.set_region(
                     byte_offset + match_pos.start(),
@@ -440,25 +436,23 @@ impl RegexpType for RegexUtf8 {
         if let Some(captures) = self.regex.captures(pattern) {
             let globals_to_set = cmp::max(interp.0.borrow().active_regexp_globals, captures.len());
             let sym = interp.intern_symbol(regexp::LAST_MATCHED_STRING);
-            let value = interp.convert(
-                captures
-                    .get(0)
-                    .as_ref()
-                    .map(regex::Match::as_str)
-                    .map(str::as_bytes),
-            );
+            let fullmatch = captures
+                .get(0)
+                .as_ref()
+                .map(regex::Match::as_str)
+                .map(str::as_bytes);
+            let value = interp.convert_mut(fullmatch);
             unsafe {
                 sys::mrb_gv_set(mrb, sym, value.inner());
             }
             for group in 1..=globals_to_set {
                 let sym = interp.intern_symbol(regexp::nth_match_group(group));
-                let value = interp.convert(
-                    captures
-                        .get(0)
-                        .as_ref()
-                        .map(regex::Match::as_str)
-                        .map(str::as_bytes),
-                );
+                let capture = captures
+                    .get(group)
+                    .as_ref()
+                    .map(regex::Match::as_str)
+                    .map(str::as_bytes);
+                let value = interp.convert_mut(capture);
                 unsafe {
                     sys::mrb_gv_set(mrb, sym, value.inner());
                 }
@@ -482,8 +476,8 @@ impl RegexpType for RegexUtf8 {
                 sys::mrb_gv_set(mrb, matchdata_sym, matchdata.inner());
             }
             if let Some(match_pos) = captures.get(0) {
-                let pre_match = interp.convert(&pattern[..match_pos.start()]);
-                let post_match = interp.convert(&pattern[match_pos.end()..]);
+                let pre_match = interp.convert_mut(&pattern[..match_pos.start()]);
+                let post_match = interp.convert_mut(&pattern[match_pos.end()..]);
                 let pre_match_sym = interp.intern_symbol(regexp::STRING_LEFT_OF_MATCH);
                 let post_match_sym = interp.intern_symbol(regexp::STRING_RIGHT_OF_MATCH);
                 unsafe {
@@ -656,7 +650,7 @@ impl RegexpType for RegexUtf8 {
                         .as_ref()
                         .map(regex::Match::as_str)
                         .map(str::as_bytes);
-                    let capture = interp.convert(matched);
+                    let capture = interp.convert_mut(matched);
                     let fullmatch = interp.intern_symbol(regexp::LAST_MATCHED_STRING);
                     unsafe {
                         sys::mrb_gv_set(mrb, fullmatch, capture.inner());
@@ -669,14 +663,14 @@ impl RegexpType for RegexUtf8 {
                             .as_ref()
                             .map(regex::Match::as_str)
                             .map(str::as_bytes);
-                        let capture = interp.convert(matched);
+                        let capture = interp.convert_mut(matched);
                         groups.push(matched);
                         unsafe {
                             sys::mrb_gv_set(mrb, sym, capture.inner());
                         }
                     }
 
-                    let matched = interp.convert(groups);
+                    let matched = interp.convert_mut(groups);
                     if let Some(pos) = captures.get(0) {
                         matchdata.set_region(pos.start(), pos.end());
                     }
@@ -701,7 +695,7 @@ impl RegexpType for RegexUtf8 {
                 }
                 for pos in iter {
                     let scanned = &haystack[pos.start()..pos.end()];
-                    let matched = interp.convert(scanned);
+                    let matched = interp.convert_mut(scanned);
                     matchdata.set_region(pos.start(), pos.end());
                     let data = matchdata.clone().try_into_ruby(interp, None).map_err(|_| {
                         Fatal::new(interp, "Failed to convert MatchData to Ruby Value")
@@ -734,7 +728,7 @@ impl RegexpType for RegexUtf8 {
                     unsafe {
                         sys::mrb_gv_set(mrb, last_match_sym, sys::mrb_sys_nil_value());
                     }
-                    return Ok(interp.convert(Vec::<Value>::new()));
+                    return Ok(interp.convert_mut(&[] as &[Value]));
                 }
                 for captures in iter {
                     let mut groups = vec![];
@@ -762,19 +756,19 @@ impl RegexpType for RegexUtf8 {
                 let mut iter = collected.iter().enumerate();
                 if let Some((_, fullcapture)) = iter.next() {
                     let fullmatch = interp.intern_symbol(regexp::LAST_MATCHED_STRING);
-                    let fullcapture = interp.convert(fullcapture.as_slice());
+                    let fullcapture = interp.convert_mut(fullcapture.as_slice());
                     unsafe {
                         sys::mrb_gv_set(mrb, fullmatch, fullcapture.inner());
                     }
                 }
                 for (group, capture) in iter {
                     let sym = interp.intern_symbol(regexp::nth_match_group(group));
-                    let capture = interp.convert(capture.as_slice());
+                    let capture = interp.convert_mut(capture.as_slice());
                     unsafe {
                         sys::mrb_gv_set(mrb, sym, capture.inner());
                     }
                 }
-                Ok(interp.convert(collected))
+                Ok(interp.convert_mut(collected))
             } else {
                 let mut collected = vec![];
                 let mut iter = self.regex.find_iter(haystack).peekable();
@@ -782,7 +776,7 @@ impl RegexpType for RegexUtf8 {
                     unsafe {
                         sys::mrb_gv_set(mrb, last_match_sym, sys::mrb_sys_nil_value());
                     }
-                    return Ok(interp.convert(Vec::<Value>::new()));
+                    return Ok(interp.convert_mut(&[] as &[Value]));
                 }
                 for pos in iter {
                     let scanned = &haystack[pos.start()..pos.end()];
@@ -798,12 +792,12 @@ impl RegexpType for RegexUtf8 {
                 }
                 if let Some(fullcapture) = collected.last().copied() {
                     let fullmatch = interp.intern_symbol(regexp::LAST_MATCHED_STRING);
-                    let fullcapture = interp.convert(fullcapture);
+                    let fullcapture = interp.convert_mut(fullcapture);
                     unsafe {
                         sys::mrb_gv_set(mrb, fullmatch, fullcapture.inner());
                     }
                 }
-                Ok(interp.convert(collected))
+                Ok(interp.convert_mut(collected))
             }
         }
     }

--- a/artichoke-backend/src/extn/core/regexp/mruby.rs
+++ b/artichoke-backend/src/extn/core/regexp/mruby.rs
@@ -75,8 +75,9 @@ unsafe extern "C" fn compile(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> s
 
 unsafe extern "C" fn escape(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {
     let pattern = mrb_get_args!(mrb, required = 1);
-    let interp = unwrap_interpreter!(mrb);
-    let result = regexp::trampoline::escape(&interp, Value::new(&interp, pattern));
+    let mut interp = unwrap_interpreter!(mrb);
+    let pattern = Value::new(&interp, pattern);
+    let result = regexp::trampoline::escape(&mut interp, pattern);
     match result {
         Ok(result) => result.inner(),
         Err(exception) => exception::raise(interp, exception),
@@ -204,9 +205,9 @@ unsafe extern "C" fn hash(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys:
 
 unsafe extern "C" fn inspect(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
     mrb_get_args!(mrb, none);
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let value = Value::new(&interp, slf);
-    let result = regexp::trampoline::inspect(&interp, value);
+    let result = regexp::trampoline::inspect(&mut interp, value);
     match result {
         Ok(result) => result.inner(),
         Err(exception) => exception::raise(interp, exception),
@@ -218,9 +219,9 @@ unsafe extern "C" fn named_captures(
     slf: sys::mrb_value,
 ) -> sys::mrb_value {
     mrb_get_args!(mrb, none);
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let value = Value::new(&interp, slf);
-    let result = regexp::trampoline::named_captures(&interp, value);
+    let result = regexp::trampoline::named_captures(&mut interp, value);
     match result {
         Ok(result) => result.inner(),
         Err(exception) => exception::raise(interp, exception),
@@ -229,9 +230,9 @@ unsafe extern "C" fn named_captures(
 
 unsafe extern "C" fn names(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
     mrb_get_args!(mrb, none);
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let value = Value::new(&interp, slf);
-    let result = regexp::trampoline::names(&interp, value);
+    let result = regexp::trampoline::names(&mut interp, value);
     match result {
         Ok(result) => result.inner(),
         Err(exception) => exception::raise(interp, exception),
@@ -251,9 +252,9 @@ unsafe extern "C" fn options(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> s
 
 unsafe extern "C" fn source(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
     mrb_get_args!(mrb, none);
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let value = Value::new(&interp, slf);
-    let result = regexp::trampoline::source(&interp, value);
+    let result = regexp::trampoline::source(&mut interp, value);
     match result {
         Ok(result) => result.inner(),
         Err(exception) => exception::raise(interp, exception),
@@ -262,9 +263,9 @@ unsafe extern "C" fn source(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sy
 
 unsafe extern "C" fn to_s(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
     mrb_get_args!(mrb, none);
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let value = Value::new(&interp, slf);
-    let result = regexp::trampoline::to_s(&interp, value);
+    let result = regexp::trampoline::to_s(&mut interp, value);
     match result {
         Ok(result) => result.inner(),
         Err(exception) => exception::raise(interp, exception),

--- a/artichoke-backend/src/extn/core/regexp/trampoline.rs
+++ b/artichoke-backend/src/extn/core/regexp/trampoline.rs
@@ -11,7 +11,7 @@ pub fn initialize(
     Regexp::initialize(interp, pattern, options, encoding, into)
 }
 
-pub fn escape(interp: &Artichoke, pattern: Value) -> Result<Value, Exception> {
+pub fn escape(interp: &mut Artichoke, pattern: Value) -> Result<Value, Exception> {
     Regexp::escape(interp, pattern)
 }
 
@@ -158,7 +158,7 @@ pub fn hash(interp: &Artichoke, regexp: Value) -> Result<Value, Exception> {
     borrow.hash(interp)
 }
 
-pub fn inspect(interp: &Artichoke, regexp: Value) -> Result<Value, Exception> {
+pub fn inspect(interp: &mut Artichoke, regexp: Value) -> Result<Value, Exception> {
     let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }.map_err(|err| {
         if let ArtichokeError::UninitializedValue("Regexp") = err {
             Exception::from(TypeError::new(interp, "uninitialized Regexp"))
@@ -173,7 +173,7 @@ pub fn inspect(interp: &Artichoke, regexp: Value) -> Result<Value, Exception> {
     borrow.inspect(interp)
 }
 
-pub fn named_captures(interp: &Artichoke, regexp: Value) -> Result<Value, Exception> {
+pub fn named_captures(interp: &mut Artichoke, regexp: Value) -> Result<Value, Exception> {
     let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }.map_err(|err| {
         if let ArtichokeError::UninitializedValue("Regexp") = err {
             Exception::from(TypeError::new(interp, "uninitialized Regexp"))
@@ -188,7 +188,7 @@ pub fn named_captures(interp: &Artichoke, regexp: Value) -> Result<Value, Except
     borrow.named_captures(interp)
 }
 
-pub fn names(interp: &Artichoke, regexp: Value) -> Result<Value, Exception> {
+pub fn names(interp: &mut Artichoke, regexp: Value) -> Result<Value, Exception> {
     let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }.map_err(|err| {
         if let ArtichokeError::UninitializedValue("Regexp") = err {
             Exception::from(TypeError::new(interp, "uninitialized Regexp"))
@@ -218,7 +218,7 @@ pub fn options(interp: &Artichoke, regexp: Value) -> Result<Value, Exception> {
     borrow.options(interp)
 }
 
-pub fn source(interp: &Artichoke, regexp: Value) -> Result<Value, Exception> {
+pub fn source(interp: &mut Artichoke, regexp: Value) -> Result<Value, Exception> {
     let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }.map_err(|err| {
         if let ArtichokeError::UninitializedValue("Regexp") = err {
             Exception::from(TypeError::new(interp, "uninitialized Regexp"))
@@ -233,7 +233,7 @@ pub fn source(interp: &Artichoke, regexp: Value) -> Result<Value, Exception> {
     borrow.source(interp)
 }
 
-pub fn to_s(interp: &Artichoke, regexp: Value) -> Result<Value, Exception> {
+pub fn to_s(interp: &mut Artichoke, regexp: Value) -> Result<Value, Exception> {
     let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }.map_err(|err| {
         if let ArtichokeError::UninitializedValue("Regexp") = err {
             Exception::from(TypeError::new(interp, "uninitialized Regexp"))

--- a/artichoke-backend/src/extn/core/string.rs
+++ b/artichoke-backend/src/extn/core/string.rs
@@ -130,7 +130,7 @@ mod tests {
     fn string_scan() {
         let mut interp = crate::interpreter().expect("init");
 
-        let s = interp.convert("abababa");
+        let s = interp.convert_mut("abababa");
         let result = s
             .funcall::<Vec<&str>>("scan", &[interp.eval(b"/./").expect("eval")], None)
             .expect("funcall");

--- a/artichoke-backend/src/extn/core/string/scan.rs
+++ b/artichoke-backend/src/extn/core/string/scan.rs
@@ -43,7 +43,8 @@ pub fn method(
                 unsafe {
                     sys::mrb_gv_set(mrb, last_match_sym, data.inner());
                 }
-                let _ = block.yield_arg::<Value>(interp, &interp.convert(pattern_bytes))?;
+                let block_arg = interp.convert_mut(pattern_bytes);
+                let _ = block.yield_arg::<Value>(interp, &block_arg)?;
                 unsafe {
                     sys::mrb_gv_set(mrb, last_match_sym, data.inner());
                 }
@@ -63,7 +64,7 @@ pub fn method(
                 .unwrap_or_default();
             let mut result = Vec::with_capacity(matches);
             for _ in 0..matches {
-                result.push(interp.convert(pattern_bytes));
+                result.push(interp.convert_mut(pattern_bytes));
             }
             if matches > 0 {
                 let regex = Regexp::lazy(pattern_bytes);
@@ -85,7 +86,7 @@ pub fn method(
                     sys::mrb_gv_set(mrb, last_match_sym, nil);
                 }
             }
-            Ok(interp.convert(result))
+            Ok(interp.convert_mut(result))
         }
     } else if let Ok(regexp) = unsafe { Regexp::try_from_ruby(interp, &pattern) } {
         regexp.borrow().inner().scan(interp, value, block)
@@ -109,7 +110,8 @@ pub fn method(
                     unsafe {
                         sys::mrb_gv_set(mrb, last_match_sym, data.inner());
                     }
-                    let _ = block.yield_arg::<Value>(interp, &interp.convert(pattern_bytes))?;
+                    let block_arg = interp.convert_mut(pattern_bytes);
+                    let _ = block.yield_arg::<Value>(interp, &block_arg)?;
                     unsafe {
                         sys::mrb_gv_set(mrb, last_match_sym, data.inner());
                     }
@@ -129,7 +131,7 @@ pub fn method(
                     .unwrap_or_default();
                 let mut result = Vec::with_capacity(matches);
                 for _ in 0..matches {
-                    result.push(interp.convert(pattern_bytes));
+                    result.push(interp.convert_mut(pattern_bytes));
                 }
                 if matches > 0 {
                     let regex = Regexp::lazy(pattern_bytes);
@@ -150,7 +152,7 @@ pub fn method(
                         sys::mrb_gv_set(mrb, last_match_sym, sys::mrb_sys_nil_value());
                     }
                 }
-                Ok(interp.convert(result))
+                Ok(interp.convert_mut(result))
             }
         } else {
             Err(Exception::from(TypeError::new(

--- a/artichoke-backend/src/extn/mod.rs
+++ b/artichoke-backend/src/extn/mod.rs
@@ -27,7 +27,7 @@ macro_rules! global_const {
             sys::mrb_define_global_const(
                 mrb,
                 concat!(stringify!($constant), "\0").as_ptr() as *const i8,
-                $interp.convert($constant).inner(),
+                $interp.convert_mut($constant).inner(),
             );
         }
     }};
@@ -37,7 +37,7 @@ macro_rules! global_const {
             sys::mrb_define_global_const(
                 mrb,
                 concat!(stringify!($constant), "\0").as_ptr() as *const i8,
-                $interp.convert($value).inner(),
+                $interp.convert_mut($value).inner(),
             );
         }
     }};

--- a/artichoke-backend/src/extn/prelude.rs
+++ b/artichoke-backend/src/extn/prelude.rs
@@ -7,7 +7,7 @@
 //! ```
 
 pub use crate::class;
-pub use crate::convert::{Convert, RustBackedValue, TryConvert};
+pub use crate::convert::{Convert, ConvertMut, RustBackedValue, TryConvert, TryConvertMut};
 pub use crate::def::{self, EnclosingRubyScope};
 pub use crate::exception::{self, Exception, RubyException};
 pub use crate::extn::core::exception::*;

--- a/artichoke-backend/src/lib.rs
+++ b/artichoke-backend/src/lib.rs
@@ -121,10 +121,16 @@ mod warn;
 mod test;
 
 pub use artichoke_core as core;
+
 /// Re-export from [`artichoke_core`](artichoke_core::convert::Convert).
-pub use artichoke_core::convert::Convert;
+pub use crate::core::convert::Convert;
+/// Re-export from [`artichoke_core`](artichoke_core::convert::ConvertMut).
+pub use crate::core::convert::ConvertMut;
 /// Re-export from [`artichoke_core`](artichoke_core::convert::TryConvert).
-pub use artichoke_core::convert::TryConvert;
+pub use crate::core::convert::TryConvert;
+/// Re-export from [`artichoke_core`](artichoke_core::convert::TryConvertMut).
+pub use crate::core::convert::TryConvertMut;
+
 pub use artichoke_core::eval::Eval;
 pub use artichoke_core::file::File;
 pub use artichoke_core::intern::Intern;

--- a/artichoke-backend/src/string.rs
+++ b/artichoke-backend/src/string.rs
@@ -10,7 +10,7 @@ use bstr::ByteSlice;
 use std::error;
 use std::fmt;
 
-use crate::convert::Convert;
+use crate::convert::ConvertMut;
 use crate::exception::{Exception, RubyException};
 use crate::extn::core::exception::Fatal;
 use crate::sys;
@@ -96,10 +96,11 @@ impl RubyException for WriteError {
         None
     }
 
-    fn as_mrb_value(&self, interp: &Artichoke) -> Option<sys::mrb_value> {
+    fn as_mrb_value(&self, interp: &mut Artichoke) -> Option<sys::mrb_value> {
+        let message = interp.convert_mut(self.message());
         let borrow = interp.0.borrow();
         let spec = borrow.class_spec::<Fatal>()?;
-        let value = spec.new_instance(interp, &[interp.convert(self.message())])?;
+        let value = spec.new_instance(interp, &[message])?;
         Some(value.inner())
     }
 }

--- a/artichoke-backend/src/test/prelude.rs
+++ b/artichoke-backend/src/test/prelude.rs
@@ -7,7 +7,7 @@
 //! ```
 
 pub use crate::class;
-pub use crate::convert::{Convert, RustBackedValue, TryConvert};
+pub use crate::convert::{Convert, ConvertMut, RustBackedValue, TryConvert, TryConvertMut};
 pub use crate::def::{self, EnclosingRubyScope};
 pub use crate::exception::{self, Exception, RubyException};
 pub use crate::extn::core::exception::*;

--- a/artichoke-backend/src/value.rs
+++ b/artichoke-backend/src/value.rs
@@ -480,54 +480,54 @@ mod tests {
 
     #[test]
     fn to_s_string() {
-        let interp = crate::interpreter().expect("init");
+        let mut interp = crate::interpreter().expect("init");
 
-        let value = interp.convert("interstate");
+        let value = interp.convert_mut("interstate");
         let string = value.to_s();
         assert_eq!(string, b"interstate");
     }
 
     #[test]
     fn debug_string() {
-        let interp = crate::interpreter().expect("init");
+        let mut interp = crate::interpreter().expect("init");
 
-        let value = interp.convert("interstate");
+        let value = interp.convert_mut("interstate");
         let debug = value.to_s_debug();
         assert_eq!(debug, r#"String<"interstate">"#);
     }
 
     #[test]
     fn inspect_string() {
-        let interp = crate::interpreter().expect("init");
+        let mut interp = crate::interpreter().expect("init");
 
-        let value = interp.convert("interstate");
+        let value = interp.convert_mut("interstate");
         let debug = value.inspect();
         assert_eq!(debug, br#""interstate""#);
     }
 
     #[test]
     fn to_s_empty_string() {
-        let interp = crate::interpreter().expect("init");
+        let mut interp = crate::interpreter().expect("init");
 
-        let value = interp.convert("");
+        let value = interp.convert_mut("");
         let string = value.to_s();
         assert_eq!(string, b"");
     }
 
     #[test]
     fn debug_empty_string() {
-        let interp = crate::interpreter().expect("init");
+        let mut interp = crate::interpreter().expect("init");
 
-        let value = interp.convert("");
+        let value = interp.convert_mut("");
         let debug = value.to_s_debug();
         assert_eq!(debug, r#"String<"">"#);
     }
 
     #[test]
     fn inspect_empty_string() {
-        let interp = crate::interpreter().expect("init");
+        let mut interp = crate::interpreter().expect("init");
 
-        let value = interp.convert("");
+        let value = interp.convert_mut("");
         let debug = value.inspect();
         assert_eq!(debug, br#""""#);
     }
@@ -572,12 +572,12 @@ mod tests {
 
     #[test]
     fn funcall() {
-        let interp = crate::interpreter().expect("init");
+        let mut interp = crate::interpreter().expect("init");
         let nil = interp.convert(None::<Value>);
         assert!(nil.funcall::<bool>("nil?", &[], None).expect("nil?"));
-        let s = interp.convert("foo");
+        let s = interp.convert_mut("foo");
         assert!(!s.funcall::<bool>("nil?", &[], None).expect("nil?"));
-        let delim = interp.convert("");
+        let delim = interp.convert_mut("");
         let split = s
             .funcall::<Vec<&str>>("split", &[delim], None)
             .expect("split");
@@ -586,18 +586,18 @@ mod tests {
 
     #[test]
     fn funcall_different_types() {
-        let interp = crate::interpreter().expect("init");
+        let mut interp = crate::interpreter().expect("init");
         let nil = interp.convert(None::<Value>);
-        let s = interp.convert("foo");
+        let s = interp.convert_mut("foo");
         let eql = nil.funcall::<bool>("==", &[s], None).unwrap();
         assert!(!eql);
     }
 
     #[test]
     fn funcall_type_error() {
-        let interp = crate::interpreter().expect("init");
+        let mut interp = crate::interpreter().expect("init");
         let nil = interp.convert(None::<Value>);
-        let s = interp.convert("foo");
+        let s = interp.convert_mut("foo");
         let err = s.funcall::<String>("+", &[nil], None).unwrap_err();
         assert_eq!("TypeError", err.name().as_str());
         assert_eq!(&b"nil cannot be converted to String"[..], err.message());
@@ -605,9 +605,9 @@ mod tests {
 
     #[test]
     fn funcall_method_not_exists() {
-        let interp = crate::interpreter().expect("init");
+        let mut interp = crate::interpreter().expect("init");
         let nil = interp.convert(None::<Value>);
-        let s = interp.convert("foo");
+        let s = interp.convert_mut("foo");
         let err = nil
             .funcall::<bool>("garbage_method_name", &[s], None)
             .unwrap_err();

--- a/artichoke-backend/src/value.rs
+++ b/artichoke-backend/src/value.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 use std::ptr;
 
-use crate::convert::{Convert, TryConvert};
+use crate::convert::{Convert, ConvertMut, TryConvert};
 use crate::exception::Exception;
 use crate::exception_handler;
 use crate::extn::core::exception::{Fatal, TypeError};
@@ -261,7 +261,9 @@ impl ValueLike for Value {
     }
 
     fn respond_to(&self, method: &str) -> Result<bool, Self::Error> {
-        let method = self.interp.convert(method);
+        // This is a hack until Value properly supports interpreter mutability.
+        let mut interp = self.interp.clone();
+        let method = interp.convert_mut(method);
         self.funcall::<bool>("respond_to?", &[method], None)
     }
 

--- a/artichoke-backend/src/warn.rs
+++ b/artichoke-backend/src/warn.rs
@@ -1,6 +1,6 @@
 use std::io::{self, Write};
 
-use crate::convert::Convert;
+use crate::convert::ConvertMut;
 use crate::exception::Exception;
 use crate::extn::core::exception::RuntimeError;
 use crate::extn::core::warning::Warning;
@@ -24,7 +24,7 @@ impl Warn for Artichoke {
                 .ok_or_else(|| ArtichokeError::NotDefined("Warn with uninitialized Warning".into()))
                 .map_err(|err| RuntimeError::new(self, err.to_string()))?
         };
-        let message = self.convert(message);
+        let message = self.convert_mut(message);
         let _ = warning.funcall::<Value>("warn", &[message], None)?;
         Ok(())
     }

--- a/artichoke-backend/tests/leak_funcall.rs
+++ b/artichoke-backend/tests/leak_funcall.rs
@@ -14,7 +14,7 @@
 //! If resident memory increases more than 10MB during the test, we likely are
 //! leaking memory.
 
-use artichoke_backend::convert::Convert;
+use artichoke_backend::convert::ConvertMut;
 use artichoke_backend::gc::MrbGarbageCollection;
 use artichoke_backend::ValueLike as _;
 
@@ -25,8 +25,8 @@ const LEAK_TOLERANCE: i64 = 1024 * 1024 * 30;
 
 #[test]
 fn funcall_arena() {
-    let interp = artichoke_backend::interpreter().expect("init");
-    let s = interp.convert("a".repeat(1024 * 1024));
+    let mut interp = artichoke_backend::interpreter().expect("init");
+    let s = interp.convert_mut("a".repeat(1024 * 1024));
 
     leak::Detector::new("ValueLike::funcall", ITERATIONS, LEAK_TOLERANCE).check_leaks(|_| {
         let expected = format!(r#""{}""#, "a".repeat(1024 * 1024));

--- a/artichoke-core/src/convert.rs
+++ b/artichoke-core/src/convert.rs
@@ -4,7 +4,10 @@ use crate::ArtichokeError;
 
 /// Infallible conversion between two types.
 ///
+/// Implementors may not allocate on the interpreter heap.
+///
 /// See [`std::convert::From`].
+/// See [`ConvertMut`].
 pub trait Convert<T, U> {
     /// Performs the infallible conversion.
     fn convert(&self, from: T) -> U;
@@ -12,7 +15,10 @@ pub trait Convert<T, U> {
 
 /// Fallible conversions between two types.
 ///
+/// Implementors may not allocate on the interpreter heap.
+///
 /// See [`std::convert::TryFrom`].
+/// See [`TryConvertMut`].
 #[allow(clippy::module_name_repetitions)]
 pub trait TryConvert<T, U> {
     /// Performs the fallible conversion.
@@ -34,5 +40,46 @@ where
     /// [`Convert::convert`].
     fn try_convert(&self, value: T) -> Result<U, ArtichokeError> {
         Ok(Convert::convert(self, value))
+    }
+}
+
+/// Mutable infallible conversion between two types.
+///
+/// Implementors may allocate on the interpreter heap.
+///
+/// See [`std::convert::From`].
+/// See [`Convert`].
+#[allow(clippy::module_name_repetitions)]
+pub trait ConvertMut<T, U> {
+    /// Performs the infallible conversion.
+    fn convert_mut(&mut self, from: T) -> U;
+}
+
+/// Mutable fallible conversions between two types.
+///
+/// Implementors may allocate on the interpreter heap.
+///
+/// See [`std::convert::TryFrom`].
+/// See [`TryConvert`].
+pub trait TryConvertMut<T, U> {
+    /// Performs the fallible conversion.
+    ///
+    /// # Errors
+    ///
+    /// If boxing or unboxing a value into the specified type fails, an error is
+    /// returned.
+    fn try_convert_mut(&mut self, value: T) -> Result<U, ArtichokeError>;
+}
+
+/// Provide a mutable fallible converter for types that implement an infallible
+/// conversion.
+impl<T, U, V> TryConvertMut<T, U> for V
+where
+    V: ConvertMut<T, U>,
+{
+    /// Blanket implementation that always succeeds by delegating to
+    /// [`Convert::convert`].
+    fn try_convert_mut(&mut self, value: T) -> Result<U, ArtichokeError> {
+        Ok(ConvertMut::convert_mut(self, value))
     }
 }

--- a/artichoke-frontend/src/ruby.rs
+++ b/artichoke-frontend/src/ruby.rs
@@ -2,7 +2,7 @@
 //!
 //! Exported as `ruby` and `artichoke` binaries.
 
-use artichoke_backend::convert::Convert;
+use artichoke_backend::convert::ConvertMut;
 use artichoke_backend::exception::Exception;
 use artichoke_backend::fs;
 use artichoke_backend::state::parser::Context;
@@ -130,7 +130,7 @@ fn execute_inline_eval(commands: Vec<OsString>, fixture: Option<&Path>) -> Resul
         };
         let sym = interp.intern_symbol(&b"$fixture"[..]);
         let mrb = interp.0.borrow().mrb;
-        let value = interp.convert(data);
+        let value = interp.convert_mut(data);
         unsafe {
             sys::mrb_gv_set(mrb, sym, value.inner());
         }
@@ -161,7 +161,7 @@ fn execute_program_file(programfile: &Path, fixture: Option<&Path>) -> Result<()
         };
         let sym = interp.intern_symbol(&b"$fixture"[..]);
         let mrb = interp.0.borrow().mrb;
-        let value = interp.convert(data);
+        let value = interp.convert_mut(data);
         unsafe {
             sys::mrb_gv_set(mrb, sym, value.inner());
         }

--- a/spec-runner/src/mspec.rs
+++ b/spec-runner/src/mspec.rs
@@ -1,4 +1,4 @@
-use artichoke_backend::{Artichoke, BootError, Convert, Eval, LoadSources, TopSelf, ValueLike};
+use artichoke_backend::{Artichoke, BootError, ConvertMut, Eval, LoadSources, TopSelf, ValueLike};
 use std::borrow::Cow;
 
 pub fn init(interp: &Artichoke) -> Result<(), BootError> {
@@ -55,7 +55,7 @@ impl Runner {
             eprintln!("{}", err);
             assert!(!self.enforce);
         }
-        let specs = self.interp.convert(self.specs);
+        let specs = self.interp.convert_mut(self.specs);
         let result = self
             .interp
             .top_self()


### PR DESCRIPTION
This PR is followup to GH-442.

This PR introduces `ConvertMut` and `TryConvertMut` traits that mirror `Convert` and `TryConvert` except the take `&mut self`. The `Mut` varieties should be used when the conversion requires allocating on the interpreter heap.

For example, `Copy` types like `bool` or `u8` can be stored inline in the `sys::mrb_value` without allocating. These types of conversions would impl `Convert`. Types like `&[u8]` and `HashMap<bool, i64>` allocate objects on the interpreter heap so they impl `ConvertMut`.

The `ConvertMut` split has caused more function signature changes in `extn`.

This PR simplifies the integer converters by funelling though `Int::from` whenever possible.

This PR fixes several bugs when setting `Regexp` globals after a match in the `RegexUtf8` backend where the `$1`, `$2`, etc globals would be set to capture 0.