### PR TITLE
Prepare Regexp module for global variable APIs

### DIFF
--- a/artichoke-backend/src/extn/core/regexp/backend/lazy.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/lazy.rs
@@ -30,7 +30,7 @@ impl Lazy {
                 interp,
                 self.literal.clone(),
                 self.literal.clone(),
-                Encoding::default(),
+                self.encoding,
             )
         })
     }
@@ -129,37 +129,39 @@ impl RegexpType for Lazy {
             .unwrap_or_default()
     }
 
-    fn case_match(&self, interp: &mut Artichoke, pattern: &[u8]) -> Result<bool, Exception> {
-        self.regexp(interp)?.inner().case_match(interp, pattern)
+    fn case_match(&self, interp: &mut Artichoke, haystack: &[u8]) -> Result<bool, Exception> {
+        self.regexp(interp)?.inner().case_match(interp, haystack)
     }
 
     fn is_match(
         &self,
         interp: &Artichoke,
-        pattern: &[u8],
+        haystack: &[u8],
         pos: Option<Int>,
     ) -> Result<bool, Exception> {
-        self.regexp(interp)?.inner().is_match(interp, pattern, pos)
+        self.regexp(interp)?.inner().is_match(interp, haystack, pos)
     }
 
     fn match_(
         &self,
         interp: &mut Artichoke,
-        pattern: &[u8],
+        haystack: &[u8],
         pos: Option<Int>,
         block: Option<Block>,
     ) -> Result<Value, Exception> {
         self.regexp(interp)?
             .inner()
-            .match_(interp, pattern, pos, block)
+            .match_(interp, haystack, pos, block)
     }
 
     fn match_operator(
         &self,
         interp: &mut Artichoke,
-        pattern: &[u8],
+        haystack: &[u8],
     ) -> Result<Option<Int>, Exception> {
-        self.regexp(interp)?.inner().match_operator(interp, pattern)
+        self.regexp(interp)?
+            .inner()
+            .match_operator(interp, haystack)
     }
 
     fn named_captures(&self, interp: &Artichoke) -> Result<NameToCaptureLocations, Exception> {

--- a/artichoke-backend/src/extn/core/regexp/backend/mod.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/mod.rs
@@ -46,19 +46,19 @@ pub trait RegexpType {
         haystack: &'a [u8],
     ) -> Result<Option<&'a [u8]>, Exception>;
 
-    fn case_match(&self, interp: &mut Artichoke, pattern: &[u8]) -> Result<bool, Exception>;
+    fn case_match(&self, interp: &mut Artichoke, haystack: &[u8]) -> Result<bool, Exception>;
 
     fn is_match(
         &self,
         interp: &Artichoke,
-        pattern: &[u8],
+        haystack: &[u8],
         pos: Option<Int>,
     ) -> Result<bool, Exception>;
 
     fn match_(
         &self,
         interp: &mut Artichoke,
-        pattern: &[u8],
+        haystack: &[u8],
         pos: Option<Int>,
         block: Option<Block>,
     ) -> Result<Value, Exception>;
@@ -66,7 +66,7 @@ pub trait RegexpType {
     fn match_operator(
         &self,
         interp: &mut Artichoke,
-        pattern: &[u8],
+        haystack: &[u8],
     ) -> Result<Option<Int>, Exception>;
 
     fn named_captures(&self, interp: &Artichoke) -> Result<NameToCaptureLocations, Exception>;

--- a/artichoke-backend/src/extn/core/regexp/backend/onig.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/onig.rs
@@ -207,9 +207,9 @@ impl RegexpType for Onig {
                 "Oniguruma backend for Regexp only supports UTF-8 haystacks",
             )
         })?;
+        regexp::clear_capture_globals(interp)?;
         let mrb = interp.0.borrow().mrb;
         if let Some(captures) = self.regex.captures(haystack) {
-            regexp::clear_capture_globals(interp)?;
             interp.0.borrow_mut().active_regexp_globals = NonZeroUsize::new(captures.len());
             let sym = interp.intern_symbol(regexp::LAST_MATCHED_STRING);
             let value = interp.convert_mut(captures.at(0));
@@ -236,7 +236,7 @@ impl RegexpType for Onig {
                 }
             }
             let matchdata = MatchData::new(
-                haystack.as_bytes().to_vec(),
+                haystack.into(),
                 Regexp::from(self.box_clone()),
                 0,
                 haystack.len(),
@@ -310,6 +310,7 @@ impl RegexpType for Onig {
                 "Oniguruma backend for Regexp only supports UTF-8 haystacks",
             )
         })?;
+        regexp::clear_capture_globals(interp)?;
         let haystack_char_len = haystack.chars().count();
         let pos = pos.unwrap_or_default();
         let pos = if pos < 0 {
@@ -333,7 +334,6 @@ impl RegexpType for Onig {
 
         let match_target = &haystack[byte_offset..];
         if let Some(captures) = self.regex.captures(match_target) {
-            regexp::clear_capture_globals(interp)?;
             interp.0.borrow_mut().active_regexp_globals = NonZeroUsize::new(captures.len());
 
             let sym = interp.intern_symbol(regexp::LAST_MATCHED_STRING);
@@ -351,7 +351,7 @@ impl RegexpType for Onig {
             }
 
             let mut matchdata = MatchData::new(
-                haystack.as_bytes().to_vec(),
+                haystack.into(),
                 Regexp::from(self.box_clone()),
                 0,
                 haystack.len(),
@@ -404,8 +404,8 @@ impl RegexpType for Onig {
                 "Oniguruma backend for Regexp only supports UTF-8 haystacks",
             )
         })?;
+        regexp::clear_capture_globals(interp)?;
         if let Some(captures) = self.regex.captures(haystack) {
-            regexp::clear_capture_globals(interp)?;
             interp.0.borrow_mut().active_regexp_globals = NonZeroUsize::new(captures.len());
 
             let sym = interp.intern_symbol(regexp::LAST_MATCHED_STRING);
@@ -423,7 +423,7 @@ impl RegexpType for Onig {
             }
 
             let matchdata = MatchData::new(
-                haystack.as_bytes().to_vec(),
+                haystack.into(),
                 Regexp::from(self.box_clone()),
                 0,
                 haystack.len(),
@@ -478,7 +478,7 @@ impl RegexpType for Onig {
                     break;
                 }
             }
-            map.push((group.as_bytes().to_owned(), indexes));
+            map.push((group.into(), indexes));
             !fatal
         });
         if fatal {
@@ -510,9 +510,9 @@ impl RegexpType for Onig {
                     captures.at(index)
                 });
                 if let Some(capture) = capture {
-                    map.insert(group.as_bytes().to_vec(), Some(capture.as_bytes().to_vec()));
+                    map.insert(group.into(), Some(capture.into()));
                 } else {
-                    map.insert(group.as_bytes().to_vec(), None);
+                    map.insert(group.into(), None);
                 }
                 true
             });
@@ -525,9 +525,9 @@ impl RegexpType for Onig {
     fn names(&self, interp: &Artichoke) -> Vec<Vec<u8>> {
         let _ = interp;
         let mut names = vec![];
-        let mut capture_names = vec![];
+        let mut capture_names = Vec::<(Vec<u8>, Vec<u32>)>::new();
         self.regex.foreach_name(|group, group_indexes| {
-            capture_names.push((group.as_bytes().to_owned(), group_indexes.to_vec()));
+            capture_names.push((group.into(), group_indexes.into()));
             true
         });
         capture_names.sort_by(|left, right| {
@@ -582,10 +582,11 @@ impl RegexpType for Onig {
                 "Oniguruma backend for Regexp only supports UTF-8 haystacks",
             )
         })?;
+        regexp::clear_capture_globals(interp)?;
         let mrb = interp.0.borrow().mrb;
         let last_match_sym = interp.intern_symbol(regexp::LAST_MATCH);
         let mut matchdata = MatchData::new(
-            haystack.as_bytes().to_vec(),
+            haystack.into(),
             Regexp::from(self.box_clone()),
             0,
             haystack.len(),
@@ -594,7 +595,6 @@ impl RegexpType for Onig {
         let len = NonZeroUsize::new(self.regex.captures_len());
         if let Some(block) = block {
             if let Some(len) = len {
-                regexp::clear_capture_globals(interp)?;
                 interp.0.borrow_mut().active_regexp_globals = Some(len);
 
                 let mut iter = self.regex.captures_iter(haystack).peekable();
@@ -661,7 +661,6 @@ impl RegexpType for Onig {
         } else {
             let mut last_pos = (0, 0);
             if let Some(len) = len {
-                regexp::clear_capture_globals(interp)?;
                 interp.0.borrow_mut().active_regexp_globals = Some(len);
 
                 let mut collected = vec![];

--- a/artichoke-backend/src/extn/core/regexp/backend/regex/utf8.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/regex/utf8.rs
@@ -1,8 +1,9 @@
 use regex::{Regex, RegexBuilder};
-use std::cmp::{self, Ordering};
+use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::fmt;
+use std::num::NonZeroUsize;
 use std::str;
 
 use crate::extn::core::matchdata::MatchData;
@@ -29,7 +30,7 @@ impl Utf8 {
         let pattern = str::from_utf8(derived.pattern.as_slice()).map_err(|_| {
             ArgumentError::new(
                 interp,
-                "Oniguruma-backed Regexp only supports UTF-8 patterns",
+                "regex crate utf8 backend for Regexp only supports UTF-8 patterns",
             )
         })?;
         let mut builder = RegexBuilder::new(pattern);
@@ -73,7 +74,7 @@ impl RegexpType for Utf8 {
         let haystack = str::from_utf8(haystack).map_err(|_| {
             ArgumentError::new(
                 interp,
-                "Oniguruma-backed Regexp only supports UTF-8 haystacks",
+                "regex crate utf8 backend for Regexp only supports UTF-8 haystacks",
             )
         })?;
         let result = self.regex.captures(haystack).map(|captures| {
@@ -119,7 +120,7 @@ impl RegexpType for Utf8 {
             let haystack = str::from_utf8(haystack).map_err(|_| {
                 ArgumentError::new(
                     interp,
-                    "Oniguruma-backed Regexp only supports UTF-8 haystacks",
+                    "regex crate utf8 backend for Regexp only supports UTF-8 haystacks",
                 )
             })?;
             self.regex
@@ -140,7 +141,7 @@ impl RegexpType for Utf8 {
         let haystack = str::from_utf8(haystack).map_err(|_| {
             ArgumentError::new(
                 interp,
-                "Oniguruma-backed Regexp only supports UTF-8 haystacks",
+                "regex crate utf8 backend for Regexp only supports UTF-8 haystacks",
             )
         })?;
         let result = self
@@ -203,16 +204,25 @@ impl RegexpType for Utf8 {
         self.derived.pattern.as_slice()
     }
 
-    fn case_match(&self, interp: &mut Artichoke, pattern: &[u8]) -> Result<bool, Exception> {
-        let pattern = str::from_utf8(pattern).map_err(|_| {
+    fn case_match(&self, interp: &mut Artichoke, haystack: &[u8]) -> Result<bool, Exception> {
+        let haystack = str::from_utf8(haystack).map_err(|_| {
             ArgumentError::new(
                 interp,
-                "Oniguruma-backed Regexp only supports UTF-8 patterns",
+                "regex crate utf8 backend for Regexp only supports UTF-8 haystack",
             )
         })?;
         let mrb = interp.0.borrow().mrb;
-        if let Some(captures) = self.regex.captures(pattern) {
-            let globals_to_set = cmp::max(interp.0.borrow().active_regexp_globals, captures.len());
+        if let Some(captures) = self.regex.captures(haystack) {
+            regexp::clear_capture_globals(interp)?;
+            // per the [docs] for `captures.len()`:
+            //
+            // > This is always at least 1, since every regex has at least one
+            // > capture group that corresponds to the full match.
+            //
+            // [docs]: https://docs.rs/regex/1.3.4/regex/struct.Captures.html#method.len
+            interp.0.borrow_mut().active_regexp_globals =
+                captures.len().checked_sub(1).and_then(NonZeroUsize::new);
+
             let sym = interp.intern_symbol(regexp::LAST_MATCHED_STRING);
             let fullmatch = captures
                 .get(0)
@@ -223,10 +233,11 @@ impl RegexpType for Utf8 {
             unsafe {
                 sys::mrb_gv_set(mrb, sym, value.inner());
             }
-            for group in 1..=globals_to_set {
+            for group in 1..captures.len() {
+                let group = unsafe { NonZeroUsize::new_unchecked(group) };
                 let sym = interp.intern_symbol(regexp::nth_match_group(group));
                 let capture = captures
-                    .get(group)
+                    .get(group.get())
                     .as_ref()
                     .map(regex::Match::as_str)
                     .map(str::as_bytes);
@@ -235,11 +246,10 @@ impl RegexpType for Utf8 {
                     sys::mrb_gv_set(mrb, sym, value.inner());
                 }
             }
-            interp.0.borrow_mut().active_regexp_globals = captures.len();
 
             if let Some(match_pos) = captures.get(0) {
-                let pre_match = &pattern[..match_pos.start()];
-                let post_match = &pattern[match_pos.end()..];
+                let pre_match = &haystack[..match_pos.start()];
+                let post_match = &haystack[match_pos.end()..];
                 let pre_match_sym = interp.intern_symbol(regexp::STRING_LEFT_OF_MATCH);
                 let post_match_sym = interp.intern_symbol(regexp::STRING_RIGHT_OF_MATCH);
                 unsafe {
@@ -248,10 +258,10 @@ impl RegexpType for Utf8 {
                 }
             }
             let matchdata = MatchData::new(
-                pattern.as_bytes().to_vec(),
+                haystack.as_bytes().to_vec(),
                 Regexp::from(self.box_clone()),
                 0,
-                pattern.len(),
+                haystack.len(),
             );
             let matchdata = matchdata.try_into_ruby(&interp, None)?;
             let matchdata_sym = interp.intern_symbol(regexp::LAST_MATCH);
@@ -274,22 +284,22 @@ impl RegexpType for Utf8 {
     fn is_match(
         &self,
         interp: &Artichoke,
-        pattern: &[u8],
+        haystack: &[u8],
         pos: Option<Int>,
     ) -> Result<bool, Exception> {
-        let pattern = str::from_utf8(pattern).map_err(|_| {
+        let haystack = str::from_utf8(haystack).map_err(|_| {
             ArgumentError::new(
                 interp,
-                "Oniguruma-backed Regexp only supports UTF-8 patterns",
+                "regex crate utf8 backend for Regexp only supports UTF-8 haystack",
             )
         })?;
-        let pattern_char_len = pattern.chars().count();
+        let haystack_char_len = haystack.chars().count();
         let pos = pos.unwrap_or_default();
         let pos = if pos < 0 {
             let pos = usize::try_from(-pos).map_err(|_| {
                 Fatal::new(interp, "Expected positive position to convert to usize")
             })?;
-            if let Some(pos) = pattern_char_len.checked_sub(pos) {
+            if let Some(pos) = haystack_char_len.checked_sub(pos) {
                 pos
             } else {
                 return Ok(false);
@@ -299,36 +309,36 @@ impl RegexpType for Utf8 {
                 .map_err(|_| Fatal::new(interp, "Expected positive position to convert to usize"))?
         };
         // onig will panic if pos is beyond the end of string
-        if pos > pattern_char_len {
+        if pos > haystack_char_len {
             return Ok(false);
         }
-        let byte_offset = pattern.chars().take(pos).map(char::len_utf8).sum();
+        let byte_offset = haystack.chars().take(pos).map(char::len_utf8).sum();
 
-        let match_target = &pattern[byte_offset..];
+        let match_target = &haystack[byte_offset..];
         Ok(self.regex.find(match_target).is_some())
     }
 
     fn match_(
         &self,
         interp: &mut Artichoke,
-        pattern: &[u8],
+        haystack: &[u8],
         pos: Option<Int>,
         block: Option<Block>,
     ) -> Result<Value, Exception> {
         let mrb = interp.0.borrow().mrb;
-        let pattern = str::from_utf8(pattern).map_err(|_| {
+        let haystack = str::from_utf8(haystack).map_err(|_| {
             ArgumentError::new(
                 interp,
-                "Oniguruma-backed Regexp only supports UTF-8 patterns",
+                "regex crate utf8 backend for Regexp only supports UTF-8 haystacks",
             )
         })?;
-        let pattern_char_len = pattern.chars().count();
+        let haystack_char_len = haystack.chars().count();
         let pos = pos.unwrap_or_default();
         let pos = if pos < 0 {
             let pos = usize::try_from(-pos).map_err(|_| {
                 Fatal::new(interp, "Expected positive position to convert to usize")
             })?;
-            if let Some(pos) = pattern_char_len.checked_sub(pos) {
+            if let Some(pos) = haystack_char_len.checked_sub(pos) {
                 pos
             } else {
                 return Ok(interp.convert(None::<Value>));
@@ -338,14 +348,23 @@ impl RegexpType for Utf8 {
                 .map_err(|_| Fatal::new(interp, "Expected positive position to convert to usize"))?
         };
         // onig will panic if pos is beyond the end of string
-        if pos > pattern_char_len {
+        if pos > haystack_char_len {
             return Ok(interp.convert(None::<Value>));
         }
-        let byte_offset = pattern.chars().take(pos).map(char::len_utf8).sum();
+        let byte_offset = haystack.chars().take(pos).map(char::len_utf8).sum();
 
-        let match_target = &pattern[byte_offset..];
+        let match_target = &haystack[byte_offset..];
         if let Some(captures) = self.regex.captures(match_target) {
-            let globals_to_set = cmp::max(interp.0.borrow().active_regexp_globals, captures.len());
+            regexp::clear_capture_globals(interp)?;
+            // per the [docs] for `captures.len()`:
+            //
+            // > This is always at least 1, since every regex has at least one
+            // > capture group that corresponds to the full match.
+            //
+            // [docs]: https://docs.rs/regex/1.3.4/regex/struct.Captures.html#method.len
+            interp.0.borrow_mut().active_regexp_globals =
+                captures.len().checked_sub(1).and_then(NonZeroUsize::new);
+
             let sym = interp.intern_symbol(regexp::LAST_MATCHED_STRING);
             let fullmatch = captures
                 .get(0)
@@ -356,10 +375,11 @@ impl RegexpType for Utf8 {
             unsafe {
                 sys::mrb_gv_set(mrb, sym, value.inner());
             }
-            for group in 1..=globals_to_set {
+            for group in 1..captures.len() {
+                let group = unsafe { NonZeroUsize::new_unchecked(group) };
                 let sym = interp.intern_symbol(regexp::nth_match_group(group));
                 let capture = captures
-                    .get(group)
+                    .get(group.get())
                     .as_ref()
                     .map(regex::Match::as_str)
                     .map(str::as_bytes);
@@ -368,13 +388,12 @@ impl RegexpType for Utf8 {
                     sys::mrb_gv_set(mrb, sym, value.inner());
                 }
             }
-            interp.0.borrow_mut().active_regexp_globals = captures.len();
 
             let mut matchdata = MatchData::new(
-                pattern.as_bytes().to_vec(),
+                haystack.as_bytes().to_vec(),
                 Regexp::from(self.box_clone()),
                 0,
-                pattern.len(),
+                haystack.len(),
             );
             if let Some(match_pos) = captures.get(0) {
                 let pre_match = &match_target[..match_pos.start()];
@@ -418,17 +437,26 @@ impl RegexpType for Utf8 {
     fn match_operator(
         &self,
         interp: &mut Artichoke,
-        pattern: &[u8],
+        haystack: &[u8],
     ) -> Result<Option<Int>, Exception> {
         let mrb = interp.0.borrow().mrb;
-        let pattern = str::from_utf8(pattern).map_err(|_| {
+        let haystack = str::from_utf8(haystack).map_err(|_| {
             ArgumentError::new(
                 interp,
-                "Oniguruma-backed Regexp only supports UTF-8 patterns",
+                "regex crate utf8 backend for Regexp only supports UTF-8 haystacks",
             )
         })?;
-        if let Some(captures) = self.regex.captures(pattern) {
-            let globals_to_set = cmp::max(interp.0.borrow().active_regexp_globals, captures.len());
+        if let Some(captures) = self.regex.captures(haystack) {
+            regexp::clear_capture_globals(interp)?;
+            // per the [docs] for `captures.len()`:
+            //
+            // > This is always at least 1, since every regex has at least one
+            // > capture group that corresponds to the full match.
+            //
+            // [docs]: https://docs.rs/regex/1.3.4/regex/struct.Captures.html#method.len
+            interp.0.borrow_mut().active_regexp_globals =
+                captures.len().checked_sub(1).and_then(NonZeroUsize::new);
+
             let sym = interp.intern_symbol(regexp::LAST_MATCHED_STRING);
             let fullmatch = captures
                 .get(0)
@@ -439,10 +467,11 @@ impl RegexpType for Utf8 {
             unsafe {
                 sys::mrb_gv_set(mrb, sym, value.inner());
             }
-            for group in 1..=globals_to_set {
+            for group in 1..captures.len() {
+                let group = unsafe { NonZeroUsize::new_unchecked(group) };
                 let sym = interp.intern_symbol(regexp::nth_match_group(group));
                 let capture = captures
-                    .get(group)
+                    .get(group.get())
                     .as_ref()
                     .map(regex::Match::as_str)
                     .map(str::as_bytes);
@@ -451,13 +480,12 @@ impl RegexpType for Utf8 {
                     sys::mrb_gv_set(mrb, sym, value.inner());
                 }
             }
-            interp.0.borrow_mut().active_regexp_globals = captures.len();
 
             let matchdata = MatchData::new(
-                pattern.as_bytes().to_vec(),
+                haystack.as_bytes().to_vec(),
                 Regexp::from(self.box_clone()),
                 0,
-                pattern.len(),
+                haystack.len(),
             );
             let matchdata = matchdata.try_into_ruby(interp, None)?;
             let matchdata_sym = interp.intern_symbol(regexp::LAST_MATCH);
@@ -465,8 +493,8 @@ impl RegexpType for Utf8 {
                 sys::mrb_gv_set(mrb, matchdata_sym, matchdata.inner());
             }
             if let Some(match_pos) = captures.get(0) {
-                let pre_match = interp.convert_mut(&pattern[..match_pos.start()]);
-                let post_match = interp.convert_mut(&pattern[match_pos.end()..]);
+                let pre_match = interp.convert_mut(&haystack[..match_pos.start()]);
+                let post_match = interp.convert_mut(&haystack[match_pos.end()..]);
                 let pre_match_sym = interp.intern_symbol(regexp::STRING_LEFT_OF_MATCH);
                 let post_match_sym = interp.intern_symbol(regexp::STRING_RIGHT_OF_MATCH);
                 unsafe {
@@ -526,7 +554,7 @@ impl RegexpType for Utf8 {
         let haystack = str::from_utf8(haystack).map_err(|_| {
             ArgumentError::new(
                 interp,
-                "Oniguruma-backed Regexp only supports UTF-8 haystacks",
+                "regex crate utf8 backend for Regexp only supports UTF-8 haystacks",
             )
         })?;
         if let Some(captures) = self.regex.captures(haystack) {
@@ -573,7 +601,7 @@ impl RegexpType for Utf8 {
         let haystack = str::from_utf8(haystack).map_err(|_| {
             ArgumentError::new(
                 interp,
-                "Oniguruma-backed Regexp only supports UTF-8 haystacks",
+                "regex crate utf8 backend for Regexp only supports UTF-8 haystacks",
             )
         })?;
         let pos = self
@@ -601,7 +629,7 @@ impl RegexpType for Utf8 {
         let haystack = str::from_utf8(haystack).map_err(|_| {
             ArgumentError::new(
                 interp,
-                "Oniguruma-backed Regexp only supports UTF-8 haystacks",
+                "regex crate utf8 backend for Regexp only supports UTF-8 haystacks",
             )
         })?;
         let mrb = interp.0.borrow().mrb;
@@ -614,18 +642,16 @@ impl RegexpType for Utf8 {
         );
 
         // regex crate always includes the zero group in the captures len.
-        let len = self.regex.captures_len() - 1;
+        let len = self
+            .regex
+            .captures_len()
+            .checked_sub(1)
+            .and_then(NonZeroUsize::new);
         if let Some(block) = block {
-            if len > 0 {
-                // zero old globals
-                let globals = interp.0.borrow().active_regexp_globals;
-                for group in 1..=globals {
-                    let sym = interp.intern_symbol(regexp::nth_match_group(group));
-                    unsafe {
-                        sys::mrb_gv_set(mrb, sym, sys::mrb_sys_nil_value());
-                    }
-                }
-                interp.0.borrow_mut().active_regexp_globals = len;
+            if let Some(len) = len {
+                regexp::clear_capture_globals(interp)?;
+                interp.0.borrow_mut().active_regexp_globals = Some(len);
+
                 let mut iter = self.regex.captures_iter(haystack).peekable();
                 if iter.peek().is_none() {
                     unsafe {
@@ -645,10 +671,11 @@ impl RegexpType for Utf8 {
                         sys::mrb_gv_set(mrb, fullmatch, capture.inner());
                     }
                     let mut groups = vec![];
-                    for group in 1..=len {
+                    for group in 1..=len.get() {
+                        let group = unsafe { NonZeroUsize::new_unchecked(group) };
                         let sym = interp.intern_symbol(regexp::nth_match_group(group));
                         let matched = captures
-                            .get(group)
+                            .get(group.get())
                             .as_ref()
                             .map(regex::Match::as_str)
                             .map(str::as_bytes);
@@ -697,17 +724,11 @@ impl RegexpType for Utf8 {
             Ok(value)
         } else {
             let mut last_pos = (0, 0);
-            if len > 0 {
+            if let Some(len) = len {
+                regexp::clear_capture_globals(interp)?;
+                interp.0.borrow_mut().active_regexp_globals = Some(len);
+
                 let mut collected = vec![];
-                // zero old globals
-                let globals = interp.0.borrow().active_regexp_globals;
-                for group in 1..=globals {
-                    let sym = interp.intern_symbol(regexp::nth_match_group(group));
-                    unsafe {
-                        sys::mrb_gv_set(mrb, sym, sys::mrb_sys_nil_value());
-                    }
-                }
-                interp.0.borrow_mut().active_regexp_globals = len;
                 let mut iter = self.regex.captures_iter(haystack).peekable();
                 if iter.peek().is_none() {
                     unsafe {
@@ -717,7 +738,7 @@ impl RegexpType for Utf8 {
                 }
                 for captures in iter {
                     let mut groups = vec![];
-                    for group in 1..=len {
+                    for group in 1..=len.get() {
                         let matched = captures
                             .get(group)
                             .as_ref()
@@ -745,6 +766,7 @@ impl RegexpType for Utf8 {
                     }
                 }
                 for (group, capture) in iter {
+                    let group = unsafe { NonZeroUsize::new_unchecked(group) };
                     let sym = interp.intern_symbol(regexp::nth_match_group(group));
                     let capture = interp.convert_mut(capture.as_slice());
                     unsafe {

--- a/artichoke-backend/src/state/mod.rs
+++ b/artichoke-backend/src/state/mod.rs
@@ -2,6 +2,7 @@ use std::any::{Any, TypeId};
 use std::collections::HashMap;
 use std::fmt;
 use std::mem;
+use std::num::NonZeroUsize;
 use std::ptr::{self, NonNull};
 
 use crate::class;
@@ -22,7 +23,7 @@ pub struct State {
     classes: HashMap<TypeId, Box<class::Spec>>,
     modules: HashMap<TypeId, Box<module::Spec>>,
     pub vfs: fs::Virtual,
-    pub active_regexp_globals: usize,
+    pub active_regexp_globals: Option<NonZeroUsize>,
     pub output: Box<dyn output::Output>,
     #[cfg(feature = "artichoke-random")]
     pub prng: prng::Prng,
@@ -48,7 +49,7 @@ impl State {
             classes: HashMap::default(),
             modules: HashMap::default(),
             vfs: fs::Virtual::new(),
-            active_regexp_globals: 0,
+            active_regexp_globals: None,
             output: Box::new(output::Process::new()),
             #[cfg(feature = "artichoke-random")]
             prng: prng::Prng::default(),


### PR DESCRIPTION
When prototyping the `Regexp` module with APIs for getting and setting
global variables, I made these changes as well. They are worthy of their
own commit and were making the diff hard to reason about.

- Rename all parameters named `pattern` that are really `haystack`.
- `regexp::nth_match_group` takes a `NonZeroUsize`.
- Remove `panic!` for `0` case in `regexp::nth_match_group`.
- Add `regexp::clear_capture_globals` API.
- `active_regexp_globals` on the interpreter `State` is now an
  `Option<NoNonZeroUsize>`.

I tried to make `regexp::nth_match_group` return a `Cow<'static, str>`
since I am planning for constant names to be `&str`, but translating
this `Cow` to the `[u8]` `Cow` expected by `intern_symbol` was invasive
and the change is expected to be undone. Skipping for now.

This is prep for more API work required by GH-442.