### PR TITLE
Define enforced specs in an external YAML config

### DIFF
--- a/doc/ruby-spec.md
+++ b/doc/ruby-spec.md
@@ -4,6 +4,9 @@ artichoke embeds a copy of [ruby/spec](/spec-runner/vendor/spec). ruby/spec is a
 set of specifications for testing the Ruby language, core, and standard library
 packages.
 
+Artichoke enforces that some ruby/specs pass. These specs are tracked in
+[`spec-runner/enforced-specs.yaml`](/spec-runner/enforced-specs.yaml).
+
 ## Running Specs
 
 You can run these specs for Artichoke crate with the `spec-runner` crate.
@@ -52,6 +55,7 @@ cargo install flamegraph
 
 ## Regression Testing
 
-Once a spec suite passes, add it to [`scripts/spec.rb`](/scripts/spec.rb). This
+Once a spec suite passes, add it to
+[`spec-runner/enforced-specs.yaml`](/spec-runner/enforced-specs.yaml). This
 script is run as part of CI and will ensure that a suite that does pass
 continues to pass.

--- a/scripts/spec.rb
+++ b/scripts/spec.rb
@@ -3,8 +3,10 @@
 
 require 'optparse'
 require 'shellwords'
+require 'yaml'
 
 WORKSPACE_ROOT = File.absolute_path(File.join(__dir__, '..'))
+SPEC_CONFIG = File.join(WORKSPACE_ROOT, 'spec-runner', 'enforced-specs.yaml')
 SPEC_ROOT = File.join(WORKSPACE_ROOT, 'spec-runner', 'vendor', 'spec')
 
 USAGE = <<~USAGE.strip
@@ -174,50 +176,19 @@ if ARGV.empty?
   puts USAGE
   exit 1
 elsif ARGV.first == 'passing'
-  runner.register(Spec.new('core', 'array', 'any'))
-  runner.register(Spec.new('core', 'array', 'append'))
-  runner.register(Spec.new('core', 'array', 'array'))
-  runner.register(Spec.new('core', 'array', 'assoc'))
-  runner.register(Spec.new('core', 'array', 'at'))
-  runner.register(Spec.new('core', 'array', 'clear'))
-  runner.register(Spec.new('core', 'array', 'collect'))
-  runner.register(Spec.new('core', 'array', 'combination'))
-  runner.register(Spec.new('core', 'array', 'compact'))
-  runner.register(Spec.new('core', 'array', 'count'))
-  runner.register(Spec.new('core', 'array', 'cycle'))
-  runner.register(Spec.new('core', 'array', 'delete_at'))
-  runner.register(Spec.new('core', 'array', 'delete_if'))
-  runner.register(Spec.new('core', 'array', 'delete'))
-  runner.register(Spec.new('core', 'array', 'drop'))
-  runner.register(Spec.new('core', 'array', 'each_index'))
-  runner.register(Spec.new('core', 'array', 'each'))
-  runner.register(Spec.new('core', 'array', 'empty'))
-  runner.register(Spec.new('core', 'array', 'frozen'))
-  runner.register(Spec.new('core', 'array', 'include'))
-  runner.register(Spec.new('core', 'array', 'last'))
-  runner.register(Spec.new('core', 'array', 'length'))
-  runner.register(Spec.new('core', 'array', 'map'))
-  runner.register(Spec.new('core', 'array', 'plus'))
-  runner.register(Spec.new('core', 'array', 'prepend'))
-  runner.register(Spec.new('core', 'array', 'push'))
-  runner.register(Spec.new('core', 'array', 'rassoc'))
-  runner.register(Spec.new('core', 'array', 'replace'))
-  runner.register(Spec.new('core', 'array', 'reverse_each'))
-  runner.register(Spec.new('core', 'array', 'reverse'))
-  runner.register(Spec.new('core', 'array', 'shift'))
-  runner.register(Spec.new('core', 'array', 'size'))
-  runner.register(Spec.new('core', 'array', 'sort_by'))
-  runner.register(Spec.new('core', 'array', 'to_ary'))
-  runner.register(Spec.new('core', 'array', 'try_convert'))
-  runner.register(Spec.new('core', 'array', 'unshift'))
-  runner.register(Spec.new('core', 'comparable'))
-  runner.register(Spec.new('core', 'matchdata'))
-  runner.register(Spec.new('core', 'regexp'))
-  runner.register(Spec.new('core', 'string', 'scan'))
-  runner.register(Spec.new('library', 'monitor'))
-  runner.register(Spec.new('library', 'stringscanner'))
-  runner.register(Spec.new('library', 'uri'))
-  runner.register(Spec.new('library', 'abbrev'))
+  conf = YAML.load_file(SPEC_CONFIG)
+  conf.fetch('specs').each_pair do |category, suites|
+    suites.map do |suite|
+      name = suite.fetch('suite')
+      if suite.key?('specs')
+        suite.fetch('specs').each do |spec|
+          runner.register(Spec.new(category, name, spec))
+        end
+      else
+        runner.register(Spec.new(category, name))
+      end
+    end
+  end
 else
   runner.register(Spec.new(*ARGV))
 end

--- a/spec-runner/enforced-specs.yaml
+++ b/spec-runner/enforced-specs.yaml
@@ -1,0 +1,54 @@
+---
+# This config file lists the ruby/specs that are enforced as passing in
+# Artichoke Ruby during CI.
+specs:
+  core:
+    - suite: array
+      specs:
+        - any
+        - append
+        - array
+        - assoc
+        - at
+        - clear
+        - collect
+        - combination
+        - compact
+        - count
+        - cycle
+        - delete_at
+        - delete_if
+        - delete
+        - drop
+        - each_index
+        - each
+        - empty
+        - frozen
+        - include
+        - last
+        - length
+        - map
+        - plus
+        - prepend
+        - push
+        - rassoc
+        - replace
+        - reverse_each
+        - reverse
+        - shift
+        - size
+        - sort_by
+        - to_ary
+        - try_convert
+        - unshift
+    - suite: comparable
+    - suite: matchdata
+    - suite: regexp
+    - suite: string
+      specs:
+        - scan
+  library:
+    - suite: abbrev
+    - suite: monitor
+    - suite: stringscanner
+    - suite: uri


### PR DESCRIPTION
This commit extracts the definitions of the enforced passing specs into
a YAML file in the spec-runner crate.

This is a required step to consume this information from Rust.

`scripts/spec.rb` still runs and passes 804 specs after this commit.