### PR TITLE
Remove validate-links build step from CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -194,6 +194,3 @@ jobs:
 
       - name: Format markdown with prettier
         run: npx prettier --prose-wrap always --check '**/*.md' '*.md'
-
-      - name: Validate links in markdown
-        run: bundle exec rake lint:links


### PR DESCRIPTION
This test is flakey and is subject to rate limits. Remove for now
and run manually when prepping for releases.