### PR TITLE
Disable default features for artichoke-backend dependency in artichoke

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,12 +58,10 @@ jobs:
       - name: Test
         run: cargo test --workspace
 
-      - name: Compile artichoke-backend with no default features
-        working-directory: artichoke-backend
+      - name: Compile artichoke with no default features
         run: cargo build --verbose --no-default-features
 
-      - name: Compile artichoke-backend with all features
-        working-directory: artichoke-backend
+      - name: Compile artichoke with all features
         run: cargo build --verbose --all-features
 
   rust:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ structopt = "0.3.10"
 
 [dependencies.artichoke-backend]
 path = "artichoke-backend"
+default-features = false
 
 [dev-dependencies]
 doc-comment = "0.3"


### PR DESCRIPTION
We are proxying all of artichoke-backend's features and setting them as default
in artichoke's Cargo.toml.

Add this test to CI.