### PR TITLE
Add sys::mrb_sys_state_debug free function

### DIFF
--- a/artichoke-backend/src/eval.rs
+++ b/artichoke-backend/src/eval.rs
@@ -4,7 +4,7 @@ use crate::exception::Exception;
 use crate::exception_handler;
 use crate::extn::core::exception::Fatal;
 use crate::ffi;
-use crate::sys::{protect, DescribeState};
+use crate::sys::{self, protect};
 use crate::value::Value;
 use crate::{Artichoke, Eval};
 
@@ -20,7 +20,7 @@ impl Eval for Artichoke {
         let mrb = self.0.borrow().mrb;
         let context = self.0.borrow_mut().parser.context_mut() as *mut _;
 
-        trace!("Evaling code on {}", mrb.debug());
+        trace!("Evaling code on {}", sys::mrb_sys_state_debug(mrb));
         match unsafe { protect::eval(mrb, context, code) } {
             Ok(value) => {
                 let value = Value::new(self, value);

--- a/artichoke-backend/src/ffi.rs
+++ b/artichoke-backend/src/ffi.rs
@@ -14,7 +14,7 @@ use std::rc::Rc;
 use crate::exception::{Exception, RubyException};
 use crate::extn::core::exception::{ArgumentError, Fatal};
 use crate::state::State;
-use crate::sys::{self, DescribeState};
+use crate::sys;
 use crate::{Artichoke, ConvertMut};
 
 #[cfg(unix)]
@@ -71,7 +71,7 @@ pub unsafe fn from_user_data(
     // At this point, `Rc::strong_count` will be increased by 1.
     trace!(
         "Extracted Artichoke from user data pointer on {}",
-        mrb.debug()
+        sys::mrb_sys_state_debug(mrb.as_mut())
     );
     Ok(Artichoke(api))
 }

--- a/artichoke-backend/src/interpreter.rs
+++ b/artichoke-backend/src/interpreter.rs
@@ -10,7 +10,7 @@ use crate::extn;
 use crate::extn::core::exception::Fatal;
 use crate::gc::MrbGarbageCollection;
 use crate::state::State;
-use crate::sys::{self, DescribeState};
+use crate::sys;
 use crate::{Artichoke, ConvertMut, Eval};
 
 /// Create and initialize an [`Artichoke`] interpreter.
@@ -58,7 +58,10 @@ pub fn interpreter() -> Result<Artichoke, Exception> {
     }
     arena.restore();
 
-    debug!("Allocated {}", mrb.debug());
+    debug!(
+        "Allocated {}",
+        sys::mrb_sys_state_debug(unsafe { mrb.as_mut() })
+    );
 
     // mruby lazily initializes some core objects like top_self and generates a
     // lot of garbage on startup. Eagerly initialize the interpreter to provide

--- a/artichoke-backend/src/state/mod.rs
+++ b/artichoke-backend/src/state/mod.rs
@@ -8,7 +8,7 @@ use std::ptr::{self, NonNull};
 use crate::class;
 use crate::fs;
 use crate::module;
-use crate::sys::{self, DescribeState};
+use crate::sys;
 
 pub mod parser;
 #[cfg(feature = "artichoke-random")]
@@ -164,12 +164,10 @@ impl State {
 
 impl fmt::Debug for State {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.mrb.debug())
-    }
-}
-
-impl fmt::Display for State {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.mrb.info())
+        write!(
+            f,
+            "Artichoke State {{ {} }}",
+            sys::mrb_sys_state_debug(self.mrb)
+        )
     }
 }

--- a/artichoke-backend/src/sys/mod.rs
+++ b/artichoke-backend/src/sys/mod.rs
@@ -7,8 +7,7 @@
 //! with bindgen.
 
 use std::ffi::CStr;
-use std::fmt;
-use std::ptr::NonNull;
+use std::fmt::Write;
 
 mod args;
 #[allow(missing_docs)]
@@ -31,7 +30,7 @@ pub use self::ffi::*;
 
 /// Version metadata `String` for embedded mruby.
 #[must_use]
-pub fn mruby_version(verbose: bool) -> String {
+pub fn mrb_sys_mruby_version(verbose: bool) -> String {
     if verbose {
         // Safety:
         //
@@ -39,202 +38,70 @@ pub fn mruby_version(verbose: bool) -> String {
         // - `MRUBY_RUBY_VERSION` is already a `CString` pulled from bindgen.
         let engine = unsafe { CStr::from_bytes_with_nul_unchecked(MRUBY_RUBY_ENGINE) };
         let version = unsafe { CStr::from_bytes_with_nul_unchecked(MRUBY_RUBY_VERSION) };
-        format!(
-            "{} {} [{}]",
-            engine.to_string_lossy(),
-            version.to_string_lossy(),
-            env!("CARGO_PKG_VERSION")
-        )
+        let mut out = String::new();
+        out.push_str(engine.to_str().unwrap_or("unknown"));
+        out.push(' ');
+        out.push_str(version.to_str().unwrap_or("0.0.0"));
+        out.push_str(" [");
+        out.push_str(env!("CARGO_PKG_VERSION"));
+        out.push(']');
+        out
     } else {
-        env!("CARGO_PKG_VERSION").to_owned()
+        String::from(env!("CARGO_PKG_VERSION"))
     }
 }
 
-/// Methods to describe an [`mrb_state`].
-pub trait DescribeState {
-    /// Wraper around [`fmt::Display`] for [`mrb_state`]. Returns Ruby engine
-    /// and interpreter version. For example:
-    ///
-    /// ```text
-    /// mruby 2.0
-    /// ```
-    fn info(&self) -> String;
-
-    /// Wrapper around [`fmt::Debug`] for [`mrb_state`]. Returns Ruby engine,
-    /// interpreter version, engine version, and [`mrb_state`] address. For
-    /// example:
-    ///
-    /// ```text
-    /// mruby 2.0 (v2.0.1 rev c078758) interpreter at 0x7f85b8800000
-    /// ```
-    fn debug(&self) -> String;
-
-    /// Returns detailed interpreter version including engine version. For
-    /// example:
-    ///
-    /// ```text
-    /// 2.0 (v2.0.1)
-    /// ```
-    fn version(&self) -> String;
-}
-
-impl DescribeState for mrb_state {
-    fn info(&self) -> String {
-        format!("{}", self)
-    }
-
-    fn debug(&self) -> String {
-        format!("{:?}", self)
-    }
-
-    fn version(&self) -> String {
-        // Safety:
-        //
-        // - `MRUBY_RUBY_VERSION` is already a `CString` pulled from bindgen.
-        let version = unsafe { CStr::from_bytes_with_nul_unchecked(MRUBY_RUBY_VERSION) };
-        format!(
-            "{} (v{}.{}.{})",
-            version.to_string_lossy(),
-            MRUBY_RELEASE_MAJOR,
-            MRUBY_RELEASE_MINOR,
-            MRUBY_RELEASE_TEENY,
-        )
-    }
-}
-
-impl fmt::Debug for mrb_state {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        // Using the unchecked function is safe because these values are C constants
-        let engine = unsafe { CStr::from_bytes_with_nul_unchecked(MRUBY_RUBY_ENGINE) };
-        let version = unsafe { CStr::from_bytes_with_nul_unchecked(MRUBY_RUBY_VERSION) };
-        write!(
-            f,
-            "{} {} (v{}.{}.{}) interpreter at {:p}",
-            engine.to_string_lossy(),
-            version.to_string_lossy(),
-            MRUBY_RELEASE_MAJOR,
-            MRUBY_RELEASE_MINOR,
-            MRUBY_RELEASE_TEENY,
-            self
-        )
-    }
-}
-
-impl fmt::Display for mrb_state {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        // Using the unchecked function is safe because these values are C constants
-        let engine = unsafe { CStr::from_bytes_with_nul_unchecked(MRUBY_RUBY_ENGINE) };
-        let version = unsafe { CStr::from_bytes_with_nul_unchecked(MRUBY_RUBY_VERSION) };
-        write!(
-            f,
-            "{} {}",
-            engine.to_string_lossy(),
-            version.to_string_lossy(),
-        )
-    }
-}
-
-impl DescribeState for &mut mrb_state {
-    fn info(&self) -> String {
-        format!("{}", **self)
-    }
-
-    fn debug(&self) -> String {
-        format!("{:?}", **self)
-    }
-
-    fn version(&self) -> String {
-        (**self).version()
-    }
-}
-
-impl DescribeState for &mrb_state {
-    fn info(&self) -> String {
-        format!("{}", **self)
-    }
-
-    fn debug(&self) -> String {
-        format!("{:?}", **self)
-    }
-
-    fn version(&self) -> String {
-        (**self).version()
-    }
-}
-
-impl DescribeState for NonNull<mrb_state> {
-    fn info(&self) -> String {
-        format!("{}", unsafe { self.as_ref() })
-    }
-
-    fn debug(&self) -> String {
-        format!("{:?}", unsafe { self.as_ref() })
-    }
-
-    fn version(&self) -> String {
-        unsafe { self.as_ref() }.version()
-    }
-}
-
-impl DescribeState for *mut mrb_state {
-    fn info(&self) -> String {
-        NonNull::new(unsafe { &mut **self })
-            .as_ref()
-            .map(DescribeState::info)
-            .unwrap_or_default()
-    }
-
-    fn debug(&self) -> String {
-        NonNull::new(unsafe { &mut **self })
-            .as_ref()
-            .map(DescribeState::debug)
-            .unwrap_or_default()
-    }
-
-    fn version(&self) -> String {
-        NonNull::new(unsafe { &mut **self })
-            .as_ref()
-            .map(DescribeState::version)
-            .unwrap_or_default()
-    }
+/// Debug representation for [`mrb_state`].
+///
+/// Returns Ruby engine, interpreter version, engine version, and [`mrb_state`]
+/// address. For example:
+///
+/// ```text
+/// mruby 2.0 (v2.0.1 rev c078758) interpreter at 0x7f85b8800000
+/// ```
+///
+/// This function is infallible and guaranteed not to panic.
+pub fn mrb_sys_state_debug(mrb: *mut mrb_state) -> String {
+    // Safety:
+    //
+    // - `MRUBY_RUBY_ENGINE` is already a `CString` pulled from bindgen.
+    // - `MRUBY_RUBY_VERSION` is already a `CString` pulled from bindgen.
+    let engine = unsafe { CStr::from_bytes_with_nul_unchecked(MRUBY_RUBY_ENGINE) };
+    let version = unsafe { CStr::from_bytes_with_nul_unchecked(MRUBY_RUBY_VERSION) };
+    let mut debug = String::new();
+    // Explicitly supressed error since we are only generating debug info and
+    // cannot panic.
+    //
+    // In practice, this call to `write!` will never panic because the `Display`
+    // impls of `str` and `i64` are not buggy and writing to a `String`
+    // `fmt::Write` will never panic on its own.
+    let _ = write!(
+        &mut debug,
+        "{} {} (v{}.{}.{}) interpreter at {:p}",
+        engine.to_str().unwrap_or("unknown"),
+        version.to_str().unwrap_or("0.0.0"),
+        MRUBY_RELEASE_MAJOR,
+        MRUBY_RELEASE_MINOR,
+        MRUBY_RELEASE_TEENY,
+        mrb
+    );
+    debug
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::sys::{mrb_close, mrb_open, DescribeState};
-
-    #[test]
-    fn interpreter_display() {
-        unsafe {
-            let mrb = mrb_open();
-            assert_eq!(format!("{}", *mrb), "mruby 2.0");
-            assert_eq!(mrb.info(), "mruby 2.0");
-            mrb_close(mrb);
-        }
-    }
+    use crate::sys;
 
     #[test]
     fn interpreter_debug() {
         unsafe {
-            let mrb = mrb_open();
+            let mrb = sys::mrb_open();
+            let debug = sys::mrb_sys_state_debug(mrb);
             assert_eq!(
-                format!("{:?}", *mrb),
+                debug,
                 format!("mruby 2.0 (v2.0.1) interpreter at {:p}", &*mrb)
             );
-            assert_eq!(
-                mrb.debug(),
-                format!("mruby 2.0 (v2.0.1) interpreter at {:p}", &*mrb)
-            );
-            mrb_close(mrb);
-        }
-    }
-
-    #[test]
-    fn version() {
-        unsafe {
-            let mrb = mrb_open();
-            assert_eq!(mrb.version(), "2.0 (v2.0.1)");
-            mrb_close(mrb);
+            sys::mrb_close(mrb);
         }
     }
 }


### PR DESCRIPTION
This function replaces the DescribeState trait and the fmt::Debug
implementations on the various mrb_state pointer types.

DescribeState was introduced because it was not possible to implement
fmt::Debug on a *mut sys::mrb_state due to conflicts with blanket impls
in std.

The trait was awkward to use and provides no additional value over a function
that takes a *mut mrb_state directly.

This removes some panicking pathways from sys and makes the debug info generation
infallible and panic free.