### PR TITLE
Fix artichoke-backend build failure when build path contains a space

### DIFF
--- a/artichoke-backend/build.rs
+++ b/artichoke-backend/build.rs
@@ -193,6 +193,7 @@ mod libmruby {
         generate_mrbgem_config();
         let status = Command::new("ruby")
             .arg(mruby_minirake())
+            .arg("--verbose")
             .arg("--jobs")
             .arg(num_cpus::get().to_string())
             .env("MRUBY_BUILD_DIR", mruby_build_dir())

--- a/artichoke-backend/mruby_build_config_null.rb
+++ b/artichoke-backend/mruby_build_config_null.rb
@@ -2,12 +2,13 @@
 
 require 'fileutils'
 require 'rbconfig'
+require 'shellwords'
 
 def windows?
   /mswin|msys|mingw|cygwin|bccwin|wince|emc/.match?(RbConfig::CONFIG['host_os'])
 end
 
-NOOP = File.join(File.dirname(File.absolute_path(__FILE__)), 'noop.rb')
+NOOP = ['ruby', File.join(File.dirname(File.absolute_path(__FILE__)), 'noop.rb')].shelljoin
 
 # mruby requires a "default" build. This default build bootstraps the
 # compilation of the "sys" build.
@@ -19,15 +20,15 @@ NOOP = File.join(File.dirname(File.absolute_path(__FILE__)), 'noop.rb')
 MRuby::Build.new do |conf|
   def build_mrbc_exec; end
 
-  conf.cc.command = "ruby #{NOOP}"
-  conf.cxx.command = "ruby #{NOOP}"
-  conf.objc.command = "ruby #{NOOP}"
-  conf.asm.command = "ruby #{NOOP}"
-  conf.gperf.command = "ruby #{NOOP}"
+  conf.cc.command = NOOP
+  conf.cxx.command = NOOP
+  conf.objc.command = NOOP
+  conf.asm.command = NOOP
+  conf.gperf.command = NOOP
   conf.gperf.compile_options = ''
-  conf.linker.command = "ruby #{NOOP}"
-  conf.archiver.command = "ruby #{NOOP}"
-  conf.mrbc.command = "ruby #{NOOP}"
+  conf.linker.command = NOOP
+  conf.archiver.command = NOOP
+  conf.mrbc.command = NOOP
 
   conf.yacc.command = 'win_bison' if windows?
 
@@ -44,15 +45,15 @@ end
 MRuby::CrossBuild.new('sys') do |conf|
   def build_mrbc_exec; end
 
-  conf.cc.command = "ruby #{NOOP}"
-  conf.cxx.command = "ruby #{NOOP}"
-  conf.objc.command = "ruby #{NOOP}"
-  conf.asm.command = "ruby #{NOOP}"
-  conf.gperf.command = "ruby #{NOOP}"
+  conf.cc.command = NOOP
+  conf.cxx.command = NOOP
+  conf.objc.command = NOOP
+  conf.asm.command = NOOP
+  conf.gperf.command = NOOP
   conf.gperf.compile_options = ''
-  conf.linker.command = "ruby #{NOOP}"
-  conf.archiver.command = "ruby #{NOOP}"
-  conf.mrbc.command = "ruby #{NOOP}"
+  conf.linker.command = NOOP
+  conf.archiver.command = NOOP
+  conf.mrbc.command = NOOP
 
   conf.yacc.command = 'win_bison' if windows?
 

--- a/artichoke-backend/vendor/mruby/lib/mruby/build/command.rb
+++ b/artichoke-backend/vendor/mruby/lib/mruby/build/command.rb
@@ -1,4 +1,5 @@
 require 'forwardable'
+require 'shellwords'
 
 module MRuby
   class Command
@@ -28,6 +29,7 @@ module MRuby
 
     private
     def _run(options, params={})
+      params = params.each_pair.map {|k, v| [k, v.shellescape]}.to_h
       return sh command + ' ' + ( options % params ) if NotFoundCommands.key? @command
       begin
         sh build.filename(command) + ' ' + ( options % params )


### PR DESCRIPTION
I am able to successfully build Artichoke when the build path contains a space:

```console
   Compiling artichoke v0.1.0-pre.0 (/Users/lopopolo/dev/repos/a space/artichoke)
    Finished dev [unoptimized + debuginfo] target(s) in 38.06s
```

See GH-591.

This issue was caused by two bugs:

- the mruby build tooling to invoke `bison` (`win_bison` on Windows) did not quote filenames when formatting command line flags.
- Artichoke nulls out all other parts of the mruby build toolchain with a NOOP script that looks like `ruby /absolute/path/to/build/dir/empty_ruby_script.rb`. This command string was not shell escaped.

The fix is to use the Ruby `shellwords` module to escape and quote these commands and parameters in this two locations.