### PR TITLE
Add cargo-deny configuration and enforce during builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -300,11 +300,13 @@ workflows:
       - x86_64-windows
       - ruby-spec
       - linter
+      - audit
       - deploy:
           requires:
             - x86_64-linux
             - x86_64-windows
             - linter
+            - audit
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -244,6 +244,33 @@ jobs:
           root: target
           paths:
             - "doc"
+  audit:
+    docker:
+      - image: circleci/ruby:2.6.3-buster
+    resource_class: large
+    steps:
+      - checkout
+      - restore_cache:
+          name: Restore sccache cache
+          key: v2-sccache-cache-stable-{{ arch }}-{{ .Environment.CIRCLE_JOB }}
+      - setup-linux-builder
+      - run:
+          name: Install cargo-deny
+          command: cargo install cargo-deny
+      - run:
+          name: Installed Toolchain Versions
+          command: |
+            cargo --version
+            cargo deny --version
+            cargo deny check --version
+      - save_cache:
+          name: Save sccache cache
+          key: v2-sccache-cache-stable-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ epoch }}
+          paths:
+            - "~/.cache/sccache"
+      - run:
+          name: Cargo Deny Check
+          command: cargo deny check
   deploy:
     docker:
       - image: node:lts

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,15 +19,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "arrayref"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -75,7 +66,7 @@ version = "0.1.0"
 name = "artichoke-frontend"
 version = "0.1.0"
 dependencies = [
- "ansi_term 0.12.1",
+ "ansi_term",
  "artichoke-backend",
  "bstr",
  "rustyline",
@@ -226,7 +217,7 @@ version = "2.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 dependencies = [
- "ansi_term 0.11.0",
+ "ansi_term",
  "atty",
  "bitflags",
  "strsim",

--- a/artichoke-frontend/Cargo.toml
+++ b/artichoke-frontend/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["artichoke", "artichoke-ruby", "ruby"]
 categories = ["command-line-utilities"]
 
 [dependencies]
-ansi_term = "0.12"
+ansi_term = "0.11" # cannot upgrade until clap 3 is released
 bstr = "0.2"
 rustyline = "6"
 structopt = "0.3"

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,39 @@
+[advisories]
+vulnerability = "deny"
+unmaintained = "deny"
+notice = "warn"
+ignore = []
+
+[licenses]
+unlicensed = "deny"
+allow = [
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "CC0-1.0",
+    "ISC",
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+]
+deny = []
+copyleft = "deny"
+allow-osi-fsf-free = "neither"
+default = "deny"
+confidence-threshold = 0.8
+
+[bans]
+multiple-versions = "deny"
+highlight = "all"
+allow = []
+deny = []
+skip = []
+skip-tree = [
+    { name = "autocfg", version = "< 1" },
+]
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-git = [
+    "https://github.com/artichoke/rust-onig",
+]

--- a/deny.toml
+++ b/deny.toml
@@ -7,13 +7,13 @@ ignore = []
 [licenses]
 unlicensed = "deny"
 allow = [
-    "BSD-2-Clause",
-    "BSD-3-Clause",
-    "CC0-1.0",
-    "ISC",
-    "MIT",
-    "Apache-2.0",
-    "Apache-2.0 WITH LLVM-exception",
+  "BSD-2-Clause",
+  "BSD-3-Clause",
+  "CC0-1.0",
+  "ISC",
+  "MIT",
+  "Apache-2.0",
+  "Apache-2.0 WITH LLVM-exception",
 ]
 deny = []
 copyleft = "deny"
@@ -27,13 +27,9 @@ highlight = "all"
 allow = []
 deny = []
 skip = []
-skip-tree = [
-    { name = "autocfg", version = "< 1" },
-]
+skip-tree = [{ name = "autocfg", version = "< 1" }]
 
 [sources]
 unknown-registry = "deny"
 unknown-git = "deny"
-allow-git = [
-    "https://github.com/artichoke/rust-onig",
-]
+allow-git = ["https://github.com/artichoke/rust-onig"]


### PR DESCRIPTION
Enforce only during builds instead of the interactive linter since
this check is less likely to break accidentally, i.e. you'd have to
add a dependency or a security advisory would have to be issued.