### PR TITLE
Add constant definition APIs to artichoke-core

### DIFF
--- a/artichoke-backend/src/constant.rs
+++ b/artichoke-backend/src/constant.rs
@@ -1,0 +1,75 @@
+use std::ffi::CString;
+
+use crate::def::{ConstantNameError, NotDefinedError};
+use crate::exception::Exception;
+use crate::sys;
+use crate::value::Value;
+use crate::{Artichoke, DefineConstant};
+
+impl DefineConstant for Artichoke {
+    type Value = Value;
+
+    type Error = Exception;
+
+    fn define_global_constant(
+        &mut self,
+        constant: &str,
+        value: Self::Value,
+    ) -> Result<(), Self::Error> {
+        let name =
+            CString::new(constant).map_err(|_| ConstantNameError::new(String::from(constant)))?;
+        let mrb = self.0.borrow().mrb;
+        unsafe {
+            sys::mrb_define_global_const(mrb, name.as_ptr() as *const i8, value.inner());
+        }
+        Ok(())
+    }
+
+    fn define_class_constant<T: 'static>(
+        &mut self,
+        constant: &str,
+        value: Self::Value,
+    ) -> Result<(), Self::Error> {
+        let name =
+            CString::new(constant).map_err(|_| ConstantNameError::new(String::from(constant)))?;
+        let borrow = self.0.borrow();
+        let mrb = borrow.mrb;
+        let mut rclass = borrow
+            .class_spec::<T>()
+            .and_then(|spec| spec.rclass(mrb))
+            .ok_or_else(|| NotDefinedError::class_constant(String::from(constant)))?;
+        unsafe {
+            sys::mrb_define_const(
+                mrb,
+                rclass.as_mut(),
+                name.as_ptr() as *const i8,
+                value.inner(),
+            );
+        }
+        Ok(())
+    }
+
+    fn define_module_constant<T: 'static>(
+        &mut self,
+        constant: &str,
+        value: Self::Value,
+    ) -> Result<(), Self::Error> {
+        let name =
+            CString::new(constant).map_err(|_| ConstantNameError::new(String::from(constant)))?;
+        let borrow = self.0.borrow();
+        let mrb = borrow.mrb;
+        let mut rclass = borrow
+            .module_spec::<T>()
+            .and_then(|spec| spec.rclass(mrb))
+            .ok_or_else(|| NotDefinedError::module_constant(String::from(constant)))?;
+        unsafe {
+            sys::mrb_define_const(
+                mrb,
+                rclass.as_mut(),
+                name.as_ptr() as *const i8,
+                value.inner(),
+            );
+        }
+        Ok(())
+    }
+}

--- a/artichoke-backend/src/def.rs
+++ b/artichoke-backend/src/def.rs
@@ -275,6 +275,7 @@ pub enum NotDefinedError {
     Module(Cow<'static, str>),
     GlobalConstant(Cow<'static, str>),
     ClassConstant(Cow<'static, str>),
+    ModuleConstant(Cow<'static, str>),
 }
 
 impl NotDefinedError {
@@ -320,6 +321,13 @@ impl NotDefinedError {
         Self::ClassConstant(item.into())
     }
 
+    pub fn module_constant<T>(item: T) -> Self
+    where
+        T: Into<Cow<'static, str>>,
+    {
+        Self::ModuleConstant(item.into())
+    }
+
     #[must_use]
     pub fn fqdn(&self) -> &str {
         match self {
@@ -327,7 +335,9 @@ impl NotDefinedError {
             | Self::Super(ref fqdn)
             | Self::Class(ref fqdn)
             | Self::Module(ref fqdn) => fqdn.as_ref(),
-            Self::GlobalConstant(ref name) | Self::ClassConstant(ref name) => name.as_ref(),
+            Self::GlobalConstant(ref name)
+            | Self::ClassConstant(ref name)
+            | Self::ModuleConstant(ref name) => name.as_ref(),
         }
     }
 
@@ -340,6 +350,7 @@ impl NotDefinedError {
             Self::Module(_) => "module",
             Self::GlobalConstant(_) => "global constant",
             Self::ClassConstant(_) => "class constant",
+            Self::ModuleConstant(_) => "module constant",
         }
     }
 }

--- a/artichoke-backend/src/extn/core/random/mruby.rs
+++ b/artichoke-backend/src/extn/core/random/mruby.rs
@@ -35,21 +35,7 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     let default = default
         .try_into_ruby(interp, None)
         .map_err(|_| NotDefinedError::class_constant("Random::DEFAULT"))?;
-    let borrow = interp.0.borrow();
-    let mut rclass = borrow
-        .class_spec::<random::Random>()
-        .and_then(|spec| spec.rclass(interp.0.borrow().mrb))
-        .ok_or_else(|| NotDefinedError::class("Random"))?;
-    let mrb = borrow.mrb;
-    unsafe {
-        sys::mrb_define_const(
-            mrb,
-            rclass.as_mut(),
-            b"DEFAULT\0".as_ptr() as *const i8,
-            default.inner(),
-        );
-    }
-    drop(borrow);
+    interp.define_class_constant::<random::Random>("DEFAULT", default)?;
     let _ = interp.eval(&include_bytes!("random.rb")[..])?;
     trace!("Patched Random onto interpreter");
     Ok(())

--- a/artichoke-backend/src/extn/mod.rs
+++ b/artichoke-backend/src/extn/mod.rs
@@ -20,52 +20,45 @@ pub const ARTICHOKE_COMPILER_VERSION: &str = env!("ARTICHOKE_COMPILER_VERSION");
 
 pub const INPUT_RECORD_SEPARATOR: &str = "\n";
 
-macro_rules! global_const {
-    ($interp:expr, $constant:ident) => {{
-        let mrb = $interp.0.borrow().mrb;
-        let name = concat!(stringify!($constant), "\0");
-        let value = $interp.convert_mut($constant);
-        unsafe {
-            sys::mrb_define_global_const(mrb, name.as_ptr() as *const i8, value.inner());
-        }
-    }};
-    ($interp:expr, $constant:ident, $value:expr) => {{
-        let mrb = $interp.0.borrow().mrb;
-        let name = concat!(stringify!($constant), "\0");
-        let value = $interp.convert_mut($value);
-        unsafe {
-            sys::mrb_define_global_const(mrb, name.as_ptr() as *const i8, value.inner());
-        }
-    }};
-    ($interp:expr, $constant:ident as Int) => {{
-        let mrb = $interp.0.borrow().mrb;
-        let constant = $constant
-            .parse::<Int>()
-            .map_err(|_| NotDefinedError::global_constant(stringify!($constant)))?;
-        let name = concat!(stringify!($constant), "\0");
-        let value = $interp.convert(constant);
-        unsafe {
-            sys::mrb_define_global_const(mrb, name.as_ptr() as *const i8, value.inner());
-        }
-    }};
-}
-
 pub fn init(interp: &mut Artichoke, backend_name: &str) -> InitializeResult<()> {
+    let copyright = interp.convert_mut(RUBY_COPYRIGHT);
+    interp.define_global_constant("RUBY_COPYRIGHT", copyright)?;
+
+    let description = interp.convert_mut(RUBY_DESCRIPTION);
+    interp.define_global_constant("RUBY_DESCRIPTION", description)?;
+
     let mut engine = String::from(RUBY_ENGINE);
     engine.push('-');
     engine.push_str(backend_name);
+    let engine = interp.convert_mut(engine);
+    interp.define_global_constant("RUBY_ENGINE", engine)?;
 
-    global_const!(interp, RUBY_COPYRIGHT);
-    global_const!(interp, RUBY_DESCRIPTION);
-    global_const!(interp, RUBY_ENGINE, engine);
-    global_const!(interp, RUBY_ENGINE_VERSION);
-    global_const!(interp, RUBY_PATCHLEVEL as Int);
-    global_const!(interp, RUBY_PLATFORM);
-    global_const!(interp, RUBY_RELEASE_DATE);
-    global_const!(interp, RUBY_REVISION as Int);
-    global_const!(interp, RUBY_VERSION);
+    let engine_version = interp.convert_mut(RUBY_ENGINE_VERSION);
+    interp.define_global_constant("RUBY_ENGINE_VERSION", engine_version)?;
 
-    global_const!(interp, ARTICHOKE_COMPILER_VERSION);
+    let patchlevel = RUBY_PATCHLEVEL
+        .parse::<Int>()
+        .map_err(|_| NotDefinedError::global_constant("RUBY_PATCHLEVEL"))?;
+    let patchlevel = interp.convert(patchlevel);
+    interp.define_global_constant("RUBY_PATCHLEVEL", patchlevel)?;
+
+    let platform = interp.convert_mut(RUBY_PLATFORM);
+    interp.define_global_constant("RUBY_PLATFORM", platform)?;
+
+    let release_date = interp.convert_mut(RUBY_RELEASE_DATE);
+    interp.define_global_constant("RUBY_RELEASE_DATE", release_date)?;
+
+    let revision = RUBY_REVISION
+        .parse::<Int>()
+        .map_err(|_| NotDefinedError::global_constant("RUBY_REVISION"))?;
+    let revision = interp.convert(revision);
+    interp.define_global_constant("RUBY_REVISION", revision)?;
+
+    let version = interp.convert_mut(RUBY_VERSION);
+    interp.define_global_constant("RUBY_VERSION", version)?;
+
+    let compiler_version = interp.convert_mut(ARTICHOKE_COMPILER_VERSION);
+    interp.define_global_constant("ARTICHOKE_COMPILER_VERSION", compiler_version)?;
 
     core::init(interp)?;
     stdlib::init(interp)?;

--- a/artichoke-backend/src/extn/prelude.rs
+++ b/artichoke-backend/src/extn/prelude.rs
@@ -17,8 +17,8 @@ pub use crate::sys;
 pub use crate::types::{Float, Int, Ruby};
 pub use crate::value::{Block, Value};
 pub use crate::{
-    Artichoke, Convert, ConvertMut, Eval, Intern, LoadSources, TryConvert, TryConvertMut,
-    ValueLike, Warn,
+    Artichoke, Convert, ConvertMut, DefineConstant, Eval, Intern, LoadSources, TryConvert,
+    TryConvertMut, ValueLike, Warn,
 };
 
 /// Type alias for errors returned from `init` functions in

--- a/artichoke-backend/src/lib.rs
+++ b/artichoke-backend/src/lib.rs
@@ -107,6 +107,7 @@ use std::rc::Rc;
 pub mod macros;
 
 pub mod class;
+mod constant;
 pub mod convert;
 pub mod def;
 mod eval;
@@ -136,6 +137,7 @@ mod test;
 
 pub use artichoke_core as core;
 
+pub use artichoke_core::constant::DefineConstant;
 pub use artichoke_core::convert::Convert;
 pub use artichoke_core::convert::ConvertMut;
 pub use artichoke_core::convert::TryConvert;

--- a/artichoke-core/src/constant.rs
+++ b/artichoke-core/src/constant.rs
@@ -1,0 +1,46 @@
+//! Define constants on an interpreter.
+//!
+//! Constants can be an arbitrary Ruby value. Constants can be defined globally,
+//! on a class, or on a module.
+
+use std::error;
+
+use crate::value::Value;
+
+/// Deifne constants on an interprter.
+///
+/// Constants can be an arbitrary Ruby value. Constants can be defined globally,
+/// on a class, or on a module.
+#[allow(clippy::module_name_repetitions)]
+pub trait DefineConstant {
+    /// Concrete type for Ruby values.
+    type Value: Value;
+
+    /// Concrete error type for fallible operations.
+    type Error: error::Error;
+
+    /// Define a global constant.
+    fn define_global_constant(
+        &mut self,
+        constant: &str,
+        value: Self::Value,
+    ) -> Result<(), Self::Error>;
+
+    /// Define a class constant.
+    ///
+    /// The class is specified by the type parameter `T`.
+    fn define_class_constant<T: 'static>(
+        &mut self,
+        constant: &str,
+        value: Self::Value,
+    ) -> Result<(), Self::Error>;
+
+    /// Define a module constant.
+    ///
+    /// The class is specified by the type parameter `T`.
+    fn define_module_constant<T: 'static>(
+        &mut self,
+        constant: &str,
+        value: Self::Value,
+    ) -> Result<(), Self::Error>;
+}

--- a/artichoke-core/src/constant.rs
+++ b/artichoke-core/src/constant.rs
@@ -20,6 +20,12 @@ pub trait DefineConstant {
     type Error: error::Error;
 
     /// Define a global constant.
+    ///
+    /// # Errors
+    ///
+    /// If the given constant name is not valid, an error is returned.
+    ///
+    /// If the interpreter cannot define the constant, an error is returned.
     fn define_global_constant(
         &mut self,
         constant: &str,
@@ -29,6 +35,14 @@ pub trait DefineConstant {
     /// Define a class constant.
     ///
     /// The class is specified by the type parameter `T`.
+    ///
+    /// # Errors
+    ///
+    /// If the class named by type `T` is not defined, an error is returned.
+    ///
+    /// If the given constant name is not valid, an error is returned.
+    ///
+    /// If the interpreter cannot define the constant, an error is returned.
     fn define_class_constant<T: 'static>(
         &mut self,
         constant: &str,
@@ -38,6 +52,14 @@ pub trait DefineConstant {
     /// Define a module constant.
     ///
     /// The class is specified by the type parameter `T`.
+    ///
+    /// # Errors
+    ///
+    /// If the module named by type `T` is not defined, an error is returned.
+    ///
+    /// If the given constant name is not valid, an error is returned.
+    ///
+    /// If the interpreter cannot define the constant, an error is returned.
     fn define_module_constant<T: 'static>(
         &mut self,
         constant: &str,

--- a/artichoke-core/src/lib.rs
+++ b/artichoke-core/src/lib.rs
@@ -32,6 +32,7 @@
 //!
 //! artichoke-core is licensed with the MIT License (c) Ryan Lopopolo.
 
+pub mod constant;
 pub mod convert;
 pub mod eval;
 pub mod file;


### PR DESCRIPTION
`DefineConstant` exposes APIs for defining global constants as well as
constants on class or module values.

Use them in extn global constants and `Random::DEFAULT`. This commit
removes the macro-based const definition approach in `extn::init`.

Related to GH-442.