### PR TITLE
Use Regexp trampoline as a VM compat layer

### DIFF
--- a/artichoke-backend/src/extn/core/matchdata/begin.rs
+++ b/artichoke-backend/src/extn/core/matchdata/begin.rs
@@ -24,7 +24,7 @@ impl<'a> Args<'a> {
     }
 }
 
-pub fn method(interp: &Artichoke, args: Args<'_>, value: &Value) -> Result<Value, Exception> {
+pub fn method(interp: &mut Artichoke, args: Args<'_>, value: &Value) -> Result<Value, Exception> {
     let data = unsafe { MatchData::try_from_ruby(interp, value) }?;
     let borrow = data.borrow();
     let haystack = &borrow.string[borrow.region.start..borrow.region.end];

--- a/artichoke-backend/src/extn/core/matchdata/end.rs
+++ b/artichoke-backend/src/extn/core/matchdata/end.rs
@@ -24,7 +24,7 @@ impl<'a> Args<'a> {
     }
 }
 
-pub fn method(interp: &Artichoke, args: Args<'_>, value: &Value) -> Result<Value, Exception> {
+pub fn method(interp: &mut Artichoke, args: Args<'_>, value: &Value) -> Result<Value, Exception> {
     let data = unsafe { MatchData::try_from_ruby(interp, value) }?;
     let borrow = data.borrow();
     let haystack = &borrow.string[borrow.region.start..borrow.region.end];

--- a/artichoke-backend/src/extn/core/matchdata/length.rs
+++ b/artichoke-backend/src/extn/core/matchdata/length.rs
@@ -5,7 +5,7 @@ use std::convert::TryFrom;
 use crate::extn::core::matchdata::MatchData;
 use crate::extn::prelude::*;
 
-pub fn method(interp: &Artichoke, value: &Value) -> Result<Value, Exception> {
+pub fn method(interp: &mut Artichoke, value: &Value) -> Result<Value, Exception> {
     let data = unsafe { MatchData::try_from_ruby(interp, value) }?;
     let borrow = data.borrow();
     let haystack = &borrow.string[borrow.region.start..borrow.region.end];

--- a/artichoke-backend/src/extn/core/matchdata/mod.rs
+++ b/artichoke-backend/src/extn/core/matchdata/mod.rs
@@ -103,10 +103,10 @@ impl MatchData {
 
     unsafe extern "C" fn begin(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
         let begin = mrb_get_args!(mrb, required = 1);
-        let interp = unwrap_interpreter!(mrb);
+        let mut interp = unwrap_interpreter!(mrb);
         let value = Value::new(&interp, slf);
         let result = begin::Args::extract(&interp, Value::new(&interp, begin))
-            .and_then(|args| begin::method(&interp, args, &value));
+            .and_then(|args| begin::method(&mut interp, args, &value));
         match result {
             Ok(result) => result.inner(),
             Err(exception) => exception::raise(interp, exception),
@@ -142,11 +142,11 @@ impl MatchData {
 
     unsafe extern "C" fn end(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
         let end = mrb_get_args!(mrb, required = 1);
-        let interp = unwrap_interpreter!(mrb);
+        let mut interp = unwrap_interpreter!(mrb);
         // TODO: Value should be consumed before the call to `exception::raise`.
         let value = Value::new(&interp, slf);
         let result = end::Args::extract(&interp, Value::new(&interp, end))
-            .and_then(|args| end::method(&interp, args, &value));
+            .and_then(|args| end::method(&mut interp, args, &value));
         match result {
             Ok(result) => result.inner(),
             Err(exception) => exception::raise(interp, exception),
@@ -155,9 +155,9 @@ impl MatchData {
 
     unsafe extern "C" fn length(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
         mrb_get_args!(mrb, none);
-        let interp = unwrap_interpreter!(mrb);
+        let mut interp = unwrap_interpreter!(mrb);
         let value = Value::new(&interp, slf);
-        let result = length::method(&interp, &value);
+        let result = length::method(&mut interp, &value);
         match result {
             Ok(result) => result.inner(),
             Err(exception) => exception::raise(interp, exception),

--- a/artichoke-backend/src/extn/core/matchdata/names.rs
+++ b/artichoke-backend/src/extn/core/matchdata/names.rs
@@ -6,5 +6,6 @@ use crate::extn::prelude::*;
 pub fn method(interp: &mut Artichoke, value: &Value) -> Result<Value, Exception> {
     let data = unsafe { MatchData::try_from_ruby(interp, value) }?;
     let borrow = data.borrow();
-    borrow.regexp.names(interp)
+    let names = borrow.regexp.names(interp);
+    Ok(interp.convert_mut(names))
 }

--- a/artichoke-backend/src/extn/core/regexp/backend/lazy.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/lazy.rs
@@ -24,7 +24,7 @@ impl Lazy {
         }
     }
 
-    pub fn regexp(&self, interp: &Artichoke) -> Result<&Regexp, Exception> {
+    pub fn regexp(&self, interp: &mut Artichoke) -> Result<&Regexp, Exception> {
         self.regexp.get_or_try_init(|| {
             Regexp::new(
                 interp,
@@ -56,7 +56,7 @@ impl RegexpType for Lazy {
 
     fn captures(
         &self,
-        interp: &Artichoke,
+        interp: &mut Artichoke,
         haystack: &[u8],
     ) -> Result<Option<Vec<NilableString>>, Exception> {
         self.regexp(interp)?.inner().captures(interp, haystack)
@@ -64,7 +64,7 @@ impl RegexpType for Lazy {
 
     fn capture_indexes_for_name(
         &self,
-        interp: &Artichoke,
+        interp: &mut Artichoke,
         name: &[u8],
     ) -> Result<Option<Vec<usize>>, Exception> {
         self.regexp(interp)?
@@ -74,7 +74,7 @@ impl RegexpType for Lazy {
 
     fn captures_len(
         &self,
-        interp: &Artichoke,
+        interp: &mut Artichoke,
         haystack: Option<&[u8]>,
     ) -> Result<usize, Exception> {
         self.regexp(interp)?.inner().captures_len(interp, haystack)
@@ -82,7 +82,7 @@ impl RegexpType for Lazy {
 
     fn capture0<'a>(
         &self,
-        interp: &Artichoke,
+        interp: &mut Artichoke,
         haystack: &'a [u8],
     ) -> Result<Option<&'a [u8]>, Exception> {
         self.regexp(interp)?.inner().capture0(interp, haystack)
@@ -117,13 +117,13 @@ impl RegexpType for Lazy {
         &self.encoding
     }
 
-    fn inspect(&self, interp: &Artichoke) -> Vec<u8> {
+    fn inspect(&self, interp: &mut Artichoke) -> Vec<u8> {
         self.regexp(interp)
             .map(|regexp| regexp.inner().inspect(interp))
             .unwrap_or_default()
     }
 
-    fn string(&self, interp: &Artichoke) -> &[u8] {
+    fn string(&self, interp: &mut Artichoke) -> &[u8] {
         self.regexp(interp)
             .map(|regexp| regexp.inner().string(interp))
             .unwrap_or_default()
@@ -135,7 +135,7 @@ impl RegexpType for Lazy {
 
     fn is_match(
         &self,
-        interp: &Artichoke,
+        interp: &mut Artichoke,
         haystack: &[u8],
         pos: Option<Int>,
     ) -> Result<bool, Exception> {
@@ -164,13 +164,13 @@ impl RegexpType for Lazy {
             .match_operator(interp, haystack)
     }
 
-    fn named_captures(&self, interp: &Artichoke) -> Result<NameToCaptureLocations, Exception> {
+    fn named_captures(&self, interp: &mut Artichoke) -> Result<NameToCaptureLocations, Exception> {
         self.regexp(interp)?.inner().named_captures(interp)
     }
 
     fn named_captures_for_haystack(
         &self,
-        interp: &Artichoke,
+        interp: &mut Artichoke,
         haystack: &[u8],
     ) -> Result<Option<HashMap<Vec<u8>, NilableString>>, Exception> {
         self.regexp(interp)?
@@ -178,7 +178,7 @@ impl RegexpType for Lazy {
             .named_captures_for_haystack(interp, haystack)
     }
 
-    fn names(&self, interp: &Artichoke) -> Vec<Vec<u8>> {
+    fn names(&self, interp: &mut Artichoke) -> Vec<Vec<u8>> {
         self.regexp(interp)
             .map(|regexp| regexp.inner().names(interp))
             .unwrap_or_default()
@@ -186,7 +186,7 @@ impl RegexpType for Lazy {
 
     fn pos(
         &self,
-        interp: &Artichoke,
+        interp: &mut Artichoke,
         haystack: &[u8],
         at: usize,
     ) -> Result<Option<(usize, usize)>, Exception> {

--- a/artichoke-backend/src/extn/core/regexp/backend/mod.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/mod.rs
@@ -7,8 +7,8 @@ pub mod lazy;
 pub mod onig;
 pub mod regex;
 
-type NilableString = Option<Vec<u8>>;
-type NameToCaptureLocations = Vec<(Vec<u8>, Vec<usize>)>;
+pub type NilableString = Option<Vec<u8>>;
+pub type NameToCaptureLocations = Vec<(Vec<u8>, Vec<usize>)>;
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub enum Scan {
@@ -28,28 +28,31 @@ pub trait RegexpType {
 
     fn encoding(&self) -> &Encoding;
 
-    fn inspect(&self, interp: &Artichoke) -> Vec<u8>;
+    fn inspect(&self, interp: &mut Artichoke) -> Vec<u8>;
 
-    fn string(&self, interp: &Artichoke) -> &[u8];
+    fn string(&self, interp: &mut Artichoke) -> &[u8];
 
     fn captures(
         &self,
-        interp: &Artichoke,
+        interp: &mut Artichoke,
         haystack: &[u8],
     ) -> Result<Option<Vec<NilableString>>, Exception>;
 
     fn capture_indexes_for_name(
         &self,
-        interp: &Artichoke,
+        interp: &mut Artichoke,
         name: &[u8],
     ) -> Result<Option<Vec<usize>>, Exception>;
 
-    fn captures_len(&self, interp: &Artichoke, haystack: Option<&[u8]>)
-        -> Result<usize, Exception>;
+    fn captures_len(
+        &self,
+        interp: &mut Artichoke,
+        haystack: Option<&[u8]>,
+    ) -> Result<usize, Exception>;
 
     fn capture0<'a>(
         &self,
-        interp: &Artichoke,
+        interp: &mut Artichoke,
         haystack: &'a [u8],
     ) -> Result<Option<&'a [u8]>, Exception>;
 
@@ -57,7 +60,7 @@ pub trait RegexpType {
 
     fn is_match(
         &self,
-        interp: &Artichoke,
+        interp: &mut Artichoke,
         haystack: &[u8],
         pos: Option<Int>,
     ) -> Result<bool, Exception>;
@@ -76,19 +79,19 @@ pub trait RegexpType {
         haystack: &[u8],
     ) -> Result<Option<usize>, Exception>;
 
-    fn named_captures(&self, interp: &Artichoke) -> Result<NameToCaptureLocations, Exception>;
+    fn named_captures(&self, interp: &mut Artichoke) -> Result<NameToCaptureLocations, Exception>;
 
     fn named_captures_for_haystack(
         &self,
-        interp: &Artichoke,
+        interp: &mut Artichoke,
         haystack: &[u8],
     ) -> Result<Option<HashMap<Vec<u8>, NilableString>>, Exception>;
 
-    fn names(&self, interp: &Artichoke) -> Vec<Vec<u8>>;
+    fn names(&self, interp: &mut Artichoke) -> Vec<Vec<u8>>;
 
     fn pos(
         &self,
-        interp: &Artichoke,
+        interp: &mut Artichoke,
         haystack: &[u8],
         at: usize,
     ) -> Result<Option<(usize, usize)>, Exception>;

--- a/artichoke-backend/src/extn/core/regexp/backend/mod.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/mod.rs
@@ -1,4 +1,6 @@
 use std::collections::HashMap;
+use std::fmt;
+use std::hash::{Hash, Hasher};
 
 use crate::extn::core::regexp::{Config, Encoding};
 use crate::extn::prelude::*;
@@ -103,3 +105,77 @@ pub trait RegexpType {
         block: Option<Block>,
     ) -> Result<Scan, Exception>;
 }
+
+impl Clone for Box<dyn RegexpType> {
+    #[inline]
+    fn clone(&self) -> Self {
+        self.box_clone()
+    }
+}
+
+impl fmt::Debug for Box<dyn RegexpType> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&self.as_ref(), f)
+    }
+}
+
+impl Hash for Box<dyn RegexpType> {
+    #[inline]
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        Hash::hash(&self.as_ref(), state)
+    }
+}
+
+impl PartialEq for Box<dyn RegexpType> {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        PartialEq::eq(&self.as_ref(), &other.as_ref())
+    }
+}
+
+impl Eq for Box<dyn RegexpType> {}
+
+impl fmt::Debug for &dyn RegexpType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.debug())
+    }
+}
+
+impl Hash for &dyn RegexpType {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.literal_config().hash(state);
+    }
+}
+
+impl PartialEq for &dyn RegexpType {
+    fn eq(&self, other: &Self) -> bool {
+        self.derived_config().pattern == other.derived_config().pattern
+            && self.encoding() == other.encoding()
+    }
+}
+
+impl Eq for &dyn RegexpType {}
+
+impl fmt::Debug for &mut dyn RegexpType {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&&*self, f)
+    }
+}
+
+impl Hash for &mut dyn RegexpType {
+    #[inline]
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        Hash::hash(&&*self, state);
+    }
+}
+
+impl PartialEq for &mut dyn RegexpType {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        PartialEq::eq(&&*self, &&*other)
+    }
+}
+
+impl Eq for &mut dyn RegexpType {}

--- a/artichoke-backend/src/extn/core/regexp/backend/onig.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/onig.rs
@@ -23,7 +23,7 @@ pub struct Onig {
 
 impl Onig {
     pub fn new(
-        interp: &Artichoke,
+        interp: &mut Artichoke,
         literal: Config,
         derived: Config,
         encoding: Encoding,
@@ -73,7 +73,7 @@ impl RegexpType for Onig {
 
     fn captures(
         &self,
-        interp: &Artichoke,
+        interp: &mut Artichoke,
         haystack: &[u8],
     ) -> Result<Option<Vec<NilableString>>, Exception> {
         let haystack = str::from_utf8(haystack).map_err(|_| {
@@ -99,7 +99,7 @@ impl RegexpType for Onig {
 
     fn capture_indexes_for_name(
         &self,
-        interp: &Artichoke,
+        interp: &mut Artichoke,
         name: &[u8],
     ) -> Result<Option<Vec<usize>>, Exception> {
         let _ = interp;
@@ -127,7 +127,7 @@ impl RegexpType for Onig {
 
     fn captures_len(
         &self,
-        interp: &Artichoke,
+        interp: &mut Artichoke,
         haystack: Option<&[u8]>,
     ) -> Result<usize, Exception> {
         let result = if let Some(haystack) = haystack {
@@ -149,7 +149,7 @@ impl RegexpType for Onig {
 
     fn capture0<'a>(
         &self,
-        interp: &Artichoke,
+        interp: &mut Artichoke,
         haystack: &'a [u8],
     ) -> Result<Option<&'a [u8]>, Exception> {
         let haystack = str::from_utf8(haystack).map_err(|_| {
@@ -195,7 +195,7 @@ impl RegexpType for Onig {
         &self.encoding
     }
 
-    fn inspect(&self, interp: &Artichoke) -> Vec<u8> {
+    fn inspect(&self, interp: &mut Artichoke) -> Vec<u8> {
         let _ = interp;
         // pattern length + 2x '/' + mix + encoding
         let mut inspect = Vec::with_capacity(self.literal.pattern.len() + 2 + 4);
@@ -211,7 +211,7 @@ impl RegexpType for Onig {
         inspect
     }
 
-    fn string(&self, interp: &Artichoke) -> &[u8] {
+    fn string(&self, interp: &mut Artichoke) -> &[u8] {
         let _ = interp;
         self.derived.pattern.as_slice()
     }
@@ -259,7 +259,7 @@ impl RegexpType for Onig {
 
     fn is_match(
         &self,
-        interp: &Artichoke,
+        interp: &mut Artichoke,
         haystack: &[u8],
         pos: Option<Int>,
     ) -> Result<bool, Exception> {
@@ -420,7 +420,7 @@ impl RegexpType for Onig {
         }
     }
 
-    fn named_captures(&self, interp: &Artichoke) -> Result<NameToCaptureLocations, Exception> {
+    fn named_captures(&self, interp: &mut Artichoke) -> Result<NameToCaptureLocations, Exception> {
         let _ = interp;
         // Use a Vec of key-value pairs because insertion order matters for spec
         // compliance.
@@ -441,7 +441,7 @@ impl RegexpType for Onig {
 
     fn named_captures_for_haystack(
         &self,
-        interp: &Artichoke,
+        interp: &mut Artichoke,
         haystack: &[u8],
     ) -> Result<Option<HashMap<Vec<u8>, NilableString>>, Exception> {
         let haystack = str::from_utf8(haystack).map_err(|_| {
@@ -472,7 +472,7 @@ impl RegexpType for Onig {
         }
     }
 
-    fn names(&self, interp: &Artichoke) -> Vec<Vec<u8>> {
+    fn names(&self, interp: &mut Artichoke) -> Vec<Vec<u8>> {
         let _ = interp;
         let mut names = vec![];
         let mut capture_names = Vec::<(Vec<u8>, Vec<u32>)>::new();
@@ -495,7 +495,7 @@ impl RegexpType for Onig {
 
     fn pos(
         &self,
-        interp: &Artichoke,
+        interp: &mut Artichoke,
         haystack: &[u8],
         at: usize,
     ) -> Result<Option<(usize, usize)>, Exception> {

--- a/artichoke-backend/src/extn/core/regexp/backend/regex/utf8.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/regex/utf8.rs
@@ -22,7 +22,7 @@ pub struct Utf8 {
 
 impl Utf8 {
     pub fn new(
-        interp: &Artichoke,
+        interp: &mut Artichoke,
         literal: Config,
         derived: Config,
         encoding: Encoding,
@@ -68,7 +68,7 @@ impl RegexpType for Utf8 {
 
     fn captures(
         &self,
-        interp: &Artichoke,
+        interp: &mut Artichoke,
         haystack: &[u8],
     ) -> Result<Option<Vec<NilableString>>, Exception> {
         let haystack = str::from_utf8(haystack).map_err(|_| {
@@ -94,7 +94,7 @@ impl RegexpType for Utf8 {
 
     fn capture_indexes_for_name(
         &self,
-        interp: &Artichoke,
+        interp: &mut Artichoke,
         name: &[u8],
     ) -> Result<Option<Vec<usize>>, Exception> {
         let _ = interp;
@@ -113,7 +113,7 @@ impl RegexpType for Utf8 {
 
     fn captures_len(
         &self,
-        interp: &Artichoke,
+        interp: &mut Artichoke,
         haystack: Option<&[u8]>,
     ) -> Result<usize, Exception> {
         let result = if let Some(haystack) = haystack {
@@ -135,7 +135,7 @@ impl RegexpType for Utf8 {
 
     fn capture0<'a>(
         &self,
-        interp: &Artichoke,
+        interp: &mut Artichoke,
         haystack: &'a [u8],
     ) -> Result<Option<&'a [u8]>, Exception> {
         let haystack = str::from_utf8(haystack).map_err(|_| {
@@ -183,7 +183,7 @@ impl RegexpType for Utf8 {
         &self.encoding
     }
 
-    fn inspect(&self, interp: &Artichoke) -> Vec<u8> {
+    fn inspect(&self, interp: &mut Artichoke) -> Vec<u8> {
         let _ = interp;
         // pattern length + 2x '/' + mix + encoding
         let mut inspect = Vec::with_capacity(self.literal.pattern.len() + 2 + 4);
@@ -199,7 +199,7 @@ impl RegexpType for Utf8 {
         inspect
     }
 
-    fn string(&self, interp: &Artichoke) -> &[u8] {
+    fn string(&self, interp: &mut Artichoke) -> &[u8] {
         let _ = interp;
         self.derived.pattern.as_slice()
     }
@@ -264,7 +264,7 @@ impl RegexpType for Utf8 {
 
     fn is_match(
         &self,
-        interp: &Artichoke,
+        interp: &mut Artichoke,
         haystack: &[u8],
         pos: Option<Int>,
     ) -> Result<bool, Exception> {
@@ -458,7 +458,7 @@ impl RegexpType for Utf8 {
         }
     }
 
-    fn named_captures(&self, interp: &Artichoke) -> Result<NameToCaptureLocations, Exception> {
+    fn named_captures(&self, interp: &mut Artichoke) -> Result<NameToCaptureLocations, Exception> {
         // Use a Vec of key-value pairs because insertion order matters for spec
         // compliance.
         let mut map = vec![];
@@ -472,7 +472,7 @@ impl RegexpType for Utf8 {
 
     fn named_captures_for_haystack(
         &self,
-        interp: &Artichoke,
+        interp: &mut Artichoke,
         haystack: &[u8],
     ) -> Result<Option<HashMap<Vec<u8>, NilableString>>, Exception> {
         let haystack = str::from_utf8(haystack).map_err(|_| {
@@ -501,7 +501,7 @@ impl RegexpType for Utf8 {
         }
     }
 
-    fn names(&self, interp: &Artichoke) -> Vec<Vec<u8>> {
+    fn names(&self, interp: &mut Artichoke) -> Vec<Vec<u8>> {
         let mut names = vec![];
         let mut capture_names = self.named_captures(interp).unwrap_or_default();
         capture_names.sort_by(|left, right| {
@@ -519,7 +519,7 @@ impl RegexpType for Utf8 {
 
     fn pos(
         &self,
-        interp: &Artichoke,
+        interp: &mut Artichoke,
         haystack: &[u8],
         at: usize,
     ) -> Result<Option<(usize, usize)>, Exception> {

--- a/artichoke-backend/src/extn/core/regexp/trampoline.rs
+++ b/artichoke-backend/src/extn/core/regexp/trampoline.rs
@@ -1,3 +1,5 @@
+use std::convert::TryFrom;
+
 use crate::extn::core::regexp::Regexp;
 use crate::extn::prelude::*;
 
@@ -8,26 +10,37 @@ pub fn initialize(
     encoding: Option<Value>,
     into: Option<Value>,
 ) -> Result<Value, Exception> {
-    Regexp::initialize(interp, pattern, options, encoding, into)
+    let (options, encoding) = interp.try_convert_mut((options, encoding))?;
+    let regexp = Regexp::initialize(interp, pattern, options, encoding)?;
+    regexp.try_into_ruby(interp, into.as_ref().map(Value::inner))
 }
 
 pub fn escape(interp: &mut Artichoke, pattern: Value) -> Result<Value, Exception> {
-    Regexp::escape(interp, pattern)
+    let pattern = Regexp::escape(interp, pattern)?;
+    Ok(interp.convert_mut(pattern))
 }
 
-pub fn union(interp: &Artichoke, patterns: &[Value]) -> Result<Value, Exception> {
-    Regexp::union(interp, patterns)
+pub fn union(interp: &mut Artichoke, patterns: Vec<Value>) -> Result<Value, Exception> {
+    let regexp = Regexp::union(interp, patterns)?;
+    regexp.try_into_ruby(interp, None)
 }
 
 pub fn is_match(
-    interp: &Artichoke,
+    interp: &mut Artichoke,
     regexp: Value,
     pattern: Value,
     pos: Option<Value>,
 ) -> Result<Value, Exception> {
     let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }?;
     let borrow = regexp.borrow();
-    borrow.is_match(interp, pattern, pos)
+    let pattern = pattern.implicitly_convert_to_nilable_string()?;
+    let pos = if let Some(pos) = pos {
+        Some(pos.implicitly_convert_to_int()?)
+    } else {
+        None
+    };
+    let is_match = borrow.is_match(interp, pattern, pos)?;
+    Ok(interp.convert(is_match))
 }
 
 pub fn match_(
@@ -39,13 +52,20 @@ pub fn match_(
 ) -> Result<Value, Exception> {
     let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }?;
     let borrow = regexp.borrow();
+    let pattern = pattern.implicitly_convert_to_nilable_string()?;
+    let pos = if let Some(pos) = pos {
+        Some(pos.implicitly_convert_to_int()?)
+    } else {
+        None
+    };
     borrow.match_(interp, pattern, pos, block)
 }
 
-pub fn eql(interp: &Artichoke, regexp: Value, other: Value) -> Result<Value, Exception> {
+pub fn eql(interp: &mut Artichoke, regexp: Value, other: Value) -> Result<Value, Exception> {
     let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }?;
     let borrow = regexp.borrow();
-    borrow.eql(interp, other)
+    let cmp = borrow.eql(interp, other);
+    Ok(interp.convert(cmp))
 }
 
 pub fn case_compare(
@@ -55,7 +75,8 @@ pub fn case_compare(
 ) -> Result<Value, Exception> {
     let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }?;
     let borrow = regexp.borrow();
-    borrow.case_compare(interp, other)
+    let cmp = borrow.case_compare(interp, other)?;
+    Ok(interp.convert(cmp))
 }
 
 pub fn match_operator(
@@ -65,59 +86,77 @@ pub fn match_operator(
 ) -> Result<Value, Exception> {
     let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }?;
     let borrow = regexp.borrow();
-    borrow.match_operator(interp, pattern)
+    let pattern = pattern.implicitly_convert_to_nilable_string()?;
+    let pos = borrow.match_operator(interp, pattern)?;
+    match pos.map(Int::try_from) {
+        Some(Ok(pos)) => Ok(interp.convert(pos)),
+        Some(Err(_)) => Err(Exception::from(ArgumentError::new(
+            interp,
+            "string too long",
+        ))),
+        None => Ok(interp.convert(None::<Value>)),
+    }
 }
 
-pub fn is_casefold(interp: &Artichoke, regexp: Value) -> Result<Value, Exception> {
+pub fn is_casefold(interp: &mut Artichoke, regexp: Value) -> Result<Value, Exception> {
     let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }?;
     let borrow = regexp.borrow();
-    borrow.is_casefold(interp)
+    let is_casefold = borrow.is_casefold(interp);
+    Ok(interp.convert(is_casefold))
 }
 
-pub fn is_fixed_encoding(interp: &Artichoke, regexp: Value) -> Result<Value, Exception> {
+pub fn is_fixed_encoding(interp: &mut Artichoke, regexp: Value) -> Result<Value, Exception> {
     let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }?;
     let borrow = regexp.borrow();
-    borrow.is_fixed_encoding(interp)
+    let is_fixed_encoding = borrow.is_fixed_encoding(interp);
+    Ok(interp.convert(is_fixed_encoding))
 }
 
-pub fn hash(interp: &Artichoke, regexp: Value) -> Result<Value, Exception> {
+pub fn hash(interp: &mut Artichoke, regexp: Value) -> Result<Value, Exception> {
     let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }?;
     let borrow = regexp.borrow();
-    borrow.hash(interp)
+    let hash = borrow.hash(interp);
+    Ok(interp.convert(hash as Int))
 }
 
 pub fn inspect(interp: &mut Artichoke, regexp: Value) -> Result<Value, Exception> {
     let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }?;
     let borrow = regexp.borrow();
-    borrow.inspect(interp)
+    let inspect = borrow.inspect(interp);
+    Ok(interp.convert_mut(inspect))
 }
 
 pub fn named_captures(interp: &mut Artichoke, regexp: Value) -> Result<Value, Exception> {
     let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }?;
     let borrow = regexp.borrow();
-    borrow.named_captures(interp)
+    let named_captures = borrow.named_captures(interp)?;
+    Ok(interp.convert_mut(named_captures))
 }
 
 pub fn names(interp: &mut Artichoke, regexp: Value) -> Result<Value, Exception> {
     let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }?;
     let borrow = regexp.borrow();
-    borrow.names(interp)
+    let names = borrow.names(interp);
+    Ok(interp.convert_mut(names))
 }
 
-pub fn options(interp: &Artichoke, regexp: Value) -> Result<Value, Exception> {
+pub fn options(interp: &mut Artichoke, regexp: Value) -> Result<Value, Exception> {
     let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }?;
     let borrow = regexp.borrow();
-    borrow.options(interp)
+    let opts = borrow.options(interp);
+    Ok(interp.convert(opts))
 }
 
 pub fn source(interp: &mut Artichoke, regexp: Value) -> Result<Value, Exception> {
     let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }?;
     let borrow = regexp.borrow();
-    borrow.source(interp)
+    let source = borrow.source(interp);
+    Ok(interp.convert_mut(source))
 }
 
 pub fn to_s(interp: &mut Artichoke, regexp: Value) -> Result<Value, Exception> {
     let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }?;
     let borrow = regexp.borrow();
-    borrow.string(interp)
+    let s = borrow.string(interp);
+    Ok(interp.convert_mut(s))
 }

--- a/artichoke-backend/src/extn/core/regexp/trampoline.rs
+++ b/artichoke-backend/src/extn/core/regexp/trampoline.rs
@@ -116,6 +116,7 @@ pub fn hash(interp: &mut Artichoke, regexp: Value) -> Result<Value, Exception> {
     let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }?;
     let borrow = regexp.borrow();
     let hash = borrow.hash(interp);
+    #[allow(clippy::cast_possible_wrap)]
     Ok(interp.convert(hash as Int))
 }
 

--- a/artichoke-backend/src/extn/core/string/trampoline.rs
+++ b/artichoke-backend/src/extn/core/string/trampoline.rs
@@ -55,7 +55,7 @@ pub fn scan(
     } else if let Ok(pattern_bytes) = pattern.implicitly_convert_to_string() {
         let string = value.clone().try_into::<&[u8]>()?;
         if let Some(ref block) = block {
-            let regex = Regexp::lazy(pattern_bytes);
+            let regex = Regexp::lazy(pattern_bytes.to_vec());
             let matchdata = MatchData::new(string.to_vec(), regex, 0, string.len());
             let patlen = pattern_bytes.len();
             if let Some(pos) = string.find(pattern_bytes) {
@@ -98,7 +98,7 @@ pub fn scan(
                 result.push(interp.convert_mut(pattern_bytes));
             }
             if matches > 0 {
-                let regex = Regexp::lazy(pattern_bytes);
+                let regex = Regexp::lazy(pattern_bytes.to_vec());
                 let mut matchdata = MatchData::new(string.to_vec(), regex, 0, string.len());
                 matchdata.set_region(last_pos, last_pos + pattern_bytes.len());
                 let data = matchdata.try_into_ruby(interp, None)?;


### PR DESCRIPTION
Followup to GH-607 by extending the native types to the `Regexp` API
instead of stopping at `RegexpType`. These changes are necessary for
refactoring `MatchData` to use modern patterns.

This PR uses the same tricks introduced in GH-610 to use the converter
infra to parse arguments out of a VM `Value`.

Related to GH-605.