### PR TITLE
Implicitly convert to string

### DIFF
--- a/artichoke-backend/src/extn/core/kernel/require.rs
+++ b/artichoke-backend/src/extn/core/kernel/require.rs
@@ -12,17 +12,7 @@ use crate::Parser;
 const RUBY_EXTENSION: &str = "rb";
 
 pub fn load(interp: &mut Artichoke, filename: Value) -> Result<Value, Exception> {
-    let ruby_type = filename.pretty_name();
-    let filename = if let Ok(filename) = filename.clone().try_into::<&[u8]>() {
-        filename
-    } else if let Ok(filename) = filename.funcall::<&[u8]>("to_str", &[], None) {
-        filename
-    } else {
-        return Err(Exception::from(TypeError::new(
-            interp,
-            format!("no implicit conversion of {} into String", ruby_type),
-        )));
-    };
+    let filename = filename.implicitly_convert_to_string()?;
     if memchr::memchr(b'\0', filename).is_some() {
         return Err(Exception::from(ArgumentError::new(
             interp,
@@ -78,17 +68,7 @@ pub fn require(
     filename: Value,
     base: Option<&Path>,
 ) -> Result<Value, Exception> {
-    let ruby_type = filename.pretty_name();
-    let filename = if let Ok(filename) = filename.clone().try_into::<&[u8]>() {
-        filename
-    } else if let Ok(filename) = filename.funcall::<&[u8]>("to_str", &[], None) {
-        filename
-    } else {
-        return Err(Exception::from(TypeError::new(
-            interp,
-            format!("no implicit conversion of {} into String", ruby_type),
-        )));
-    };
+    let filename = filename.implicitly_convert_to_string()?;
     if memchr::memchr(b'\0', filename).is_some() {
         return Err(Exception::from(ArgumentError::new(
             interp,

--- a/artichoke-backend/src/extn/core/matchdata/element_reference.rs
+++ b/artichoke-backend/src/extn/core/matchdata/element_reference.rs
@@ -7,90 +7,49 @@ use crate::extn::core::matchdata::MatchData;
 use crate::extn::prelude::*;
 
 #[derive(Debug, Clone, Copy)]
-pub enum Args<'a> {
-    Empty,
+enum Args<'a> {
     Index(Int),
     Name(&'a [u8]),
     StartLen(Int, usize),
 }
 
-impl<'a> Args<'a> {
-    pub fn num_captures(interp: &Artichoke, value: &Value) -> Result<usize, Exception> {
-        let data = unsafe { MatchData::try_from_ruby(interp, value) }?;
-        let borrow = data.borrow();
-        borrow.regexp.inner().captures_len(interp, None)
-    }
-
-    pub fn extract(
-        interp: &Artichoke,
-        elem: Value,
-        len: Option<Value>,
-        num_captures: usize,
-    ) -> Result<Self, Exception> {
-        if let Some(len) = len {
-            let start = elem.implicitly_convert_to_int()?;
-            let len = len.implicitly_convert_to_int()?;
-            if let Ok(len) = usize::try_from(len) {
-                Ok(Self::StartLen(start, len))
-            } else {
-                Ok(Self::Empty)
-            }
-        } else {
-            let name = elem.pretty_name();
-            // TODO: GH-452 - use Value::implicitly_convert_to_string
-            if let Ok(index) = elem.implicitly_convert_to_int() {
-                Ok(Self::Index(index))
-            } else if let Ok(name) = elem.clone().try_into::<&[u8]>() {
-                Ok(Self::Name(name))
-            } else if let Ok(name) = elem.funcall::<&[u8]>("to_str", &[], None) {
-                Ok(Self::Name(name))
-            } else {
-                let rangelen = Int::try_from(num_captures)
-                    .map_err(|_| Fatal::new(interp, "Range length exceeds Integer max"))?;
-                match unsafe { Self::is_range(interp, &elem, rangelen) } {
-                    Ok(Some(args)) => Ok(args),
-                    Ok(None) => Ok(Self::Empty),
-                    Err(_) => Err(Exception::from(TypeError::new(
-                        interp,
-                        format!("no implicit conversion of {} into Integer", name),
-                    ))),
-                }
-            }
-        }
-    }
-
-    unsafe fn is_range(
-        interp: &Artichoke,
-        first: &Value,
-        length: Int,
-    ) -> Result<Option<Self>, Exception> {
-        let mut start = mem::MaybeUninit::<sys::mrb_int>::uninit();
-        let mut len = mem::MaybeUninit::<sys::mrb_int>::uninit();
-        let mrb = interp.0.borrow().mrb;
-        // `mrb_range_beg_len` can raise.
-        // TODO: Wrap this in a call to `mrb_protect`.
-        let check_range = sys::mrb_range_beg_len(
-            mrb,
-            first.inner(),
-            start.as_mut_ptr(),
-            len.as_mut_ptr(),
-            length,
-            0_u8,
-        );
-        let start = start.assume_init();
-        let len = len.assume_init();
-        if check_range == sys::mrb_range_beg_len::MRB_RANGE_OK {
-            let len = usize::try_from(len)
-                .map_err(|_| TypeError::new(interp, "no implicit conversion into Integer"))?;
-            Ok(Some(Self::StartLen(start, len)))
-        } else {
-            Ok(None)
-        }
+// TODO: GH-308 - extract this function into `sys::protect`
+unsafe fn is_range<'a>(
+    interp: &'a Artichoke,
+    first: &Value,
+    length: Int,
+) -> Result<Option<(Int, usize)>, Exception> {
+    let mut start = mem::MaybeUninit::<sys::mrb_int>::uninit();
+    let mut len = mem::MaybeUninit::<sys::mrb_int>::uninit();
+    let mrb = interp.0.borrow().mrb;
+    // `mrb_range_beg_len` can raise.
+    // TODO: GH-308 - wrap this in a call to `mrb_protect`.
+    let check_range = sys::mrb_range_beg_len(
+        mrb,
+        first.inner(),
+        start.as_mut_ptr(),
+        len.as_mut_ptr(),
+        length,
+        0_u8,
+    );
+    let start = start.assume_init();
+    let len = len.assume_init();
+    if check_range == sys::mrb_range_beg_len::MRB_RANGE_OK {
+        let len = usize::try_from(len)
+            .map_err(|_| TypeError::new(interp, "no implicit conversion into Integer"))?;
+        Ok(Some((start, len)))
+    } else {
+        Ok(None)
     }
 }
 
-pub fn method(interp: &mut Artichoke, args: Args, value: &Value) -> Result<Value, Exception> {
-    let data = unsafe { MatchData::try_from_ruby(interp, value) }?;
+pub fn method(
+    interp: &mut Artichoke,
+    value: Value,
+    elem: Value,
+    len: Option<Value>,
+) -> Result<Value, Exception> {
+    let data = unsafe { MatchData::try_from_ruby(interp, &value) }?;
     let borrow = data.borrow();
     let haystack = &borrow.string[borrow.region.start..borrow.region.end];
     let mut captures = if let Some(captures) = borrow.regexp.inner().captures(interp, haystack)? {
@@ -98,8 +57,35 @@ pub fn method(interp: &mut Artichoke, args: Args, value: &Value) -> Result<Value
     } else {
         return Ok(interp.convert(None::<Value>));
     };
+    let args = if let Some(len) = len {
+        let start = elem.implicitly_convert_to_int()?;
+        let len = len.implicitly_convert_to_int()?;
+        if let Ok(len) = usize::try_from(len) {
+            Args::StartLen(start, len)
+        } else {
+            return Ok(interp.convert(None::<Value>));
+        }
+    } else {
+        if let Ok(index) = elem.implicitly_convert_to_int() {
+            Args::Index(index)
+        } else if let Ok(name) = elem.implicitly_convert_to_string() {
+            Args::Name(name)
+        } else {
+            let rangelen = Int::try_from(borrow.regexp.inner().captures_len(interp, None)?)
+                .map_err(|_| Fatal::new(interp, "Range length exceeds Integer max"))?;
+            match unsafe { is_range(interp, &elem, rangelen) } {
+                Ok(Some((start, len))) => Args::StartLen(start, len),
+                Ok(None) => return Ok(interp.convert(None::<Value>)),
+                Err(_) => {
+                    let mut message = String::from("no implicit conversion of ");
+                    message.push_str(elem.pretty_name());
+                    message.push_str(" into Integer");
+                    return Err(Exception::from(TypeError::new(interp, message)));
+                }
+            }
+        }
+    };
     match args {
-        Args::Empty => Ok(interp.convert(None::<Value>)),
         Args::Index(index) => {
             if index < 0 {
                 // Positive Int must be usize

--- a/artichoke-backend/src/extn/core/matchdata/element_reference.rs
+++ b/artichoke-backend/src/extn/core/matchdata/element_reference.rs
@@ -37,6 +37,7 @@ impl<'a> Args<'a> {
             }
         } else {
             let name = elem.pretty_name();
+            // TODO: GH-452 - use Value::implicitly_convert_to_string
             if let Ok(index) = elem.implicitly_convert_to_int() {
                 Ok(Self::Index(index))
             } else if let Ok(name) = elem.clone().try_into::<&[u8]>() {

--- a/artichoke-backend/src/extn/core/matchdata/element_reference.rs
+++ b/artichoke-backend/src/extn/core/matchdata/element_reference.rs
@@ -65,23 +65,21 @@ pub fn method(
         } else {
             return Ok(interp.convert(None::<Value>));
         }
+    } else if let Ok(index) = elem.implicitly_convert_to_int() {
+        Args::Index(index)
+    } else if let Ok(name) = elem.implicitly_convert_to_string() {
+        Args::Name(name)
     } else {
-        if let Ok(index) = elem.implicitly_convert_to_int() {
-            Args::Index(index)
-        } else if let Ok(name) = elem.implicitly_convert_to_string() {
-            Args::Name(name)
-        } else {
-            let rangelen = Int::try_from(borrow.regexp.inner().captures_len(interp, None)?)
-                .map_err(|_| Fatal::new(interp, "Range length exceeds Integer max"))?;
-            match unsafe { is_range(interp, &elem, rangelen) } {
-                Ok(Some((start, len))) => Args::StartLen(start, len),
-                Ok(None) => return Ok(interp.convert(None::<Value>)),
-                Err(_) => {
-                    let mut message = String::from("no implicit conversion of ");
-                    message.push_str(elem.pretty_name());
-                    message.push_str(" into Integer");
-                    return Err(Exception::from(TypeError::new(interp, message)));
-                }
+        let rangelen = Int::try_from(borrow.regexp.inner().captures_len(interp, None)?)
+            .map_err(|_| Fatal::new(interp, "Range length exceeds Integer max"))?;
+        match unsafe { is_range(interp, &elem, rangelen) } {
+            Ok(Some((start, len))) => Args::StartLen(start, len),
+            Ok(None) => return Ok(interp.convert(None::<Value>)),
+            Err(_) => {
+                let mut message = String::from("no implicit conversion of ");
+                message.push_str(elem.pretty_name());
+                message.push_str(" into Integer");
+                return Err(Exception::from(TypeError::new(interp, message)));
             }
         }
     };

--- a/artichoke-backend/src/extn/core/matchdata/mod.rs
+++ b/artichoke-backend/src/extn/core/matchdata/mod.rs
@@ -197,11 +197,11 @@ impl MatchData {
     }
 
     unsafe extern "C" fn offset(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
-        let elem = mrb_get_args!(mrb, required = 1);
+        let offset = mrb_get_args!(mrb, required = 1);
         let mut interp = unwrap_interpreter!(mrb);
         let value = Value::new(&interp, slf);
-        let result = offset::Args::extract(&interp, Value::new(&interp, elem))
-            .and_then(|args| offset::method(&mut interp, args, &value));
+        let offset = Value::new(&interp, offset);
+        let result = offset::method(&mut interp, value, offset);
         match result {
             Ok(result) => result.inner(),
             Err(exception) => exception::raise(interp, exception),

--- a/artichoke-backend/src/extn/core/matchdata/mod.rs
+++ b/artichoke-backend/src/extn/core/matchdata/mod.rs
@@ -131,16 +131,9 @@ impl MatchData {
         let (elem, len) = mrb_get_args!(mrb, required = 1, optional = 1);
         let mut interp = unwrap_interpreter!(mrb);
         let value = Value::new(&interp, slf);
-        let result = element_reference::Args::num_captures(&interp, &value)
-            .and_then(|num_captures| {
-                element_reference::Args::extract(
-                    &interp,
-                    Value::new(&interp, elem),
-                    len.map(|len| Value::new(&interp, len)),
-                    num_captures,
-                )
-            })
-            .and_then(|args| element_reference::method(&mut interp, args, &value));
+        let elem = Value::new(&interp, elem);
+        let len = len.map(|len| Value::new(&interp, len));
+        let result = element_reference::method(&mut interp, value, elem, len);
         match result {
             Ok(result) => result.inner(),
             Err(exception) => exception::raise(interp, exception),

--- a/artichoke-backend/src/extn/core/regexp/mod.rs
+++ b/artichoke-backend/src/extn/core/regexp/mod.rs
@@ -233,7 +233,7 @@ impl Regexp {
                 } else {
                     let bytes = first.implicitly_convert_to_string()?;
                     let pattern = str::from_utf8(bytes).map_err(|_| {
-                        ArgumentError::new(interp, "Self::union only supports UTF-8 patterns")
+                        ArgumentError::new(interp, "Regexp::union only supports UTF-8 patterns")
                     })?;
                     patterns.push(syntax::escape(pattern).into_bytes());
                 }
@@ -243,7 +243,7 @@ impl Regexp {
                     } else {
                         let bytes = pattern.implicitly_convert_to_string()?;
                         let pattern = str::from_utf8(bytes).map_err(|_| {
-                            ArgumentError::new(interp, "Self::union only supports UTF-8 patterns")
+                            ArgumentError::new(interp, "Regexp::union only supports UTF-8 patterns")
                         })?;
                         patterns.push(syntax::escape(pattern).into_bytes());
                     }

--- a/artichoke-backend/src/extn/core/string/scan.rs
+++ b/artichoke-backend/src/extn/core/string/scan.rs
@@ -18,17 +18,16 @@ pub fn method(
         )
     })?;
     if let Ruby::Symbol = pattern.ruby_type() {
-        Err(Exception::from(TypeError::new(
-            interp,
-            format!(
-                "wrong argument type {} (expected Regexp)",
-                pattern.pretty_name()
-            ),
-        )))
-    } else if let Ok(pattern_bytes) = pattern.clone().try_into::<&[u8]>() {
+        let mut message = String::from("wrong argument type ");
+        message.push_str(pattern.pretty_name());
+        message.push_str(" (expected Regexp)");
+        Err(Exception::from(TypeError::new(interp, message)))
+    } else if let Ok(regexp) = unsafe { Regexp::try_from_ruby(interp, &pattern) } {
+        regexp.borrow().inner().scan(interp, value, block)
+    } else if let Ok(pattern_bytes) = pattern.implicitly_convert_to_string() {
         if let Some(ref block) = block {
-            let mrb = interp.0.borrow().mrb;
             let regex = Regexp::lazy(pattern_bytes);
+            let mrb = interp.0.borrow().mrb;
             let last_match_sym = interp.intern_symbol(regexp::LAST_MATCH);
             let mut matchdata = MatchData::new(string.to_vec(), regex, 0, string.len());
             let patlen = pattern_bytes.len();
@@ -76,83 +75,16 @@ pub fn method(
             } else {
                 let mrb = interp.0.borrow().mrb;
                 let last_match_sym = interp.intern_symbol(regexp::LAST_MATCH);
-                let nil = interp.convert(None::<Value>).inner();
                 unsafe {
-                    sys::mrb_gv_set(mrb, last_match_sym, nil);
+                    sys::mrb_gv_set(mrb, last_match_sym, sys::mrb_sys_nil_value());
                 }
             }
             Ok(interp.convert_mut(result))
         }
-    } else if let Ok(regexp) = unsafe { Regexp::try_from_ruby(interp, &pattern) } {
-        regexp.borrow().inner().scan(interp, value, block)
     } else {
-        let pattern_type_name = pattern.pretty_name();
-        let pattern_bytes = pattern.funcall::<&[u8]>("to_str", &[], None);
-        if let Ok(pattern_bytes) = pattern_bytes {
-            if let Some(ref block) = block {
-                let regex = Regexp::lazy(pattern_bytes);
-                let mrb = interp.0.borrow().mrb;
-                let last_match_sym = interp.intern_symbol(regexp::LAST_MATCH);
-                let mut matchdata = MatchData::new(string.to_vec(), regex, 0, string.len());
-                let patlen = pattern_bytes.len();
-                let mut restore_nil = true;
-                for pos in string.find_iter(pattern_bytes) {
-                    restore_nil = false;
-                    matchdata.set_region(pos, pos + patlen);
-                    let data = matchdata.clone().try_into_ruby(interp, None)?;
-                    unsafe {
-                        sys::mrb_gv_set(mrb, last_match_sym, data.inner());
-                    }
-                    let block_arg = interp.convert_mut(pattern_bytes);
-                    let _ = block.yield_arg::<Value>(interp, &block_arg)?;
-                    unsafe {
-                        sys::mrb_gv_set(mrb, last_match_sym, data.inner());
-                    }
-                }
-                if restore_nil {
-                    unsafe {
-                        sys::mrb_gv_set(mrb, last_match_sym, sys::mrb_sys_nil_value());
-                    }
-                }
-                Ok(value)
-            } else {
-                let (matches, last_pos) = string
-                    .find_iter(pattern_bytes)
-                    .enumerate()
-                    .last()
-                    .map(|(m, p)| (m + 1, p))
-                    .unwrap_or_default();
-                let mut result = Vec::with_capacity(matches);
-                for _ in 0..matches {
-                    result.push(interp.convert_mut(pattern_bytes));
-                }
-                if matches > 0 {
-                    let regex = Regexp::lazy(pattern_bytes);
-                    let mrb = interp.0.borrow().mrb;
-                    let last_match_sym = interp.intern_symbol(regexp::LAST_MATCH);
-                    let mut matchdata = MatchData::new(string.to_vec(), regex, 0, string.len());
-                    matchdata.set_region(last_pos, last_pos + pattern_bytes.len());
-                    let data = matchdata.try_into_ruby(interp, None)?;
-                    unsafe {
-                        sys::mrb_gv_set(mrb, last_match_sym, data.inner());
-                    }
-                } else {
-                    let mrb = interp.0.borrow().mrb;
-                    let last_match_sym = interp.intern_symbol(regexp::LAST_MATCH);
-                    unsafe {
-                        sys::mrb_gv_set(mrb, last_match_sym, sys::mrb_sys_nil_value());
-                    }
-                }
-                Ok(interp.convert_mut(result))
-            }
-        } else {
-            Err(Exception::from(TypeError::new(
-                interp,
-                format!(
-                    "wrong argument type {} (expected Regexp)",
-                    pattern_type_name
-                ),
-            )))
-        }
+        let mut message = String::from("wrong argument type ");
+        message.push_str(pattern.pretty_name());
+        message.push_str(" (expected Regexp)");
+        Err(Exception::from(TypeError::new(interp, message)))
     }
 }

--- a/artichoke-backend/src/extn/core/string/scan.rs
+++ b/artichoke-backend/src/extn/core/string/scan.rs
@@ -46,8 +46,9 @@ pub fn method(
                 }
             }
             if restore_nil {
+                let nil = interp.convert(None::<Value>).inner();
                 unsafe {
-                    sys::mrb_gv_set(mrb, last_match_sym, sys::mrb_sys_nil_value());
+                    sys::mrb_gv_set(mrb, last_match_sym, nil);
                 }
             }
             Ok(value)
@@ -75,8 +76,9 @@ pub fn method(
             } else {
                 let mrb = interp.0.borrow().mrb;
                 let last_match_sym = interp.intern_symbol(regexp::LAST_MATCH);
+                let nil = interp.convert(None::<Value>).inner();
                 unsafe {
-                    sys::mrb_gv_set(mrb, last_match_sym, sys::mrb_sys_nil_value());
+                    sys::mrb_gv_set(mrb, last_match_sym, nil);
                 }
             }
             Ok(interp.convert_mut(result))

--- a/artichoke-backend/src/value.rs
+++ b/artichoke-backend/src/value.rs
@@ -112,32 +112,103 @@ impl Value {
         )
     }
 
-    pub fn implicitly_convert_to_int(&self) -> Result<Int, Exception> {
+    pub fn implicitly_convert_to_int(&self) -> Result<Int, TypeError> {
         let int = if let Ok(int) = self.clone().try_into::<Int>() {
             int
-        } else {
-            let pretty_name = self.pretty_name();
-            if let Ok(maybe_int) = self.funcall::<Self>("to_int", &[], None) {
-                let gives_pretty_name = maybe_int.pretty_name();
-                if let Ok(int) = maybe_int.try_into::<Int>() {
+        } else if let Ok(true) = self.respond_to("to_int") {
+            if let Ok(maybe) = self.funcall::<Self>("to_int", &[], None) {
+                let gives_pretty_name = maybe.pretty_name();
+                if let Ok(int) = maybe.try_into::<Int>() {
                     int
                 } else {
-                    return Err(Exception::from(TypeError::new(
-                        &self.interp,
-                        format!(
-                            "can't convert {} to Integer ({}#to_int gives {})",
-                            pretty_name, pretty_name, gives_pretty_name
-                        ),
-                    )));
+                    let mut message = String::from("can't convert ");
+                    message.push_str(self.pretty_name());
+                    message.push_str(" to Integer (");
+                    message.push_str(self.pretty_name());
+                    message.push_str("#to_int gives ");
+                    message.push_str(gives_pretty_name);
+                    message.push(')');
+                    return Err(TypeError::new(&self.interp, message));
                 }
             } else {
-                return Err(Exception::from(TypeError::new(
-                    &self.interp,
-                    format!("no implicit conversion of {} into Integer", pretty_name),
-                )));
+                let mut message = String::from("no implicit conversion of ");
+                message.push_str(self.pretty_name());
+                message.push_str(" into Integer");
+                return Err(TypeError::new(&self.interp, message));
             }
+        } else {
+            let mut message = String::from("no implicit conversion of ");
+            message.push_str(self.pretty_name());
+            message.push_str(" into Integer");
+            return Err(TypeError::new(&self.interp, message));
         };
         Ok(int)
+    }
+
+    pub fn implicitly_convert_to_string(&self) -> Result<&[u8], TypeError> {
+        let string = if let Ok(string) = self.clone().try_into::<&[u8]>() {
+            string
+        } else if let Ok(true) = self.respond_to("to_str") {
+            if let Ok(maybe) = self.funcall::<Self>("to_str", &[], None) {
+                let gives_pretty_name = maybe.pretty_name();
+                if let Ok(string) = maybe.try_into::<&[u8]>() {
+                    string
+                } else {
+                    let mut message = String::from("can't convert ");
+                    message.push_str(self.pretty_name());
+                    message.push_str(" to String (");
+                    message.push_str(self.pretty_name());
+                    message.push_str("#to_str gives ");
+                    message.push_str(gives_pretty_name);
+                    message.push(')');
+                    return Err(TypeError::new(&self.interp, message));
+                }
+            } else {
+                let mut message = String::from("no implicit conversion of ");
+                message.push_str(self.pretty_name());
+                message.push_str(" into String");
+                return Err(TypeError::new(&self.interp, message));
+            }
+        } else {
+            let mut message = String::from("no implicit conversion of ");
+            message.push_str(self.pretty_name());
+            message.push_str(" into String");
+            return Err(TypeError::new(&self.interp, message));
+        };
+        Ok(string)
+    }
+
+    pub fn implicitly_convert_to_nilable_string(&self) -> Result<Option<&[u8]>, TypeError> {
+        let string = if let Ok(string) = self.clone().try_into::<Option<&[u8]>>() {
+            string
+        } else if let Ok(true) = self.respond_to("to_str") {
+            if let Ok(maybe) = self.funcall::<Self>("to_str", &[], None) {
+                let gives_pretty_name = maybe.pretty_name();
+                if let Ok(string) = maybe.try_into::<&[u8]>() {
+                    Some(string)
+                } else {
+                    let mut message = String::from("can't convert ");
+                    message.push_str(self.pretty_name());
+                    message.push_str(" to String (");
+                    message.push_str(self.pretty_name());
+                    message.push_str("#to_str gives ");
+                    message.push_str(gives_pretty_name);
+                    message.push(')');
+                    return Err(TypeError::new(&self.interp, message));
+                }
+            } else {
+                let mut message = String::from("no implicit conversion of ");
+                message.push_str(self.pretty_name());
+                message.push_str(" into String");
+                return Err(TypeError::new(&self.interp, message));
+            }
+        } else {
+            let mut message = String::from("no implicit conversion of ");
+            message.push_str(self.pretty_name());
+            message.push_str(" into String");
+            return Err(TypeError::new(&self.interp, message));
+        };
+        Ok(string)
     }
 }
 


### PR DESCRIPTION
Implement `Value::implicitly_convert_to_string` and `Value::implicitly_convert_to_nilable_string`.

Modify all sites manually doing a funcall on `to_str`.

This unifies many different and subtly incorrect ways to call this method.

These implementations and `implicitly_convert_to_int` are modified to return `TypeError` and check if the receiver `responds_to?` the converter before making the funcall.

Fixes GH-452
cc GH-310