### PR TITLE
Trigger workflows on push event

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -1,9 +1,5 @@
 name: Audit
-on:
-  pull_request:
-  push:
-    branches:
-      - master
+on: [push]
 jobs:
   rust:
     runs-on: ubuntu-latest

--- a/.github/workflows/rustdoc.yaml
+++ b/.github/workflows/rustdoc.yaml
@@ -1,9 +1,5 @@
 name: Documentation
-on:
-  pull_request:
-  push:
-    branches:
-      - master
+on: [push]
 jobs:
   rustdoc:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Triggering on pull_request meant some jobs only got kicked off
when PRs were 'synchronized', but not on initial creation.