### PR TITLE
Add compile time features for selecting output strategy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,4 +47,6 @@ default = [
 core-env-system = ["artichoke-backend/core-env-system"]
 core-math-extra = ["artichoke-backend/core-math-extra"]
 core-random = ["artichoke-backend/core-random"]
+output-strategy-capture = ["artichoke-backend/output-strategy-capture"]
+output-strategy-null = ["artichoke-backend/output-strategy-null"]
 stdlib-securerandom = ["artichoke-backend/stdlib-securerandom"]

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -55,4 +55,6 @@ default = [
 core-env-system = []
 core-math-extra = ["libm"]
 core-random = ["rand", "rand_pcg"]
+output-strategy-capture = []
+output-strategy-null = ["output-strategy-capture"]
 stdlib-securerandom = ["base64", "hex", "rand", "uuid"]

--- a/artichoke-backend/src/extn/core/kernel/mod.rs
+++ b/artichoke-backend/src/extn/core/kernel/mod.rs
@@ -1,5 +1,6 @@
 use crate::extn::core::artichoke;
 use crate::extn::prelude::*;
+use crate::state::output::Output;
 
 pub mod integer;
 pub mod require;

--- a/artichoke-backend/src/state/mod.rs
+++ b/artichoke-backend/src/state/mod.rs
@@ -24,7 +24,7 @@ pub struct State {
     modules: HashMap<TypeId, Box<module::Spec>>,
     pub vfs: fs::Virtual,
     pub active_regexp_globals: Option<NonZeroUsize>,
-    pub output: Box<dyn output::Output>,
+    pub output: output::Strategy,
     #[cfg(feature = "core-random")]
     pub prng: prng::Prng,
 }
@@ -50,7 +50,7 @@ impl State {
             modules: HashMap::default(),
             vfs: fs::Virtual::new(),
             active_regexp_globals: None,
-            output: Box::new(output::Process::new()),
+            output: output::Strategy::new(),
             #[cfg(feature = "core-random")]
             prng: prng::Prng::default(),
         };
@@ -142,7 +142,7 @@ impl fmt::Debug for State {
             .field("modules", &self.modules)
             .field("vfs", &self.vfs)
             .field("active_regexp_globals", &self.active_regexp_globals)
-            .field("output", self.output.as_debug());
+            .field("output", &self.output);
         #[cfg(feature = "core-random")]
         fmt.field("prng", &self.prng);
         fmt.finish()

--- a/artichoke-backend/src/state/output.rs
+++ b/artichoke-backend/src/state/output.rs
@@ -1,6 +1,19 @@
 use std::fmt;
 use std::io::{self, Write};
 
+#[cfg(all(
+    not(feature = "output-strategy-capture"),
+    not(feature = "output-strategy-null")
+))]
+pub type Strategy = Process;
+#[cfg(all(
+    feature = "output-strategy-capture",
+    not(feature = "output-strategy-null")
+))]
+pub type Strategy = Captured;
+#[cfg(all(feature = "output-strategy-capture", feature = "output-strategy-null"))]
+pub type Strategy = Null;
+
 pub trait Output: Send + Sync {
     fn as_debug(&self) -> &dyn fmt::Debug;
 

--- a/artichoke-backend/src/warn.rs
+++ b/artichoke-backend/src/warn.rs
@@ -4,6 +4,7 @@ use crate::def::NotDefinedError;
 use crate::exception::Exception;
 use crate::extn::core::exception::IOError;
 use crate::extn::core::warning::Warning;
+use crate::state::output::Output;
 use crate::value::Value;
 use crate::{Artichoke, ConvertMut, ValueLike, Warn};
 


### PR DESCRIPTION
By default use Process stdout and stdio. Allow overriding to a capture
buffer or null.

Use compile time features to use a concrete type in the State struct and
avoid infecting everything with lifetimes to allow a &mut Capture reference.

This will make the playground easier to integrate with the new approach.