### PR TITLE
Experiment with using trampoline modules as a VM compat layer

### DIFF
--- a/artichoke-backend/src/extn/core/integer/mod.rs
+++ b/artichoke-backend/src/extn/core/integer/mod.rs
@@ -69,6 +69,7 @@ pub fn chr(
 }
 
 pub fn element_reference(interp: &Artichoke, value: Int, bit: Value) -> Result<Int, Exception> {
+    let _ = interp;
     let bit = bit.implicitly_convert_to_int()?;
     if let Ok(bit) = u32::try_from(bit) {
         Ok(value.checked_shr(bit).map_or(0, |v| v & 1))
@@ -142,8 +143,9 @@ pub fn div(interp: &mut Artichoke, value: Int, denominator: Value) -> Result<Quo
     }
 }
 
-#[inline]
-pub fn size(interp: &Artichoke, value: Int) -> usize {
+#[must_use]
+pub const fn size(interp: &Artichoke, value: Int) -> usize {
+    let _ = interp;
     let _ = value;
     mem::size_of::<Int>()
 }

--- a/artichoke-backend/src/extn/core/integer/trampoline.rs
+++ b/artichoke-backend/src/extn/core/integer/trampoline.rs
@@ -1,4 +1,4 @@
-use crate::extn::core::integer;
+use crate::extn::core::integer::{self, Quotient};
 use crate::extn::prelude::*;
 
 pub fn chr(
@@ -7,7 +7,8 @@ pub fn chr(
     encoding: Option<Value>,
 ) -> Result<Value, Exception> {
     let value = value.try_into::<Int>()?;
-    integer::chr(interp, value, encoding)
+    let s = integer::chr(interp, value, encoding)?;
+    Ok(interp.convert_mut(s))
 }
 
 pub fn element_reference(
@@ -16,15 +17,23 @@ pub fn element_reference(
     bit: Value,
 ) -> Result<Value, Exception> {
     let value = value.try_into::<Int>()?;
-    integer::element_reference(interp, value, bit)
+    let bit = integer::element_reference(interp, value, bit)?;
+    Ok(interp.convert(bit))
 }
 
 pub fn div(interp: &mut Artichoke, value: Value, denominator: Value) -> Result<Value, Exception> {
     let value = value.try_into::<Int>()?;
-    integer::div(interp, value, denominator)
+    let quotient = integer::div(interp, value, denominator)?;
+    match quotient {
+        Quotient::Int(num) => Ok(interp.convert(num)),
+        Quotient::Float(num) => Ok(interp.convert_mut(num)),
+    }
 }
 
 pub fn size(interp: &Artichoke, value: Value) -> Result<Value, Exception> {
     let value = value.try_into::<Int>()?;
-    integer::size(interp, value).map_err(Exception::from)
+    // This `as` cast is lossless because size_of::<Int> is guaranteed to be
+    // less than `Int::MAX`.
+    let size = integer::size(interp, value) as Int;
+    Ok(interp.convert(size))
 }


### PR DESCRIPTION
This commit tries to formalize the idea of what the `trampoline` modules
in `extn` are useful for. I propose all core `extn` APIs accept native
types as parameters and return native types. `trampoline` modules are
responsible for boxing and unboxing values as the glue layer between the
core and the Ruby VM.

This commit tries this approach out on the `Integer` module.