### PR TITLE
Use i64 for Fixnum backend on all targets

### DIFF
--- a/artichoke-backend/build.rs
+++ b/artichoke-backend/build.rs
@@ -319,11 +319,7 @@ mod libmruby {
 
     pub fn build(target: &Triple) {
         fs::create_dir_all(mruby_build_dir()).unwrap();
-        let mrb_int = if let Architecture::Wasm32 = target.architecture {
-            "MRB_INT32"
-        } else {
-            "MRB_INT64"
-        };
+        let mrb_int = "MRB_INT64";
         staticlib(target, mrb_int);
         bindgen(target, mrb_int);
     }

--- a/artichoke-backend/src/convert.rs
+++ b/artichoke-backend/src/convert.rs
@@ -32,6 +32,7 @@ where
 
     /// Blanket implementation that always succeeds by delegating to
     /// [`Convert::convert`].
+    #[inline]
     fn try_convert(&self, value: T) -> Result<U, Self::Error> {
         Ok(Convert::convert(self, value))
     }
@@ -49,6 +50,7 @@ where
 
     /// Blanket implementation that always succeeds by delegating to
     /// [`Convert::convert`].
+    #[inline]
     fn try_convert_mut(&mut self, value: T) -> Result<U, Self::Error> {
         Ok(ConvertMut::convert_mut(self, value))
     }
@@ -63,6 +65,7 @@ pub struct UnboxRubyError {
 
 impl UnboxRubyError {
     #[must_use]
+    #[inline]
     pub fn new(value: &Value, into: Rust) -> Self {
         Self {
             from: value.ruby_type(),
@@ -137,6 +140,7 @@ pub struct BoxIntoRubyError {
 
 impl BoxIntoRubyError {
     #[must_use]
+    #[inline]
     pub fn new(from: Rust, into: Ruby) -> Self {
         Self { from, into }
     }

--- a/artichoke-backend/src/extn/core/string/trampoline.rs
+++ b/artichoke-backend/src/extn/core/string/trampoline.rs
@@ -31,7 +31,7 @@ pub fn ord(interp: &mut Artichoke, value: Value) -> Result<Value, Exception> {
     } else {
         return Err(Exception::from(ArgumentError::new(interp, "empty string")));
     };
-    interp.try_convert(ord)
+    Ok(interp.convert(ord))
 }
 
 pub fn scan(

--- a/artichoke-backend/src/extn/core/time/trampoline.rs
+++ b/artichoke-backend/src/extn/core/time/trampoline.rs
@@ -11,89 +11,69 @@ pub fn now(interp: &Artichoke) -> Result<Value, Exception> {
 pub fn day(interp: &Artichoke, time: Value) -> Result<Value, Exception> {
     let time = unsafe { Time::try_from_ruby(interp, &time) }?;
     let day = time.borrow().inner().day();
-    let result = interp
-        .try_convert(day)
-        .map_err(|_| RuntimeError::new(interp, "Time day component too large"))?;
+    let result = interp.convert(day);
     Ok(result)
 }
 
 pub fn hour(interp: &Artichoke, time: Value) -> Result<Value, Exception> {
     let time = unsafe { Time::try_from_ruby(interp, &time) }?;
     let hour = time.borrow().inner().hour();
-    let result = interp
-        .try_convert(hour)
-        .map_err(|_| RuntimeError::new(interp, "Time hour component too large"))?;
+    let result = interp.convert(hour);
     Ok(result)
 }
 
 pub fn minute(interp: &Artichoke, time: Value) -> Result<Value, Exception> {
     let time = unsafe { Time::try_from_ruby(interp, &time) }?;
     let minute = time.borrow().inner().minute();
-    let result = interp
-        .try_convert(minute)
-        .map_err(|_| RuntimeError::new(interp, "Time minute component too large"))?;
+    let result = interp.convert(minute);
     Ok(result)
 }
 
 pub fn month(interp: &Artichoke, time: Value) -> Result<Value, Exception> {
     let time = unsafe { Time::try_from_ruby(interp, &time) }?;
     let month = time.borrow().inner().month();
-    let result = interp
-        .try_convert(month)
-        .map_err(|_| RuntimeError::new(interp, "Time month component too large"))?;
+    let result = interp.convert(month);
     Ok(result)
 }
 
 pub fn nanosecond(interp: &Artichoke, time: Value) -> Result<Value, Exception> {
     let time = unsafe { Time::try_from_ruby(interp, &time) }?;
     let nanosecond = time.borrow().inner().nanosecond();
-    let result = interp
-        .try_convert(nanosecond)
-        .map_err(|_| RuntimeError::new(interp, "Time nanosecond component too large"))?;
+    let result = interp.convert(nanosecond);
     Ok(result)
 }
 
 pub fn second(interp: &Artichoke, time: Value) -> Result<Value, Exception> {
     let time = unsafe { Time::try_from_ruby(interp, &time) }?;
     let second = time.borrow().inner().second();
-    let result = interp
-        .try_convert(second)
-        .map_err(|_| RuntimeError::new(interp, "Time second component too large"))?;
+    let result = interp.convert(second);
     Ok(result)
 }
 
 pub fn microsecond(interp: &Artichoke, time: Value) -> Result<Value, Exception> {
     let time = unsafe { Time::try_from_ruby(interp, &time) }?;
     let microsecond = time.borrow().inner().microsecond();
-    let result = interp
-        .try_convert(microsecond)
-        .map_err(|_| RuntimeError::new(interp, "Time microsecond component too large"))?;
+    let result = interp.convert(microsecond);
     Ok(result)
 }
 
 pub fn weekday(interp: &Artichoke, time: Value) -> Result<Value, Exception> {
     let time = unsafe { Time::try_from_ruby(interp, &time) }?;
     let weekday = time.borrow().inner().weekday();
-    let result = interp
-        .try_convert(weekday)
-        .map_err(|_| RuntimeError::new(interp, "Time weekday component too large"))?;
+    let result = interp.convert(weekday);
     Ok(result)
 }
 
 pub fn year_day(interp: &Artichoke, time: Value) -> Result<Value, Exception> {
     let time = unsafe { Time::try_from_ruby(interp, &time) }?;
     let year_day = time.borrow().inner().year_day();
-    let result = interp
-        .try_convert(year_day)
-        .map_err(|_| RuntimeError::new(interp, "Time year_day component too large"))?;
+    let result = interp.convert(year_day);
     Ok(result)
 }
 
 pub fn year(interp: &Artichoke, time: Value) -> Result<Value, Exception> {
     let time = unsafe { Time::try_from_ruby(interp, &time) }?;
     let year = time.borrow().inner().year();
-    let result = interp
-        .try_convert(year)
-        .map_err(|_| RuntimeError::new(interp, "Time year component too large"))?;
+    let result = interp.convert(year);
     Ok(result)
 }

--- a/artichoke-backend/src/types.rs
+++ b/artichoke-backend/src/types.rs
@@ -1,13 +1,36 @@
 use crate::sys;
 
+/// Artichoke native floating point type.
+///
+/// `Float` is the backend to the `Float` class.
+///
+/// The `Float` type alias is for the `f64` floating point primitive.
+///
+/// ```
+/// # use std::any::TypeId;
+/// # use std::mem;
+/// # use artichoke_backend::types::Float;
+/// assert_eq!(mem::size_of::<f64>(), mem::size_of::<Float>());
+/// assert_eq!(TypeId::of::<f64>(), TypeId::of::<Float>());
+/// ```
 pub type Float = f64;
 
-// Parameterize Fixnum integer type based on architecture.
-#[cfg(not(target_arch = "wasm32"))]
+/// Artichoke native integer type.
+///
+/// `Int` is the fixed size (`Fixnum`) backend to the `Integer` class.
+///
+/// The `Int` type alias is for the `i64` integer primitive.
+///
+/// ```
+/// # use std::any::TypeId;
+/// # use std::mem;
+/// # use artichoke_backend::types::Int;
+/// assert_eq!(mem::size_of::<i64>(), mem::size_of::<Int>());
+/// assert_eq!(i64::min_value(), Int::min_value());
+/// assert_eq!(i64::max_value(), Int::max_value());
+/// assert_eq!(TypeId::of::<i64>(), TypeId::of::<Int>());
+/// ```
 pub type Int = i64;
-// wasm32 builds target 32-bit Ruby `Integer`s.
-#[cfg(target_arch = "wasm32")]
-pub type Int = i32;
 
 pub use crate::core::types::{Ruby, Rust};
 


### PR DESCRIPTION
This PR simplifies Artichoke's numeric tower by using `i64` as the
Fixnum backend on all targets. This removes conditional compilation of
the `Int` type alias for `wasm32` targets and adds tests to assert that
`Int` is `i64`.

This change simplifies the implementation of integer converters by
allowing all targets to use lossless converters for `u32`. This change
is propagated to all `extn` callsites and partially undoes GH-596.

`build.rs` is modified to always pass `MRB_INT64` when compiling mruby
so Artichoke can safely assume all builds use `i64` `Fixnum`.

Because this change removes a source of platform-divergence, it helps
reduce the need for GH-413.

This PR cleans up the tests for the fixnum converter and annotates all
of the passthrough converters with `#[inline]`.