### PR TITLE
Handle nested option of Vec without cloning in MatchData#[]

### DIFF
--- a/artichoke-backend/src/extn/core/matchdata/element_reference.rs
+++ b/artichoke-backend/src/extn/core/matchdata/element_reference.rs
@@ -129,9 +129,15 @@ pub fn method(interp: &mut Artichoke, args: Args, value: &Value) -> Result<Value
                 let group = indexes
                     .iter()
                     .copied()
-                    .filter_map(|index| captures.get(index).and_then(Clone::clone))
+                    .filter_map(|index| {
+                        if let Some(Some(group)) = captures.get(index) {
+                            Some(group)
+                        } else {
+                            None
+                        }
+                    })
                     .last();
-                Ok(interp.convert_mut(group))
+                Ok(interp.convert_mut(group.map(Vec::as_slice)))
             } else {
                 let mut message = String::from("undefined group name reference: \"");
                 string::escape_unicode(&mut message, name)?;


### PR DESCRIPTION
The iterator expression returns:

    Option<&Option<Vec<u8>>>

This code is refactored to avoid a clone by using a nested pattern and
coercing the resultant `&Vec<u8>` to a slice, which can be correctly
processed by the converter.

This avoids an unnecessary allocation and makes the code easier to read.