### PR TITLE
Enforce rust_2018_idioms lint group

### DIFF
--- a/artichoke-backend/src/class.rs
+++ b/artichoke-backend/src/class.rs
@@ -194,7 +194,7 @@ impl Spec {
     }
 
     #[must_use]
-    pub fn fqname(&self) -> Cow<str> {
+    pub fn fqname(&self) -> Cow<'_, str> {
         if let Some(scope) = self.enclosing_scope() {
             Cow::Owned(format!("{}::{}", scope.fqname(), self.name()))
         } else {
@@ -238,7 +238,7 @@ impl Spec {
 }
 
 impl fmt::Display for Spec {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "artichoke class spec -- {}", self.fqname())
     }
 }

--- a/artichoke-backend/src/convert.rs
+++ b/artichoke-backend/src/convert.rs
@@ -72,7 +72,7 @@ impl UnboxRubyError {
 }
 
 impl fmt::Display for UnboxRubyError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "failed to convert from {} to {}", self.from, self.into)
     }
 }
@@ -143,7 +143,7 @@ impl BoxIntoRubyError {
 }
 
 impl fmt::Display for BoxIntoRubyError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "failed to convert from {} to {}", self.from, self.into)
     }
 }

--- a/artichoke-backend/src/def.rs
+++ b/artichoke-backend/src/def.rs
@@ -165,7 +165,7 @@ impl EnclosingRubyScope {
     /// The current implemention results in recursive calls to this function
     /// for each enclosing scope.
     #[must_use]
-    pub fn fqname(&self) -> Cow<str> {
+    pub fn fqname(&self) -> Cow<'_, str> {
         match self {
             Self::Class { spec } => spec.fqname(),
             Self::Module { spec } => spec.fqname(),
@@ -207,7 +207,7 @@ impl ConstantNameError {
 }
 
 impl fmt::Display for ConstantNameError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Invalid constant name contained a NUL byte")
     }
 }
@@ -352,7 +352,7 @@ impl NotDefinedError {
 }
 
 impl fmt::Display for NotDefinedError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{} '{}' not defined", self.item_type(), self.fqdn())
     }
 }

--- a/artichoke-backend/src/exception.rs
+++ b/artichoke-backend/src/exception.rs
@@ -30,7 +30,7 @@ impl RubyException for Exception {
 }
 
 impl fmt::Display for Exception {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
     }
 }
@@ -147,7 +147,7 @@ impl CaughtException {
 }
 
 impl fmt::Display for CaughtException {
-    fn fmt(&self, mut f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, mut f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let classname = self.name();
         write!(f, "{} (", classname)?;
         string::format_unicode_debug_into(&mut f, self.message())

--- a/artichoke-backend/src/extn/core/array/inline_buffer.rs
+++ b/artichoke-backend/src/extn/core/array/inline_buffer.rs
@@ -65,7 +65,7 @@ impl<'a> FromIterator<&'a Option<Value>> for InlineBuffer {
 }
 
 impl fmt::Debug for InlineBuffer {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_list()
             .entries(iter::repeat("Value").take(self.len()))
             .finish()

--- a/artichoke-backend/src/extn/core/env/mod.rs
+++ b/artichoke-backend/src/extn/core/env/mod.rs
@@ -19,7 +19,7 @@ impl RustBackedValue for Environ {
 }
 
 impl fmt::Debug for Environ {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if let Ok(backend) = self.0.downcast_ref::<System>() {
             f.debug_struct("Environ").field("backend", backend).finish()
         } else if let Ok(backend) = self.0.downcast_ref::<Memory>() {

--- a/artichoke-backend/src/extn/core/exception/mod.rs
+++ b/artichoke-backend/src/extn/core/exception/mod.rs
@@ -346,7 +346,7 @@ macro_rules! ruby_exception_impl {
         }
 
         impl fmt::Display for $exception {
-            fn fmt(&self, mut f: &mut fmt::Formatter) -> fmt::Result {
+            fn fmt(&self, mut f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 let classname = self.name();
                 write!(f, "{} (", classname)?;
                 string::format_unicode_debug_into(&mut f, self.message())

--- a/artichoke-backend/src/extn/core/matchdata/begin.rs
+++ b/artichoke-backend/src/extn/core/matchdata/begin.rs
@@ -24,7 +24,7 @@ impl<'a> Args<'a> {
     }
 }
 
-pub fn method(interp: &Artichoke, args: Args, value: &Value) -> Result<Value, Exception> {
+pub fn method(interp: &Artichoke, args: Args<'_>, value: &Value) -> Result<Value, Exception> {
     let data = unsafe { MatchData::try_from_ruby(interp, value) }?;
     let borrow = data.borrow();
     let haystack = &borrow.string[borrow.region.start..borrow.region.end];

--- a/artichoke-backend/src/extn/core/matchdata/end.rs
+++ b/artichoke-backend/src/extn/core/matchdata/end.rs
@@ -24,7 +24,7 @@ impl<'a> Args<'a> {
     }
 }
 
-pub fn method(interp: &Artichoke, args: Args, value: &Value) -> Result<Value, Exception> {
+pub fn method(interp: &Artichoke, args: Args<'_>, value: &Value) -> Result<Value, Exception> {
     let data = unsafe { MatchData::try_from_ruby(interp, value) }?;
     let borrow = data.borrow();
     let haystack = &borrow.string[borrow.region.start..borrow.region.end];

--- a/artichoke-backend/src/extn/core/random/mod.rs
+++ b/artichoke-backend/src/extn/core/random/mod.rs
@@ -41,7 +41,7 @@ impl RustBackedValue for Random {
 }
 
 impl fmt::Debug for Random {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if let Ok(inner) = self.inner().downcast_ref::<Rand<SmallRng>>() {
             f.debug_struct("Random")
                 .field("backend_type", &"Rand<SmallRng>")

--- a/artichoke-backend/src/extn/core/regexp/backend/lazy.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/lazy.rs
@@ -37,7 +37,7 @@ impl Lazy {
 }
 
 impl fmt::Display for Lazy {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         string::format_unicode_debug_into(f, self.literal.pattern.as_slice())
             .map_err(string::WriteError::into_inner)
     }

--- a/artichoke-backend/src/extn/core/regexp/backend/onig.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/onig.rs
@@ -53,7 +53,7 @@ impl Onig {
 }
 
 impl fmt::Display for Onig {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         string::format_unicode_debug_into(f, self.derived.pattern.as_slice())
             .map_err(string::WriteError::into_inner)
     }

--- a/artichoke-backend/src/extn/core/regexp/backend/regex/utf8.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/regex/utf8.rs
@@ -54,7 +54,7 @@ impl Utf8 {
 }
 
 impl fmt::Display for Utf8 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         string::format_unicode_debug_into(f, self.derived.pattern.as_slice())
             .map_err(string::WriteError::into_inner)
     }

--- a/artichoke-backend/src/extn/core/regexp/mod.rs
+++ b/artichoke-backend/src/extn/core/regexp/mod.rs
@@ -439,7 +439,7 @@ impl Clone for Box<dyn RegexpType> {
 }
 
 impl fmt::Debug for Box<dyn RegexpType> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.debug())
     }
 }
@@ -460,7 +460,7 @@ impl PartialEq for Box<dyn RegexpType> {
 impl Eq for Box<dyn RegexpType> {}
 
 impl fmt::Debug for &dyn RegexpType {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.debug())
     }
 }

--- a/artichoke-backend/src/extn/core/time/mod.rs
+++ b/artichoke-backend/src/extn/core/time/mod.rs
@@ -30,7 +30,7 @@ impl RustBackedValue for Time {
 }
 
 impl fmt::Debug for Time {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if let Ok(backend) = self.0.downcast_ref::<Chrono<Local>>() {
             f.debug_struct("Time").field("backend", backend).finish()
         } else {

--- a/artichoke-backend/src/ffi.rs
+++ b/artichoke-backend/src/ffi.rs
@@ -81,7 +81,7 @@ pub unsafe fn from_user_data(
 pub struct InterpreterExtractError;
 
 impl fmt::Display for InterpreterExtractError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "Failed to extract Artichoke Ruby interpreter from mrb_state userdata"
@@ -158,7 +158,7 @@ pub fn os_str_to_bytes(value: &OsStr) -> Result<Cow<'_, [u8]>, ConvertBytesError
 pub struct ConvertBytesError;
 
 impl fmt::Display for ConvertBytesError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Could not convert between bytes and platform string")
     }
 }

--- a/artichoke-backend/src/fs.rs
+++ b/artichoke-backend/src/fs.rs
@@ -65,7 +65,7 @@ impl Extension {
 }
 
 impl fmt::Debug for Extension {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Extension")
             .field("hook", &"fn(&mut Artichoke) -> Result<(), Exception>")
             .finish()

--- a/artichoke-backend/src/interpreter.rs
+++ b/artichoke-backend/src/interpreter.rs
@@ -81,7 +81,7 @@ pub fn interpreter() -> Result<Artichoke, Exception> {
 pub struct InterpreterAllocError;
 
 impl fmt::Display for InterpreterAllocError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Failed to allocate Artichoke interpreter")
     }
 }

--- a/artichoke-backend/src/io.rs
+++ b/artichoke-backend/src/io.rs
@@ -30,7 +30,7 @@ impl From<io::Error> for Exception {
 }
 
 impl fmt::Display for IOError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "IOError: {}", self.message)
     }
 }

--- a/artichoke-backend/src/lib.rs
+++ b/artichoke-backend/src/lib.rs
@@ -2,6 +2,7 @@
 #![deny(clippy::pedantic)]
 #![allow(clippy::missing_errors_doc)]
 #![deny(intra_doc_link_resolution_failure)]
+#![warn(rust_2018_idioms)]
 
 //! # artichoke-backend
 //!

--- a/artichoke-backend/src/method.rs
+++ b/artichoke-backend/src/method.rs
@@ -108,7 +108,7 @@ impl Spec {
 }
 
 impl fmt::Display for Spec {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.method_type() {
             Type::Class => write!(f, "self method spec -- {}", self.name),
             Type::Global => write!(f, "global method spec -- {}", self.name),

--- a/artichoke-backend/src/module.rs
+++ b/artichoke-backend/src/module.rs
@@ -159,7 +159,7 @@ impl Spec {
     }
 
     #[must_use]
-    pub fn fqname(&self) -> Cow<str> {
+    pub fn fqname(&self) -> Cow<'_, str> {
         if let Some(scope) = self.enclosing_scope() {
             Cow::Owned(format!("{}::{}", scope.fqname(), self.name()))
         } else {
@@ -216,7 +216,7 @@ impl Spec {
 }
 
 impl fmt::Display for Spec {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "artichoke module spec -- {}", self.fqname())
     }
 }

--- a/artichoke-backend/src/state/mod.rs
+++ b/artichoke-backend/src/state/mod.rs
@@ -133,7 +133,7 @@ impl State {
 }
 
 impl fmt::Debug for State {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut fmt = f.debug_struct("State");
         fmt.field("mrb", &sys::mrb_sys_state_debug(self.mrb))
             .field("parser", &self.parser)

--- a/artichoke-backend/src/state/parser.rs
+++ b/artichoke-backend/src/state/parser.rs
@@ -16,7 +16,7 @@ pub struct State {
 }
 
 impl fmt::Debug for State {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("parser::State")
             .field("context", &"non-null mrb_context")
             .field("stack", &self.stack)

--- a/artichoke-backend/src/string.rs
+++ b/artichoke-backend/src/string.rs
@@ -80,7 +80,7 @@ impl WriteError {
 }
 
 impl fmt::Display for WriteError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Unable to write escaped Unicode into destination")
     }
 }

--- a/artichoke-backend/src/value.rs
+++ b/artichoke-backend/src/value.rs
@@ -340,14 +340,14 @@ impl Convert<Value, Value> for Artichoke {
 }
 
 impl fmt::Display for Value {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let string_repr = self.to_s();
         write!(f, "{}", String::from_utf8_lossy(string_repr.as_slice()))
     }
 }
 
 impl fmt::Debug for Value {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.to_s_debug())
     }
 }
@@ -375,7 +375,7 @@ pub struct Block {
 }
 
 impl fmt::Debug for Block {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "proc")
     }
 }
@@ -439,7 +439,7 @@ pub struct ArgCountError {
 }
 
 impl fmt::Display for ArgCountError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Too many arguments for function call: ")?;
         write!(
             f,

--- a/artichoke-core/src/lib.rs
+++ b/artichoke-core/src/lib.rs
@@ -1,6 +1,7 @@
 #![deny(clippy::all)]
 #![deny(clippy::pedantic)]
 #![deny(missing_docs, intra_doc_link_resolution_failure)]
+#![warn(rust_2018_idioms)]
 #![forbid(unsafe_code)]
 
 //! # artichoke-core

--- a/artichoke-core/src/parser.rs
+++ b/artichoke-core/src/parser.rs
@@ -49,7 +49,7 @@ pub enum IncrementLinenoError {
 }
 
 impl fmt::Display for IncrementLinenoError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Overflow(max) => write!(f, "Parser exceeded maximum line count: {}", max),
         }

--- a/artichoke-core/src/types.rs
+++ b/artichoke-core/src/types.rs
@@ -32,7 +32,7 @@ pub enum Rust {
 }
 
 impl fmt::Display for Rust {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Rust ")?;
         match self {
             Self::Bool => write!(f, "bool"),
@@ -147,7 +147,7 @@ impl Ruby {
 }
 
 impl fmt::Display for Ruby {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Ruby {}", self.class_name())
     }
 }

--- a/artichoke-frontend/src/bin/airb.rs
+++ b/artichoke-frontend/src/bin/airb.rs
@@ -1,6 +1,7 @@
 #![deny(clippy::all)]
 #![deny(clippy::pedantic)]
 #![deny(intra_doc_link_resolution_failure)]
+#![warn(rust_2018_idioms)]
 
 //! `airb` is the Artichoke implementation of `irb` and is an interactive Ruby shell
 //! and [REPL](https://en.wikipedia.org/wiki/Read%E2%80%93eval%E2%80%93print_loop).

--- a/artichoke-frontend/src/bin/artichoke.rs
+++ b/artichoke-frontend/src/bin/artichoke.rs
@@ -1,6 +1,7 @@
 #![deny(clippy::all)]
 #![deny(clippy::pedantic)]
 #![deny(intra_doc_link_resolution_failure)]
+#![warn(rust_2018_idioms)]
 
 //! `artichoke` is the `ruby` binary frontend to Artichoke.
 //!

--- a/artichoke-frontend/src/lib.rs
+++ b/artichoke-frontend/src/lib.rs
@@ -1,6 +1,7 @@
 #![deny(clippy::all)]
 #![deny(clippy::pedantic)]
 #![deny(missing_docs, intra_doc_link_resolution_failure)]
+#![warn(rust_2018_idioms)]
 
 //!  `artichoke-frontend` crate provides binaries for interacting with the
 //!  artichoke interpreter in the [`artichoke-backend`](artichoke_backend)

--- a/artichoke-frontend/src/repl.rs
+++ b/artichoke-frontend/src/repl.rs
@@ -36,7 +36,7 @@ mod filename_test {
 struct ParserAllocError;
 
 impl fmt::Display for ParserAllocError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Failed to initialize Ruby parser")
     }
 }
@@ -48,7 +48,7 @@ impl error::Error for ParserAllocError {}
 struct ParserLineCountError;
 
 impl fmt::Display for ParserLineCountError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "The interpreter has parsed too many lines and must exit")
     }
 }
@@ -62,7 +62,7 @@ impl error::Error for ParserLineCountError {}
 struct ParserInternalError;
 
 impl fmt::Display for ParserInternalError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "A fatal parsing error occurred")
     }
 }
@@ -74,7 +74,7 @@ impl error::Error for ParserInternalError {}
 struct UnhandledReadlineError(ReadlineError);
 
 impl fmt::Display for UnhandledReadlineError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Unhandled REPL Readline error: {}", self.0)
     }
 }

--- a/spec-runner/src/main.rs
+++ b/spec-runner/src/main.rs
@@ -1,6 +1,7 @@
 #![deny(clippy::all)]
 #![deny(clippy::pedantic)]
 #![deny(intra_doc_link_resolution_failure)]
+#![warn(rust_2018_idioms)]
 
 //! `spec-runner` is a wrapper around `MSpec` and ruby/spec that works with the
 //! Artichoke virtual filesystem.


### PR DESCRIPTION
- Warn on lint group errors.
- Apply cargo autofixes with `cargo fix --edition-idioms`.