### PR TITLE
Return Exception error type from TryConvert implementations

### DIFF
--- a/artichoke-backend/src/convert.rs
+++ b/artichoke-backend/src/convert.rs
@@ -62,6 +62,7 @@ pub struct UnboxRubyError {
 }
 
 impl UnboxRubyError {
+    #[must_use]
     pub fn new(value: &Value, into: Rust) -> Self {
         Self {
             from: value.ruby_type(),
@@ -139,6 +140,7 @@ pub struct BoxIntoRubyError {
 }
 
 impl BoxIntoRubyError {
+    #[must_use]
     pub fn new(from: Rust, into: Ruby) -> Self {
         Self { from, into }
     }

--- a/artichoke-backend/src/convert.rs
+++ b/artichoke-backend/src/convert.rs
@@ -1,3 +1,13 @@
+use std::error;
+use std::fmt;
+
+use crate::exception::{Exception, RubyException};
+use crate::extn::core::exception::TypeError;
+use crate::sys;
+use crate::types::{Ruby, Rust};
+use crate::value::Value;
+use crate::{Artichoke, ConvertMut};
+
 mod array;
 mod boolean;
 mod bytes;
@@ -9,3 +19,154 @@ mod object;
 mod string;
 
 pub use object::RustBackedValue;
+
+/// Failed to convert from boxed Ruby value to a Rust type.
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub struct UnboxRubyError {
+    pub from: Ruby,
+    pub into: Rust,
+}
+
+impl UnboxRubyError {
+    pub fn new(value: &Value, into: Rust) -> Self {
+        Self {
+            from: value.ruby_type(),
+            into,
+        }
+    }
+}
+
+impl fmt::Display for UnboxRubyError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "failed to convert from {} to {}", self.from, self.into)
+    }
+}
+
+impl error::Error for UnboxRubyError {}
+
+impl RubyException for UnboxRubyError {
+    fn box_clone(&self) -> Box<dyn RubyException> {
+        Box::new(*self)
+    }
+
+    fn message(&self) -> &[u8] {
+        &b"Failed to convert from Ruby value to Rust type"[..]
+    }
+
+    fn name(&self) -> String {
+        String::from("TypeError")
+    }
+
+    fn vm_backtrace(&self, interp: &Artichoke) -> Option<Vec<Vec<u8>>> {
+        let _ = interp;
+        None
+    }
+
+    fn as_mrb_value(&self, interp: &mut Artichoke) -> Option<sys::mrb_value> {
+        let message = interp.convert_mut(self.to_string());
+        let borrow = interp.0.borrow();
+        let spec = borrow.class_spec::<TypeError>()?;
+        let value = spec.new_instance(interp, &[message])?;
+        Some(value.inner())
+    }
+}
+
+impl From<UnboxRubyError> for Exception {
+    fn from(exception: UnboxRubyError) -> Self {
+        Self::from(Box::<dyn RubyException>::from(exception))
+    }
+}
+
+impl From<Box<UnboxRubyError>> for Exception {
+    fn from(exception: Box<UnboxRubyError>) -> Self {
+        Self::from(Box::<dyn RubyException>::from(exception))
+    }
+}
+
+#[allow(clippy::use_self)]
+impl From<UnboxRubyError> for Box<dyn RubyException> {
+    fn from(exception: UnboxRubyError) -> Box<dyn RubyException> {
+        Box::new(exception)
+    }
+}
+
+#[allow(clippy::use_self)]
+impl From<Box<UnboxRubyError>> for Box<dyn RubyException> {
+    fn from(exception: Box<UnboxRubyError>) -> Box<dyn RubyException> {
+        exception
+    }
+}
+
+/// Failed to convert from Rust type to a boxed Ruby value.
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub struct BoxIntoRubyError {
+    pub from: Rust,
+    pub into: Ruby,
+}
+
+impl BoxIntoRubyError {
+    pub fn new(from: Rust, into: Ruby) -> Self {
+        Self { from, into }
+    }
+}
+
+impl fmt::Display for BoxIntoRubyError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "failed to convert from {} to {}", self.from, self.into)
+    }
+}
+
+impl error::Error for BoxIntoRubyError {}
+
+impl RubyException for BoxIntoRubyError {
+    fn box_clone(&self) -> Box<dyn RubyException> {
+        Box::new(*self)
+    }
+
+    fn message(&self) -> &[u8] {
+        &b"Failed to convert from Rust type to Ruby value"[..]
+    }
+
+    fn name(&self) -> String {
+        String::from("TypeError")
+    }
+
+    fn vm_backtrace(&self, interp: &Artichoke) -> Option<Vec<Vec<u8>>> {
+        let _ = interp;
+        None
+    }
+
+    fn as_mrb_value(&self, interp: &mut Artichoke) -> Option<sys::mrb_value> {
+        let message = interp.convert_mut(self.to_string());
+        let borrow = interp.0.borrow();
+        let spec = borrow.class_spec::<TypeError>()?;
+        let value = spec.new_instance(interp, &[message])?;
+        Some(value.inner())
+    }
+}
+
+impl From<BoxIntoRubyError> for Exception {
+    fn from(exception: BoxIntoRubyError) -> Self {
+        Self::from(Box::<dyn RubyException>::from(exception))
+    }
+}
+
+impl From<Box<BoxIntoRubyError>> for Exception {
+    fn from(exception: Box<BoxIntoRubyError>) -> Self {
+        Self::from(Box::<dyn RubyException>::from(exception))
+    }
+}
+
+#[allow(clippy::use_self)]
+impl From<BoxIntoRubyError> for Box<dyn RubyException> {
+    fn from(exception: BoxIntoRubyError) -> Box<dyn RubyException> {
+        Box::new(exception)
+    }
+}
+
+#[allow(clippy::use_self)]
+impl From<Box<BoxIntoRubyError>> for Box<dyn RubyException> {
+    fn from(exception: Box<BoxIntoRubyError>) -> Box<dyn RubyException> {
+        exception
+    }
+}

--- a/artichoke-backend/src/convert/array.rs
+++ b/artichoke-backend/src/convert/array.rs
@@ -1,10 +1,11 @@
 use std::iter::FromIterator;
 
-use crate::convert::RustBackedValue;
+use crate::convert::{RustBackedValue, UnboxRubyError};
+use crate::exception::Exception;
 use crate::extn::core::array::{Array, InlineBuffer};
 use crate::types::{Int, Ruby, Rust};
 use crate::value::Value;
-use crate::{Artichoke, ArtichokeError, Convert, ConvertMut, TryConvert};
+use crate::{Artichoke, Convert, ConvertMut, TryConvert};
 
 impl ConvertMut<&[Value], Value> for Artichoke {
     fn convert_mut(&mut self, value: &[Value]) -> Value {
@@ -140,286 +141,186 @@ impl ConvertMut<Vec<Vec<Option<&str>>>, Value> for Artichoke {
 }
 
 impl TryConvert<Value, Vec<Value>> for Artichoke {
-    fn try_convert(&self, value: Value) -> Result<Vec<Value>, ArtichokeError> {
-        match value.ruby_type() {
-            Ruby::Array => {
-                unreachable!("mrb_array implementation is obsoleted by extn::core::array")
-            }
-            Ruby::Data => {
-                let array = unsafe { Array::try_from_ruby(self, &value) }.map_err(|_| {
-                    ArtichokeError::ConvertToRust {
-                        from: Ruby::Object,
-                        to: Rust::Vec,
-                    }
-                })?;
-                let borrow = array.borrow();
-                Ok(borrow.as_vec(self))
-            }
-            type_tag => Err(ArtichokeError::ConvertToRust {
-                from: type_tag,
-                to: Rust::Vec,
-            }),
+    type Error = Exception;
+
+    fn try_convert(&self, value: Value) -> Result<Vec<Value>, Self::Error> {
+        if let Ruby::Data = value.ruby_type() {
+            let array = unsafe { Array::try_from_ruby(self, &value) }?;
+            let borrow = array.borrow();
+            Ok(borrow.as_vec(self))
+        } else {
+            Err(Exception::from(UnboxRubyError::new(&value, Rust::Vec)))
         }
     }
 }
 
 impl TryConvert<Value, Vec<Vec<u8>>> for Artichoke {
-    fn try_convert(&self, value: Value) -> Result<Vec<Vec<u8>>, ArtichokeError> {
-        match value.ruby_type() {
-            Ruby::Array => {
-                unreachable!("mrb_array implementation is obsoleted by extn::core::array")
+    type Error = Exception;
+
+    fn try_convert(&self, value: Value) -> Result<Vec<Vec<u8>>, Self::Error> {
+        if let Ruby::Data = value.ruby_type() {
+            let array = unsafe { Array::try_from_ruby(self, &value) }?;
+            let borrow = array.borrow();
+            let array = borrow.as_vec(self);
+            let mut buf = Vec::with_capacity(array.len());
+            for elem in array {
+                buf.push(self.try_convert(elem)?);
             }
-            Ruby::Data => {
-                let array = unsafe { Array::try_from_ruby(self, &value) }.map_err(|_| {
-                    ArtichokeError::ConvertToRust {
-                        from: Ruby::Object,
-                        to: Rust::Vec,
-                    }
-                })?;
-                let borrow = array.borrow();
-                let array = borrow.as_vec(self);
-                let mut buf = Vec::with_capacity(array.len());
-                for elem in array {
-                    buf.push(self.try_convert(elem)?);
-                }
-                Ok(buf)
-            }
-            type_tag => Err(ArtichokeError::ConvertToRust {
-                from: type_tag,
-                to: Rust::Vec,
-            }),
+            Ok(buf)
+        } else {
+            Err(Exception::from(UnboxRubyError::new(&value, Rust::Vec)))
         }
     }
 }
 
 impl TryConvert<Value, Vec<Option<Vec<u8>>>> for Artichoke {
-    fn try_convert(&self, value: Value) -> Result<Vec<Option<Vec<u8>>>, ArtichokeError> {
-        match value.ruby_type() {
-            Ruby::Array => {
-                unreachable!("mrb_array implementation is obsoleted by extn::core::array")
+    type Error = Exception;
+
+    fn try_convert(&self, value: Value) -> Result<Vec<Option<Vec<u8>>>, Self::Error> {
+        if let Ruby::Data = value.ruby_type() {
+            let array = unsafe { Array::try_from_ruby(self, &value) }?;
+            let borrow = array.borrow();
+            let array = borrow.as_vec(self);
+            let mut buf = Vec::with_capacity(array.len());
+            for elem in array {
+                buf.push(self.try_convert(elem)?);
             }
-            Ruby::Data => {
-                let array = unsafe { Array::try_from_ruby(self, &value) }.map_err(|_| {
-                    ArtichokeError::ConvertToRust {
-                        from: Ruby::Object,
-                        to: Rust::Vec,
-                    }
-                })?;
-                let borrow = array.borrow();
-                let array = borrow.as_vec(self);
-                let mut buf = Vec::with_capacity(array.len());
-                for elem in array {
-                    buf.push(self.try_convert(elem)?);
-                }
-                Ok(buf)
-            }
-            type_tag => Err(ArtichokeError::ConvertToRust {
-                from: type_tag,
-                to: Rust::Vec,
-            }),
+            Ok(buf)
+        } else {
+            Err(Exception::from(UnboxRubyError::new(&value, Rust::Vec)))
         }
     }
 }
 
 impl<'a> TryConvert<Value, Vec<&'a [u8]>> for Artichoke {
-    fn try_convert(&self, value: Value) -> Result<Vec<&'a [u8]>, ArtichokeError> {
-        match value.ruby_type() {
-            Ruby::Array => {
-                unreachable!("mrb_array implementation is obsoleted by extn::core::array")
+    type Error = Exception;
+
+    fn try_convert(&self, value: Value) -> Result<Vec<&'a [u8]>, Self::Error> {
+        if let Ruby::Data = value.ruby_type() {
+            let array = unsafe { Array::try_from_ruby(self, &value) }?;
+            let borrow = array.borrow();
+            let array = borrow.as_vec(self);
+            let mut buf = Vec::with_capacity(array.len());
+            for elem in array {
+                buf.push(self.try_convert(elem)?);
             }
-            Ruby::Data => {
-                let array = unsafe { Array::try_from_ruby(self, &value) }.map_err(|_| {
-                    ArtichokeError::ConvertToRust {
-                        from: Ruby::Object,
-                        to: Rust::Vec,
-                    }
-                })?;
-                let borrow = array.borrow();
-                let array = borrow.as_vec(self);
-                let mut buf = Vec::with_capacity(array.len());
-                for elem in array {
-                    buf.push(self.try_convert(elem)?);
-                }
-                Ok(buf)
-            }
-            type_tag => Err(ArtichokeError::ConvertToRust {
-                from: type_tag,
-                to: Rust::Vec,
-            }),
+            Ok(buf)
+        } else {
+            Err(Exception::from(UnboxRubyError::new(&value, Rust::Vec)))
         }
     }
 }
 
 impl<'a> TryConvert<Value, Vec<Option<&'a [u8]>>> for Artichoke {
-    fn try_convert(&self, value: Value) -> Result<Vec<Option<&'a [u8]>>, ArtichokeError> {
-        match value.ruby_type() {
-            Ruby::Array => {
-                unreachable!("mrb_array implementation is obsoleted by extn::core::array")
+    type Error = Exception;
+
+    fn try_convert(&self, value: Value) -> Result<Vec<Option<&'a [u8]>>, Self::Error> {
+        if let Ruby::Data = value.ruby_type() {
+            let array = unsafe { Array::try_from_ruby(self, &value) }?;
+            let borrow = array.borrow();
+            let array = borrow.as_vec(self);
+            let mut buf = Vec::with_capacity(array.len());
+            for elem in array {
+                buf.push(self.try_convert(elem)?);
             }
-            Ruby::Data => {
-                let array = unsafe { Array::try_from_ruby(self, &value) }.map_err(|_| {
-                    ArtichokeError::ConvertToRust {
-                        from: Ruby::Object,
-                        to: Rust::Vec,
-                    }
-                })?;
-                let borrow = array.borrow();
-                let array = borrow.as_vec(self);
-                let mut buf = Vec::with_capacity(array.len());
-                for elem in array {
-                    buf.push(self.try_convert(elem)?);
-                }
-                Ok(buf)
-            }
-            type_tag => Err(ArtichokeError::ConvertToRust {
-                from: type_tag,
-                to: Rust::Vec,
-            }),
+            Ok(buf)
+        } else {
+            Err(Exception::from(UnboxRubyError::new(&value, Rust::Vec)))
         }
     }
 }
 
 impl TryConvert<Value, Vec<String>> for Artichoke {
-    fn try_convert(&self, value: Value) -> Result<Vec<String>, ArtichokeError> {
-        match value.ruby_type() {
-            Ruby::Array => {
-                unreachable!("mrb_array implementation is obsoleted by extn::core::array")
+    type Error = Exception;
+
+    fn try_convert(&self, value: Value) -> Result<Vec<String>, Self::Error> {
+        if let Ruby::Data = value.ruby_type() {
+            let array = unsafe { Array::try_from_ruby(self, &value) }?;
+            let borrow = array.borrow();
+            let array = borrow.as_vec(self);
+            let mut buf = Vec::with_capacity(array.len());
+            for elem in array {
+                buf.push(self.try_convert(elem)?);
             }
-            Ruby::Data => {
-                let array = unsafe { Array::try_from_ruby(self, &value) }.map_err(|_| {
-                    ArtichokeError::ConvertToRust {
-                        from: Ruby::Object,
-                        to: Rust::Vec,
-                    }
-                })?;
-                let borrow = array.borrow();
-                let array = borrow.as_vec(self);
-                let mut buf = Vec::with_capacity(array.len());
-                for elem in array {
-                    buf.push(self.try_convert(elem)?);
-                }
-                Ok(buf)
-            }
-            type_tag => Err(ArtichokeError::ConvertToRust {
-                from: type_tag,
-                to: Rust::Vec,
-            }),
+            Ok(buf)
+        } else {
+            Err(Exception::from(UnboxRubyError::new(&value, Rust::Vec)))
         }
     }
 }
 
 impl TryConvert<Value, Vec<Option<String>>> for Artichoke {
-    fn try_convert(&self, value: Value) -> Result<Vec<Option<String>>, ArtichokeError> {
-        match value.ruby_type() {
-            Ruby::Array => {
-                unreachable!("mrb_array implementation is obsoleted by extn::core::array")
+    type Error = Exception;
+
+    fn try_convert(&self, value: Value) -> Result<Vec<Option<String>>, Self::Error> {
+        if let Ruby::Data = value.ruby_type() {
+            let array = unsafe { Array::try_from_ruby(self, &value) }?;
+            let borrow = array.borrow();
+            let array = borrow.as_vec(self);
+            let mut buf = Vec::with_capacity(array.len());
+            for elem in array {
+                buf.push(self.try_convert(elem)?);
             }
-            Ruby::Data => {
-                let array = unsafe { Array::try_from_ruby(self, &value) }.map_err(|_| {
-                    ArtichokeError::ConvertToRust {
-                        from: Ruby::Object,
-                        to: Rust::Vec,
-                    }
-                })?;
-                let borrow = array.borrow();
-                let array = borrow.as_vec(self);
-                let mut buf = Vec::with_capacity(array.len());
-                for elem in array {
-                    buf.push(self.try_convert(elem)?);
-                }
-                Ok(buf)
-            }
-            type_tag => Err(ArtichokeError::ConvertToRust {
-                from: type_tag,
-                to: Rust::Vec,
-            }),
+            Ok(buf)
+        } else {
+            Err(Exception::from(UnboxRubyError::new(&value, Rust::Vec)))
         }
     }
 }
 
 impl<'a> TryConvert<Value, Vec<&'a str>> for Artichoke {
-    fn try_convert(&self, value: Value) -> Result<Vec<&'a str>, ArtichokeError> {
-        match value.ruby_type() {
-            Ruby::Array => {
-                unreachable!("mrb_array implementation is obsoleted by extn::core::array")
+    type Error = Exception;
+
+    fn try_convert(&self, value: Value) -> Result<Vec<&'a str>, Self::Error> {
+        if let Ruby::Data = value.ruby_type() {
+            let array = unsafe { Array::try_from_ruby(self, &value) }?;
+            let borrow = array.borrow();
+            let array = borrow.as_vec(self);
+            let mut buf = Vec::with_capacity(array.len());
+            for elem in array {
+                buf.push(self.try_convert(elem)?);
             }
-            Ruby::Data => {
-                let array = unsafe { Array::try_from_ruby(self, &value) }.map_err(|_| {
-                    ArtichokeError::ConvertToRust {
-                        from: Ruby::Object,
-                        to: Rust::Vec,
-                    }
-                })?;
-                let borrow = array.borrow();
-                let array = borrow.as_vec(self);
-                let mut buf = Vec::with_capacity(array.len());
-                for elem in array {
-                    buf.push(self.try_convert(elem)?);
-                }
-                Ok(buf)
-            }
-            type_tag => Err(ArtichokeError::ConvertToRust {
-                from: type_tag,
-                to: Rust::Vec,
-            }),
+            Ok(buf)
+        } else {
+            Err(Exception::from(UnboxRubyError::new(&value, Rust::Vec)))
         }
     }
 }
 
 impl<'a> TryConvert<Value, Vec<Option<&'a str>>> for Artichoke {
-    fn try_convert(&self, value: Value) -> Result<Vec<Option<&'a str>>, ArtichokeError> {
-        match value.ruby_type() {
-            Ruby::Array => {
-                unreachable!("mrb_array implementation is obsoleted by extn::core::array")
+    type Error = Exception;
+
+    fn try_convert(&self, value: Value) -> Result<Vec<Option<&'a str>>, Self::Error> {
+        if let Ruby::Data = value.ruby_type() {
+            let array = unsafe { Array::try_from_ruby(self, &value) }?;
+            let borrow = array.borrow();
+            let array = borrow.as_vec(self);
+            let mut buf = Vec::with_capacity(array.len());
+            for elem in array {
+                buf.push(self.try_convert(elem)?);
             }
-            Ruby::Data => {
-                let array = unsafe { Array::try_from_ruby(self, &value) }.map_err(|_| {
-                    ArtichokeError::ConvertToRust {
-                        from: Ruby::Object,
-                        to: Rust::Vec,
-                    }
-                })?;
-                let borrow = array.borrow();
-                let array = borrow.as_vec(self);
-                let mut buf = Vec::with_capacity(array.len());
-                for elem in array {
-                    buf.push(self.try_convert(elem)?);
-                }
-                Ok(buf)
-            }
-            type_tag => Err(ArtichokeError::ConvertToRust {
-                from: type_tag,
-                to: Rust::Vec,
-            }),
+            Ok(buf)
+        } else {
+            Err(Exception::from(UnboxRubyError::new(&value, Rust::Vec)))
         }
     }
 }
 
 impl TryConvert<Value, Vec<Int>> for Artichoke {
-    fn try_convert(&self, value: Value) -> Result<Vec<Int>, ArtichokeError> {
-        match value.ruby_type() {
-            Ruby::Array => {
-                unreachable!("mrb_array implementation is obsoleted by extn::core::array")
+    type Error = Exception;
+
+    fn try_convert(&self, value: Value) -> Result<Vec<Int>, Self::Error> {
+        if let Ruby::Data = value.ruby_type() {
+            let array = unsafe { Array::try_from_ruby(self, &value) }?;
+            let borrow = array.borrow();
+            let array = borrow.as_vec(self);
+            let mut buf = Vec::with_capacity(array.len());
+            for elem in array {
+                buf.push(self.try_convert(elem)?);
             }
-            Ruby::Data => {
-                let array = unsafe { Array::try_from_ruby(self, &value) }.map_err(|_| {
-                    ArtichokeError::ConvertToRust {
-                        from: Ruby::Object,
-                        to: Rust::Vec,
-                    }
-                })?;
-                let borrow = array.borrow();
-                let array = borrow.as_vec(self);
-                let mut buf = Vec::with_capacity(array.len());
-                for elem in array {
-                    buf.push(self.try_convert(elem)?);
-                }
-                Ok(buf)
-            }
-            type_tag => Err(ArtichokeError::ConvertToRust {
-                from: type_tag,
-                to: Rust::Vec,
-            }),
+            Ok(buf)
+        } else {
+            Err(Exception::from(UnboxRubyError::new(&value, Rust::Vec)))
         }
     }
 }

--- a/artichoke-backend/src/convert/boolean.rs
+++ b/artichoke-backend/src/convert/boolean.rs
@@ -47,12 +47,8 @@ mod tests {
         let mut interp = crate::interpreter().expect("init");
         // get a mrb_value that can't be converted to a primitive type.
         let value = interp.eval(b"Object.new").expect("eval");
-        let expected = Err(ArtichokeError::ConvertToRust {
-            from: Ruby::Object,
-            to: Rust::Bool,
-        });
         let result = value.try_into::<bool>();
-        assert_eq!(result, expected);
+        assert!(result.is_err());
     }
 
     #[quickcheck]
@@ -91,10 +87,6 @@ mod tests {
         let interp = crate::interpreter().expect("init");
         let value = interp.convert(i);
         let value = value.try_into::<bool>();
-        let expected = Err(ArtichokeError::ConvertToRust {
-            from: Ruby::Fixnum,
-            to: Rust::Bool,
-        });
-        value == expected
+        value.is_err()
     }
 }

--- a/artichoke-backend/src/convert/bytes.rs
+++ b/artichoke-backend/src/convert/bytes.rs
@@ -84,12 +84,8 @@ mod tests {
         let mut interp = crate::interpreter().expect("init");
         // get a mrb_value that can't be converted to a primitive type.
         let value = interp.eval(b"Object.new").expect("eval");
-        let expected = Err(ArtichokeError::ConvertToRust {
-            from: Ruby::Object,
-            to: Rust::Bytes,
-        });
         let result = value.try_into::<Vec<u8>>();
-        assert_eq!(result, expected);
+        assert!(result.is_err());
     }
 
     #[allow(clippy::needless_pass_by_value)]
@@ -126,10 +122,6 @@ mod tests {
         let interp = crate::interpreter().expect("init");
         let value = interp.convert(b);
         let value = value.try_into::<Vec<u8>>();
-        let expected = Err(ArtichokeError::ConvertToRust {
-            from: Ruby::Bool,
-            to: Rust::Bytes,
-        });
-        value == expected
+        value.is_err()
     }
 }

--- a/artichoke-backend/src/convert/fixnum.rs
+++ b/artichoke-backend/src/convert/fixnum.rs
@@ -125,12 +125,8 @@ mod tests {
         let mut interp = crate::interpreter().expect("init");
         // get a mrb_value that can't be converted to a primitive type.
         let value = interp.eval(b"Object.new").expect("eval");
-        let expected = Err(ArtichokeError::ConvertToRust {
-            from: Ruby::Object,
-            to: Rust::SignedInt,
-        });
         let result = value.try_into::<Int>();
-        assert_eq!(result, expected);
+        assert!(result.is_err());
     }
 
     #[quickcheck]
@@ -162,26 +158,17 @@ mod tests {
         let interp = crate::interpreter().expect("init");
         let value = interp.convert(b);
         let value = value.try_into::<Int>();
-        let expected = Err(ArtichokeError::ConvertToRust {
-            from: Ruby::Bool,
-            to: Rust::SignedInt,
-        });
-        value == expected
+        value.is_err()
     }
 
     #[test]
     fn fixnum_to_usize() {
         let interp = crate::interpreter().expect("init");
         let value = Convert::<_, Value>::convert(&interp, 100);
-        let value = value.try_into::<usize>();
-        let expected = Ok(100);
-        assert_eq!(value, expected);
+        let value = value.try_into::<usize>().unwrap();
+        assert_eq!(value, 100);
         let value = Convert::<_, Value>::convert(&interp, -100);
         let value = value.try_into::<usize>();
-        let expected = Err(ArtichokeError::ConvertToRust {
-            from: Ruby::Fixnum,
-            to: Rust::UnsignedInt,
-        });
-        assert_eq!(value, expected);
+        assert!(value.is_err());
     }
 }

--- a/artichoke-backend/src/convert/float.rs
+++ b/artichoke-backend/src/convert/float.rs
@@ -38,12 +38,8 @@ mod tests {
         let mut interp = crate::interpreter().expect("init");
         // get a mrb_value that can't be converted to a primitive type.
         let value = interp.eval(b"Object.new").expect("eval");
-        let expected = Err(ArtichokeError::ConvertToRust {
-            from: Ruby::Object,
-            to: Rust::Float,
-        });
         let result = value.try_into::<Float>();
-        assert_eq!(result, expected);
+        assert!(result.is_err());
     }
 
     #[quickcheck]
@@ -75,10 +71,6 @@ mod tests {
         let interp = crate::interpreter().expect("init");
         let value = interp.convert(b);
         let value = value.try_into::<Float>();
-        let expected = Err(ArtichokeError::ConvertToRust {
-            from: Ruby::Bool,
-            to: Rust::Float,
-        });
-        value == expected
+        value.is_err()
     }
 }

--- a/artichoke-backend/src/convert/nilable.rs
+++ b/artichoke-backend/src/convert/nilable.rs
@@ -1,10 +1,11 @@
 //! Converters for nilable primitive Ruby types. Excludes collection types
 //! Array and Hash.
 
+use crate::exception::Exception;
 use crate::sys;
 use crate::types::{Int, Ruby};
 use crate::value::Value;
-use crate::{Artichoke, ArtichokeError, Convert, ConvertMut, TryConvert};
+use crate::{Artichoke, Convert, ConvertMut, TryConvert};
 
 impl Convert<Option<Value>, Value> for Artichoke {
     fn convert(&self, value: Option<Value>) -> Value {
@@ -69,7 +70,9 @@ impl Convert<Value, Option<Value>> for Artichoke {
 }
 
 impl<'a> TryConvert<Value, Option<bool>> for Artichoke {
-    fn try_convert(&self, value: Value) -> Result<Option<bool>, ArtichokeError> {
+    type Error = Exception;
+
+    fn try_convert(&self, value: Value) -> Result<Option<bool>, Self::Error> {
         if let Ruby::Nil = value.ruby_type() {
             Ok(None)
         } else {
@@ -79,7 +82,9 @@ impl<'a> TryConvert<Value, Option<bool>> for Artichoke {
 }
 
 impl<'a> TryConvert<Value, Option<Vec<u8>>> for Artichoke {
-    fn try_convert(&self, value: Value) -> Result<Option<Vec<u8>>, ArtichokeError> {
+    type Error = Exception;
+
+    fn try_convert(&self, value: Value) -> Result<Option<Vec<u8>>, Self::Error> {
         if let Ruby::Nil = value.ruby_type() {
             Ok(None)
         } else {
@@ -89,7 +94,9 @@ impl<'a> TryConvert<Value, Option<Vec<u8>>> for Artichoke {
 }
 
 impl<'a> TryConvert<Value, Option<&'a [u8]>> for Artichoke {
-    fn try_convert(&self, value: Value) -> Result<Option<&'a [u8]>, ArtichokeError> {
+    type Error = Exception;
+
+    fn try_convert(&self, value: Value) -> Result<Option<&'a [u8]>, Self::Error> {
         if let Ruby::Nil = value.ruby_type() {
             Ok(None)
         } else {
@@ -99,7 +106,9 @@ impl<'a> TryConvert<Value, Option<&'a [u8]>> for Artichoke {
 }
 
 impl<'a> TryConvert<Value, Option<String>> for Artichoke {
-    fn try_convert(&self, value: Value) -> Result<Option<String>, ArtichokeError> {
+    type Error = Exception;
+
+    fn try_convert(&self, value: Value) -> Result<Option<String>, Self::Error> {
         if let Ruby::Nil = value.ruby_type() {
             Ok(None)
         } else {
@@ -109,7 +118,9 @@ impl<'a> TryConvert<Value, Option<String>> for Artichoke {
 }
 
 impl<'a> TryConvert<Value, Option<&'a str>> for Artichoke {
-    fn try_convert(&self, value: Value) -> Result<Option<&'a str>, ArtichokeError> {
+    type Error = Exception;
+
+    fn try_convert(&self, value: Value) -> Result<Option<&'a str>, Self::Error> {
         if let Ruby::Nil = value.ruby_type() {
             Ok(None)
         } else {
@@ -119,7 +130,9 @@ impl<'a> TryConvert<Value, Option<&'a str>> for Artichoke {
 }
 
 impl<'a> TryConvert<Value, Option<Int>> for Artichoke {
-    fn try_convert(&self, value: Value) -> Result<Option<Int>, ArtichokeError> {
+    type Error = Exception;
+
+    fn try_convert(&self, value: Value) -> Result<Option<Int>, Self::Error> {
         if let Ruby::Nil = value.ruby_type() {
             Ok(None)
         } else {

--- a/artichoke-backend/src/convert/string.rs
+++ b/artichoke-backend/src/convert/string.rs
@@ -1,8 +1,10 @@
 use std::str;
 
+use crate::convert::UnboxRubyError;
+use crate::exception::Exception;
 use crate::types::Rust;
 use crate::value::Value;
-use crate::{Artichoke, ArtichokeError, ConvertMut, TryConvert};
+use crate::{Artichoke, ConvertMut, TryConvert};
 
 impl ConvertMut<String, Value> for Artichoke {
     fn convert_mut(&mut self, value: String) -> Value {
@@ -21,26 +23,23 @@ impl ConvertMut<&str, Value> for Artichoke {
 }
 
 impl TryConvert<Value, String> for Artichoke {
-    fn try_convert(&self, value: Value) -> Result<String, ArtichokeError> {
+    type Error = Exception;
+
+    fn try_convert(&self, value: Value) -> Result<String, Self::Error> {
         TryConvert::<_, &str>::try_convert(self, value).map(String::from)
     }
 }
 
 impl<'a> TryConvert<Value, &'a str> for Artichoke {
-    fn try_convert(&self, value: Value) -> Result<&'a str, ArtichokeError> {
-        let type_tag = value.ruby_type();
-        self.try_convert(value)
-            .ok()
-            .and_then(|bytes| {
-                // This converter requires that the bytes be valid UTF-8 data.
-                // If the `Value` contains binary data, use the `Vec<u8>` or
-                // `&[u8]` converter.
-                str::from_utf8(bytes).ok()
-            })
-            .ok_or(ArtichokeError::ConvertToRust {
-                from: type_tag,
-                to: Rust::String,
-            })
+    type Error = Exception;
+
+    fn try_convert(&self, value: Value) -> Result<&'a str, Self::Error> {
+        let err = UnboxRubyError::new(&value, Rust::String);
+        let bytes = self.try_convert(value)?;
+        // This converter requires that the bytes be valid UTF-8 data. If the
+        // `Value` contains binary data, use the `Vec<u8>` or `&[u8]` converter.
+        let string = str::from_utf8(bytes).map_err(|_| err)?;
+        Ok(string)
     }
 }
 

--- a/artichoke-backend/src/convert/string.rs
+++ b/artichoke-backend/src/convert/string.rs
@@ -57,12 +57,8 @@ mod tests {
         let mut interp = crate::interpreter().expect("init");
         // get a mrb_value that can't be converted to a primitive type.
         let value = interp.eval(b"Object.new").expect("eval");
-        let expected = Err(ArtichokeError::ConvertToRust {
-            from: Ruby::Object,
-            to: Rust::String,
-        });
         let result = value.try_into::<String>();
-        assert_eq!(result, expected);
+        assert!(result.is_err());
     }
 
     #[allow(clippy::needless_pass_by_value)]
@@ -99,12 +95,8 @@ mod tests {
     fn roundtrip_err(b: bool) -> bool {
         let interp = crate::interpreter().expect("init");
         let value = interp.convert(b);
-        let value = value.try_into::<String>();
-        let expected = Err(ArtichokeError::ConvertToRust {
-            from: Ruby::Bool,
-            to: Rust::String,
-        });
-        value == expected
+        let result = value.try_into::<String>();
+        result.is_err()
     }
 
     #[test]

--- a/artichoke-backend/src/extn/core/array/ffi.rs
+++ b/artichoke-backend/src/extn/core/array/ffi.rs
@@ -11,9 +11,7 @@ use crate::gc::MrbGarbageCollection;
 unsafe extern "C" fn artichoke_ary_new(mrb: *mut sys::mrb_state) -> sys::mrb_value {
     let interp = unwrap_interpreter!(mrb);
     let result = Array(InlineBuffer::default());
-    let result = result
-        .try_into_ruby(&interp, None)
-        .map_err(|_| Fatal::new(&interp, "Unable to initialize Ruby Array from Rust Array"));
+    let result = result.try_into_ruby(&interp, None);
     match result {
         Ok(value) => value.inner(),
         Err(exception) => exception::raise(interp, exception),
@@ -30,9 +28,7 @@ unsafe extern "C" fn artichoke_ary_new_capa(
     let result = Array(InlineBuffer::with_capacity(
         usize::try_from(capa).unwrap_or_default(),
     ));
-    let result = result
-        .try_into_ruby(&interp, None)
-        .map_err(|_| Fatal::new(&interp, "Unable to initialize Ruby Array from Rust Array"));
+    let result = result.try_into_ruby(&interp, None);
     match result {
         Ok(value) => value.inner(),
         Err(exception) => exception::raise(interp, exception),
@@ -51,9 +47,7 @@ unsafe extern "C" fn artichoke_ary_new_from_values(
     let values = slice::from_raw_parts(vals, size);
     let result = InlineBuffer::from(values);
     let result = Array(result);
-    let result = result
-        .try_into_ruby(&interp, None)
-        .map_err(|_| Fatal::new(&interp, "Unable to initialize Ruby Array from Rust Array"));
+    let result = result.try_into_ruby(&interp, None);
     match result {
         Ok(value) => {
             let basic = sys::mrb_sys_basic_ptr(value.inner());
@@ -77,9 +71,7 @@ unsafe extern "C" fn artichoke_ary_splat(
     }
     let result = InlineBuffer::from(vec![value.inner()]);
     let result = Array(result);
-    let result = result
-        .try_into_ruby(&interp, None)
-        .map_err(|_| Fatal::new(&interp, "Unable to initialize Ruby Array from Rust Array"));
+    let result = result.try_into_ruby(&interp, None);
     match result {
         Ok(value) => value.inner(),
         Err(exception) => exception::raise(interp, exception),

--- a/artichoke-backend/src/extn/core/kernel/mod.rs
+++ b/artichoke-backend/src/extn/core/kernel/mod.rs
@@ -163,17 +163,17 @@ mod tests {
             .def_file_for_type::<TestFile>(b"file.rb")
             .expect("def file");
         let result = interp.eval(b"require 'file'").expect("eval");
-        let require_result = result.try_into::<bool>();
-        assert_eq!(require_result, Ok(true));
+        let require_result = result.try_into::<bool>().unwrap();
+        assert_eq!(require_result, true);
         let result = interp.eval(b"@i").expect("eval");
-        let i_result = result.try_into::<i64>();
-        assert_eq!(i_result, Ok(255));
+        let i_result = result.try_into::<i64>().unwrap();
+        assert_eq!(i_result, 255);
         let result = interp.eval(b"@i = 1000; require 'file'").expect("eval");
-        let second_require_result = result.try_into::<bool>();
-        assert_eq!(second_require_result, Ok(false));
+        let second_require_result = result.try_into::<bool>().unwrap();
+        assert_eq!(second_require_result, false);
         let result = interp.eval(b"@i").expect("eval");
-        let second_i_result = result.try_into::<i64>();
-        assert_eq!(second_i_result, Ok(1000));
+        let second_i_result = result.try_into::<i64>().unwrap();
+        assert_eq!(second_i_result, 1000);
         let err = interp.eval(b"require 'non-existent-source'").unwrap_err();
         assert_eq!(
             &b"cannot load such file -- non-existent-source"[..],

--- a/artichoke-backend/src/extn/core/matchdata/regexp.rs
+++ b/artichoke-backend/src/extn/core/matchdata/regexp.rs
@@ -7,11 +7,6 @@ pub fn method(interp: &Artichoke, value: &Value) -> Result<Value, Exception> {
     let data = unsafe { MatchData::try_from_ruby(interp, value) }?;
     let borrow = data.borrow();
     let regexp = borrow.regexp.clone();
-    let regexp = regexp.try_into_ruby(interp, None).map_err(|_| {
-        Fatal::new(
-            interp,
-            "Unable to initialize Ruby Regexp Value from Rust Regexp",
-        )
-    })?;
+    let regexp = regexp.try_into_ruby(interp, None)?;
     Ok(regexp)
 }

--- a/artichoke-backend/src/extn/core/regexp/backend/onig.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/onig.rs
@@ -241,9 +241,7 @@ impl RegexpType for Onig {
                 0,
                 pattern.len(),
             );
-            let matchdata = matchdata.try_into_ruby(&interp, None).map_err(|_| {
-                Fatal::new(interp, "Could not create Ruby Value from Rust MatchData")
-            })?;
+            let matchdata = matchdata.try_into_ruby(&interp, None)?;
             let matchdata_sym = interp.intern_symbol(regexp::LAST_MATCH);
             unsafe {
                 sys::mrb_gv_set(mrb, matchdata_sym, matchdata.inner());
@@ -367,12 +365,7 @@ impl RegexpType for Onig {
                 }
                 matchdata.set_region(byte_offset + match_pos.0, byte_offset + match_pos.1);
             }
-            let data = matchdata.try_into_ruby(interp, None).map_err(|_| {
-                Fatal::new(
-                    interp,
-                    "Failed to initialize Ruby MatchData Value with Rust MatchData",
-                )
-            })?;
+            let data = matchdata.try_into_ruby(interp, None)?;
             let matchdata_sym = interp.intern_symbol(regexp::LAST_MATCH);
             unsafe {
                 sys::mrb_gv_set(mrb, matchdata_sym, data.inner());
@@ -431,12 +424,7 @@ impl RegexpType for Onig {
                 0,
                 pattern.len(),
             );
-            let matchdata = matchdata.try_into_ruby(interp, None).map_err(|_| {
-                Fatal::new(
-                    interp,
-                    "Failed to initialize Ruby MatchData Value with Rust MatchData",
-                )
-            })?;
+            let matchdata = matchdata.try_into_ruby(interp, None)?;
             let matchdata_sym = interp.intern_symbol(regexp::LAST_MATCH);
             unsafe {
                 sys::mrb_gv_set(mrb, matchdata_sym, matchdata.inner());
@@ -639,9 +627,7 @@ impl RegexpType for Onig {
                     if let Some(pos) = captures.pos(0) {
                         matchdata.set_region(pos.0, pos.1);
                     }
-                    let data = matchdata.clone().try_into_ruby(interp, None).map_err(|_| {
-                        Fatal::new(interp, "Failed to convert MatchData to Ruby Value")
-                    })?;
+                    let data = matchdata.clone().try_into_ruby(interp, None)?;
                     unsafe {
                         sys::mrb_gv_set(mrb, last_match_sym, data.inner());
                     }
@@ -662,9 +648,7 @@ impl RegexpType for Onig {
                     let scanned = &haystack[pos.0..pos.1];
                     let matched = interp.convert_mut(scanned);
                     matchdata.set_region(pos.0, pos.1);
-                    let data = matchdata.clone().try_into_ruby(interp, None).map_err(|_| {
-                        Fatal::new(interp, "Failed to convert MatchData to Ruby Value")
-                    })?;
+                    let data = matchdata.clone().try_into_ruby(interp, None)?;
                     unsafe {
                         sys::mrb_gv_set(mrb, last_match_sym, data.inner());
                     }
@@ -708,9 +692,7 @@ impl RegexpType for Onig {
                     collected.push(groups);
                 }
                 matchdata.set_region(last_pos.0, last_pos.1);
-                let data = matchdata
-                    .try_into_ruby(interp, None)
-                    .map_err(|_| Fatal::new(interp, "Failed to convert MatchData to Ruby Value"))?;
+                let data = matchdata.try_into_ruby(interp, None)?;
                 unsafe {
                     sys::mrb_gv_set(mrb, last_match_sym, data.inner());
                 }
@@ -745,9 +727,7 @@ impl RegexpType for Onig {
                     collected.push(scanned);
                 }
                 matchdata.set_region(last_pos.0, last_pos.1);
-                let data = matchdata
-                    .try_into_ruby(interp, None)
-                    .map_err(|_| Fatal::new(interp, "Failed to convert MatchData to Ruby Value"))?;
+                let data = matchdata.try_into_ruby(interp, None)?;
                 unsafe {
                     sys::mrb_gv_set(mrb, last_match_sym, data.inner());
                 }

--- a/artichoke-backend/src/extn/core/regexp/backend/regex/utf8.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/regex/utf8.rs
@@ -255,9 +255,7 @@ impl RegexpType for Utf8 {
                 0,
                 pattern.len(),
             );
-            let matchdata = matchdata.try_into_ruby(&interp, None).map_err(|_| {
-                Fatal::new(interp, "Could not create Ruby Value from Rust MatchData")
-            })?;
+            let matchdata = matchdata.try_into_ruby(&interp, None)?;
             let matchdata_sym = interp.intern_symbol(regexp::LAST_MATCH);
             unsafe {
                 sys::mrb_gv_set(mrb, matchdata_sym, matchdata.inner());
@@ -394,12 +392,7 @@ impl RegexpType for Utf8 {
                     byte_offset + match_pos.end(),
                 );
             }
-            let data = matchdata.try_into_ruby(interp, None).map_err(|_| {
-                Fatal::new(
-                    interp,
-                    "Failed to initialize Ruby MatchData Value with Rust MatchData",
-                )
-            })?;
+            let data = matchdata.try_into_ruby(interp, None)?;
             let matchdata_sym = interp.intern_symbol(regexp::LAST_MATCH);
             unsafe {
                 sys::mrb_gv_set(mrb, matchdata_sym, data.inner());
@@ -468,12 +461,7 @@ impl RegexpType for Utf8 {
                 0,
                 pattern.len(),
             );
-            let matchdata = matchdata.try_into_ruby(interp, None).map_err(|_| {
-                Fatal::new(
-                    interp,
-                    "Failed to initialize Ruby MatchData Value with Rust MatchData",
-                )
-            })?;
+            let matchdata = matchdata.try_into_ruby(interp, None)?;
             let matchdata_sym = interp.intern_symbol(regexp::LAST_MATCH);
             unsafe {
                 sys::mrb_gv_set(mrb, matchdata_sym, matchdata.inner());
@@ -677,9 +665,7 @@ impl RegexpType for Utf8 {
                     if let Some(pos) = captures.get(0) {
                         matchdata.set_region(pos.start(), pos.end());
                     }
-                    let data = matchdata.clone().try_into_ruby(interp, None).map_err(|_| {
-                        Fatal::new(interp, "Failed to convert MatchData to Ruby Value")
-                    })?;
+                    let data = matchdata.clone().try_into_ruby(interp, None)?;
                     unsafe {
                         sys::mrb_gv_set(mrb, last_match_sym, data.inner());
                     }
@@ -700,9 +686,7 @@ impl RegexpType for Utf8 {
                     let scanned = &haystack[pos.start()..pos.end()];
                     let matched = interp.convert_mut(scanned);
                     matchdata.set_region(pos.start(), pos.end());
-                    let data = matchdata.clone().try_into_ruby(interp, None).map_err(|_| {
-                        Fatal::new(interp, "Failed to convert MatchData to Ruby Value")
-                    })?;
+                    let data = matchdata.clone().try_into_ruby(interp, None)?;
                     unsafe {
                         sys::mrb_gv_set(mrb, last_match_sym, data.inner());
                     }
@@ -750,9 +734,7 @@ impl RegexpType for Utf8 {
                     collected.push(groups);
                 }
                 matchdata.set_region(last_pos.0, last_pos.1);
-                let data = matchdata
-                    .try_into_ruby(interp, None)
-                    .map_err(|_| Fatal::new(interp, "Failed to convert MatchData to Ruby Value"))?;
+                let data = matchdata.try_into_ruby(interp, None)?;
                 unsafe {
                     sys::mrb_gv_set(mrb, last_match_sym, data.inner());
                 }
@@ -787,9 +769,7 @@ impl RegexpType for Utf8 {
                     collected.push(scanned);
                 }
                 matchdata.set_region(last_pos.0, last_pos.1);
-                let data = matchdata
-                    .try_into_ruby(interp, None)
-                    .map_err(|_| Fatal::new(interp, "Failed to convert MatchData to Ruby Value"))?;
+                let data = matchdata.try_into_ruby(interp, None)?;
                 unsafe {
                     sys::mrb_gv_set(mrb, last_match_sym, data.inner());
                 }

--- a/artichoke-backend/src/extn/core/regexp/enc.rs
+++ b/artichoke-backend/src/extn/core/regexp/enc.rs
@@ -64,7 +64,7 @@ impl PartialEq for Encoding {
 impl Eq for Encoding {}
 
 pub fn parse(value: &Value) -> Result<Encoding, Error> {
-    if let Ok(encoding) = value.itself::<Int>() {
+    if let Ok(encoding) = value.clone().try_into::<Int>() {
         // Only deal with Encoding opts
         let encoding = encoding & !regexp::ALL_REGEXP_OPTS;
         if encoding == regexp::FIXEDENCODING {
@@ -76,7 +76,7 @@ pub fn parse(value: &Value) -> Result<Encoding, Error> {
         } else {
             Err(Error::InvalidEncoding)
         }
-    } else if let Ok(encoding) = value.itself::<&str>() {
+    } else if let Ok(encoding) = value.clone().try_into::<&str>() {
         if encoding.contains('u') && encoding.contains('n') {
             return Err(Error::InvalidEncoding);
         }

--- a/artichoke-backend/src/extn/core/regexp/mod.rs
+++ b/artichoke-backend/src/extn/core/regexp/mod.rs
@@ -191,14 +191,7 @@ impl Regexp {
             derived_config,
             encoding.unwrap_or_default(),
         )?;
-        let regexp = regexp
-            .try_into_ruby(interp, into.as_ref().map(Value::inner))
-            .map_err(|_| {
-                Fatal::new(
-                    interp,
-                    "Failed to initialize Regexp Ruby Value with Rust Regexp",
-                )
-            })?;
+        let regexp = regexp.try_into_ruby(interp, into.as_ref().map(Value::inner))?;
         Ok(regexp)
     }
 
@@ -307,12 +300,7 @@ impl Regexp {
             options: Options::default(),
         };
         let regexp = Self::new(interp, literal_config, derived_config, Encoding::default())?;
-        let regexp = regexp.try_into_ruby(interp, None).map_err(|_| {
-            Fatal::new(
-                interp,
-                "Failed to initialize Regexp Ruby Value with Rust Regexp",
-            )
-        })?;
+        let regexp = regexp.try_into_ruby(interp, None)?;
         Ok(regexp)
     }
 

--- a/artichoke-backend/src/extn/core/regexp/opts.rs
+++ b/artichoke-backend/src/extn/core/regexp/opts.rs
@@ -79,19 +79,19 @@ pub fn parse(value: &Value) -> Options {
     // Regexp::EXTENDED, Regexp::IGNORECASE, and Regexp::MULTILINE, logically
     // or-ed together. Otherwise, if options is not nil or false, the regexp
     // will be case insensitive.
-    if let Ok(options) = value.itself::<Int>() {
+    if let Ok(options) = value.clone().try_into::<Int>() {
         Options {
             multiline: options & regexp::MULTILINE > 0,
             ignore_case: options & regexp::IGNORECASE > 0,
             extended: options & regexp::EXTENDED > 0,
             literal: options & regexp::LITERAL > 0,
         }
-    } else if let Ok(options) = value.itself::<Option<bool>>() {
+    } else if let Ok(options) = value.clone().try_into::<Option<bool>>() {
         match options {
             Some(false) | None => Options::default(),
             _ => Options::ignore_case(),
         }
-    } else if let Ok(options) = value.itself::<Option<&str>>() {
+    } else if let Ok(options) = value.clone().try_into::<Option<&str>>() {
         if let Some(options) = options {
             Options {
                 multiline: options.contains('m'),

--- a/artichoke-backend/src/extn/core/string.rs
+++ b/artichoke-backend/src/extn/core/string.rs
@@ -67,9 +67,11 @@ mod tests {
         let mut interp = crate::interpreter().expect("init");
 
         let value = interp.eval(br#""cat o' 9 tails" =~ /\d/"#).unwrap();
-        assert_eq!(value.try_into::<Option<i64>>(), Ok(Some(7)));
+        let value = value.try_into::<Option<i64>>().unwrap();
+        assert_eq!(value, Some(7));
         let value = interp.eval(br#""cat o' 9 tails" =~ 9"#).unwrap();
-        assert_eq!(value.try_into::<Option<i64>>(), Ok(None));
+        let value = value.try_into::<Option<i64>>().unwrap();
+        assert!(value.is_none());
     }
 
     #[test]

--- a/artichoke-backend/src/extn/core/string/scan.rs
+++ b/artichoke-backend/src/extn/core/string/scan.rs
@@ -36,10 +36,7 @@ pub fn method(
             for pos in string.find_iter(pattern_bytes) {
                 restore_nil = false;
                 matchdata.set_region(pos, pos + patlen);
-                let data = matchdata
-                    .clone()
-                    .try_into_ruby(interp, None)
-                    .map_err(|_| Fatal::new(interp, "Failed to convert MatchData to Ruby Value"))?;
+                let data = matchdata.clone().try_into_ruby(interp, None)?;
                 unsafe {
                     sys::mrb_gv_set(mrb, last_match_sym, data.inner());
                 }
@@ -72,9 +69,7 @@ pub fn method(
                 let last_match_sym = interp.intern_symbol(regexp::LAST_MATCH);
                 let mut matchdata = MatchData::new(string.to_vec(), regex, 0, string.len());
                 matchdata.set_region(last_pos, last_pos + pattern_bytes.len());
-                let data = matchdata
-                    .try_into_ruby(interp, None)
-                    .map_err(|_| Fatal::new(interp, "Failed to convert MatchData to Ruby Value"))?;
+                let data = matchdata.try_into_ruby(interp, None)?;
                 unsafe {
                     sys::mrb_gv_set(mrb, last_match_sym, data.inner());
                 }
@@ -104,9 +99,7 @@ pub fn method(
                 for pos in string.find_iter(pattern_bytes) {
                     restore_nil = false;
                     matchdata.set_region(pos, pos + patlen);
-                    let data = matchdata.clone().try_into_ruby(interp, None).map_err(|_| {
-                        Fatal::new(interp, "Failed to convert MatchData to Ruby Value")
-                    })?;
+                    let data = matchdata.clone().try_into_ruby(interp, None)?;
                     unsafe {
                         sys::mrb_gv_set(mrb, last_match_sym, data.inner());
                     }
@@ -139,9 +132,7 @@ pub fn method(
                     let last_match_sym = interp.intern_symbol(regexp::LAST_MATCH);
                     let mut matchdata = MatchData::new(string.to_vec(), regex, 0, string.len());
                     matchdata.set_region(last_pos, last_pos + pattern_bytes.len());
-                    let data = matchdata.try_into_ruby(interp, None).map_err(|_| {
-                        Fatal::new(interp, "Failed to convert MatchData to Ruby Value")
-                    })?;
+                    let data = matchdata.try_into_ruby(interp, None)?;
                     unsafe {
                         sys::mrb_gv_set(mrb, last_match_sym, data.inner());
                     }

--- a/artichoke-backend/tests/manual.rs
+++ b/artichoke-backend/tests/manual.rs
@@ -78,8 +78,10 @@ fn define_rust_backed_ruby_class() {
 
     let _ = interp.eval(b"require 'container'").expect("require");
     let result = interp.eval(b"Container.new(15).value").expect("eval");
-    assert_eq!(result.try_into::<Int>(), Ok(15));
+    let result = result.try_into::<Int>().unwrap();
+    assert_eq!(result, 15);
     // Ensure Rc is cloned correctly and still points to valid memory.
-    let result = interp.eval(b"Container.new(15).value").expect("eval");
-    assert_eq!(result.try_into::<Int>(), Ok(15));
+    let result = interp.eval(b"Container.new(105).value").expect("eval");
+    let result = result.try_into::<Int>().unwrap();
+    assert_eq!(result, 105);
 }

--- a/artichoke-core/src/convert.rs
+++ b/artichoke-core/src/convert.rs
@@ -1,7 +1,6 @@
 //! Convert between Rust and Ruby objects.
 
 use std::error;
-use std::fmt;
 
 /// Infallible conversion between two types.
 ///
@@ -34,23 +33,6 @@ pub trait TryConvert<T, U> {
     fn try_convert(&self, value: T) -> Result<U, Self::Error>;
 }
 
-/// Provide a fallible converter for types that implement an infallible
-/// conversion.
-impl<T, U, V> TryConvert<T, U> for V
-where
-    V: Convert<T, U>,
-{
-    // TODO: this should be the never type.
-    // https://github.com/rust-lang/rust/issues/35121
-    type Error = Infallible;
-
-    /// Blanket implementation that always succeeds by delegating to
-    /// [`Convert::convert`].
-    fn try_convert(&self, value: T) -> Result<U, Self::Error> {
-        Ok(Convert::convert(self, value))
-    }
-}
-
 /// Mutable infallible conversion between two types.
 ///
 /// Implementors may allocate on the interpreter heap.
@@ -80,38 +62,4 @@ pub trait TryConvertMut<T, U> {
     /// If boxing or unboxing a value into the specified type fails, an error is
     /// returned.
     fn try_convert_mut(&mut self, value: T) -> Result<U, Self::Error>;
-}
-
-/// Provide a mutable fallible converter for types that implement an infallible
-/// conversion.
-impl<T, U, V> TryConvertMut<T, U> for V
-where
-    V: ConvertMut<T, U>,
-{
-    // TODO: this should be the never type.
-    // https://github.com/rust-lang/rust/issues/35121
-    type Error = Infallible;
-
-    /// Blanket implementation that always succeeds by delegating to
-    /// [`Convert::convert`].
-    fn try_convert_mut(&mut self, value: T) -> Result<U, Self::Error> {
-        Ok(ConvertMut::convert_mut(self, value))
-    }
-}
-
-/// Uninhabital error type for infallible conversions.
-pub enum Infallible {}
-
-impl error::Error for Infallible {}
-
-impl fmt::Debug for Infallible {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "This error is unreachable")
-    }
-}
-
-impl fmt::Display for Infallible {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "This error is unreachable")
-    }
 }

--- a/artichoke-core/src/types.rs
+++ b/artichoke-core/src/types.rs
@@ -3,7 +3,7 @@
 use std::fmt;
 
 /// Classes of Rust types.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
 pub enum Rust {
     /// Rust `bool` type.
     Bool,
@@ -33,12 +33,23 @@ pub enum Rust {
 
 impl fmt::Display for Rust {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "Rust ")?;
+        match self {
+            Self::Bool => write!(f, "bool"),
+            Self::Bytes => write!(f, "Vec<u8>"),
+            Self::Float => write!(f, "f64"),
+            Self::Map => write!(f, "HashMap"),
+            Self::Object => write!(f, "RustBackedValue"),
+            Self::SignedInt => write!(f, "i64"),
+            Self::String => write!(f, "String"),
+            Self::UnsignedInt => write!(f, "u64"),
+            Self::Vec => write!(f, "Vec<Value>"),
+        }
     }
 }
 
 /// Classes of Ruby types.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
 pub enum Ruby {
     /// Ruby `Array` type.
     Array,

--- a/artichoke-core/src/value.rs
+++ b/artichoke-core/src/value.rs
@@ -41,8 +41,6 @@ where
 
     /// Consume `self` and try to convert `self` to type `T`.
     ///
-    /// If you do not want to consume this [`Value`], use [`Value::itself`].
-    ///
     /// # Errors
     ///
     /// If a [`TryConvert`] conversion fails, then an error is returned.

--- a/artichoke-core/src/value.rs
+++ b/artichoke-core/src/value.rs
@@ -3,7 +3,6 @@
 use std::error;
 
 use crate::convert::TryConvert;
-use crate::ArtichokeError;
 
 /// A boxed Ruby value owned by the interpreter.
 ///
@@ -38,7 +37,7 @@ where
         block: Option<Self::Block>,
     ) -> Result<T, Self::Error>
     where
-        Self::Artichoke: TryConvert<Self, T>;
+        Self::Artichoke: TryConvert<Self, T, Error = Self::Error>;
 
     /// Consume `self` and try to convert `self` to type `T`.
     ///
@@ -47,21 +46,9 @@ where
     /// # Errors
     ///
     /// If a [`TryConvert`] conversion fails, then an error is returned.
-    fn try_into<T>(self) -> Result<T, ArtichokeError>
+    fn try_into<T>(self) -> Result<T, Self::Error>
     where
-        Self::Artichoke: TryConvert<Self, T>;
-
-    /// Call `#itself` on this [`Value`] and try to convert the result to type
-    /// `T`.
-    ///
-    /// If you want to consume this [`Value`], use [`Value::try_into`].
-    ///
-    /// # Errors
-    ///
-    /// If a [`TryConvert`] conversion fails, then an error is returned.
-    fn itself<T>(&self) -> Result<T, ArtichokeError>
-    where
-        Self::Artichoke: TryConvert<Self, T>;
+        Self::Artichoke: TryConvert<Self, T, Error = Self::Error>;
 
     /// Call `#freeze` on this [`Value`].
     ///


### PR DESCRIPTION
This PR continues the push toward removing the `ArtichokeError` type and moving toward a unified error abstraction where all APIs return a variant of `dyn RubyException`.

This PR introduces two new error types in `artichoke_backend::convert`:

- `UnboxRubyError`: returned when failing to unbox a Ruby `Value` into a Rust native type. Raisable as a Ruby `TypeError`.
- `BoxIntoRubyError`: returned when failing to box a Rust value into a Ruby `Value`. This usually occurs when the Ruby box does not have sufficient capacity to store the Rust value. For example, trying to box a `u64` on wasm32. Raisable as a Ruby `TypeError`.

To wire up this change, the converter traits in `artichoke-core` have been modified to encode the error type as an associated type.

`ValueLike::itself` has been removed.

This PR significantly simplified most converter implementations, eliminated many panicking branches, and allowed errors to be propagated as is instead of wrapped.

One thing to look into is whether `RubyException::message` should return a `Cow<[u8]>`.

Expect a followup PR to remove `ArtichokeError` and `BootError`.