### PR TITLE
Disable unicode cargo feature in bstr

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,6 @@ version = "0.1.0"
 dependencies = [
  "ansi_term",
  "artichoke-backend",
- "bstr",
  "rustyline",
  "structopt",
 ]
@@ -141,16 +140,8 @@ version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "502ae1441a0a5adb8fbd38a5955a6416b9493e92b465de5e4a9bde6a539c2c48"
 dependencies = [
- "lazy_static",
  "memchr",
- "regex-automata",
 ]
-
-[[package]]
-name = "byteorder"
-version = "1.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 
 [[package]]
 name = "c2-chacha"
@@ -617,15 +608,6 @@ dependencies = [
  "memchr",
  "regex-syntax",
  "thread_local",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92b73c2a1770c255c240eaa4ee600df1704a38dc3feaa6e949e7fcd4f8dc09f9"
-dependencies = [
- "byteorder",
 ]
 
 [[package]]

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["artichoke", "artichoke-ruby", "ruby"]
 
 [dependencies]
 base64 = { version = "0.11", optional = true }
-bstr = "0.2"
+bstr = { version = "0.2", default-features = false, features = ["std"] }
 chrono = "0.4"
 dtoa = "0.4"
 hex = { version = "0.4", optional = true }

--- a/artichoke-frontend/Cargo.toml
+++ b/artichoke-frontend/Cargo.toml
@@ -12,7 +12,6 @@ categories = ["command-line-utilities"]
 
 [dependencies]
 ansi_term = "0.11" # cannot upgrade until clap 3 is released
-bstr = "0.2"
 rustyline = "6"
 structopt = "0.3"
 


### PR DESCRIPTION
Disable `bstr` `unicode` cargo feature since it is unused in
`artichoke-backend`. This change removes some dependencies of `bstr`
from the `Cargo.lock` file.

Remove `bstr` dependency from `artichoke-frontend`. This dependency
likely has not been used since the introduction of the `string` module
in `artichoke-backend`.