### PR TITLE
Add InterpreterAllocError for interpreter initialization failures

### DIFF
--- a/artichoke-backend/src/interpreter.rs
+++ b/artichoke-backend/src/interpreter.rs
@@ -1,28 +1,32 @@
 use std::cell::RefCell;
+use std::error;
 use std::ffi::c_void;
+use std::fmt;
 use std::ptr::NonNull;
 use std::rc::Rc;
 
+use crate::exception::{Exception, RubyException};
 use crate::extn;
+use crate::extn::core::exception::Fatal;
 use crate::gc::MrbGarbageCollection;
 use crate::state::State;
 use crate::sys::{self, DescribeState};
-use crate::{Artichoke, ArtichokeError, BootError, Eval};
+use crate::{Artichoke, ConvertMut, Eval};
 
 /// Create and initialize an [`Artichoke`] interpreter.
 ///
 /// This function creates a new [`State`], embeds it in the [`sys::mrb_state`],
 /// initializes an [in memory virtual filesystem](crate::fs::Virtual), and loads
 /// the [`extn`] extensions to Ruby Core and Stdlib.
-pub fn interpreter() -> Result<Artichoke, BootError> {
+pub fn interpreter() -> Result<Artichoke, Exception> {
     let mut mrb = if let Some(mrb) = NonNull::new(unsafe { sys::mrb_open() }) {
         mrb
     } else {
-        error!("Failed to allocate mrb interprter");
-        return Err(BootError::from(ArtichokeError::New));
+        error!("Failed to allocate Artichoke interprter");
+        return Err(Exception::from(InterpreterAllocError));
     };
 
-    let state = State::new(unsafe { mrb.as_mut() }).ok_or(ArtichokeError::New)?;
+    let state = State::new(unsafe { mrb.as_mut() }).ok_or(InterpreterAllocError)?;
     let api = Rc::new(RefCell::new(state));
 
     // Transmute the smart pointer that wraps the API and store it in the user
@@ -67,6 +71,70 @@ pub fn interpreter() -> Result<Artichoke, BootError> {
     interp.full_gc();
 
     Ok(interp)
+}
+
+#[derive(Debug, Clone)]
+pub struct InterpreterAllocError;
+
+impl fmt::Display for InterpreterAllocError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Failed to allocate Artichoke interpreter")
+    }
+}
+
+impl error::Error for InterpreterAllocError {}
+
+impl RubyException for InterpreterAllocError {
+    fn box_clone(&self) -> Box<dyn RubyException> {
+        Box::new(self.clone())
+    }
+
+    fn message(&self) -> &[u8] {
+        &b"Failed to allocate Artichoke Ruby interpreter"[..]
+    }
+
+    fn name(&self) -> String {
+        String::from("fatal")
+    }
+
+    fn vm_backtrace(&self, interp: &Artichoke) -> Option<Vec<Vec<u8>>> {
+        let _ = interp;
+        None
+    }
+
+    fn as_mrb_value(&self, interp: &mut Artichoke) -> Option<sys::mrb_value> {
+        let message = interp.convert_mut(self.message());
+        let borrow = interp.0.borrow();
+        let spec = borrow.class_spec::<Fatal>()?;
+        let value = spec.new_instance(interp, &[message])?;
+        Some(value.inner())
+    }
+}
+
+impl From<InterpreterAllocError> for Exception {
+    fn from(exception: InterpreterAllocError) -> Self {
+        Self::from(Box::<dyn RubyException>::from(exception))
+    }
+}
+
+impl From<Box<InterpreterAllocError>> for Exception {
+    fn from(exception: Box<InterpreterAllocError>) -> Self {
+        Self::from(Box::<dyn RubyException>::from(exception))
+    }
+}
+
+#[allow(clippy::use_self)]
+impl From<InterpreterAllocError> for Box<dyn RubyException> {
+    fn from(exception: InterpreterAllocError) -> Box<dyn RubyException> {
+        Box::new(exception)
+    }
+}
+
+#[allow(clippy::use_self)]
+impl From<Box<InterpreterAllocError>> for Box<dyn RubyException> {
+    fn from(exception: Box<InterpreterAllocError>) -> Box<dyn RubyException> {
+        exception
+    }
 }
 
 #[cfg(test)]

--- a/artichoke-backend/src/interpreter.rs
+++ b/artichoke-backend/src/interpreter.rs
@@ -74,6 +74,7 @@ pub fn interpreter() -> Result<Artichoke, Exception> {
 }
 
 #[derive(Debug, Clone)]
+#[allow(clippy::module_name_repetitions)]
 pub struct InterpreterAllocError;
 
 impl fmt::Display for InterpreterAllocError {

--- a/artichoke-core/src/lib.rs
+++ b/artichoke-core/src/lib.rs
@@ -64,10 +64,6 @@ pub enum ArtichokeError {
         /// Destination type of conversion.
         to: types::Rust,
     },
-    /// Constant name is invalid for the VM backend.
-    ///
-    /// For example, if the name contains a NUL byte, or is invalid UTF-8.
-    InvalidConstantName,
     /// Class or module with this name is not defined in the artichoke VM.
     NotDefined(Cow<'static, str>),
     /// Arg count exceeds maximum allowed by the VM.
@@ -94,7 +90,6 @@ impl fmt::Display for ArtichokeError {
             Self::ConvertToRust { from, to } => {
                 write!(f, "Failed to convert from {} to {}", from, to)
             }
-            Self::InvalidConstantName => write!(f, "Invalid constant name"),
             Self::NotDefined(fqname) => write!(f, "{} not defined", fqname),
             Self::TooManyArgs { given, max } => write!(
                 f,

--- a/artichoke-core/src/lib.rs
+++ b/artichoke-core/src/lib.rs
@@ -68,8 +68,6 @@ pub enum ArtichokeError {
     ///
     /// For example, if the name contains a NUL byte, or is invalid UTF-8.
     InvalidConstantName,
-    /// Unable to initalize interpreter.
-    New,
     /// Class or module with this name is not defined in the artichoke VM.
     NotDefined(Cow<'static, str>),
     /// Arg count exceeds maximum allowed by the VM.
@@ -97,7 +95,6 @@ impl fmt::Display for ArtichokeError {
                 write!(f, "Failed to convert from {} to {}", from, to)
             }
             Self::InvalidConstantName => write!(f, "Invalid constant name"),
-            Self::New => write!(f, "Failed to create interpreter"),
             Self::NotDefined(fqname) => write!(f, "{} not defined", fqname),
             Self::TooManyArgs { given, max } => write!(
                 f,


### PR DESCRIPTION
This commit modifies the return type of the `interpreter` constructor to
return `Exception` error type instead of `BootError`. This allows a
single error type that unifies `extn` initialization errors with
allocation failures behind a `std::error::Error` implementing type.

The `ArtichokeError::New` variants are replaced by a specialized error
type that implements `RubyException` and can be raised as a `fatal`.

The only remaining public API that returns `ArtichokeError` is the
converter suite.