### PR TITLE
Fix cargo install snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,11 @@ You can install a pre-release build of Artichoke using `cargo`, Rust's package
 manager, by running:
 
 ```sh
-cargo install --git https://github.com/artichoke/artichoke --locked
+cargo install --git https://github.com/artichoke/artichoke --locked artichoke
 ```
 
-If instead you'd like to build Artichoke locally, you'll need Rust, clang, and
-Ruby. [`BUILD.md`](BUILD.md) has more detail on
+To install via `cargo install` or to checkout and build locally, you'll need
+Rust, clang, and Ruby. [`BUILD.md`](BUILD.md) has more detail on
 [how to set up the compiler toolchain](BUILD.md#prerequisites).
 
 ## Usage


### PR DESCRIPTION
Artichoke repo is a workspace with multiple binary targets. cargo
install needs to know to install the artichoke crate.