### PR TITLE
Install cargo-deny from public GitHub release

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -12,18 +12,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          override: true
-          components: rustfmt, rust-src
-
-      - name: Install cargo-deny
-        run: cargo install cargo-deny
+      - name: Fetch cargo-audit
+        run: |
+          curl -sL "$RELEASE" | sudo tar xvz -C /usr/local/bin/ --strip-components=1
+        env:
+          RELEASE: "https://github.com/EmbarkStudios/cargo-deny/releases/download/0.6.6/cargo-deny-0.6.6-x86_64-unknown-linux-musl.tar.gz"
 
       - name: Run cargo-deny
-        run: cargo deny check
+        run: cargo-deny check
 
   js:
     name: Audit JS Dependencies


### PR DESCRIPTION
Use a blessed build instead of compiling from source. This should
speed up this workflow significantly and remove a failure mode
(compilation failures from mismatched stable compiler and public
release).