### PR TITLE
Improve support for OsStrings in artichoke-backend

### DIFF
--- a/artichoke-backend/src/extn/core/env/backend/system.rs
+++ b/artichoke-backend/src/extn/core/env/backend/system.rs
@@ -52,8 +52,8 @@ impl EnvType for System {
         } else {
             let name = ffi::bytes_to_os_str(name)?;
             if let Some(value) = std::env::var_os(name) {
-                let value = ffi::os_str_to_bytes(value.as_os_str())?;
-                Ok(Some(value.to_vec().into()))
+                let value = ffi::os_string_to_bytes(value)?;
+                Ok(Some(value.into()))
             } else {
                 Ok(None)
             }
@@ -124,9 +124,9 @@ impl EnvType for System {
         let _ = interp;
         let mut map = HashMap::default();
         for (name, value) in std::env::vars_os() {
-            let name = ffi::os_str_to_bytes(name.as_os_str())?;
-            let value = ffi::os_str_to_bytes(value.as_os_str())?;
-            map.insert(name.to_vec(), value.to_vec());
+            let name = ffi::os_string_to_bytes(name)?;
+            let value = ffi::os_string_to_bytes(value)?;
+            map.insert(name, value);
         }
         Ok(map)
     }

--- a/artichoke-backend/src/extn/core/kernel/require.rs
+++ b/artichoke-backend/src/extn/core/kernel/require.rs
@@ -80,8 +80,8 @@ pub fn require(
 
     if path.is_relative() && path.extension() != Some(OsStr::new(RUBY_EXTENSION)) {
         let mut with_rb_ext = Vec::with_capacity(filename.len() + 3);
-        with_rb_ext.extend(filename.iter());
-        with_rb_ext.extend(b".rb".iter());
+        with_rb_ext.extend_from_slice(filename);
+        with_rb_ext.extend_from_slice(b".rb");
         let rb_ext = ffi::bytes_to_os_str(with_rb_ext.as_slice())?;
         let path = if let Some(base) = base {
             base.join(rb_ext)

--- a/artichoke-backend/src/ffi.rs
+++ b/artichoke-backend/src/ffi.rs
@@ -2,10 +2,10 @@
 //!
 //! These functions are unsafe. Use them carefully.
 
-use bstr::ByteSlice;
+use bstr::{ByteSlice, ByteVec};
 use std::cell::RefCell;
 use std::error;
-use std::ffi::OsStr;
+use std::ffi::{OsStr, OsString};
 use std::fmt;
 use std::mem;
 use std::ptr::NonNull;
@@ -140,6 +140,14 @@ pub fn bytes_to_os_str(value: &[u8]) -> Result<&OsStr, ConvertBytesError> {
 #[inline]
 pub fn os_str_to_bytes(value: &OsStr) -> Result<&[u8], ConvertBytesError> {
     <[u8]>::from_os_str(value).ok_or(ConvertBytesError)
+}
+
+/// Convert a platform-specific [`OsString`] to a byte vec.
+///
+/// Unsupported platforms fallback to converting through `String`.
+#[inline]
+pub fn os_string_to_bytes(value: OsString) -> Result<Vec<u8>, ConvertBytesError> {
+    Vec::from_os_string(value).map_err(|_| ConvertBytesError)
 }
 
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]


### PR DESCRIPTION
- Add   TryConvertMut` impls for `OsString` and `&OsStr`.
- Add `ffi` function for converting directly from owned `OsString` to
  owned `Vec<u8>`.
- Directly convert owned string sin `env::backend::system`.

Follow up to GH-572.