### PR TITLE
Rename HashOfStringToArrayOfInt type alias to NameToCaptureLocations

### DIFF
--- a/artichoke-backend/src/extn/core/regexp/backend/lazy.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/lazy.rs
@@ -5,7 +5,7 @@ use std::fmt;
 use crate::extn::core::regexp::{Config, Encoding, Regexp, RegexpType};
 use crate::extn::prelude::*;
 
-use super::{HashOfStringToArrayOfInt, NilableString};
+use super::{NameToCaptureLocations, NilableString};
 
 pub struct Lazy {
     literal: Config,
@@ -163,7 +163,7 @@ impl RegexpType for Lazy {
         self.regexp(interp)?.inner().match_operator(interp, pattern)
     }
 
-    fn named_captures(&self, interp: &Artichoke) -> Result<HashOfStringToArrayOfInt, Exception> {
+    fn named_captures(&self, interp: &Artichoke) -> Result<NameToCaptureLocations, Exception> {
         self.regexp(interp)?.inner().named_captures(interp)
     }
 

--- a/artichoke-backend/src/extn/core/regexp/backend/mod.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/mod.rs
@@ -8,7 +8,7 @@ pub mod onig;
 pub mod regex;
 
 type NilableString = Option<Vec<u8>>;
-type HashOfStringToArrayOfInt = Vec<(Vec<u8>, Vec<Int>)>;
+type NameToCaptureLocations = Vec<(Vec<u8>, Vec<Int>)>;
 
 pub trait RegexpType {
     fn box_clone(&self) -> Box<dyn RegexpType>;
@@ -69,7 +69,7 @@ pub trait RegexpType {
         pattern: &[u8],
     ) -> Result<Option<Int>, Exception>;
 
-    fn named_captures(&self, interp: &Artichoke) -> Result<HashOfStringToArrayOfInt, Exception>;
+    fn named_captures(&self, interp: &Artichoke) -> Result<NameToCaptureLocations, Exception>;
 
     fn named_captures_for_haystack(
         &self,

--- a/artichoke-backend/src/extn/core/regexp/backend/onig.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/onig.rs
@@ -10,7 +10,7 @@ use crate::extn::core::matchdata::MatchData;
 use crate::extn::core::regexp::{self, Config, Encoding, Regexp, RegexpType};
 use crate::extn::prelude::*;
 
-use super::{HashOfStringToArrayOfInt, NilableString};
+use super::{NameToCaptureLocations, NilableString};
 
 #[derive(Clone)]
 pub struct Onig {
@@ -471,7 +471,7 @@ impl RegexpType for Onig {
         }
     }
 
-    fn named_captures(&self, interp: &Artichoke) -> Result<HashOfStringToArrayOfInt, Exception> {
+    fn named_captures(&self, interp: &Artichoke) -> Result<NameToCaptureLocations, Exception> {
         // Use a Vec of key-value pairs because insertion order matters for spec
         // compliance.
         let mut map = vec![];

--- a/artichoke-backend/src/extn/core/regexp/backend/regex/utf8.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/regex/utf8.rs
@@ -9,7 +9,7 @@ use crate::extn::core::matchdata::MatchData;
 use crate::extn::core::regexp::{self, Config, Encoding, Regexp, RegexpType};
 use crate::extn::prelude::*;
 
-use super::super::{HashOfStringToArrayOfInt, NilableString};
+use super::super::{NameToCaptureLocations, NilableString};
 
 #[derive(Clone)]
 pub struct Utf8 {
@@ -508,7 +508,7 @@ impl RegexpType for Utf8 {
         }
     }
 
-    fn named_captures(&self, interp: &Artichoke) -> Result<HashOfStringToArrayOfInt, Exception> {
+    fn named_captures(&self, interp: &Artichoke) -> Result<NameToCaptureLocations, Exception> {
         // Use a Vec of key-value pairs because insertion order matters for spec
         // compliance.
         let mut map = vec![];


### PR DESCRIPTION
The new name actually names the type by its purpose, which makes the code easier
to read.