### PR TITLE
Add SecureRandom implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,12 +35,14 @@ name = "artichoke-backend"
 version = "0.1.0"
 dependencies = [
  "artichoke-core",
+ "base64",
  "bindgen",
  "bstr",
  "cc",
  "chrono",
  "downcast",
  "fs_extra",
+ "hex",
  "itoa",
  "libc",
  "log",
@@ -54,6 +56,7 @@ dependencies = [
  "rustc_version",
  "smallvec",
  "target-lexicon",
+ "uuid",
  "walkdir",
 ]
 
@@ -310,6 +313,12 @@ checksum = "1010591b26bbfe835e9faeabeb11866061cc7dcebffd56ad7d0942d0e61aefd8"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "hex"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
 
 [[package]]
 name = "itoa"
@@ -898,6 +907,15 @@ name = "utf8parse"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8772a4ccbb4e89959023bc5b7cb8623a795caa7092d99f3aa9501b9484d4557d"
+
+[[package]]
+name = "uuid"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fde2f6a4bea1d6e007c4ad38c6839fa71cbb63b6dbf5b595aa38dc9b1093c11"
+dependencies = [
+ "rand",
+]
 
 [[package]]
 name = "vec_map"

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -10,14 +10,18 @@ license = "MIT"
 keywords = ["artichoke", "artichoke-ruby", "ruby"]
 
 [dependencies]
+base64 = { version = "0.11", optional = true }
 bstr = "0.2"
 chrono = "0.4"
 downcast = "0.10"
+hex = { version = "0.4", optional = true }
 itoa = "0.4.5"
 log = "0.4"
 once_cell = "1"
+rand = { version = "0.7", optional = true, features = ["small_rng"] }
 regex = "1"
 smallvec = "1"
+uuid = { version = "0.8", optional = true, features = ["v4"] }
 
 [dependencies.artichoke-core]
 path = "../artichoke-core"
@@ -26,20 +30,16 @@ path = "../artichoke-core"
 git = "https://github.com/artichoke/rust-onig"
 rev = "11bc679d45b6799df2866cb4c90e1d542c4ba4c0"
 
-[dependencies.rand]
-version = "0.7"
-optional = true
-features = ["small_rng"]
-
 [dev-dependencies]
 libc = "0.2"
+quickcheck = { version = "0.9", default-features = false }
 quickcheck_macros = "0.9"
 
-[dev-dependencies.quickcheck]
-version = "0.9"
-default-features = false
-
 [build-dependencies]
+bindgen = { version = "0.53.1", default-features = false, features = [
+  "runtime"
+] }
+cc = { version = "1.0", features = ["parallel"] }
 chrono = "0.4"
 fs_extra = "1.1.0"
 num_cpus = "1"
@@ -47,16 +47,7 @@ rustc_version = "0.2.3"
 target-lexicon = "0.10.0"
 walkdir = "2"
 
-[build-dependencies.bindgen]
-version = "0.53.1"
-default-features = false
-features = ["runtime"]
-
-[build-dependencies.cc]
-version = "1.0"
-features = ["parallel"]
-
 [features]
 default = ["artichoke-random", "artichoke-system-environ"]
-artichoke-random = ["rand"]
+artichoke-random = ["base64", "hex", "rand", "uuid"]
 artichoke-system-environ = []

--- a/artichoke-backend/src/extn/core/random/mod.rs
+++ b/artichoke-backend/src/extn/core/random/mod.rs
@@ -44,12 +44,12 @@ impl fmt::Debug for Random {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if let Ok(inner) = self.inner().downcast_ref::<Rand<SmallRng>>() {
             f.debug_struct("Random")
-                .field("backend_type", &"Rand<SmallRng>")
+                .field("backend", &inner)
                 .field("seed", &inner.seed())
                 .finish()
         } else {
             f.debug_struct("Random")
-                .field("backend_type", &"unknown")
+                .field("backend", &"unknown")
                 .finish()
         }
     }

--- a/artichoke-backend/src/extn/stdlib/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/mod.rs
@@ -6,6 +6,8 @@ pub mod forwardable;
 pub mod json;
 pub mod monitor;
 pub mod ostruct;
+#[cfg(feature = "artichoke-random")]
+pub mod securerandom;
 pub mod set;
 pub mod strscan;
 
@@ -16,6 +18,8 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     json::init(interp)?;
     monitor::init(interp)?;
     ostruct::init(interp)?;
+    #[cfg(feature = "artichoke-random")]
+    securerandom::mruby::init(interp)?;
     set::init(interp)?;
     strscan::init(interp)?;
     uri::init(interp)?;
@@ -24,6 +28,8 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
 
 pub mod uri {
     //! Ruby URI package, implemented with embedded sources from MRI 2.6.3.
-    // See scripts/auto_import/.
+    //!
+    //! See `scripts/auto_import/`.
+
     include!(concat!(env!("OUT_DIR"), "/src/generated/uri.rs"));
 }

--- a/artichoke-backend/src/extn/stdlib/securerandom/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/securerandom/mod.rs
@@ -1,0 +1,133 @@
+use rand::distributions::Alphanumeric;
+use rand::{self, Rng, RngCore};
+use std::convert::TryFrom;
+use std::iter;
+use uuid::Uuid;
+
+use crate::extn::prelude::*;
+
+pub mod mruby;
+pub mod trampoline;
+
+const DEFAULT_REQUESTED_BYTES: usize = 16;
+
+#[derive(Debug)]
+pub struct SecureRandom;
+
+impl SecureRandom {
+    pub fn random_bytes(interp: &mut Artichoke, len: Option<Value>) -> Result<Vec<u8>, Exception> {
+        let len = if let Some(len) = len {
+            match len.implicitly_convert_to_int()? {
+                len if len < 0 => {
+                    return Err(Exception::from(ArgumentError::new(
+                        interp,
+                        "negative string size (or size too big)",
+                    )))
+                }
+                len if len == 0 => return Ok(Vec::new()),
+                len => usize::try_from(len)
+                    .map_err(|_| Fatal::new(interp, "positive Int must be usize"))?,
+            }
+        } else {
+            DEFAULT_REQUESTED_BYTES
+        };
+        let mut rng = rand::thread_rng();
+        let mut bytes = vec![0; len];
+        rng.fill_bytes(&mut bytes);
+        Ok(bytes)
+    }
+
+    pub fn random_number(interp: &mut Artichoke, max: Option<Value>) -> Result<Value, Exception> {
+        #[derive(Debug, Clone, Copy)]
+        enum Max {
+            Float(Float),
+            Int(Int),
+            None,
+        }
+        let max = if let Some(max) = max {
+            if let Ok(max) = max.clone().try_into::<Int>() {
+                Max::Int(max)
+            } else if let Ok(max) = max.clone().try_into::<Float>() {
+                Max::Float(max)
+            } else {
+                let max = max.implicitly_convert_to_int().map_err(|_| {
+                    let mut message = b"invalid argument - ".to_vec();
+                    message.extend(max.inspect().as_slice());
+                    ArgumentError::new_raw(interp, message)
+                })?;
+                Max::Int(max)
+            }
+        } else {
+            Max::None
+        };
+        let mut rng = rand::thread_rng();
+        match max {
+            Max::Float(max) if max <= 0.0 => {
+                let number = rng.gen_range(0.0, 1.0);
+                Ok(interp.convert_mut(number))
+            }
+            Max::Float(max) => {
+                let number = rng.gen_range(0.0, max);
+                Ok(interp.convert_mut(number))
+            }
+            Max::Int(max) if max <= 0 => {
+                let number = rng.gen_range(0.0, 1.0);
+                Ok(interp.convert_mut(number))
+            }
+            Max::Int(max) => {
+                let number = rng.gen_range(0, max);
+                Ok(interp.convert(number))
+            }
+            Max::None => {
+                let number = rng.gen_range(0.0, 1.0);
+                Ok(interp.convert_mut(number))
+            }
+        }
+    }
+
+    pub fn hex(interp: &mut Artichoke, len: Option<Value>) -> Result<String, Exception> {
+        Self::random_bytes(interp, len).map(hex::encode)
+    }
+
+    pub fn base64(interp: &mut Artichoke, len: Option<Value>) -> Result<String, Exception> {
+        Self::random_bytes(interp, len).map(|bytes| base64::encode(bytes.as_slice()))
+    }
+
+    pub fn alphanumeric(interp: &mut Artichoke, len: Option<Value>) -> Result<String, Exception> {
+        let len = if let Some(len) = len {
+            match len.implicitly_convert_to_int()? {
+                len if len < 0 => {
+                    return Err(Exception::from(ArgumentError::new(
+                        interp,
+                        "negative string size (or size too big)",
+                    )))
+                }
+                len if len == 0 => return Ok(String::new()),
+                len => usize::try_from(len)
+                    .map_err(|_| Fatal::new(interp, "positive Int must be usize"))?,
+            }
+        } else {
+            DEFAULT_REQUESTED_BYTES
+        };
+        let mut rng = rand::thread_rng();
+        let string = iter::repeat(())
+            .map(|_| rng.sample(Alphanumeric))
+            .take(len)
+            .collect::<String>();
+        Ok(string)
+    }
+
+    pub fn uuid(interp: &mut Artichoke) -> String {
+        let _ = interp;
+        let uuid = Uuid::new_v4();
+        let mut buf = Uuid::encode_buffer();
+        let enc = uuid.to_hyphenated().encode_lower(&mut buf);
+        enc.to_owned()
+    }
+}
+
+impl RustBackedValue for SecureRandom {
+    fn ruby_type_name() -> &'static str {
+        "SecureRandom"
+    }
+}

--- a/artichoke-backend/src/extn/stdlib/securerandom/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/securerandom/mod.rs
@@ -11,7 +11,7 @@ pub mod trampoline;
 
 const DEFAULT_REQUESTED_BYTES: usize = 16;
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub struct SecureRandom;
 
 impl SecureRandom {
@@ -123,11 +123,5 @@ impl SecureRandom {
         let mut buf = Uuid::encode_buffer();
         let enc = uuid.to_hyphenated().encode_lower(&mut buf);
         enc.to_owned()
-    }
-}
-
-impl RustBackedValue for SecureRandom {
-    fn ruby_type_name() -> &'static str {
-        "SecureRandom"
     }
 }

--- a/artichoke-backend/src/extn/stdlib/securerandom/mruby.rs
+++ b/artichoke-backend/src/extn/stdlib/securerandom/mruby.rs
@@ -22,9 +22,8 @@ impl File for SecureRandomFile {
         {
             return Ok(());
         }
-        let spec = class::Spec::new("SecureRandom", None, None)?; // No destructor since SecureRandom is a ZST
-        class::Builder::for_spec(interp, &spec)
-            .value_is_rust_object()
+        let spec = module::Spec::new(interp, "SecureRandom", None)?;
+        module::Builder::for_spec(interp, &spec)
             .add_self_method(
                 "alphanumeric",
                 artichoke_securerandom_alphanumeric,
@@ -51,7 +50,7 @@ impl File for SecureRandomFile {
         interp
             .0
             .borrow_mut()
-            .def_class::<securerandom::SecureRandom>(spec);
+            .def_module::<securerandom::SecureRandom>(spec);
 
         trace!("Patched SecureRandom onto interpreter");
         Ok(())

--- a/artichoke-backend/src/extn/stdlib/securerandom/mruby.rs
+++ b/artichoke-backend/src/extn/stdlib/securerandom/mruby.rs
@@ -1,0 +1,158 @@
+use crate::extn::prelude::*;
+use crate::extn::stdlib::securerandom::{self, trampoline};
+use crate::File;
+
+pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
+    interp.def_file_for_type::<SecureRandomFile>(&b"securerandom.rb"[..])?;
+    Ok(())
+}
+
+pub struct SecureRandomFile;
+
+impl File for SecureRandomFile {
+    type Artichoke = Artichoke;
+    type Error = Exception;
+
+    fn require(interp: &mut Self::Artichoke) -> Result<(), Self::Error> {
+        if interp
+            .0
+            .borrow()
+            .class_spec::<securerandom::SecureRandom>()
+            .is_some()
+        {
+            return Ok(());
+        }
+        let spec = class::Spec::new("SecureRandom", None, None)?; // No destructor since SecureRandom is a ZST
+        class::Builder::for_spec(interp, &spec)
+            .value_is_rust_object()
+            .add_self_method(
+                "alphanumeric",
+                artichoke_securerandom_alphanumeric,
+                sys::mrb_args_opt(1),
+            )?
+            .add_self_method(
+                "base64",
+                artichoke_securerandom_base64,
+                sys::mrb_args_opt(1),
+            )?
+            .add_self_method("hex", artichoke_securerandom_hex, sys::mrb_args_opt(1))?
+            .add_self_method(
+                "random_bytes",
+                artichoke_securerandom_random_bytes,
+                sys::mrb_args_opt(1),
+            )?
+            .add_self_method(
+                "random_number",
+                artichoke_securerandom_random_number,
+                sys::mrb_args_opt(1),
+            )?
+            .add_self_method("uuid", artichoke_securerandom_uuid, sys::mrb_args_none())?
+            .define()?;
+        interp
+            .0
+            .borrow_mut()
+            .def_class::<securerandom::SecureRandom>(spec);
+
+        trace!("Patched SecureRandom onto interpreter");
+        Ok(())
+    }
+}
+
+#[no_mangle]
+unsafe extern "C" fn artichoke_securerandom_alphanumeric(
+    mrb: *mut sys::mrb_state,
+    _slf: sys::mrb_value,
+) -> sys::mrb_value {
+    let len = mrb_get_args!(mrb, optional = 1);
+    let mut interp = unwrap_interpreter!(mrb);
+    let len = len
+        .map(|len| Value::new(&interp, len))
+        .and_then(|len| interp.convert(len));
+    let result = trampoline::alphanumeric(&mut interp, len);
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => exception::raise(interp, exception),
+    }
+}
+
+#[no_mangle]
+unsafe extern "C" fn artichoke_securerandom_base64(
+    mrb: *mut sys::mrb_state,
+    _slf: sys::mrb_value,
+) -> sys::mrb_value {
+    let len = mrb_get_args!(mrb, optional = 1);
+    let mut interp = unwrap_interpreter!(mrb);
+    let len = len
+        .map(|len| Value::new(&interp, len))
+        .and_then(|len| interp.convert(len));
+    let result = trampoline::base64(&mut interp, len);
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => exception::raise(interp, exception),
+    }
+}
+
+#[no_mangle]
+unsafe extern "C" fn artichoke_securerandom_hex(
+    mrb: *mut sys::mrb_state,
+    _slf: sys::mrb_value,
+) -> sys::mrb_value {
+    let len = mrb_get_args!(mrb, optional = 1);
+    let mut interp = unwrap_interpreter!(mrb);
+    let len = len
+        .map(|len| Value::new(&interp, len))
+        .and_then(|len| interp.convert(len));
+    let result = trampoline::hex(&mut interp, len);
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => exception::raise(interp, exception),
+    }
+}
+
+#[no_mangle]
+unsafe extern "C" fn artichoke_securerandom_random_bytes(
+    mrb: *mut sys::mrb_state,
+    _slf: sys::mrb_value,
+) -> sys::mrb_value {
+    let len = mrb_get_args!(mrb, optional = 1);
+    let mut interp = unwrap_interpreter!(mrb);
+    let len = len
+        .map(|len| Value::new(&interp, len))
+        .and_then(|len| interp.convert(len));
+    let result = trampoline::random_bytes(&mut interp, len);
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => exception::raise(interp, exception),
+    }
+}
+
+#[no_mangle]
+unsafe extern "C" fn artichoke_securerandom_random_number(
+    mrb: *mut sys::mrb_state,
+    _slf: sys::mrb_value,
+) -> sys::mrb_value {
+    let max = mrb_get_args!(mrb, optional = 1);
+    let mut interp = unwrap_interpreter!(mrb);
+    let max = max
+        .map(|max| Value::new(&interp, max))
+        .and_then(|max| interp.convert(max));
+    let result = trampoline::random_number(&mut interp, max);
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => exception::raise(interp, exception),
+    }
+}
+
+#[no_mangle]
+unsafe extern "C" fn artichoke_securerandom_uuid(
+    mrb: *mut sys::mrb_state,
+    _slf: sys::mrb_value,
+) -> sys::mrb_value {
+    mrb_get_args!(mrb, none);
+    let mut interp = unwrap_interpreter!(mrb);
+    let result = trampoline::uuid(&mut interp);
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => exception::raise(interp, exception),
+    }
+}

--- a/artichoke-backend/src/extn/stdlib/securerandom/trampoline.rs
+++ b/artichoke-backend/src/extn/stdlib/securerandom/trampoline.rs
@@ -1,0 +1,27 @@
+use crate::extn::prelude::*;
+use crate::extn::stdlib::securerandom::SecureRandom;
+
+pub fn alphanumeric(interp: &mut Artichoke, len: Option<Value>) -> Result<Value, Exception> {
+    SecureRandom::alphanumeric(interp, len).map(|bytes| interp.convert_mut(bytes))
+}
+
+pub fn base64(interp: &mut Artichoke, len: Option<Value>) -> Result<Value, Exception> {
+    SecureRandom::base64(interp, len).map(|bytes| interp.convert_mut(bytes))
+}
+
+pub fn hex(interp: &mut Artichoke, len: Option<Value>) -> Result<Value, Exception> {
+    SecureRandom::hex(interp, len).map(|bytes| interp.convert_mut(bytes))
+}
+
+pub fn random_bytes(interp: &mut Artichoke, len: Option<Value>) -> Result<Value, Exception> {
+    SecureRandom::random_bytes(interp, len).map(|bytes| interp.convert_mut(bytes))
+}
+
+pub fn random_number(interp: &mut Artichoke, max: Option<Value>) -> Result<Value, Exception> {
+    SecureRandom::random_number(interp, max)
+}
+
+pub fn uuid(interp: &mut Artichoke) -> Result<Value, Exception> {
+    let uuid = SecureRandom::uuid(interp);
+    Ok(interp.convert_mut(uuid))
+}

--- a/artichoke-backend/src/value.rs
+++ b/artichoke-backend/src/value.rs
@@ -113,8 +113,15 @@ impl Value {
     }
 
     pub fn implicitly_convert_to_int(&self) -> Result<Int, TypeError> {
-        let int = if let Ok(int) = self.clone().try_into::<Int>() {
-            int
+        let int = if let Ok(int) = self.clone().try_into::<Option<Int>>() {
+            if let Some(int) = int {
+                int
+            } else {
+                return Err(TypeError::new(
+                    &self.interp,
+                    "no implicit conversion from nil to integer",
+                ));
+            }
         } else if let Ok(true) = self.respond_to("to_int") {
             if let Ok(maybe) = self.funcall::<Self>("to_int", &[], None) {
                 let gives_pretty_name = maybe.pretty_name();

--- a/spec-runner/enforced-specs.yaml
+++ b/spec-runner/enforced-specs.yaml
@@ -50,6 +50,10 @@ core:
 library:
   - suite: abbrev
   - suite: monitor
+  - suite: securerandom
+    skip:
+      - random_bytes # specs require ASCII-8BIT encoding for Strings
+      - random_number # missing support for Bignum and Range arguments
   - suite: stringscanner
   - suite: uri
     skip:


### PR DESCRIPTION
Based on rand::thread_rng, hex crate, base64 crate, uuid crate.

This implementation of `SecureRandom` supports these APIs:

- `SecureRandom::alphanumeric`
- `SecureRandom::base64`
- `SecureRandom::hex`
- `SecureRandom::random_bytes`
- `SecureRandom::random_number`
- `SecureRandom::uuid`

Fixes GH-34.

I am pleasantly surprised how little code it took to achieve this 😄 