### PR TITLE
NotDefinedError takes a Cow<str>

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,6 +67,7 @@ version = "0.1.0"
 dependencies = [
  "ansi_term",
  "artichoke-backend",
+ "bstr",
  "rustyline",
  "structopt",
 ]

--- a/artichoke-backend/src/class.rs
+++ b/artichoke-backend/src/class.rs
@@ -78,17 +78,17 @@ impl<'a> Builder<'a> {
         let mrb = self.interp.0.borrow().mrb;
         let mut super_class = if let Some(spec) = self.super_class {
             spec.rclass(mrb)
-                .ok_or_else(|| NotDefinedError::Super(spec.fqname().into_owned()))?
+                .ok_or_else(|| NotDefinedError::super_class(spec.fqname().into_owned()))?
         } else {
             let rclass = unsafe { (*mrb).object_class };
-            NonNull::new(rclass).ok_or_else(|| NotDefinedError::Super(String::from("Object")))?
+            NonNull::new(rclass).ok_or_else(|| NotDefinedError::super_class("Object"))?
         };
         let mut rclass = if let Some(rclass) = self.spec.rclass(mrb) {
             rclass
         } else if let Some(scope) = self.spec.enclosing_scope() {
             let mut scope_rclass = scope
                 .rclass(mrb)
-                .ok_or_else(|| NotDefinedError::EnclosingScope(scope.fqname().into_owned()))?;
+                .ok_or_else(|| NotDefinedError::enclosing_scope(scope.fqname().into_owned()))?;
             let rclass = unsafe {
                 sys::mrb_define_class_under(
                     mrb,
@@ -98,13 +98,13 @@ impl<'a> Builder<'a> {
                 )
             };
             NonNull::new(rclass)
-                .ok_or_else(|| NotDefinedError::Class(self.spec.name.as_ref().to_owned()))?
+                .ok_or_else(|| NotDefinedError::class(self.spec.name.as_ref().to_owned()))?
         } else {
             let rclass = unsafe {
                 sys::mrb_define_class(mrb, self.spec.name_c_str().as_ptr(), super_class.as_mut())
             };
             NonNull::new(rclass)
-                .ok_or_else(|| NotDefinedError::Class(self.spec.name.as_ref().to_owned()))?
+                .ok_or_else(|| NotDefinedError::class(self.spec.name.as_ref().to_owned()))?
         };
         for method in &self.methods {
             unsafe {

--- a/artichoke-backend/src/convert/object.rs
+++ b/artichoke-backend/src/convert/object.rs
@@ -48,7 +48,7 @@ where
         let mrb = borrow.mrb;
         let spec = borrow
             .class_spec::<Self>()
-            .ok_or_else(|| NotDefinedError::Class(String::from(Self::ruby_type_name())))?;
+            .ok_or_else(|| NotDefinedError::class(Self::ruby_type_name()))?;
         let data = Rc::new(RefCell::new(self));
         let ptr = Rc::into_raw(data);
         let obj = if let Some(mut slf) = slf {
@@ -59,7 +59,7 @@ where
         } else {
             let mut rclass = spec
                 .rclass(mrb)
-                .ok_or_else(|| NotDefinedError::Class(String::from(Self::ruby_type_name())))?;
+                .ok_or_else(|| NotDefinedError::class(Self::ruby_type_name()))?;
             unsafe {
                 let alloc = sys::mrb_data_object_alloc(
                     mrb,
@@ -105,11 +105,11 @@ where
         let mrb = borrow.mrb;
         let spec = borrow
             .class_spec::<Self>()
-            .ok_or_else(|| NotDefinedError::Class(String::from(Self::ruby_type_name())))?;
+            .ok_or_else(|| NotDefinedError::class(Self::ruby_type_name()))?;
         // Sanity check that the RClass matches.
         let mut rclass = spec
             .rclass(mrb)
-            .ok_or_else(|| NotDefinedError::Class(String::from(Self::ruby_type_name())))?;
+            .ok_or_else(|| NotDefinedError::class(Self::ruby_type_name()))?;
         if !ptr::eq(
             sys::mrb_sys_class_of_value(mrb, slf.inner()),
             rclass.as_mut(),

--- a/artichoke-backend/src/def.rs
+++ b/artichoke-backend/src/def.rs
@@ -269,23 +269,65 @@ impl From<Box<ConstantNameError>> for Box<dyn RubyException> {
 
 #[derive(Debug, Clone)]
 pub enum NotDefinedError {
-    EnclosingScope(String),
-    Super(String),
-    Class(String),
-    Module(String),
-    GlobalConstant(String),
-    ClassConstant(String),
+    EnclosingScope(Cow<'static, str>),
+    Super(Cow<'static, str>),
+    Class(Cow<'static, str>),
+    Module(Cow<'static, str>),
+    GlobalConstant(Cow<'static, str>),
+    ClassConstant(Cow<'static, str>),
 }
 
 impl NotDefinedError {
+    pub fn enclosing_scope<T>(item: T) -> Self
+    where
+        T: Into<Cow<'static, str>>,
+    {
+        Self::EnclosingScope(item.into())
+    }
+
+    pub fn super_class<T>(item: T) -> Self
+    where
+        T: Into<Cow<'static, str>>,
+    {
+        Self::Super(item.into())
+    }
+
+    pub fn class<T>(item: T) -> Self
+    where
+        T: Into<Cow<'static, str>>,
+    {
+        Self::Class(item.into())
+    }
+
+    pub fn module<T>(item: T) -> Self
+    where
+        T: Into<Cow<'static, str>>,
+    {
+        Self::Module(item.into())
+    }
+
+    pub fn global_constant<T>(item: T) -> Self
+    where
+        T: Into<Cow<'static, str>>,
+    {
+        Self::GlobalConstant(item.into())
+    }
+
+    pub fn class_constant<T>(item: T) -> Self
+    where
+        T: Into<Cow<'static, str>>,
+    {
+        Self::ClassConstant(item.into())
+    }
+
     #[must_use]
     pub fn fqdn(&self) -> &str {
         match self {
             Self::EnclosingScope(ref fqdn)
             | Self::Super(ref fqdn)
             | Self::Class(ref fqdn)
-            | Self::Module(ref fqdn) => fqdn.as_str(),
-            Self::GlobalConstant(ref name) | Self::ClassConstant(ref name) => name.as_str(),
+            | Self::Module(ref fqdn) => fqdn.as_ref(),
+            Self::GlobalConstant(ref name) | Self::ClassConstant(ref name) => name.as_ref(),
         }
     }
 

--- a/artichoke-backend/src/extn/core/env/mruby.rs
+++ b/artichoke-backend/src/extn/core/env/mruby.rs
@@ -11,7 +11,7 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
         .borrow_mut()
         .module_spec::<artichoke::Artichoke>()
         .map(EnclosingRubyScope::module)
-        .ok_or_else(|| NotDefinedError::Module(String::from("Artichoke")))?;
+        .ok_or_else(|| NotDefinedError::module("Artichoke"))?;
     let spec = class::Spec::new(
         "Environ",
         Some(scope),

--- a/artichoke-backend/src/extn/core/kernel/mod.rs
+++ b/artichoke-backend/src/extn/core/kernel/mod.rs
@@ -28,7 +28,7 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
         .borrow()
         .module_spec::<artichoke::Artichoke>()
         .map(EnclosingRubyScope::module)
-        .ok_or_else(|| NotDefinedError::Module(String::from("Artichoke")))?;
+        .ok_or_else(|| NotDefinedError::module("Artichoke"))?;
     let spec = module::Spec::new(interp, "Kernel", Some(scope))?;
     module::Builder::for_spec(interp, &spec)
         .add_method("Integer", Kernel::integer, sys::mrb_args_req_and_opt(1, 1))?

--- a/artichoke-backend/src/extn/core/random/mruby.rs
+++ b/artichoke-backend/src/extn/core/random/mruby.rs
@@ -34,12 +34,12 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     let default = random::Random::interpreter_prng_delegate();
     let default = default
         .try_into_ruby(interp, None)
-        .map_err(|_| NotDefinedError::ClassConstant(String::from("Random::DEFAULT")))?;
+        .map_err(|_| NotDefinedError::class_constant("Random::DEFAULT"))?;
     let borrow = interp.0.borrow();
     let mut rclass = borrow
         .class_spec::<random::Random>()
         .and_then(|spec| spec.rclass(interp.0.borrow().mrb))
-        .ok_or_else(|| NotDefinedError::Class(String::from("Random")))?;
+        .ok_or_else(|| NotDefinedError::class("Random"))?;
     let mrb = borrow.mrb;
     unsafe {
         sys::mrb_define_const(

--- a/artichoke-backend/src/extn/mod.rs
+++ b/artichoke-backend/src/extn/mod.rs
@@ -41,7 +41,7 @@ macro_rules! global_const {
         let mrb = $interp.0.borrow().mrb;
         let constant = $constant
             .parse::<Int>()
-            .map_err(|_| NotDefinedError::GlobalConstant(String::from(stringify!($constant))))?;
+            .map_err(|_| NotDefinedError::global_constant(stringify!($constant)))?;
         let name = concat!(stringify!($constant), "\0");
         let value = $interp.convert(constant);
         unsafe {

--- a/artichoke-backend/src/module.rs
+++ b/artichoke-backend/src/module.rs
@@ -78,7 +78,7 @@ impl<'a> Builder<'a> {
         } else if let Some(scope) = self.spec.enclosing_scope() {
             let mut scope_rclass = scope
                 .rclass(mrb)
-                .ok_or_else(|| NotDefinedError::EnclosingScope(scope.fqname().into_owned()))?;
+                .ok_or_else(|| NotDefinedError::enclosing_scope(scope.fqname().into_owned()))?;
             let rclass = unsafe {
                 sys::mrb_define_module_under(
                     mrb,
@@ -87,11 +87,11 @@ impl<'a> Builder<'a> {
                 )
             };
             NonNull::new(rclass)
-                .ok_or_else(|| NotDefinedError::Module(self.spec.name.as_ref().to_owned()))?
+                .ok_or_else(|| NotDefinedError::module(self.spec.name.as_ref().to_owned()))?
         } else {
             let rclass = unsafe { sys::mrb_define_module(mrb, self.spec.name_c_str().as_ptr()) };
             NonNull::new(rclass)
-                .ok_or_else(|| NotDefinedError::Module(self.spec.name.as_ref().to_owned()))?
+                .ok_or_else(|| NotDefinedError::module(self.spec.name.as_ref().to_owned()))?
         };
         for method in self.methods {
             unsafe {

--- a/artichoke-backend/src/warn.rs
+++ b/artichoke-backend/src/warn.rs
@@ -17,9 +17,9 @@ impl Warn for Artichoke {
             let borrow = self.0.borrow();
             let spec = borrow
                 .module_spec::<Warning>()
-                .ok_or_else(|| NotDefinedError::Module(String::from("Warning")))?;
+                .ok_or_else(|| NotDefinedError::module("Warning"))?;
             spec.value(self)
-                .ok_or_else(|| NotDefinedError::Module(String::from("Warning")))?
+                .ok_or_else(|| NotDefinedError::module("Warning"))?
         };
         let message = self.convert_mut(message);
         let _ = warning.funcall::<Value>("warn", &[message], None)?;


### PR DESCRIPTION
Make `NotDefinedError` store `Cow<'static, str>` and add constructors
for all variants that use an `Into<Cow<'static, str>>` type bound.