### PR TITLE
Optimize Cargo release profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ members = [
 ]
 
 [profile.release]
-debug = true
+codegen-units = 1
 lto = true


### PR DESCRIPTION
- Remove debug symbols
- Build with codegen-units = 1

The resulting binaries are about 10% smaller at similar performance.

## Before

```console
$ ls -la target/release/{airb,artichoke,spec-runner}
-rwxr-xr-x  2 lopopolo  staff   4.1M Mar  4 18:42 target/release/airb*
-rwxr-xr-x  2 lopopolo  staff   4.3M Mar  4 18:42 target/release/artichoke*
-rwxr-xr-x  2 lopopolo  staff    11M Mar  4 18:43 target/release/spec-runner*
```

## After

```console
$ ls -la target/release/{airb,artichoke,spec-runner}
-rwxr-xr-x  2 lopopolo  staff   3.8M Mar  4 18:48 target/release/airb*
-rwxr-xr-x  2 lopopolo  staff   4.0M Mar  4 18:48 target/release/artichoke*
-rwxr-xr-x  2 lopopolo  staff    11M Mar  4 18:50 target/release/spec-runner*
```

`spec-runner` is unchanged because its size is dominated by the mspec and ruby/spec source embeds.