### PR TITLE
Add a restriction lint job to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -247,7 +247,7 @@ jobs:
   audit:
     docker:
       - image: circleci/ruby:2.6.3-buster
-    resource_class: large
+    resource_class: medium
     steps:
       - checkout
       - restore_cache:
@@ -271,6 +271,131 @@ jobs:
       - run:
           name: Cargo Deny Check
           command: cargo deny check
+  restriction:
+    # this job is not enforced, currently informational only
+    docker:
+      - image: circleci/ruby:2.6.3-buster
+    resource_class: medium
+    steps:
+      - checkout
+      - restore_cache:
+          name: Restore sccache cache
+          key: v2-sccache-cache-stable-{{ arch }}-{{ .Environment.CIRCLE_JOB }}
+      - setup-linux-builder
+      - run:
+          name: Install cargo-expand
+          command: cargo install cargo-expand
+      - run:
+          name: Installed Toolchain Versions
+          command: |
+            cargo --version
+            cargo expand --version
+      - save_cache:
+          name: Save sccache cache
+          key: v2-sccache-cache-stable-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ epoch }}
+          paths:
+            - "~/.cache/sccache"
+      - run:
+          name: panicking pathways - artichoke-core
+          working_directory: "artichoke-core"
+          command: |
+            echo "panic!, todo!, and unreachable!"
+            cargo expand | grep "::std::rt::begin_panic_fmt" | wc -l
+            echo "format!"
+            cargo expand | grep "::alloc::fmt::format" | wc -l
+            echo "print! and println!"
+            cargo expand | grep "::std::io::_print" | wc -l
+            echo "eprint! and eprintln!"
+            cargo expand | grep "::std::io::_eprint" | wc -l
+      - run:
+          name: panicking pathways - artichoke-backend
+          working_directory: "artichoke-backend"
+          command: |
+            echo "panic!, todo!, and unreachable!"
+            cargo expand | grep "::std::rt::begin_panic_fmt" | wc -l
+            echo "format!"
+            cargo expand | grep "::alloc::fmt::format" | wc -l
+            echo "print! and println!"
+            cargo expand | grep "::std::io::_print" | wc -l
+            echo "eprint! and eprintln!"
+            cargo expand | grep "::std::io::_eprint" | wc -l
+      - run:
+          name: panicking pathways - artichoke-frontend lib
+          working_directory: "artichoke-frontend"
+          command: |
+            echo "panic!, todo!, and unreachable!"
+            cargo expand --lib | grep "::std::rt::begin_panic_fmt" | wc -l
+            echo "format!"
+            cargo expand --lib | grep "::alloc::fmt::format" | wc -l
+            echo "print! and println!"
+            cargo expand --lib | grep "::std::io::_print" | wc -l
+            echo "eprint! and eprintln!"
+            cargo expand --lib | grep "::std::io::_eprint" | wc -l
+      - run:
+          name: panicking pathways - artichoke-frontend artichoke bin
+          working_directory: "artichoke-frontend"
+          command: |
+            echo "panic!, todo!, and unreachable!"
+            cargo expand --bin artichoke | grep "::std::rt::begin_panic_fmt" | wc -l
+            echo "format!"
+            cargo expand --bin artichoke | grep "::alloc::fmt::format" | wc -l
+            echo "print! and println!"
+            cargo expand --bin artichoke | grep "::std::io::_print" | wc -l
+            echo "eprint! and eprintln!"
+            cargo expand --bin artichoke | grep "::std::io::_eprint" | wc -l
+      - run:
+          name: panicking pathways - artichoke-frontend ruby bin
+          working_directory: "artichoke-frontend"
+          command: |
+            echo "panic!, todo!, and unreachable!"
+            cargo expand --bin ruby | grep "::std::rt::begin_panic_fmt" | wc -l
+            echo "format!"
+            cargo expand --bin ruby | grep "::alloc::fmt::format" | wc -l
+            echo "print! and println!"
+            cargo expand --bin ruby | grep "::std::io::_print" | wc -l
+            echo "eprint! and eprintln!"
+            cargo expand --bin ruby | grep "::std::io::_eprint" | wc -l
+      - run:
+          name: panicking pathways - artichoke-frontend airb bin
+          working_directory: "artichoke-frontend"
+          command: |
+            echo "panic!, todo!, and unreachable!"
+            cargo expand --bin airb | grep "::std::rt::begin_panic_fmt" | wc -l
+            echo "format!"
+            cargo expand --bin airb | grep "::alloc::fmt::format" | wc -l
+            echo "print! and println!"
+            cargo expand --bin airb | grep "::std::io::_print" | wc -l
+            echo "eprint! and eprintln!"
+            cargo expand --bin airb | grep "::std::io::_eprint" | wc -l
+      - run:
+          name: panicking pathways - spec-runner
+          working_directory: "spec-runner"
+          command: |
+            echo "panic!, todo!, and unreachable!"
+            cargo expand | grep "::std::rt::begin_panic_fmt" | wc -l
+            echo "format!"
+            cargo expand | grep "::alloc::fmt::format" | wc -l
+            echo "print! and println!"
+            cargo expand | grep "::std::io::_print" | wc -l
+            echo "eprint! and eprintln!"
+            cargo expand | grep "::std::io::_eprint" | wc -l
+      - run:
+          # Search for "restriction lints": https://rust-lang.github.io/rust-clippy/master/index.html
+          name: clippy restriction lints
+          command: |
+            cargo clippy -- \
+            -W clippy::dbg_macro \
+            -W clippy::get_unwrap \
+            -W clippy::indexing_slicing \
+            -W clippy::option_expect_used \
+            -W clippy::option_unwrap_used \
+            -W clippy::panic \
+            -W clippy::print_stdout \
+            -W clippy::result_expect_used \
+            -W clippy::result_unwrap_used \
+            -W clippy::todo \
+            -W clippy::unimplemented \
+            -W clippy::unreachable
   deploy:
     docker:
       - image: node:lts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -286,6 +286,10 @@ jobs:
           name: Install nightly Rust
           command: rustup install nightly
       - run:
+          name: Install Rust Toolchain
+          command: |
+            rustup component add clippy
+      - run:
           name: Install cargo-expand
           command: cargo install cargo-expand
       - run:
@@ -293,6 +297,7 @@ jobs:
           command: |
             cargo --version
             cargo expand --version
+            cargo clippy -- --version
       - save_cache:
           name: Save sccache cache
           key: v2-sccache-cache-stable-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ epoch }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -288,6 +288,7 @@ jobs:
       - run:
           name: Install Rust Toolchain
           command: |
+            rustup component add rustfmt
             rustup component add clippy
       - run:
           name: Install cargo-expand
@@ -297,6 +298,7 @@ jobs:
           command: |
             cargo --version
             cargo expand --version
+            rustfmt --version
             cargo clippy -- --version
       - save_cache:
           name: Save sccache cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -426,6 +426,7 @@ workflows:
       - ruby-spec
       - linter
       - audit
+      - restriction
       - deploy:
           requires:
             - x86_64-linux

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -303,85 +303,85 @@ jobs:
           working_directory: "artichoke-core"
           command: |
             echo "panic!, todo!, and unreachable!"
-            cargo expand 2>/dev/null | grep "::std::rt::begin_panic_fmt" || : | wc -l
+            cargo expand 2>/dev/null | (grep "::std::rt::begin_panic_fmt" || :) | wc -l
             echo "format!"
-            cargo expand 2>/dev/null | grep "::alloc::fmt::format" || : | wc -l
+            cargo expand 2>/dev/null | (grep "::alloc::fmt::format" || :) | wc -l
             echo "print! and println!"
-            cargo expand 2>/dev/null | grep "::std::io::_print" || : | wc -l
+            cargo expand 2>/dev/null | (grep "::std::io::_print" || :) | wc -l
             echo "eprint! and eprintln!"
-            cargo expand 2>/dev/null | grep "::std::io::_eprint" || : | wc -l
+            cargo expand 2>/dev/null | (grep "::std::io::_eprint" || :) | wc -l
       - run:
           name: panicking pathways - artichoke-backend
           working_directory: "artichoke-backend"
           command: |
             echo "panic!, todo!, and unreachable!"
-            cargo expand 2>/dev/null | grep "::std::rt::begin_panic_fmt" || : | wc -l
+            cargo expand 2>/dev/null | (grep "::std::rt::begin_panic_fmt" || :) | wc -l
             echo "format!"
-            cargo expand 2>/dev/null | grep "::alloc::fmt::format" || : | wc -l
+            cargo expand 2>/dev/null | (grep "::alloc::fmt::format" || :) | wc -l
             echo "print! and println!"
-            cargo expand 2>/dev/null | grep "::std::io::_print" || : | wc -l
+            cargo expand 2>/dev/null | (grep "::std::io::_print" || :) | wc -l
             echo "eprint! and eprintln!"
-            cargo expand 2>/dev/null | grep "::std::io::_eprint" || : | wc -l
+            cargo expand 2>/dev/null | (grep "::std::io::_eprint" || :) | wc -l
       - run:
           name: panicking pathways - artichoke-frontend lib
           working_directory: "artichoke-frontend"
           command: |
             echo "panic!, todo!, and unreachable!"
-            cargo expand --lib | grep "::std::rt::begin_panic_fmt" || : | wc -l
+            cargo expand --lib | (grep "::std::rt::begin_panic_fmt" || :) | wc -l
             echo "format!"
-            cargo expand --lib | grep "::alloc::fmt::format" || : | wc -l
+            cargo expand --lib | (grep "::alloc::fmt::format" || :) | wc -l
             echo "print! and println!"
-            cargo expand --lib | grep "::std::io::_print" || : | wc -l
+            cargo expand --lib | (grep "::std::io::_print" || :) | wc -l
             echo "eprint! and eprintln!"
-            cargo expand --lib | grep "::std::io::_eprint" || : | wc -l
+            cargo expand --lib | (grep "::std::io::_eprint" || :) | wc -l
       - run:
           name: panicking pathways - artichoke-frontend artichoke bin
           working_directory: "artichoke-frontend"
           command: |
             echo "panic!, todo!, and unreachable!"
-            cargo expand --bin artichoke | grep "::std::rt::begin_panic_fmt" || : | wc -l
+            cargo expand --bin artichoke | (grep "::std::rt::begin_panic_fmt" || :) | wc -l
             echo "format!"
-            cargo expand --bin artichoke | grep "::alloc::fmt::format" || : | wc -l
+            cargo expand --bin artichoke | (grep "::alloc::fmt::format" || :) | wc -l
             echo "print! and println!"
-            cargo expand --bin artichoke | grep "::std::io::_print" || : | wc -l
+            cargo expand --bin artichoke | (grep "::std::io::_print" || :) | wc -l
             echo "eprint! and eprintln!"
-            cargo expand --bin artichoke | grep "::std::io::_eprint" || : | wc -l
+            cargo expand --bin artichoke | (grep "::std::io::_eprint" || :) | wc -l
       - run:
           name: panicking pathways - artichoke-frontend ruby bin
           working_directory: "artichoke-frontend"
           command: |
             echo "panic!, todo!, and unreachable!"
-            cargo expand --bin ruby | grep "::std::rt::begin_panic_fmt" || : | wc -l
+            cargo expand --bin ruby | (grep "::std::rt::begin_panic_fmt" || :) | wc -l
             echo "format!"
-            cargo expand --bin ruby | grep "::alloc::fmt::format" || : | wc -l
+            cargo expand --bin ruby | (grep "::alloc::fmt::format" || :) | wc -l
             echo "print! and println!"
-            cargo expand --bin ruby | grep "::std::io::_print" || : | wc -l
+            cargo expand --bin ruby | (grep "::std::io::_print" || :) | wc -l
             echo "eprint! and eprintln!"
-            cargo expand --bin ruby | grep "::std::io::_eprint" || : | wc -l
+            cargo expand --bin ruby | (grep "::std::io::_eprint" || :) | wc -l
       - run:
           name: panicking pathways - artichoke-frontend airb bin
           working_directory: "artichoke-frontend"
           command: |
             echo "panic!, todo!, and unreachable!"
-            cargo expand --bin airb | grep "::std::rt::begin_panic_fmt" || : | wc -l
+            cargo expand --bin airb | (grep "::std::rt::begin_panic_fmt" || :) | wc -l
             echo "format!"
-            cargo expand --bin airb | grep "::alloc::fmt::format" || : | wc -l
+            cargo expand --bin airb | (grep "::alloc::fmt::format" || :) | wc -l
             echo "print! and println!"
-            cargo expand --bin airb | grep "::std::io::_print" || : | wc -l
+            cargo expand --bin airb | (grep "::std::io::_print" || :) | wc -l
             echo "eprint! and eprintln!"
-            cargo expand --bin airb | grep "::std::io::_eprint" || : | wc -l
+            cargo expand --bin airb | (grep "::std::io::_eprint" || :) | wc -l
       - run:
           name: panicking pathways - spec-runner
           working_directory: "spec-runner"
           command: |
             echo "panic!, todo!, and unreachable!"
-            cargo expand 2>/dev/null | grep "::std::rt::begin_panic_fmt" || : | wc -l
+            cargo expand 2>/dev/null | (grep "::std::rt::begin_panic_fmt" || :) | wc -l
             echo "format!"
-            cargo expand 2>/dev/null | grep "::alloc::fmt::format" || : | wc -l
+            cargo expand 2>/dev/null | (grep "::alloc::fmt::format" || :) | wc -l
             echo "print! and println!"
-            cargo expand 2>/dev/null | grep "::std::io::_print" || : | wc -l
+            cargo expand 2>/dev/null | (grep "::std::io::_print" || :) | wc -l
             echo "eprint! and eprintln!"
-            cargo expand 2>/dev/null | grep "::std::io::_eprint" || : | wc -l
+            cargo expand 2>/dev/null | (grep "::std::io::_eprint" || :) | wc -l
       - run:
           # Search for "restriction lints": https://rust-lang.github.io/rust-clippy/master/index.html
           name: clippy restriction lints

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -403,7 +403,7 @@ jobs:
             -W clippy::result_unwrap_used \
             -W clippy::todo \
             -W clippy::unimplemented \
-            -W clippy::unreachable
+            -W clippy::unreachable || :
   deploy:
     docker:
       - image: node:lts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -332,49 +332,49 @@ jobs:
           working_directory: "artichoke-frontend"
           command: |
             echo "panic!, todo!, and unreachable!"
-            cargo expand --lib | (grep "::std::rt::begin_panic_fmt" || :) | wc -l
+            cargo expand --lib 2>/dev/null | (grep "::std::rt::begin_panic_fmt" || :) | wc -l
             echo "format!"
-            cargo expand --lib | (grep "::alloc::fmt::format" || :) | wc -l
+            cargo expand --lib 2>/dev/null | (grep "::alloc::fmt::format" || :) | wc -l
             echo "print! and println!"
-            cargo expand --lib | (grep "::std::io::_print" || :) | wc -l
+            cargo expand --lib 2>/dev/null | (grep "::std::io::_print" || :) | wc -l
             echo "eprint! and eprintln!"
-            cargo expand --lib | (grep "::std::io::_eprint" || :) | wc -l
+            cargo expand --lib 2>/dev/null | (grep "::std::io::_eprint" || :) | wc -l
       - run:
           name: panicking pathways - artichoke-frontend artichoke bin
           working_directory: "artichoke-frontend"
           command: |
             echo "panic!, todo!, and unreachable!"
-            cargo expand --bin artichoke | (grep "::std::rt::begin_panic_fmt" || :) | wc -l
+            cargo expand --bin artichoke 2>/dev/null | (grep "::std::rt::begin_panic_fmt" || :) | wc -l
             echo "format!"
-            cargo expand --bin artichoke | (grep "::alloc::fmt::format" || :) | wc -l
+            cargo expand --bin artichoke 2>/dev/null | (grep "::alloc::fmt::format" || :) | wc -l
             echo "print! and println!"
-            cargo expand --bin artichoke | (grep "::std::io::_print" || :) | wc -l
+            cargo expand --bin artichoke 2>/dev/null | (grep "::std::io::_print" || :) | wc -l
             echo "eprint! and eprintln!"
-            cargo expand --bin artichoke | (grep "::std::io::_eprint" || :) | wc -l
+            cargo expand --bin artichoke 2>/dev/null | (grep "::std::io::_eprint" || :) | wc -l
       - run:
           name: panicking pathways - artichoke-frontend ruby bin
           working_directory: "artichoke-frontend"
           command: |
             echo "panic!, todo!, and unreachable!"
-            cargo expand --bin ruby | (grep "::std::rt::begin_panic_fmt" || :) | wc -l
+            cargo expand --bin ruby 2>/dev/null | (grep "::std::rt::begin_panic_fmt" || :) | wc -l
             echo "format!"
-            cargo expand --bin ruby | (grep "::alloc::fmt::format" || :) | wc -l
+            cargo expand --bin ruby 2>/dev/null | (grep "::alloc::fmt::format" || :) | wc -l
             echo "print! and println!"
-            cargo expand --bin ruby | (grep "::std::io::_print" || :) | wc -l
+            cargo expand --bin ruby 2>/dev/null | (grep "::std::io::_print" || :) | wc -l
             echo "eprint! and eprintln!"
-            cargo expand --bin ruby | (grep "::std::io::_eprint" || :) | wc -l
+            cargo expand --bin ruby 2>/dev/null | (grep "::std::io::_eprint" || :) | wc -l
       - run:
           name: panicking pathways - artichoke-frontend airb bin
           working_directory: "artichoke-frontend"
           command: |
             echo "panic!, todo!, and unreachable!"
-            cargo expand --bin airb | (grep "::std::rt::begin_panic_fmt" || :) | wc -l
+            cargo expand --bin airb 2>/dev/null | (grep "::std::rt::begin_panic_fmt" || :) | wc -l
             echo "format!"
-            cargo expand --bin airb | (grep "::alloc::fmt::format" || :) | wc -l
+            cargo expand --bin airb 2>/dev/null | (grep "::alloc::fmt::format" || :) | wc -l
             echo "print! and println!"
-            cargo expand --bin airb | (grep "::std::io::_print" || :) | wc -l
+            cargo expand --bin airb 2>/dev/null | (grep "::std::io::_print" || :) | wc -l
             echo "eprint! and eprintln!"
-            cargo expand --bin airb | (grep "::std::io::_eprint" || :) | wc -l
+            cargo expand --bin airb 2>/dev/null | (grep "::std::io::_eprint" || :) | wc -l
       - run:
           name: panicking pathways - spec-runner
           working_directory: "spec-runner"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -303,85 +303,85 @@ jobs:
           working_directory: "artichoke-core"
           command: |
             echo "panic!, todo!, and unreachable!"
-            cargo expand | grep "::std::rt::begin_panic_fmt" | wc -l
+            cargo expand 2>/dev/null | grep "::std::rt::begin_panic_fmt" || : | wc -l
             echo "format!"
-            cargo expand | grep "::alloc::fmt::format" | wc -l
+            cargo expand 2>/dev/null | grep "::alloc::fmt::format" || : | wc -l
             echo "print! and println!"
-            cargo expand | grep "::std::io::_print" | wc -l
+            cargo expand 2>/dev/null | grep "::std::io::_print" || : | wc -l
             echo "eprint! and eprintln!"
-            cargo expand | grep "::std::io::_eprint" | wc -l
+            cargo expand 2>/dev/null | grep "::std::io::_eprint" || : | wc -l
       - run:
           name: panicking pathways - artichoke-backend
           working_directory: "artichoke-backend"
           command: |
             echo "panic!, todo!, and unreachable!"
-            cargo expand | grep "::std::rt::begin_panic_fmt" | wc -l
+            cargo expand 2>/dev/null | grep "::std::rt::begin_panic_fmt" || : | wc -l
             echo "format!"
-            cargo expand | grep "::alloc::fmt::format" | wc -l
+            cargo expand 2>/dev/null | grep "::alloc::fmt::format" || : | wc -l
             echo "print! and println!"
-            cargo expand | grep "::std::io::_print" | wc -l
+            cargo expand 2>/dev/null | grep "::std::io::_print" || : | wc -l
             echo "eprint! and eprintln!"
-            cargo expand | grep "::std::io::_eprint" | wc -l
+            cargo expand 2>/dev/null | grep "::std::io::_eprint" || : | wc -l
       - run:
           name: panicking pathways - artichoke-frontend lib
           working_directory: "artichoke-frontend"
           command: |
             echo "panic!, todo!, and unreachable!"
-            cargo expand --lib | grep "::std::rt::begin_panic_fmt" | wc -l
+            cargo expand --lib | grep "::std::rt::begin_panic_fmt" || : | wc -l
             echo "format!"
-            cargo expand --lib | grep "::alloc::fmt::format" | wc -l
+            cargo expand --lib | grep "::alloc::fmt::format" || : | wc -l
             echo "print! and println!"
-            cargo expand --lib | grep "::std::io::_print" | wc -l
+            cargo expand --lib | grep "::std::io::_print" || : | wc -l
             echo "eprint! and eprintln!"
-            cargo expand --lib | grep "::std::io::_eprint" | wc -l
+            cargo expand --lib | grep "::std::io::_eprint" || : | wc -l
       - run:
           name: panicking pathways - artichoke-frontend artichoke bin
           working_directory: "artichoke-frontend"
           command: |
             echo "panic!, todo!, and unreachable!"
-            cargo expand --bin artichoke | grep "::std::rt::begin_panic_fmt" | wc -l
+            cargo expand --bin artichoke | grep "::std::rt::begin_panic_fmt" || : | wc -l
             echo "format!"
-            cargo expand --bin artichoke | grep "::alloc::fmt::format" | wc -l
+            cargo expand --bin artichoke | grep "::alloc::fmt::format" || : | wc -l
             echo "print! and println!"
-            cargo expand --bin artichoke | grep "::std::io::_print" | wc -l
+            cargo expand --bin artichoke | grep "::std::io::_print" || : | wc -l
             echo "eprint! and eprintln!"
-            cargo expand --bin artichoke | grep "::std::io::_eprint" | wc -l
+            cargo expand --bin artichoke | grep "::std::io::_eprint" || : | wc -l
       - run:
           name: panicking pathways - artichoke-frontend ruby bin
           working_directory: "artichoke-frontend"
           command: |
             echo "panic!, todo!, and unreachable!"
-            cargo expand --bin ruby | grep "::std::rt::begin_panic_fmt" | wc -l
+            cargo expand --bin ruby | grep "::std::rt::begin_panic_fmt" || : | wc -l
             echo "format!"
-            cargo expand --bin ruby | grep "::alloc::fmt::format" | wc -l
+            cargo expand --bin ruby | grep "::alloc::fmt::format" || : | wc -l
             echo "print! and println!"
-            cargo expand --bin ruby | grep "::std::io::_print" | wc -l
+            cargo expand --bin ruby | grep "::std::io::_print" || : | wc -l
             echo "eprint! and eprintln!"
-            cargo expand --bin ruby | grep "::std::io::_eprint" | wc -l
+            cargo expand --bin ruby | grep "::std::io::_eprint" || : | wc -l
       - run:
           name: panicking pathways - artichoke-frontend airb bin
           working_directory: "artichoke-frontend"
           command: |
             echo "panic!, todo!, and unreachable!"
-            cargo expand --bin airb | grep "::std::rt::begin_panic_fmt" | wc -l
+            cargo expand --bin airb | grep "::std::rt::begin_panic_fmt" || : | wc -l
             echo "format!"
-            cargo expand --bin airb | grep "::alloc::fmt::format" | wc -l
+            cargo expand --bin airb | grep "::alloc::fmt::format" || : | wc -l
             echo "print! and println!"
-            cargo expand --bin airb | grep "::std::io::_print" | wc -l
+            cargo expand --bin airb | grep "::std::io::_print" || : | wc -l
             echo "eprint! and eprintln!"
-            cargo expand --bin airb | grep "::std::io::_eprint" | wc -l
+            cargo expand --bin airb | grep "::std::io::_eprint" || : | wc -l
       - run:
           name: panicking pathways - spec-runner
           working_directory: "spec-runner"
           command: |
             echo "panic!, todo!, and unreachable!"
-            cargo expand | grep "::std::rt::begin_panic_fmt" | wc -l
+            cargo expand 2>/dev/null | grep "::std::rt::begin_panic_fmt" || : | wc -l
             echo "format!"
-            cargo expand | grep "::alloc::fmt::format" | wc -l
+            cargo expand 2>/dev/null | grep "::alloc::fmt::format" || : | wc -l
             echo "print! and println!"
-            cargo expand | grep "::std::io::_print" | wc -l
+            cargo expand 2>/dev/null | grep "::std::io::_print" || : | wc -l
             echo "eprint! and eprintln!"
-            cargo expand | grep "::std::io::_eprint" | wc -l
+            cargo expand 2>/dev/null | grep "::std::io::_eprint" || : | wc -l
       - run:
           # Search for "restriction lints": https://rust-lang.github.io/rust-clippy/master/index.html
           name: clippy restriction lints

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -283,6 +283,9 @@ jobs:
           key: v2-sccache-cache-stable-{{ arch }}-{{ .Environment.CIRCLE_JOB }}
       - setup-linux-builder
       - run:
+          name: Install nightly Rust
+          command: rustup install nightly
+      - run:
           name: Install cargo-expand
           command: cargo install cargo-expand
       - run:

--- a/artichoke-backend/build.rs
+++ b/artichoke-backend/build.rs
@@ -1,5 +1,6 @@
 #![deny(clippy::all)]
 #![deny(clippy::pedantic)]
+#![allow(clippy::restriction)]
 #![deny(warnings, intra_doc_link_resolution_failure)]
 #![doc(deny(warnings))]
 

--- a/artichoke-backend/src/extn/core/array/mruby.rs
+++ b/artichoke-backend/src/extn/core/array/mruby.rs
@@ -67,7 +67,6 @@ unsafe extern "C" fn ary_len(mrb: *mut sys::mrb_state, ary: sys::mrb_value) -> s
 }
 
 unsafe extern "C" fn ary_concat(mrb: *mut sys::mrb_state, ary: sys::mrb_value) -> sys::mrb_value {
-    println!("ary concat C");
     let other = mrb_get_args!(mrb, optional = 1);
     let interp = unwrap_interpreter!(mrb);
     let array = Value::new(&interp, ary);

--- a/artichoke-backend/src/sys/mod.rs
+++ b/artichoke-backend/src/sys/mod.rs
@@ -17,6 +17,7 @@ mod args;
 #[allow(non_snake_case)]
 #[allow(clippy::all)]
 #[allow(clippy::pedantic)]
+#[allow(clippy::restriction)]
 mod ffi {
     include!(concat!(env!("OUT_DIR"), "/ffi.rs"));
 }

--- a/spec-runner/build.rs
+++ b/spec-runner/build.rs
@@ -1,5 +1,6 @@
 #![deny(clippy::all)]
 #![deny(clippy::pedantic)]
+#![allow(clippy::restriction)]
 #![deny(warnings, intra_doc_link_resolution_failure)]
 #![doc(deny(warnings))]
 


### PR DESCRIPTION
The restriction job logs less than good patterns that we one day should
eliminate. Restriction lint passes fall into these categories:

- Identify code that may panic.
- Identify code that is checked in debugging code.
- Identify unimplemented APIs.

This job makes use of cargo-expand to find known panicking formatting
macros in `std` and clippy with manually opted-in restriction lints such
as `dbg_macro`, `index_slicing`, or `result_unwrap_used`.

This job will not be required to pass for PRs to merge. It is intended
to gather metrics and eventually drive these lint failures to zero
before a public release.

This PR fixes one restriction lint error: a stray `println!` in `Array` FFI code.