### PR TITLE
Print backtraces of top-level exceptions in ruby frontend #478

### DIFF
--- a/src/ruby.rs
+++ b/src/ruby.rs
@@ -8,8 +8,8 @@ use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
 use structopt::StructOpt;
 
-use crate::backend::exception::RubyException;
 use crate::backend::exception::Exception;
+use crate::backend::exception::RubyException;
 use crate::backend::extn::core::exception::{IOError, LoadError};
 use crate::backend::ffi;
 use crate::backend::state::parser::Context;
@@ -165,7 +165,10 @@ fn load_error(file: &OsStr, message: &str) -> Result<String, Exception> {
     Ok(buf)
 }
 
-fn handle_exception(interp: &mut artichoke_backend::Artichoke, exc: artichoke_backend::exception::Exception) -> Result<(), Exception> {
+fn handle_exception(
+    interp: &mut artichoke_backend::Artichoke,
+    exc: artichoke_backend::exception::Exception
+) -> Result<(), Exception> {
     if let Some(backtrace) = exc.vm_backtrace(interp) {
         writeln!(
             io::stderr(),

--- a/src/ruby.rs
+++ b/src/ruby.rs
@@ -73,7 +73,7 @@ pub fn entrypoint() -> Result<(), Exception> {
             .map_err(|_| IOError::new(&interp, "Could not read program from STDIN"))?;
         let _ = interp
             .eval(program.as_slice())
-            .map_err(|exc| handle_exception(&mut interp, exc));
+            .map_err(|exc| handle_exception(&mut interp, &exc));
 
         Ok(())
     }
@@ -105,7 +105,7 @@ fn execute_inline_eval(commands: Vec<OsString>, fixture: Option<&Path>) -> Resul
     }
     for command in commands {
         if let Err(exc) = interp.eval_os_str(command.as_os_str()) {
-            handle_exception(&mut interp, exc)?;
+            handle_exception(&mut interp, &exc)?;
             return Ok(()); // short circuit, but don't return an error since we already printed it
         }
     }
@@ -152,7 +152,7 @@ fn execute_program_file(programfile: &Path, fixture: Option<&Path>) -> Result<()
 
     let _ = interp
         .eval(program.as_slice())
-        .map_err(|exc| handle_exception(&mut interp, exc));
+        .map_err(|exc| handle_exception(&mut interp, &exc));
 
     Ok(())
 }
@@ -167,7 +167,7 @@ fn load_error(file: &OsStr, message: &str) -> Result<String, Exception> {
 
 fn handle_exception(
     interp: &mut artichoke_backend::Artichoke,
-    exc: artichoke_backend::exception::Exception,
+    exc: &artichoke_backend::exception::Exception,
 ) -> Result<(), Exception> {
     if let Some(backtrace) = exc.vm_backtrace(interp) {
         writeln!(

--- a/src/ruby.rs
+++ b/src/ruby.rs
@@ -71,7 +71,9 @@ pub fn entrypoint() -> Result<(), Exception> {
         io::stdin()
             .read_to_end(&mut program)
             .map_err(|_| IOError::new(&interp, "Could not read program from STDIN"))?;
-        let _ = interp.eval(program.as_slice()).map_err(|exc| handle_exception(&mut interp, exc));
+        let _ = interp
+            .eval(program.as_slice())
+            .map_err(|exc| handle_exception(&mut interp, exc));
 
         Ok(())
     }
@@ -148,7 +150,9 @@ fn execute_program_file(programfile: &Path, fixture: Option<&Path>) -> Result<()
         }
     };
 
-    let _ = interp.eval(program.as_slice()).map_err(|exc| handle_exception(&mut interp, exc));
+    let _ = interp
+        .eval(program.as_slice())
+        .map_err(|exc| handle_exception(&mut interp, exc));
 
     Ok(())
 }

--- a/src/ruby.rs
+++ b/src/ruby.rs
@@ -167,7 +167,7 @@ fn load_error(file: &OsStr, message: &str) -> Result<String, Exception> {
 
 fn handle_exception(
     interp: &mut artichoke_backend::Artichoke,
-    exc: artichoke_backend::exception::Exception
+    exc: artichoke_backend::exception::Exception,
 ) -> Result<(), Exception> {
     if let Some(backtrace) = exc.vm_backtrace(interp) {
         writeln!(


### PR DESCRIPTION
Submitted for review to address issue https://github.com/artichoke/artichoke/issues/478
Please let me know if there is a suggestion for a test that would cover this change that I could add.
