### PR TITLE
ConstantNameError holds a Cow<str>

### DIFF
--- a/artichoke-backend/src/def.rs
+++ b/artichoke-backend/src/def.rs
@@ -195,12 +195,12 @@ impl Hash for EnclosingRubyScope {
 }
 
 #[derive(Debug, Clone)]
-pub struct ConstantNameError(String);
+pub struct ConstantNameError(Cow<'static, str>);
 
 impl ConstantNameError {
     pub fn new<T>(name: T) -> Self
     where
-        T: Into<String>,
+        T: Into<Cow<'static, str>>,
     {
         Self(name.into())
     }


### PR DESCRIPTION
This error type is already constructed with a constructor that takes
`Into<String>`. All callers already have `Cow<'static, str>`. Plumb the
cow through and potentially avoid an allocation.