### PR TITLE
Add Eval::eval_os_str API to artichoke-core

### DIFF
--- a/artichoke-backend/src/eval.rs
+++ b/artichoke-backend/src/eval.rs
@@ -1,6 +1,9 @@
+use std::ffi::OsStr;
+
 use crate::exception::Exception;
 use crate::exception_handler;
 use crate::extn::core::exception::Fatal;
+use crate::ffi;
 use crate::sys::{protect, DescribeState};
 use crate::value::Value;
 use crate::{Artichoke, Eval};
@@ -37,6 +40,11 @@ impl Eval for Artichoke {
                 Err(exception_handler::last_error(self, exception)?)
             }
         }
+    }
+
+    fn eval_os_str(&mut self, code: &OsStr) -> Result<Self::Value, Self::Error> {
+        let code = ffi::os_str_to_bytes(code)?;
+        self.eval(&code)
     }
 }
 

--- a/artichoke-backend/src/ffi/unix.rs
+++ b/artichoke-backend/src/ffi/unix.rs
@@ -1,0 +1,13 @@
+use std::borrow::Cow;
+use std::ffi::OsStr;
+use std::os::unix::ffi::OsStrExt;
+
+use crate::ffi::ConvertBytesError;
+
+pub fn os_str_to_bytes(value: &OsStr) -> Result<Cow<'_, [u8]>, ConvertBytesError> {
+    Ok(value.as_bytes().into())
+}
+
+pub fn bytes_to_os_str(value: &[u8]) -> Result<Cow<'_, OsStr>, ConvertBytesError> {
+    Ok(OsStr::from_bytes(value).into())
+}

--- a/artichoke-backend/src/ffi/unknown.rs
+++ b/artichoke-backend/src/ffi/unknown.rs
@@ -1,0 +1,20 @@
+use std::borrow::Cow;
+use std::ffi::OsStr;
+use std::str;
+
+use crate::ffi::ConvertBytesError;
+
+pub fn os_str_to_bytes(value: &OsStr) -> Result<Cow<'_, [u8]>, ConvertBytesError> {
+    value
+        .to_str()
+        .map(str::as_bytes)
+        .map(Into::into)
+        .ok_or(ConvertBytesError)
+}
+
+pub fn bytes_to_os_str(value: &[u8]) -> Result<Cow<'_, OsStr>, ConvertBytesError> {
+    str::from_utf8(value)
+        .map(OsStr::new)
+        .map(Into::into)
+        .map_err(|_| ConvertBytesError)
+}

--- a/artichoke-backend/src/ffi/windows.rs
+++ b/artichoke-backend/src/ffi/windows.rs
@@ -1,0 +1,20 @@
+use std::borrow::Cow;
+use std::ffi::OsStr;
+use std::str;
+
+use crate::ffi::ConvertBytesError;
+
+pub fn os_str_to_bytes(value: &OsStr) -> Result<Cow<'_, [u8]>, ConvertBytesError> {
+    value
+        .to_str()
+        .map(str::as_bytes)
+        .map(Into::into)
+        .ok_or(ConvertBytesError)
+}
+
+pub fn bytes_to_os_str(value: &[u8]) -> Result<Cow<'_, OsStr>, ConvertBytesError> {
+    str::from_utf8(value)
+        .map(OsStr::new)
+        .map(Into::into)
+        .map_err(|_| ConvertBytesError)
+}

--- a/artichoke-backend/src/fs.rs
+++ b/artichoke-backend/src/fs.rs
@@ -1,10 +1,8 @@
 //! [`Artichoke`] virtual filesystem used for storing Ruby sources.
 
 use artichoke_vfs::{FakeFileSystem, FileSystem};
-use std::ffi::OsStr;
 use std::path::{Component, Path, PathBuf};
 
-use crate::exception::Exception;
 use crate::{Artichoke, ArtichokeError};
 
 pub const RUBY_LOAD_PATH: &str = "/src/lib";
@@ -145,50 +143,4 @@ fn absolutize_relative_to(path: &Path, cwd: &Path) -> Result<PathBuf, ArtichokeE
         }
     }
     Ok(components.into_iter().collect())
-}
-
-#[cfg(unix)]
-pub fn osstr_to_bytes<'a>(interp: &Artichoke, value: &'a OsStr) -> Result<&'a [u8], Exception> {
-    use std::os::unix::ffi::OsStrExt;
-
-    let _ = interp;
-    Ok(value.as_bytes())
-}
-
-#[cfg(not(unix))]
-pub fn osstr_to_bytes<'a>(interp: &Artichoke, value: &'a OsStr) -> Result<&'a [u8], Exception> {
-    use crate::extn::core::exception::Fatal;
-
-    if let Some(converted) = value.to_str() {
-        Ok(converted.as_bytes())
-    } else {
-        Err(Exception::from(Fatal::new(
-            interp,
-            // TODO: Add a ticket number to this message.
-            "non UTF-8 ENV keys and values are not yet supported on this Artichoke platform",
-        )))
-    }
-}
-
-#[cfg(unix)]
-pub fn bytes_to_osstr<'a>(interp: &Artichoke, value: &'a [u8]) -> Result<&'a OsStr, Exception> {
-    use std::os::unix::ffi::OsStrExt;
-
-    let _ = interp;
-    Ok(OsStr::from_bytes(value))
-}
-
-#[cfg(not(unix))]
-pub fn bytes_to_osstr<'a>(interp: &Artichoke, value: &'a [u8]) -> Result<&'a OsStr, Exception> {
-    use crate::extn::core::exception::Fatal;
-
-    if let Ok(converted) = std::str::from_utf8(value) {
-        Ok(OsStr::new(converted))
-    } else {
-        Err(Exception::from(Fatal::new(
-            interp,
-            // TODO: Add a ticket number to this message.
-            "non UTF-8 ENV keys and values are not yet supported on this Artichoke platform",
-        )))
-    }
 }

--- a/artichoke-backend/src/load.rs
+++ b/artichoke-backend/src/load.rs
@@ -2,7 +2,8 @@ use std::borrow::Cow;
 use std::io;
 use std::path::Path;
 
-use crate::fs::{self, RUBY_LOAD_PATH};
+use crate::ffi;
+use crate::fs::RUBY_LOAD_PATH;
 use crate::{Artichoke, ArtichokeError, File, LoadSources};
 
 impl LoadSources for Artichoke {
@@ -13,10 +14,10 @@ impl LoadSources for Artichoke {
         T: File<Artichoke = Self>,
     {
         let api = self.0.borrow();
-        let path = fs::bytes_to_osstr(self, filename).map_err(|err| {
+        let path = ffi::bytes_to_os_str(filename).map_err(|err| {
             ArtichokeError::Vfs(io::Error::new(io::ErrorKind::Other, err.to_string()))
         })?;
-        let path = Path::new(path);
+        let path = Path::new(&path);
         let path = if path.is_relative() {
             Path::new(RUBY_LOAD_PATH).join(path)
         } else {
@@ -44,10 +45,10 @@ impl LoadSources for Artichoke {
         T: Into<Cow<'static, [u8]>>,
     {
         let api = self.0.borrow();
-        let path = fs::bytes_to_osstr(self, filename).map_err(|err| {
+        let path = ffi::bytes_to_os_str(filename).map_err(|err| {
             ArtichokeError::Vfs(io::Error::new(io::ErrorKind::Other, err.to_string()))
         })?;
-        let path = Path::new(path);
+        let path = Path::new(&path);
         let path = if path.is_relative() {
             Path::new(RUBY_LOAD_PATH).join(path)
         } else {

--- a/artichoke-core/src/eval.rs
+++ b/artichoke-core/src/eval.rs
@@ -1,5 +1,7 @@
 //! Run code on an Artichoke interpreter.
 
+use std::ffi::OsStr;
+
 use crate::value::Value;
 
 /// Interpreters that implement [`Eval`] expose methods for injecting code and
@@ -21,4 +23,15 @@ pub trait Eval {
     ///
     /// If an exception is raised on the interpreter, then an error is returned.
     fn eval(&mut self, code: &[u8]) -> Result<Self::Value, Self::Error>;
+
+    /// Eval code on the Artichoke interpreter using the current `Context` when
+    /// given code as an [`OsStr`].
+    ///
+    /// # Errors
+    ///
+    /// If an exception is raised on the interpreter, then an error is returned.
+    ///
+    /// If `code` cannot be converted to a `&[u8]` on the current platform, then
+    /// an error is returned.
+    fn eval_os_str(&mut self, code: &OsStr) -> Result<Self::Value, Self::Error>;
 }


### PR DESCRIPTION
The `ruby` CLI frontend must eval `-e` inline eval strings directly from
the command line args. Rust + Clap + StructOpt exposes these as
`OsString`.

Rather than expose `artichoke-backend` internals for ffi adapters or
duplicate `OsStr` <=> bytes conversions, this commit adds a new `Eval`
API that takes an `OsStr` directly and does the conversion in
`artichoke-backend`.

This commit extracts the conversion functions from the `fs` module
(where they were originally extracted from `extn::core::env`). Since
these converters are platform-specific code, move them to the `ffi`
module.

The converters use a custom error type which implements `RubyException`
and `Into<Exception>`, which eliminates the need for these APIs to take
an interpreter.

This commit moves the platform specific FFI functions to their own
modules which are multiplexed using import aliasing. There is platform
support for unix, windows, and not(any(unix, windows)). For now, windows
and unknown platform have the same implementation which delegates to
`OsStr::to_str` and `str::from_utf8`.

See GH-339.