### PR TITLE
Clean up string module

### DIFF
--- a/artichoke-backend/src/exception.rs
+++ b/artichoke-backend/src/exception.rs
@@ -152,10 +152,11 @@ impl CaughtException {
 }
 
 impl fmt::Display for CaughtException {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, mut f: &mut fmt::Formatter) -> fmt::Result {
         let classname = self.name();
         write!(f, "{} (", classname)?;
-        string::escape_unicode(f, self.message()).map_err(string::WriteError::into_inner)?;
+        string::format_unicode_debug_into(&mut f, self.message())
+            .map_err(string::WriteError::into_inner)?;
         write!(f, ")")
     }
 }

--- a/artichoke-backend/src/extn/core/exception/mod.rs
+++ b/artichoke-backend/src/extn/core/exception/mod.rs
@@ -350,10 +350,10 @@ macro_rules! ruby_exception_impl {
         }
 
         impl fmt::Display for $exception {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            fn fmt(&self, mut f: &mut fmt::Formatter) -> fmt::Result {
                 let classname = self.name();
                 write!(f, "{} (", classname)?;
-                string::escape_unicode(f, self.message())
+                string::format_unicode_debug_into(&mut f, self.message())
                     .map_err(string::WriteError::into_inner)?;
                 write!(f, ")")
             }

--- a/artichoke-backend/src/extn/core/kernel/integer.rs
+++ b/artichoke-backend/src/extn/core/kernel/integer.rs
@@ -180,7 +180,7 @@ pub fn method(interp: &Artichoke, arg: Value, radix: Option<Value>) -> Result<Va
 
 fn invalid_value_err(interp: &Artichoke, arg: &[u8]) -> Result<ArgumentError, Exception> {
     let mut message = String::from(r#"invalid value for Integer(): ""#);
-    string::escape_unicode(&mut message, arg)?;
+    string::format_unicode_debug_into(&mut message, arg)?;
     message.push('"');
     Ok(ArgumentError::new(interp, message))
 }

--- a/artichoke-backend/src/extn/core/kernel/require.rs
+++ b/artichoke-backend/src/extn/core/kernel/require.rs
@@ -58,7 +58,7 @@ pub fn load(interp: &mut Artichoke, filename: Value) -> Result<Value, Exception>
     }
     let _ = interp.pop_context();
     let mut logged_filename = String::new();
-    string::escape_unicode(&mut logged_filename, filename)?;
+    string::format_unicode_debug_into(&mut logged_filename, filename)?;
     trace!(r#"Successful load of "{}" at {:?}"#, logged_filename, path,);
     Ok(interp.convert(true))
 }
@@ -131,7 +131,7 @@ pub fn require(
                 return Err(Exception::from(load_error(interp, b"internal error")?));
             }
             let mut logged_filename = String::new();
-            string::escape_unicode(&mut logged_filename, filename)?;
+            string::format_unicode_debug_into(&mut logged_filename, filename)?;
             trace!(
                 r#"Successful require of "{}" at {:?}"#,
                 logged_filename,
@@ -187,7 +187,7 @@ pub fn require(
                     return Err(Exception::from(load_error(interp, b"internal error")?));
                 }
                 let mut logged_filename = String::new();
-                string::escape_unicode(&mut logged_filename, filename)?;
+                string::format_unicode_debug_into(&mut logged_filename, filename)?;
                 trace!(
                     r#"Successful require of "{}" at {:?}"#,
                     logged_filename,
@@ -243,7 +243,7 @@ pub fn require(
         return Err(Exception::from(load_error(interp, b"internal error")?));
     }
     let mut logged_filename = String::new();
-    string::escape_unicode(&mut logged_filename, filename)?;
+    string::format_unicode_debug_into(&mut logged_filename, filename)?;
     trace!(
         r#"Successful require of "{}" at {:?}"#,
         logged_filename,
@@ -273,6 +273,6 @@ pub fn require_relative(interp: &mut Artichoke, file: Value) -> Result<Value, Ex
 
 fn load_error(interp: &Artichoke, filename: &[u8]) -> Result<LoadError, Exception> {
     let mut message = String::from("cannot load such file -- ");
-    string::escape_unicode(&mut message, filename)?;
+    string::format_unicode_debug_into(&mut message, filename)?;
     Ok(LoadError::new(interp, message))
 }

--- a/artichoke-backend/src/extn/core/matchdata/element_reference.rs
+++ b/artichoke-backend/src/extn/core/matchdata/element_reference.rs
@@ -119,7 +119,7 @@ pub fn method(
                 Ok(interp.convert_mut(group))
             } else {
                 let mut message = String::from("undefined group name reference: \"");
-                string::escape_unicode(&mut message, name)?;
+                string::format_unicode_debug_into(&mut message, name)?;
                 message.push('"');
                 Err(Exception::from(IndexError::new(interp, message)))
             }

--- a/artichoke-frontend/src/bin/artichoke.rs
+++ b/artichoke-frontend/src/bin/artichoke.rs
@@ -32,12 +32,13 @@
 //!     <programfile>
 //! ```
 
-use artichoke_frontend::ruby::{self, Error};
+use artichoke_frontend::ruby;
+use std::io::{self, Write};
+use std::process;
 
 fn main() {
-    match ruby::entrypoint() {
-        Ok(_) => {}
-        Err(Error::Ruby(err)) => eprintln!("{}", err),
-        Err(Error::Fail(err)) => eprintln!("{}", err),
+    if let Err(err) = ruby::entrypoint() {
+        let _ = writeln!(io::stderr(), "{}", err);
+        process::exit(1);
     }
 }


### PR DESCRIPTION
- Rename `string::escape_unicode` to
  `string::format_unicode_debug_into`.
- Rename writer type parameters to `W` for int and unicode debug
  formatters.
- Remove `&mut` from writer parameter.
- Remove the `impl From<fmt::Error> for WriteError` conversion.
- Sync docs for `format_unicode_debug_into` from BurntSushi/bstr#37.

While fixing up the use of `escape_unicode` in `artichoke-frontend`, I
got a bit distracted and let the scope of this change creep.

- Unify Ruby CLI errors on `Exception`. Imports `IOError` and
  `LoadError` to manually construct some errors from strings.
- Do not use `eprintln!` in `artichoke` binary to suppress broken pipe
  errors instead of panicking.
- Set exit code to 1 on error in `artichoke` binary.
