### PR TITLE
Rename features for Random core class and SecureRandom stdlib module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,6 +52,7 @@ dependencies = [
  "quickcheck",
  "quickcheck_macros",
  "rand",
+ "rand_pcg",
  "regex",
  "rustc_version",
  "smallvec",
@@ -550,7 +551,6 @@ dependencies = [
  "rand_chacha",
  "rand_core",
  "rand_hc",
- "rand_pcg",
 ]
 
 [[package]]

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -19,7 +19,8 @@ itoa = "0.4"
 libm = { version = "0.2", optional = true }
 log = "0.4"
 once_cell = "1"
-rand = { version = "0.7", optional = true, features = ["small_rng"] }
+rand = { version = "0.7", optional = true }
+rand_pcg = { version = "0.2", optional = true }
 regex = "1"
 smallvec = "1"
 uuid = { version = "0.8", optional = true, features = ["v4"] }
@@ -47,7 +48,8 @@ rustc_version = "0.2.3"
 target-lexicon = "0.10.0"
 
 [features]
-default = ["artichoke-random", "core-env-system", "core-math-extra"]
-artichoke-random = ["base64", "hex", "rand", "uuid"]
+default = ["core-env-system", "core-math-extra", "core-random", "stdlib-securerandom"]
 core-env-system = []
 core-math-extra = ["libm"]
+core-random = ["rand", "rand_pcg"]
+stdlib-securerandom = ["base64", "hex", "rand", "uuid"]

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -48,7 +48,12 @@ rustc_version = "0.2.3"
 target-lexicon = "0.10.0"
 
 [features]
-default = ["core-env-system", "core-math-extra", "core-random", "stdlib-securerandom"]
+default = [
+  "core-env-system",
+  "core-math-extra",
+  "core-random",
+  "stdlib-securerandom"
+]
 core-env-system = []
 core-math-extra = ["libm"]
 core-random = ["rand", "rand_pcg"]

--- a/artichoke-backend/src/extn/core/mod.rs
+++ b/artichoke-backend/src/extn/core/mod.rs
@@ -20,7 +20,7 @@ pub mod module;
 pub mod numeric;
 pub mod object;
 pub mod proc;
-#[cfg(feature = "artichoke-random")]
+#[cfg(feature = "core-random")]
 pub mod random;
 pub mod range;
 pub mod regexp;
@@ -55,7 +55,7 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     module::init(interp)?;
     object::init(interp)?;
     proc::init(interp)?;
-    #[cfg(feature = "artichoke-random")]
+    #[cfg(feature = "core-random")]
     random::mruby::init(interp)?;
     range::init(interp)?;
     regexp::mruby::init(interp)?;

--- a/artichoke-backend/src/extn/core/random/backend/rand.rs
+++ b/artichoke-backend/src/extn/core/random/backend/rand.rs
@@ -1,5 +1,5 @@
-use rand::rngs::SmallRng;
 use rand::{self, Rng, SeedableRng};
+use rand_pcg::Pcg64;
 use std::fmt;
 
 use crate::extn::core::random::backend::{InternalState, RandType};
@@ -7,7 +7,7 @@ use crate::extn::prelude::*;
 
 #[must_use]
 pub fn new(seed: Option<u64>) -> Box<dyn RandType> {
-    Box::new(Rand::<SmallRng>::new(seed))
+    Box::new(Rand::<Pcg64>::new(seed))
 }
 
 #[derive(Debug, Clone)]

--- a/artichoke-backend/src/extn/stdlib/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/mod.rs
@@ -6,7 +6,7 @@ pub mod forwardable;
 pub mod json;
 pub mod monitor;
 pub mod ostruct;
-#[cfg(feature = "artichoke-random")]
+#[cfg(feature = "stdlib-securerandom")]
 pub mod securerandom;
 pub mod set;
 pub mod strscan;
@@ -18,7 +18,7 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     json::init(interp)?;
     monitor::init(interp)?;
     ostruct::init(interp)?;
-    #[cfg(feature = "artichoke-random")]
+    #[cfg(feature = "stdlib-securerandom")]
     securerandom::mruby::init(interp)?;
     set::init(interp)?;
     strscan::init(interp)?;

--- a/artichoke-backend/src/state/mod.rs
+++ b/artichoke-backend/src/state/mod.rs
@@ -12,7 +12,7 @@ use crate::sys;
 
 pub mod output;
 pub mod parser;
-#[cfg(feature = "artichoke-random")]
+#[cfg(feature = "core-random")]
 pub mod prng;
 
 // NOTE: `State` assumes that it it is stored in `mrb_state->ud` wrapped in a
@@ -25,7 +25,7 @@ pub struct State {
     pub vfs: fs::Virtual,
     pub active_regexp_globals: Option<NonZeroUsize>,
     pub output: Box<dyn output::Output>,
-    #[cfg(feature = "artichoke-random")]
+    #[cfg(feature = "core-random")]
     pub prng: prng::Prng,
 }
 
@@ -38,7 +38,7 @@ impl State {
     /// - `Regexp` global state.
     /// - [In memory virtual filesystem](fs::Virtual).
     /// - Ruby parser and file context.
-    /// - [Intepreter-level PRNG](prng::Prng) (behind the `artichoke-random`
+    /// - [Intepreter-level PRNG](prng::Prng) (behind the `core-random`
     ///   feature).
     /// - IO capturing strategy.
     pub fn new(mrb: &mut sys::mrb_state) -> Option<Self> {
@@ -51,7 +51,7 @@ impl State {
             vfs: fs::Virtual::new(),
             active_regexp_globals: None,
             output: Box::new(output::Process::new()),
-            #[cfg(feature = "artichoke-random")]
+            #[cfg(feature = "core-random")]
             prng: prng::Prng::default(),
         };
         Some(state)
@@ -143,7 +143,7 @@ impl fmt::Debug for State {
             .field("vfs", &self.vfs)
             .field("active_regexp_globals", &self.active_regexp_globals)
             .field("output", self.output.as_debug());
-        #[cfg(feature = "artichoke-random")]
+        #[cfg(feature = "core-random")]
         fmt.field("prng", &self.prng);
         fmt.finish()
     }

--- a/artichoke-backend/src/state/prng.rs
+++ b/artichoke-backend/src/state/prng.rs
@@ -1,4 +1,4 @@
-use rand::rngs::SmallRng;
+use rand_pcg::Pcg64;
 
 use crate::extn::core::random::backend::rand::Rand;
 use crate::extn::core::random::backend::InternalState;
@@ -6,7 +6,7 @@ use crate::types::{Float, Int};
 
 #[derive(Debug)]
 pub struct Prng {
-    random: Rand<SmallRng>,
+    random: Rand<Pcg64>,
 }
 
 impl Prng {


### PR DESCRIPTION
Split the features for randomness APIs. This PR removes the
`artichoke-random` feature and replaces it with:

- `core-random`: gates the implementation of the `Random` core class.
  Depends only on `rand` and `small_rng` crates.
- `stdlib-securerandom`: gates the implementation of the `SecureRandom`
  module in the standard library. Depends on `rand`, `hex`, `base64`,
  and `uuid`.

This PR aligns feature names with those of core `Math` and core `ENV`.
It makes it possible to depend either on a fast predictable RNG or a
CSPRNG or both with minimal dependency footprint.

To enable depending only on `rand` without the `small_rng` feature when
only enabling the `stdlib-securerandom` feature, `small_rng` is pulled
in as a top-level dependency instead of by a feature on `rand`.