### PR TITLE
Some small refactorings and cleanups

### DIFF
--- a/artichoke-backend/build.rs
+++ b/artichoke-backend/build.rs
@@ -9,7 +9,10 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use target_lexicon::Triple;
 
-fn enumerate_sources<T: AsRef<Path>>(path: T, into: &mut Vec<PathBuf>) -> io::Result<()> {
+fn enumerate_sources<T>(path: T, into: &mut Vec<PathBuf>) -> io::Result<()>
+where
+    T: AsRef<Path>,
+{
     let mut stack = vec![PathBuf::from(path.as_ref())];
     into.push(PathBuf::from(path.as_ref()));
     while let Some(from) = stack.pop() {
@@ -562,7 +565,10 @@ mod release {
         emit("ARTICHOKE_COMPILER_VERSION", compiler_version());
     }
 
-    fn emit<T: fmt::Display>(env: &str, value: T) {
+    fn emit<T>(env: &str, value: T)
+    where
+        T: fmt::Display,
+    {
         println!("cargo:rustc-env={}={}", env, value);
     }
 
@@ -723,7 +729,11 @@ mod build {
         }
     }
 
-    fn copy_dir_recursive<F: AsRef<Path>, T: AsRef<Path>>(from: F, to: T) -> io::Result<()> {
+    fn copy_dir_recursive<T, U>(from: T, to: U) -> io::Result<()>
+    where
+        T: AsRef<Path>,
+        U: AsRef<Path>,
+    {
         let mut stack = vec![PathBuf::from(from.as_ref())];
         let dest_root = PathBuf::from(to.as_ref());
         let input_root_depth = from.as_ref().components().count();

--- a/artichoke-backend/src/class.rs
+++ b/artichoke-backend/src/class.rs
@@ -254,7 +254,7 @@ impl Eq for Spec {}
 
 impl PartialEq for Spec {
     fn eq(&self, other: &Self) -> bool {
-        self.name == other.name
+        self.fqname() == other.fqname()
     }
 }
 

--- a/artichoke-backend/src/constant.rs
+++ b/artichoke-backend/src/constant.rs
@@ -25,11 +25,14 @@ impl DefineConstant for Artichoke {
         Ok(())
     }
 
-    fn define_class_constant<T: 'static>(
+    fn define_class_constant<T>(
         &mut self,
         constant: &str,
         value: Self::Value,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<(), Self::Error>
+    where
+        T: 'static,
+    {
         let name =
             CString::new(constant).map_err(|_| ConstantNameError::new(String::from(constant)))?;
         let borrow = self.0.borrow();
@@ -49,11 +52,14 @@ impl DefineConstant for Artichoke {
         Ok(())
     }
 
-    fn define_module_constant<T: 'static>(
+    fn define_module_constant<T>(
         &mut self,
         constant: &str,
         value: Self::Value,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<(), Self::Error>
+    where
+        T: 'static,
+    {
         let name =
             CString::new(constant).map_err(|_| ConstantNameError::new(String::from(constant)))?;
         let borrow = self.0.borrow();

--- a/artichoke-backend/src/def.rs
+++ b/artichoke-backend/src/def.rs
@@ -34,14 +34,15 @@ pub type Free = unsafe extern "C" fn(mrb: *mut sys::mrb_state, data: *mut c_void
 ///
 /// This function assumes it is called by the mruby VM as a free function for
 /// an [`MRB_TT_DATA`](sys::mrb_vtype::MRB_TT_DATA).
-pub unsafe extern "C" fn rust_data_free<T: 'static + RustBackedValue>(
-    _mrb: *mut sys::mrb_state,
-    data: *mut c_void,
-) {
+pub unsafe extern "C" fn rust_data_free<T>(_mrb: *mut sys::mrb_state, data: *mut c_void)
+where
+    T: 'static + RustBackedValue,
+{
     if data.is_null() {
         panic!(
-            "Received null pointer in rust_data_free<{}>",
-            T::ruby_type_name()
+            "Received null pointer in rust_data_free<{}>: {:p}",
+            T::ruby_type_name(),
+            data
         );
     }
     let data = Rc::from_raw(data as *const RefCell<T>);

--- a/artichoke-backend/src/exception_handler.rs
+++ b/artichoke-backend/src/exception_handler.rs
@@ -1,5 +1,3 @@
-use std::ptr;
-
 use crate::exception::{CaughtException, Exception};
 use crate::gc::MrbGarbageCollection;
 use crate::value::Value;
@@ -21,14 +19,6 @@ pub fn last_error(interp: &Artichoke, exception: Value) -> Result<Exception, Exc
     // `mrb_value`. `Value::funcall` handles errors by calling this
     // function, so not clearing the exception results in a stack overflow.
 
-    // Safety:
-    //
-    // - Artichoke is guaranteed to be constructed with a non-null `mrb`
-    //   pointer by `ffi::from_user_data` and `interpreter::interpreter`.
-    unsafe {
-        let mrb = interp.0.borrow().mrb;
-        (*mrb).exc = ptr::null_mut();
-    }
     // Generate exception metadata in by executing the Ruby code:
     //
     // ```ruby

--- a/artichoke-backend/src/extn/core/array/inline_buffer.rs
+++ b/artichoke-backend/src/extn/core/array/inline_buffer.rs
@@ -37,7 +37,10 @@ impl<'a> From<&'a [Value]> for InlineBuffer {
 }
 
 impl FromIterator<Value> for InlineBuffer {
-    fn from_iter<I: IntoIterator<Item = Value>>(iter: I) -> Self {
+    fn from_iter<I>(iter: I) -> Self
+    where
+        I: IntoIterator<Item = Value>,
+    {
         Self(SmallVec::from_iter(
             iter.into_iter().map(|elem| elem.inner()),
         ))
@@ -45,7 +48,10 @@ impl FromIterator<Value> for InlineBuffer {
 }
 
 impl FromIterator<Option<Value>> for InlineBuffer {
-    fn from_iter<I: IntoIterator<Item = Option<Value>>>(iter: I) -> Self {
+    fn from_iter<I>(iter: I) -> Self
+    where
+        I: IntoIterator<Item = Option<Value>>,
+    {
         Self(SmallVec::from_iter(iter.into_iter().map(|elem| {
             elem.map_or_else(|| unsafe { sys::mrb_sys_nil_value() }, |elem| elem.inner())
         })))
@@ -53,13 +59,13 @@ impl FromIterator<Option<Value>> for InlineBuffer {
 }
 
 impl<'a> FromIterator<&'a Option<Value>> for InlineBuffer {
-    fn from_iter<I: IntoIterator<Item = &'a Option<Value>>>(iter: I) -> Self {
+    fn from_iter<I>(iter: I) -> Self
+    where
+        I: IntoIterator<Item = &'a Option<Value>>,
+    {
         Self(SmallVec::from_iter(iter.into_iter().map(|elem| {
-            if let Some(elem) = elem {
-                elem.inner()
-            } else {
-                unsafe { sys::mrb_sys_nil_value() }
-            }
+            elem.as_ref()
+                .map_or_else(|| unsafe { sys::mrb_sys_nil_value() }, |elem| elem.inner())
         })))
     }
 }

--- a/artichoke-backend/src/extn/core/array/inline_buffer.rs
+++ b/artichoke-backend/src/extn/core/array/inline_buffer.rs
@@ -53,7 +53,8 @@ impl FromIterator<Option<Value>> for InlineBuffer {
         I: IntoIterator<Item = Option<Value>>,
     {
         Self(SmallVec::from_iter(iter.into_iter().map(|elem| {
-            elem.map_or_else(|| unsafe { sys::mrb_sys_nil_value() }, |elem| elem.inner())
+            elem.as_ref()
+                .map_or_else(|| unsafe { sys::mrb_sys_nil_value() }, Value::inner)
         })))
     }
 }
@@ -65,7 +66,7 @@ impl<'a> FromIterator<&'a Option<Value>> for InlineBuffer {
     {
         Self(SmallVec::from_iter(iter.into_iter().map(|elem| {
             elem.as_ref()
-                .map_or_else(|| unsafe { sys::mrb_sys_nil_value() }, |elem| elem.inner())
+                .map_or_else(|| unsafe { sys::mrb_sys_nil_value() }, Value::inner)
         })))
     }
 }

--- a/artichoke-backend/src/extn/stdlib/securerandom/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/securerandom/mod.rs
@@ -12,7 +12,11 @@ const DEFAULT_REQUESTED_BYTES: usize = 16;
 
 #[cfg(test)]
 mod tests {
-    fn rng_must_be_cryptographically_secure<T: rand::CryptoRng>(_rng: T) {}
+    fn rng_must_be_cryptographically_secure<T>(_rng: T)
+    where
+        T: rand::CryptoRng,
+    {
+    }
 
     #[test]
     fn rand_thread_rng_must_be_cryptographically_secure() {
@@ -23,116 +27,112 @@ mod tests {
 #[derive(Debug, Clone, Copy)]
 pub struct SecureRandom;
 
-impl SecureRandom {
-    pub fn random_bytes(interp: &mut Artichoke, len: Option<Value>) -> Result<Vec<u8>, Exception> {
-        let len = if let Some(len) = len {
-            let len = len.implicitly_convert_to_int()?;
-            if let Ok(len) = usize::try_from(len) {
-                if len == 0 {
-                    return Ok(Vec::new());
-                }
-                len
-            } else {
+pub fn random_bytes(interp: &mut Artichoke, len: Option<Value>) -> Result<Vec<u8>, Exception> {
+    let len = if let Some(len) = len {
+        let len = len.implicitly_convert_to_int()?;
+        match usize::try_from(len) {
+            Ok(0) => return Ok(Vec::new()),
+            Ok(len) => len,
+            Err(_) => {
                 return Err(Exception::from(ArgumentError::new(
                     interp,
                     "negative string size (or size too big)",
-                )));
-            }
-        } else {
-            DEFAULT_REQUESTED_BYTES
-        };
-        let mut rng = rand::thread_rng();
-        let mut bytes = vec![0; len];
-        rng.try_fill_bytes(&mut bytes)
-            .map_err(|err| RuntimeError::new(interp, err.to_string()))?;
-        Ok(bytes)
-    }
-
-    pub fn random_number(interp: &mut Artichoke, max: Option<Value>) -> Result<Value, Exception> {
-        #[derive(Debug, Clone, Copy)]
-        enum Max {
-            Float(Float),
-            Int(Int),
-            None,
-        }
-        let max = if let Some(max) = max {
-            if let Ok(max) = max.clone().try_into::<Int>() {
-                Max::Int(max)
-            } else if let Ok(max) = max.clone().try_into::<Float>() {
-                Max::Float(max)
-            } else {
-                let max = max.implicitly_convert_to_int().map_err(|_| {
-                    let mut message = b"invalid argument - ".to_vec();
-                    message.extend(max.inspect().as_slice());
-                    ArgumentError::new_raw(interp, message)
-                })?;
-                Max::Int(max)
-            }
-        } else {
-            Max::None
-        };
-        let mut rng = rand::thread_rng();
-        match max {
-            Max::Float(max) if max <= 0.0 => {
-                let number = rng.gen_range(0.0, 1.0);
-                Ok(interp.convert_mut(number))
-            }
-            Max::Float(max) => {
-                let number = rng.gen_range(0.0, max);
-                Ok(interp.convert_mut(number))
-            }
-            Max::Int(max) if max <= 0 => {
-                let number = rng.gen_range(0.0, 1.0);
-                Ok(interp.convert_mut(number))
-            }
-            Max::Int(max) => {
-                let number = rng.gen_range(0, max);
-                Ok(interp.convert(number))
-            }
-            Max::None => {
-                let number = rng.gen_range(0.0, 1.0);
-                Ok(interp.convert_mut(number))
+                )))
             }
         }
-    }
+    } else {
+        DEFAULT_REQUESTED_BYTES
+    };
+    let mut rng = rand::thread_rng();
+    let mut bytes = vec![0; len];
+    rng.try_fill_bytes(&mut bytes)
+        .map_err(|err| RuntimeError::new(interp, err.to_string()))?;
+    Ok(bytes)
+}
 
-    pub fn hex(interp: &mut Artichoke, len: Option<Value>) -> Result<String, Exception> {
-        let bytes = Self::random_bytes(interp, len)?;
-        Ok(hex::encode(bytes))
+pub fn random_number(interp: &mut Artichoke, max: Option<Value>) -> Result<Value, Exception> {
+    #[derive(Debug, Clone, Copy)]
+    enum Max {
+        Float(Float),
+        Int(Int),
+        None,
     }
-
-    pub fn base64(interp: &mut Artichoke, len: Option<Value>) -> Result<String, Exception> {
-        let bytes = Self::random_bytes(interp, len)?;
-        Ok(base64::encode(bytes.as_slice()))
+    let max = if let Some(max) = max {
+        if let Ok(max) = max.clone().try_into::<Int>() {
+            Max::Int(max)
+        } else if let Ok(max) = max.clone().try_into::<Float>() {
+            Max::Float(max)
+        } else {
+            let max = max.implicitly_convert_to_int().map_err(|_| {
+                let mut message = b"invalid argument - ".to_vec();
+                message.extend(max.inspect().as_slice());
+                ArgumentError::new_raw(interp, message)
+            })?;
+            Max::Int(max)
+        }
+    } else {
+        Max::None
+    };
+    let mut rng = rand::thread_rng();
+    match max {
+        Max::Float(max) if max <= 0.0 => {
+            let number = rng.gen_range(0.0, 1.0);
+            Ok(interp.convert_mut(number))
+        }
+        Max::Float(max) => {
+            let number = rng.gen_range(0.0, max);
+            Ok(interp.convert_mut(number))
+        }
+        Max::Int(max) if max <= 0 => {
+            let number = rng.gen_range(0.0, 1.0);
+            Ok(interp.convert_mut(number))
+        }
+        Max::Int(max) => {
+            let number = rng.gen_range(0, max);
+            Ok(interp.convert(number))
+        }
+        Max::None => {
+            let number = rng.gen_range(0.0, 1.0);
+            Ok(interp.convert_mut(number))
+        }
     }
+}
 
-    pub fn alphanumeric(interp: &mut Artichoke, len: Option<Value>) -> Result<String, Exception> {
-        let len = if let Some(len) = len {
-            let len = len.implicitly_convert_to_int()?;
-            if let Ok(len) = usize::try_from(len) {
-                if len == 0 {
-                    return Ok(String::new());
-                }
-                len
-            } else {
+pub fn hex(interp: &mut Artichoke, len: Option<Value>) -> Result<String, Exception> {
+    let bytes = random_bytes(interp, len)?;
+    Ok(hex::encode(bytes))
+}
+
+pub fn base64(interp: &mut Artichoke, len: Option<Value>) -> Result<String, Exception> {
+    let bytes = random_bytes(interp, len)?;
+    Ok(base64::encode(bytes.as_slice()))
+}
+
+pub fn alphanumeric(interp: &mut Artichoke, len: Option<Value>) -> Result<String, Exception> {
+    let len = if let Some(len) = len {
+        let len = len.implicitly_convert_to_int()?;
+        match usize::try_from(len) {
+            Ok(0) => return Ok(String::new()),
+            Ok(len) => len,
+            Err(_) => {
                 return Err(Exception::from(ArgumentError::new(
                     interp,
                     "negative string size (or size too big)",
-                )));
+                )))
             }
-        } else {
-            DEFAULT_REQUESTED_BYTES
-        };
-        let rng = rand::thread_rng();
-        let string = rng.sample_iter(Alphanumeric).take(len).collect();
-        Ok(string)
-    }
+        }
+    } else {
+        DEFAULT_REQUESTED_BYTES
+    };
+    let rng = rand::thread_rng();
+    let string = rng.sample_iter(Alphanumeric).take(len).collect();
+    Ok(string)
+}
 
-    pub fn uuid(interp: &mut Artichoke) -> String {
-        let _ = interp;
-        let uuid = Uuid::new_v4();
-        let mut buf = Uuid::encode_buffer();
-        let enc = uuid.to_hyphenated().encode_lower(&mut buf);
-        enc.to_owned()
-    }
+pub fn uuid(interp: &mut Artichoke) -> String {
+    let _ = interp;
+    let uuid = Uuid::new_v4();
+    let mut buf = Uuid::encode_buffer();
+    let enc = uuid.to_hyphenated().encode_lower(&mut buf);
+    enc.to_owned()
 }

--- a/artichoke-backend/src/extn/stdlib/securerandom/trampoline.rs
+++ b/artichoke-backend/src/extn/stdlib/securerandom/trampoline.rs
@@ -1,27 +1,27 @@
 use crate::extn::prelude::*;
-use crate::extn::stdlib::securerandom::SecureRandom;
+use crate::extn::stdlib::securerandom;
 
 pub fn alphanumeric(interp: &mut Artichoke, len: Option<Value>) -> Result<Value, Exception> {
-    SecureRandom::alphanumeric(interp, len).map(|bytes| interp.convert_mut(bytes))
+    securerandom::alphanumeric(interp, len).map(|bytes| interp.convert_mut(bytes))
 }
 
 pub fn base64(interp: &mut Artichoke, len: Option<Value>) -> Result<Value, Exception> {
-    SecureRandom::base64(interp, len).map(|bytes| interp.convert_mut(bytes))
+    securerandom::base64(interp, len).map(|bytes| interp.convert_mut(bytes))
 }
 
 pub fn hex(interp: &mut Artichoke, len: Option<Value>) -> Result<Value, Exception> {
-    SecureRandom::hex(interp, len).map(|bytes| interp.convert_mut(bytes))
+    securerandom::hex(interp, len).map(|bytes| interp.convert_mut(bytes))
 }
 
 pub fn random_bytes(interp: &mut Artichoke, len: Option<Value>) -> Result<Value, Exception> {
-    SecureRandom::random_bytes(interp, len).map(|bytes| interp.convert_mut(bytes))
+    securerandom::random_bytes(interp, len).map(|bytes| interp.convert_mut(bytes))
 }
 
 pub fn random_number(interp: &mut Artichoke, max: Option<Value>) -> Result<Value, Exception> {
-    SecureRandom::random_number(interp, max)
+    securerandom::random_number(interp, max)
 }
 
 pub fn uuid(interp: &mut Artichoke) -> Result<Value, Exception> {
-    let uuid = SecureRandom::uuid(interp);
+    let uuid = securerandom::uuid(interp);
     Ok(interp.convert_mut(uuid))
 }

--- a/artichoke-backend/src/module.rs
+++ b/artichoke-backend/src/module.rs
@@ -232,7 +232,7 @@ impl Eq for Spec {}
 
 impl PartialEq for Spec {
     fn eq(&self, other: &Self) -> bool {
-        self.name == other.name
+        self.fqname() == other.fqname()
     }
 }
 

--- a/artichoke-backend/tests/leak/mod.rs
+++ b/artichoke-backend/tests/leak/mod.rs
@@ -1,4 +1,5 @@
-use std::convert::AsRef;
+#[cfg(target_os = "linux")]
+use std::mem::MaybeUninit;
 
 #[derive(Debug)]
 pub struct Detector {
@@ -8,9 +9,12 @@ pub struct Detector {
 }
 
 impl Detector {
-    pub fn new<T: AsRef<str>>(test: T, iterations: usize, tolerance: i64) -> Self {
+    pub fn new<T>(test: T, iterations: usize, tolerance: i64) -> Self
+    where
+        T: Into<String>,
+    {
         Self {
-            test: test.as_ref().to_owned(),
+            test: test.into(),
             iterations,
             tolerance,
         }
@@ -47,7 +51,7 @@ impl Detector {
 
 #[cfg(target_os = "linux")]
 fn resident_memsize() -> i64 {
-    let mut out = std::mem::MaybeUninit::<libc::rusage>::uninit();
+    let mut out = MaybeUninit::<libc::rusage>::uninit();
     assert!(unsafe { libc::getrusage(libc::RUSAGE_SELF, out.as_mut_ptr()) } == 0);
     let out = unsafe { out.assume_init() };
     out.ru_maxrss

--- a/artichoke-core/src/constant.rs
+++ b/artichoke-core/src/constant.rs
@@ -43,11 +43,13 @@ pub trait DefineConstant {
     /// If the given constant name is not valid, an error is returned.
     ///
     /// If the interpreter cannot define the constant, an error is returned.
-    fn define_class_constant<T: 'static>(
+    fn define_class_constant<T>(
         &mut self,
         constant: &str,
         value: Self::Value,
-    ) -> Result<(), Self::Error>;
+    ) -> Result<(), Self::Error>
+    where
+        T: 'static;
 
     /// Define a module constant.
     ///
@@ -60,9 +62,11 @@ pub trait DefineConstant {
     /// If the given constant name is not valid, an error is returned.
     ///
     /// If the interpreter cannot define the constant, an error is returned.
-    fn define_module_constant<T: 'static>(
+    fn define_module_constant<T>(
         &mut self,
         constant: &str,
         value: Self::Value,
-    ) -> Result<(), Self::Error>;
+    ) -> Result<(), Self::Error>
+    where
+        T: 'static;
 }


### PR DESCRIPTION
- Convert inline type bounds to where clauses. Skip functions with a
  single `AsRef<Path>` parameter or `Hasher` parameter.
- Fix `PartialEq` implementation for `class::Spec` and `module::Spec` to
  compare fully qualified type names instead of local names.
- Add address of null pointer in panic branch of `def::rust_data_free`.
- Move `mrb->exc` pointer reset from exception handler to protect base
  function. Exception handler now has no unsafe or pointer code.
- Leak gauge takes `Into<String>` instead of `AsRef<str>` since it
  requires an owned `String`.
- Simplify computation of byte `len` in `SecureRandom` by using a
  multi-branch match statement.
- Make `SecureRandom` functions free functions instead of associated
  functions.
- Simplify implementation of some `FromIterator` traits in
  `InlineBuffer`.