### PR TITLE
Replave map(_).flatten() with and_then(_)

### DIFF
--- a/artichoke-backend/src/extn/core/matchdata/element_reference.rs
+++ b/artichoke-backend/src/extn/core/matchdata/element_reference.rs
@@ -129,7 +129,7 @@ pub fn method(interp: &mut Artichoke, args: Args, value: &Value) -> Result<Value
                 let group = indexes
                     .iter()
                     .copied()
-                    .filter_map(|index| captures.get(index).map(Option::as_deref).flatten())
+                    .filter_map(|index| captures.get(index).and_then(Option::as_deref))
                     .last();
                 Ok(interp.convert_mut(group))
             } else {


### PR DESCRIPTION
Followup to GH-519.

https://www.reddit.com/r/rust/comments/f3cvkr/using_optionas_deref_and_optionflatten_to_remove/

See also https://github.com/rust-lang/rust-clippy/issues/5175