### PR TITLE
Optimize random and securerandom implementations

### DIFF
--- a/artichoke-backend/src/extn/core/random/backend/rand.rs
+++ b/artichoke-backend/src/extn/core/random/backend/rand.rs
@@ -1,4 +1,3 @@
-use rand::distributions::{Distribution, Uniform};
 use rand::rngs::SmallRng;
 use rand::{self, Rng, SeedableRng};
 
@@ -28,6 +27,7 @@ where
 }
 
 impl<T> Rand<T> {
+    #[inline]
     pub fn seed(&self) -> u64 {
         self.seed
     }
@@ -52,19 +52,20 @@ impl<T> Rand<T>
 where
     T: Rng,
 {
+    #[inline]
     pub fn bytes(&mut self, buf: &mut [u8]) {
         self.rng.fill_bytes(buf);
     }
 
+    #[inline]
     pub fn rand_int(&mut self, max: Int) -> Int {
-        let between = Uniform::from(0..max);
-        between.sample(&mut self.rng)
+        self.rng.gen_range(0, max)
     }
 
+    #[inline]
     pub fn rand_float(&mut self, max: Option<Float>) -> Float {
         let max = max.unwrap_or(1.0);
-        let between = Uniform::from(0.0..max);
-        between.sample(&mut self.rng)
+        self.rng.gen_range(0.0, max)
     }
 }
 

--- a/artichoke-backend/src/extn/core/random/backend/rand.rs
+++ b/artichoke-backend/src/extn/core/random/backend/rand.rs
@@ -54,6 +54,8 @@ where
 {
     #[inline]
     pub fn bytes(&mut self, buf: &mut [u8]) {
+        // TODO: use non-panicking ``Rng::try_fill_bytes`, which requires a
+        // custom error type and returning `Result<(), Exception>`.
         self.rng.fill_bytes(buf);
     }
 

--- a/artichoke-backend/src/extn/core/random/mod.rs
+++ b/artichoke-backend/src/extn/core/random/mod.rs
@@ -87,9 +87,12 @@ pub fn bytes(interp: &mut Artichoke, rand: Value, size: Value) -> Result<Value, 
     let rand = unsafe { Random::try_from_ruby(interp, &rand) }?;
     let size = size.implicitly_convert_to_int()?;
     if let Ok(size) = usize::try_from(size) {
+        if size == 0 {
+            return Ok(interp.convert_mut(""));
+        }
         let mut buf = vec![0; size];
         let mut borrow = rand.borrow_mut();
-        borrow.inner_mut().bytes(interp, buf.as_mut_slice());
+        borrow.inner_mut().bytes(interp, &mut buf);
         Ok(interp.convert_mut(buf))
     } else {
         Err(Exception::from(ArgumentError::new(
@@ -184,8 +187,12 @@ pub fn urandom(interp: &mut Artichoke, size: Value) -> Result<Value, Exception> 
     let size = size.implicitly_convert_to_int()?;
     let size = usize::try_from(size)
         .map_err(|_| ArgumentError::new(interp, "negative string size (or size too big)"))?;
+    if size == 0 {
+        return Ok(interp.convert_mut(""));
+    }
     let mut bytes = vec![0; size];
     let mut rng = rand::thread_rng();
-    rng.fill_bytes(bytes.as_mut_slice());
+    rng.try_fill_bytes(&mut bytes)
+        .map_err(|err| RuntimeError::new(interp, err.to_string()))?;
     Ok(interp.convert_mut(bytes))
 }

--- a/artichoke-backend/src/extn/core/random/mod.rs
+++ b/artichoke-backend/src/extn/core/random/mod.rs
@@ -73,13 +73,16 @@ pub fn initialize(
 
 pub fn eql(interp: &Artichoke, rand: Value, other: Value) -> Result<Value, Exception> {
     let rand = unsafe { Random::try_from_ruby(interp, &rand) }?;
-    let other = unsafe { Random::try_from_ruby(interp, &other) }?;
-    if ptr::eq(rand.as_ref(), other.as_ref()) {
-        Ok(interp.convert(true))
+    if let Ok(other) = unsafe { Random::try_from_ruby(interp, &other) } {
+        if ptr::eq(rand.as_ref(), other.as_ref()) {
+            Ok(interp.convert(true))
+        } else {
+            let this_seed = rand.borrow().inner().seed(interp);
+            let other_seed = other.borrow().inner().seed(interp);
+            Ok(interp.convert(this_seed == other_seed))
+        }
     } else {
-        let this_seed = rand.borrow().inner().seed(interp);
-        let other_seed = other.borrow().inner().seed(interp);
-        Ok(interp.convert(this_seed == other_seed))
+        Ok(interp.convert(false))
     }
 }
 

--- a/artichoke-backend/src/state/prng.rs
+++ b/artichoke-backend/src/state/prng.rs
@@ -11,6 +11,7 @@ pub struct Prng {
 
 impl Prng {
     #[must_use]
+    #[inline]
     pub fn new(seed: Option<u64>) -> Self {
         Self {
             random: Rand::new(seed),
@@ -18,32 +19,39 @@ impl Prng {
     }
 
     #[must_use]
+    #[inline]
     pub fn seed(&self) -> u64 {
         self.random.seed()
     }
 
+    #[inline]
     pub fn reseed(&mut self, new_seed: Option<u64>) {
         self.random = Rand::new(new_seed);
     }
 
+    #[inline]
     pub fn has_same_internal_state(&self, other: &dyn RandType) -> bool {
         self.random.has_same_internal_state(other)
     }
 
+    #[inline]
     pub fn bytes(&mut self, buf: &mut [u8]) {
         self.random.bytes(buf);
     }
 
+    #[inline]
     pub fn rand_int(&mut self, max: Int) -> Int {
         self.random.rand_int(max)
     }
 
+    #[inline]
     pub fn rand_float(&mut self, max: Option<Float>) -> Float {
         self.random.rand_float(max)
     }
 }
 
 impl Default for Prng {
+    #[inline]
     fn default() -> Self {
         Self::new(None)
     }


### PR DESCRIPTION
- `#[inline]` annotate a bunch of short functions.
- Use `Rng::gen_range` instead of sampling a distribution for
  single-shot `Rng` use because `gen_range` is optimized for this use
  case.
- Short circuit when requested byte length is zero instead of allocating
  an empty buffer and invoking the RNG.
- Use `RngCore::try_fill_bytes` whenever possible since we can propagate
  its failures as `RuntimeError`s instead of panicking.
- Simplify byte length calculations to only do one `usize` check in
  `SecureRandom`. Parse, don't validate!
- Unchain `hex` and `base64` functions in `SecureRandom` for
  readability.