### PR TITLE
Remove ArtichokeError and BootError

### DIFF
--- a/artichoke-backend/src/extn/prelude.rs
+++ b/artichoke-backend/src/extn/prelude.rs
@@ -17,8 +17,8 @@ pub use crate::sys;
 pub use crate::types::{Float, Int, Ruby};
 pub use crate::value::{Block, Value};
 pub use crate::{
-    Artichoke, ArtichokeError, Convert, ConvertMut, Eval, Intern, LoadSources, TryConvert,
-    TryConvertMut, ValueLike, Warn,
+    Artichoke, Convert, ConvertMut, Eval, Intern, LoadSources, TryConvert, TryConvertMut,
+    ValueLike, Warn,
 };
 
 /// Type alias for errors returned from `init` functions in

--- a/artichoke-backend/src/lib.rs
+++ b/artichoke-backend/src/lib.rs
@@ -100,8 +100,6 @@ extern crate downcast;
 extern crate log;
 
 use std::cell::RefCell;
-use std::error;
-use std::fmt;
 use std::rc::Rc;
 
 #[macro_use]
@@ -150,11 +148,8 @@ pub use artichoke_core::parser::Parser;
 pub use artichoke_core::top_self::TopSelf;
 pub use artichoke_core::value::Value as ValueLike;
 pub use artichoke_core::warn::Warn;
-pub use artichoke_core::ArtichokeError;
 
 pub use interpreter::interpreter;
-
-use crate::exception::Exception;
 
 /// Interpreter instance.
 ///
@@ -201,48 +196,5 @@ impl Artichoke {
     /// [`Value`](value::Value)s.
     pub fn close(self) {
         self.0.borrow_mut().close();
-    }
-}
-
-/// Error returned when initializing an [`Artichoke`] interpreter.
-///
-/// This error type allows static errors as well as dynamic errors raised on the
-/// Ruby interpreter.
-#[derive(Debug)]
-pub struct BootError(BootErrorType);
-
-#[derive(Debug)]
-enum BootErrorType {
-    Artichoke(ArtichokeError),
-    Ruby(Exception),
-}
-
-impl fmt::Display for BootError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self.0 {
-            BootErrorType::Artichoke(ref err) => write!(f, "{}", err),
-            BootErrorType::Ruby(ref exc) => write!(f, "{}", exc),
-        }
-    }
-}
-
-impl error::Error for BootError {
-    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
-        match self.0 {
-            BootErrorType::Artichoke(ref err) => Some(err),
-            BootErrorType::Ruby(ref exc) => Some(exc),
-        }
-    }
-}
-
-impl From<ArtichokeError> for BootError {
-    fn from(err: ArtichokeError) -> Self {
-        Self(BootErrorType::Artichoke(err))
-    }
-}
-
-impl From<Exception> for BootError {
-    fn from(err: Exception) -> Self {
-        Self(BootErrorType::Ruby(err))
     }
 }

--- a/artichoke-backend/src/test/prelude.rs
+++ b/artichoke-backend/src/test/prelude.rs
@@ -18,6 +18,6 @@ pub use crate::sys;
 pub use crate::types::{Float, Int, Ruby, Rust};
 pub use crate::value::{Block, Value};
 pub use crate::{
-    Artichoke, ArtichokeError, BootError, Convert, ConvertMut, Eval, File, LoadSources, Parser,
-    TryConvert, TryConvertMut, ValueLike, Warn,
+    Artichoke, Convert, ConvertMut, Eval, File, LoadSources, Parser, TryConvert, TryConvertMut,
+    ValueLike, Warn,
 };

--- a/artichoke-core/src/lib.rs
+++ b/artichoke-core/src/lib.rs
@@ -32,9 +32,6 @@
 //!
 //! artichoke-core is licensed with the MIT License (c) Ryan Lopopolo.
 
-use std::error;
-use std::fmt;
-
 pub mod convert;
 pub mod eval;
 pub mod file;
@@ -45,37 +42,3 @@ pub mod top_self;
 pub mod types;
 pub mod value;
 pub mod warn;
-
-/// Errors returned by Artichoke interpreters.
-#[derive(Debug, PartialEq, Eq)]
-pub enum ArtichokeError {
-    /// Failed to convert from a Rust type to a [`Value`](value::Value).
-    ConvertToRuby {
-        /// Source type of conversion.
-        from: types::Rust,
-        /// Destination type of conversion.
-        to: types::Ruby,
-    },
-    /// Failed to convert from a [`Value`](value::Value) to a Rust type.
-    ConvertToRust {
-        /// Source type of conversion.
-        from: types::Ruby,
-        /// Destination type of conversion.
-        to: types::Rust,
-    },
-}
-
-impl fmt::Display for ArtichokeError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Self::ConvertToRuby { from, to } => {
-                write!(f, "Failed to convert from {} to {}", from, to)
-            }
-            Self::ConvertToRust { from, to } => {
-                write!(f, "Failed to convert from {} to {}", from, to)
-            }
-        }
-    }
-}
-
-impl error::Error for ArtichokeError {}

--- a/artichoke-frontend/src/bin/artichoke.rs
+++ b/artichoke-frontend/src/bin/artichoke.rs
@@ -39,7 +39,6 @@ use artichoke_frontend::ruby::{self, Error};
 fn main() {
     match ruby::entrypoint() {
         Ok(_) => {}
-        Err(Error::Artichoke(err)) => eprintln!("{}", err),
         Err(Error::Ruby(err)) => eprintln!("{}", err),
         Err(Error::Fail(err)) => eprintln!("{}", err),
     }

--- a/artichoke-frontend/src/bin/ruby.rs
+++ b/artichoke-frontend/src/bin/ruby.rs
@@ -39,7 +39,6 @@ use artichoke_frontend::ruby::{self, Error};
 fn main() {
     match ruby::entrypoint() {
         Ok(_) => {}
-        Err(Error::Artichoke(err)) => eprintln!("{}", err),
         Err(Error::Ruby(err)) => eprintln!("{}", err),
         Err(Error::Fail(err)) => eprintln!("{}", err),
     }

--- a/artichoke-frontend/src/repl.rs
+++ b/artichoke-frontend/src/repl.rs
@@ -9,7 +9,7 @@ use ansi_term::Style;
 use artichoke_backend::exception::{Exception, RubyException};
 use artichoke_backend::gc::MrbGarbageCollection;
 use artichoke_backend::state::parser::Context;
-use artichoke_backend::{Artichoke, BootError, Eval, Parser as _, ValueLike};
+use artichoke_backend::{Artichoke, Eval, Parser as _, ValueLike};
 use rustyline::error::ReadlineError;
 use rustyline::Editor;
 use std::io::{self, Write};
@@ -40,8 +40,6 @@ pub enum Error {
     ReplInit,
     /// Unrecoverable [`Parser`] error.
     ReplParse(parser::Error),
-    /// Error during Artichoke interpreter initialization.
-    Artichoke(BootError),
     /// Exception thrown by eval.
     Ruby(Exception),
     /// IO error when writing to output or error streams.
@@ -51,12 +49,6 @@ pub enum Error {
 impl From<parser::Error> for Error {
     fn from(err: parser::Error) -> Self {
         Self::ReplParse(err)
-    }
-}
-
-impl From<BootError> for Error {
-    fn from(err: BootError) -> Self {
-        Self::Artichoke(err)
     }
 }
 
@@ -94,14 +86,10 @@ impl Default for PromptConfig {
 }
 
 fn preamble(interp: &mut Artichoke) -> Result<String, Error> {
-    let description = interp
-        .eval(b"RUBY_DESCRIPTION")?
-        .try_into::<&str>()
-        .map_err(BootError::from)?;
+    let description = interp.eval(b"RUBY_DESCRIPTION")?.try_into::<&str>()?;
     let compiler = interp
         .eval(b"ARTICHOKE_COMPILER_VERSION")?
-        .try_into::<&str>()
-        .map_err(BootError::from)?;
+        .try_into::<&str>()?;
     let mut buf = String::new();
     buf.push_str(description);
     buf.push('\n');

--- a/artichoke-frontend/src/ruby.rs
+++ b/artichoke-frontend/src/ruby.rs
@@ -7,7 +7,7 @@ use artichoke_backend::ffi;
 use artichoke_backend::state::parser::Context;
 use artichoke_backend::string;
 use artichoke_backend::sys;
-use artichoke_backend::{BootError, ConvertMut, Eval, Intern, Parser as _};
+use artichoke_backend::{ConvertMut, Eval, Intern, Parser as _};
 use std::ffi::{OsStr, OsString};
 use std::io::{self, Read};
 use std::path::{Path, PathBuf};
@@ -50,18 +50,10 @@ struct Opt {
 /// Error from Ruby CLI frontend
 #[derive(Debug)]
 pub enum Error {
-    /// Error from Artichoke interpreter initialization.
-    Artichoke(BootError),
     /// Ruby `Exception` thrown during eval.
     Ruby(Exception),
     /// Fatal error from CLI internals.
     Fail(String),
-}
-
-impl From<BootError> for Error {
-    fn from(err: BootError) -> Self {
-        Self::Artichoke(err)
-    }
 }
 
 impl From<Exception> for Error {

--- a/spec-runner/src/mspec.rs
+++ b/spec-runner/src/mspec.rs
@@ -1,7 +1,8 @@
-use artichoke_backend::{Artichoke, BootError, ConvertMut, Eval, LoadSources, TopSelf, ValueLike};
+use artichoke_backend::exception::Exception;
+use artichoke_backend::{Artichoke, ConvertMut, Eval, LoadSources, TopSelf, ValueLike};
 use std::borrow::Cow;
 
-pub fn init(interp: &mut Artichoke) -> Result<(), BootError> {
+pub fn init(interp: &mut Artichoke) -> Result<(), Exception> {
     for source in Sources::iter() {
         let content = Sources::get(&source).unwrap();
         interp.def_rb_source_file(source.as_bytes(), content)?;
@@ -29,7 +30,7 @@ impl Runner {
         }
     }
 
-    pub fn add_spec<T>(&mut self, source: &str, contents: T) -> Result<(), BootError>
+    pub fn add_spec<T>(&mut self, source: &str, contents: T) -> Result<(), Exception>
     where
         T: Into<Cow<'static, [u8]>>,
     {
@@ -41,7 +42,7 @@ impl Runner {
         Ok(())
     }
 
-    pub fn run(mut self) -> Result<bool, BootError> {
+    pub fn run(mut self) -> Result<bool, Exception> {
         init(&mut self.interp).unwrap();
         self.interp
             .def_rb_source_file(b"/src/spec_helper.rb", &b""[..])?;


### PR DESCRIPTION
This completes the migration to a unified error type in Artichoke that
began with GH-311. All uses of the `ArtichokeError` enum have been
migrated to specialized error types that implement `std::error::Error`
and `RubyException`. This enables them to be handled by standard Rust
error handling mechanisms as well as be raisable on an Artichoke
interpreter.

`BootError` was always a temporary stopgap to bridge the
`ArtichokeError` and `Exception` error types in frontend and `extn` code
as the rollout and migration was executed.

The following PRs contributed to this fix:

- GH-311
- GH-371
- GH-387
- GH-430
- GH-437
- GH-457
- GH-461
- GH-463
- GH-465
- GH-470
- GH-474
- GH-496
- GH-497
- GH-500
- GH-507
- GH-508
- GH-509
- GH-510
- GH-511
- GH-512