### PR TITLE
Fix compilation errors on emscripten target

### DIFF
--- a/artichoke-backend/src/extn/core/random/backend/rand.rs
+++ b/artichoke-backend/src/extn/core/random/backend/rand.rs
@@ -1,13 +1,17 @@
-use rand::{self, Rng, SeedableRng};
-use rand_pcg::Pcg64;
+use rand::{self, SeedableRng};
 use std::fmt;
 
 use crate::extn::core::random::backend::{InternalState, RandType};
 use crate::extn::prelude::*;
 
+#[cfg(all(not(target_os = "emscripten"), target_pointer_width = "64"))]
+pub type Rng = rand_pcg::Pcg64Mcg;
+#[cfg(not(all(not(target_os = "emscripten"), target_pointer_width = "64")))]
+pub type Rng = rand_pcg::Pcg32;
+
 #[must_use]
 pub fn new(seed: Option<u64>) -> Box<dyn RandType> {
-    Box::new(Rand::<Pcg64>::new(seed))
+    Box::new(Rand::<Rng>::new(seed))
 }
 
 #[derive(Debug, Clone)]
@@ -47,7 +51,7 @@ where
 
 impl<T> Rand<T>
 where
-    T: Rng,
+    T: rand::Rng,
 {
     #[inline]
     pub fn bytes(&mut self, buf: &mut [u8]) {
@@ -70,7 +74,7 @@ where
 
 impl<T> RandType for Rand<T>
 where
-    T: 'static + Rng + fmt::Debug,
+    T: 'static + rand::Rng + fmt::Debug,
 {
     fn as_debug(&self) -> &dyn fmt::Debug {
         self

--- a/artichoke-backend/src/extn/core/string/trampoline.rs
+++ b/artichoke-backend/src/extn/core/string/trampoline.rs
@@ -31,7 +31,7 @@ pub fn ord(interp: &mut Artichoke, value: Value) -> Result<Value, Exception> {
     } else {
         return Err(Exception::from(ArgumentError::new(interp, "empty string")));
     };
-    Ok(interp.convert(ord))
+    interp.try_convert(ord)
 }
 
 pub fn scan(

--- a/artichoke-backend/src/state/prng.rs
+++ b/artichoke-backend/src/state/prng.rs
@@ -1,12 +1,10 @@
-use rand_pcg::Pcg64;
-
-use crate::extn::core::random::backend::rand::Rand;
+use crate::extn::core::random::backend::rand::{Rand, Rng};
 use crate::extn::core::random::backend::InternalState;
 use crate::types::{Float, Int};
 
 #[derive(Debug)]
 pub struct Prng {
-    random: Rand<Pcg64>,
+    random: Rand<Rng>,
 }
 
 impl Prng {


### PR DESCRIPTION
- rand_pcg does conditional pub based on target os and pointer width
- lossless convert from u32 is not supported on targets with i32 int

`uuid` v4 feature requires wiring through additional features to connect
to a runtime. Skipping for now.