### PR TITLE
Remove RubyException::box_clone

### DIFF
--- a/artichoke-backend/src/convert.rs
+++ b/artichoke-backend/src/convert.rs
@@ -80,10 +80,6 @@ impl fmt::Display for UnboxRubyError {
 impl error::Error for UnboxRubyError {}
 
 impl RubyException for UnboxRubyError {
-    fn box_clone(&self) -> Box<dyn RubyException> {
-        Box::new(*self)
-    }
-
     fn message(&self) -> &[u8] {
         &b"Failed to convert from Ruby value to Rust type"[..]
     }
@@ -92,7 +88,7 @@ impl RubyException for UnboxRubyError {
         String::from("TypeError")
     }
 
-    fn vm_backtrace(&self, interp: &Artichoke) -> Option<Vec<Vec<u8>>> {
+    fn vm_backtrace(&self, interp: &mut Artichoke) -> Option<Vec<Vec<u8>>> {
         let _ = interp;
         None
     }
@@ -155,10 +151,6 @@ impl fmt::Display for BoxIntoRubyError {
 impl error::Error for BoxIntoRubyError {}
 
 impl RubyException for BoxIntoRubyError {
-    fn box_clone(&self) -> Box<dyn RubyException> {
-        Box::new(*self)
-    }
-
     fn message(&self) -> &[u8] {
         &b"Failed to convert from Rust type to Ruby value"[..]
     }
@@ -167,7 +159,7 @@ impl RubyException for BoxIntoRubyError {
         String::from("TypeError")
     }
 
-    fn vm_backtrace(&self, interp: &Artichoke) -> Option<Vec<Vec<u8>>> {
+    fn vm_backtrace(&self, interp: &mut Artichoke) -> Option<Vec<Vec<u8>>> {
         let _ = interp;
         None
     }

--- a/artichoke-backend/src/def.rs
+++ b/artichoke-backend/src/def.rs
@@ -215,10 +215,6 @@ impl fmt::Display for ConstantNameError {
 impl error::Error for ConstantNameError {}
 
 impl RubyException for ConstantNameError {
-    fn box_clone(&self) -> Box<dyn RubyException> {
-        Box::new(self.clone())
-    }
-
     fn message(&self) -> &[u8] {
         &b"Invalid constant name contained a NUL byte"[..]
     }
@@ -227,7 +223,7 @@ impl RubyException for ConstantNameError {
         String::from("NameError")
     }
 
-    fn vm_backtrace(&self, interp: &Artichoke) -> Option<Vec<Vec<u8>>> {
+    fn vm_backtrace(&self, interp: &mut Artichoke) -> Option<Vec<Vec<u8>>> {
         let _ = interp;
         None
     }
@@ -364,10 +360,6 @@ impl fmt::Display for NotDefinedError {
 impl error::Error for NotDefinedError {}
 
 impl RubyException for NotDefinedError {
-    fn box_clone(&self) -> Box<dyn RubyException> {
-        Box::new(self.clone())
-    }
-
     fn message(&self) -> &[u8] {
         &b"Class-like not defined"[..]
     }
@@ -376,7 +368,7 @@ impl RubyException for NotDefinedError {
         String::from("ScriptError")
     }
 
-    fn vm_backtrace(&self, interp: &Artichoke) -> Option<Vec<Vec<u8>>> {
+    fn vm_backtrace(&self, interp: &mut Artichoke) -> Option<Vec<Vec<u8>>> {
         let _ = interp;
         None
     }

--- a/artichoke-backend/src/exception.rs
+++ b/artichoke-backend/src/exception.rs
@@ -10,10 +10,6 @@ use crate::{Artichoke, ValueLike};
 pub struct Exception(Box<dyn RubyException>);
 
 impl RubyException for Exception {
-    fn box_clone(&self) -> Box<dyn RubyException> {
-        self.0.box_clone()
-    }
-
     fn message(&self) -> &[u8] {
         self.0.message()
     }
@@ -23,7 +19,7 @@ impl RubyException for Exception {
         self.0.name()
     }
 
-    fn vm_backtrace(&self, interp: &Artichoke) -> Option<Vec<Vec<u8>>> {
+    fn vm_backtrace(&self, interp: &mut Artichoke) -> Option<Vec<Vec<u8>>> {
         self.0.vm_backtrace(interp)
     }
 
@@ -80,13 +76,7 @@ pub unsafe fn raise(mut interp: Artichoke, exception: impl RubyException + fmt::
 /// [`exception::raise`](raise). Rust code can re-raise a trait object to
 /// propagate exceptions from native code back into the interpreter.
 #[allow(clippy::module_name_repetitions)]
-pub trait RubyException: error::Error
-where
-    Self: 'static,
-{
-    /// Clone `self` and return a new boxed trait object.
-    fn box_clone(&self) -> Box<dyn RubyException>;
-
+pub trait RubyException: error::Error + 'static {
     /// Message of the `Exception`.
     ///
     /// This value is a byte slice since Ruby `String`s are equivalent to
@@ -97,17 +87,13 @@ where
     fn name(&self) -> String;
 
     /// Optional backtrace specified by a `Vec` of frames.
-    fn vm_backtrace(&self, interp: &Artichoke) -> Option<Vec<Vec<u8>>>;
+    fn vm_backtrace(&self, interp: &mut Artichoke) -> Option<Vec<Vec<u8>>>;
 
     /// Return a raiseable [`sys::mrb_value`].
     fn as_mrb_value(&self, interp: &mut Artichoke) -> Option<sys::mrb_value>;
 }
 
 impl RubyException for Box<dyn RubyException> {
-    fn box_clone(&self) -> Box<dyn RubyException> {
-        self.as_ref().box_clone()
-    }
-
     fn message(&self) -> &[u8] {
         self.as_ref().message()
     }
@@ -116,7 +102,7 @@ impl RubyException for Box<dyn RubyException> {
         self.as_ref().name()
     }
 
-    fn vm_backtrace(&self, interp: &Artichoke) -> Option<Vec<Vec<u8>>> {
+    fn vm_backtrace(&self, interp: &mut Artichoke) -> Option<Vec<Vec<u8>>> {
         self.as_ref().vm_backtrace(interp)
     }
 
@@ -164,10 +150,6 @@ impl fmt::Display for CaughtException {
 impl error::Error for CaughtException {}
 
 impl RubyException for CaughtException {
-    fn box_clone(&self) -> Box<dyn RubyException> {
-        Box::new(self.clone())
-    }
-
     fn message(&self) -> &[u8] {
         self.message.as_slice()
     }
@@ -176,7 +158,7 @@ impl RubyException for CaughtException {
         self.name.clone()
     }
 
-    fn vm_backtrace(&self, interp: &Artichoke) -> Option<Vec<Vec<u8>>> {
+    fn vm_backtrace(&self, interp: &mut Artichoke) -> Option<Vec<Vec<u8>>> {
         let _ = interp;
         self.value.funcall("backtrace", &[], None).ok()
     }

--- a/artichoke-backend/src/exception_handler.rs
+++ b/artichoke-backend/src/exception_handler.rs
@@ -67,7 +67,7 @@ mod tests {
         assert_eq!(&b"waffles"[..], err.message());
         assert_eq!(
             Some(vec![Vec::from(&b"(eval):1"[..])]),
-            err.vm_backtrace(&interp)
+            err.vm_backtrace(&mut interp)
         );
     }
 
@@ -77,7 +77,7 @@ mod tests {
         let err = interp.eval(b"def bad; (; end").unwrap_err();
         assert_eq!("SyntaxError", err.name().as_str());
         assert_eq!(&b"syntax error"[..], err.message());
-        assert_eq!(None, err.vm_backtrace(&interp));
+        assert_eq!(None, err.vm_backtrace(&mut interp));
     }
 
     #[test]

--- a/artichoke-backend/src/extn/core/exception/mod.rs
+++ b/artichoke-backend/src/extn/core/exception/mod.rs
@@ -323,10 +323,6 @@ macro_rules! ruby_exception_impl {
         }
 
         impl RubyException for $exception {
-            fn box_clone(&self) -> Box<dyn RubyException> {
-                Box::new(self.clone())
-            }
-
             fn message(&self) -> &[u8] {
                 self.message.as_ref()
             }
@@ -335,7 +331,7 @@ macro_rules! ruby_exception_impl {
                 String::from(stringify!($exception))
             }
 
-            fn vm_backtrace(&self, interp: &Artichoke) -> Option<Vec<Vec<u8>>> {
+            fn vm_backtrace(&self, interp: &mut Artichoke) -> Option<Vec<Vec<u8>>> {
                 let _ = interp;
                 None
             }
@@ -440,7 +436,7 @@ mod tests {
         assert_eq!(Vec::from(&b"something went wrong"[..]), err.message());
         assert_eq!(
             Some(vec![Vec::from(&b"(eval):1"[..])]),
-            err.vm_backtrace(&interp)
+            err.vm_backtrace(&mut interp)
         );
     }
 }

--- a/artichoke-backend/src/extn/core/kernel/mod.rs
+++ b/artichoke-backend/src/extn/core/kernel/mod.rs
@@ -181,7 +181,7 @@ mod tests {
             err.message()
         );
         let expected = vec![Vec::from(&b"(eval):1"[..])];
-        assert_eq!(Some(expected), err.vm_backtrace(&interp),);
+        assert_eq!(Some(expected), err.vm_backtrace(&mut interp),);
     }
 
     #[test]
@@ -215,7 +215,7 @@ mod tests {
         let err = interp.eval(b"require '/src'").unwrap_err();
         assert_eq!(&b"cannot load such file -- /src"[..], err.message());
         let expected = vec![Vec::from(&b"(eval):1"[..])];
-        assert_eq!(Some(expected), err.vm_backtrace(&interp),);
+        assert_eq!(Some(expected), err.vm_backtrace(&mut interp),);
     }
 
     #[test]

--- a/artichoke-backend/src/extn/core/thread.rs
+++ b/artichoke-backend/src/extn/core/thread.rs
@@ -192,6 +192,6 @@ end.join
             Vec::from(&b"/src/lib/thread.rb:122:in initialize"[..]),
             Vec::from(&b"(eval):2"[..]),
         ];
-        assert_eq!(Some(expected_backtrace), err.vm_backtrace(&interp));
+        assert_eq!(Some(expected_backtrace), err.vm_backtrace(&mut interp));
     }
 }

--- a/artichoke-backend/src/ffi.rs
+++ b/artichoke-backend/src/ffi.rs
@@ -92,10 +92,6 @@ impl fmt::Display for InterpreterExtractError {
 impl error::Error for InterpreterExtractError {}
 
 impl RubyException for InterpreterExtractError {
-    fn box_clone(&self) -> Box<dyn RubyException> {
-        Box::new(*self)
-    }
-
     fn message(&self) -> &[u8] {
         &b"Failed to extract Artichoke Ruby interpreter from mrb_state"[..]
     }
@@ -104,7 +100,7 @@ impl RubyException for InterpreterExtractError {
         String::from("fatal")
     }
 
-    fn vm_backtrace(&self, interp: &Artichoke) -> Option<Vec<Vec<u8>>> {
+    fn vm_backtrace(&self, interp: &mut Artichoke) -> Option<Vec<Vec<u8>>> {
         let _ = interp;
         None
     }
@@ -170,10 +166,6 @@ impl fmt::Display for ConvertBytesError {
 impl error::Error for ConvertBytesError {}
 
 impl RubyException for ConvertBytesError {
-    fn box_clone(&self) -> Box<dyn RubyException> {
-        Box::new(*self)
-    }
-
     fn message(&self) -> &[u8] {
         &b"invalid byte sequence"[..]
     }
@@ -182,7 +174,7 @@ impl RubyException for ConvertBytesError {
         String::from("ArgumentError")
     }
 
-    fn vm_backtrace(&self, interp: &Artichoke) -> Option<Vec<Vec<u8>>> {
+    fn vm_backtrace(&self, interp: &mut Artichoke) -> Option<Vec<Vec<u8>>> {
         let _ = interp;
         None
     }

--- a/artichoke-backend/src/interpreter.rs
+++ b/artichoke-backend/src/interpreter.rs
@@ -89,10 +89,6 @@ impl fmt::Display for InterpreterAllocError {
 impl error::Error for InterpreterAllocError {}
 
 impl RubyException for InterpreterAllocError {
-    fn box_clone(&self) -> Box<dyn RubyException> {
-        Box::new(*self)
-    }
-
     fn message(&self) -> &[u8] {
         &b"Failed to allocate Artichoke Ruby interpreter"[..]
     }
@@ -101,7 +97,7 @@ impl RubyException for InterpreterAllocError {
         String::from("fatal")
     }
 
-    fn vm_backtrace(&self, interp: &Artichoke) -> Option<Vec<Vec<u8>>> {
+    fn vm_backtrace(&self, interp: &mut Artichoke) -> Option<Vec<Vec<u8>>> {
         let _ = interp;
         None
     }

--- a/artichoke-backend/src/string.rs
+++ b/artichoke-backend/src/string.rs
@@ -92,10 +92,6 @@ impl error::Error for WriteError {
 }
 
 impl RubyException for WriteError {
-    fn box_clone(&self) -> Box<dyn RubyException> {
-        Box::new(self.clone())
-    }
-
     fn message(&self) -> &[u8] {
         &b"Unable to escape Unicode message"[..]
     }
@@ -104,7 +100,7 @@ impl RubyException for WriteError {
         String::from("fatal")
     }
 
-    fn vm_backtrace(&self, interp: &Artichoke) -> Option<Vec<Vec<u8>>> {
+    fn vm_backtrace(&self, interp: &mut Artichoke) -> Option<Vec<Vec<u8>>> {
         let _ = interp;
         None
     }

--- a/artichoke-backend/src/value.rs
+++ b/artichoke-backend/src/value.rs
@@ -452,10 +452,6 @@ impl fmt::Display for ArgCountError {
 impl error::Error for ArgCountError {}
 
 impl RubyException for ArgCountError {
-    fn box_clone(&self) -> Box<dyn RubyException> {
-        Box::new(*self)
-    }
-
     fn message(&self) -> &[u8] {
         &b"Too many arguments"[..]
     }
@@ -464,7 +460,7 @@ impl RubyException for ArgCountError {
         String::from("ArgumentError")
     }
 
-    fn vm_backtrace(&self, interp: &Artichoke) -> Option<Vec<Vec<u8>>> {
+    fn vm_backtrace(&self, interp: &mut Artichoke) -> Option<Vec<Vec<u8>>> {
         let _ = interp;
         None
     }

--- a/artichoke-backend/tests/leak_unbounded_arena_growth.rs
+++ b/artichoke-backend/tests/leak_unbounded_arena_growth.rs
@@ -48,7 +48,7 @@ end
         let arena = interp.create_arena_savepoint();
         let result = interp.eval(code).unwrap_err();
         arena.restore();
-        assert_eq!(expected, result.vm_backtrace(&interp));
+        assert_eq!(expected, result.vm_backtrace(&mut interp));
         drop(result);
         interp.incremental_gc();
     });

--- a/artichoke-frontend/src/repl.rs
+++ b/artichoke-frontend/src/repl.rs
@@ -157,7 +157,7 @@ pub fn run(
                         output.write_all(result.as_slice())?;
                     }
                     Err(exc) => {
-                        if let Some(backtrace) = exc.vm_backtrace(&interp) {
+                        if let Some(backtrace) = exc.vm_backtrace(&mut interp) {
                             writeln!(
                                 error,
                                 "{} (most recent call last)",


### PR DESCRIPTION
This API was unused.

Modify `RubyException::vm_backtrace` to take `&mut Artichoke`.