### PR TITLE
Trampoline as VM Compat Layer: Regexp

### DIFF
--- a/artichoke-backend/src/convert/array.rs
+++ b/artichoke-backend/src/convert/array.rs
@@ -140,6 +140,14 @@ impl ConvertMut<Vec<Option<&[u8]>>, Value> for Artichoke {
     }
 }
 
+impl ConvertMut<Vec<Vec<Option<Vec<u8>>>>, Value> for Artichoke {
+    fn convert_mut(&mut self, value: Vec<Vec<Option<Vec<u8>>>>) -> Value {
+        let iter = value.into_iter().map(|item| self.convert_mut(item));
+        let ary = Array::new(InlineBuffer::from_iter(iter));
+        ary.try_into_ruby(self, None).expect("Array into Value")
+    }
+}
+
 impl ConvertMut<Vec<Vec<Option<&[u8]>>>, Value> for Artichoke {
     fn convert_mut(&mut self, value: Vec<Vec<Option<&[u8]>>>) -> Value {
         let iter = value.into_iter().map(|item| self.convert_mut(item));

--- a/artichoke-backend/src/extn/core/regexp/backend/lazy.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/lazy.rs
@@ -2,7 +2,7 @@ use once_cell::sync::OnceCell;
 use std::collections::HashMap;
 use std::fmt;
 
-use crate::extn::core::regexp::{Config, Encoding, Regexp, RegexpType};
+use crate::extn::core::regexp::{Config, Encoding, Regexp, RegexpType, Scan};
 use crate::extn::prelude::*;
 
 use super::{NameToCaptureLocations, NilableString};
@@ -196,9 +196,9 @@ impl RegexpType for Lazy {
     fn scan(
         &self,
         interp: &mut Artichoke,
-        haystack: Value,
+        haystack: &[u8],
         block: Option<Block>,
-    ) -> Result<Value, Exception> {
+    ) -> Result<Scan, Exception> {
         self.regexp(interp)?.inner().scan(interp, haystack, block)
     }
 }

--- a/artichoke-backend/src/extn/core/regexp/backend/lazy.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/lazy.rs
@@ -158,7 +158,7 @@ impl RegexpType for Lazy {
         &self,
         interp: &mut Artichoke,
         haystack: &[u8],
-    ) -> Result<Option<Int>, Exception> {
+    ) -> Result<Option<usize>, Exception> {
         self.regexp(interp)?
             .inner()
             .match_operator(interp, haystack)

--- a/artichoke-backend/src/extn/core/regexp/backend/mod.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/mod.rs
@@ -10,6 +10,13 @@ pub mod regex;
 type NilableString = Option<Vec<u8>>;
 type NameToCaptureLocations = Vec<(Vec<u8>, Vec<usize>)>;
 
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub enum Scan {
+    Collected(Vec<Vec<Option<Vec<u8>>>>),
+    Patterns(Vec<Vec<u8>>),
+    Haystack,
+}
+
 pub trait RegexpType {
     fn box_clone(&self) -> Box<dyn RegexpType>;
 
@@ -89,7 +96,7 @@ pub trait RegexpType {
     fn scan(
         &self,
         interp: &mut Artichoke,
-        haystack: Value,
+        haystack: &[u8],
         block: Option<Block>,
-    ) -> Result<Value, Exception>;
+    ) -> Result<Scan, Exception>;
 }

--- a/artichoke-backend/src/extn/core/regexp/backend/mod.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/mod.rs
@@ -67,7 +67,7 @@ pub trait RegexpType {
         &self,
         interp: &mut Artichoke,
         haystack: &[u8],
-    ) -> Result<Option<Int>, Exception>;
+    ) -> Result<Option<usize>, Exception>;
 
     fn named_captures(&self, interp: &Artichoke) -> Result<NameToCaptureLocations, Exception>;
 

--- a/artichoke-backend/src/extn/core/regexp/backend/mod.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/mod.rs
@@ -8,7 +8,7 @@ pub mod onig;
 pub mod regex;
 
 type NilableString = Option<Vec<u8>>;
-type NameToCaptureLocations = Vec<(Vec<u8>, Vec<Int>)>;
+type NameToCaptureLocations = Vec<(Vec<u8>, Vec<usize>)>;
 
 pub trait RegexpType {
     fn box_clone(&self) -> Box<dyn RegexpType>;

--- a/artichoke-backend/src/extn/core/regexp/backend/onig.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/onig.rs
@@ -273,17 +273,16 @@ impl RegexpType for Onig {
         let pos = pos.unwrap_or_default();
         let pos = if let Ok(pos) = usize::try_from(pos) {
             pos
-        } else if let Ok(pos) = usize::try_from(-pos) {
-            if let Some(pos) = haystack_char_len.checked_sub(pos) {
+        } else {
+            let pos = pos
+                .checked_neg()
+                .and_then(|pos| usize::try_from(pos).ok())
+                .and_then(|pos| haystack_char_len.checked_sub(pos));
+            if let Some(pos) = pos {
                 pos
             } else {
                 return Ok(false);
             }
-        } else {
-            return Err(Exception::from(ArgumentError::new(
-                interp,
-                "invalid position",
-            )));
         };
         let offset = haystack.chars().take(pos).map(char::len_utf8).sum();
         if let Some(haystack) = haystack.get(offset..) {
@@ -311,17 +310,16 @@ impl RegexpType for Onig {
         let pos = pos.unwrap_or_default();
         let pos = if let Ok(pos) = usize::try_from(pos) {
             pos
-        } else if let Ok(pos) = usize::try_from(-pos) {
-            if let Some(pos) = haystack_char_len.checked_sub(pos) {
+        } else {
+            let pos = pos
+                .checked_neg()
+                .and_then(|pos| usize::try_from(pos).ok())
+                .and_then(|pos| haystack_char_len.checked_sub(pos));
+            if let Some(pos) = pos {
                 pos
             } else {
                 return Ok(interp.convert(None::<Value>));
             }
-        } else {
-            return Err(Exception::from(ArgumentError::new(
-                interp,
-                "invalid position",
-            )));
         };
         let offset = haystack.chars().take(pos).map(char::len_utf8).sum();
         let target = if let Some(haystack) = haystack.get(offset..) {

--- a/artichoke-backend/src/extn/core/regexp/backend/onig.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/onig.rs
@@ -366,7 +366,7 @@ impl RegexpType for Onig {
         &self,
         interp: &mut Artichoke,
         haystack: &[u8],
-    ) -> Result<Option<Int>, Exception> {
+    ) -> Result<Option<usize>, Exception> {
         let haystack = str::from_utf8(haystack).map_err(|_| {
             ArgumentError::new(
                 interp,
@@ -398,9 +398,7 @@ impl RegexpType for Onig {
                 let post_match = interp.convert_mut(&haystack[match_pos.1..]);
                 interp.set_global_variable(regexp::STRING_LEFT_OF_MATCH, &pre_match)?;
                 interp.set_global_variable(regexp::STRING_RIGHT_OF_MATCH, &post_match)?;
-                let pos = Int::try_from(match_pos.0).map_err(|_| {
-                    Fatal::new(interp, "Match position does not fit in Integer max")
-                })?;
+                let pos = match_pos.0;
                 Ok(Some(pos))
             } else {
                 Ok(Some(0))

--- a/artichoke-backend/src/extn/core/regexp/backend/onig.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/onig.rs
@@ -8,7 +8,7 @@ use std::rc::Rc;
 use std::str;
 
 use crate::extn::core::matchdata::MatchData;
-use crate::extn::core::regexp::{self, Config, Encoding, Regexp, RegexpType};
+use crate::extn::core::regexp::{self, Config, Encoding, Regexp, RegexpType, Scan};
 use crate::extn::prelude::*;
 
 use super::{NameToCaptureLocations, NilableString};
@@ -515,17 +515,9 @@ impl RegexpType for Onig {
     fn scan(
         &self,
         interp: &mut Artichoke,
-        value: Value,
+        haystack: &[u8],
         block: Option<Block>,
-    ) -> Result<Value, Exception> {
-        let haystack = if let Ok(haystack) = value.clone().try_into::<&[u8]>() {
-            haystack
-        } else {
-            return Err(Exception::from(ArgumentError::new(
-                interp,
-                "Regexp scan expected String haystack",
-            )));
-        };
+    ) -> Result<Scan, Exception> {
         let haystack = str::from_utf8(haystack).map_err(|_| {
             ArgumentError::new(
                 interp,
@@ -548,7 +540,7 @@ impl RegexpType for Onig {
                 let mut iter = self.regex.captures_iter(haystack).peekable();
                 if iter.peek().is_none() {
                     interp.unset_global_variable(regexp::LAST_MATCH)?;
-                    return Ok(value);
+                    return Ok(Scan::Haystack);
                 }
                 for captures in iter {
                     let fullcapture = interp.convert_mut(captures.at(0));
@@ -576,7 +568,7 @@ impl RegexpType for Onig {
                 let mut iter = self.regex.find_iter(haystack).peekable();
                 if iter.peek().is_none() {
                     interp.unset_global_variable(regexp::LAST_MATCH)?;
-                    return Ok(value);
+                    return Ok(Scan::Haystack);
                 }
                 for pos in iter {
                     let scanned = &haystack[pos.0..pos.1];
@@ -588,7 +580,7 @@ impl RegexpType for Onig {
                     interp.set_global_variable(regexp::LAST_MATCH, &data)?;
                 }
             }
-            Ok(value)
+            Ok(Scan::Haystack)
         } else {
             let mut last_pos = (0, 0);
             if let Some(len) = len {
@@ -598,12 +590,12 @@ impl RegexpType for Onig {
                 let mut iter = self.regex.captures_iter(haystack).peekable();
                 if iter.peek().is_none() {
                     interp.unset_global_variable(regexp::LAST_MATCH)?;
-                    return Ok(interp.convert_mut(&[] as &[Value]));
+                    return Ok(Scan::Collected(Vec::new()));
                 }
                 for captures in iter {
                     let mut groups = Vec::with_capacity(len.get());
                     for group in 1..=len.get() {
-                        groups.push(captures.at(group));
+                        groups.push(captures.at(group).map(str::as_bytes).map(Vec::from));
                     }
 
                     if let Some(pos) = captures.pos(0) {
@@ -625,27 +617,27 @@ impl RegexpType for Onig {
                     let group = unsafe { NonZeroUsize::new_unchecked(group) };
                     interp.set_global_variable(regexp::nth_match_group(group), &capture)?;
                 }
-                Ok(interp.convert_mut(collected))
+                Ok(Scan::Collected(collected))
             } else {
                 let mut collected = vec![];
                 let mut iter = self.regex.find_iter(haystack).peekable();
                 if iter.peek().is_none() {
                     interp.unset_global_variable(regexp::LAST_MATCH)?;
-                    return Ok(interp.convert_mut(&[] as &[Value]));
+                    return Ok(Scan::Patterns(Vec::new()));
                 }
                 for pos in iter {
                     let scanned = &haystack[pos.0..pos.1];
                     last_pos = pos;
-                    collected.push(scanned);
+                    collected.push(Vec::from(scanned.as_bytes()));
                 }
                 matchdata.set_region(last_pos.0, last_pos.1);
                 let data = matchdata.try_into_ruby(interp, None)?;
                 interp.set_global_variable(regexp::LAST_MATCH, &data)?;
-                if let Some(fullcapture) = collected.last().copied() {
-                    let fullcapture = interp.convert_mut(fullcapture);
-                    interp.set_global_variable(regexp::LAST_MATCHED_STRING, &fullcapture)?;
-                }
-                Ok(interp.convert_mut(collected))
+
+                let last_matched = collected.last().map(Vec::as_slice);
+                let last_matched = interp.convert_mut(last_matched);
+                interp.set_global_variable(regexp::LAST_MATCHED_STRING, &last_matched)?;
+                Ok(Scan::Patterns(collected))
             }
         }
     }

--- a/artichoke-backend/src/extn/core/regexp/backend/onig.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/onig.rs
@@ -34,15 +34,21 @@ impl Onig {
                 "Oniguruma backend for Regexp only supports UTF-8 patterns",
             )
         })?;
-        let regex = Regex::with_options(pattern, derived.options.flags(), Syntax::ruby()).map_err(
-            |err| {
-                if literal.options.literal {
-                    Exception::from(SyntaxError::new(interp, err.description().to_owned()))
-                } else {
-                    Exception::from(RegexpError::new(interp, err.description().to_owned()))
-                }
-            },
-        )?;
+        let regex = match Regex::with_options(pattern, derived.options.flags(), Syntax::ruby()) {
+            Ok(regex) => regex,
+            Err(err) if literal.options.literal => {
+                return Err(Exception::from(SyntaxError::new(
+                    interp,
+                    err.description().to_owned(),
+                )))
+            }
+            Err(err) => {
+                return Err(Exception::from(RegexpError::new(
+                    interp,
+                    err.description().to_owned(),
+                )))
+            }
+        };
         let regexp = Self {
             literal,
             derived,

--- a/artichoke-backend/src/extn/core/regexp/backend/regex/utf8.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/regex/utf8.rs
@@ -398,7 +398,7 @@ impl RegexpType for Utf8 {
         &self,
         interp: &mut Artichoke,
         haystack: &[u8],
-    ) -> Result<Option<Int>, Exception> {
+    ) -> Result<Option<usize>, Exception> {
         let haystack = str::from_utf8(haystack).map_err(|_| {
             ArgumentError::new(
                 interp,
@@ -447,9 +447,7 @@ impl RegexpType for Utf8 {
                 let post_match = interp.convert_mut(&haystack[match_pos.end()..]);
                 interp.set_global_variable(regexp::STRING_LEFT_OF_MATCH, &pre_match)?;
                 interp.set_global_variable(regexp::STRING_RIGHT_OF_MATCH, &post_match)?;
-                let pos = Int::try_from(match_pos.start()).map_err(|_| {
-                    Fatal::new(interp, "Match position does not fit in Integer max")
-                })?;
+                let pos = match_pos.start();
                 Ok(Some(pos))
             } else {
                 Ok(Some(0))

--- a/artichoke-backend/src/extn/core/regexp/backend/regex/utf8.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/regex/utf8.rs
@@ -466,17 +466,7 @@ impl RegexpType for Utf8 {
         let mut map = vec![];
         for group in self.regex.capture_names().filter_map(convert::identity) {
             if let Some(indexes) = self.capture_indexes_for_name(interp, group.as_bytes())? {
-                let mut group_indexes = Vec::with_capacity(indexes.len());
-                for idx in indexes {
-                    let idx = Int::try_from(idx).map_err(|_| {
-                        Fatal::new(
-                            interp,
-                            "Regexp named capture index does not fit in Integer max",
-                        )
-                    })?;
-                    group_indexes.push(idx);
-                }
-                map.push((Vec::<u8>::from(group), group_indexes));
+                map.push((group.into(), indexes));
             }
         }
         Ok(map)
@@ -516,8 +506,8 @@ impl RegexpType for Utf8 {
         let mut names = vec![];
         let mut capture_names = self.named_captures(interp).unwrap_or_default();
         capture_names.sort_by(|left, right| {
-            let left = left.1.iter().copied().fold(Int::max_value(), Int::min);
-            let right = right.1.iter().copied().fold(Int::max_value(), Int::min);
+            let left = left.1.iter().copied().fold(usize::max_value(), usize::min);
+            let right = right.1.iter().copied().fold(usize::max_value(), usize::min);
             left.partial_cmp(&right).unwrap_or(Ordering::Equal)
         });
         for (name, _) in capture_names {

--- a/artichoke-backend/src/extn/core/regexp/backend/regex/utf8.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/regex/utf8.rs
@@ -486,10 +486,11 @@ impl RegexpType for Utf8 {
         if let Some(captures) = self.regex.captures(haystack) {
             let mut map = HashMap::with_capacity(captures.len());
             for (group, group_indexes) in self.named_captures(interp)? {
-                let capture = group_indexes.iter().rev().copied().find_map(|index| {
-                    let index = usize::try_from(index).unwrap_or_default();
-                    captures.get(index)
-                });
+                let capture = group_indexes
+                    .iter()
+                    .rev()
+                    .copied()
+                    .find_map(|index| captures.get(index));
                 if let Some(capture) = capture {
                     map.insert(group, Some(capture.as_str().into()));
                 } else {

--- a/artichoke-backend/src/extn/core/regexp/backend/regex/utf8.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/regex/utf8.rs
@@ -37,13 +37,13 @@ impl Utf8 {
         builder.case_insensitive(derived.options.ignore_case);
         builder.multi_line(derived.options.multiline);
         builder.ignore_whitespace(derived.options.extended);
-        let regex = builder.build().map_err(|err| {
-            if literal.options.literal {
-                Exception::from(SyntaxError::new(interp, err.to_string()))
-            } else {
-                Exception::from(RegexpError::new(interp, err.to_string()))
+        let regex = match builder.build() {
+            Ok(regex) => regex,
+            Err(err) if literal.options.literal => {
+                return Err(Exception::from(SyntaxError::new(interp, err.to_string())));
             }
-        })?;
+            Err(err) => return Err(Exception::from(RegexpError::new(interp, err.to_string()))),
+        };
         let regexp = Self {
             literal,
             derived,

--- a/artichoke-backend/src/extn/core/regexp/backend/regex/utf8.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/regex/utf8.rs
@@ -278,17 +278,16 @@ impl RegexpType for Utf8 {
         let pos = pos.unwrap_or_default();
         let pos = if let Ok(pos) = usize::try_from(pos) {
             pos
-        } else if let Ok(pos) = usize::try_from(-pos) {
-            if let Some(pos) = haystack_char_len.checked_sub(pos) {
+        } else {
+            let pos = pos
+                .checked_neg()
+                .and_then(|pos| usize::try_from(pos).ok())
+                .and_then(|pos| haystack_char_len.checked_sub(pos));
+            if let Some(pos) = pos {
                 pos
             } else {
                 return Ok(false);
             }
-        } else {
-            return Err(Exception::from(ArgumentError::new(
-                interp,
-                "invalid position",
-            )));
         };
         let offset = haystack.chars().take(pos).map(char::len_utf8).sum();
         if let Some(haystack) = haystack.get(offset..) {
@@ -316,17 +315,16 @@ impl RegexpType for Utf8 {
         let pos = pos.unwrap_or_default();
         let pos = if let Ok(pos) = usize::try_from(pos) {
             pos
-        } else if let Ok(pos) = usize::try_from(-pos) {
-            if let Some(pos) = haystack_char_len.checked_sub(pos) {
+        } else {
+            let pos = pos
+                .checked_neg()
+                .and_then(|pos| usize::try_from(pos).ok())
+                .and_then(|pos| haystack_char_len.checked_sub(pos));
+            if let Some(pos) = pos {
                 pos
             } else {
                 return Ok(interp.convert(None::<Value>));
             }
-        } else {
-            return Err(Exception::from(ArgumentError::new(
-                interp,
-                "invalid position",
-            )));
         };
         let offset = haystack.chars().take(pos).map(char::len_utf8).sum();
         let target = if let Some(haystack) = haystack.get(offset..) {

--- a/artichoke-backend/src/extn/core/regexp/mod.rs
+++ b/artichoke-backend/src/extn/core/regexp/mod.rs
@@ -391,8 +391,15 @@ impl Regexp {
         } else {
             return Ok(interp.convert(None::<Value>));
         };
-        let result = self.0.match_operator(interp, pattern)?;
-        Ok(interp.convert(result))
+        let pos = self.0.match_operator(interp, pattern)?;
+        match pos.map(Int::try_from) {
+            Some(Ok(pos)) => Ok(interp.convert(pos)),
+            Some(Err(_)) => Err(Exception::from(ArgumentError::new(
+                interp,
+                "string too long",
+            ))),
+            None => Ok(interp.convert(None::<Value>)),
+        }
     }
 
     pub fn named_captures(&self, interp: &mut Artichoke) -> Result<Value, Exception> {

--- a/artichoke-backend/src/extn/core/regexp/mod.rs
+++ b/artichoke-backend/src/extn/core/regexp/mod.rs
@@ -404,7 +404,22 @@ impl Regexp {
 
     pub fn named_captures(&self, interp: &mut Artichoke) -> Result<Value, Exception> {
         let captures = self.0.named_captures(interp)?;
-        Ok(interp.convert_mut(captures))
+        let mut converted = Vec::with_capacity(captures.len());
+        for (name, indexes) in captures {
+            let mut fixnums = Vec::with_capacity(indexes.len());
+            for idx in indexes {
+                if let Ok(idx) = Int::try_from(idx) {
+                    fixnums.push(idx);
+                } else {
+                    return Err(Exception::from(ArgumentError::new(
+                        interp,
+                        "string too long",
+                    )));
+                }
+            }
+            converted.push((name, fixnums));
+        }
+        Ok(interp.convert_mut(converted))
     }
 
     pub fn names(&self, interp: &mut Artichoke) -> Result<Value, Exception> {

--- a/artichoke-backend/src/extn/core/regexp/mod.rs
+++ b/artichoke-backend/src/extn/core/regexp/mod.rs
@@ -22,7 +22,7 @@ pub mod opts;
 pub mod syntax;
 pub mod trampoline;
 
-pub use backend::RegexpType;
+pub use backend::{RegexpType, Scan};
 pub use enc::Encoding;
 pub use opts::Options;
 


### PR DESCRIPTION
Continuation of GH-605. Push conversions of `RegexpType` parameters and outputs out to the trampoline layer in `Regexp` and `String`.

This PR changes the signatures for the internals of `Regexp#=~`, `Regexp#named_captures`, and `String#scan`.

This approach continues to simplify the implementation of the core types and makes them easier to call as standalone APIs.

This code picks up the `pos` and `usize` handling improvements of GH-600 and applies them to `Regexp` and its backends.

This commit fixes a bug where `$&` was not unset if there was no match.