### PR TITLE
Add Math module implementation from Ruby Core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,6 +44,7 @@ dependencies = [
  "hex",
  "itoa",
  "libc",
+ "libm",
  "log",
  "num_cpus",
  "once_cell",
@@ -354,6 +355,12 @@ dependencies = [
  "cc",
  "winapi",
 ]
+
+[[package]]
+name = "libm"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
 
 [[package]]
 name = "linked-hash-map"

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -16,6 +16,7 @@ chrono = "0.4"
 downcast = "0.10"
 hex = { version = "0.4", optional = true }
 itoa = "0.4.5"
+libm = "0.2"
 log = "0.4"
 once_cell = "1"
 rand = { version = "0.7", optional = true, features = ["small_rng"] }

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -16,7 +16,7 @@ chrono = "0.4"
 downcast = "0.10"
 hex = { version = "0.4", optional = true }
 itoa = "0.4.5"
-libm = "0.2"
+libm = { version = "0.2", optional = true }
 log = "0.4"
 once_cell = "1"
 rand = { version = "0.7", optional = true, features = ["small_rng"] }
@@ -47,6 +47,7 @@ rustc_version = "0.2.3"
 target-lexicon = "0.10.0"
 
 [features]
-default = ["artichoke-random", "artichoke-system-environ"]
+default = ["artichoke-random", "artichoke-system-environ", "core-math-extra"]
 artichoke-random = ["base64", "hex", "rand", "uuid"]
 artichoke-system-environ = []
+core-math-extra = ["libm"]

--- a/artichoke-backend/src/extn/core/integer/mod.rs
+++ b/artichoke-backend/src/extn/core/integer/mod.rs
@@ -110,9 +110,9 @@ pub fn div(interp: &mut Artichoke, value: Int, denominator: Value) -> Result<Val
                 if denominator.respond_to("to_f")? {
                     let coerced = denominator.funcall::<Value>("to_f", &[], None)?;
                     if let Ruby::Float = coerced.ruby_type() {
-                        let denominator = coerced.try_into::<Float>()?;
+                        let denom = coerced.try_into::<Float>()?;
                         #[allow(clippy::cast_precision_loss)]
-                        Ok(interp.convert_mut(value as types::Float / denominator))
+                        Ok(interp.convert_mut(value as types::Float / denom))
                     } else {
                         let mut message = String::from("can't convert ");
                         message.push_str(denominator.pretty_name());

--- a/artichoke-backend/src/extn/core/integer/mod.rs
+++ b/artichoke-backend/src/extn/core/integer/mod.rs
@@ -1,7 +1,7 @@
 use std::convert::TryFrom;
 use std::mem;
 
-use crate::extn::core::float::Float;
+use crate::extn::core::numeric::Numeric;
 use crate::extn::prelude::*;
 use crate::types;
 
@@ -98,9 +98,42 @@ pub fn div(interp: &mut Artichoke, value: Int, denominator: Value) -> Result<Val
             Ok(interp.convert_mut(value as types::Float / denominator))
         }
         _ => {
-            let mut message = String::from(denominator.pretty_name());
-            message.push_str(" can't be coerced into Integer");
-            Err(Exception::from(TypeError::new(interp, message)))
+            let borrow = interp.0.borrow();
+            let numeric = borrow
+                .class_spec::<Numeric>()
+                .ok_or_else(|| NotDefinedError::class("Numeric"))?;
+            let numeric = numeric
+                .value(interp)
+                .ok_or_else(|| NotDefinedError::class("Numeric"))?;
+            drop(borrow);
+            if let Ok(true) = denominator.funcall("is_a?", &[numeric], None) {
+                if denominator.respond_to("to_f")? {
+                    let coerced = denominator.funcall::<Value>("to_f", &[], None)?;
+                    if let Ruby::Float = coerced.ruby_type() {
+                        let denominator = coerced.try_into::<Float>()?;
+                        #[allow(clippy::cast_precision_loss)]
+                        Ok(interp.convert_mut(value as types::Float / denominator))
+                    } else {
+                        let mut message = String::from("can't convert ");
+                        message.push_str(denominator.pretty_name());
+                        message.push_str(" into Float (");
+                        message.push_str(denominator.pretty_name());
+                        message.push_str("#to_f gives ");
+                        message.push_str(coerced.pretty_name());
+                        message.push(')');
+                        Err(Exception::from(TypeError::new(interp, message)))
+                    }
+                } else {
+                    let mut message = String::from("can't convert ");
+                    message.push_str(denominator.pretty_name());
+                    message.push_str(" into Float");
+                    Err(Exception::from(TypeError::new(interp, message)))
+                }
+            } else {
+                let mut message = String::from(denominator.pretty_name());
+                message.push_str(" can't be coerced into Integer");
+                Err(Exception::from(TypeError::new(interp, message)))
+            }
         }
     }
 }

--- a/artichoke-backend/src/extn/core/integer/mod.rs
+++ b/artichoke-backend/src/extn/core/integer/mod.rs
@@ -94,16 +94,8 @@ pub fn div(interp: &mut Artichoke, value: Int, denominator: Value) -> Result<Val
         }
         Ruby::Float => {
             let denominator = denominator.try_into::<types::Float>()?;
-            if denominator == 0.0 {
-                match value {
-                    x if x > 0 => Ok(interp.convert_mut(Float::INFINITY)),
-                    x if x < 0 => Ok(interp.convert_mut(Float::NEG_INFINITY)),
-                    _ => Ok(interp.convert_mut(Float::NAN)),
-                }
-            } else {
-                #[allow(clippy::cast_precision_loss)]
-                Ok(interp.convert_mut(value as types::Float / denominator))
-            }
+            #[allow(clippy::cast_precision_loss)]
+            Ok(interp.convert_mut(value as types::Float / denominator))
         }
         _ => {
             let mut message = String::from(denominator.pretty_name());

--- a/artichoke-backend/src/extn/core/math/mod.rs
+++ b/artichoke-backend/src/extn/core/math/mod.rs
@@ -1,11 +1,8 @@
 use std::borrow::Cow;
-use std::convert::TryFrom;
 use std::error;
 use std::f64;
 use std::fmt;
-use std::num::FpCategory;
 
-use crate::extn::core::float;
 use crate::extn::core::numeric::Numeric;
 use crate::extn::prelude::*;
 
@@ -230,6 +227,10 @@ pub fn gamma(interp: &mut Artichoke, value: Value) -> Result<Float, Exception> {
 
 #[cfg(feature = "core-math-extra")]
 pub fn gamma(interp: &mut Artichoke, value: Value) -> Result<Float, Exception> {
+    use crate::extn::core::float;
+    use std::convert::TryFrom;
+    use std::num::FpCategory;
+
     let value = value_to_float(interp, value)?;
     // `gamma(n)` is the same as `n!` for integer n > 0. `gamma` returns float
     // and might be an approximation so include a lookup table for as many `n`
@@ -313,6 +314,8 @@ pub fn ldexp(interp: &mut Artichoke, fraction: Value, exponent: Value) -> Result
 
 #[cfg(feature = "core-math-extra")]
 pub fn ldexp(interp: &mut Artichoke, fraction: Value, exponent: Value) -> Result<Float, Exception> {
+    use std::convert::TryFrom;
+
     let fraction = value_to_float(interp, fraction)?;
     let exponent = exponent.implicitly_convert_to_int().or_else(|err| {
         if let Ok(exponent) = exponent.try_into::<Float>() {

--- a/artichoke-backend/src/extn/core/math/mod.rs
+++ b/artichoke-backend/src/extn/core/math/mod.rs
@@ -1,0 +1,365 @@
+use std::borrow::Cow;
+use std::error;
+use std::f64;
+use std::fmt;
+
+use crate::extn::core::numeric::Numeric;
+use crate::extn::prelude::*;
+
+pub mod mruby;
+
+pub const E: f64 = f64::consts::E;
+pub const PI: f64 = f64::consts::PI;
+
+#[derive(Debug)]
+pub struct Math;
+
+fn value_to_float(interp: &mut Artichoke, value: Value) -> Result<Float, Exception> {
+    if let Ok(value) = value.clone().try_into::<Float>() {
+        Ok(value)
+    } else if let Ok(value) = value.clone().try_into::<Int>() {
+        Ok(value as Float)
+    } else if let Ruby::Nil = value.ruby_type() {
+        Err(Exception::from(TypeError::new(
+            interp,
+            "can't convert nil into Float",
+        )))
+    } else {
+        let borrow = interp.0.borrow();
+        let numeric = borrow
+            .class_spec::<Numeric>()
+            .ok_or_else(|| NotDefinedError::class("Numeric"))?;
+        let numeric = numeric
+            .value(interp)
+            .ok_or_else(|| NotDefinedError::class("Numeric"))?;
+        drop(borrow);
+        if let Ok(true) = value.funcall("is_a?", &[numeric], None) {
+            Ok(value.funcall::<Float>("to_f", &[], None)?)
+        } else {
+            let mut message = String::from("can't convert ");
+            message.push_str(value.pretty_name());
+            message.push_str(" into Float");
+            Err(Exception::from(TypeError::new(interp, message)))
+        }
+    }
+}
+
+pub fn acos(interp: &mut Artichoke, value: Value) -> Result<Float, Exception> {
+    let value = value_to_float(interp, value)?;
+    if value.is_nan() {
+        return Ok(value);
+    }
+    let result = value.acos();
+    if result.is_nan() {
+        Err(Exception::from(DomainError::new(
+            r#"Numerical argument is out of domain - "acos""#,
+        )))
+    } else {
+        Ok(result)
+    }
+}
+
+pub fn acosh(interp: &mut Artichoke, value: Value) -> Result<Float, Exception> {
+    let value = value_to_float(interp, value)?;
+    if value.is_nan() {
+        return Ok(value);
+    }
+    let result = value.acosh();
+    if result.is_nan() {
+        Err(Exception::from(DomainError::new(
+            r#"Numerical argument is out of domain - "acosh""#,
+        )))
+    } else {
+        Ok(result)
+    }
+}
+
+pub fn asin(interp: &mut Artichoke, value: Value) -> Result<Float, Exception> {
+    let value = value_to_float(interp, value)?;
+    if value.is_nan() {
+        return Ok(value);
+    }
+    let result = value.asin();
+    if result.is_nan() {
+        Err(Exception::from(DomainError::new(
+            r#"Numerical argument is out of domain - "asin""#,
+        )))
+    } else {
+        Ok(result)
+    }
+}
+
+pub fn asinh(interp: &mut Artichoke, value: Value) -> Result<Float, Exception> {
+    let value = value_to_float(interp, value)?;
+    let result = value.asinh();
+    Ok(result)
+}
+
+pub fn atan(interp: &mut Artichoke, value: Value) -> Result<Float, Exception> {
+    let value = value_to_float(interp, value)?;
+    let result = value.atan();
+    Ok(result)
+}
+
+pub fn atan2(interp: &mut Artichoke, value: Value, other: Value) -> Result<Float, Exception> {
+    let value = value_to_float(interp, value)?;
+    let other = value_to_float(interp, other)?;
+    let result = value.atan2(other);
+    Ok(result)
+}
+
+pub fn atanh(interp: &mut Artichoke, value: Value) -> Result<Float, Exception> {
+    let value = value_to_float(interp, value)?;
+    if value.is_nan() {
+        return Ok(value);
+    }
+    let result = value.atanh();
+    if result.is_nan() {
+        Err(Exception::from(DomainError::new(
+            r#"Numerical argument is out of domain - "atanh""#,
+        )))
+    } else {
+        Ok(result)
+    }
+}
+
+pub fn cbrt(interp: &mut Artichoke, value: Value) -> Result<Float, Exception> {
+    let value = value_to_float(interp, value)?;
+    let result = value.cbrt();
+    Ok(result)
+}
+
+pub fn cos(interp: &mut Artichoke, value: Value) -> Result<Float, Exception> {
+    let value = value_to_float(interp, value)?;
+    let result = value.cos();
+    Ok(result)
+}
+
+pub fn cosh(interp: &mut Artichoke, value: Value) -> Result<Float, Exception> {
+    let value = value_to_float(interp, value)?;
+    let result = value.cosh();
+    Ok(result)
+}
+
+pub fn erf(interp: &mut Artichoke, value: Value) -> Result<Float, Exception> {
+    let _ = value;
+    Err(Exception::from(NotImplementedError::new(
+        interp,
+        "depend on libm or statsrs",
+    )))
+}
+
+pub fn erfc(interp: &mut Artichoke, value: Value) -> Result<Float, Exception> {
+    let _ = value;
+    Err(Exception::from(NotImplementedError::new(
+        interp,
+        "depend on libm or statsrs",
+    )))
+}
+
+pub fn exp(interp: &mut Artichoke, value: Value) -> Result<Float, Exception> {
+    let value = value_to_float(interp, value)?;
+    let result = value.exp();
+    Ok(result)
+}
+
+pub fn frexp(interp: &mut Artichoke, value: Value) -> Result<(Float, Int), Exception> {
+    let _ = value;
+    Err(Exception::from(NotImplementedError::new(
+        interp,
+        "depend on libm or statsrs",
+    )))
+}
+
+pub fn gamma(interp: &mut Artichoke, value: Value) -> Result<Float, Exception> {
+    let _ = value;
+    Err(Exception::from(NotImplementedError::new(
+        interp,
+        "depend on libm or statsrs",
+    )))
+}
+
+pub fn hypot(interp: &mut Artichoke, value: Value, other: Value) -> Result<Float, Exception> {
+    let value = value_to_float(interp, value)?;
+    let other = value_to_float(interp, other)?;
+    let result = value.hypot(other);
+    Ok(result)
+}
+
+pub fn ldexp(interp: &mut Artichoke, fraction: Value, exponent: Value) -> Result<Float, Exception> {
+    let _ = fraction;
+    let _ = exponent;
+    Err(Exception::from(NotImplementedError::new(
+        interp,
+        "depend on libm or statsrs",
+    )))
+}
+
+pub fn lgamma(interp: &mut Artichoke, value: Value) -> Result<(Float, Int), Exception> {
+    let _ = value;
+    Err(Exception::from(NotImplementedError::new(
+        interp,
+        "depend on libm or statsrs",
+    )))
+}
+
+pub fn log(interp: &mut Artichoke, value: Value, base: Option<Value>) -> Result<Float, Exception> {
+    let value = value_to_float(interp, value)?;
+    if value.is_nan() {
+        return Ok(value);
+    }
+    let result = if let Some(base) = base {
+        let base = value_to_float(interp, base)?;
+        if base.is_nan() {
+            return Ok(base);
+        }
+        value.log(base)
+    } else {
+        value.ln()
+    };
+    if result.is_nan() {
+        Err(Exception::from(DomainError::new(
+            r#"Numerical argument is out of domain - "log""#,
+        )))
+    } else {
+        Ok(result)
+    }
+}
+
+pub fn log10(interp: &mut Artichoke, value: Value) -> Result<Float, Exception> {
+    let value = value_to_float(interp, value)?;
+    if value.is_nan() {
+        return Ok(value);
+    }
+    let result = value.log10();
+    if result.is_nan() {
+        Err(Exception::from(DomainError::new(
+            r#"Numerical argument is out of domain - "log10""#,
+        )))
+    } else {
+        Ok(result)
+    }
+}
+
+pub fn log2(interp: &mut Artichoke, value: Value) -> Result<Float, Exception> {
+    let value = value_to_float(interp, value)?;
+    if value.is_nan() {
+        return Ok(value);
+    }
+    let result = value.log2();
+    if result.is_nan() {
+        Err(Exception::from(DomainError::new(
+            r#"Numerical argument is out of domain - "log2""#,
+        )))
+    } else {
+        Ok(result)
+    }
+}
+
+pub fn sin(interp: &mut Artichoke, value: Value) -> Result<Float, Exception> {
+    let value = value_to_float(interp, value)?;
+    let result = value.sin();
+    Ok(result)
+}
+
+pub fn sinh(interp: &mut Artichoke, value: Value) -> Result<Float, Exception> {
+    let value = value_to_float(interp, value)?;
+    let result = value.sinh();
+    Ok(result)
+}
+
+pub fn sqrt(interp: &mut Artichoke, value: Value) -> Result<Float, Exception> {
+    let value = value_to_float(interp, value)?;
+    if value.is_nan() {
+        return Ok(value);
+    }
+    let result = value.sqrt();
+    if result.is_nan() {
+        Err(Exception::from(DomainError::new(
+            r#"Numerical argument is out of domain - "sqrt""#,
+        )))
+    } else {
+        Ok(result)
+    }
+}
+
+pub fn tan(interp: &mut Artichoke, value: Value) -> Result<Float, Exception> {
+    let value = value_to_float(interp, value)?;
+    let result = value.tan();
+    Ok(result)
+}
+
+pub fn tanh(interp: &mut Artichoke, value: Value) -> Result<Float, Exception> {
+    let value = value_to_float(interp, value)?;
+    let result = value.tanh();
+    Ok(result)
+}
+
+#[derive(Debug, Clone)]
+struct DomainError(Cow<'static, str>);
+
+impl DomainError {
+    pub fn new<T>(name: T) -> Self
+    where
+        T: Into<Cow<'static, str>>,
+    {
+        Self(name.into())
+    }
+}
+
+impl fmt::Display for DomainError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl error::Error for DomainError {}
+
+impl RubyException for DomainError {
+    fn message(&self) -> &[u8] {
+        self.0.as_ref().as_bytes()
+    }
+
+    fn name(&self) -> String {
+        String::from("DomainError")
+    }
+
+    fn vm_backtrace(&self, interp: &mut Artichoke) -> Option<Vec<Vec<u8>>> {
+        let _ = interp;
+        None
+    }
+
+    fn as_mrb_value(&self, interp: &mut Artichoke) -> Option<sys::mrb_value> {
+        let message = interp.convert_mut(self.message());
+        let borrow = interp.0.borrow();
+        let spec = borrow.class_spec::<Self>()?;
+        let value = spec.new_instance(interp, &[message])?;
+        Some(value.inner())
+    }
+}
+
+impl From<DomainError> for Exception {
+    fn from(exception: DomainError) -> Self {
+        Self::from(Box::<dyn RubyException>::from(exception))
+    }
+}
+
+impl From<Box<DomainError>> for Exception {
+    fn from(exception: Box<DomainError>) -> Self {
+        Self::from(Box::<dyn RubyException>::from(exception))
+    }
+}
+
+#[allow(clippy::use_self)]
+impl From<DomainError> for Box<dyn RubyException> {
+    fn from(exception: DomainError) -> Box<dyn RubyException> {
+        Box::new(exception)
+    }
+}
+
+#[allow(clippy::use_self)]
+impl From<Box<DomainError>> for Box<dyn RubyException> {
+    fn from(exception: Box<DomainError>) -> Box<dyn RubyException> {
+        exception
+    }
+}

--- a/artichoke-backend/src/extn/core/math/mruby.rs
+++ b/artichoke-backend/src/extn/core/math/mruby.rs
@@ -1,0 +1,431 @@
+use crate::extn::core::math;
+use crate::extn::prelude::*;
+
+pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
+    if interp.0.borrow().module_spec::<math::Math>().is_some() {
+        return Ok(());
+    }
+    let spec = module::Spec::new(interp, "Math", None)?;
+    module::Builder::for_spec(interp, &spec)
+        .add_module_method("acos", artichoke_math_acos, sys::mrb_args_req(1))?
+        .add_module_method("acosh", artichoke_math_acosh, sys::mrb_args_req(1))?
+        .add_module_method("asin", artichoke_math_asin, sys::mrb_args_req(1))?
+        .add_module_method("asinh", artichoke_math_asinh, sys::mrb_args_req(1))?
+        .add_module_method("atan", artichoke_math_atan, sys::mrb_args_req(1))?
+        .add_module_method("atan2", artichoke_math_atan2, sys::mrb_args_req(2))?
+        .add_module_method("atanh", artichoke_math_atanh, sys::mrb_args_req(1))?
+        .add_module_method("cbrt", artichoke_math_cbrt, sys::mrb_args_req(1))?
+        .add_module_method("cos", artichoke_math_cos, sys::mrb_args_req(1))?
+        .add_module_method("cosh", artichoke_math_cosh, sys::mrb_args_req(1))?
+        .add_module_method("erf", artichoke_math_erf, sys::mrb_args_req(1))?
+        .add_module_method("erfc", artichoke_math_erfc, sys::mrb_args_req(1))?
+        .add_module_method("exp", artichoke_math_exp, sys::mrb_args_req(1))?
+        .add_module_method("frexp", artichoke_math_frexp, sys::mrb_args_req(1))?
+        .add_module_method("gamma", artichoke_math_gamma, sys::mrb_args_req(1))?
+        .add_module_method("hypot", artichoke_math_hypot, sys::mrb_args_req(2))?
+        .add_module_method("ldexp", artichoke_math_ldexp, sys::mrb_args_req(2))?
+        .add_module_method("lgamma", artichoke_math_lgamma, sys::mrb_args_req(1))?
+        .add_module_method("log", artichoke_math_log, sys::mrb_args_req_and_opt(1, 1))?
+        .add_module_method("log10", artichoke_math_log10, sys::mrb_args_req(1))?
+        .add_module_method("log2", artichoke_math_log2, sys::mrb_args_req(1))?
+        .add_module_method("sin", artichoke_math_sin, sys::mrb_args_req(1))?
+        .add_module_method("sinh", artichoke_math_sinh, sys::mrb_args_req(1))?
+        .add_module_method("sqrt", artichoke_math_sqrt, sys::mrb_args_req(1))?
+        .add_module_method("tan", artichoke_math_tan, sys::mrb_args_req(1))?
+        .add_module_method("tanh", artichoke_math_tanh, sys::mrb_args_req(1))?
+        .define()?;
+
+    let domainerror =
+        class::Spec::new("DomainError", Some(EnclosingRubyScope::module(&spec)), None)?;
+    class::Builder::for_spec(interp, &domainerror)
+        .with_super_class(interp.0.borrow().class_spec::<StandardError>())
+        .define()?;
+    interp
+        .0
+        .borrow_mut()
+        .def_class::<math::DomainError>(domainerror);
+
+    interp.0.borrow_mut().def_module::<math::Math>(spec);
+    let e = interp.convert_mut(math::E);
+    interp.define_module_constant::<math::Math>("E", e)?;
+    let pi = interp.convert_mut(math::PI);
+    interp.define_module_constant::<math::Math>("PI", pi)?;
+    Ok(())
+}
+
+unsafe extern "C" fn artichoke_math_acos(
+    mrb: *mut sys::mrb_state,
+    _slf: sys::mrb_value,
+) -> sys::mrb_value {
+    let value = mrb_get_args!(mrb, required = 1);
+    let mut interp = unwrap_interpreter!(mrb);
+    let value = Value::new(&interp, value);
+    let result = math::acos(&mut interp, value).map(|result| interp.convert_mut(result));
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => exception::raise(interp, exception),
+    }
+}
+
+unsafe extern "C" fn artichoke_math_acosh(
+    mrb: *mut sys::mrb_state,
+    _slf: sys::mrb_value,
+) -> sys::mrb_value {
+    let value = mrb_get_args!(mrb, required = 1);
+    let mut interp = unwrap_interpreter!(mrb);
+    let value = Value::new(&interp, value);
+    let result = math::acosh(&mut interp, value).map(|result| interp.convert_mut(result));
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => exception::raise(interp, exception),
+    }
+}
+
+unsafe extern "C" fn artichoke_math_asin(
+    mrb: *mut sys::mrb_state,
+    _slf: sys::mrb_value,
+) -> sys::mrb_value {
+    let value = mrb_get_args!(mrb, required = 1);
+    let mut interp = unwrap_interpreter!(mrb);
+    let value = Value::new(&interp, value);
+    let result = math::asin(&mut interp, value).map(|result| interp.convert_mut(result));
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => exception::raise(interp, exception),
+    }
+}
+
+unsafe extern "C" fn artichoke_math_asinh(
+    mrb: *mut sys::mrb_state,
+    _slf: sys::mrb_value,
+) -> sys::mrb_value {
+    let value = mrb_get_args!(mrb, required = 1);
+    let mut interp = unwrap_interpreter!(mrb);
+    let value = Value::new(&interp, value);
+    let result = math::asinh(&mut interp, value).map(|result| interp.convert_mut(result));
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => exception::raise(interp, exception),
+    }
+}
+
+unsafe extern "C" fn artichoke_math_atan(
+    mrb: *mut sys::mrb_state,
+    _slf: sys::mrb_value,
+) -> sys::mrb_value {
+    let value = mrb_get_args!(mrb, required = 1);
+    let mut interp = unwrap_interpreter!(mrb);
+    let value = Value::new(&interp, value);
+    let result = math::atan(&mut interp, value).map(|result| interp.convert_mut(result));
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => exception::raise(interp, exception),
+    }
+}
+
+unsafe extern "C" fn artichoke_math_atan2(
+    mrb: *mut sys::mrb_state,
+    _slf: sys::mrb_value,
+) -> sys::mrb_value {
+    let (value, other) = mrb_get_args!(mrb, required = 2);
+    let mut interp = unwrap_interpreter!(mrb);
+    let value = Value::new(&interp, value);
+    let other = Value::new(&interp, other);
+    let result = math::atan2(&mut interp, value, other).map(|result| interp.convert_mut(result));
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => exception::raise(interp, exception),
+    }
+}
+
+unsafe extern "C" fn artichoke_math_atanh(
+    mrb: *mut sys::mrb_state,
+    _slf: sys::mrb_value,
+) -> sys::mrb_value {
+    let value = mrb_get_args!(mrb, required = 1);
+    let mut interp = unwrap_interpreter!(mrb);
+    let value = Value::new(&interp, value);
+    let result = math::atanh(&mut interp, value).map(|result| interp.convert_mut(result));
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => exception::raise(interp, exception),
+    }
+}
+
+unsafe extern "C" fn artichoke_math_cbrt(
+    mrb: *mut sys::mrb_state,
+    _slf: sys::mrb_value,
+) -> sys::mrb_value {
+    let value = mrb_get_args!(mrb, required = 1);
+    let mut interp = unwrap_interpreter!(mrb);
+    let value = Value::new(&interp, value);
+    let result = math::cbrt(&mut interp, value).map(|result| interp.convert_mut(result));
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => exception::raise(interp, exception),
+    }
+}
+
+unsafe extern "C" fn artichoke_math_cos(
+    mrb: *mut sys::mrb_state,
+    _slf: sys::mrb_value,
+) -> sys::mrb_value {
+    let value = mrb_get_args!(mrb, required = 1);
+    let mut interp = unwrap_interpreter!(mrb);
+    let value = Value::new(&interp, value);
+    let result = math::cos(&mut interp, value).map(|result| interp.convert_mut(result));
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => exception::raise(interp, exception),
+    }
+}
+
+unsafe extern "C" fn artichoke_math_cosh(
+    mrb: *mut sys::mrb_state,
+    _slf: sys::mrb_value,
+) -> sys::mrb_value {
+    let value = mrb_get_args!(mrb, required = 1);
+    let mut interp = unwrap_interpreter!(mrb);
+    let value = Value::new(&interp, value);
+    let result = math::cosh(&mut interp, value).map(|result| interp.convert_mut(result));
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => exception::raise(interp, exception),
+    }
+}
+
+unsafe extern "C" fn artichoke_math_erf(
+    mrb: *mut sys::mrb_state,
+    _slf: sys::mrb_value,
+) -> sys::mrb_value {
+    let value = mrb_get_args!(mrb, required = 1);
+    let mut interp = unwrap_interpreter!(mrb);
+    let value = Value::new(&interp, value);
+    let result = math::erf(&mut interp, value).map(|result| interp.convert_mut(result));
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => exception::raise(interp, exception),
+    }
+}
+
+unsafe extern "C" fn artichoke_math_erfc(
+    mrb: *mut sys::mrb_state,
+    _slf: sys::mrb_value,
+) -> sys::mrb_value {
+    let value = mrb_get_args!(mrb, required = 1);
+    let mut interp = unwrap_interpreter!(mrb);
+    let value = Value::new(&interp, value);
+    let result = math::erfc(&mut interp, value).map(|result| interp.convert_mut(result));
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => exception::raise(interp, exception),
+    }
+}
+
+unsafe extern "C" fn artichoke_math_exp(
+    mrb: *mut sys::mrb_state,
+    _slf: sys::mrb_value,
+) -> sys::mrb_value {
+    let value = mrb_get_args!(mrb, required = 1);
+    let mut interp = unwrap_interpreter!(mrb);
+    let value = Value::new(&interp, value);
+    let result = math::exp(&mut interp, value).map(|result| interp.convert_mut(result));
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => exception::raise(interp, exception),
+    }
+}
+
+unsafe extern "C" fn artichoke_math_frexp(
+    mrb: *mut sys::mrb_state,
+    _slf: sys::mrb_value,
+) -> sys::mrb_value {
+    let value = mrb_get_args!(mrb, required = 1);
+    let mut interp = unwrap_interpreter!(mrb);
+    let value = Value::new(&interp, value);
+    let result = math::frexp(&mut interp, value).map(|(fraction, exponent)| {
+        let fraction = interp.convert_mut(fraction);
+        let exponent = interp.convert(exponent);
+        interp.convert_mut(&[fraction, exponent][..])
+    });
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => exception::raise(interp, exception),
+    }
+}
+
+unsafe extern "C" fn artichoke_math_gamma(
+    mrb: *mut sys::mrb_state,
+    _slf: sys::mrb_value,
+) -> sys::mrb_value {
+    let value = mrb_get_args!(mrb, required = 1);
+    let mut interp = unwrap_interpreter!(mrb);
+    let value = Value::new(&interp, value);
+    let result = math::gamma(&mut interp, value).map(|result| interp.convert_mut(result));
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => exception::raise(interp, exception),
+    }
+}
+
+unsafe extern "C" fn artichoke_math_hypot(
+    mrb: *mut sys::mrb_state,
+    _slf: sys::mrb_value,
+) -> sys::mrb_value {
+    let (value, other) = mrb_get_args!(mrb, required = 2);
+    let mut interp = unwrap_interpreter!(mrb);
+    let value = Value::new(&interp, value);
+    let other = Value::new(&interp, other);
+    let result = math::hypot(&mut interp, value, other).map(|result| interp.convert_mut(result));
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => exception::raise(interp, exception),
+    }
+}
+
+unsafe extern "C" fn artichoke_math_ldexp(
+    mrb: *mut sys::mrb_state,
+    _slf: sys::mrb_value,
+) -> sys::mrb_value {
+    let (fraction, exponent) = mrb_get_args!(mrb, required = 2);
+    let mut interp = unwrap_interpreter!(mrb);
+    let fraction = Value::new(&interp, fraction);
+    let exponent = Value::new(&interp, exponent);
+    let result =
+        math::ldexp(&mut interp, fraction, exponent).map(|result| interp.convert_mut(result));
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => exception::raise(interp, exception),
+    }
+}
+
+unsafe extern "C" fn artichoke_math_lgamma(
+    mrb: *mut sys::mrb_state,
+    _slf: sys::mrb_value,
+) -> sys::mrb_value {
+    let value = mrb_get_args!(mrb, required = 1);
+    let mut interp = unwrap_interpreter!(mrb);
+    let value = Value::new(&interp, value);
+    let result = math::lgamma(&mut interp, value).map(|(result, sign)| {
+        let result = interp.convert_mut(result);
+        let sign = interp.convert(sign);
+        interp.convert_mut(&[result, sign][..])
+    });
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => exception::raise(interp, exception),
+    }
+}
+
+unsafe extern "C" fn artichoke_math_log(
+    mrb: *mut sys::mrb_state,
+    _slf: sys::mrb_value,
+) -> sys::mrb_value {
+    let (value, base) = mrb_get_args!(mrb, required = 1, optional = 1);
+    let mut interp = unwrap_interpreter!(mrb);
+    let value = Value::new(&interp, value);
+    let base = base.map(|base| Value::new(&interp, base));
+    let result = math::log(&mut interp, value, base).map(|result| interp.convert_mut(result));
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => exception::raise(interp, exception),
+    }
+}
+
+unsafe extern "C" fn artichoke_math_log10(
+    mrb: *mut sys::mrb_state,
+    _slf: sys::mrb_value,
+) -> sys::mrb_value {
+    let value = mrb_get_args!(mrb, required = 1);
+    let mut interp = unwrap_interpreter!(mrb);
+    let value = Value::new(&interp, value);
+    let result = math::log10(&mut interp, value).map(|result| interp.convert_mut(result));
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => exception::raise(interp, exception),
+    }
+}
+
+unsafe extern "C" fn artichoke_math_log2(
+    mrb: *mut sys::mrb_state,
+    _slf: sys::mrb_value,
+) -> sys::mrb_value {
+    let value = mrb_get_args!(mrb, required = 1);
+    let mut interp = unwrap_interpreter!(mrb);
+    let value = Value::new(&interp, value);
+    let result = math::log2(&mut interp, value).map(|result| interp.convert_mut(result));
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => exception::raise(interp, exception),
+    }
+}
+
+unsafe extern "C" fn artichoke_math_sin(
+    mrb: *mut sys::mrb_state,
+    _slf: sys::mrb_value,
+) -> sys::mrb_value {
+    let value = mrb_get_args!(mrb, required = 1);
+    let mut interp = unwrap_interpreter!(mrb);
+    let value = Value::new(&interp, value);
+    let result = math::sin(&mut interp, value).map(|result| interp.convert_mut(result));
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => exception::raise(interp, exception),
+    }
+}
+
+unsafe extern "C" fn artichoke_math_sinh(
+    mrb: *mut sys::mrb_state,
+    _slf: sys::mrb_value,
+) -> sys::mrb_value {
+    let value = mrb_get_args!(mrb, required = 1);
+    let mut interp = unwrap_interpreter!(mrb);
+    let value = Value::new(&interp, value);
+    let result = math::sinh(&mut interp, value).map(|result| interp.convert_mut(result));
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => exception::raise(interp, exception),
+    }
+}
+
+unsafe extern "C" fn artichoke_math_sqrt(
+    mrb: *mut sys::mrb_state,
+    _slf: sys::mrb_value,
+) -> sys::mrb_value {
+    let value = mrb_get_args!(mrb, required = 1);
+    let mut interp = unwrap_interpreter!(mrb);
+    let value = Value::new(&interp, value);
+    let result = math::sqrt(&mut interp, value).map(|result| interp.convert_mut(result));
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => exception::raise(interp, exception),
+    }
+}
+
+unsafe extern "C" fn artichoke_math_tan(
+    mrb: *mut sys::mrb_state,
+    _slf: sys::mrb_value,
+) -> sys::mrb_value {
+    let value = mrb_get_args!(mrb, required = 1);
+    let mut interp = unwrap_interpreter!(mrb);
+    let value = Value::new(&interp, value);
+    let result = math::tan(&mut interp, value).map(|result| interp.convert_mut(result));
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => exception::raise(interp, exception),
+    }
+}
+
+unsafe extern "C" fn artichoke_math_tanh(
+    mrb: *mut sys::mrb_state,
+    _slf: sys::mrb_value,
+) -> sys::mrb_value {
+    let value = mrb_get_args!(mrb, required = 1);
+    let mut interp = unwrap_interpreter!(mrb);
+    let value = Value::new(&interp, value);
+    let result = math::tanh(&mut interp, value).map(|result| interp.convert_mut(result));
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => exception::raise(interp, exception),
+    }
+}

--- a/artichoke-backend/src/extn/core/mod.rs
+++ b/artichoke-backend/src/extn/core/mod.rs
@@ -14,6 +14,7 @@ pub mod hash;
 pub mod integer;
 pub mod kernel;
 pub mod matchdata;
+pub mod math;
 pub mod method;
 pub mod module;
 pub mod numeric;
@@ -49,6 +50,7 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     float::init(interp)?;
     kernel::init(interp)?;
     matchdata::init(interp)?;
+    math::mruby::init(interp)?;
     method::init(interp)?;
     module::init(interp)?;
     object::init(interp)?;

--- a/artichoke-backend/src/intern.rs
+++ b/artichoke-backend/src/intern.rs
@@ -12,7 +12,7 @@ impl Intern for Artichoke {
     {
         match symbol.into() {
             Cow::Borrowed(bytes) => unsafe {
-                sys::mrb_intern_static(
+                sys::mrb_intern(
                     self.0.borrow().mrb,
                     bytes.as_ptr() as *const i8,
                     bytes.len(),

--- a/artichoke-backend/src/sys/mod.rs
+++ b/artichoke-backend/src/sys/mod.rs
@@ -1,4 +1,4 @@
-#![deny(missing_docs, warnings, intra_doc_link_resolution_failure)]
+#![deny(missing_docs, intra_doc_link_resolution_failure)]
 
 //! Rust bindings for mruby, customized for Artichoke.
 //!

--- a/artichoke-backend/vendor/mruby/src/vm.c
+++ b/artichoke-backend/vendor/mruby/src/vm.c
@@ -2280,19 +2280,7 @@ RETRY_TRY_BLOCK:
         {
           mrb_float x = (mrb_float)mrb_fixnum(regs[a]);
           mrb_float y = mrb_float(regs[a+1]);
-          mrb_float f;
-          if (y == 0) {
-            if (x > 0) {
-              f = INFINITY;
-            } else if (x < 0) {
-              f = -INFINITY;
-            } else /* if (x == 0) */ {
-              f = NAN;
-            }
-          }
-          else {
-            f = x / y;
-          }
+          mrb_float f = x / y;
           SET_FLOAT_VALUE(mrb, regs[a], f);
         }
         break;
@@ -2300,19 +2288,7 @@ RETRY_TRY_BLOCK:
         {
           mrb_float x = mrb_float(regs[a]);
           mrb_float y = (mrb_float)mrb_fixnum(regs[a+1]);
-          mrb_float f;
-          if (y == 0) {
-            if (x > 0) {
-              f = INFINITY;
-            } else if (x < 0) {
-              f = -INFINITY;
-            } else /* if (x == 0) */ {
-              f = NAN;
-            }
-          }
-          else {
-            f = x / y;
-          }
+          mrb_float f = x / y;
           SET_FLOAT_VALUE(mrb, regs[a], f);
         }
         break;
@@ -2320,19 +2296,7 @@ RETRY_TRY_BLOCK:
         {
           mrb_float x = mrb_float(regs[a]);
           mrb_float y = mrb_float(regs[a+1]);
-          mrb_float f;
-          if (y == 0) {
-            if (x > 0) {
-              f = INFINITY;
-            } else if (x < 0) {
-              f = -INFINITY;
-            } else /* if (x == 0) */ {
-              f = NAN;
-            }
-          }
-          else {
-            f = x / y;
-          }
+          mrb_float f = x / y;
           SET_FLOAT_VALUE(mrb, regs[a], f);
         }
         break;

--- a/spec-runner/enforced-specs.yaml
+++ b/spec-runner/enforced-specs.yaml
@@ -43,6 +43,9 @@ core:
       - unshift
   - suite: comparable
   - suite: matchdata
+  - suite: math
+    skip:
+      - log2 # missing support for Bignum
   - suite: regexp
   - suite: string
     specs:

--- a/spec-runner/enforced-specs.yaml
+++ b/spec-runner/enforced-specs.yaml
@@ -45,6 +45,7 @@ core:
   - suite: matchdata
   - suite: math
     skip:
+      - gamma # missing support for Bignum
       - log2 # missing support for Bignum
   - suite: regexp
   - suite: string


### PR DESCRIPTION
Add a complete implementation of the `Math` module in Ruby Core.

Most functions in `Math` can be implemented with using `std`. Some functions, like `ldexp` and `erf` are not implemented in `std`. These functions are by default implemented to raise `NotImplementedError`.

`artichoke-backend` adds a new feature `core-math-extra` which is optional but enabled by default. This feature pulls in a dependency on `libm`, a pure Rust implementation of math functions in `musl`.

Some functions require `Bigint` support to pass ruby/spec.

The implementation of `Math::gamma` required inspiration from CRuby's implementation.

This PR fixes a segfault from improper assumption of lifetimes in `Intern::intern_symbol`.

This PR adds proper `Float` coercion behavior for `Numeric` subclasses to integer division.

This PR simplifies the division implementation in the mruby VM.