### PR TITLE
Refactor airb and REPL backend to modernize patterns

### DIFF
--- a/artichoke-frontend/src/bin/airb.rs
+++ b/artichoke-frontend/src/bin/airb.rs
@@ -14,8 +14,12 @@
 //! ```
 
 use artichoke_frontend::repl;
-use std::io;
+use std::io::{self, Write};
+use std::process;
 
-fn main() -> Result<(), repl::Error> {
-    repl::run(io::stdout(), io::stderr(), None)
+fn main() {
+    if let Err(err) = repl::run(io::stdout(), io::stderr(), None) {
+        let _ = write!(io::stderr(), "{}", err);
+        process::exit(1);
+    }
 }


### PR DESCRIPTION
Binary:

- Write error `Display` to stderr.
- Exit with status code `1` on error.

Parser:

- Move `CodeTooLong` and and `TooManyLines` parser conditions from error
  types into the `State` enum.
- Add `State::is_fatal` so the REPL loop can exit early.
- Store `NonNull` owning pointers in the `Parser` struct.
- Significantly shrink the size of the `unsafe` block in `Parser::parse`
  by using the guarantees from the `NonNull` pointers.

REPL:

- Add `ParserAllocFailure` for failures to allocate the mruby parser.
- Add `ParserLineCountError` for `TooManyLines` parser state.
- Add `ParserInternalError` for fatal parser errors.
- Add `UnhandledReadlineError` for wrapping unknown `Err` variants from
  `rustyline`.
- Use `Box<dyn Error>` as the error type in the REPL.
- Remove useless `continue` in match terminal position.