### PR TITLE
Address followups to GH-594 artichoke entrypoint backtrace formatting

### DIFF
--- a/artichoke-backend/src/extn/core/hash/hash.rb
+++ b/artichoke-backend/src/extn/core/hash/hash.rb
@@ -178,7 +178,7 @@ class Hash
     elsif !not_set
       default
     else
-      raise KeyError, "Key not found: #{key.inspect}"
+      raise KeyError, "key not found: #{key.inspect}"
     end
   end
 

--- a/src/bin/artichoke.rs
+++ b/src/bin/artichoke.rs
@@ -39,8 +39,12 @@ use std::io::{self, Write};
 use std::process;
 
 fn main() {
-    if let Err(err) = ruby::entrypoint() {
-        let _ = writeln!(io::stderr(), "{}", err);
-        process::exit(1);
+    match ruby::entrypoint() {
+        Ok(Ok(())) => {}
+        Ok(Err(())) => process::exit(1),
+        Err(err) => {
+            let _ = writeln!(io::stderr(), "{}", err);
+            process::exit(1);
+        }
     }
 }

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -218,9 +218,6 @@ pub fn run(
                 for line in buf.lines() {
                     rl.add_history_entry(line);
                     interp
-                        .0
-                        .borrow_mut()
-                        .parser
                         .add_fetch_lineno(1)
                         .map_err(|_| ParserLineCountError)?;
                 }


### PR DESCRIPTION
This commit adds some polish to backtrace printing. Followup to GH-594.

- Fix case of `KeyError` message returned from `Hash#fetch`.
- Set exit code on exception in artichoke endpoint even if backtrace is
  successfully printed.
- Clean up imports.
- Use new globals APIs instead of delegating to `sys`, GH-562.
- Rename `handle_exception` to `format_backtrace_into` and pass an
  `io::Write`.
- Make `format_backtrace_into` public.
- Reorder exception message and exception name in output.
- Print top frame with no indent like MRI.