### PR TITLE
Add a test to ensure the SecureRandom uses a CSPRNG

### DIFF
--- a/artichoke-backend/src/extn/stdlib/securerandom/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/securerandom/mod.rs
@@ -11,6 +11,16 @@ pub mod trampoline;
 
 const DEFAULT_REQUESTED_BYTES: usize = 16;
 
+#[cfg(test)]
+mod tests {
+    fn rng_must_be_cryptographically_secure<T: rand::CryptoRng>(_rng: T) {}
+
+    #[test]
+    fn rand_thread_rng_must_be_cryptographically_secure() {
+        rng_must_be_cryptographically_secure(rand::thread_rng())
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 pub struct SecureRandom;
 


### PR DESCRIPTION
`rand` has a `CryptoRng` marker trait that is added to PRNGs that are
cryptographically secure. `ThreadRng`, which is returned by the
currently used `rand::thread_rng` API is a `CryptoRng`.

Add a test to assert the `CryptoRng` bound on `rand::thread_rng`.

Inspired by this twitter thread:
https://twitter.com/rsthau/status/1234824812490563585

Followup to GH-554.