### PR TITLE
Improve handling of Array indexes

### DIFF
--- a/artichoke-backend/src/extn/core/array/array.rb
+++ b/artichoke-backend/src/extn/core/array/array.rb
@@ -165,10 +165,14 @@ class Array
       idx += 1
       next if left.equal?(right)
 
-      cmp = left <=> right
-      return false if cmp.nil?
-      raise ArgumentError unless cmp.is_a?(Numeric)
-      return false unless cmp.zero?
+      if left.is_a?(Comparable)
+        cmp = left <=> right
+        return false if cmp.nil?
+        raise ArgumentError unless cmp.is_a?(Numeric)
+        return false unless cmp.zero?
+      else
+        return false unless left == right
+      end
     end
     true
   rescue NoMethodError

--- a/artichoke-backend/src/extn/core/array/inline_buffer_test.rb
+++ b/artichoke-backend/src/extn/core/array/inline_buffer_test.rb
@@ -58,14 +58,14 @@ end
 def empty_slice
   a = []
   raise unless a[0, 0] == []
-  raise unless a[1, 10] == []
+  raise unless a[1, 10] == nil
 end
 
 def inline_slice
   a = [1, 2, 3]
   raise unless a[0, 0] == []
   raise unless a[1, 10] == [2, 3]
-  raise unless a[10, 5] == []
+  raise unless a[10, 5] == nil
 end
 
 def dynamic_slice
@@ -74,7 +74,7 @@ def dynamic_slice
   raise unless a[1, 10] == [2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
   raise unless a[10, 5] == [11, 12, 13, 14, 15]
   raise unless a[22, 10] == [23, 24, 25]
-  raise unless a[100, 10] == []
+  raise unless a[100, 10] == nil
 end
 
 def inline_set
@@ -414,3 +414,5 @@ def reverse
   a.reverse!
   raise unless a == [10, 9, 8, 7, 6, 5, 4, 3, 2, 1]
 end
+
+spec if $PROGRAM_NAME == __FILE__

--- a/artichoke-backend/src/extn/core/array/inline_buffer_test.rb
+++ b/artichoke-backend/src/extn/core/array/inline_buffer_test.rb
@@ -58,14 +58,14 @@ end
 def empty_slice
   a = []
   raise unless a[0, 0] == []
-  raise unless a[1, 10] == nil
+  raise unless a[1, 10].nil?
 end
 
 def inline_slice
   a = [1, 2, 3]
   raise unless a[0, 0] == []
   raise unless a[1, 10] == [2, 3]
-  raise unless a[10, 5] == nil
+  raise unless a[10, 5].nil?
 end
 
 def dynamic_slice
@@ -74,7 +74,7 @@ def dynamic_slice
   raise unless a[1, 10] == [2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
   raise unless a[10, 5] == [11, 12, 13, 14, 15]
   raise unless a[22, 10] == [23, 24, 25]
-  raise unless a[100, 10] == nil
+  raise unless a[100, 10].nil?
 end
 
 def inline_set


### PR DESCRIPTION
This commit helps Artichoke pass 10 more Array ruby/specs.

This commit sweeps through the Array implementation for all conversions
between `Int` and `usize` and improves handling of the conversion.

- Remove many `Fatal` errors by coalescing index transforms into
  `Option` chains.
- Parse positive values first, handle negative values second.
- Use `checked_neg` when transforming `Int` to handle `Int::MIN`.

This commit properly handles returning `nil` for out of range `Array#[]`
indexes.

This commit marks known bad parts of `Range` extraction.

This commit improves the `Array#==` implementation to handle types that
don't implement `Comparable`.