### PR TITLE
Upgrade to base64 0.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,9 +83,9 @@ checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 
 [[package]]
 name = "base64"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
+checksum = "7d5ca2cd0adc3f48f9e9ea5a6bbdf9ccc0bfade884847e484d452414c7ccffb3"
 
 [[package]]
 name = "bindgen"

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT"
 keywords = ["artichoke", "artichoke-ruby", "ruby"]
 
 [dependencies]
-base64 = { version = "0.11", optional = true }
+base64 = { version = "0.12", optional = true }
 bstr = { version = "0.2", default-features = false, features = ["std"] }
 chrono = "0.4"
 dtoa = "0.4"

--- a/artichoke-backend/src/extn/stdlib/securerandom/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/securerandom/mod.rs
@@ -105,7 +105,7 @@ pub fn hex(interp: &mut Artichoke, len: Option<Value>) -> Result<String, Excepti
 
 pub fn base64(interp: &mut Artichoke, len: Option<Value>) -> Result<String, Exception> {
     let bytes = random_bytes(interp, len)?;
-    Ok(base64::encode(bytes.as_slice()))
+    Ok(base64::encode(bytes))
 }
 
 pub fn alphanumeric(interp: &mut Artichoke, len: Option<Value>) -> Result<String, Exception> {


### PR DESCRIPTION
Brings in 

> Relaxed type restrictions to just AsRef<[ut8]> for main encode*/decode* functions

This matches `hex`, already in use in `securerandom`.