### PR TITLE
Use constant definition APIs from artichoke-core in extn

### DIFF
--- a/artichoke-backend/src/extn/core/float/mod.rs
+++ b/artichoke-backend/src/extn/core/float/mod.rs
@@ -8,8 +8,8 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     let spec = class::Spec::new("Float", None, None)?;
     interp.0.borrow_mut().def_class::<Float>(spec);
     let _ = interp.eval(&include_bytes!("float.rb")[..])?;
-    // TODO: Add proper constant defs to class::Spec, see GH-158.
-    let _ = interp.eval(format!("class Float; EPSILON={} end", Float::EPSILON).as_bytes())?;
+    let epsilon = interp.convert_mut(Float::EPSILON);
+    interp.define_class_constant::<Float>("EPSILON", epsilon)?;
     trace!("Patched Float onto interpreter");
     Ok(())
 }

--- a/artichoke-backend/src/extn/core/regexp/mruby.rs
+++ b/artichoke-backend/src/extn/core/regexp/mruby.rs
@@ -33,15 +33,16 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
         .define()?;
     interp.0.borrow_mut().def_class::<regexp::Regexp>(spec);
     let _ = interp.eval(&include_bytes!("regexp.rb")[..])?;
-    // TODO: Add proper constant defs to class::Spec, see GH-27.
-    let _ = interp.eval(format!(
-        "class Regexp; IGNORECASE = {}; EXTENDED = {}; MULTILINE = {}; FIXEDENCODING = {}; NOENCODING = {}; end",
-        regexp::IGNORECASE,
-        regexp::EXTENDED,
-        regexp::MULTILINE,
-        regexp::FIXEDENCODING,
-        regexp::NOENCODING,
-    ).as_bytes())?;
+    let ignorecase = interp.convert(regexp::IGNORECASE);
+    interp.define_class_constant::<regexp::Regexp>("IGNORECASE", ignorecase)?;
+    let extended = interp.convert(regexp::EXTENDED);
+    interp.define_class_constant::<regexp::Regexp>("EXTENDED", extended)?;
+    let multiline = interp.convert(regexp::MULTILINE);
+    interp.define_class_constant::<regexp::Regexp>("MULTILINE", multiline)?;
+    let fixed_encoding = interp.convert(regexp::FIXEDENCODING);
+    interp.define_class_constant::<regexp::Regexp>("FIXEDENCODING", fixed_encoding)?;
+    let no_encoding = interp.convert(regexp::NOENCODING);
+    interp.define_class_constant::<regexp::Regexp>("NOENCODING", no_encoding)?;
     trace!("Patched Regexp onto interpreter");
     Ok(())
 }


### PR DESCRIPTION
`Float` and `Regexp` both define constants by string formatting `i64`s
and `f64`s  into a code string with `format!` and evaling it on the
interpreter. This is not ideal.

GH-526 added constant definition APIs to `artichoke-core` and
implemented them for `artichoke-backend`. This commit wires it up in
`extn`. The resulting code has more localized failures - errors are
reported on the granularity of defining a single constant. The constant
values are converted into proper `Value`s directly from their native
Rust form.

See also GH-27, the issue referenced by both of the TODOs (the TODO in
`float.rs` refers to the issue number from lopopolo/ferrocarril before
it was migrated to the artichoke/artichoke repo).