### PR TITLE
Replace some instances of format! panic-free variants

### DIFF
--- a/artichoke-backend/src/class.rs
+++ b/artichoke-backend/src/class.rs
@@ -196,12 +196,12 @@ impl Spec {
     #[must_use]
     pub fn fqname(&self) -> Cow<'_, str> {
         if let Some(scope) = self.enclosing_scope() {
-            Cow::Owned(format!("{}::{}", scope.fqname(), self.name()))
+            let mut fqname = String::from(scope.fqname());
+            fqname.push_str("::");
+            fqname.push_str(self.name.as_ref());
+            fqname.into()
         } else {
-            match &self.name {
-                Cow::Borrowed(name) => Cow::Borrowed(name),
-                Cow::Owned(name) => Cow::Borrowed(name.as_str()),
-            }
+            self.name.as_ref().into()
         }
     }
 

--- a/artichoke-backend/src/extn/core/random/mod.rs
+++ b/artichoke-backend/src/extn/core/random/mod.rs
@@ -133,10 +133,11 @@ pub fn rand(interp: &mut Artichoke, rand: Value, max: Option<Value>) -> Result<V
             let number = borrow.inner_mut().rand_float(interp, Some(max));
             Ok(interp.convert_mut(number))
         }
-        Max::Int(max) if max < 1 => Err(Exception::from(ArgumentError::new(
-            interp,
-            format!("invalid argument - {}", max),
-        ))),
+        Max::Int(max) if max < 1 => {
+            let mut message = String::from("invalid argument - ");
+            string::format_int_into(&mut message, max)?;
+            Err(Exception::from(ArgumentError::new(interp, message)))
+        }
         Max::Int(max) => {
             let mut borrow = rand.borrow_mut();
             let number = borrow.inner_mut().rand_int(interp, max);

--- a/artichoke-backend/src/module.rs
+++ b/artichoke-backend/src/module.rs
@@ -161,12 +161,12 @@ impl Spec {
     #[must_use]
     pub fn fqname(&self) -> Cow<'_, str> {
         if let Some(scope) = self.enclosing_scope() {
-            Cow::Owned(format!("{}::{}", scope.fqname(), self.name()))
+            let mut fqname = String::from(scope.fqname());
+            fqname.push_str("::");
+            fqname.push_str(self.name.as_ref());
+            fqname.into()
         } else {
-            match &self.name {
-                Cow::Borrowed(name) => Cow::Borrowed(name),
-                Cow::Owned(name) => Cow::Borrowed(name.as_str()),
-            }
+            self.name.as_ref().into()
         }
     }
 


### PR DESCRIPTION
- Use the `itoa` crate via `string::format_int_into` to replace interpolation of integers in `extn::core::random` implementation.
- Use string buffer builder instead of `format!` for concatenating strings and literals in `def` family of `fqname` implementations.