### PR TITLE
Switch over to GitHub actions for rustdoc publish

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -406,27 +406,6 @@ jobs:
             -W clippy::todo \
             -W clippy::unimplemented \
             -W clippy::unreachable || :
-  deploy:
-    docker:
-      - image: node:lts
-    steps:
-      - checkout
-      - add_ssh_keys:
-          fingerprints:
-            - "55:f0:9b:74:3a:ff:3b:33:1e:bc:98:e7:63:6c:ed:bd"
-      - attach_workspace:
-          at: target
-      - run:
-          name: Copy doc asset overrides
-          command: cp assets/* target/doc
-      - run: npm install -g gh-pages@2.1.1
-      - run:
-          name: Deploy docs to gh-pages branch
-          command: |
-            gh-pages \
-              --user "Artichoke CI <ci@artichokeruby.org>" \
-              --message "[skip ci] build docs" \
-              --dist target/doc
 workflows:
   version: 2
   build:
@@ -437,12 +416,3 @@ workflows:
       - linter
       - audit
       - restriction
-      - deploy:
-          requires:
-            - x86_64-linux
-            - x86_64-windows
-            - linter
-            - audit
-          filters:
-            branches:
-              only: master

--- a/.github/workflows/rustdoc.yaml
+++ b/.github/workflows/rustdoc.yaml
@@ -44,7 +44,7 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3
         if: github.ref == 'refs/heads/master'
         with:
-          deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./target/doc
           publish_branch: gh-pages
           user_name: artichoke-ci


### PR DESCRIPTION
Fix a missing credential for peaceiris/actions-gh-pages and remove the
CircleCI job.