### PR TITLE
Use Random and SecureRandom trampolines as VM compat layer

### DIFF
--- a/artichoke-backend/src/extn/core/random/mod.rs
+++ b/artichoke-backend/src/extn/core/random/mod.rs
@@ -85,6 +85,7 @@ impl Random {
     }
 
     #[inline]
+    #[must_use]
     pub fn inner(&self) -> &dyn backend::RandType {
         self.0.as_ref()
     }
@@ -175,6 +176,7 @@ impl Random {
         seed
     }
 
+    #[must_use]
     pub fn new_seed() -> Int {
         let mut rng = rand::thread_rng();
         rng.gen::<Int>()
@@ -195,6 +197,7 @@ impl fmt::Debug for Random {
     }
 }
 
+#[allow(clippy::module_name_repetitions)]
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
 pub enum RandomNumberMax {
     Float(Float),
@@ -240,6 +243,7 @@ impl TryConvert<Option<Value>, RandomNumberMax> for Artichoke {
     }
 }
 
+#[allow(clippy::module_name_repetitions)]
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
 pub enum RandomNumber {
     Integer(Int),

--- a/artichoke-backend/src/extn/core/random/trampoline.rs
+++ b/artichoke-backend/src/extn/core/random/trampoline.rs
@@ -1,0 +1,60 @@
+use crate::extn::core::random::{self, Random};
+use crate::extn::prelude::*;
+
+pub fn initialize(
+    interp: &mut Artichoke,
+    seed: Option<Value>,
+    into: Value,
+) -> Result<Value, Exception> {
+    let seed = interp.try_convert(seed)?;
+    let rand = Random::initialize(interp, seed)?;
+    let rand = rand.try_into_ruby(interp, Some(into.inner()))?;
+    Ok(rand)
+}
+
+pub fn equal(interp: &mut Artichoke, rand: Value, other: Value) -> Result<Value, Exception> {
+    let rand = unsafe { Random::try_from_ruby(interp, &rand)? };
+    let borrow = rand.borrow();
+    let eql = borrow.eql(interp, other);
+    Ok(interp.convert(eql))
+}
+
+pub fn bytes(interp: &mut Artichoke, rand: Value, size: Value) -> Result<Value, Exception> {
+    let rand = unsafe { Random::try_from_ruby(interp, &rand)? };
+    let mut borrow = rand.borrow_mut();
+    let size = size.implicitly_convert_to_int()?;
+    let buf = borrow.bytes(interp, size)?;
+    Ok(interp.convert_mut(buf))
+}
+
+pub fn rand(interp: &mut Artichoke, rand: Value, max: Option<Value>) -> Result<Value, Exception> {
+    let rand = unsafe { Random::try_from_ruby(interp, &rand)? };
+    let mut borrow = rand.borrow_mut();
+    let max = interp.try_convert(max)?;
+    let num = borrow.rand(interp, max)?;
+    Ok(interp.convert_mut(num))
+}
+
+pub fn seed(interp: &mut Artichoke, rand: Value) -> Result<Value, Exception> {
+    let rand = unsafe { Random::try_from_ruby(interp, &rand)? };
+    let borrow = rand.borrow();
+    let seed = borrow.seed(interp);
+    Ok(interp.convert(seed))
+}
+
+pub fn new_seed(interp: &mut Artichoke) -> Result<Value, Exception> {
+    let seed = Random::new_seed();
+    Ok(interp.convert(seed))
+}
+
+pub fn srand(interp: &mut Artichoke, seed: Option<Value>) -> Result<Value, Exception> {
+    let seed = interp.try_convert(seed)?;
+    let old_seed = random::srand(interp, seed)?;
+    Ok(interp.convert(old_seed))
+}
+
+pub fn urandom(interp: &mut Artichoke, size: Value) -> Result<Value, Exception> {
+    let size = size.implicitly_convert_to_int()?;
+    let buf = random::urandom(interp, size)?;
+    Ok(interp.convert_mut(buf))
+}

--- a/artichoke-backend/src/extn/stdlib/securerandom/trampoline.rs
+++ b/artichoke-backend/src/extn/stdlib/securerandom/trampoline.rs
@@ -1,26 +1,38 @@
 use crate::extn::prelude::*;
 use crate::extn::stdlib::securerandom;
 
+#[inline]
 pub fn alphanumeric(interp: &mut Artichoke, len: Option<Value>) -> Result<Value, Exception> {
-    securerandom::alphanumeric(interp, len).map(|bytes| interp.convert_mut(bytes))
+    let alpha = securerandom::alphanumeric(interp, len)?;
+    Ok(interp.convert_mut(alpha))
 }
 
+#[inline]
 pub fn base64(interp: &mut Artichoke, len: Option<Value>) -> Result<Value, Exception> {
-    securerandom::base64(interp, len).map(|bytes| interp.convert_mut(bytes))
+    let base64 = securerandom::base64(interp, len)?;
+    Ok(interp.convert_mut(base64))
 }
 
+#[inline]
 pub fn hex(interp: &mut Artichoke, len: Option<Value>) -> Result<Value, Exception> {
-    securerandom::hex(interp, len).map(|bytes| interp.convert_mut(bytes))
+    let hex = securerandom::hex(interp, len)?;
+    Ok(interp.convert_mut(hex))
 }
 
+#[inline]
 pub fn random_bytes(interp: &mut Artichoke, len: Option<Value>) -> Result<Value, Exception> {
-    securerandom::random_bytes(interp, len).map(|bytes| interp.convert_mut(bytes))
+    let bytes = securerandom::random_bytes(interp, len)?;
+    Ok(interp.convert_mut(bytes))
 }
 
+#[inline]
 pub fn random_number(interp: &mut Artichoke, max: Option<Value>) -> Result<Value, Exception> {
-    securerandom::random_number(interp, max)
+    let max = interp.try_convert(max)?;
+    let num = securerandom::random_number(interp, max)?;
+    Ok(interp.convert_mut(num))
 }
 
+#[inline]
 pub fn uuid(interp: &mut Artichoke) -> Result<Value, Exception> {
     let uuid = securerandom::uuid(interp);
     Ok(interp.convert_mut(uuid))


### PR DESCRIPTION
Return native types from SecureRandom functions.

This PR introduces a new pattern where API parameters are concrete types
that can be parsed from an incoming VM arg with `TryConvert`.

This PR introduces a new pattern where API reuslts are concrete types
that can be returned into the VM with `Convert` and `ConvertMut`
implementations.

This PR introduces a trampoline module to `core::random` similarly to the `securerandom` trampoline.

Related to GH-605.