### PR TITLE
Fix std::error deprecations

### DIFF
--- a/artichoke-backend/src/def.rs
+++ b/artichoke-backend/src/def.rs
@@ -213,15 +213,7 @@ impl fmt::Display for ConstantNameError {
     }
 }
 
-impl error::Error for ConstantNameError {
-    fn description(&self) -> &str {
-        "Invalid constant name contained a NUL byte"
-    }
-
-    fn cause(&self) -> Option<&dyn error::Error> {
-        None
-    }
-}
+impl error::Error for ConstantNameError {}
 
 impl RubyException for ConstantNameError {
     fn box_clone(&self) -> Box<dyn RubyException> {
@@ -229,14 +221,14 @@ impl RubyException for ConstantNameError {
     }
 
     fn message(&self) -> &[u8] {
-        error::Error::description(self).as_bytes()
+        &b"Invalid constant name contained a NUL byte"[..]
     }
 
     fn name(&self) -> String {
         String::from("NameError")
     }
 
-    fn backtrace(&self, interp: &Artichoke) -> Option<Vec<Vec<u8>>> {
+    fn vm_backtrace(&self, interp: &Artichoke) -> Option<Vec<Vec<u8>>> {
         let _ = interp;
         None
     }
@@ -317,15 +309,7 @@ impl fmt::Display for NotDefinedError {
     }
 }
 
-impl error::Error for NotDefinedError {
-    fn description(&self) -> &str {
-        "Class-like not defined"
-    }
-
-    fn cause(&self) -> Option<&dyn error::Error> {
-        None
-    }
-}
+impl error::Error for NotDefinedError {}
 
 impl RubyException for NotDefinedError {
     fn box_clone(&self) -> Box<dyn RubyException> {
@@ -333,14 +317,14 @@ impl RubyException for NotDefinedError {
     }
 
     fn message(&self) -> &[u8] {
-        error::Error::description(self).as_bytes()
+        &b"Class-like not defined"[..]
     }
 
     fn name(&self) -> String {
         String::from("ScriptError")
     }
 
-    fn backtrace(&self, interp: &Artichoke) -> Option<Vec<Vec<u8>>> {
+    fn vm_backtrace(&self, interp: &Artichoke) -> Option<Vec<Vec<u8>>> {
         let _ = interp;
         None
     }

--- a/artichoke-backend/src/exception.rs
+++ b/artichoke-backend/src/exception.rs
@@ -1,6 +1,7 @@
 use std::error;
 use std::fmt;
 
+use crate::string;
 use crate::sys;
 use crate::value::Value;
 use crate::{Artichoke, ValueLike};
@@ -22,8 +23,8 @@ impl RubyException for Exception {
         self.0.name()
     }
 
-    fn backtrace(&self, interp: &Artichoke) -> Option<Vec<Vec<u8>>> {
-        self.0.backtrace(interp)
+    fn vm_backtrace(&self, interp: &Artichoke) -> Option<Vec<Vec<u8>>> {
+        self.0.vm_backtrace(interp)
     }
 
     fn as_mrb_value(&self, interp: &mut Artichoke) -> Option<sys::mrb_value> {
@@ -37,15 +38,7 @@ impl fmt::Display for Exception {
     }
 }
 
-impl error::Error for Exception {
-    fn description(&self) -> &str {
-        "Ruby Exception thrown on Artichoke VM"
-    }
-
-    fn cause(&self) -> Option<&dyn error::Error> {
-        None
-    }
-}
+impl error::Error for Exception {}
 
 impl From<Box<dyn RubyException>> for Exception {
     fn from(exc: Box<dyn RubyException>) -> Self {
@@ -87,7 +80,7 @@ pub unsafe fn raise(mut interp: Artichoke, exception: impl RubyException + fmt::
 /// [`exception::raise`](raise). Rust code can re-raise a trait object to
 /// propagate exceptions from native code back into the interpreter.
 #[allow(clippy::module_name_repetitions)]
-pub trait RubyException
+pub trait RubyException: error::Error
 where
     Self: 'static,
 {
@@ -104,7 +97,7 @@ where
     fn name(&self) -> String;
 
     /// Optional backtrace specified by a `Vec` of frames.
-    fn backtrace(&self, interp: &Artichoke) -> Option<Vec<Vec<u8>>>;
+    fn vm_backtrace(&self, interp: &Artichoke) -> Option<Vec<Vec<u8>>>;
 
     /// Return a raiseable [`sys::mrb_value`].
     fn as_mrb_value(&self, interp: &mut Artichoke) -> Option<sys::mrb_value>;
@@ -123,8 +116,8 @@ impl RubyException for Box<dyn RubyException> {
         self.as_ref().name()
     }
 
-    fn backtrace(&self, interp: &Artichoke) -> Option<Vec<Vec<u8>>> {
-        self.as_ref().backtrace(interp)
+    fn vm_backtrace(&self, interp: &Artichoke) -> Option<Vec<Vec<u8>>> {
+        self.as_ref().vm_backtrace(interp)
     }
 
     fn as_mrb_value(&self, interp: &mut Artichoke) -> Option<sys::mrb_value> {
@@ -132,57 +125,9 @@ impl RubyException for Box<dyn RubyException> {
     }
 }
 
-impl fmt::Debug for Box<dyn RubyException> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let classname = self.name();
-        let message = String::from_utf8_lossy(self.message());
-        write!(f, "{} ({})", classname, message)
-    }
-}
+impl error::Error for Box<dyn RubyException> {}
 
-impl fmt::Display for Box<dyn RubyException> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let classname = self.name();
-        let message = String::from_utf8_lossy(self.message());
-        write!(f, "{} ({})", classname, message)
-    }
-}
-
-impl error::Error for Box<dyn RubyException> {
-    fn description(&self) -> &str {
-        "Ruby Exception thrown on Artichoke VM"
-    }
-
-    fn cause(&self) -> Option<&dyn error::Error> {
-        None
-    }
-}
-
-impl fmt::Debug for &dyn RubyException {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let classname = self.name();
-        let message = String::from_utf8_lossy(self.message());
-        write!(f, "{} ({})", classname, message)
-    }
-}
-
-impl fmt::Display for &dyn RubyException {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let classname = self.name();
-        let message = String::from_utf8_lossy(self.message());
-        write!(f, "{} ({})", classname, message)
-    }
-}
-
-impl error::Error for &dyn RubyException {
-    fn description(&self) -> &str {
-        "Ruby Exception thrown on Artichoke VM"
-    }
-
-    fn cause(&self) -> Option<&dyn error::Error> {
-        None
-    }
-}
+impl error::Error for &dyn RubyException {}
 
 /// An `Exception` rescued with [`sys::mrb_protect`].
 ///
@@ -206,6 +151,17 @@ impl CaughtException {
     }
 }
 
+impl fmt::Display for CaughtException {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let classname = self.name();
+        write!(f, "{} (", classname)?;
+        string::escape_unicode(f, self.message()).map_err(|err| err.into_inner())?;
+        write!(f, ")")
+    }
+}
+
+impl error::Error for CaughtException {}
+
 impl RubyException for CaughtException {
     fn box_clone(&self) -> Box<dyn RubyException> {
         Box::new(self.clone())
@@ -219,7 +175,7 @@ impl RubyException for CaughtException {
         self.name.clone()
     }
 
-    fn backtrace(&self, interp: &Artichoke) -> Option<Vec<Vec<u8>>> {
+    fn vm_backtrace(&self, interp: &Artichoke) -> Option<Vec<Vec<u8>>> {
         let _ = interp;
         self.value.funcall("backtrace", &[], None).ok()
     }
@@ -240,13 +196,5 @@ impl From<CaughtException> for Box<dyn RubyException> {
 impl From<CaughtException> for Exception {
     fn from(exc: CaughtException) -> Self {
         Self(Box::new(exc))
-    }
-}
-
-impl fmt::Display for CaughtException {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let classname = self.name();
-        let message = String::from_utf8_lossy(self.message());
-        write!(f, "{} ({})", classname, message)
     }
 }

--- a/artichoke-backend/src/exception.rs
+++ b/artichoke-backend/src/exception.rs
@@ -155,7 +155,7 @@ impl fmt::Display for CaughtException {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let classname = self.name();
         write!(f, "{} (", classname)?;
-        string::escape_unicode(f, self.message()).map_err(|err| err.into_inner())?;
+        string::escape_unicode(f, self.message()).map_err(string::WriteError::into_inner)?;
         write!(f, ")")
     }
 }

--- a/artichoke-backend/src/exception_handler.rs
+++ b/artichoke-backend/src/exception_handler.rs
@@ -67,7 +67,7 @@ mod tests {
         assert_eq!(&b"waffles"[..], err.message());
         assert_eq!(
             Some(vec![Vec::from(&b"(eval):1"[..])]),
-            err.backtrace(&interp)
+            err.vm_backtrace(&interp)
         );
     }
 
@@ -77,7 +77,7 @@ mod tests {
         let err = interp.eval(b"def bad; (; end").unwrap_err();
         assert_eq!("SyntaxError", err.name().as_str());
         assert_eq!(&b"syntax error"[..], err.message());
-        assert_eq!(None, err.backtrace(&interp));
+        assert_eq!(None, err.vm_backtrace(&interp));
     }
 
     #[test]

--- a/artichoke-backend/src/extn/core/exception/mod.rs
+++ b/artichoke-backend/src/extn/core/exception/mod.rs
@@ -347,7 +347,7 @@ macro_rules! ruby_exception_impl {
                 String::from(stringify!($exception))
             }
 
-            fn backtrace(&self, interp: &Artichoke) -> Option<Vec<Vec<u8>>> {
+            fn vm_backtrace(&self, interp: &Artichoke) -> Option<Vec<Vec<u8>>> {
                 let _ = interp;
                 None
             }
@@ -367,8 +367,9 @@ macro_rules! ruby_exception_impl {
         {
             fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 let classname = self.name();
-                let message = String::from_utf8_lossy(self.message());
-                write!(f, "{} ({})", classname, message)
+                write!(f, "{} (", classname)?;
+                string::escape_unicode(f, self.message()).map_err(|err| err.into_inner())?;
+                write!(f, ")")
             }
         }
 
@@ -378,20 +379,13 @@ macro_rules! ruby_exception_impl {
         {
             fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 let classname = self.name();
-                let message = String::from_utf8_lossy(self.message());
-                write!(f, "{} ({})", classname, message)
+                write!(f, "{} (", classname)?;
+                string::escape_unicode(f, self.message()).map_err(|err| err.into_inner())?;
+                write!(f, ")")
             }
         }
 
-        impl error::Error for $exception {
-            fn description(&self) -> &str {
-                concat!("Ruby Exception: ", stringify!($exception))
-            }
-
-            fn cause(&self) -> Option<&dyn error::Error> {
-                None
-            }
-        }
+        impl error::Error for $exception {}
     };
 }
 

--- a/artichoke-backend/src/extn/core/exception/mod.rs
+++ b/artichoke-backend/src/extn/core/exception/mod.rs
@@ -368,7 +368,8 @@ macro_rules! ruby_exception_impl {
             fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 let classname = self.name();
                 write!(f, "{} (", classname)?;
-                string::escape_unicode(f, self.message()).map_err(|err| err.into_inner())?;
+                string::escape_unicode(f, self.message())
+                    .map_err(string::WriteError::into_inner)?;
                 write!(f, ")")
             }
         }
@@ -380,7 +381,8 @@ macro_rules! ruby_exception_impl {
             fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 let classname = self.name();
                 write!(f, "{} (", classname)?;
-                string::escape_unicode(f, self.message()).map_err(|err| err.into_inner())?;
+                string::escape_unicode(f, self.message())
+                    .map_err(string::WriteError::into_inner)?;
                 write!(f, ")")
             }
         }
@@ -466,7 +468,7 @@ mod tests {
         assert_eq!(Vec::from(&b"something went wrong"[..]), err.message());
         assert_eq!(
             Some(vec![Vec::from(&b"(eval):1"[..])]),
-            err.backtrace(&interp)
+            err.vm_backtrace(&interp)
         );
     }
 }

--- a/artichoke-backend/src/extn/core/kernel/mod.rs
+++ b/artichoke-backend/src/extn/core/kernel/mod.rs
@@ -180,7 +180,7 @@ mod tests {
             err.message()
         );
         let expected = vec![Vec::from(&b"(eval):1"[..])];
-        assert_eq!(Some(expected), err.backtrace(&interp),);
+        assert_eq!(Some(expected), err.vm_backtrace(&interp),);
     }
 
     #[test]
@@ -214,7 +214,7 @@ mod tests {
         let err = interp.eval(b"require '/src'").unwrap_err();
         assert_eq!(&b"cannot load such file -- /src"[..], err.message());
         let expected = vec![Vec::from(&b"(eval):1"[..])];
-        assert_eq!(Some(expected), err.backtrace(&interp),);
+        assert_eq!(Some(expected), err.vm_backtrace(&interp),);
     }
 
     #[test]

--- a/artichoke-backend/src/extn/core/thread.rs
+++ b/artichoke-backend/src/extn/core/thread.rs
@@ -187,6 +187,6 @@ end.join
             Vec::from(&b"/src/lib/thread.rb:122:in initialize"[..]),
             Vec::from(&b"(eval):2"[..]),
         ];
-        assert_eq!(Some(expected_backtrace), err.backtrace(&interp));
+        assert_eq!(Some(expected_backtrace), err.vm_backtrace(&interp));
     }
 }

--- a/artichoke-backend/src/ffi.rs
+++ b/artichoke-backend/src/ffi.rs
@@ -94,19 +94,11 @@ pub struct ConvertBytesError;
 
 impl fmt::Display for ConvertBytesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", error::Error::description(self))
+        write!(f, "Could not convert between bytes and platform string")
     }
 }
 
-impl error::Error for ConvertBytesError {
-    fn description(&self) -> &str {
-        "Could not convert between bytes and platform string"
-    }
-
-    fn cause(&self) -> Option<&dyn error::Error> {
-        None
-    }
-}
+impl error::Error for ConvertBytesError {}
 
 impl RubyException for ConvertBytesError {
     fn box_clone(&self) -> Box<dyn RubyException> {
@@ -121,7 +113,7 @@ impl RubyException for ConvertBytesError {
         String::from("ArgumentError")
     }
 
-    fn backtrace(&self, interp: &Artichoke) -> Option<Vec<Vec<u8>>> {
+    fn vm_backtrace(&self, interp: &Artichoke) -> Option<Vec<Vec<u8>>> {
         let _ = interp;
         None
     }

--- a/artichoke-backend/src/lib.rs
+++ b/artichoke-backend/src/lib.rs
@@ -216,11 +216,7 @@ impl fmt::Display for BootError {
 }
 
 impl error::Error for BootError {
-    fn description(&self) -> &str {
-        "Artichoke interpreter boot error"
-    }
-
-    fn cause(&self) -> Option<&dyn error::Error> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match self.0 {
             BootErrorType::Artichoke(ref err) => Some(err),
             BootErrorType::Ruby(ref exc) => Some(exc),

--- a/artichoke-backend/src/string.rs
+++ b/artichoke-backend/src/string.rs
@@ -56,6 +56,12 @@ where
 #[derive(Debug, Clone)]
 pub struct WriteError(fmt::Error);
 
+impl WriteError {
+    pub fn into_inner(self) -> fmt::Error {
+        self.0
+    }
+}
+
 impl From<fmt::Error> for WriteError {
     fn from(err: fmt::Error) -> Self {
         Self(err)
@@ -69,11 +75,7 @@ impl fmt::Display for WriteError {
 }
 
 impl error::Error for WriteError {
-    fn description(&self) -> &str {
-        "Write error"
-    }
-
-    fn cause(&self) -> Option<&dyn error::Error> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         Some(&self.0)
     }
 }
@@ -91,7 +93,7 @@ impl RubyException for WriteError {
         String::from("fatal")
     }
 
-    fn backtrace(&self, interp: &Artichoke) -> Option<Vec<Vec<u8>>> {
+    fn vm_backtrace(&self, interp: &Artichoke) -> Option<Vec<Vec<u8>>> {
         let _ = interp;
         None
     }

--- a/artichoke-backend/src/string.rs
+++ b/artichoke-backend/src/string.rs
@@ -57,6 +57,7 @@ where
 pub struct WriteError(fmt::Error);
 
 impl WriteError {
+    #[must_use]
     pub fn into_inner(self) -> fmt::Error {
         self.0
     }

--- a/artichoke-backend/tests/leak_unbounded_arena_growth.rs
+++ b/artichoke-backend/tests/leak_unbounded_arena_growth.rs
@@ -49,7 +49,7 @@ end
         let arena = interp.create_arena_savepoint();
         let result = interp.eval(code).unwrap_err();
         arena.restore();
-        assert_eq!(expected, result.backtrace(&interp));
+        assert_eq!(expected, result.vm_backtrace(&interp));
         drop(result);
         interp.incremental_gc();
     });

--- a/artichoke-core/src/lib.rs
+++ b/artichoke-core/src/lib.rs
@@ -99,12 +99,4 @@ impl fmt::Display for ArtichokeError {
     }
 }
 
-impl error::Error for ArtichokeError {
-    fn description(&self) -> &str {
-        "Artichoke interpreter error"
-    }
-
-    fn cause(&self) -> Option<&dyn error::Error> {
-        None
-    }
-}
+impl error::Error for ArtichokeError {}

--- a/artichoke-core/src/parser.rs
+++ b/artichoke-core/src/parser.rs
@@ -65,12 +65,4 @@ impl fmt::Display for IncrementLinenoError {
     }
 }
 
-impl error::Error for IncrementLinenoError {
-    fn description(&self) -> &str {
-        "Error manipulating line number in parser state"
-    }
-
-    fn cause(&self) -> Option<&dyn error::Error> {
-        None
-    }
-}
+impl error::Error for IncrementLinenoError {}

--- a/artichoke-frontend/src/repl.rs
+++ b/artichoke-frontend/src/repl.rs
@@ -172,7 +172,7 @@ pub fn run(
                         output.write_all(result.as_slice())?;
                     }
                     Err(exc) => {
-                        if let Some(backtrace) = exc.backtrace(&interp) {
+                        if let Some(backtrace) = exc.vm_backtrace(&interp) {
                             writeln!(
                                 error,
                                 "{} (most recent call last)",


### PR DESCRIPTION
- Remove `description` implementations. `description` is soft
  deprecated.
- Convert `cause` implementations to `source`. `cause` is deprecated and
  `source` supports downcasting.
- Remove empty `source` implementations.
- Inline static str when code previously called `description`.
- Rename `RubyException::backtrace` to `RubyException::vm_backtrace` to
  address upcomming `std::backtrace` name reservation.
- Add `WriteError::into_inner` for extracting inner `fmt::Error` for use
  in `Debug` and `Display` impls.
- Replace `String::from_utf8_lossy` with `string::escape_unicode` in
  several `Debug` and `Display` impls.
- Add a `std::error::Error` supertrait to `RubyException`.
- Add missing error impls.
- Update frontend backtrace callsite.