### PR TITLE
Doc cleanup

### DIFF
--- a/artichoke-backend/src/class.rs
+++ b/artichoke-backend/src/class.rs
@@ -13,7 +13,7 @@ use crate::types::Int;
 use crate::value::Value;
 use crate::Artichoke;
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct Builder<'a> {
     interp: &'a Artichoke,
     spec: &'a Spec,

--- a/artichoke-backend/src/extn/stdlib/securerandom/mruby.rs
+++ b/artichoke-backend/src/extn/stdlib/securerandom/mruby.rs
@@ -7,6 +7,7 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     Ok(())
 }
 
+#[derive(Debug)]
 pub struct SecureRandomFile;
 
 impl File for SecureRandomFile {

--- a/artichoke-backend/src/lib.rs
+++ b/artichoke-backend/src/lib.rs
@@ -1,7 +1,8 @@
-#![deny(clippy::all)]
-#![deny(clippy::pedantic)]
+#![warn(clippy::all)]
+#![warn(clippy::pedantic)]
 #![allow(clippy::missing_errors_doc)]
-#![deny(intra_doc_link_resolution_failure)]
+#![warn(intra_doc_link_resolution_failure)]
+#![warn(missing_debug_implementations)]
 #![warn(rust_2018_idioms)]
 
 //! # artichoke-backend
@@ -74,25 +75,8 @@
 //! The [`convert` module](convert) provides implementations for conversions
 //! between boxed Ruby values and native Rust types like `i64` and
 //! `HashMap<String, Option<Vec<u8>>>` using an `artichoke-backend` interpreter.
-//!
-//! ## License
-//!
-//! artichoke-backend is licensed with the MIT License (c) Ryan Lopopolo.
-//!
-//! Some portions of artichoke-backend are derived from
-//! [mruby](https://github.com/mruby/mruby) which is Copyright (c) 2019 mruby
-//! developers. mruby is licensed with the
-//! [MIT License](https://github.com/mruby/mruby/blob/master/LICENSE).
-//!
-//! Some portions of artichoke-backend are derived from Ruby @
-//! [2.6.3](https://github.com/ruby/ruby/tree/v2_6_3) which is copyright Yukihiro
-//! Matsumoto \<matz@netlab.jp\>. Ruby is licensed with the
-//! [2-clause BSDL License](https://github.com/ruby/ruby/blob/v2_6_3/COPYING).
-//!
-//! artichoke-backend vendors headers provided by
-//! [emsdk](https://github.com/emscripten-core/emsdk) which is Copyright (c) 2018
-//! Emscripten authors. emsdk is licensed with the
-//! [MIT/Expat License](https://github.com/emscripten-core/emsdk/blob/master/LICENSE).
+
+#![doc(html_root_url = "https://artichoke.github.io/artichoke/artichoke_backend")]
 
 #[macro_use]
 extern crate log;

--- a/artichoke-backend/src/module.rs
+++ b/artichoke-backend/src/module.rs
@@ -12,7 +12,7 @@ use crate::sys;
 use crate::value::Value;
 use crate::{Artichoke, Intern};
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct Builder<'a> {
     interp: &'a Artichoke,
     spec: &'a Spec,

--- a/artichoke-backend/src/sys/mod.rs
+++ b/artichoke-backend/src/sys/mod.rs
@@ -10,6 +10,7 @@ use std::ffi::CStr;
 use std::fmt::Write;
 
 mod args;
+#[allow(missing_debug_implementations)]
 #[allow(missing_docs)]
 #[allow(non_camel_case_types)]
 #[allow(non_upper_case_globals)]

--- a/artichoke-core/src/lib.rs
+++ b/artichoke-core/src/lib.rs
@@ -1,6 +1,7 @@
-#![deny(clippy::all)]
-#![deny(clippy::pedantic)]
-#![deny(missing_docs, intra_doc_link_resolution_failure)]
+#![warn(clippy::all)]
+#![warn(clippy::pedantic)]
+#![warn(missing_docs, intra_doc_link_resolution_failure)]
+#![warn(missing_debug_implementations)]
 #![warn(rust_2018_idioms)]
 #![forbid(unsafe_code)]
 
@@ -27,10 +28,8 @@
 //! [evaluating code](eval::Eval),
 //! [converting Rust data structures to boxed `Value`s on the interpreter heap](convert::ConvertMut),
 //! and [interning `Symbol`s](intern::Intern).
-//!
-//! ## License
-//!
-//! artichoke-core is licensed with the MIT License (c) Ryan Lopopolo.
+
+#![doc(html_root_url = "https://artichoke.github.io/artichoke/artichoke_core")]
 
 pub mod constant;
 pub mod convert;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,21 +6,21 @@
 
 //! Artichoke Ruby
 //!
-//! This crate is a Rust, and Ruby implementation of the Ruby programming
-//! language. Artichoke is not production-ready, but intends to be a
-//! [MRI-compliant](https://github.com/ruby/spec) implementation of Ruby 2.6.3.
+//! This crate is a Rust and Ruby implementation of the [Ruby programming
+//! language][rubylang]. Artichoke is not production-ready, but intends to be a
+//! [MRI-compliant][rubyspec] implementation of Ruby 2.6.3.
 //!
 //! This crate provides:
 //!
-//! - An embeddable Ruby interpreter, which can be crated with the
+//! - An embeddable Ruby interpreter, which can be created with the
 //!   [`interpreter`] function.
 //! - A Rust and Ruby implementation of Ruby Core and Standard Library using
 //!   high-quality Rust dependencies and modern Ruby.
 //! - Support for injecting Rust code and types into the interpreter with a
 //!   rubygems-style [`File`](backend::File) API.
 //! - The ability to disable parts of the interpreter VM or library functions at
-//!   compile time. For example, access to the system environ can be denied by
-//!   disabling the `core-env-system` feature.
+//!   compile time. For example, deny access to the system environ by disabling
+//!   the `core-env-system` feature.
 //!
 //! ## Usage
 //!
@@ -48,6 +48,32 @@
 //! # Ok(())
 //! # }
 //! ```
+//!
+//! ## Crate Features
+//!
+//! - `core-env-system` - **Enabled** by default. This activates the `std::env`
+//!   backend for the [`ENV` object][core-obj-env]. When this feature is
+//!   disabled, access to the environ is emulated with an in-memory store.
+//! - `core-math-extra` - **Enabled** by default. This enables additional
+//!   dependencies to implement some functions in the
+//!   [`Math` module][core-mod-math].  When this feature is disabled, these
+//!   functions raise `NotImplementedError`.
+//! - `core-random` - **Enabled** by default. This includes an implementation of
+//!   the [`Random` class][core-class-random]. This feature includes additional
+//!   dependencies. When this feature is disabled, Artichoke does not have
+//!   support for generating psuedorandom numbers.
+//! - `stdlib-securerandom` - **Enabled** by default. This feature includes an
+//!   implementation of a CSPRNG for the
+//!   [`SecureRandom` module][stdlib-mod-securerandom]. This feature includes
+//!   additional dependencies.  When this feature is disabled, the
+//!   `SecureRandom` module is not present.
+//!
+//! [rubylang]: https://www.ruby-lang.org/
+//! [rubyspec]: https://github.com/ruby/spec
+//! [core-obj-env]: https://ruby-doc.org/core-2.6.3/ENV.html
+//! [core-mod-math]: https://ruby-doc.org/core-2.6.3/Math.html
+//! [core-class-random]: https://ruby-doc.org/core-2.6.3/Random.html
+//! [stdlib-mod-securerandom]: https://ruby-doc.org/stdlib-2.6.3/libdoc/securerandom/rdoc/SecureRandom.html
 
 #![doc(html_root_url = "https://docs.rs/artichoke/0.1.0-pre.0")]
 


### PR DESCRIPTION
- Turn all deny pragmas into warn pragmas
- Add missing_debug_implementations warning.
- Add missing debug impls.
- Add doc html_root annotations to artichoke-core and artichoke-backend.
- Remove license blurb from artichoke-core crate-level docs.
- Remove license blurb from artichoke-backend crate-level docs.
- Fix typos in artichoke crate-level docs.
- Add docs on available features to artichoke crate-level docs.