### PR TITLE
Add Debug impls for every public struct and enum

### DIFF
--- a/artichoke-backend/scripts/auto_import/rust_glue.rs.erb
+++ b/artichoke-backend/scripts/auto_import/rust_glue.rs.erb
@@ -21,5 +21,7 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     Ok(())
 }
 <% constants.each_with_index do |(constant, _), i| %>
+#[derive(Debug)]
 pub struct <%= constant %>;
+
 <% end %>

--- a/artichoke-backend/src/class.rs
+++ b/artichoke-backend/src/class.rs
@@ -122,7 +122,7 @@ impl<'a> Builder<'a> {
     }
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct Spec {
     name: Cow<'static, str>,
     cstring: CString,
@@ -234,16 +234,6 @@ impl Spec {
             // Class exists in root scope.
             NonNull::new(unsafe { sys::mrb_class_get(mrb, self.name_c_str().as_ptr()) })
         }
-    }
-}
-
-impl fmt::Debug for Spec {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self)?;
-        if self.data_type.dfree.is_some() {
-            write!(f, " -- with free func")?;
-        }
-        Ok(())
     }
 }
 

--- a/artichoke-backend/src/def.rs
+++ b/artichoke-backend/src/def.rs
@@ -100,7 +100,7 @@ pub type Method =
 /// Because there is no C API to resolve class and module names directly, each
 /// class-like holds a reference to its enclosing scope so it can recursively
 /// resolve its enclosing [`RClass *`](sys::RClass).
-#[derive(Clone, Debug)]
+#[derive(Debug, Clone)]
 pub enum EnclosingRubyScope {
     /// Reference to a Ruby `Class` enclosing scope.
     Class {

--- a/artichoke-backend/src/extn/core/array/inline_buffer.rs
+++ b/artichoke-backend/src/extn/core/array/inline_buffer.rs
@@ -1,6 +1,7 @@
 use smallvec::SmallVec;
 use std::cmp;
-use std::iter::FromIterator;
+use std::fmt;
+use std::iter::{self, FromIterator};
 
 use crate::extn::core::array::ArrayType;
 use crate::extn::prelude::*;
@@ -60,6 +61,14 @@ impl<'a> FromIterator<&'a Option<Value>> for InlineBuffer {
                 unsafe { sys::mrb_sys_nil_value() }
             }
         })))
+    }
+}
+
+impl fmt::Debug for InlineBuffer {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_list()
+            .entries(iter::repeat("Value").take(self.len()))
+            .finish()
     }
 }
 

--- a/artichoke-backend/src/extn/core/array/mod.rs
+++ b/artichoke-backend/src/extn/core/array/mod.rs
@@ -12,13 +12,8 @@ pub mod trampoline;
 pub use backend::ArrayType;
 pub use inline_buffer::InlineBuffer;
 
+#[derive(Debug, Clone)]
 pub struct Array(InlineBuffer);
-
-impl Clone for Array {
-    fn clone(&self) -> Self {
-        Self(self.0.clone())
-    }
-}
 
 impl Array {
     #[must_use]

--- a/artichoke-backend/src/extn/core/artichoke/mod.rs
+++ b/artichoke-backend/src/extn/core/artichoke/mod.rs
@@ -11,6 +11,8 @@ pub fn init(interp: &mut crate::Artichoke) -> InitializeResult<()> {
     Ok(())
 }
 
+#[derive(Debug)]
 pub struct Artichoke;
 
+#[derive(Debug)]
 pub struct Kernel;

--- a/artichoke-backend/src/extn/core/comparable/mod.rs
+++ b/artichoke-backend/src/extn/core/comparable/mod.rs
@@ -12,4 +12,5 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     Ok(())
 }
 
+#[derive(Debug)]
 pub struct Comparable;

--- a/artichoke-backend/src/extn/core/enumerable/mod.rs
+++ b/artichoke-backend/src/extn/core/enumerable/mod.rs
@@ -12,4 +12,5 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     Ok(())
 }
 
+#[derive(Debug)]
 pub struct Enumerable;

--- a/artichoke-backend/src/extn/core/enumerator/mod.rs
+++ b/artichoke-backend/src/extn/core/enumerator/mod.rs
@@ -13,4 +13,5 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     Ok(())
 }
 
+#[derive(Debug)]
 pub struct Enumerator;

--- a/artichoke-backend/src/extn/core/env/backend/mod.rs
+++ b/artichoke-backend/src/extn/core/env/backend/mod.rs
@@ -22,3 +22,8 @@ pub trait EnvType {
 
     fn as_map(&self, interp: &Artichoke) -> Result<HashMap<Vec<u8>, Vec<u8>>, Exception>;
 }
+
+#[allow(clippy::missing_safety_doc)]
+mod internal {
+    downcast!(dyn super::EnvType);
+}

--- a/artichoke-backend/src/extn/core/exception/mod.rs
+++ b/artichoke-backend/src/extn/core/exception/mod.rs
@@ -265,7 +265,7 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
 
 macro_rules! ruby_exception_impl {
     ($exception:ident) => {
-        #[derive(Clone)]
+        #[derive(Debug, Clone)]
         pub struct $exception {
             message: Cow<'static, [u8]>,
         }
@@ -295,40 +295,28 @@ macro_rules! ruby_exception_impl {
         }
 
         #[allow(clippy::use_self)]
-        impl From<$exception> for exception::Exception
-        where
-            $exception: RubyException,
-        {
+        impl From<$exception> for exception::Exception {
             fn from(exception: $exception) -> exception::Exception {
                 exception::Exception::from(Box::<dyn RubyException>::from(exception))
             }
         }
 
         #[allow(clippy::use_self)]
-        impl From<Box<$exception>> for exception::Exception
-        where
-            $exception: RubyException,
-        {
+        impl From<Box<$exception>> for exception::Exception {
             fn from(exception: Box<$exception>) -> exception::Exception {
                 exception::Exception::from(Box::<dyn RubyException>::from(exception))
             }
         }
 
         #[allow(clippy::use_self)]
-        impl From<$exception> for Box<dyn RubyException>
-        where
-            $exception: RubyException,
-        {
+        impl From<$exception> for Box<dyn RubyException> {
             fn from(exception: $exception) -> Box<dyn RubyException> {
                 Box::new(exception)
             }
         }
 
         #[allow(clippy::use_self)]
-        impl From<Box<$exception>> for Box<dyn RubyException>
-        where
-            $exception: RubyException,
-        {
+        impl From<Box<$exception>> for Box<dyn RubyException> {
             fn from(exception: Box<$exception>) -> Box<dyn RubyException> {
                 exception
             }
@@ -361,23 +349,7 @@ macro_rules! ruby_exception_impl {
             }
         }
 
-        impl fmt::Debug for $exception
-        where
-            $exception: RubyException,
-        {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                let classname = self.name();
-                write!(f, "{} (", classname)?;
-                string::escape_unicode(f, self.message())
-                    .map_err(string::WriteError::into_inner)?;
-                write!(f, ")")
-            }
-        }
-
-        impl fmt::Display for $exception
-        where
-            $exception: RubyException,
-        {
+        impl fmt::Display for $exception {
             fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 let classname = self.name();
                 write!(f, "{} (", classname)?;

--- a/artichoke-backend/src/extn/core/float/mod.rs
+++ b/artichoke-backend/src/extn/core/float/mod.rs
@@ -14,6 +14,7 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     Ok(())
 }
 
+#[derive(Debug)]
 pub struct Float;
 
 impl Float {

--- a/artichoke-backend/src/extn/core/hash/mod.rs
+++ b/artichoke-backend/src/extn/core/hash/mod.rs
@@ -11,4 +11,5 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     Ok(())
 }
 
+#[derive(Debug)]
 pub struct Hash;

--- a/artichoke-backend/src/extn/core/integer/mod.rs
+++ b/artichoke-backend/src/extn/core/integer/mod.rs
@@ -8,6 +8,7 @@ use crate::types;
 pub mod mruby;
 pub mod trampoline;
 
+#[derive(Debug)]
 pub struct Integer;
 
 pub fn chr(

--- a/artichoke-backend/src/extn/core/kernel/mod.rs
+++ b/artichoke-backend/src/extn/core/kernel/mod.rs
@@ -39,6 +39,7 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     Ok(())
 }
 
+#[derive(Debug)]
 pub struct Kernel;
 
 impl Kernel {

--- a/artichoke-backend/src/extn/core/method/mod.rs
+++ b/artichoke-backend/src/extn/core/method/mod.rs
@@ -11,4 +11,5 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     Ok(())
 }
 
+#[derive(Debug)]
 pub struct Method;

--- a/artichoke-backend/src/extn/core/module/mod.rs
+++ b/artichoke-backend/src/extn/core/module/mod.rs
@@ -11,4 +11,5 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     Ok(())
 }
 
+#[derive(Debug)]
 pub struct Module;

--- a/artichoke-backend/src/extn/core/numeric/mod.rs
+++ b/artichoke-backend/src/extn/core/numeric/mod.rs
@@ -11,4 +11,5 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     Ok(())
 }
 
+#[derive(Debug)]
 pub struct Numeric;

--- a/artichoke-backend/src/extn/core/object/mod.rs
+++ b/artichoke-backend/src/extn/core/object/mod.rs
@@ -11,4 +11,5 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     Ok(())
 }
 
+#[derive(Debug)]
 pub struct Object;

--- a/artichoke-backend/src/extn/core/proc/mod.rs
+++ b/artichoke-backend/src/extn/core/proc/mod.rs
@@ -11,4 +11,5 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     Ok(())
 }
 
+#[derive(Debug)]
 pub struct Proc;

--- a/artichoke-backend/src/extn/core/random/mod.rs
+++ b/artichoke-backend/src/extn/core/random/mod.rs
@@ -1,11 +1,16 @@
 use rand::{self, Rng, RngCore};
 use std::convert::TryFrom;
+use std::fmt;
 use std::ptr;
+
+use rand::rngs::SmallRng;
 
 use crate::extn::prelude::*;
 
 pub mod backend;
 pub mod mruby;
+
+use backend::rand::Rand;
 
 pub struct Random(Box<dyn backend::RandType>);
 
@@ -32,6 +37,21 @@ impl Random {
 impl RustBackedValue for Random {
     fn ruby_type_name() -> &'static str {
         "Random"
+    }
+}
+
+impl fmt::Debug for Random {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if let Ok(inner) = self.inner().downcast_ref::<Rand<SmallRng>>() {
+            f.debug_struct("Random")
+                .field("backend_type", &"Rand<SmallRng>")
+                .field("seed", &inner.seed())
+                .finish()
+        } else {
+            f.debug_struct("Random")
+                .field("backend_type", &"unknown")
+                .finish()
+        }
     }
 }
 

--- a/artichoke-backend/src/extn/core/range/mod.rs
+++ b/artichoke-backend/src/extn/core/range/mod.rs
@@ -11,4 +11,5 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     Ok(())
 }
 
+#[derive(Debug)]
 pub struct Range;

--- a/artichoke-backend/src/extn/core/regexp/backend/lazy.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/lazy.rs
@@ -7,6 +7,7 @@ use crate::extn::prelude::*;
 
 use super::{NameToCaptureLocations, NilableString};
 
+#[derive(Debug)]
 pub struct Lazy {
     literal: Config,
     encoding: Encoding,
@@ -32,18 +33,6 @@ impl Lazy {
                 Encoding::default(),
             )
         })
-    }
-}
-
-impl fmt::Debug for Lazy {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "/{}/{}{}",
-            String::from_utf8_lossy(self.literal.pattern.as_slice()).replace("/", r"\/"),
-            self.literal.options.modifier_string(),
-            Encoding::default().string()
-        )
     }
 }
 

--- a/artichoke-backend/src/extn/core/regexp/backend/onig.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/onig.rs
@@ -12,7 +12,7 @@ use crate::extn::prelude::*;
 
 use super::{NameToCaptureLocations, NilableString};
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct Onig {
     literal: Config,
     derived: Config,
@@ -49,18 +49,6 @@ impl Onig {
             regex: Rc::new(regex),
         };
         Ok(regexp)
-    }
-}
-
-impl fmt::Debug for Onig {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "/{}/{}{}",
-            String::from_utf8_lossy(self.literal.pattern.as_slice()).replace("/", r"\/"),
-            self.literal.options.modifier_string(),
-            self.encoding.string()
-        )
     }
 }
 

--- a/artichoke-backend/src/extn/core/regexp/backend/regex/utf8.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/regex/utf8.rs
@@ -11,7 +11,7 @@ use crate::extn::prelude::*;
 
 use super::super::{NameToCaptureLocations, NilableString};
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct Utf8 {
     literal: Config,
     derived: Config,
@@ -50,18 +50,6 @@ impl Utf8 {
             regex,
         };
         Ok(regexp)
-    }
-}
-
-impl fmt::Debug for Utf8 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "/{}/{}{}",
-            String::from_utf8_lossy(self.literal.pattern.as_slice()).replace("/", r"\/"),
-            self.literal.options.modifier_string(),
-            self.encoding.string()
-        )
     }
 }
 

--- a/artichoke-backend/src/extn/core/string.rs
+++ b/artichoke-backend/src/extn/core/string.rs
@@ -17,6 +17,7 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     Ok(())
 }
 
+#[derive(Debug)]
 #[allow(clippy::module_name_repetitions)]
 pub struct RString;
 

--- a/artichoke-backend/src/extn/core/symbol/mod.rs
+++ b/artichoke-backend/src/extn/core/symbol/mod.rs
@@ -11,4 +11,5 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     Ok(())
 }
 
+#[derive(Debug)]
 pub struct Symbol;

--- a/artichoke-backend/src/extn/core/thread.rs
+++ b/artichoke-backend/src/extn/core/thread.rs
@@ -20,7 +20,10 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     Ok(())
 }
 
+#[derive(Debug)]
 pub struct Thread;
+
+#[derive(Debug)]
 pub struct Mutex;
 
 #[cfg(test)]

--- a/artichoke-backend/src/extn/core/time/backend/mod.rs
+++ b/artichoke-backend/src/extn/core/time/backend/mod.rs
@@ -74,3 +74,9 @@ pub trait TimeType: Any {
 pub trait MakeTime: Any {
     fn now(&self, interp: &Artichoke) -> Box<dyn TimeType>;
 }
+
+#[allow(clippy::missing_safety_doc)]
+mod internal {
+    downcast!(dyn super::TimeType);
+    downcast!(dyn super::MakeTime);
+}

--- a/artichoke-backend/src/extn/core/time/mod.rs
+++ b/artichoke-backend/src/extn/core/time/mod.rs
@@ -1,14 +1,18 @@
+use chrono::Local;
+use std::fmt;
+
 use crate::convert::RustBackedValue;
 
 pub mod backend;
 pub mod mruby;
 pub mod trampoline;
 
-use backend::{chrono, MakeTime, TimeType};
+use backend::chrono::{Chrono, Factory};
+use backend::{MakeTime, TimeType};
 
 #[must_use]
 pub fn factory() -> impl MakeTime {
-    chrono::Factory
+    Factory
 }
 
 pub struct Time(Box<dyn TimeType>);
@@ -22,5 +26,15 @@ impl Time {
 impl RustBackedValue for Time {
     fn ruby_type_name() -> &'static str {
         "Time"
+    }
+}
+
+impl fmt::Debug for Time {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if let Ok(backend) = self.0.downcast_ref::<Chrono<Local>>() {
+            f.debug_struct("Time").field("backend", backend).finish()
+        } else {
+            f.debug_struct("Time").field("backend", &"unknown").finish()
+        }
     }
 }

--- a/artichoke-backend/src/extn/core/warning/mod.rs
+++ b/artichoke-backend/src/extn/core/warning/mod.rs
@@ -12,4 +12,5 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     Ok(())
 }
 
+#[derive(Debug)]
 pub struct Warning;

--- a/artichoke-backend/src/extn/stdlib/abbrev.rs
+++ b/artichoke-backend/src/extn/stdlib/abbrev.rs
@@ -7,6 +7,7 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     Ok(())
 }
 
+#[derive(Debug)]
 pub struct Abbrev;
 
 // Abbrev tests from Ruby stdlib docs

--- a/artichoke-backend/src/extn/stdlib/delegate.rs
+++ b/artichoke-backend/src/extn/stdlib/delegate.rs
@@ -9,5 +9,8 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     Ok(())
 }
 
+#[derive(Debug)]
 pub struct Delegator;
+
+#[derive(Debug)]
 pub struct SimpleDelegator;

--- a/artichoke-backend/src/extn/stdlib/forwardable.rs
+++ b/artichoke-backend/src/extn/stdlib/forwardable.rs
@@ -11,6 +11,7 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     Ok(())
 }
 
+#[derive(Debug)]
 pub struct Forwardable;
 
 // Forwardable tests from Ruby stdlib docs

--- a/artichoke-backend/src/extn/stdlib/monitor.rs
+++ b/artichoke-backend/src/extn/stdlib/monitor.rs
@@ -7,6 +7,7 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     Ok(())
 }
 
+#[derive(Debug)]
 pub struct Monitor;
 
 // Monitor tests from ruby/spec

--- a/artichoke-backend/src/extn/stdlib/ostruct.rs
+++ b/artichoke-backend/src/extn/stdlib/ostruct.rs
@@ -7,4 +7,5 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     Ok(())
 }
 
+#[derive(Debug)]
 pub struct OpenStruct;

--- a/artichoke-backend/src/extn/stdlib/set.rs
+++ b/artichoke-backend/src/extn/stdlib/set.rs
@@ -9,6 +9,9 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     Ok(())
 }
 
+#[derive(Debug)]
 pub struct Set;
+
+#[derive(Debug)]
 #[allow(clippy::module_name_repetitions)]
 pub struct SortedSet;

--- a/artichoke-backend/src/extn/stdlib/strscan.rs
+++ b/artichoke-backend/src/extn/stdlib/strscan.rs
@@ -7,6 +7,7 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     Ok(())
 }
 
+#[derive(Debug)]
 pub struct StringScanner;
 
 // StringScanner tests from Ruby stdlib docs

--- a/artichoke-backend/src/method.rs
+++ b/artichoke-backend/src/method.rs
@@ -15,7 +15,7 @@ pub enum Type {
     Module,
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct Spec {
     name: Cow<'static, str>,
     cstring: CString,
@@ -104,12 +104,6 @@ impl Spec {
                 self.args,
             ),
         }
-    }
-}
-
-impl fmt::Debug for Spec {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self)
     }
 }
 

--- a/artichoke-backend/src/module.rs
+++ b/artichoke-backend/src/module.rs
@@ -102,7 +102,7 @@ impl<'a> Builder<'a> {
     }
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct Spec {
     name: Cow<'static, str>,
     sym: sys::mrb_sym,
@@ -212,12 +212,6 @@ impl Spec {
                 NonNull::new(unsafe { sys::mrb_module_get(mrb, self.name_c_str().as_ptr()) })
             }
         }
-    }
-}
-
-impl fmt::Debug for Spec {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self)
     }
 }
 

--- a/artichoke-backend/src/state/mod.rs
+++ b/artichoke-backend/src/state/mod.rs
@@ -164,10 +164,16 @@ impl State {
 
 impl fmt::Debug for State {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "Artichoke State {{ {} }}",
-            sys::mrb_sys_state_debug(self.mrb)
-        )
+        let mut fmt = f.debug_struct("State");
+        fmt.field("mrb", &sys::mrb_sys_state_debug(self.mrb))
+            .field("parser", &self.parser)
+            .field("classes", &self.classes)
+            .field("modules", &self.modules)
+            .field("vfs", &self.vfs)
+            .field("active_regexp_globals", &self.active_regexp_globals)
+            .field("captured_output", &self.captured_output);
+        #[cfg(feature = "artichoke-random")]
+        fmt.field("prng", &self.prng);
+        fmt.finish()
     }
 }

--- a/artichoke-backend/src/state/parser.rs
+++ b/artichoke-backend/src/state/parser.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
 use std::convert::TryFrom;
 use std::ffi::{CStr, CString};
+use std::fmt;
 use std::ptr::NonNull;
 
 use crate::core::parser::IncrementLinenoError;
@@ -12,6 +13,15 @@ pub const TOP_FILENAME: &[u8] = b"(eval)";
 pub struct State {
     context: NonNull<sys::mrbc_context>,
     stack: Vec<Context>,
+}
+
+impl fmt::Debug for State {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("parser::State")
+            .field("context", &"non-null mrb_context")
+            .field("stack", &self.stack)
+            .finish()
+    }
 }
 
 impl State {

--- a/artichoke-backend/src/state/prng.rs
+++ b/artichoke-backend/src/state/prng.rs
@@ -4,6 +4,7 @@ use crate::extn::core::random::backend::rand::Rand;
 use crate::extn::core::random::backend::RandType;
 use crate::types::{Float, Int};
 
+#[derive(Debug)]
 pub struct Prng {
     random: Rand<SmallRng>,
 }

--- a/artichoke-backend/src/value.rs
+++ b/artichoke-backend/src/value.rs
@@ -374,6 +374,12 @@ pub struct Block {
     value: sys::mrb_value,
 }
 
+impl fmt::Debug for Block {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "proc")
+    }
+}
+
 impl Block {
     /// Construct a new [`Value`] from an interpreter and [`sys::mrb_value`].
     #[must_use]

--- a/artichoke-backend/tests/leak/mod.rs
+++ b/artichoke-backend/tests/leak/mod.rs
@@ -1,5 +1,6 @@
 use std::convert::AsRef;
 
+#[derive(Debug)]
 pub struct Detector {
     test: String,
     iterations: usize,

--- a/artichoke-core/src/parser.rs
+++ b/artichoke-core/src/parser.rs
@@ -39,21 +39,13 @@ pub trait Parser {
 ///
 /// Errors include overflows of the interpreters line counter.
 #[non_exhaustive]
-#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum IncrementLinenoError {
     /// An overflow occurred when incrementing the line number.
     ///
     /// This error is reported based on the internal parser storage width
     /// and contains the max value the parser can store.
     Overflow(usize),
-}
-
-impl fmt::Debug for IncrementLinenoError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Self::Overflow(max) => write!(f, "Parser exceeded maximum line count: {}", max),
-        }
-    }
 }
 
 impl fmt::Display for IncrementLinenoError {

--- a/artichoke-frontend/src/parser.rs
+++ b/artichoke-frontend/src/parser.rs
@@ -59,6 +59,7 @@ pub enum Error {
 }
 
 /// Wraps a [`artichoke_backend`] mruby parser.
+// TODO: add a `Debug` impl
 pub struct Parser {
     parser: *mut sys::mrb_parser_state,
     context: *mut sys::mrbc_context,

--- a/artichoke-frontend/src/repl.rs
+++ b/artichoke-frontend/src/repl.rs
@@ -65,6 +65,7 @@ impl From<io::Error> for Error {
 }
 
 /// Configuration for the REPL readline prompt.
+#[derive(Debug, Clone)]
 pub struct PromptConfig {
     /// Basic prompt for start of a new expression.
     pub simple: String,


### PR DESCRIPTION
Most of these were able to be derived. Ones that touch FFI objects were
built manually with `DebugStruct`.

One parser struct in `artichoke-frontend` was not touched because it
consists solely of two raw pointers.

Rust API guidelines say that all public types should implement `Debug`.

https://github.com/rust-lang/api-guidelines/blob/master/src/checklist.md