### PR TITLE
Refactor frontend code

### DIFF
--- a/src/backtrace.rs
+++ b/src/backtrace.rs
@@ -1,0 +1,138 @@
+//! Utilities for formatting Ruby backtraces.
+
+use ansi_term::Style;
+use std::io;
+
+use crate::backend::exception::{Exception, RubyException};
+use crate::backend::Artichoke;
+
+/// Format an `Exception` backtrace into an [`io::Write`] suitable for
+/// displaying in a Ruby REPL.
+///
+/// This backtrace has the same style and formatting as one returned from the
+/// `irb` command in MRI.
+///
+/// # Examples
+///
+/// Executing the following Ruby code:
+///
+/// ```ruby
+/// def fail; raise RuntimeError, "bang!"; end
+/// fail
+/// ```
+///
+/// Results in this stacktrace:
+///
+/// ```txt
+/// Traceback (most recent call last):
+///     2: from (airb):2
+///     1: from (airb):1:in fail
+/// RuntimeError (bang!)
+/// ```
+///
+/// # Errors
+///
+/// If writing into the provided `out` writer fails, an error is returned.
+pub fn format_repl_trace_into<W, E>(
+    mut error: W,
+    interp: &mut Artichoke,
+    exc: &E,
+) -> Result<(), Exception>
+where
+    W: io::Write,
+    E: RubyException,
+{
+    if let Some(backtrace) = exc.vm_backtrace(interp) {
+        writeln!(
+            error,
+            "{} (most recent call last):",
+            Style::new().bold().paint("Traceback")
+        )?;
+        for (num, frame) in backtrace.into_iter().enumerate().rev() {
+            write!(error, "\t{}: from ", num + 1)?;
+            error.write_all(frame.as_slice())?;
+            writeln!(error)?;
+        }
+    }
+    write!(
+        error,
+        "{} {}",
+        Style::new().bold().paint(exc.name()),
+        Style::new().bold().paint("(")
+    )?;
+    Style::new()
+        .bold()
+        .underline()
+        .paint(exc.message())
+        .write_to(&mut error)?;
+    writeln!(error, "{}", Style::new().bold().paint(")"))?;
+    Ok(())
+}
+
+/// Format an `Exception` backtrace into an [`io::Write`] suitable for
+/// displaying in a Ruby CLI.
+///
+/// This backtrace has the same style and formatting as one returned from the
+/// `ruby` command in MRI.
+///
+/// # Examples
+///
+/// Executing the following Ruby code:
+///
+/// ```ruby
+/// def fail; raise RuntimeError, "bang!"; end
+/// fail
+/// ```
+///
+/// Results in this stacktrace:
+///
+/// ```txt
+/// Traceback (most recent call last):
+///     2: from -e:1
+/// -e:1:in fail: bang! (RuntimeError)
+/// ```
+///
+/// # Errors
+///
+/// If writing into the provided `out` writer fails, an error is returned.
+pub fn format_cli_trace_into<W, E>(
+    mut error: W,
+    interp: &mut Artichoke,
+    exc: &E,
+) -> Result<(), Exception>
+where
+    W: io::Write,
+    E: RubyException,
+{
+    let mut top = None;
+    if let Some(backtrace) = exc.vm_backtrace(interp) {
+        writeln!(
+            error,
+            "{} (most recent call last):",
+            Style::new().bold().paint("Traceback")
+        )?;
+        let mut iter = backtrace.into_iter().enumerate();
+        top = iter.next();
+        for (num, frame) in iter.rev() {
+            write!(error, "\t{}: from ", num + 1)?;
+            error.write_all(frame.as_slice())?;
+            writeln!(error)?;
+        }
+    }
+    if let Some((_, frame)) = top {
+        error.write_all(frame.as_slice())?;
+        write!(error, ": ")?;
+    }
+    Style::new()
+        .bold()
+        .paint(exc.message())
+        .write_to(&mut error)?;
+    writeln!(
+        error,
+        " {}{}{}",
+        Style::new().bold().paint("("),
+        Style::new().bold().underline().paint(exc.name()),
+        Style::new().bold().paint(")")
+    )?;
+    Ok(())
+}

--- a/src/backtrace.rs
+++ b/src/backtrace.rs
@@ -1,4 +1,4 @@
-//! Utilities for formatting Ruby backtraces.
+//! Format Ruby `Exception` backtraces.
 
 use ansi_term::Style;
 use std::io;

--- a/src/bin/artichoke.rs
+++ b/src/bin/artichoke.rs
@@ -39,7 +39,7 @@ use std::io::{self, Write};
 use std::process;
 
 fn main() {
-    match ruby::entrypoint() {
+    match ruby::entrypoint(io::stdin(), io::stderr()) {
         Ok(Ok(())) => {}
         Ok(Err(())) => process::exit(1),
         Err(err) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,6 +89,7 @@ doc_comment::doctest!("../spec-runner/README.md");
 pub use artichoke_backend as backend;
 pub use backend::interpreter;
 
+pub mod backtrace;
 pub mod parser;
 pub mod repl;
 pub mod ruby;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -109,6 +109,8 @@ impl Parser {
     /// If the underlying parser returns a UTF-8 invalid error message, an error
     /// is returned.
     pub fn parse(&mut self, code: &[u8]) -> State {
+        use sys::mrb_lex_state_enum::*;
+
         let len = if let Ok(len) = isize::try_from(code.len()) {
             len
         } else {
@@ -151,30 +153,30 @@ impl Parser {
             #[allow(clippy::match_same_arms)]
             let code_has_unterminated_expression = match parser.lstate {
                 // beginning of a statement, that means previous line ended
-                sys::mrb_lex_state_enum::EXPR_BEG => false,
+                EXPR_BEG => false,
                 // a message dot was the last token, there has to come more
-                sys::mrb_lex_state_enum::EXPR_DOT => true,
+                EXPR_DOT => true,
                 // class keyword is not enough! we need also a name of the class
-                sys::mrb_lex_state_enum::EXPR_CLASS => true,
+                EXPR_CLASS => true,
                 // a method name is necessary
-                sys::mrb_lex_state_enum::EXPR_FNAME => true,
+                EXPR_FNAME => true,
                 // if, elsif, etc. without condition
-                sys::mrb_lex_state_enum::EXPR_VALUE => true,
+                EXPR_VALUE => true,
                 // an argument is the last token
-                sys::mrb_lex_state_enum::EXPR_ARG => false,
+                EXPR_ARG => false,
                 // a block/proc/lambda argument is the last token
-                sys::mrb_lex_state_enum::EXPR_CMDARG => false,
+                EXPR_CMDARG => false,
                 // an expression was ended
-                sys::mrb_lex_state_enum::EXPR_END => false,
+                EXPR_END => false,
                 // closing parenthesis
-                sys::mrb_lex_state_enum::EXPR_ENDARG => false,
+                EXPR_ENDARG => false,
                 // definition end
-                sys::mrb_lex_state_enum::EXPR_ENDFN => false,
+                EXPR_ENDFN => false,
                 // jump keyword like break, return, ...
-                sys::mrb_lex_state_enum::EXPR_MID => false,
+                EXPR_MID => false,
                 // this token is unreachable and is used to do integer math on the
                 // values of `mrb_lex_state_enum`.
-                sys::mrb_lex_state_enum::EXPR_MAX_STATE => false,
+                EXPR_MAX_STATE => false,
             };
             if code_has_unterminated_expression {
                 State::UnterminatedBlock

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,4 +1,7 @@
-//! Parser for Ruby code that determines if it is fit to eval on an interpreter.
+//! Detect if Ruby code parses successfully.
+//!
+//! The REPL needs to check if code is valid to determine whether it should
+//! enter multiline editing mode.
 
 use std::convert::TryFrom;
 use std::ffi::CStr;

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -1,5 +1,4 @@
-//! A REPL (read–eval–print–loop) for an artichoke interpreter exposed by
-//! the [`artichoke-backend`](artichoke_backend) crate.
+//! A REPL (read–eval–print–loop) for an Artichoke interpreter.
 //!
 //! The REPL is readline enabled, but does not save history. The REPL supports
 //! multi-line Ruby expressions, CTRL-C to break out of an expression, and can

--- a/src/ruby.rs
+++ b/src/ruby.rs
@@ -1,6 +1,7 @@
-//! Infrastructure for `ruby` CLI.
+//! Artichoke CLI entrypoint.
 //!
-//! Exported as `artichoke` binary.
+//! Artichoke's version of the `ruby` CLI. This module is exported as the
+//! `artichoke` binary.
 
 use std::ffi::{OsStr, OsString};
 use std::io;

--- a/src/ruby.rs
+++ b/src/ruby.rs
@@ -2,18 +2,18 @@
 //!
 //! Exported as `artichoke` binary.
 
-use ansi_term::Style;
 use std::ffi::{OsStr, OsString};
-use std::io::{self, Read};
+use std::io;
 use std::path::{Path, PathBuf};
 use structopt::StructOpt;
 
-use crate::backend::exception::{Exception, RubyException};
+use crate::backend::exception::Exception;
 use crate::backend::extn::core::exception::{IOError, LoadError};
 use crate::backend::ffi;
 use crate::backend::state::parser::Context;
 use crate::backend::string;
 use crate::backend::{Artichoke, ConvertMut, Eval, Globals, Parser as _};
+use crate::backtrace;
 
 const INLINE_EVAL_SWITCH_FILENAME: &[u8] = b"-e";
 
@@ -53,34 +53,42 @@ struct Opt {
 /// # Errors
 ///
 /// If an exception is raised on the interpreter, then an error is returned.
-pub fn entrypoint() -> Result<Result<(), ()>, Exception> {
+pub fn entrypoint<R, W>(mut input: R, error: W) -> Result<Result<(), ()>, Exception>
+where
+    R: io::Read,
+    W: io::Write,
+{
     let opt = Opt::from_args();
     if opt.copyright {
         let mut interp = crate::interpreter()?;
         let _ = interp.eval(b"puts RUBY_COPYRIGHT")?;
         Ok(Ok(()))
     } else if !opt.commands.is_empty() {
-        execute_inline_eval(opt.commands, opt.fixture.as_ref().map(Path::new))
+        execute_inline_eval(error, opt.commands, opt.fixture.as_deref())
     } else if let Some(programfile) = opt.programfile {
-        execute_program_file(programfile.as_path(), opt.fixture.as_ref().map(Path::new))
+        execute_program_file(error, programfile.as_path(), opt.fixture.as_deref())
     } else {
         let mut interp = crate::interpreter()?;
         let mut program = vec![];
-        io::stdin()
+        input
             .read_to_end(&mut program)
             .map_err(|_| IOError::new(&interp, "Could not read program from STDIN"))?;
-        if let Err(exc) = interp.eval(program.as_slice()) {
-            format_backtrace_into(io::stdout(), &mut interp, &exc)?;
+        if let Err(ref exc) = interp.eval(program.as_slice()) {
+            backtrace::format_cli_trace_into(error, &mut interp, exc)?;
             return Ok(Err(()));
         }
         Ok(Ok(()))
     }
 }
 
-fn execute_inline_eval(
+fn execute_inline_eval<W>(
+    error: W,
     commands: Vec<OsString>,
     fixture: Option<&Path>,
-) -> Result<Result<(), ()>, Exception> {
+) -> Result<Result<(), ()>, Exception>
+where
+    W: io::Write,
+{
     let mut interp = crate::interpreter()?;
     interp.pop_context();
     // safety:
@@ -90,20 +98,11 @@ fn execute_inline_eval(
     // - A test asserts that `INLINE_EVAL_SWITCH_FILENAME` has no NUL bytes.
     interp.push_context(unsafe { Context::new_unchecked(INLINE_EVAL_SWITCH_FILENAME) });
     if let Some(ref fixture) = fixture {
-        let data = if let Ok(data) = std::fs::read(fixture) {
-            data
-        } else {
-            return Err(Exception::from(LoadError::new(
-                &interp,
-                load_error(fixture.as_os_str(), "No such file or directory")?,
-            )));
-        };
-        let value = interp.convert_mut(data);
-        interp.set_global_variable(&b"$fixture"[..], &value)?;
+        setup_fixture_hack(&mut interp, fixture)?;
     }
     for command in commands {
-        if let Err(exc) = interp.eval_os_str(command.as_os_str()) {
-            format_backtrace_into(io::stdout(), &mut interp, &exc)?;
+        if let Err(ref exc) = interp.eval_os_str(command.as_os_str()) {
+            backtrace::format_cli_trace_into(error, &mut interp, exc)?;
             // short circuit, but don't return an error since we already printed it
             return Ok(Err(()));
         }
@@ -113,22 +112,17 @@ fn execute_inline_eval(
     Ok(Ok(()))
 }
 
-fn execute_program_file(
+fn execute_program_file<W>(
+    error: W,
     programfile: &Path,
     fixture: Option<&Path>,
-) -> Result<Result<(), ()>, Exception> {
+) -> Result<Result<(), ()>, Exception>
+where
+    W: io::Write,
+{
     let mut interp = crate::interpreter()?;
     if let Some(ref fixture) = fixture {
-        let data = if let Ok(data) = std::fs::read(fixture) {
-            data
-        } else {
-            return Err(Exception::from(LoadError::new(
-                &interp,
-                load_error(fixture.as_os_str(), "No such file or directory")?,
-            )));
-        };
-        let value = interp.convert_mut(data);
-        interp.set_global_variable(&b"$fixture"[..], &value)?;
+        setup_fixture_hack(&mut interp, fixture)?;
     }
     let program = match std::fs::read(programfile) {
         Ok(programfile) => programfile,
@@ -136,76 +130,51 @@ fn execute_program_file(
             return match err.kind() {
                 io::ErrorKind::NotFound => Err(Exception::from(LoadError::new(
                     &interp,
-                    load_error(programfile.as_os_str(), "No such file or directory")?,
+                    load_error(programfile, "No such file or directory")?,
                 ))),
                 io::ErrorKind::PermissionDenied => Err(Exception::from(LoadError::new(
                     &interp,
-                    load_error(programfile.as_os_str(), "Permission denied")?,
+                    load_error(programfile, "Permission denied")?,
                 ))),
                 _ => Err(Exception::from(LoadError::new(
                     &interp,
-                    load_error(programfile.as_os_str(), "Could not read file")?,
+                    load_error(programfile, "Could not read file")?,
                 ))),
             }
         }
     };
-    if let Err(exc) = interp.eval(program.as_slice()) {
-        format_backtrace_into(io::stdout(), &mut interp, &exc)?;
+    if let Err(ref exc) = interp.eval(program.as_slice()) {
+        backtrace::format_cli_trace_into(error, &mut interp, exc)?;
         return Ok(Err(()));
     }
     Ok(Ok(()))
 }
 
-fn load_error(file: &OsStr, message: &str) -> Result<String, Exception> {
+fn load_error<P: AsRef<OsStr>>(file: P, message: &str) -> Result<String, Exception> {
     let mut buf = String::from(message);
     buf.push_str(" -- ");
-    let path = ffi::os_str_to_bytes(file)?;
+    let path = ffi::os_str_to_bytes(file.as_ref())?;
     string::format_unicode_debug_into(&mut buf, &path)?;
     Ok(buf)
 }
 
-/// Format an [`Exception`] backtrace into the given writer.
-///
-/// # Errors
-///
-/// If writing into the provided `out` writer fails, an error is returned.
-pub fn format_backtrace_into<W>(
-    mut out: W,
-    interp: &mut Artichoke,
-    exc: &Exception,
-) -> Result<(), Exception>
-where
-    W: io::Write,
-{
-    let mut top = None;
-    if let Some(backtrace) = exc.vm_backtrace(interp) {
-        writeln!(
-            out,
-            "{} (most recent call last):",
-            Style::new().bold().paint("Traceback")
-        )?;
-        let mut iter = backtrace.into_iter().enumerate();
-        top = iter.next();
-        for (num, frame) in iter.rev() {
-            write!(out, "\t{}: from ", num + 1)?;
-            out.write_all(frame.as_slice())?;
-            writeln!(out)?;
-        }
-    }
-    if let Some((_, frame)) = top {
-        out.write_all(frame.as_slice())?;
-        write!(out, ": ")?;
-    }
-    Style::new()
-        .bold()
-        .paint(exc.message())
-        .write_to(&mut out)?;
-    writeln!(
-        out,
-        " {}{}{}",
-        Style::new().bold().paint("("),
-        Style::new().bold().underline().paint(exc.name()),
-        Style::new().bold().paint(")")
-    )?;
+// This function exists to provide a workaround for Artichoke not being able to
+// read from the local filesystem.
+//
+// By passing the `--fixture PATH` argument, this function loads the file at
+// `PATH` into memory and stores it in the interpreter bound to the `$fixture`
+// global.
+#[inline]
+fn setup_fixture_hack<P: AsRef<Path>>(interp: &mut Artichoke, fixture: P) -> Result<(), Exception> {
+    let data = if let Ok(data) = std::fs::read(fixture.as_ref()) {
+        data
+    } else {
+        return Err(Exception::from(LoadError::new(
+            &interp,
+            load_error(fixture.as_ref(), "No such file or directory")?,
+        )));
+    };
+    let value = interp.convert_mut(data);
+    interp.set_global_variable(&b"$fixture"[..], &value)?;
     Ok(())
 }


### PR DESCRIPTION
- Parameterize `ruby::entrypoint` by input and error streams.
- Move backtrace printers to the `backtrace` module.
- Extract fixture setup to one place so it is easier to remove when the
  time comes.
- Add `AsRef` generic parameters where appropriate.
- Use `Option::as_deref` in a few places for cleaner code.