### PR TITLE
Implement Numeric coercion

### DIFF
--- a/artichoke-backend/src/extn/core/float/mod.rs
+++ b/artichoke-backend/src/extn/core/float/mod.rs
@@ -42,8 +42,39 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     Ok(())
 }
 
-#[derive(Debug)]
-pub struct Float;
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
+pub struct Float(types::Float);
+
+impl ConvertMut<Float, Value> for Artichoke {
+    #[inline]
+    fn convert_mut(&mut self, from: Float) -> Value {
+        self.convert_mut(from.0)
+    }
+}
+
+impl TryConvert<Value, Float> for Artichoke {
+    type Error = Exception;
+
+    #[inline]
+    fn try_convert(&self, value: Value) -> Result<Float, Self::Error> {
+        let num = self.try_convert(value)?;
+        Ok(Float(num))
+    }
+}
+
+impl From<types::Float> for Float {
+    #[inline]
+    fn from(flt: types::Float) -> Self {
+        Self(flt)
+    }
+}
+
+impl From<Float> for types::Float {
+    #[inline]
+    fn from(flt: Float) -> Self {
+        flt.as_f64()
+    }
+}
 
 impl Float {
     /// The minimum number of significant decimal digits in a double-precision
@@ -147,4 +178,19 @@ impl Float {
     /// [stackoverflow]: https://stackoverflow.com/a/28122536
     /// [round]: https://doc.rust-lang.org/1.42.0/std/primitive.f64.html#method.round
     pub const ROUNDS: Int = -1;
+
+    #[inline]
+    pub fn new(num: types::Float) -> Self {
+        Self(num)
+    }
+
+    #[inline]
+    pub fn as_f64(self) -> f64 {
+        self.0
+    }
+
+    #[inline]
+    pub fn modulo(self, other: Self) -> Self {
+        Self(self.0 % other.0)
+    }
 }

--- a/artichoke-backend/src/extn/core/float/mod.rs
+++ b/artichoke-backend/src/extn/core/float/mod.rs
@@ -195,16 +195,19 @@ impl Float {
     pub const ROUNDS: Int = -1;
 
     #[inline]
+    #[must_use]
     pub fn new(num: types::Float) -> Self {
         Self(num)
     }
 
     #[inline]
+    #[must_use]
     pub fn as_f64(self) -> f64 {
         self.0
     }
 
     #[inline]
+    #[must_use]
     pub fn modulo(self, other: Self) -> Self {
         Self(self.0 % other.0)
     }

--- a/artichoke-backend/src/extn/core/float/mod.rs
+++ b/artichoke-backend/src/extn/core/float/mod.rs
@@ -223,7 +223,7 @@ impl Float {
         let coerced = numeric::coerce(interp, x, other)?;
         match coerced {
             Coercion::Float(x, y) => Ok((x % y).into()),
-            Coercion::Integer(x, y) => Ok(Outcome::Integer(x % y)),
+            Coercion::Integer(x, y) => Ok((x % y).into()),
         }
     }
 }

--- a/artichoke-backend/src/extn/core/integer/mod.rs
+++ b/artichoke-backend/src/extn/core/integer/mod.rs
@@ -57,17 +57,20 @@ impl From<Int> for Outcome {
 
 impl Integer {
     #[inline]
+    #[must_use]
     pub fn new(int: Int) -> Self {
         Self(int)
     }
 
     #[inline]
+    #[must_use]
     pub fn as_i64(self) -> i64 {
         self.0
     }
 
     #[allow(clippy::cast_precision_loss)]
     #[inline]
+    #[must_use]
     pub fn as_f64(self) -> f64 {
         self.0 as f64
     }
@@ -182,6 +185,8 @@ impl Integer {
     }
 
     #[must_use]
+    // Future Bignum support requires taking self.
+    #[allow(clippy::unused_self)]
     pub const fn size(self, interp: &Artichoke) -> usize {
         let _ = interp;
         mem::size_of::<Int>()

--- a/artichoke-backend/src/extn/core/integer/mod.rs
+++ b/artichoke-backend/src/extn/core/integer/mod.rs
@@ -185,10 +185,7 @@ impl Integer {
     }
 
     #[must_use]
-    // Future Bignum support requires taking self.
-    #[allow(clippy::unused_self)]
-    pub const fn size(self, interp: &Artichoke) -> usize {
-        let _ = interp;
+    pub const fn size() -> usize {
         mem::size_of::<Int>()
     }
 }

--- a/artichoke-backend/src/extn/core/integer/mod.rs
+++ b/artichoke-backend/src/extn/core/integer/mod.rs
@@ -171,7 +171,7 @@ impl Integer {
                         interp,
                         "divided by 0",
                     ))),
-                    Coercion::Float(numer, denom) => Ok(Outcome::Float(numer / denom)),
+                    Coercion::Float(numer, denom) => Ok((numer / denom).into()),
                     Coercion::Integer(numer, denom) if numer < 0 && (numer % denom) != 0 => {
                         Ok(((numer / denom) - 1).into())
                     }

--- a/artichoke-backend/src/extn/core/integer/mruby.rs
+++ b/artichoke-backend/src/extn/core/integer/mruby.rs
@@ -70,12 +70,11 @@ unsafe extern "C" fn artichoke_integer_div(
 
 unsafe extern "C" fn artichoke_integer_size(
     mrb: *mut sys::mrb_state,
-    slf: sys::mrb_value,
+    _slf: sys::mrb_value,
 ) -> sys::mrb_value {
     mrb_get_args!(mrb, none);
     let interp = unwrap_interpreter!(mrb);
-    let value = Value::new(&interp, slf);
-    let result = trampoline::size(&interp, value);
+    let result = trampoline::size(&interp);
     match result {
         Ok(value) => value.inner(),
         Err(exception) => exception::raise(interp, exception),

--- a/artichoke-backend/src/extn/core/integer/trampoline.rs
+++ b/artichoke-backend/src/extn/core/integer/trampoline.rs
@@ -1,4 +1,4 @@
-use crate::extn::core::integer::{self, Quotient};
+use crate::extn::core::integer::Integer;
 use crate::extn::prelude::*;
 
 pub fn chr(
@@ -6,8 +6,8 @@ pub fn chr(
     value: Value,
     encoding: Option<Value>,
 ) -> Result<Value, Exception> {
-    let value = value.try_into::<Int>()?;
-    let s = integer::chr(interp, value, encoding)?;
+    let value = value.try_into::<Integer>()?;
+    let s = value.chr(interp, encoding)?;
     Ok(interp.convert_mut(s))
 }
 
@@ -16,24 +16,21 @@ pub fn element_reference(
     value: Value,
     bit: Value,
 ) -> Result<Value, Exception> {
-    let value = value.try_into::<Int>()?;
-    let bit = integer::element_reference(interp, value, bit)?;
+    let value = value.try_into::<Integer>()?;
+    let bit = value.bit(interp, bit)?;
     Ok(interp.convert(bit))
 }
 
 pub fn div(interp: &mut Artichoke, value: Value, denominator: Value) -> Result<Value, Exception> {
-    let value = value.try_into::<Int>()?;
-    let quotient = integer::div(interp, value, denominator)?;
-    match quotient {
-        Quotient::Int(num) => Ok(interp.convert(num)),
-        Quotient::Float(num) => Ok(interp.convert_mut(num)),
-    }
+    let value = value.try_into::<Integer>()?;
+    let quotient = value.div(interp, denominator)?;
+    Ok(interp.convert_mut(quotient))
 }
 
 pub fn size(interp: &Artichoke, value: Value) -> Result<Value, Exception> {
-    let value = value.try_into::<Int>()?;
+    let value = value.try_into::<Integer>()?;
     // This `as` cast is lossless because size_of::<Int> is guaranteed to be
     // less than `Int::MAX`.
-    let size = integer::size(interp, value) as Int;
+    let size = value.size(interp) as Int;
     Ok(interp.convert(size))
 }

--- a/artichoke-backend/src/extn/core/integer/trampoline.rs
+++ b/artichoke-backend/src/extn/core/integer/trampoline.rs
@@ -27,10 +27,9 @@ pub fn div(interp: &mut Artichoke, value: Value, denominator: Value) -> Result<V
     Ok(interp.convert_mut(quotient))
 }
 
-pub fn size(interp: &Artichoke, value: Value) -> Result<Value, Exception> {
-    let value = value.try_into::<Integer>()?;
+pub fn size(interp: &Artichoke) -> Result<Value, Exception> {
     // This `as` cast is lossless because size_of::<Int> is guaranteed to be
     // less than `Int::MAX`.
-    let size = value.size(interp) as Int;
+    let size = Integer::size() as Int;
     Ok(interp.convert(size))
 }

--- a/artichoke-backend/src/extn/core/numeric/mod.rs
+++ b/artichoke-backend/src/extn/core/numeric/mod.rs
@@ -1,3 +1,4 @@
+use crate::extn::core::integer::Integer;
 use crate::extn::prelude::*;
 
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
@@ -13,3 +14,135 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
 
 #[derive(Debug)]
 pub struct Numeric;
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum Outcome {
+    Float(Float),
+    Integer(Int),
+    // TODO: Complex? Rational?
+}
+
+impl ConvertMut<Outcome, Value> for Artichoke {
+    fn convert_mut(&mut self, from: Outcome) -> Value {
+        match from {
+            Outcome::Float(num) => self.convert_mut(num),
+            Outcome::Integer(num) => self.convert(num),
+        }
+    }
+}
+
+const MAX_COERCE_DEPTH: u8 = 15;
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum Coercion {
+    Float(Float, Float),
+    Integer(Int, Int),
+    // TODO: Complex? Rational?
+}
+
+/// If `y` is the same type as `x`, returns an array `[y, x]`. Otherwise,
+/// returns an array with both `y` and `x` represented as `Float` objects.
+///
+/// This coercion mechanism is used by Ruby to handle mixed-type numeric
+/// operations: it is intended to find a compatible common type between the two
+/// operands of the operator.
+///
+/// See [`Numeric#coerce`][numeric].
+///
+/// # Coercion enum
+///
+/// Artichoke represents the `[y, x]` tuple Array as the [`Coercion`] enum, which
+/// orders its values `Coercion::Integer(x, y)`.
+///
+/// # Examples
+///
+/// ```
+/// # use artichoke_backend::{Convert, ConvertMut};
+/// # use artichoke_backend::extn::core::numeric::{self, Coercion};
+/// # fn main() -> Result<(), Box<std::error::Error>> {
+/// # let mut interp = artichoke_backend::interpreter()?;
+/// let x = interp.convert(1_i64);
+/// let y = interp.convert_mut(2.5_f64);
+/// assert_eq!(Coercion::Float(1.0, 2.5), numeric::coerce(&mut interp, x, y)?);
+/// let x = interp.convert_mut(1.2_f64);
+/// let y = interp.convert(3_i64);
+/// assert_eq!(Coercion::Float(1.2, 3.0), numeric::coerce(&mut interp, x, y)?);
+/// let x = interp.convert(1_i64);
+/// let y = interp.convert(2_i64);
+/// assert_eq!(Coercion::Integer(1, 2), numeric::coerce(&mut interp, x, y)?);
+/// # Ok(())
+/// # }
+/// ```
+///
+/// [numeric]: https://ruby-doc.org/core-2.6.3/Numeric.html#method-i-coerce
+pub fn coerce(interp: &mut Artichoke, x: Value, y: Value) -> Result<Coercion, Exception> {
+    fn do_coerce(
+        interp: &mut Artichoke,
+        x: Value,
+        y: Value,
+        depth: u8,
+    ) -> Result<Coercion, Exception> {
+        if depth > MAX_COERCE_DEPTH {
+            return Err(Exception::from(SystemStackError::new(
+                interp,
+                "stack level too deep",
+            )));
+        }
+        match (x.ruby_type(), y.ruby_type()) {
+            (Ruby::Float, Ruby::Float) => Ok(Coercion::Float(x.try_into()?, y.try_into()?)),
+            (Ruby::Float, Ruby::Fixnum) => {
+                let y = y.try_into::<Integer>()?;
+                Ok(Coercion::Float(x.try_into()?, y.as_f64()))
+            }
+            (Ruby::Fixnum, Ruby::Float) => {
+                let x = x.try_into::<Integer>()?;
+                Ok(Coercion::Float(x.as_f64(), y.try_into::<Float>()?))
+            }
+            (Ruby::Fixnum, Ruby::Fixnum) => Ok(Coercion::Integer(x.try_into()?, y.try_into()?)),
+            _ => {
+                let class_of_numeric = {
+                    let borrow = interp.0.borrow();
+                    let numeric = borrow
+                        .class_spec::<Numeric>()
+                        .ok_or_else(|| NotDefinedError::class("Numeric"))?;
+                    numeric
+                        .value(interp)
+                        .ok_or_else(|| NotDefinedError::class("Numeric"))?
+                };
+                if let Ok(true) = y.funcall("is_a?", &[class_of_numeric], None) {
+                    if y.respond_to("coerce")? {
+                        let mut coerced = y
+                            .funcall::<Vec<Value>>("coerce", &[x.clone()], None)
+                            .map_err(|_| TypeError::new(interp, "coerce must return [x, y]"))?
+                            .into_iter();
+                        let y = coerced.next();
+                        let x = coerced.next();
+                        if coerced.next().is_some() {
+                            Err(Exception::from(TypeError::new(
+                                interp,
+                                "coerce must return [x, y]",
+                            )))
+                        } else if let (Some(x), Some(y)) = (x, y) {
+                            do_coerce(interp, x, y, depth + 1)
+                        } else {
+                            Err(Exception::from(TypeError::new(
+                                interp,
+                                "coerce must return [x, y]",
+                            )))
+                        }
+                    } else {
+                        let mut message = String::from("can't convert ");
+                        message.push_str(y.pretty_name());
+                        message.push_str(" into Float");
+                        Err(Exception::from(TypeError::new(interp, message)))
+                    }
+                } else {
+                    let mut message = String::from(y.pretty_name());
+                    message.push_str(" can't be coerced into Float");
+                    Err(Exception::from(TypeError::new(interp, message)))
+                }
+            }
+        }
+    }
+    do_coerce(interp, x, y, 0)
+}

--- a/artichoke-backend/src/extn/core/numeric/mod.rs
+++ b/artichoke-backend/src/extn/core/numeric/mod.rs
@@ -112,7 +112,7 @@ pub fn coerce(interp: &mut Artichoke, x: Value, y: Value) -> Result<Coercion, Ex
                 if let Ok(true) = y.funcall("is_a?", &[class_of_numeric], None) {
                     if y.respond_to("coerce")? {
                         let mut coerced = y
-                            .funcall::<Vec<Value>>("coerce", &[x.clone()], None)
+                            .funcall::<Vec<Value>>("coerce", &[x], None)
                             .map_err(|_| TypeError::new(interp, "coerce must return [x, y]"))?
                             .into_iter();
                         let y = coerced.next();

--- a/artichoke-backend/src/types.rs
+++ b/artichoke-backend/src/types.rs
@@ -2,7 +2,8 @@ use crate::sys;
 
 /// Artichoke native floating point type.
 ///
-/// `Float` is the backend to the `Float` class.
+/// `Float` is the backend to the [`Float`](crate::extn::core::float::Float)
+/// class.
 ///
 /// The `Float` type alias is for the `f64` floating point primitive.
 ///
@@ -17,7 +18,8 @@ pub type Float = f64;
 
 /// Artichoke native integer type.
 ///
-/// `Int` is the fixed size (`Fixnum`) backend to the `Integer` class.
+/// `Int` is the fixed size (`Fixnum`) backend to the
+/// [`Integer`](crate::extn::core::integer::Integer) class.
 ///
 /// The `Int` type alias is for the `i64` integer primitive.
 ///

--- a/artichoke-backend/vendor/mruby/src/vm.c
+++ b/artichoke-backend/vendor/mruby/src/vm.c
@@ -2272,7 +2272,11 @@ RETRY_TRY_BLOCK:
             mrb_raise(mrb, mrb_exc_get(mrb, "ZeroDivisionError"), "divided by 0");
           }
 #endif
-          SET_INT_VALUE(regs[a], y ? x / y : 0);
+          if (x < 0) {
+            SET_INT_VALUE(regs[a], (x / y) - 1);
+          } else {
+            SET_INT_VALUE(regs[a], x / y);
+          }
         }
         break;
 #ifndef MRB_WITHOUT_FLOAT

--- a/artichoke-backend/vendor/mruby/src/vm.c
+++ b/artichoke-backend/vendor/mruby/src/vm.c
@@ -2272,7 +2272,7 @@ RETRY_TRY_BLOCK:
             mrb_raise(mrb, mrb_exc_get(mrb, "ZeroDivisionError"), "divided by 0");
           }
 #endif
-          if (x < 0) {
+          if (x < 0 && (x % y) != 0) {
             SET_INT_VALUE(regs[a], (x / y) - 1);
           } else {
             SET_INT_VALUE(regs[a], x / y);


### PR DESCRIPTION
This PR pokes around in the numeric core classes. The intent is to implement `Integer`, `Float`, and `Numeric` in Rust.

To achieve this, the `Integer` and `Float` types in `extn::core` are now tuple structs that wrap and underlying primitive type. Ruby core APIs are dangled off this struct. These structs have `Convert`, `ConvertMut`, and `TryConvert` support.

This PR implements `numeric::coerce` which drives all of the numeric conversions in `numeric.c` in MRI.

This PR implements `Float#%` using the new converter and container types. Coercions require returning an arbitrary numeric type from any arithmetic operations, which is represented by `numeric::Outcome` sum type.

1 additional Integer divide spec passes due to this PR.