### PR TITLE
Remove downcast dependency and all use of Any

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,7 +40,6 @@ dependencies = [
  "bstr",
  "cc",
  "chrono",
- "downcast",
  "dtoa",
  "hex",
  "itoa",
@@ -260,12 +259,6 @@ dependencies = [
  "redox_users",
  "winapi",
 ]
-
-[[package]]
-name = "downcast"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bb454f0228b18c7f4c3b0ebbee346ed9c52e7443b0999cd543ff3571205701d"
 
 [[package]]
 name = "dtoa"

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -13,7 +13,6 @@ keywords = ["artichoke", "artichoke-ruby", "ruby"]
 base64 = { version = "0.11", optional = true }
 bstr = "0.2"
 chrono = "0.4"
-downcast = "0.10"
 dtoa = "0.4"
 hex = { version = "0.4", optional = true }
 itoa = "0.4"

--- a/artichoke-backend/src/extn/core/array/backend/mod.rs
+++ b/artichoke-backend/src/extn/core/array/backend/mod.rs
@@ -1,8 +1,6 @@
-use std::any::Any;
-
 use crate::extn::prelude::*;
 
-pub trait ArrayType: Any {
+pub trait ArrayType {
     fn box_clone(&self) -> Box<dyn ArrayType>;
 
     fn gc_mark(&self, interp: &Artichoke);
@@ -62,9 +60,4 @@ pub trait ArrayType: Any {
     ) -> Result<Value, Exception>;
 
     fn reverse(&mut self, interp: &Artichoke) -> Result<(), Exception>;
-}
-
-#[allow(clippy::missing_safety_doc)]
-mod internal {
-    downcast!(dyn super::ArrayType);
 }

--- a/artichoke-backend/src/extn/core/array/inline_buffer.rs
+++ b/artichoke-backend/src/extn/core/array/inline_buffer.rs
@@ -144,14 +144,14 @@ impl ArrayType for InlineBuffer {
         realloc: &mut Option<Vec<Box<dyn ArrayType>>>,
     ) -> Result<usize, Exception> {
         let _ = realloc;
-        if let Ok(buffer) = with.downcast_ref::<Self>() {
-            Self::set_slice(self, interp, start, drain, buffer)
-        } else {
-            Err(Exception::from(Fatal::new(
-                interp,
-                "set slice on InlineBuffer with unknown ArrayType",
-            )))
+        let mut slice = Vec::with_capacity(with.len());
+        for idx in 0..with.len() {
+            if let Some(elem) = with.get(interp, idx)? {
+                slice.push(elem);
+            }
         }
+        let buffer = Self::from(slice);
+        Self::set_slice(self, interp, start, drain, &buffer)
     }
 
     fn concat(
@@ -161,14 +161,14 @@ impl ArrayType for InlineBuffer {
         realloc: &mut Option<Vec<Box<dyn ArrayType>>>,
     ) -> Result<(), Exception> {
         let _ = realloc;
-        if let Ok(buffer) = other.downcast_ref::<Self>() {
-            Self::concat(self, interp, buffer)
-        } else {
-            Err(Exception::from(Fatal::new(
-                interp,
-                "concat on InlineBuffer with unknown ArrayType",
-            )))
+        let mut slice = Vec::with_capacity(other.len());
+        for idx in 0..other.len() {
+            if let Some(elem) = other.get(interp, idx)? {
+                slice.push(elem);
+            }
         }
+        let buffer = Self::from(slice);
+        Self::concat(self, interp, &buffer)
     }
 
     fn pop(

--- a/artichoke-backend/src/extn/core/env/backend/memory.rs
+++ b/artichoke-backend/src/extn/core/env/backend/memory.rs
@@ -1,6 +1,7 @@
 use bstr::ByteSlice;
 use std::borrow::Cow;
 use std::collections::HashMap;
+use std::fmt;
 
 use crate::extn::core::env::backend::EnvType;
 use crate::extn::prelude::*;
@@ -18,6 +19,10 @@ impl Memory {
 }
 
 impl EnvType for Memory {
+    fn as_debug(&self) -> &dyn fmt::Debug {
+        self
+    }
+
     fn get<'a>(
         &'a self,
         interp: &Artichoke,

--- a/artichoke-backend/src/extn/core/env/backend/mod.rs
+++ b/artichoke-backend/src/extn/core/env/backend/mod.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
 use std::collections::HashMap;
+use std::fmt;
 
 use crate::extn::prelude::*;
 
@@ -7,6 +8,9 @@ pub mod memory;
 pub mod system;
 
 pub trait EnvType {
+    /// Return a `dyn Debug` representation of this `Environ`.
+    fn as_debug(&self) -> &dyn fmt::Debug;
+
     fn get<'a>(
         &'a self,
         interp: &Artichoke,
@@ -21,9 +25,4 @@ pub trait EnvType {
     ) -> Result<(), Exception>;
 
     fn as_map(&self, interp: &Artichoke) -> Result<HashMap<Vec<u8>, Vec<u8>>, Exception>;
-}
-
-#[allow(clippy::missing_safety_doc)]
-mod internal {
-    downcast!(dyn super::EnvType);
 }

--- a/artichoke-backend/src/extn/core/env/backend/system.rs
+++ b/artichoke-backend/src/extn/core/env/backend/system.rs
@@ -1,6 +1,7 @@
 use bstr::ByteSlice;
 use std::borrow::Cow;
 use std::collections::HashMap;
+use std::fmt;
 
 use crate::extn::core::env::backend::EnvType;
 use crate::extn::prelude::*;
@@ -17,6 +18,10 @@ impl System {
 }
 
 impl EnvType for System {
+    fn as_debug(&self) -> &dyn fmt::Debug {
+        self
+    }
+
     fn get<'a>(
         &'a self,
         interp: &Artichoke,

--- a/artichoke-backend/src/extn/core/random/backend/default.rs
+++ b/artichoke-backend/src/extn/core/random/backend/default.rs
@@ -1,10 +1,16 @@
-use crate::extn::core::random::backend::RandType;
+use std::fmt;
+
+use crate::extn::core::random::backend::{InternalState, RandType};
 use crate::extn::prelude::*;
 
 #[derive(Default, Debug, Clone, Copy)]
 pub struct Default;
 
 impl RandType for Default {
+    fn as_debug(&self) -> &dyn fmt::Debug {
+        self
+    }
+
     fn bytes(&mut self, interp: &mut Artichoke, buf: &mut [u8]) {
         let mut borrow = interp.0.borrow_mut();
         borrow.prng.bytes(buf);
@@ -15,9 +21,9 @@ impl RandType for Default {
         borrow.prng.seed()
     }
 
-    fn has_same_internal_state(&self, interp: &Artichoke, other: &dyn RandType) -> bool {
+    fn internal_state(&self, interp: &Artichoke) -> InternalState {
         let borrow = interp.0.borrow();
-        borrow.prng.has_same_internal_state(other)
+        borrow.prng.internal_state()
     }
 
     fn rand_int(&mut self, interp: &mut Artichoke, max: Int) -> Int {

--- a/artichoke-backend/src/extn/core/random/backend/mod.rs
+++ b/artichoke-backend/src/extn/core/random/backend/mod.rs
@@ -1,4 +1,4 @@
-use std::any::Any;
+use std::fmt;
 
 use crate::extn::prelude::*;
 
@@ -6,7 +6,10 @@ pub mod default;
 pub mod rand;
 
 /// Common API for [`Random`](crate::extn::core::random::Random) backends.
-pub trait RandType: Any {
+pub trait RandType {
+    /// Return a `dyn Debug` representation of this `Random`.
+    fn as_debug(&self) -> &dyn fmt::Debug;
+
     /// Completely fill a buffer with random bytes.
     fn bytes(&mut self, interp: &mut Artichoke, buf: &mut [u8]);
 
@@ -15,7 +18,7 @@ pub trait RandType: Any {
 
     /// Return true if this and `other` would return the same sequence of random
     /// data.
-    fn has_same_internal_state(&self, interp: &Artichoke, other: &dyn RandType) -> bool;
+    fn internal_state(&self, interp: &Artichoke) -> InternalState;
 
     /// Return a random `Integer` between 0 and `max` -- `[0, max)`.
     fn rand_int(&mut self, interp: &mut Artichoke, max: Int) -> Int;
@@ -27,7 +30,8 @@ pub trait RandType: Any {
     fn rand_float(&mut self, interp: &mut Artichoke, max: Option<Float>) -> Float;
 }
 
-#[allow(clippy::missing_safety_doc)]
-mod internal {
-    downcast!(dyn super::RandType);
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum InternalState {
+    Rand { seed: u64 },
 }

--- a/artichoke-backend/src/extn/core/random/mod.rs
+++ b/artichoke-backend/src/extn/core/random/mod.rs
@@ -3,14 +3,10 @@ use std::convert::TryFrom;
 use std::fmt;
 use std::ptr;
 
-use rand::rngs::SmallRng;
-
 use crate::extn::prelude::*;
 
 pub mod backend;
 pub mod mruby;
-
-use backend::rand::Rand;
 
 pub struct Random(Box<dyn backend::RandType>);
 
@@ -42,16 +38,9 @@ impl RustBackedValue for Random {
 
 impl fmt::Debug for Random {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if let Ok(inner) = self.inner().downcast_ref::<Rand<SmallRng>>() {
-            f.debug_struct("Random")
-                .field("backend", &inner)
-                .field("seed", &inner.seed())
-                .finish()
-        } else {
-            f.debug_struct("Random")
-                .field("backend", &"unknown")
-                .finish()
-        }
+        f.debug_struct("Random")
+            .field("backend", self.0.as_debug())
+            .finish()
     }
 }
 

--- a/artichoke-backend/src/extn/core/time/backend/chrono.rs
+++ b/artichoke-backend/src/extn/core/time/backend/chrono.rs
@@ -1,4 +1,5 @@
 use chrono::{DateTime, Datelike, Local, TimeZone, Timelike, Weekday};
+use std::fmt;
 
 use crate::extn::core::time::backend::{MakeTime, TimeType};
 use crate::Artichoke;
@@ -15,7 +16,11 @@ impl<T: TimeZone> Chrono<T> {
     }
 }
 
-impl<T: TimeZone> TimeType for Chrono<T> {
+impl<T: 'static + TimeZone + fmt::Debug> TimeType for Chrono<T> {
+    fn as_debug(&self) -> &dyn fmt::Debug {
+        self
+    }
+
     fn day(&self) -> u32 {
         self.0.day()
     }
@@ -97,8 +102,14 @@ impl<T: TimeZone> TimeType for Chrono<T> {
 }
 
 impl MakeTime for Factory {
-    fn now(&self, interp: &Artichoke) -> Box<dyn TimeType> {
+    type Time = Chrono<Local>;
+
+    fn as_debug(&self) -> &dyn fmt::Debug {
+        self
+    }
+
+    fn now(&self, interp: &Artichoke) -> Self::Time {
         let _ = interp;
-        Box::new(Chrono::new(Local::now()))
+        Chrono::new(Local::now())
     }
 }

--- a/artichoke-backend/src/extn/core/time/backend/mod.rs
+++ b/artichoke-backend/src/extn/core/time/backend/mod.rs
@@ -1,11 +1,14 @@
-use std::any::Any;
+use std::fmt;
 
 use crate::Artichoke;
 
 pub mod chrono;
 
 /// Common API for [`Time`](crate::extn::core::time::Time) backends.
-pub trait TimeType: Any {
+pub trait TimeType {
+    /// Return a `dyn Debug` representation of this `Time`.
+    fn as_debug(&self) -> &dyn fmt::Debug;
+
     /// Returns the day of the month (1..n) for time.
     fn day(&self) -> u32;
 
@@ -71,12 +74,14 @@ pub trait TimeType: Any {
     fn is_sunday(&self) -> bool;
 }
 
-pub trait MakeTime: Any {
-    fn now(&self, interp: &Artichoke) -> Box<dyn TimeType>;
-}
+/// Common API for [`Time`](crate::extn::core::time::Time) constructors.
+pub trait MakeTime {
+    /// Concrete type for `Time` backends constructed by this factory.
+    type Time: TimeType;
 
-#[allow(clippy::missing_safety_doc)]
-mod internal {
-    downcast!(dyn super::TimeType);
-    downcast!(dyn super::MakeTime);
+    /// Return a `dyn Debug` representation of this `Time`.
+    fn as_debug(&self) -> &dyn fmt::Debug;
+
+    /// Construct the current time.
+    fn now(&self, interp: &Artichoke) -> Self::Time;
 }

--- a/artichoke-backend/src/extn/core/time/mod.rs
+++ b/artichoke-backend/src/extn/core/time/mod.rs
@@ -1,4 +1,3 @@
-use chrono::Local;
 use std::fmt;
 
 use crate::convert::RustBackedValue;
@@ -7,7 +6,7 @@ pub mod backend;
 pub mod mruby;
 pub mod trampoline;
 
-use backend::chrono::{Chrono, Factory};
+use backend::chrono::Factory;
 use backend::{MakeTime, TimeType};
 
 #[must_use]
@@ -31,10 +30,8 @@ impl RustBackedValue for Time {
 
 impl fmt::Debug for Time {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if let Ok(backend) = self.0.downcast_ref::<Chrono<Local>>() {
-            f.debug_struct("Time").field("backend", backend).finish()
-        } else {
-            f.debug_struct("Time").field("backend", &"unknown").finish()
-        }
+        f.debug_struct("Time")
+            .field("backend", self.0.as_debug())
+            .finish()
     }
 }

--- a/artichoke-backend/src/extn/core/time/trampoline.rs
+++ b/artichoke-backend/src/extn/core/time/trampoline.rs
@@ -3,7 +3,7 @@ use crate::extn::core::time::{self, Time};
 use crate::extn::prelude::*;
 
 pub fn now(interp: &Artichoke) -> Result<Value, Exception> {
-    let now = Time(time::factory().now(interp));
+    let now = Time(Box::new(time::factory().now(interp)));
     let result = now.try_into_ruby(&interp, None)?;
     Ok(result)
 }

--- a/artichoke-backend/src/lib.rs
+++ b/artichoke-backend/src/lib.rs
@@ -95,8 +95,6 @@
 //! [MIT/Expat License](https://github.com/emscripten-core/emsdk/blob/master/LICENSE).
 
 #[macro_use]
-extern crate downcast;
-#[macro_use]
 extern crate log;
 
 use std::cell::RefCell;

--- a/artichoke-backend/src/state/mod.rs
+++ b/artichoke-backend/src/state/mod.rs
@@ -142,7 +142,7 @@ impl fmt::Debug for State {
             .field("modules", &self.modules)
             .field("vfs", &self.vfs)
             .field("active_regexp_globals", &self.active_regexp_globals)
-            .field("output", &self.output.backend_name());
+            .field("output", self.output.as_debug());
         #[cfg(feature = "artichoke-random")]
         fmt.field("prng", &self.prng);
         fmt.finish()

--- a/artichoke-backend/src/state/output.rs
+++ b/artichoke-backend/src/state/output.rs
@@ -1,7 +1,8 @@
+use std::fmt;
 use std::io::{self, Write};
 
 pub trait Output: Send + Sync {
-    fn backend_name(&self) -> &str;
+    fn as_debug(&self) -> &dyn fmt::Debug;
 
     fn write_stdout(&mut self, bytes: &[u8]) -> io::Result<()>;
 
@@ -18,11 +19,6 @@ pub trait Output: Send + Sync {
     }
 }
 
-#[allow(clippy::missing_safety_doc)]
-mod internal {
-    downcast!(dyn super::Output);
-}
-
 #[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq)]
 pub struct Process;
 
@@ -34,8 +30,8 @@ impl Process {
 }
 
 impl Output for Process {
-    fn backend_name(&self) -> &str {
-        "Process"
+    fn as_debug(&self) -> &dyn fmt::Debug {
+        self
     }
 
     fn write_stdout(&mut self, bytes: &[u8]) -> io::Result<()> {
@@ -76,8 +72,8 @@ impl Captured {
 }
 
 impl Output for Captured {
-    fn backend_name(&self) -> &str {
-        "Captured"
+    fn as_debug(&self) -> &dyn fmt::Debug {
+        self
     }
 
     fn write_stdout(&mut self, bytes: &[u8]) -> io::Result<()> {
@@ -90,8 +86,8 @@ impl Output for Captured {
 }
 
 impl<'a> Output for &'a mut Captured {
-    fn backend_name(&self) -> &str {
-        "Captured"
+    fn as_debug(&self) -> &dyn fmt::Debug {
+        self
     }
 
     fn write_stdout(&mut self, bytes: &[u8]) -> io::Result<()> {
@@ -114,8 +110,8 @@ impl Null {
 }
 
 impl Output for Null {
-    fn backend_name(&self) -> &str {
-        "Null"
+    fn as_debug(&self) -> &dyn fmt::Debug {
+        self
     }
 
     fn write_stdout(&mut self, bytes: &[u8]) -> io::Result<()> {

--- a/artichoke-backend/src/state/prng.rs
+++ b/artichoke-backend/src/state/prng.rs
@@ -1,7 +1,7 @@
 use rand::rngs::SmallRng;
 
 use crate::extn::core::random::backend::rand::Rand;
-use crate::extn::core::random::backend::RandType;
+use crate::extn::core::random::backend::InternalState;
 use crate::types::{Float, Int};
 
 #[derive(Debug)]
@@ -29,9 +29,10 @@ impl Prng {
         self.random = Rand::new(new_seed);
     }
 
+    #[must_use]
     #[inline]
-    pub fn has_same_internal_state(&self, other: &dyn RandType) -> bool {
-        self.random.has_same_internal_state(other)
+    pub fn internal_state(&self) -> InternalState {
+        self.random.internal_state()
     }
 
     #[inline]


### PR DESCRIPTION
This commit removes the `downcast` dependency from `artichoke-backend`
and replaces all instances of downcasting trait objects with dynamically
dispatched APIs.

One common use for downcasting in Artichoke was to get a concrete type
to feed into a `debug_struct` invocation in a `Debug` implementation.
This pattern can be used by adding a `fn as_debug(&self) -> &dyn fmt::Debug`
method to the trait definition, allowing concrete implementations of a
trait to forward their debug impls.

`ArrayType` used downcasting to specialize some operations for
`InlineBuffer` types. `ArrayType` is kept for compatibility and for the
medium term I expect `InlineBuffer` to remain the only implementation.
This PR reallocates a temporary `InlineBuffer` to make the
implementation work for all `ArrayType`s.

`RandType` implementations used downcasting to check internal state for
equality. This use was replaced with an enum that can represent internal
state for all `RandType` implementations.

There are no more imports of `std::any::Any` in this workspace.

This change prevents generics from leaking out of backend
implementations, like `SmallRng` in the `Rand` backend.