### PR TITLE
Refactor output capturing at the State

### DIFF
--- a/artichoke-backend/src/state/output.rs
+++ b/artichoke-backend/src/state/output.rs
@@ -95,3 +95,28 @@ impl<'a> Output for &'a mut Captured {
         self.stderr.write_all(bytes)
     }
 }
+
+#[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub struct Null;
+
+impl Null {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Output for Null {
+    fn backend_name(&self) -> &str {
+        "Null"
+    }
+
+    fn write_stdout(&mut self, bytes: &[u8]) -> io::Result<()> {
+        let _ = bytes;
+        Ok(())
+    }
+
+    fn write_stderr(&mut self, bytes: &[u8]) -> io::Result<()> {
+        let _ = bytes;
+        Ok(())
+    }
+}

--- a/artichoke-backend/src/state/output.rs
+++ b/artichoke-backend/src/state/output.rs
@@ -18,12 +18,16 @@ pub trait Output: Send + Sync {
     }
 }
 
-downcast!(dyn Output);
+#[allow(clippy::missing_safety_doc)]
+mod internal {
+    downcast!(dyn super::Output);
+}
 
 #[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq)]
 pub struct Process;
 
 impl Process {
+    #[must_use]
     pub fn new() -> Self {
         Self
     }
@@ -50,6 +54,7 @@ pub struct Captured {
 }
 
 impl Captured {
+    #[must_use]
     pub fn new() -> Self {
         Self::default()
     }
@@ -59,10 +64,12 @@ impl Captured {
         self.stderr.clear();
     }
 
+    #[must_use]
     pub fn stdout(&self) -> &[u8] {
         self.stdout.as_slice()
     }
 
+    #[must_use]
     pub fn stderr(&self) -> &[u8] {
         self.stderr.as_slice()
     }
@@ -100,6 +107,7 @@ impl<'a> Output for &'a mut Captured {
 pub struct Null;
 
 impl Null {
+    #[must_use]
     pub fn new() -> Self {
         Self
     }

--- a/artichoke-backend/src/state/output.rs
+++ b/artichoke-backend/src/state/output.rs
@@ -18,6 +18,8 @@ pub trait Output: 'static + Send + Sync {
     }
 }
 
+downcast!(dyn Output);
+
 #[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq)]
 pub struct Process;
 

--- a/artichoke-backend/src/state/output.rs
+++ b/artichoke-backend/src/state/output.rs
@@ -1,0 +1,81 @@
+use std::io::{self, Write};
+
+pub trait Output: 'static + Send + Sync {
+    fn backend_name(&self) -> &str;
+
+    fn write_stdout(&mut self, bytes: &[u8]) -> io::Result<()>;
+
+    fn write_stderr(&mut self, bytes: &[u8]) -> io::Result<()>;
+
+    fn print(&mut self, bytes: &[u8]) {
+        let _ = self.write_stdout(bytes);
+    }
+
+    fn puts(&mut self, bytes: &[u8]) {
+        let _ = self
+            .write_stdout(bytes)
+            .and_then(|_| self.write_stdout(b"\n"));
+    }
+}
+
+#[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub struct Process;
+
+impl Process {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Output for Process {
+    fn backend_name(&self) -> &str {
+        "Process"
+    }
+
+    fn write_stdout(&mut self, bytes: &[u8]) -> io::Result<()> {
+        io::stdout().write_all(bytes)
+    }
+
+    fn write_stderr(&mut self, bytes: &[u8]) -> io::Result<()> {
+        io::stderr().write_all(bytes)
+    }
+}
+
+#[derive(Default, Debug, Clone, Hash, PartialEq, Eq)]
+pub struct Captured {
+    stdout: Vec<u8>,
+    stderr: Vec<u8>,
+}
+
+impl Captured {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn clear(&mut self) {
+        self.stdout.clear();
+        self.stderr.clear();
+    }
+
+    pub fn stdout(&self) -> &[u8] {
+        self.stdout.as_slice()
+    }
+
+    pub fn stderr(&self) -> &[u8] {
+        self.stderr.as_slice()
+    }
+}
+
+impl Output for Captured {
+    fn backend_name(&self) -> &str {
+        "Captured"
+    }
+
+    fn write_stdout(&mut self, bytes: &[u8]) -> io::Result<()> {
+        self.stdout.write_all(bytes)
+    }
+
+    fn write_stderr(&mut self, bytes: &[u8]) -> io::Result<()> {
+        self.stderr.write_all(bytes)
+    }
+}

--- a/artichoke-backend/src/state/output.rs
+++ b/artichoke-backend/src/state/output.rs
@@ -1,6 +1,6 @@
 use std::io::{self, Write};
 
-pub trait Output: 'static + Send + Sync {
+pub trait Output: Send + Sync {
     fn backend_name(&self) -> &str;
 
     fn write_stdout(&mut self, bytes: &[u8]) -> io::Result<()>;
@@ -69,6 +69,20 @@ impl Captured {
 }
 
 impl Output for Captured {
+    fn backend_name(&self) -> &str {
+        "Captured"
+    }
+
+    fn write_stdout(&mut self, bytes: &[u8]) -> io::Result<()> {
+        self.stdout.write_all(bytes)
+    }
+
+    fn write_stderr(&mut self, bytes: &[u8]) -> io::Result<()> {
+        self.stderr.write_all(bytes)
+    }
+}
+
+impl<'a> Output for &'a mut Captured {
     fn backend_name(&self) -> &str {
         "Captured"
     }


### PR DESCRIPTION
Refactor output capturing in the `State`. The `State` has methods for printing and overriding output behavior by capturing into a buffer.

Replace this with a single `output` field on the state that is a trait object pointing to a concrete output implementation. This PR includes three implementations, one that uses the native stdout and stderr of the process, one that captures stdout and stderr into two buffers, and one that drops all output.

This inches closer to a model where the `State` is just a container for components that hold domain specific state. See GH-442.