### PR TITLE
Remove converter trait reexports from artichoke_backend::convert

### DIFF
--- a/artichoke-backend/src/convert.rs
+++ b/artichoke-backend/src/convert.rs
@@ -8,13 +8,4 @@ mod nilable;
 mod object;
 mod string;
 
-/// Re-export from [`artichoke_core`](artichoke_core::convert::Convert).
-pub use crate::core::convert::Convert;
-/// Re-export from [`artichoke_core`](artichoke_core::convert::ConvertMut).
-pub use crate::core::convert::ConvertMut;
-/// Re-export from [`artichoke_core`](artichoke_core::convert::TryConvert).
-pub use crate::core::convert::TryConvert;
-/// Re-export from [`artichoke_core`](artichoke_core::convert::TryConvertMut).
-pub use crate::core::convert::TryConvertMut;
-
-pub use self::object::RustBackedValue;
+pub use object::RustBackedValue;

--- a/artichoke-backend/src/convert/array.rs
+++ b/artichoke-backend/src/convert/array.rs
@@ -1,10 +1,10 @@
 use std::iter::FromIterator;
 
-use crate::convert::{Convert, ConvertMut, RustBackedValue, TryConvert};
+use crate::convert::RustBackedValue;
 use crate::extn::core::array::{Array, InlineBuffer};
 use crate::types::{Int, Ruby, Rust};
 use crate::value::Value;
-use crate::{Artichoke, ArtichokeError};
+use crate::{Artichoke, ArtichokeError, Convert, ConvertMut, TryConvert};
 
 impl ConvertMut<&[Value], Value> for Artichoke {
     fn convert_mut(&mut self, value: &[Value]) -> Value {

--- a/artichoke-backend/src/convert/boolean.rs
+++ b/artichoke-backend/src/convert/boolean.rs
@@ -1,8 +1,7 @@
-use crate::convert::{Convert, TryConvert};
 use crate::sys;
 use crate::types::{Ruby, Rust};
 use crate::value::Value;
-use crate::{Artichoke, ArtichokeError};
+use crate::{Artichoke, ArtichokeError, Convert, TryConvert};
 
 impl Convert<bool, Value> for Artichoke {
     fn convert(&self, value: bool) -> Value {

--- a/artichoke-backend/src/convert/bytes.rs
+++ b/artichoke-backend/src/convert/bytes.rs
@@ -2,11 +2,10 @@ use std::convert::TryFrom;
 use std::ffi::CStr;
 use std::slice;
 
-use crate::convert::{ConvertMut, TryConvert};
 use crate::sys;
 use crate::types::{Ruby, Rust};
 use crate::value::Value;
-use crate::{Artichoke, ArtichokeError};
+use crate::{Artichoke, ArtichokeError, ConvertMut, TryConvert};
 
 impl ConvertMut<Vec<u8>, Value> for Artichoke {
     fn convert_mut(&mut self, value: Vec<u8>) -> Value {

--- a/artichoke-backend/src/convert/fixnum.rs
+++ b/artichoke-backend/src/convert/fixnum.rs
@@ -1,10 +1,9 @@
 use std::convert::TryFrom;
 
-use crate::convert::{Convert, TryConvert};
 use crate::sys;
 use crate::types::{Int, Ruby, Rust};
 use crate::value::Value;
-use crate::{Artichoke, ArtichokeError};
+use crate::{Artichoke, ArtichokeError, Convert, TryConvert};
 
 impl Convert<u8, Value> for Artichoke {
     fn convert(&self, value: u8) -> Value {

--- a/artichoke-backend/src/convert/float.rs
+++ b/artichoke-backend/src/convert/float.rs
@@ -1,8 +1,7 @@
-use crate::convert::{ConvertMut, TryConvert};
 use crate::sys;
 use crate::types::{Float, Ruby, Rust};
 use crate::value::Value;
-use crate::{Artichoke, ArtichokeError};
+use crate::{Artichoke, ArtichokeError, ConvertMut, TryConvert};
 
 // TODO: when ,mruby is gone, float conversion should not allocate.
 impl ConvertMut<Float, Value> for Artichoke {

--- a/artichoke-backend/src/convert/hash.rs
+++ b/artichoke-backend/src/convert/hash.rs
@@ -1,12 +1,12 @@
 use std::collections::HashMap;
 use std::convert::TryFrom;
 
-use crate::convert::{ConvertMut, RustBackedValue, TryConvert};
+use crate::convert::RustBackedValue;
 use crate::extn::core::array;
 use crate::sys;
 use crate::types::{Int, Ruby, Rust};
 use crate::value::Value;
-use crate::{Artichoke, ArtichokeError};
+use crate::{Artichoke, ArtichokeError, ConvertMut, TryConvert};
 
 // TODO: implement `PartialEq`, `Eq`, and `Hash` on `Value`, see GH-159.
 // TODO: implement `Convert<HashMap<Value, Value>>`, see GH-160.

--- a/artichoke-backend/src/convert/nilable.rs
+++ b/artichoke-backend/src/convert/nilable.rs
@@ -1,11 +1,10 @@
 //! Converters for nilable primitive Ruby types. Excludes collection types
 //! Array and Hash.
 
-use crate::convert::{Convert, ConvertMut, TryConvert};
 use crate::sys;
 use crate::types::{Int, Ruby};
 use crate::value::Value;
-use crate::{Artichoke, ArtichokeError};
+use crate::{Artichoke, ArtichokeError, Convert, ConvertMut, TryConvert};
 
 impl Convert<Option<Value>, Value> for Artichoke {
     fn convert(&self, value: Option<Value>) -> Value {

--- a/artichoke-backend/src/convert/string.rs
+++ b/artichoke-backend/src/convert/string.rs
@@ -1,9 +1,8 @@
 use std::str;
 
-use crate::convert::{ConvertMut, TryConvert};
 use crate::types::Rust;
 use crate::value::Value;
-use crate::{Artichoke, ArtichokeError};
+use crate::{Artichoke, ArtichokeError, ConvertMut, TryConvert};
 
 impl ConvertMut<String, Value> for Artichoke {
     fn convert_mut(&mut self, value: String) -> Value {

--- a/artichoke-backend/src/def.rs
+++ b/artichoke-backend/src/def.rs
@@ -8,13 +8,12 @@ use std::ptr::NonNull;
 use std::rc::Rc;
 
 use crate::class;
-use crate::convert::ConvertMut;
 use crate::convert::RustBackedValue;
 use crate::exception::{Exception, RubyException};
 use crate::extn::core::exception::{NameError, ScriptError};
 use crate::module;
 use crate::sys;
-use crate::Artichoke;
+use crate::{Artichoke, ConvertMut};
 
 /// Typedef for an mruby free function for an [`mrb_value`](sys::mrb_value) with
 /// `tt` [`MRB_TT_DATA`](sys::mrb_vtype::MRB_TT_DATA).

--- a/artichoke-backend/src/extn/prelude.rs
+++ b/artichoke-backend/src/extn/prelude.rs
@@ -7,7 +7,7 @@
 //! ```
 
 pub use crate::class;
-pub use crate::convert::{Convert, ConvertMut, RustBackedValue, TryConvert, TryConvertMut};
+pub use crate::convert::RustBackedValue;
 pub use crate::def::{self, EnclosingRubyScope, NotDefinedError};
 pub use crate::exception::{self, Exception, RubyException};
 pub use crate::extn::core::exception::*;
@@ -16,7 +16,10 @@ pub use crate::string;
 pub use crate::sys;
 pub use crate::types::{Float, Int, Ruby};
 pub use crate::value::{Block, Value};
-pub use crate::{Artichoke, ArtichokeError, Eval, Intern, LoadSources, ValueLike, Warn};
+pub use crate::{
+    Artichoke, ArtichokeError, Convert, ConvertMut, Eval, Intern, LoadSources, TryConvert,
+    TryConvertMut, ValueLike, Warn,
+};
 
 /// Type alias for errors returned from `init` functions in
 /// [`extn`](crate::extn).

--- a/artichoke-backend/src/ffi.rs
+++ b/artichoke-backend/src/ffi.rs
@@ -11,12 +11,11 @@ use std::mem;
 use std::ptr::NonNull;
 use std::rc::Rc;
 
-use crate::convert::ConvertMut;
 use crate::exception::{Exception, RubyException};
 use crate::extn::core::exception::ArgumentError;
 use crate::state::State;
 use crate::sys::{self, DescribeState};
-use crate::{Artichoke, ArtichokeError};
+use crate::{Artichoke, ArtichokeError, ConvertMut};
 
 #[cfg(unix)]
 mod unix;

--- a/artichoke-backend/src/io.rs
+++ b/artichoke-backend/src/io.rs
@@ -2,11 +2,10 @@ use std::error;
 use std::fmt;
 use std::io;
 
-use crate::convert::ConvertMut;
 use crate::exception::{Exception, RubyException};
 use crate::extn::core::exception;
 use crate::sys;
-use crate::Artichoke;
+use crate::{Artichoke, ConvertMut};
 
 #[derive(Debug)]
 pub struct IOError {

--- a/artichoke-backend/src/lib.rs
+++ b/artichoke-backend/src/lib.rs
@@ -138,15 +138,10 @@ mod test;
 
 pub use artichoke_core as core;
 
-/// Re-export from [`artichoke_core`](artichoke_core::convert::Convert).
-pub use crate::core::convert::Convert;
-/// Re-export from [`artichoke_core`](artichoke_core::convert::ConvertMut).
-pub use crate::core::convert::ConvertMut;
-/// Re-export from [`artichoke_core`](artichoke_core::convert::TryConvert).
-pub use crate::core::convert::TryConvert;
-/// Re-export from [`artichoke_core`](artichoke_core::convert::TryConvertMut).
-pub use crate::core::convert::TryConvertMut;
-
+pub use artichoke_core::convert::Convert;
+pub use artichoke_core::convert::ConvertMut;
+pub use artichoke_core::convert::TryConvert;
+pub use artichoke_core::convert::TryConvertMut;
 pub use artichoke_core::eval::Eval;
 pub use artichoke_core::file::File;
 pub use artichoke_core::intern::Intern;

--- a/artichoke-backend/src/string.rs
+++ b/artichoke-backend/src/string.rs
@@ -10,11 +10,10 @@ use bstr::ByteSlice;
 use std::error;
 use std::fmt;
 
-use crate::convert::ConvertMut;
 use crate::exception::{Exception, RubyException};
 use crate::extn::core::exception::Fatal;
 use crate::sys;
-use crate::Artichoke;
+use crate::{Artichoke, ConvertMut};
 
 /// Write a UTF-8 representation of a (potentially) binary `String`.
 ///

--- a/artichoke-backend/src/test/prelude.rs
+++ b/artichoke-backend/src/test/prelude.rs
@@ -7,7 +7,7 @@
 //! ```
 
 pub use crate::class;
-pub use crate::convert::{Convert, ConvertMut, RustBackedValue, TryConvert, TryConvertMut};
+pub use crate::convert::RustBackedValue;
 pub use crate::def::{self, EnclosingRubyScope};
 pub use crate::exception::{self, Exception, RubyException};
 pub use crate::extn::core::exception::*;
@@ -18,5 +18,6 @@ pub use crate::sys;
 pub use crate::types::{Float, Int, Ruby, Rust};
 pub use crate::value::{Block, Value};
 pub use crate::{
-    Artichoke, ArtichokeError, BootError, Eval, File, LoadSources, Parser, ValueLike, Warn,
+    Artichoke, ArtichokeError, BootError, Convert, ConvertMut, Eval, File, LoadSources, Parser,
+    TryConvert, TryConvertMut, ValueLike, Warn,
 };

--- a/artichoke-backend/src/value.rs
+++ b/artichoke-backend/src/value.rs
@@ -1,14 +1,13 @@
 use std::fmt;
 use std::ptr;
 
-use crate::convert::{Convert, ConvertMut, TryConvert};
 use crate::exception::Exception;
 use crate::exception_handler;
 use crate::extn::core::exception::{Fatal, TypeError};
 use crate::gc::MrbGarbageCollection;
 use crate::sys::{self, protect};
 use crate::types::{self, Int, Ruby};
-use crate::{Artichoke, ArtichokeError, Intern, ValueLike};
+use crate::{Artichoke, ArtichokeError, Convert, ConvertMut, Intern, TryConvert, ValueLike};
 
 /// Max argument count for function calls including initialize and yield.
 pub const MRB_FUNCALL_ARGC_MAX: usize = 16;

--- a/artichoke-backend/src/warn.rs
+++ b/artichoke-backend/src/warn.rs
@@ -1,11 +1,10 @@
 use std::io::{self, Write};
 
-use crate::convert::ConvertMut;
 use crate::def::NotDefinedError;
 use crate::exception::Exception;
 use crate::extn::core::warning::Warning;
 use crate::value::Value;
-use crate::{Artichoke, ValueLike, Warn};
+use crate::{Artichoke, ConvertMut, ValueLike, Warn};
 
 impl Warn for Artichoke {
     type Error = Exception;

--- a/artichoke-backend/tests/leak_funcall.rs
+++ b/artichoke-backend/tests/leak_funcall.rs
@@ -14,8 +14,8 @@
 //! If resident memory increases more than 10MB during the test, we likely are
 //! leaking memory.
 
-use artichoke_backend::convert::ConvertMut;
 use artichoke_backend::gc::MrbGarbageCollection;
+use artichoke_backend::ConvertMut;
 use artichoke_backend::ValueLike as _;
 
 mod leak;

--- a/artichoke-backend/tests/manual.rs
+++ b/artichoke-backend/tests/manual.rs
@@ -6,13 +6,13 @@
 extern crate artichoke_backend;
 
 use artichoke_backend::class;
-use artichoke_backend::convert::{Convert, RustBackedValue};
+use artichoke_backend::convert::RustBackedValue;
 use artichoke_backend::def;
 use artichoke_backend::exception::Exception;
 use artichoke_backend::sys;
 use artichoke_backend::types::Int;
 use artichoke_backend::value::Value;
-use artichoke_backend::{Artichoke, Eval, File, LoadSources, ValueLike};
+use artichoke_backend::{Artichoke, Convert, Eval, File, LoadSources, ValueLike};
 
 #[derive(Clone, Debug, Default)]
 struct Container {

--- a/artichoke-frontend/src/ruby.rs
+++ b/artichoke-frontend/src/ruby.rs
@@ -2,13 +2,12 @@
 //!
 //! Exported as `ruby` and `artichoke` binaries.
 
-use artichoke_backend::convert::ConvertMut;
 use artichoke_backend::exception::Exception;
 use artichoke_backend::ffi;
 use artichoke_backend::state::parser::Context;
 use artichoke_backend::string;
 use artichoke_backend::sys;
-use artichoke_backend::{BootError, Eval, Intern, Parser as _};
+use artichoke_backend::{BootError, ConvertMut, Eval, Intern, Parser as _};
 use std::ffi::{OsStr, OsString};
 use std::io::{self, Read};
 use std::path::{Path, PathBuf};


### PR DESCRIPTION
Simplify the module tree in artichoke-backend by removing redundant
exports of `Convert`, `ConvertMut`, `TryConvert`, and `TryConvertMut`
from the `artichoke_backend::convert` module.

Modify all imports to use the traits at the crate root which are already
reexported from artichoke-core.