### PR TITLE
Remove some uses of format!

### DIFF
--- a/artichoke-backend/src/extn/core/array/mod.rs
+++ b/artichoke-backend/src/extn/core/array/mod.rs
@@ -49,15 +49,14 @@ impl Array {
             if let Ok(ary) = unsafe { Self::try_from_ruby(interp, &first) } {
                 ary.borrow().0.clone()
             } else if first.respond_to("to_ary")? {
-                let ruby_type = first.pretty_name();
                 let other = first.funcall("to_ary", &[], None)?;
                 if let Ok(other) = unsafe { Self::try_from_ruby(interp, &other) } {
                     other.borrow().0.clone()
                 } else {
                     let mut message = String::from("can't convert ");
-                    message.push_str(ruby_type);
+                    message.push_str(first.pretty_name());
                     message.push_str(" to Array (");
-                    message.push_str(ruby_type);
+                    message.push_str(first.pretty_name());
                     message.push_str("#to_ary gives ");
                     message.push_str(other.pretty_name());
                     return Err(Exception::from(TypeError::new(interp, message)));
@@ -150,15 +149,14 @@ impl Array {
             if let Ok(other) = unsafe { Self::try_from_ruby(interp, &elem) } {
                 self.0.set_slice(interp, start, drain, &other.borrow().0)?;
             } else if elem.respond_to("to_ary")? {
-                let ruby_type = elem.pretty_name();
                 let other = elem.funcall("to_ary", &[], None)?;
                 if let Ok(other) = unsafe { Self::try_from_ruby(interp, &other) } {
                     self.0.set_slice(interp, start, drain, &other.borrow().0)?;
                 } else {
                     let mut message = String::from("can't convert ");
-                    message.push_str(ruby_type);
+                    message.push_str(elem.pretty_name());
                     message.push_str(" to Array (");
-                    message.push_str(ruby_type);
+                    message.push_str(elem.pretty_name());
                     message.push_str("#to_ary gives ");
                     message.push_str(other.pretty_name());
                     return Err(Exception::from(TypeError::new(interp, message)));
@@ -217,15 +215,14 @@ impl Array {
         if let Ok(other) = unsafe { Self::try_from_ruby(interp, &other) } {
             self.0.concat(interp, &other.borrow().0)?;
         } else if other.respond_to("to_ary")? {
-            let ruby_type = other.pretty_name();
-            let other = other.funcall("to_ary", &[], None)?;
-            if let Ok(other) = unsafe { Self::try_from_ruby(interp, &other) } {
+            let arr = other.funcall("to_ary", &[], None)?;
+            if let Ok(other) = unsafe { Self::try_from_ruby(interp, &arr) } {
                 self.0.concat(interp, &other.borrow().0)?;
             } else {
                 let mut message = String::from("can't convert ");
-                message.push_str(ruby_type);
+                message.push_str(other.pretty_name());
                 message.push_str(" to Array (");
-                message.push_str(ruby_type);
+                message.push_str(other.pretty_name());
                 message.push_str("#to_ary gives ");
                 message.push_str(other.pretty_name());
                 return Err(Exception::from(TypeError::new(interp, message)));

--- a/artichoke-backend/src/extn/core/array/mod.rs
+++ b/artichoke-backend/src/extn/core/array/mod.rs
@@ -54,14 +54,13 @@ impl Array {
                 if let Ok(other) = unsafe { Self::try_from_ruby(interp, &other) } {
                     other.borrow().0.clone()
                 } else {
-                    return Err(Exception::from(TypeError::new(
-                        interp,
-                        format!(
-                            "can't convert {classname} to Array ({classname}#to_ary gives {gives})",
-                            classname = ruby_type,
-                            gives = other.pretty_name()
-                        ),
-                    )));
+                    let mut message = String::from("can't convert ");
+                    message.push_str(ruby_type);
+                    message.push_str(" to Array (");
+                    message.push_str(ruby_type);
+                    message.push_str("#to_ary gives ");
+                    message.push_str(other.pretty_name());
+                    return Err(Exception::from(TypeError::new(interp, message)));
                 }
             } else {
                 let len = first.implicitly_convert_to_int()?;
@@ -156,14 +155,13 @@ impl Array {
                 if let Ok(other) = unsafe { Self::try_from_ruby(interp, &other) } {
                     self.0.set_slice(interp, start, drain, &other.borrow().0)?;
                 } else {
-                    return Err(Exception::from(TypeError::new(
-                        interp,
-                        format!(
-                            "can't convert {classname} to Array ({classname}#to_ary gives {gives})",
-                            classname = ruby_type,
-                            gives = other.pretty_name()
-                        ),
-                    )));
+                    let mut message = String::from("can't convert ");
+                    message.push_str(ruby_type);
+                    message.push_str(" to Array (");
+                    message.push_str(ruby_type);
+                    message.push_str("#to_ary gives ");
+                    message.push_str(other.pretty_name());
+                    return Err(Exception::from(TypeError::new(interp, message)));
                 }
             } else {
                 self.0.set_with_drain(interp, start, drain, elem.clone())?;
@@ -224,23 +222,19 @@ impl Array {
             if let Ok(other) = unsafe { Self::try_from_ruby(interp, &other) } {
                 self.0.concat(interp, &other.borrow().0)?;
             } else {
-                return Err(Exception::from(TypeError::new(
-                    interp,
-                    format!(
-                        "can't convert {classname} to Array ({classname}#to_ary gives {gives})",
-                        classname = ruby_type,
-                        gives = other.pretty_name()
-                    ),
-                )));
+                let mut message = String::from("can't convert ");
+                message.push_str(ruby_type);
+                message.push_str(" to Array (");
+                message.push_str(ruby_type);
+                message.push_str("#to_ary gives ");
+                message.push_str(other.pretty_name());
+                return Err(Exception::from(TypeError::new(interp, message)));
             }
         } else {
-            return Err(Exception::from(TypeError::new(
-                interp,
-                format!(
-                    "no implicit conversion of {classname} into Array",
-                    classname = other.pretty_name(),
-                ),
-            )));
+            let mut message = String::from("no implicit conversion of ");
+            message.push_str(other.pretty_name());
+            message.push_str(" into Array");
+            return Err(Exception::from(TypeError::new(interp, message)));
         };
         Ok(())
     }

--- a/artichoke-backend/src/extn/core/regexp/backend/onig.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/onig.rs
@@ -54,11 +54,8 @@ impl Onig {
 
 impl fmt::Display for Onig {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "{}",
-            String::from_utf8_lossy(self.derived.pattern.as_slice())
-        )
+        string::format_unicode_debug_into(f, self.derived.pattern.as_slice())
+            .map_err(string::WriteError::into_inner)
     }
 }
 
@@ -153,7 +150,20 @@ impl RegexpType for Onig {
     }
 
     fn debug(&self) -> String {
-        format!("{:?}", self)
+        let mut debug = String::from("/");
+        let mut pattern = String::new();
+        // Explicitly supress this error because `debug` is infallible and
+        // cannot panic.
+        //
+        // In practice this error will never be triggered since the only
+        // fallible call in `string::format_unicode_debug_into` is to `write!` which never
+        // `panic!`s for a `String` formatter, which we are using here.
+        let _ = string::format_unicode_debug_into(&mut pattern, self.literal.pattern.as_slice());
+        debug.push_str(pattern.replace("/", r"\/").as_str());
+        debug.push('/');
+        debug.push_str(self.literal.options.modifier_string().as_str());
+        debug.push_str(self.encoding.string());
+        debug
     }
 
     fn literal_config(&self) -> &Config {


### PR DESCRIPTION
Implement `fmt::Display` and `RegexpType::debug` with `string::format_unicode_debug_into` for `Regexp` backends. This removes a `String::from_utf8_lossy` and some panicking pathways.

Replace calls to `format!` for string interpolation in `Array` impl to use a mutable `String` builder.