### PR TITLE
Improve converter test coverage

### DIFF
--- a/artichoke-backend/src/convert/array.rs
+++ b/artichoke-backend/src/convert/array.rs
@@ -364,3 +364,129 @@ impl TryConvert<Value, Vec<Int>> for Artichoke {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use quickcheck_macros::quickcheck;
+
+    use crate::test::prelude::*;
+
+    #[test]
+    fn fail_convert() {
+        let mut interp = crate::interpreter().unwrap();
+        // get a Ruby value that can't be converted to a primitive type.
+        let value = interp.eval(b"Object.new").unwrap();
+        let result = value.try_into::<Vec<Value>>();
+        assert!(result.is_err());
+    }
+
+    #[quickcheck]
+    fn arr_int(arr: Vec<Int>) -> bool {
+        let mut interp = crate::interpreter().unwrap();
+        // Borrowed converter
+        let value = interp.convert_mut(arr.as_slice());
+        let len = value.funcall::<usize>("length", &[], None).unwrap();
+        if len != arr.len() {
+            return false;
+        }
+        let empty = value.funcall::<bool>("empty?", &[], None).unwrap();
+        if empty != arr.is_empty() {
+            return false;
+        }
+        let recovered: Vec<Int> = interp.try_convert(value).unwrap();
+        if recovered != arr {
+            return false;
+        }
+        // Owned converter
+        let value = interp.convert_mut(arr.to_vec());
+        let len = value.funcall::<usize>("length", &[], None).unwrap();
+        if len != arr.len() {
+            return false;
+        }
+        let empty = value.funcall::<bool>("empty?", &[], None).unwrap();
+        if empty != arr.is_empty() {
+            return false;
+        }
+        let recovered: Vec<Int> = interp.try_convert(value).unwrap();
+        if recovered != arr {
+            return false;
+        }
+        true
+    }
+
+    #[quickcheck]
+    fn arr_utf8(arr: Vec<String>) -> bool {
+        let mut interp = crate::interpreter().unwrap();
+        // Borrowed converter
+        let value = interp.convert_mut(arr.as_slice());
+        let len = value.funcall::<usize>("length", &[], None).unwrap();
+        if len != arr.len() {
+            return false;
+        }
+        let empty = value.funcall::<bool>("empty?", &[], None).unwrap();
+        if empty != arr.is_empty() {
+            return false;
+        }
+        let recovered: Vec<String> = interp.try_convert(value).unwrap();
+        if recovered != arr {
+            return false;
+        }
+        // Owned converter
+        let value = interp.convert_mut(arr.to_vec());
+        let len = value.funcall::<usize>("length", &[], None).unwrap();
+        if len != arr.len() {
+            return false;
+        }
+        let empty = value.funcall::<bool>("empty?", &[], None).unwrap();
+        if empty != arr.is_empty() {
+            return false;
+        }
+        let recovered: Vec<String> = interp.try_convert(value).unwrap();
+        if recovered != arr {
+            return false;
+        }
+        true
+    }
+
+    #[quickcheck]
+    fn arr_nilable_bstr(arr: Vec<Option<Vec<u8>>>) -> bool {
+        let mut interp = crate::interpreter().unwrap();
+        // Borrowed converter
+        let value = interp.convert_mut(arr.as_slice());
+        let len = value.funcall::<usize>("length", &[], None).unwrap();
+        if len != arr.len() {
+            return false;
+        }
+        let empty = value.funcall::<bool>("empty?", &[], None).unwrap();
+        if empty != arr.is_empty() {
+            return false;
+        }
+        let recovered: Vec<Option<Vec<u8>>> = interp.try_convert(value).unwrap();
+        if recovered != arr {
+            return false;
+        }
+        // Owned converter
+        let value = interp.convert_mut(arr.to_vec());
+        let len = value.funcall::<usize>("length", &[], None).unwrap();
+        if len != arr.len() {
+            return false;
+        }
+        let empty = value.funcall::<bool>("empty?", &[], None).unwrap();
+        if empty != arr.is_empty() {
+            return false;
+        }
+        let recovered: Vec<Option<Vec<u8>>> = interp.try_convert(value).unwrap();
+        if recovered != arr {
+            return false;
+        }
+        true
+    }
+
+    #[quickcheck]
+    fn roundtrip_err(i: i64) -> bool {
+        let interp = crate::interpreter().unwrap();
+        let value = interp.convert(i);
+        let value = value.try_into::<Vec<Value>>();
+        value.is_err()
+    }
+}

--- a/artichoke-backend/src/convert/fixnum.rs
+++ b/artichoke-backend/src/convert/fixnum.rs
@@ -149,7 +149,7 @@ mod tests {
     #[test]
     fn fail_convert() {
         let mut interp = crate::interpreter().unwrap();
-        // get a mrb_value that can't be converted to a primitive type.
+        // get a Ruby value that can't be converted to a primitive type.
         let value = interp.eval(b"Object.new").unwrap();
         let result = value.try_into::<Int>();
         assert!(result.is_err());

--- a/artichoke-backend/src/convert/float.rs
+++ b/artichoke-backend/src/convert/float.rs
@@ -35,23 +35,23 @@ mod tests {
 
     #[test]
     fn fail_convert() {
-        let mut interp = crate::interpreter().expect("init");
-        // get a mrb_value that can't be converted to a primitive type.
-        let value = interp.eval(b"Object.new").expect("eval");
+        let mut interp = crate::interpreter().unwrap();
+        // get a Ruby Value that can't be converted to a primitive type.
+        let value = interp.eval(b"Object.new").unwrap();
         let result = value.try_into::<Float>();
         assert!(result.is_err());
     }
 
     #[quickcheck]
     fn convert_to_float(f: Float) -> bool {
-        let mut interp = crate::interpreter().expect("init");
+        let mut interp = crate::interpreter().unwrap();
         let value = interp.convert_mut(f);
         value.ruby_type() == Ruby::Float
     }
 
     #[quickcheck]
     fn float_with_value(f: Float) -> bool {
-        let mut interp = crate::interpreter().expect("init");
+        let mut interp = crate::interpreter().unwrap();
         let value = interp.convert_mut(f);
         let inner = value.inner();
         let cdouble = unsafe { sys::mrb_sys_float_to_cdouble(inner) };
@@ -60,15 +60,15 @@ mod tests {
 
     #[quickcheck]
     fn roundtrip(f: Float) -> bool {
-        let mut interp = crate::interpreter().expect("init");
+        let mut interp = crate::interpreter().unwrap();
         let value = interp.convert_mut(f);
-        let value = value.try_into::<Float>().expect("convert");
+        let value = value.try_into::<Float>().unwrap();
         (value - f).abs() < std::f64::EPSILON
     }
 
     #[quickcheck]
     fn roundtrip_err(b: bool) -> bool {
-        let interp = crate::interpreter().expect("init");
+        let interp = crate::interpreter().unwrap();
         let value = interp.convert(b);
         let value = value.try_into::<Float>();
         value.is_err()


### PR DESCRIPTION
- Add quickcheck coverage for Array and Hash.
- Add a functional test for Bytes using quickcheck.
- Add a functional test for String using quickcheck.
- Convert all `expect` to `unwrap`.