### PR TITLE
Return Exception errors from RustBackedValue APIs

### DIFF
--- a/artichoke-backend/src/convert/array.rs
+++ b/artichoke-backend/src/convert/array.rs
@@ -146,7 +146,12 @@ impl TryConvert<Value, Vec<Value>> for Artichoke {
                 unreachable!("mrb_array implementation is obsoleted by extn::core::array")
             }
             Ruby::Data => {
-                let array = unsafe { Array::try_from_ruby(self, &value)? };
+                let array = unsafe { Array::try_from_ruby(self, &value) }.map_err(|_| {
+                    ArtichokeError::ConvertToRust {
+                        from: Ruby::Object,
+                        to: Rust::Vec,
+                    }
+                })?;
                 let borrow = array.borrow();
                 Ok(borrow.as_vec(self))
             }
@@ -165,7 +170,12 @@ impl TryConvert<Value, Vec<Vec<u8>>> for Artichoke {
                 unreachable!("mrb_array implementation is obsoleted by extn::core::array")
             }
             Ruby::Data => {
-                let array = unsafe { Array::try_from_ruby(self, &value)? };
+                let array = unsafe { Array::try_from_ruby(self, &value) }.map_err(|_| {
+                    ArtichokeError::ConvertToRust {
+                        from: Ruby::Object,
+                        to: Rust::Vec,
+                    }
+                })?;
                 let borrow = array.borrow();
                 let array = borrow.as_vec(self);
                 let mut buf = Vec::with_capacity(array.len());
@@ -189,7 +199,12 @@ impl TryConvert<Value, Vec<Option<Vec<u8>>>> for Artichoke {
                 unreachable!("mrb_array implementation is obsoleted by extn::core::array")
             }
             Ruby::Data => {
-                let array = unsafe { Array::try_from_ruby(self, &value)? };
+                let array = unsafe { Array::try_from_ruby(self, &value) }.map_err(|_| {
+                    ArtichokeError::ConvertToRust {
+                        from: Ruby::Object,
+                        to: Rust::Vec,
+                    }
+                })?;
                 let borrow = array.borrow();
                 let array = borrow.as_vec(self);
                 let mut buf = Vec::with_capacity(array.len());
@@ -213,7 +228,12 @@ impl<'a> TryConvert<Value, Vec<&'a [u8]>> for Artichoke {
                 unreachable!("mrb_array implementation is obsoleted by extn::core::array")
             }
             Ruby::Data => {
-                let array = unsafe { Array::try_from_ruby(self, &value)? };
+                let array = unsafe { Array::try_from_ruby(self, &value) }.map_err(|_| {
+                    ArtichokeError::ConvertToRust {
+                        from: Ruby::Object,
+                        to: Rust::Vec,
+                    }
+                })?;
                 let borrow = array.borrow();
                 let array = borrow.as_vec(self);
                 let mut buf = Vec::with_capacity(array.len());
@@ -237,7 +257,12 @@ impl<'a> TryConvert<Value, Vec<Option<&'a [u8]>>> for Artichoke {
                 unreachable!("mrb_array implementation is obsoleted by extn::core::array")
             }
             Ruby::Data => {
-                let array = unsafe { Array::try_from_ruby(self, &value)? };
+                let array = unsafe { Array::try_from_ruby(self, &value) }.map_err(|_| {
+                    ArtichokeError::ConvertToRust {
+                        from: Ruby::Object,
+                        to: Rust::Vec,
+                    }
+                })?;
                 let borrow = array.borrow();
                 let array = borrow.as_vec(self);
                 let mut buf = Vec::with_capacity(array.len());
@@ -261,7 +286,12 @@ impl TryConvert<Value, Vec<String>> for Artichoke {
                 unreachable!("mrb_array implementation is obsoleted by extn::core::array")
             }
             Ruby::Data => {
-                let array = unsafe { Array::try_from_ruby(self, &value)? };
+                let array = unsafe { Array::try_from_ruby(self, &value) }.map_err(|_| {
+                    ArtichokeError::ConvertToRust {
+                        from: Ruby::Object,
+                        to: Rust::Vec,
+                    }
+                })?;
                 let borrow = array.borrow();
                 let array = borrow.as_vec(self);
                 let mut buf = Vec::with_capacity(array.len());
@@ -285,7 +315,12 @@ impl TryConvert<Value, Vec<Option<String>>> for Artichoke {
                 unreachable!("mrb_array implementation is obsoleted by extn::core::array")
             }
             Ruby::Data => {
-                let array = unsafe { Array::try_from_ruby(self, &value)? };
+                let array = unsafe { Array::try_from_ruby(self, &value) }.map_err(|_| {
+                    ArtichokeError::ConvertToRust {
+                        from: Ruby::Object,
+                        to: Rust::Vec,
+                    }
+                })?;
                 let borrow = array.borrow();
                 let array = borrow.as_vec(self);
                 let mut buf = Vec::with_capacity(array.len());
@@ -309,7 +344,12 @@ impl<'a> TryConvert<Value, Vec<&'a str>> for Artichoke {
                 unreachable!("mrb_array implementation is obsoleted by extn::core::array")
             }
             Ruby::Data => {
-                let array = unsafe { Array::try_from_ruby(self, &value)? };
+                let array = unsafe { Array::try_from_ruby(self, &value) }.map_err(|_| {
+                    ArtichokeError::ConvertToRust {
+                        from: Ruby::Object,
+                        to: Rust::Vec,
+                    }
+                })?;
                 let borrow = array.borrow();
                 let array = borrow.as_vec(self);
                 let mut buf = Vec::with_capacity(array.len());
@@ -333,7 +373,12 @@ impl<'a> TryConvert<Value, Vec<Option<&'a str>>> for Artichoke {
                 unreachable!("mrb_array implementation is obsoleted by extn::core::array")
             }
             Ruby::Data => {
-                let array = unsafe { Array::try_from_ruby(self, &value)? };
+                let array = unsafe { Array::try_from_ruby(self, &value) }.map_err(|_| {
+                    ArtichokeError::ConvertToRust {
+                        from: Ruby::Object,
+                        to: Rust::Vec,
+                    }
+                })?;
                 let borrow = array.borrow();
                 let array = borrow.as_vec(self);
                 let mut buf = Vec::with_capacity(array.len());
@@ -357,7 +402,12 @@ impl TryConvert<Value, Vec<Int>> for Artichoke {
                 unreachable!("mrb_array implementation is obsoleted by extn::core::array")
             }
             Ruby::Data => {
-                let array = unsafe { Array::try_from_ruby(self, &value)? };
+                let array = unsafe { Array::try_from_ruby(self, &value) }.map_err(|_| {
+                    ArtichokeError::ConvertToRust {
+                        from: Ruby::Object,
+                        to: Rust::Vec,
+                    }
+                })?;
                 let borrow = array.borrow();
                 let array = borrow.as_vec(self);
                 let mut buf = Vec::with_capacity(array.len());

--- a/artichoke-backend/src/extn/core/array/mod.rs
+++ b/artichoke-backend/src/extn/core/array/mod.rs
@@ -104,9 +104,7 @@ impl Array {
             InlineBuffer::default()
         };
         let result = Self(result);
-        let result = result
-            .try_into_ruby(interp, Some(into.inner()))
-            .map_err(|_| Fatal::new(interp, "Unable to initialize Ruby Array from Rust Array"))?;
+        let result = result.try_into_ruby(interp, Some(into.inner()))?;
         Ok(result)
     }
 
@@ -137,9 +135,7 @@ impl Array {
         if let Some(len) = len {
             let result = self.0.slice(interp, start, len)?;
             let result = Self(result);
-            let result = result.try_into_ruby(interp, None).map_err(|_| {
-                Fatal::new(interp, "Unable to initialize Ruby Array from Rust Array")
-            })?;
+            let result = result.try_into_ruby(interp, None)?;
             Ok(result)
         } else {
             let result = self.0.get(interp, start)?;

--- a/artichoke-backend/src/extn/core/array/trampoline.rs
+++ b/artichoke-backend/src/extn/core/array/trampoline.rs
@@ -9,12 +9,7 @@ pub fn clear(interp: &Artichoke, ary: Value) -> Result<Value, Exception> {
             "can't modify frozen Array",
         )));
     }
-    let array = unsafe { Array::try_from_ruby(interp, &ary) }.map_err(|_| {
-        Fatal::new(
-            interp,
-            "Unable to extract Rust Array from Ruby Array receiver",
-        )
-    })?;
+    let array = unsafe { Array::try_from_ruby(interp, &ary) }?;
     let mut borrow = array.borrow_mut();
     borrow.clear();
     Ok(ary)
@@ -26,12 +21,7 @@ pub fn element_reference(
     first: Value,
     second: Option<Value>,
 ) -> Result<Value, Exception> {
-    let array = unsafe { Array::try_from_ruby(interp, &ary) }.map_err(|_| {
-        Fatal::new(
-            interp,
-            "Unable to extract Rust Array from Ruby Array receiver",
-        )
-    })?;
+    let array = unsafe { Array::try_from_ruby(interp, &ary) }?;
     let borrow = array.borrow();
     borrow.element_reference(interp, first, second)
 }
@@ -49,12 +39,7 @@ pub fn element_assignment(
             "can't modify frozen Array",
         )));
     }
-    let array = unsafe { Array::try_from_ruby(interp, &ary) }.map_err(|_| {
-        Fatal::new(
-            interp,
-            "Unable to extract Rust Array from Ruby Array receiver",
-        )
-    })?;
+    let array = unsafe { Array::try_from_ruby(interp, &ary) }?;
     // TODO: properly handle self-referential sets.
     if ary == first || ary == second || Some(ary) == third {
         return Ok(interp.convert(None::<Value>));
@@ -75,12 +60,7 @@ pub fn pop(interp: &Artichoke, ary: Value) -> Result<Value, Exception> {
             "can't modify frozen Array",
         )));
     }
-    let array = unsafe { Array::try_from_ruby(interp, &ary) }.map_err(|_| {
-        Fatal::new(
-            interp,
-            "Unable to extract Rust Array from Ruby Array receiver",
-        )
-    })?;
+    let array = unsafe { Array::try_from_ruby(interp, &ary) }?;
     let mut borrow = array.borrow_mut();
     let gc_was_enabled = interp.disable_gc();
     let result = borrow.pop(interp);
@@ -98,12 +78,7 @@ pub fn concat(interp: &Artichoke, ary: Value, other: Option<Value>) -> Result<Va
         )));
     }
     if let Some(other) = other {
-        let array = unsafe { Array::try_from_ruby(interp, &ary) }.map_err(|_| {
-            Fatal::new(
-                interp,
-                "Unable to extract Rust Array from Ruby Array receiver",
-            )
-        })?;
+        let array = unsafe { Array::try_from_ruby(interp, &ary) }?;
         let mut borrow = array.borrow_mut();
         let gc_was_enabled = interp.disable_gc();
         borrow.concat(interp, other)?;
@@ -121,12 +96,7 @@ pub fn push(interp: &Artichoke, ary: Value, value: Value) -> Result<Value, Excep
             "can't modify frozen Array",
         )));
     }
-    let array = unsafe { Array::try_from_ruby(interp, &ary) }.map_err(|_| {
-        Fatal::new(
-            interp,
-            "Unable to extract Rust Array from Ruby Array receiver",
-        )
-    })?;
+    let array = unsafe { Array::try_from_ruby(interp, &ary) }?;
     let idx = array.borrow().len();
     let mut borrow = array.borrow_mut();
     let gc_was_enabled = interp.disable_gc();
@@ -144,12 +114,7 @@ pub fn reverse_bang(interp: &Artichoke, ary: Value) -> Result<Value, Exception> 
             "can't modify frozen Array",
         )));
     }
-    let array = unsafe { Array::try_from_ruby(interp, &ary) }.map_err(|_| {
-        Fatal::new(
-            interp,
-            "Unable to extract Rust Array from Ruby Array receiver",
-        )
-    })?;
+    let array = unsafe { Array::try_from_ruby(interp, &ary) }?;
     let mut borrow = array.borrow_mut();
     let gc_was_enabled = interp.disable_gc();
     borrow.reverse(interp)?;
@@ -160,12 +125,7 @@ pub fn reverse_bang(interp: &Artichoke, ary: Value) -> Result<Value, Exception> 
 }
 
 pub fn len(interp: &Artichoke, ary: Value) -> Result<usize, Exception> {
-    let array = unsafe { Array::try_from_ruby(interp, &ary) }.map_err(|_| {
-        Fatal::new(
-            interp,
-            "Unable to extract Rust Array from Ruby Array receiver",
-        )
-    })?;
+    let array = unsafe { Array::try_from_ruby(interp, &ary) }?;
     let borrow = array.borrow();
     Ok(borrow.len())
 }
@@ -181,16 +141,9 @@ pub fn initialize(
 }
 
 pub fn initialize_copy(interp: &Artichoke, ary: Value, from: Value) -> Result<Value, Exception> {
-    let from = unsafe { Array::try_from_ruby(interp, &from) }.map_err(|_| {
-        Fatal::new(
-            interp,
-            "Unable to extract Rust Array from Ruby Array receiver",
-        )
-    })?;
+    let from = unsafe { Array::try_from_ruby(interp, &from) }?;
     let borrow = from.borrow();
     let result = borrow.clone();
-    let result = result
-        .try_into_ruby(interp, Some(ary.inner()))
-        .map_err(|_| Fatal::new(interp, "Unable to initialize Ruby Array from Rust Array"))?;
+    let result = result.try_into_ruby(interp, Some(ary.inner()))?;
     Ok(result)
 }

--- a/artichoke-backend/src/extn/core/env/mod.rs
+++ b/artichoke-backend/src/extn/core/env/mod.rs
@@ -18,18 +18,14 @@ impl RustBackedValue for Environ {
 #[cfg(feature = "artichoke-system-environ")]
 pub fn initialize(interp: &Artichoke, into: Option<sys::mrb_value>) -> Result<Value, Exception> {
     let obj = Environ(Box::new(backend::system::System::new()));
-    let result = obj
-        .try_into_ruby(&interp, into)
-        .map_err(|_| Fatal::new(interp, "Unable to initialize Ruby ENV with Rust ENV"))?;
+    let result = obj.try_into_ruby(&interp, into)?;
     Ok(result)
 }
 
 #[cfg(not(feature = "artichoke-system-environ"))]
 pub fn initialize(interp: &Artichoke, into: Option<sys::mrb_value>) -> Result<Value, Exception> {
     let obj = Environ(Box::new(backend::memory::Memory::new()));
-    let result = obj
-        .try_into_ruby(&interp, into)
-        .map_err(|_| Fatal::new(interp, "Unable to initialize Ruby ENV with Rust ENV"))?;
+    let result = obj.try_into_ruby(&interp, into)?;
     Ok(result)
 }
 
@@ -38,8 +34,7 @@ pub fn element_reference(
     obj: Value,
     name: &Value,
 ) -> Result<Value, Exception> {
-    let obj = unsafe { Environ::try_from_ruby(interp, &obj) }
-        .map_err(|_| Fatal::new(interp, "Unable to extract Rust ENV from Ruby ENV receiver"))?;
+    let obj = unsafe { Environ::try_from_ruby(interp, &obj) }?;
     let ruby_type = name.pretty_name();
     let name = if let Ok(name) = name.clone().try_into::<&[u8]>() {
         name
@@ -62,8 +57,7 @@ pub fn element_assignment(
     name: &Value,
     value: Value,
 ) -> Result<Value, Exception> {
-    let obj = unsafe { Environ::try_from_ruby(interp, &obj) }
-        .map_err(|_| Fatal::new(interp, "Unable to extract Rust ENV from Ruby ENV receiver"))?;
+    let obj = unsafe { Environ::try_from_ruby(interp, &obj) }?;
     let name_type_name = name.pretty_name();
     let name = if let Ok(name) = name.clone().try_into::<&[u8]>() {
         name
@@ -92,8 +86,7 @@ pub fn element_assignment(
 }
 
 pub fn to_h(interp: &mut Artichoke, obj: Value) -> Result<Value, Exception> {
-    let obj = unsafe { Environ::try_from_ruby(interp, &obj) }
-        .map_err(|_| Fatal::new(interp, "Unable to extract Rust ENV from Ruby ENV receiver"))?;
+    let obj = unsafe { Environ::try_from_ruby(interp, &obj) }?;
     let result = obj.borrow().0.as_map(interp)?;
     Ok(interp.convert_mut(result))
 }

--- a/artichoke-backend/src/extn/core/matchdata/begin.rs
+++ b/artichoke-backend/src/extn/core/matchdata/begin.rs
@@ -25,12 +25,7 @@ impl<'a> Args<'a> {
 }
 
 pub fn method(interp: &Artichoke, args: Args, value: &Value) -> Result<Value, Exception> {
-    let data = unsafe { MatchData::try_from_ruby(interp, value) }.map_err(|_| {
-        Fatal::new(
-            interp,
-            "Unable to extract Rust MatchData from Ruby MatchData receiver",
-        )
-    })?;
+    let data = unsafe { MatchData::try_from_ruby(interp, value) }?;
     let borrow = data.borrow();
     let haystack = &borrow.string[borrow.region.start..borrow.region.end];
     let index = match args {

--- a/artichoke-backend/src/extn/core/matchdata/captures.rs
+++ b/artichoke-backend/src/extn/core/matchdata/captures.rs
@@ -4,12 +4,7 @@ use crate::extn::core::matchdata::MatchData;
 use crate::extn::prelude::*;
 
 pub fn method(interp: &mut Artichoke, value: &Value) -> Result<Value, Exception> {
-    let data = unsafe { MatchData::try_from_ruby(interp, value) }.map_err(|_| {
-        Fatal::new(
-            interp,
-            "Unable to extract Rust MatchData from Ruby MatchData receiver",
-        )
-    })?;
+    let data = unsafe { MatchData::try_from_ruby(interp, value) }?;
     let borrow = data.borrow();
     let haystack = &borrow.string[borrow.region.start..borrow.region.end];
     let captures = borrow.regexp.inner().captures(interp, haystack)?;

--- a/artichoke-backend/src/extn/core/matchdata/element_reference.rs
+++ b/artichoke-backend/src/extn/core/matchdata/element_reference.rs
@@ -16,12 +16,7 @@ pub enum Args<'a> {
 
 impl<'a> Args<'a> {
     pub fn num_captures(interp: &Artichoke, value: &Value) -> Result<usize, Exception> {
-        let data = unsafe { MatchData::try_from_ruby(interp, value) }.map_err(|_| {
-            Fatal::new(
-                interp,
-                "Unable to extract Rust MatchData from Ruby MatchData receiver",
-            )
-        })?;
+        let data = unsafe { MatchData::try_from_ruby(interp, value) }?;
         let borrow = data.borrow();
         borrow.regexp.inner().captures_len(interp, None)
     }
@@ -94,12 +89,7 @@ impl<'a> Args<'a> {
 }
 
 pub fn method(interp: &mut Artichoke, args: Args, value: &Value) -> Result<Value, Exception> {
-    let data = unsafe { MatchData::try_from_ruby(interp, value) }.map_err(|_| {
-        Fatal::new(
-            interp,
-            "Unable to extract Rust MatchData from Ruby MatchData receiver",
-        )
-    })?;
+    let data = unsafe { MatchData::try_from_ruby(interp, value) }?;
     let borrow = data.borrow();
     let haystack = &borrow.string[borrow.region.start..borrow.region.end];
     let mut captures = if let Some(captures) = borrow.regexp.inner().captures(interp, haystack)? {

--- a/artichoke-backend/src/extn/core/matchdata/end.rs
+++ b/artichoke-backend/src/extn/core/matchdata/end.rs
@@ -25,12 +25,7 @@ impl<'a> Args<'a> {
 }
 
 pub fn method(interp: &Artichoke, args: Args, value: &Value) -> Result<Value, Exception> {
-    let data = unsafe { MatchData::try_from_ruby(interp, value) }.map_err(|_| {
-        Fatal::new(
-            interp,
-            "Unable to extract Rust MatchData from Ruby MatchData receiver",
-        )
-    })?;
+    let data = unsafe { MatchData::try_from_ruby(interp, value) }?;
     let borrow = data.borrow();
     let haystack = &borrow.string[borrow.region.start..borrow.region.end];
     let index = match args {

--- a/artichoke-backend/src/extn/core/matchdata/length.rs
+++ b/artichoke-backend/src/extn/core/matchdata/length.rs
@@ -6,12 +6,7 @@ use crate::extn::core::matchdata::MatchData;
 use crate::extn::prelude::*;
 
 pub fn method(interp: &Artichoke, value: &Value) -> Result<Value, Exception> {
-    let data = unsafe { MatchData::try_from_ruby(interp, value) }.map_err(|_| {
-        Fatal::new(
-            interp,
-            "Unable to extract Rust MatchData from Ruby MatchData receiver",
-        )
-    })?;
+    let data = unsafe { MatchData::try_from_ruby(interp, value) }?;
     let borrow = data.borrow();
     let haystack = &borrow.string[borrow.region.start..borrow.region.end];
     let len = borrow.regexp.inner().captures_len(interp, Some(haystack))?;

--- a/artichoke-backend/src/extn/core/matchdata/named_captures.rs
+++ b/artichoke-backend/src/extn/core/matchdata/named_captures.rs
@@ -4,12 +4,7 @@ use crate::extn::core::matchdata::MatchData;
 use crate::extn::prelude::*;
 
 pub fn method(interp: &mut Artichoke, value: &Value) -> Result<Value, Exception> {
-    let data = unsafe { MatchData::try_from_ruby(interp, value) }.map_err(|_| {
-        Fatal::new(
-            interp,
-            "Unable to extract Rust MatchData from Ruby MatchData receiver",
-        )
-    })?;
+    let data = unsafe { MatchData::try_from_ruby(interp, value) }?;
     let borrow = data.borrow();
     let haystack = &borrow.string[borrow.region.start..borrow.region.end];
     let named_captures = borrow

--- a/artichoke-backend/src/extn/core/matchdata/names.rs
+++ b/artichoke-backend/src/extn/core/matchdata/names.rs
@@ -4,12 +4,7 @@ use crate::extn::core::matchdata::MatchData;
 use crate::extn::prelude::*;
 
 pub fn method(interp: &mut Artichoke, value: &Value) -> Result<Value, Exception> {
-    let data = unsafe { MatchData::try_from_ruby(interp, value) }.map_err(|_| {
-        Fatal::new(
-            interp,
-            "Unable to extract Rust MatchData from Ruby MatchData receiver",
-        )
-    })?;
+    let data = unsafe { MatchData::try_from_ruby(interp, value) }?;
     let borrow = data.borrow();
     borrow.regexp.names(interp)
 }

--- a/artichoke-backend/src/extn/core/matchdata/offset.rs
+++ b/artichoke-backend/src/extn/core/matchdata/offset.rs
@@ -25,12 +25,7 @@ impl<'a> Args<'a> {
 }
 
 pub fn method(interp: &mut Artichoke, args: Args, value: &Value) -> Result<Value, Exception> {
-    let data = unsafe { MatchData::try_from_ruby(interp, value) }.map_err(|_| {
-        Fatal::new(
-            interp,
-            "Unable to extract Rust MatchData from Ruby MatchData receiver",
-        )
-    })?;
+    let data = unsafe { MatchData::try_from_ruby(interp, value) }?;
     let borrow = data.borrow();
     let haystack = &borrow.string[borrow.region.start..borrow.region.end];
     let index = match args {

--- a/artichoke-backend/src/extn/core/matchdata/post_match.rs
+++ b/artichoke-backend/src/extn/core/matchdata/post_match.rs
@@ -4,12 +4,7 @@ use crate::extn::core::matchdata::MatchData;
 use crate::extn::prelude::*;
 
 pub fn method(interp: &mut Artichoke, value: &Value) -> Result<Value, Exception> {
-    let data = unsafe { MatchData::try_from_ruby(interp, value) }.map_err(|_| {
-        Fatal::new(
-            interp,
-            "Unable to extract Rust MatchData from Ruby MatchData receiver",
-        )
-    })?;
+    let data = unsafe { MatchData::try_from_ruby(interp, value) }?;
     let borrow = data.borrow();
     let post_match = &borrow.string[borrow.region.end..];
     Ok(interp.convert_mut(post_match))

--- a/artichoke-backend/src/extn/core/matchdata/pre_match.rs
+++ b/artichoke-backend/src/extn/core/matchdata/pre_match.rs
@@ -4,12 +4,7 @@ use crate::extn::core::matchdata::MatchData;
 use crate::extn::prelude::*;
 
 pub fn method(interp: &mut Artichoke, value: &Value) -> Result<Value, Exception> {
-    let data = unsafe { MatchData::try_from_ruby(interp, value) }.map_err(|_| {
-        Fatal::new(
-            interp,
-            "Unable to extract Rust MatchData from Ruby MatchData receiver",
-        )
-    })?;
+    let data = unsafe { MatchData::try_from_ruby(interp, value) }?;
     let borrow = data.borrow();
     let pre_match = &borrow.string[0..borrow.region.start];
     Ok(interp.convert_mut(pre_match))

--- a/artichoke-backend/src/extn/core/matchdata/regexp.rs
+++ b/artichoke-backend/src/extn/core/matchdata/regexp.rs
@@ -4,12 +4,7 @@ use crate::extn::core::matchdata::MatchData;
 use crate::extn::prelude::*;
 
 pub fn method(interp: &Artichoke, value: &Value) -> Result<Value, Exception> {
-    let data = unsafe { MatchData::try_from_ruby(interp, value) }.map_err(|_| {
-        Fatal::new(
-            interp,
-            "Unable to extract Rust MatchData from Ruby MatchData receiver",
-        )
-    })?;
+    let data = unsafe { MatchData::try_from_ruby(interp, value) }?;
     let borrow = data.borrow();
     let regexp = borrow.regexp.clone();
     let regexp = regexp.try_into_ruby(interp, None).map_err(|_| {

--- a/artichoke-backend/src/extn/core/matchdata/string.rs
+++ b/artichoke-backend/src/extn/core/matchdata/string.rs
@@ -4,12 +4,7 @@ use crate::extn::core::matchdata::MatchData;
 use crate::extn::prelude::*;
 
 pub fn method(interp: &mut Artichoke, value: &Value) -> Result<Value, Exception> {
-    let data = unsafe { MatchData::try_from_ruby(interp, value) }.map_err(|_| {
-        Fatal::new(
-            interp,
-            "Unable to extract Rust MatchData from Ruby MatchData receiver",
-        )
-    })?;
+    let data = unsafe { MatchData::try_from_ruby(interp, value) }?;
     let mut result = interp.convert_mut(data.borrow().string.as_slice());
     result
         .freeze()

--- a/artichoke-backend/src/extn/core/matchdata/to_a.rs
+++ b/artichoke-backend/src/extn/core/matchdata/to_a.rs
@@ -4,12 +4,7 @@ use crate::extn::core::matchdata::MatchData;
 use crate::extn::prelude::*;
 
 pub fn method(interp: &mut Artichoke, value: &Value) -> Result<Value, Exception> {
-    let data = unsafe { MatchData::try_from_ruby(interp, value) }.map_err(|_| {
-        Fatal::new(
-            interp,
-            "Unable to extract Rust MatchData from Ruby MatchData receiver",
-        )
-    })?;
+    let data = unsafe { MatchData::try_from_ruby(interp, value) }?;
     let borrow = data.borrow();
     let haystack = &borrow.string[borrow.region.start..borrow.region.end];
     if let Some(captures) = borrow.regexp.inner().captures(interp, haystack)? {

--- a/artichoke-backend/src/extn/core/matchdata/to_s.rs
+++ b/artichoke-backend/src/extn/core/matchdata/to_s.rs
@@ -4,12 +4,7 @@ use crate::extn::core::matchdata::MatchData;
 use crate::extn::prelude::*;
 
 pub fn method(interp: &mut Artichoke, value: &Value) -> Result<Value, Exception> {
-    let data = unsafe { MatchData::try_from_ruby(interp, value) }.map_err(|_| {
-        Fatal::new(
-            interp,
-            "Unable to extract Rust MatchData from Ruby MatchData receiver",
-        )
-    })?;
+    let data = unsafe { MatchData::try_from_ruby(interp, value) }?;
     let borrow = data.borrow();
     let haystack = &borrow.string[borrow.region.start..borrow.region.end];
     let fullcapture = borrow.regexp.inner().capture0(interp, haystack)?;

--- a/artichoke-backend/src/extn/core/regexp/trampoline.rs
+++ b/artichoke-backend/src/extn/core/regexp/trampoline.rs
@@ -25,16 +25,7 @@ pub fn is_match(
     pattern: Value,
     pos: Option<Value>,
 ) -> Result<Value, Exception> {
-    let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }.map_err(|err| {
-        if let ArtichokeError::UninitializedValue("Regexp") = err {
-            Exception::from(TypeError::new(interp, "uninitialized Regexp"))
-        } else {
-            Exception::from(Fatal::new(
-                interp,
-                "Unable to extract Rust Regexp from Ruby Regexp receiver",
-            ))
-        }
-    })?;
+    let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }?;
     let borrow = regexp.borrow();
     borrow.is_match(interp, pattern, pos)
 }
@@ -46,31 +37,13 @@ pub fn match_(
     pos: Option<Value>,
     block: Option<Block>,
 ) -> Result<Value, Exception> {
-    let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }.map_err(|err| {
-        if let ArtichokeError::UninitializedValue("Regexp") = err {
-            Exception::from(TypeError::new(interp, "uninitialized Regexp"))
-        } else {
-            Exception::from(Fatal::new(
-                interp,
-                "Unable to extract Rust Regexp from Ruby Regexp receiver",
-            ))
-        }
-    })?;
+    let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }?;
     let borrow = regexp.borrow();
     borrow.match_(interp, pattern, pos, block)
 }
 
 pub fn eql(interp: &Artichoke, regexp: Value, other: Value) -> Result<Value, Exception> {
-    let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }.map_err(|err| {
-        if let ArtichokeError::UninitializedValue("Regexp") = err {
-            Exception::from(TypeError::new(interp, "uninitialized Regexp"))
-        } else {
-            Exception::from(Fatal::new(
-                interp,
-                "Unable to extract Rust Regexp from Ruby Regexp receiver",
-            ))
-        }
-    })?;
+    let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }?;
     let borrow = regexp.borrow();
     borrow.eql(interp, other)
 }
@@ -80,16 +53,7 @@ pub fn case_compare(
     regexp: Value,
     other: Value,
 ) -> Result<Value, Exception> {
-    let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }.map_err(|err| {
-        if let ArtichokeError::UninitializedValue("Regexp") = err {
-            Exception::from(TypeError::new(interp, "uninitialized Regexp"))
-        } else {
-            Exception::from(Fatal::new(
-                interp,
-                "Unable to extract Rust Regexp from Ruby Regexp receiver",
-            ))
-        }
-    })?;
+    let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }?;
     let borrow = regexp.borrow();
     borrow.case_compare(interp, other)
 }
@@ -99,151 +63,61 @@ pub fn match_operator(
     regexp: Value,
     pattern: Value,
 ) -> Result<Value, Exception> {
-    let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }.map_err(|err| {
-        if let ArtichokeError::UninitializedValue("Regexp") = err {
-            Exception::from(TypeError::new(interp, "uninitialized Regexp"))
-        } else {
-            Exception::from(Fatal::new(
-                interp,
-                "Unable to extract Rust Regexp from Ruby Regexp receiver",
-            ))
-        }
-    })?;
+    let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }?;
     let borrow = regexp.borrow();
     borrow.match_operator(interp, pattern)
 }
 
 pub fn is_casefold(interp: &Artichoke, regexp: Value) -> Result<Value, Exception> {
-    let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }.map_err(|err| {
-        if let ArtichokeError::UninitializedValue("Regexp") = err {
-            Exception::from(TypeError::new(interp, "uninitialized Regexp"))
-        } else {
-            Exception::from(Fatal::new(
-                interp,
-                "Unable to extract Rust Regexp from Ruby Regexp receiver",
-            ))
-        }
-    })?;
+    let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }?;
     let borrow = regexp.borrow();
     borrow.is_casefold(interp)
 }
 
 pub fn is_fixed_encoding(interp: &Artichoke, regexp: Value) -> Result<Value, Exception> {
-    let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }.map_err(|err| {
-        if let ArtichokeError::UninitializedValue("Regexp") = err {
-            Exception::from(TypeError::new(interp, "uninitialized Regexp"))
-        } else {
-            Exception::from(Fatal::new(
-                interp,
-                "Unable to extract Rust Regexp from Ruby Regexp receiver",
-            ))
-        }
-    })?;
+    let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }?;
     let borrow = regexp.borrow();
     borrow.is_fixed_encoding(interp)
 }
 
 pub fn hash(interp: &Artichoke, regexp: Value) -> Result<Value, Exception> {
-    let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }.map_err(|err| {
-        if let ArtichokeError::UninitializedValue("Regexp") = err {
-            Exception::from(TypeError::new(interp, "uninitialized Regexp"))
-        } else {
-            Exception::from(Fatal::new(
-                interp,
-                "Unable to extract Rust Regexp from Ruby Regexp receiver",
-            ))
-        }
-    })?;
+    let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }?;
     let borrow = regexp.borrow();
     borrow.hash(interp)
 }
 
 pub fn inspect(interp: &mut Artichoke, regexp: Value) -> Result<Value, Exception> {
-    let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }.map_err(|err| {
-        if let ArtichokeError::UninitializedValue("Regexp") = err {
-            Exception::from(TypeError::new(interp, "uninitialized Regexp"))
-        } else {
-            Exception::from(Fatal::new(
-                interp,
-                "Unable to extract Rust Regexp from Ruby Regexp receiver",
-            ))
-        }
-    })?;
+    let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }?;
     let borrow = regexp.borrow();
     borrow.inspect(interp)
 }
 
 pub fn named_captures(interp: &mut Artichoke, regexp: Value) -> Result<Value, Exception> {
-    let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }.map_err(|err| {
-        if let ArtichokeError::UninitializedValue("Regexp") = err {
-            Exception::from(TypeError::new(interp, "uninitialized Regexp"))
-        } else {
-            Exception::from(Fatal::new(
-                interp,
-                "Unable to extract Rust Regexp from Ruby Regexp receiver",
-            ))
-        }
-    })?;
+    let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }?;
     let borrow = regexp.borrow();
     borrow.named_captures(interp)
 }
 
 pub fn names(interp: &mut Artichoke, regexp: Value) -> Result<Value, Exception> {
-    let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }.map_err(|err| {
-        if let ArtichokeError::UninitializedValue("Regexp") = err {
-            Exception::from(TypeError::new(interp, "uninitialized Regexp"))
-        } else {
-            Exception::from(Fatal::new(
-                interp,
-                "Unable to extract Rust Regexp from Ruby Regexp receiver",
-            ))
-        }
-    })?;
+    let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }?;
     let borrow = regexp.borrow();
     borrow.names(interp)
 }
 
 pub fn options(interp: &Artichoke, regexp: Value) -> Result<Value, Exception> {
-    let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }.map_err(|err| {
-        if let ArtichokeError::UninitializedValue("Regexp") = err {
-            Exception::from(TypeError::new(interp, "uninitialized Regexp"))
-        } else {
-            Exception::from(Fatal::new(
-                interp,
-                "Unable to extract Rust Regexp from Ruby Regexp receiver",
-            ))
-        }
-    })?;
+    let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }?;
     let borrow = regexp.borrow();
     borrow.options(interp)
 }
 
 pub fn source(interp: &mut Artichoke, regexp: Value) -> Result<Value, Exception> {
-    let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }.map_err(|err| {
-        if let ArtichokeError::UninitializedValue("Regexp") = err {
-            Exception::from(TypeError::new(interp, "uninitialized Regexp"))
-        } else {
-            Exception::from(Fatal::new(
-                interp,
-                "Unable to extract Rust Regexp from Ruby Regexp receiver",
-            ))
-        }
-    })?;
+    let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }?;
     let borrow = regexp.borrow();
     borrow.source(interp)
 }
 
 pub fn to_s(interp: &mut Artichoke, regexp: Value) -> Result<Value, Exception> {
-    let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }.map_err(|err| {
-        if let ArtichokeError::UninitializedValue("Regexp") = err {
-            Exception::from(TypeError::new(interp, "uninitialized Regexp"))
-        } else {
-            Exception::from(Fatal::new(
-                interp,
-                "Unable to extract Rust Regexp from Ruby Regexp receiver",
-            ))
-        }
-    })?;
+    let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }?;
     let borrow = regexp.borrow();
     borrow.string(interp)
 }

--- a/artichoke-backend/src/extn/core/time/trampoline.rs
+++ b/artichoke-backend/src/extn/core/time/trampoline.rs
@@ -4,19 +4,12 @@ use crate::extn::prelude::*;
 
 pub fn now(interp: &Artichoke) -> Result<Value, Exception> {
     let now = Time(time::factory().now(interp));
-    let result = now
-        .try_into_ruby(&interp, None)
-        .map_err(|_| Fatal::new(interp, "Unable to initialize Ruby Time with Rust Time"))?;
+    let result = now.try_into_ruby(&interp, None)?;
     Ok(result)
 }
 
 pub fn day(interp: &Artichoke, time: Value) -> Result<Value, Exception> {
-    let time = unsafe { Time::try_from_ruby(interp, &time) }.map_err(|_| {
-        Fatal::new(
-            interp,
-            "Unable to extract Rust Time from Ruby Time receiver",
-        )
-    })?;
+    let time = unsafe { Time::try_from_ruby(interp, &time) }?;
     let day = time.borrow().inner().day();
     let result = interp
         .try_convert(day)
@@ -25,12 +18,7 @@ pub fn day(interp: &Artichoke, time: Value) -> Result<Value, Exception> {
 }
 
 pub fn hour(interp: &Artichoke, time: Value) -> Result<Value, Exception> {
-    let time = unsafe { Time::try_from_ruby(interp, &time) }.map_err(|_| {
-        Fatal::new(
-            interp,
-            "Unable to extract Rust Time from Ruby Time receiver",
-        )
-    })?;
+    let time = unsafe { Time::try_from_ruby(interp, &time) }?;
     let hour = time.borrow().inner().hour();
     let result = interp
         .try_convert(hour)
@@ -39,12 +27,7 @@ pub fn hour(interp: &Artichoke, time: Value) -> Result<Value, Exception> {
 }
 
 pub fn minute(interp: &Artichoke, time: Value) -> Result<Value, Exception> {
-    let time = unsafe { Time::try_from_ruby(interp, &time) }.map_err(|_| {
-        Fatal::new(
-            interp,
-            "Unable to extract Rust Time from Ruby Time receiver",
-        )
-    })?;
+    let time = unsafe { Time::try_from_ruby(interp, &time) }?;
     let minute = time.borrow().inner().minute();
     let result = interp
         .try_convert(minute)
@@ -53,12 +36,7 @@ pub fn minute(interp: &Artichoke, time: Value) -> Result<Value, Exception> {
 }
 
 pub fn month(interp: &Artichoke, time: Value) -> Result<Value, Exception> {
-    let time = unsafe { Time::try_from_ruby(interp, &time) }.map_err(|_| {
-        Fatal::new(
-            interp,
-            "Unable to extract Rust Time from Ruby Time receiver",
-        )
-    })?;
+    let time = unsafe { Time::try_from_ruby(interp, &time) }?;
     let month = time.borrow().inner().month();
     let result = interp
         .try_convert(month)
@@ -67,12 +45,7 @@ pub fn month(interp: &Artichoke, time: Value) -> Result<Value, Exception> {
 }
 
 pub fn nanosecond(interp: &Artichoke, time: Value) -> Result<Value, Exception> {
-    let time = unsafe { Time::try_from_ruby(interp, &time) }.map_err(|_| {
-        Fatal::new(
-            interp,
-            "Unable to extract Rust Time from Ruby Time receiver",
-        )
-    })?;
+    let time = unsafe { Time::try_from_ruby(interp, &time) }?;
     let nanosecond = time.borrow().inner().nanosecond();
     let result = interp
         .try_convert(nanosecond)
@@ -81,12 +54,7 @@ pub fn nanosecond(interp: &Artichoke, time: Value) -> Result<Value, Exception> {
 }
 
 pub fn second(interp: &Artichoke, time: Value) -> Result<Value, Exception> {
-    let time = unsafe { Time::try_from_ruby(interp, &time) }.map_err(|_| {
-        Fatal::new(
-            interp,
-            "Unable to extract Rust Time from Ruby Time receiver",
-        )
-    })?;
+    let time = unsafe { Time::try_from_ruby(interp, &time) }?;
     let second = time.borrow().inner().second();
     let result = interp
         .try_convert(second)
@@ -95,12 +63,7 @@ pub fn second(interp: &Artichoke, time: Value) -> Result<Value, Exception> {
 }
 
 pub fn microsecond(interp: &Artichoke, time: Value) -> Result<Value, Exception> {
-    let time = unsafe { Time::try_from_ruby(interp, &time) }.map_err(|_| {
-        Fatal::new(
-            interp,
-            "Unable to extract Rust Time from Ruby Time receiver",
-        )
-    })?;
+    let time = unsafe { Time::try_from_ruby(interp, &time) }?;
     let microsecond = time.borrow().inner().microsecond();
     let result = interp
         .try_convert(microsecond)
@@ -109,12 +72,7 @@ pub fn microsecond(interp: &Artichoke, time: Value) -> Result<Value, Exception> 
 }
 
 pub fn weekday(interp: &Artichoke, time: Value) -> Result<Value, Exception> {
-    let time = unsafe { Time::try_from_ruby(interp, &time) }.map_err(|_| {
-        Fatal::new(
-            interp,
-            "Unable to extract Rust Time from Ruby Time receiver",
-        )
-    })?;
+    let time = unsafe { Time::try_from_ruby(interp, &time) }?;
     let weekday = time.borrow().inner().weekday();
     let result = interp
         .try_convert(weekday)
@@ -123,12 +81,7 @@ pub fn weekday(interp: &Artichoke, time: Value) -> Result<Value, Exception> {
 }
 
 pub fn year_day(interp: &Artichoke, time: Value) -> Result<Value, Exception> {
-    let time = unsafe { Time::try_from_ruby(interp, &time) }.map_err(|_| {
-        Fatal::new(
-            interp,
-            "Unable to extract Rust Time from Ruby Time receiver",
-        )
-    })?;
+    let time = unsafe { Time::try_from_ruby(interp, &time) }?;
     let year_day = time.borrow().inner().year_day();
     let result = interp
         .try_convert(year_day)
@@ -137,12 +90,7 @@ pub fn year_day(interp: &Artichoke, time: Value) -> Result<Value, Exception> {
 }
 
 pub fn year(interp: &Artichoke, time: Value) -> Result<Value, Exception> {
-    let time = unsafe { Time::try_from_ruby(interp, &time) }.map_err(|_| {
-        Fatal::new(
-            interp,
-            "Unable to extract Rust Time from Ruby Time receiver",
-        )
-    })?;
+    let time = unsafe { Time::try_from_ruby(interp, &time) }?;
     let year = time.borrow().inner().year();
     let result = interp
         .try_convert(year)

--- a/artichoke-backend/tests/manual.rs
+++ b/artichoke-backend/tests/manual.rs
@@ -33,12 +33,10 @@ impl Container {
         let inner = mrb_get_args!(mrb, required = 1);
         let interp = unwrap_interpreter!(mrb);
         let inner = Value::new(&interp, inner);
-        inner
-            .try_into::<Int>()
-            .and_then(|inner| {
-                let container = Box::new(Self { inner });
-                container.try_into_ruby(&interp, Some(slf))
-            })
+        let inner = inner.try_into::<Int>().unwrap_or_default();
+        let container = Box::new(Self { inner });
+        container
+            .try_into_ruby(&interp, Some(slf))
             .unwrap_or_else(|_| interp.convert(None::<Value>))
             .inner()
     }

--- a/artichoke-core/src/lib.rs
+++ b/artichoke-core/src/lib.rs
@@ -32,7 +32,6 @@
 //!
 //! artichoke-core is licensed with the MIT License (c) Ryan Lopopolo.
 
-use std::borrow::Cow;
 use std::error;
 use std::fmt;
 
@@ -64,8 +63,6 @@ pub enum ArtichokeError {
         /// Destination type of conversion.
         to: types::Rust,
     },
-    /// Class or module with this name is not defined in the artichoke VM.
-    NotDefined(Cow<'static, str>),
     /// Arg count exceeds maximum allowed by the VM.
     TooManyArgs {
         /// Number of arguments supplied.
@@ -75,8 +72,6 @@ pub enum ArtichokeError {
     },
     /// Attempted to use an uninitialized interpreter.
     Uninitialized,
-    /// Attempted to extract Rust object from uninitialized `Value`.
-    UninitializedValue(&'static str),
     /// Eval or funcall returned an interpreter-internal value.
     UnreachableValue,
 }
@@ -90,18 +85,12 @@ impl fmt::Display for ArtichokeError {
             Self::ConvertToRust { from, to } => {
                 write!(f, "Failed to convert from {} to {}", from, to)
             }
-            Self::NotDefined(fqname) => write!(f, "{} not defined", fqname),
             Self::TooManyArgs { given, max } => write!(
                 f,
                 "Too many args for funcall. Gave {}, but max is {}",
                 given, max
             ),
             Self::Uninitialized => write!(f, "Interpreter not initialized"),
-            Self::UninitializedValue(class) => write!(
-                f,
-                "Attempted to extract pointer from uninitialized Value with class {}",
-                class
-            ),
             Self::UnreachableValue => write!(f, "Extracted unreachable type from interpreter"),
         }
     }


### PR DESCRIPTION
This patch adds consistent handling for allocated but uninitialized
values and returns either `TypeError` or `NotDefinedError` in Rust.

This commit removes two error variants in `ArtichokeError`:
`UninitializedValue` and `NotDefined`.