### PR TITLE
Replace all usage of format! macro with panic-free alternatives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,6 +41,7 @@ dependencies = [
  "cc",
  "chrono",
  "downcast",
+ "dtoa",
  "hex",
  "itoa",
  "libc",

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -14,8 +14,9 @@ base64 = { version = "0.11", optional = true }
 bstr = "0.2"
 chrono = "0.4"
 downcast = "0.10"
+dtoa = "0.4"
 hex = { version = "0.4", optional = true }
-itoa = "0.4.5"
+itoa = "0.4"
 libm = { version = "0.2", optional = true }
 log = "0.4"
 once_cell = "1"

--- a/artichoke-backend/src/extn/core/kernel/integer.rs
+++ b/artichoke-backend/src/extn/core/kernel/integer.rs
@@ -24,7 +24,7 @@ pub fn method(interp: &Artichoke, arg: Value, radix: Option<Value>) -> Result<Va
     };
     let radix = match radix.map(u32::try_from) {
         Some(Ok(radix)) if radix >= 2 && radix <= 36 => Some(radix),
-        Some(Ok(radix)) => return Err(Exception::from(invalid_radix_error(interp, radix))),
+        Some(Ok(radix)) => return Err(Exception::from(invalid_radix_error(interp, radix)?)),
         Some(Err(_)) => return Err(Exception::from(ArgumentError::new(interp, "invalid radix"))),
         None => None,
     };
@@ -174,7 +174,7 @@ pub fn method(interp: &Artichoke, arg: Value, radix: Option<Value>) -> Result<Va
         }
         (Some(_), Some(_)) => Err(Exception::from(invalid_value_err(interp, arg.as_bytes())?)),
         (Some(radix), None) | (None, Some(radix)) => {
-            Err(Exception::from(invalid_radix_error(interp, radix)))
+            Err(Exception::from(invalid_radix_error(interp, radix)?))
         }
     }
 }
@@ -186,6 +186,11 @@ fn invalid_value_err(interp: &Artichoke, arg: &[u8]) -> Result<ArgumentError, Ex
     Ok(ArgumentError::new(interp, message))
 }
 
-fn invalid_radix_error(interp: &Artichoke, radix: u32) -> ArgumentError {
-    ArgumentError::new(interp, format!("invalid radix {}", radix))
+fn invalid_radix_error(
+    interp: &Artichoke,
+    radix: u32,
+) -> Result<ArgumentError, string::WriteError> {
+    let mut message = String::from("invalid radix ");
+    string::format_int_into(&mut message, radix)?;
+    Ok(ArgumentError::new(interp, message))
 }

--- a/artichoke-backend/src/extn/core/matchdata/begin.rs
+++ b/artichoke-backend/src/extn/core/matchdata/begin.rs
@@ -36,18 +36,23 @@ pub fn method(interp: &Artichoke, args: Args<'_>, value: &Value) -> Result<Value
                 let idx = usize::try_from(-index).map_err(|_| {
                     Fatal::new(interp, "Expected positive position to convert to usize")
                 })?;
-                captures_len.checked_sub(idx).ok_or_else(|| {
-                    IndexError::new(interp, format!("index {} out of matches", index))
-                })?
+                if let Some(index) = captures_len.checked_sub(idx) {
+                    index
+                } else {
+                    let mut message = String::from("index ");
+                    string::format_int_into(&mut message, index)?;
+                    message.push_str(" out of matches");
+                    return Err(Exception::from(IndexError::new(interp, message)));
+                }
             } else {
                 let idx = usize::try_from(index).map_err(|_| {
                     Fatal::new(interp, "Expected positive position to convert to usize")
                 })?;
                 if idx > captures_len {
-                    return Err(Exception::from(IndexError::new(
-                        interp,
-                        format!("index {} out of matches", index),
-                    )));
+                    let mut message = String::from("index ");
+                    string::format_int_into(&mut message, index)?;
+                    message.push_str(" out of matches");
+                    return Err(Exception::from(IndexError::new(interp, message)));
                 }
                 idx
             }

--- a/artichoke-backend/src/extn/core/matchdata/end.rs
+++ b/artichoke-backend/src/extn/core/matchdata/end.rs
@@ -36,18 +36,23 @@ pub fn method(interp: &Artichoke, args: Args<'_>, value: &Value) -> Result<Value
                 let idx = usize::try_from(-index).map_err(|_| {
                     Fatal::new(interp, "Expected positive position to convert to usize")
                 })?;
-                captures_len.checked_sub(idx).ok_or_else(|| {
-                    IndexError::new(interp, format!("index {} out of matches", index))
-                })?
+                if let Some(index) = captures_len.checked_sub(idx) {
+                    index
+                } else {
+                    let mut message = String::from("index ");
+                    string::format_int_into(&mut message, index)?;
+                    message.push_str(" out of matches");
+                    return Err(Exception::from(IndexError::new(interp, message)));
+                }
             } else {
                 let idx = usize::try_from(index).map_err(|_| {
                     Fatal::new(interp, "Expected positive position to convert to usize")
                 })?;
                 if idx > captures_len {
-                    return Err(Exception::from(IndexError::new(
-                        interp,
-                        format!("index {} out of matches", index),
-                    )));
+                    let mut message = String::from("index ");
+                    string::format_int_into(&mut message, index)?;
+                    message.push_str(" out of matches");
+                    return Err(Exception::from(IndexError::new(interp, message)));
                 }
                 idx
             }

--- a/artichoke-backend/src/extn/core/random/mod.rs
+++ b/artichoke-backend/src/extn/core/random/mod.rs
@@ -119,10 +119,11 @@ pub fn rand(interp: &mut Artichoke, rand: Value, max: Option<Value>) -> Result<V
         Max::None
     };
     match max {
-        Max::Float(max) if max < 0.0 => Err(Exception::from(ArgumentError::new(
-            interp,
-            format!("invalid argument - {}", max),
-        ))),
+        Max::Float(max) if max < 0.0 => {
+            let mut message = b"invalid argument - ".to_vec();
+            string::write_float_into(&mut message, max)?;
+            Err(Exception::from(ArgumentError::new_raw(interp, message)))
+        }
         Max::Float(max) if max == 0.0 => {
             let mut borrow = rand.borrow_mut();
             let number = borrow.inner_mut().rand_float(interp, None);

--- a/artichoke-backend/src/string.rs
+++ b/artichoke-backend/src/string.rs
@@ -162,7 +162,7 @@ impl From<Box<WriteError>> for Box<dyn RubyException> {
     }
 }
 
-/// Error type for [`format_float_into`].
+/// Error type for [`write_float_into`].
 ///
 /// This error type wraps an [`io::Error`].
 #[derive(Debug)]

--- a/artichoke-backend/src/string.rs
+++ b/artichoke-backend/src/string.rs
@@ -9,6 +9,7 @@
 use bstr::ByteSlice;
 use std::error;
 use std::fmt;
+use std::io;
 
 use crate::exception::{Exception, RubyException};
 use crate::extn::core::exception::Fatal;
@@ -66,13 +67,27 @@ where
     Ok(())
 }
 
-/// Error type for [`format_unicode_debug_into`].
+pub fn write_float_into<W, F>(f: W, value: F) -> Result<(), IoWriteError>
+where
+    W: io::Write,
+    F: dtoa::Floating,
+{
+    // Potentially replace with a `fmt` variant for better ergonomics like
+    // `format_into_int` above.
+    //
+    // See: https://github.com/dtolnay/dtoa/issues/18
+    dtoa::write(f, value).map_err(IoWriteError)?;
+    Ok(())
+}
+
+/// Error type for [`format_unicode_debug_into`] and [`format_int_into`].
 ///
 /// This error type wraps a [`fmt::Error`].
 #[derive(Debug, Clone)]
 pub struct WriteError(fmt::Error);
 
 impl WriteError {
+    #[inline]
     #[must_use]
     pub fn into_inner(self) -> fmt::Error {
         self.0
@@ -81,21 +96,24 @@ impl WriteError {
 
 impl fmt::Display for WriteError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Unable to write escaped Unicode into destination")
+        write!(f, "Unable to write message into destination")
     }
 }
 
 impl error::Error for WriteError {
+    #[inline]
     fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         Some(&self.0)
     }
 }
 
 impl RubyException for WriteError {
+    #[inline]
     fn message(&self) -> &[u8] {
-        &b"Unable to escape Unicode message"[..]
+        &b"Unable to write message into destination"[..]
     }
 
+    #[inline]
     fn name(&self) -> String {
         String::from("fatal")
     }
@@ -115,12 +133,14 @@ impl RubyException for WriteError {
 }
 
 impl From<WriteError> for Exception {
+    #[inline]
     fn from(exception: WriteError) -> Self {
         Self::from(Box::<dyn RubyException>::from(exception))
     }
 }
 
 impl From<Box<WriteError>> for Exception {
+    #[inline]
     fn from(exception: Box<WriteError>) -> Self {
         Self::from(Box::<dyn RubyException>::from(exception))
     }
@@ -128,6 +148,7 @@ impl From<Box<WriteError>> for Exception {
 
 #[allow(clippy::use_self)]
 impl From<WriteError> for Box<dyn RubyException> {
+    #[inline]
     fn from(exception: WriteError) -> Box<dyn RubyException> {
         Box::new(exception)
     }
@@ -135,7 +156,90 @@ impl From<WriteError> for Box<dyn RubyException> {
 
 #[allow(clippy::use_self)]
 impl From<Box<WriteError>> for Box<dyn RubyException> {
+    #[inline]
     fn from(exception: Box<WriteError>) -> Box<dyn RubyException> {
+        exception
+    }
+}
+
+/// Error type for [`format_float_into`].
+///
+/// This error type wraps an [`io::Error`].
+#[derive(Debug)]
+pub struct IoWriteError(io::Error);
+
+impl IoWriteError {
+    #[inline]
+    #[must_use]
+    pub fn into_inner(self) -> io::Error {
+        self.0
+    }
+}
+
+impl fmt::Display for IoWriteError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Unable to write message into destination")
+    }
+}
+
+impl error::Error for IoWriteError {
+    #[inline]
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        Some(&self.0)
+    }
+}
+
+impl RubyException for IoWriteError {
+    #[inline]
+    fn message(&self) -> &[u8] {
+        &b"Unable to write message"[..]
+    }
+
+    #[inline]
+    fn name(&self) -> String {
+        String::from("fatal")
+    }
+
+    fn vm_backtrace(&self, interp: &mut Artichoke) -> Option<Vec<Vec<u8>>> {
+        let _ = interp;
+        None
+    }
+
+    fn as_mrb_value(&self, interp: &mut Artichoke) -> Option<sys::mrb_value> {
+        let message = interp.convert_mut(self.message());
+        let borrow = interp.0.borrow();
+        let spec = borrow.class_spec::<Fatal>()?;
+        let value = spec.new_instance(interp, &[message])?;
+        Some(value.inner())
+    }
+}
+
+impl From<IoWriteError> for Exception {
+    #[inline]
+    fn from(exception: IoWriteError) -> Self {
+        Self::from(Box::<dyn RubyException>::from(exception))
+    }
+}
+
+impl From<Box<IoWriteError>> for Exception {
+    #[inline]
+    fn from(exception: Box<IoWriteError>) -> Self {
+        Self::from(Box::<dyn RubyException>::from(exception))
+    }
+}
+
+#[allow(clippy::use_self)]
+impl From<IoWriteError> for Box<dyn RubyException> {
+    #[inline]
+    fn from(exception: IoWriteError) -> Box<dyn RubyException> {
+        Box::new(exception)
+    }
+}
+
+#[allow(clippy::use_self)]
+impl From<Box<IoWriteError>> for Box<dyn RubyException> {
+    #[inline]
+    fn from(exception: Box<IoWriteError>) -> Box<dyn RubyException> {
         exception
     }
 }

--- a/artichoke-backend/src/value.rs
+++ b/artichoke-backend/src/value.rs
@@ -640,7 +640,7 @@ mod tests {
 
         let value = interp.convert_mut("interstate");
         let debug = value.to_s_debug();
-        assert_eq!(debug, r#"String<"interstate">"#);
+        assert_eq!(debug, r#"String<\"interstate\">"#);
     }
 
     #[test]
@@ -667,7 +667,7 @@ mod tests {
 
         let value = interp.convert_mut("");
         let debug = value.to_s_debug();
-        assert_eq!(debug, r#"String<"">"#);
+        assert_eq!(debug, r#"String<\"\">"#);
     }
 
     #[test]

--- a/artichoke-backend/src/value.rs
+++ b/artichoke-backend/src/value.rs
@@ -6,6 +6,7 @@ use crate::exception::{Exception, RubyException};
 use crate::exception_handler;
 use crate::extn::core::exception::{ArgumentError, Fatal, TypeError};
 use crate::gc::MrbGarbageCollection;
+use crate::string;
 use crate::sys::{self, protect};
 use crate::types::{self, Int, Ruby};
 use crate::{Artichoke, Convert, ConvertMut, Intern, TryConvert, ValueLike};
@@ -105,11 +106,13 @@ impl Value {
     #[must_use]
     pub fn to_s_debug(&self) -> String {
         let inspect = self.inspect();
-        format!(
-            "{}<{}>",
-            self.ruby_type().class_name(),
-            String::from_utf8_lossy(&inspect)
-        )
+        let mut debug = String::from(self.ruby_type().class_name());
+        debug.push('<');
+        // It is safe to suppress this error since the `fmt::Write` impl for
+        // `String` does not return `Err`.
+        let _ = string::format_unicode_debug_into(&mut debug, inspect.as_slice());
+        debug.push('>');
+        debug
     }
 
     pub fn implicitly_convert_to_int(&self) -> Result<Int, TypeError> {
@@ -348,8 +351,10 @@ impl Convert<Value, Value> for Artichoke {
 
 impl fmt::Display for Value {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let string_repr = self.to_s();
-        write!(f, "{}", String::from_utf8_lossy(string_repr.as_slice()))
+        let display = self.to_s();
+        string::format_unicode_debug_into(f, display.as_slice())
+            .map_err(string::WriteError::into_inner)?;
+        Ok(())
     }
 }
 

--- a/artichoke-backend/tests/leak_unbounded_arena_growth.rs
+++ b/artichoke-backend/tests/leak_unbounded_arena_growth.rs
@@ -71,7 +71,7 @@ end
 
     // Value::to_s_debug
     let interp = artichoke_backend::interpreter().expect("init");
-    let expected = format!(r#"String<"{}">"#, "a".repeat(1024 * 1024));
+    let expected = format!(r#"String<\"{}\">"#, "a".repeat(1024 * 1024));
     leak::Detector::new("to_s_debug", ITERATIONS, 3 * LEAK_TOLERANCE).check_leaks_with_finalizer(
         |_| {
             let mut interp = interp.clone();


### PR DESCRIPTION
Replace all usage of the `format!` macro in non-test and non-build code
to use either:

- mutable `String` builder with `push` and `push_str` for concatenation
  use cases.
- `string::format_int_into` + `String` builder for interpolating integer
  values.
- `string::write_float_into` + `String` builder for interpolating float
  values.

This PR adds a dependency on `dtoa` in artichoke-backend. This dep is
the float equivalent of `itoa` that was added in GH-547.

This PR continues the work in GH-547.

This type of formatting is predominantly used when building `Exception`
messages, so the performance speed up will not be noticable.

Filed dtolnay/dtoa#18 to investigate adding a `dtoa::fmt` variant to
make the `string` API similar to `format_int_into`, which can take a
`String`.

This commit removes all uses of `String::from_utf8_lossy` in Artichoke.