### PR TITLE
Reimplement MatchData using modern patterns

### DIFF
--- a/artichoke-backend/src/extn/core/matchdata/args.rs
+++ b/artichoke-backend/src/extn/core/matchdata/args.rs
@@ -1,0 +1,33 @@
+use std::mem;
+
+use crate::extn::prelude::*;
+
+// TODO(GH-308): extract this function into `sys::protect`
+pub unsafe fn is_range<'a>(
+    interp: &'a Artichoke,
+    first: &Value,
+    length: Int,
+) -> Result<Option<(Int, Int)>, TypeError> {
+    use sys::mrb_range_beg_len::*;
+
+    let mut start = mem::MaybeUninit::<sys::mrb_int>::uninit();
+    let mut len = mem::MaybeUninit::<sys::mrb_int>::uninit();
+    let mrb = interp.0.borrow().mrb;
+    // NOTE: `mrb_range_beg_len` can raise.
+    // TODO(GH-308): wrap this in a call to `mrb_protect`.
+    let check_range = sys::mrb_range_beg_len(
+        mrb,
+        first.inner(),
+        start.as_mut_ptr(),
+        len.as_mut_ptr(),
+        length,
+        0_u8,
+    );
+    let start = start.assume_init();
+    let len = len.assume_init();
+    if check_range == MRB_RANGE_OK {
+        Ok(Some((start, len)))
+    } else {
+        Ok(None)
+    }
+}

--- a/artichoke-backend/src/extn/core/matchdata/mod.rs
+++ b/artichoke-backend/src/extn/core/matchdata/mod.rs
@@ -1,81 +1,124 @@
-//! [ruby/spec](https://github.com/ruby/spec) compliant implementation of
-//! [`MatchData`](https://ruby-doc.org/core-2.6.3/MatchData.html).
+//! An implementation of [`MatchData`][matchdata] for all [`Regexp`] backends.
 //!
-//! Each function on `MatchData` is implemented as its own module which contains
-//! the `Args` struct for invoking the function.
+//! `MatchData` is mostly implemented in Rust with some methods implemented in
+//! Ruby. `MatchData` lazily computes matches by delegating to its underlying
+//! [`Regexp`] instance on access.
 //!
-//! [`MatchData#==`](https://ruby-doc.org/core-2.6.3/MatchData.html#method-i-3D-3D),
-//! [`MatchData#eql?`](https://ruby-doc.org/core-2.6.3/MatchData.html#method-i-eql-3F),
-//! [`MatchData#inspect`](https://ruby-doc.org/core-2.6.3/MatchData.html#method-i-inspect),
-//! and
-//! [`MatchData#values_at`](https://ruby-doc.org/core-2.6.3/MatchData.html#method-i-values_at)
-//! are
-//! [implemented in Ruby](https://github.com/artichoke/artichoke/blob/master/artichoke-backend/src/extn/core/matchdata/matchdata.rb).
+//! `MatchData` passes all non-skipped [ruby/spec][rubyspec]s.
+//!
+//! [matchdata]: https://ruby-doc.org/core-2.6.3/MatchData.html
+//! [rubyspec]: https://github.com/ruby/spec
 
+use std::collections::HashMap;
+use std::convert::TryFrom;
+use std::ops::{Bound, RangeBounds};
+use std::str;
+
+use crate::extn::core::regexp::backend::NilableString;
 use crate::extn::core::regexp::Regexp;
 use crate::extn::prelude::*;
 
-pub mod begin;
-pub mod captures;
-pub mod element_reference;
-pub mod end;
-pub mod length;
-pub mod named_captures;
-pub mod names;
-pub mod offset;
-pub mod post_match;
-pub mod pre_match;
-pub mod regexp;
-pub mod string;
-pub mod to_a;
-pub mod to_s;
-
-pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
-    if interp.0.borrow().class_spec::<MatchData>().is_some() {
-        return Ok(());
-    }
-    let spec = class::Spec::new("MatchData", None, Some(def::rust_data_free::<MatchData>))?;
-    class::Builder::for_spec(interp, &spec)
-        .value_is_rust_object()
-        .add_method("begin", MatchData::begin, sys::mrb_args_req(1))?
-        .add_method("captures", MatchData::captures, sys::mrb_args_none())?
-        .add_method(
-            "[]",
-            MatchData::element_reference,
-            sys::mrb_args_req_and_opt(1, 1),
-        )?
-        .add_method("length", MatchData::length, sys::mrb_args_none())?
-        .add_method(
-            "named_captures",
-            MatchData::named_captures,
-            sys::mrb_args_none(),
-        )?
-        .add_method("names", MatchData::names, sys::mrb_args_none())?
-        .add_method("offset", MatchData::offset, sys::mrb_args_req(1))?
-        .add_method("post_match", MatchData::post_match, sys::mrb_args_none())?
-        .add_method("pre_match", MatchData::pre_match, sys::mrb_args_none())?
-        .add_method("regexp", MatchData::regexp, sys::mrb_args_none())?
-        .add_method("size", MatchData::length, sys::mrb_args_none())?
-        .add_method("string", MatchData::string, sys::mrb_args_none())?
-        .add_method("to_a", MatchData::to_a, sys::mrb_args_none())?
-        .add_method("to_s", MatchData::to_s, sys::mrb_args_none())?
-        .add_method("end", MatchData::end, sys::mrb_args_req(1))?
-        .define()?;
-    interp.0.borrow_mut().def_class::<MatchData>(spec);
-    let _ = interp.eval(&include_bytes!("matchdata.rb")[..])?;
-    trace!("Patched MatchData onto interpreter");
-    Ok(())
-}
+mod args;
+pub mod mruby;
+pub mod trampoline;
 
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
 pub struct Region {
-    start: usize,
-    end: usize,
+    start: Bound<usize>,
+    end: Bound<usize>,
 }
 
-#[derive(Debug, Clone)]
+impl Region {
+    fn from_range<R>(bounds: R) -> Self
+    where
+        R: RangeBounds<usize>,
+    {
+        let start = match bounds.start_bound() {
+            Bound::Included(&bound) => Bound::Included(bound),
+            Bound::Excluded(&bound) => Bound::Excluded(bound),
+            Bound::Unbounded => Bound::Unbounded,
+        };
+        let end = match bounds.end_bound() {
+            Bound::Included(&bound) => Bound::Included(bound),
+            Bound::Excluded(&bound) => Bound::Excluded(bound),
+            Bound::Unbounded => Bound::Unbounded,
+        };
+        Region { start, end }
+    }
+
+    fn offset(&self) -> usize {
+        match self.start {
+            Bound::Included(bound) => bound,
+            Bound::Excluded(bound) => bound.checked_sub(1).unwrap_or_default(),
+            Bound::Unbounded => 0,
+        }
+    }
+}
+
+impl RangeBounds<usize> for Region {
+    fn start_bound(&self) -> Bound<&usize> {
+        match self.start {
+            Bound::Included(ref bound) => Bound::Included(bound),
+            Bound::Excluded(ref bound) => Bound::Excluded(bound),
+            Bound::Unbounded => Bound::Unbounded,
+        }
+    }
+
+    fn end_bound(&self) -> Bound<&usize> {
+        match self.end {
+            Bound::Included(ref bound) => Bound::Included(bound),
+            Bound::Excluded(ref bound) => Bound::Excluded(bound),
+            Bound::Unbounded => Bound::Unbounded,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub enum Capture<'a> {
+    GroupIndex(Int),
+    GroupName(&'a [u8]),
+}
+
+impl<'a> TryConvert<&'a Value, Capture<'a>> for Artichoke {
+    type Error = TypeError;
+
+    fn try_convert(&self, value: &'a Value) -> Result<Capture<'a>, Self::Error> {
+        if let Ok(name) = value.implicitly_convert_to_string() {
+            Ok(Capture::GroupName(name))
+        } else {
+            let idx = value.implicitly_convert_to_int()?;
+            Ok(Capture::GroupIndex(idx))
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub enum CaptureAt<'a> {
+    GroupIndex(Int),
+    GroupName(&'a [u8]),
+    StartLen(Int, Int),
+}
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub enum CaptureMatch {
+    None,
+    Single(Option<Vec<u8>>),
+    Range(Vec<Option<Vec<u8>>>),
+}
+
+impl ConvertMut<CaptureMatch, Value> for Artichoke {
+    fn convert_mut(&mut self, value: CaptureMatch) -> Value {
+        match value {
+            CaptureMatch::None => self.convert(None::<Value>),
+            CaptureMatch::Single(capture) => self.convert_mut(capture),
+            CaptureMatch::Range(captures) => self.convert_mut(captures),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub struct MatchData {
-    string: Vec<u8>,
+    haystack: Vec<u8>,
     regexp: Regexp,
     region: Region,
 }
@@ -88,190 +131,284 @@ impl RustBackedValue for MatchData {
 
 impl MatchData {
     #[must_use]
-    pub fn new(string: Vec<u8>, regexp: Regexp, start: usize, end: usize) -> Self {
-        let region = Region { start, end };
+    pub fn new<R>(haystack: Vec<u8>, regexp: Regexp, bounds: R) -> Self
+    where
+        R: RangeBounds<usize>,
+    {
+        let region = Region::from_range(bounds);
         Self {
-            string,
+            haystack,
             regexp,
             region,
         }
     }
 
-    pub fn set_region(&mut self, start: usize, end: usize) {
-        self.region = Region { start, end };
+    pub fn set_region<R>(&mut self, bounds: R)
+    where
+        R: RangeBounds<usize>,
+    {
+        self.region = Region::from_range(bounds);
     }
 
-    unsafe extern "C" fn begin(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
-        let begin = mrb_get_args!(mrb, required = 1);
-        let mut interp = unwrap_interpreter!(mrb);
-        let value = Value::new(&interp, slf);
-        let result = begin::Args::extract(&interp, Value::new(&interp, begin))
-            .and_then(|args| begin::method(&mut interp, args, &value));
-        match result {
-            Ok(result) => result.inner(),
-            Err(exception) => exception::raise(interp, exception),
+    #[must_use]
+    pub fn matched_region(&self) -> &[u8] {
+        let matched = match (self.region.start, self.region.end) {
+            (Bound::Included(start), Bound::Included(end)) => self.haystack.get(start..=end),
+            (Bound::Included(start), Bound::Excluded(end)) => self.haystack.get(start..end),
+            (Bound::Included(start), Bound::Unbounded) => self.haystack.get(start..),
+            (Bound::Excluded(start), Bound::Included(end)) => self.haystack.get((start + 1)..=end),
+            (Bound::Excluded(start), Bound::Excluded(end)) => self.haystack.get((start + 1)..end),
+            (Bound::Excluded(start), Bound::Unbounded) => self.haystack.get(start + 1..),
+            (Bound::Unbounded, Bound::Included(end)) => self.haystack.get(..=end),
+            (Bound::Unbounded, Bound::Excluded(end)) => self.haystack.get(..end),
+            (Bound::Unbounded, Bound::Unbounded) => self.haystack.get(..),
+        };
+        matched.unwrap_or_default()
+    }
+
+    #[inline]
+    pub fn begin(
+        &self,
+        interp: &mut Artichoke,
+        capture: Capture<'_>,
+    ) -> Result<Option<usize>, Exception> {
+        if let Some([begin, _]) = self.offset(interp, capture)? {
+            Ok(Some(begin))
+        } else {
+            Ok(None)
         }
     }
 
-    unsafe extern "C" fn captures(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
-        mrb_get_args!(mrb, none);
-        let mut interp = unwrap_interpreter!(mrb);
-        let value = Value::new(&interp, slf);
-        let result = captures::method(&mut interp, &value);
-        match result {
-            Ok(result) => result.inner(),
-            Err(exception) => exception::raise(interp, exception),
+    pub fn capture_at(
+        &self,
+        interp: &mut Artichoke,
+        at: CaptureAt<'_>,
+    ) -> Result<CaptureMatch, Exception> {
+        let haystack = self.matched_region();
+        let captures = if let Some(captures) = self.regexp.inner().captures(interp, haystack)? {
+            captures
+        } else {
+            return Ok(CaptureMatch::None);
+        };
+        match at {
+            CaptureAt::GroupIndex(index) => {
+                if let Ok(idx) = usize::try_from(index) {
+                    if let Some(capture) = captures.into_iter().nth(idx) {
+                        Ok(CaptureMatch::Single(capture))
+                    } else {
+                        Ok(CaptureMatch::None)
+                    }
+                } else {
+                    let idx = index
+                        .checked_neg()
+                        .and_then(|index| usize::try_from(index).ok())
+                        .and_then(|index| captures.len().checked_sub(index));
+                    match idx {
+                        Some(0) | None => Ok(CaptureMatch::None),
+                        Some(idx) => {
+                            if let Some(capture) = captures.into_iter().nth(idx) {
+                                Ok(CaptureMatch::Single(capture))
+                            } else {
+                                Ok(CaptureMatch::None)
+                            }
+                        }
+                    }
+                }
+            }
+            CaptureAt::GroupName(name) => {
+                let indexes = self.regexp.inner().capture_indexes_for_name(interp, name)?;
+                if let Some(indexes) = indexes {
+                    let capture = indexes
+                        .iter()
+                        .copied()
+                        .filter_map(|index| captures.get(index).and_then(Option::as_deref))
+                        .last();
+                    Ok(CaptureMatch::Single(capture.map(<[_]>::to_vec)))
+                } else {
+                    let mut message = String::from("undefined group name reference: \"");
+                    string::format_unicode_debug_into(&mut message, name)?;
+                    message.push('"');
+                    Err(Exception::from(IndexError::new(interp, message)))
+                }
+            }
+            CaptureAt::StartLen(start, len) => {
+                if let Ok(len) = usize::try_from(len) {
+                    let start = if let Ok(start) = usize::try_from(start) {
+                        start
+                    } else {
+                        let idx = start
+                            .checked_neg()
+                            .and_then(|index| usize::try_from(index).ok())
+                            .and_then(|index| captures.len().checked_sub(index));
+                        if let Some(start) = idx {
+                            start
+                        } else {
+                            return Ok(CaptureMatch::None);
+                        }
+                    };
+                    let matches = captures
+                        .into_iter()
+                        .skip(start)
+                        .take(len)
+                        .collect::<Vec<_>>();
+                    Ok(CaptureMatch::Range(matches))
+                } else {
+                    Ok(CaptureMatch::None)
+                }
+            }
         }
     }
 
-    unsafe extern "C" fn element_reference(
-        mrb: *mut sys::mrb_state,
-        slf: sys::mrb_value,
-    ) -> sys::mrb_value {
-        let (elem, len) = mrb_get_args!(mrb, required = 1, optional = 1);
-        let mut interp = unwrap_interpreter!(mrb);
-        let value = Value::new(&interp, slf);
-        let elem = Value::new(&interp, elem);
-        let len = len.map(|len| Value::new(&interp, len));
-        let result = element_reference::method(&mut interp, value, elem, len);
-        match result {
-            Ok(result) => result.inner(),
-            Err(exception) => exception::raise(interp, exception),
+    pub fn captures(
+        &self,
+        interp: &mut Artichoke,
+    ) -> Result<Option<Vec<Option<Vec<u8>>>>, Exception> {
+        let haystack = self.matched_region();
+        let captures = self.regexp.inner().captures(interp, haystack)?;
+        if let Some(mut captures) = captures {
+            // Panic safety:
+            //
+            // All Regexp matches are guaranteed to have a zero capture group.
+            captures.remove(0);
+            Ok(Some(captures))
+        } else {
+            Ok(None)
         }
     }
 
-    unsafe extern "C" fn end(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
-        let end = mrb_get_args!(mrb, required = 1);
-        let mut interp = unwrap_interpreter!(mrb);
-        // TODO: Value should be consumed before the call to `exception::raise`.
-        let value = Value::new(&interp, slf);
-        let result = end::Args::extract(&interp, Value::new(&interp, end))
-            .and_then(|args| end::method(&mut interp, args, &value));
-        match result {
-            Ok(result) => result.inner(),
-            Err(exception) => exception::raise(interp, exception),
+    #[inline]
+    pub fn end(
+        &self,
+        interp: &mut Artichoke,
+        capture: Capture<'_>,
+    ) -> Result<Option<usize>, Exception> {
+        if let Some([_, end]) = self.offset(interp, capture)? {
+            Ok(Some(end))
+        } else {
+            Ok(None)
         }
     }
 
-    unsafe extern "C" fn length(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
-        mrb_get_args!(mrb, none);
-        let mut interp = unwrap_interpreter!(mrb);
-        let value = Value::new(&interp, slf);
-        let result = length::method(&mut interp, &value);
-        match result {
-            Ok(result) => result.inner(),
-            Err(exception) => exception::raise(interp, exception),
+    #[inline]
+    pub fn len(&self, interp: &mut Artichoke) -> Result<usize, Exception> {
+        let haystack = self.matched_region();
+        self.regexp.inner().captures_len(interp, Some(haystack))
+    }
+
+    #[inline]
+    pub fn named_captures(
+        &self,
+        interp: &mut Artichoke,
+    ) -> Result<Option<HashMap<Vec<u8>, NilableString>>, Exception> {
+        let haystack = self.matched_region();
+        self.regexp
+            .inner()
+            .named_captures_for_haystack(interp, haystack)
+    }
+
+    #[inline]
+    pub fn names(&self, interp: &mut Artichoke) -> Vec<Vec<u8>> {
+        self.regexp.names(interp)
+    }
+
+    pub fn offset(
+        &self,
+        interp: &mut Artichoke,
+        capture: Capture<'_>,
+    ) -> Result<Option<[usize; 2]>, Exception> {
+        let haystack = self.matched_region();
+        let index = match capture {
+            Capture::GroupIndex(index) => {
+                let captures_len = self.regexp.inner().captures_len(interp, Some(haystack))?;
+                match usize::try_from(index) {
+                    Ok(idx) if idx < captures_len => idx,
+                    _ => {
+                        let mut message = String::from("index ");
+                        string::format_int_into(&mut message, index)?;
+                        message.push_str(" out of matches");
+                        return Err(Exception::from(IndexError::new(interp, message)));
+                    }
+                }
+            }
+            Capture::GroupName(name) => {
+                let indexes = self.regexp.inner().capture_indexes_for_name(interp, name)?;
+                if let Some(index) = indexes.and_then(|indexes| indexes.last().copied()) {
+                    index
+                } else {
+                    return Ok(None);
+                }
+            }
+        };
+        if let Some((begin, end)) = self.regexp.inner().pos(interp, haystack, index)? {
+            let begin = if let Some(Ok(haystack)) = haystack.get(..begin).map(str::from_utf8) {
+                haystack.chars().count()
+            } else {
+                haystack.len()
+            };
+            let end = if let Some(Ok(haystack)) = haystack.get(..end).map(str::from_utf8) {
+                haystack.chars().count()
+            } else {
+                haystack.len()
+            };
+            let offset = self.region.offset();
+            Ok(Some([offset + begin, offset + end]))
+        } else {
+            Ok(None)
         }
     }
 
-    unsafe extern "C" fn named_captures(
-        mrb: *mut sys::mrb_state,
-        slf: sys::mrb_value,
-    ) -> sys::mrb_value {
-        mrb_get_args!(mrb, none);
-        let mut interp = unwrap_interpreter!(mrb);
-        let value = Value::new(&interp, slf);
-        let result = named_captures::method(&mut interp, &value);
-        match result {
-            Ok(result) => result.inner(),
-            Err(exception) => exception::raise(interp, exception),
-        }
+    #[must_use]
+    pub fn pre(&self) -> &[u8] {
+        let pre = match self.region.start {
+            Bound::Included(start) => self.haystack.get(..start),
+            Bound::Excluded(start) => self.haystack.get(..=start),
+            Bound::Unbounded => return &[],
+        };
+        pre.unwrap_or_else(|| {
+            // if start is out of range, the whole haystack is the pre match
+            self.haystack.as_slice()
+        })
     }
 
-    unsafe extern "C" fn names(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
-        mrb_get_args!(mrb, none);
-        let mut interp = unwrap_interpreter!(mrb);
-        let value = Value::new(&interp, slf);
-        let result = names::method(&mut interp, &value);
-        match result {
-            Ok(result) => result.inner(),
-            Err(exception) => exception::raise(interp, exception),
-        }
+    #[must_use]
+    pub fn post(&self) -> &[u8] {
+        let post = match self.region.end {
+            Bound::Included(end) => self.haystack.get(end + 1..),
+            Bound::Excluded(end) => self.haystack.get(end..),
+            Bound::Unbounded => return &[],
+        };
+        post.unwrap_or_else(|| {
+            // if end is out of range, there is no post match
+            &[]
+        })
     }
 
-    unsafe extern "C" fn offset(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
-        let offset = mrb_get_args!(mrb, required = 1);
-        let mut interp = unwrap_interpreter!(mrb);
-        let value = Value::new(&interp, slf);
-        let offset = Value::new(&interp, offset);
-        let result = offset::method(&mut interp, value, offset);
-        match result {
-            Ok(result) => result.inner(),
-            Err(exception) => exception::raise(interp, exception),
-        }
+    #[inline]
+    #[must_use]
+    pub fn regexp(&self) -> &Regexp {
+        &self.regexp
     }
 
-    unsafe extern "C" fn post_match(
-        mrb: *mut sys::mrb_state,
-        slf: sys::mrb_value,
-    ) -> sys::mrb_value {
-        mrb_get_args!(mrb, none);
-        let mut interp = unwrap_interpreter!(mrb);
-        let value = Value::new(&interp, slf);
-        let result = post_match::method(&mut interp, &value);
-        match result {
-            Ok(result) => result.inner(),
-            Err(exception) => exception::raise(interp, exception),
-        }
+    #[inline]
+    pub fn regexp_mut(&mut self) -> &mut Regexp {
+        &mut self.regexp
     }
 
-    unsafe extern "C" fn pre_match(
-        mrb: *mut sys::mrb_state,
-        slf: sys::mrb_value,
-    ) -> sys::mrb_value {
-        mrb_get_args!(mrb, none);
-        let mut interp = unwrap_interpreter!(mrb);
-        let value = Value::new(&interp, slf);
-        let result = pre_match::method(&mut interp, &value);
-        match result {
-            Ok(result) => result.inner(),
-            Err(exception) => exception::raise(interp, exception),
-        }
+    #[inline]
+    #[must_use]
+    pub fn string(&self) -> &[u8] {
+        self.haystack.as_slice()
     }
 
-    unsafe extern "C" fn regexp(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
-        mrb_get_args!(mrb, none);
-        let interp = unwrap_interpreter!(mrb);
-        let value = Value::new(&interp, slf);
-        let result = regexp::method(&interp, &value);
-        match result {
-            Ok(result) => result.inner(),
-            Err(exception) => exception::raise(interp, exception),
-        }
+    #[inline]
+    pub fn to_a(&self, interp: &mut Artichoke) -> Result<Option<Vec<NilableString>>, Exception> {
+        let haystack = self.matched_region();
+        self.regexp.inner().captures(interp, haystack)
     }
 
-    unsafe extern "C" fn string(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
-        mrb_get_args!(mrb, none);
-        let mut interp = unwrap_interpreter!(mrb);
-        let value = Value::new(&interp, slf);
-        let result = string::method(&mut interp, &value);
-        match result {
-            Ok(result) => result.inner(),
-            Err(exception) => exception::raise(interp, exception),
-        }
-    }
-
-    #[allow(clippy::wrong_self_convention)]
-    unsafe extern "C" fn to_a(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
-        mrb_get_args!(mrb, none);
-        let mut interp = unwrap_interpreter!(mrb);
-        let value = Value::new(&interp, slf);
-        let result = to_a::method(&mut interp, &value);
-        match result {
-            Ok(result) => result.inner(),
-            Err(exception) => exception::raise(interp, exception),
-        }
-    }
-
-    #[allow(clippy::wrong_self_convention)]
-    unsafe extern "C" fn to_s(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
-        mrb_get_args!(mrb, none);
-        let mut interp = unwrap_interpreter!(mrb);
-        let value = Value::new(&interp, slf);
-        let result = to_s::method(&mut interp, &value);
-        match result {
-            Ok(result) => result.inner(),
-            Err(exception) => exception::raise(interp, exception),
-        }
+    #[inline]
+    pub fn to_s(&self, interp: &mut Artichoke) -> Result<Option<&[u8]>, Exception> {
+        let haystack = self.matched_region();
+        self.regexp.inner().capture0(interp, haystack)
     }
 }

--- a/artichoke-backend/src/extn/core/matchdata/mruby.rs
+++ b/artichoke-backend/src/extn/core/matchdata/mruby.rs
@@ -1,0 +1,265 @@
+use crate::extn::core::matchdata::{self, trampoline};
+use crate::extn::prelude::*;
+use crate::sys;
+
+pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
+    if interp
+        .0
+        .borrow()
+        .class_spec::<matchdata::MatchData>()
+        .is_some()
+    {
+        return Ok(());
+    }
+    let spec = class::Spec::new(
+        "MatchData",
+        None,
+        Some(def::rust_data_free::<matchdata::MatchData>),
+    )?;
+    class::Builder::for_spec(interp, &spec)
+        .value_is_rust_object()
+        .add_method("begin", artichoke_matchdata_begin, sys::mrb_args_req(1))?
+        .add_method(
+            "captures",
+            artichoke_matchdata_captures,
+            sys::mrb_args_none(),
+        )?
+        .add_method(
+            "[]",
+            artichoke_matchdata_element_reference,
+            sys::mrb_args_req_and_opt(1, 1),
+        )?
+        .add_method("length", artichoke_matchdata_length, sys::mrb_args_none())?
+        .add_method(
+            "named_captures",
+            artichoke_matchdata_named_captures,
+            sys::mrb_args_none(),
+        )?
+        .add_method("names", artichoke_matchdata_names, sys::mrb_args_none())?
+        .add_method("offset", artichoke_matchdata_offset, sys::mrb_args_req(1))?
+        .add_method(
+            "post_match",
+            artichoke_matchdata_post_match,
+            sys::mrb_args_none(),
+        )?
+        .add_method(
+            "pre_match",
+            artichoke_matchdata_pre_match,
+            sys::mrb_args_none(),
+        )?
+        .add_method("regexp", artichoke_matchdata_regexp, sys::mrb_args_none())?
+        .add_method("size", artichoke_matchdata_length, sys::mrb_args_none())?
+        .add_method("string", artichoke_matchdata_string, sys::mrb_args_none())?
+        .add_method("to_a", artichoke_matchdata_to_a, sys::mrb_args_none())?
+        .add_method("to_s", artichoke_matchdata_to_s, sys::mrb_args_none())?
+        .add_method("end", artichoke_matchdata_end, sys::mrb_args_req(1))?
+        .define()?;
+    interp
+        .0
+        .borrow_mut()
+        .def_class::<matchdata::MatchData>(spec);
+    let _ = interp.eval(&include_bytes!("matchdata.rb")[..])?;
+    trace!("Patched MatchData onto interpreter");
+    Ok(())
+}
+
+unsafe extern "C" fn artichoke_matchdata_begin(
+    mrb: *mut sys::mrb_state,
+    slf: sys::mrb_value,
+) -> sys::mrb_value {
+    let begin = mrb_get_args!(mrb, required = 1);
+    let mut interp = unwrap_interpreter!(mrb);
+    let value = Value::new(&interp, slf);
+    let begin = Value::new(&interp, begin);
+    let result = trampoline::begin(&mut interp, value, begin);
+    match result {
+        Ok(result) => result.inner(),
+        Err(exception) => exception::raise(interp, exception),
+    }
+}
+
+unsafe extern "C" fn artichoke_matchdata_captures(
+    mrb: *mut sys::mrb_state,
+    slf: sys::mrb_value,
+) -> sys::mrb_value {
+    mrb_get_args!(mrb, none);
+    let mut interp = unwrap_interpreter!(mrb);
+    let value = Value::new(&interp, slf);
+    let result = trampoline::captures(&mut interp, value);
+    match result {
+        Ok(result) => result.inner(),
+        Err(exception) => exception::raise(interp, exception),
+    }
+}
+
+unsafe extern "C" fn artichoke_matchdata_element_reference(
+    mrb: *mut sys::mrb_state,
+    slf: sys::mrb_value,
+) -> sys::mrb_value {
+    let (elem, len) = mrb_get_args!(mrb, required = 1, optional = 1);
+    let mut interp = unwrap_interpreter!(mrb);
+    let value = Value::new(&interp, slf);
+    let elem = Value::new(&interp, elem);
+    let len = len.map(|len| Value::new(&interp, len));
+    let result = trampoline::element_reference(&mut interp, value, elem, len);
+    match result {
+        Ok(result) => result.inner(),
+        Err(exception) => exception::raise(interp, exception),
+    }
+}
+
+unsafe extern "C" fn artichoke_matchdata_end(
+    mrb: *mut sys::mrb_state,
+    slf: sys::mrb_value,
+) -> sys::mrb_value {
+    let end = mrb_get_args!(mrb, required = 1);
+    let mut interp = unwrap_interpreter!(mrb);
+    let value = Value::new(&interp, slf);
+    let end = Value::new(&interp, end);
+    let result = trampoline::end(&mut interp, value, end);
+    match result {
+        Ok(result) => result.inner(),
+        Err(exception) => exception::raise(interp, exception),
+    }
+}
+
+unsafe extern "C" fn artichoke_matchdata_length(
+    mrb: *mut sys::mrb_state,
+    slf: sys::mrb_value,
+) -> sys::mrb_value {
+    mrb_get_args!(mrb, none);
+    let mut interp = unwrap_interpreter!(mrb);
+    let value = Value::new(&interp, slf);
+    let result = trampoline::length(&mut interp, value);
+    match result {
+        Ok(result) => result.inner(),
+        Err(exception) => exception::raise(interp, exception),
+    }
+}
+
+unsafe extern "C" fn artichoke_matchdata_named_captures(
+    mrb: *mut sys::mrb_state,
+    slf: sys::mrb_value,
+) -> sys::mrb_value {
+    mrb_get_args!(mrb, none);
+    let mut interp = unwrap_interpreter!(mrb);
+    let value = Value::new(&interp, slf);
+    let result = trampoline::named_captures(&mut interp, value);
+    match result {
+        Ok(result) => result.inner(),
+        Err(exception) => exception::raise(interp, exception),
+    }
+}
+
+unsafe extern "C" fn artichoke_matchdata_names(
+    mrb: *mut sys::mrb_state,
+    slf: sys::mrb_value,
+) -> sys::mrb_value {
+    mrb_get_args!(mrb, none);
+    let mut interp = unwrap_interpreter!(mrb);
+    let value = Value::new(&interp, slf);
+    let result = trampoline::names(&mut interp, value);
+    match result {
+        Ok(result) => result.inner(),
+        Err(exception) => exception::raise(interp, exception),
+    }
+}
+
+unsafe extern "C" fn artichoke_matchdata_offset(
+    mrb: *mut sys::mrb_state,
+    slf: sys::mrb_value,
+) -> sys::mrb_value {
+    let offset = mrb_get_args!(mrb, required = 1);
+    let mut interp = unwrap_interpreter!(mrb);
+    let value = Value::new(&interp, slf);
+    let offset = Value::new(&interp, offset);
+    let result = trampoline::offset(&mut interp, value, offset);
+    match result {
+        Ok(result) => result.inner(),
+        Err(exception) => exception::raise(interp, exception),
+    }
+}
+
+unsafe extern "C" fn artichoke_matchdata_post_match(
+    mrb: *mut sys::mrb_state,
+    slf: sys::mrb_value,
+) -> sys::mrb_value {
+    mrb_get_args!(mrb, none);
+    let mut interp = unwrap_interpreter!(mrb);
+    let value = Value::new(&interp, slf);
+    let result = trampoline::post_match(&mut interp, value);
+    match result {
+        Ok(result) => result.inner(),
+        Err(exception) => exception::raise(interp, exception),
+    }
+}
+
+unsafe extern "C" fn artichoke_matchdata_pre_match(
+    mrb: *mut sys::mrb_state,
+    slf: sys::mrb_value,
+) -> sys::mrb_value {
+    mrb_get_args!(mrb, none);
+    let mut interp = unwrap_interpreter!(mrb);
+    let value = Value::new(&interp, slf);
+    let result = trampoline::pre_match(&mut interp, value);
+    match result {
+        Ok(result) => result.inner(),
+        Err(exception) => exception::raise(interp, exception),
+    }
+}
+
+unsafe extern "C" fn artichoke_matchdata_regexp(
+    mrb: *mut sys::mrb_state,
+    slf: sys::mrb_value,
+) -> sys::mrb_value {
+    mrb_get_args!(mrb, none);
+    let mut interp = unwrap_interpreter!(mrb);
+    let value = Value::new(&interp, slf);
+    let result = trampoline::regexp(&mut interp, value);
+    match result {
+        Ok(result) => result.inner(),
+        Err(exception) => exception::raise(interp, exception),
+    }
+}
+
+unsafe extern "C" fn artichoke_matchdata_string(
+    mrb: *mut sys::mrb_state,
+    slf: sys::mrb_value,
+) -> sys::mrb_value {
+    mrb_get_args!(mrb, none);
+    let mut interp = unwrap_interpreter!(mrb);
+    let value = Value::new(&interp, slf);
+    let result = trampoline::string(&mut interp, value);
+    match result {
+        Ok(result) => result.inner(),
+        Err(exception) => exception::raise(interp, exception),
+    }
+}
+
+unsafe extern "C" fn artichoke_matchdata_to_a(
+    mrb: *mut sys::mrb_state,
+    slf: sys::mrb_value,
+) -> sys::mrb_value {
+    mrb_get_args!(mrb, none);
+    let mut interp = unwrap_interpreter!(mrb);
+    let value = Value::new(&interp, slf);
+    let result = trampoline::to_a(&mut interp, value);
+    match result {
+        Ok(result) => result.inner(),
+        Err(exception) => exception::raise(interp, exception),
+    }
+}
+
+unsafe extern "C" fn artichoke_matchdata_to_s(
+    mrb: *mut sys::mrb_state,
+    slf: sys::mrb_value,
+) -> sys::mrb_value {
+    mrb_get_args!(mrb, none);
+    let mut interp = unwrap_interpreter!(mrb);
+    let value = Value::new(&interp, slf);
+    let result = trampoline::to_s(&mut interp, value);
+    match result {
+        Ok(result) => result.inner(),
+        Err(exception) => exception::raise(interp, exception),
+    }
+}

--- a/artichoke-backend/src/extn/core/matchdata/trampoline.rs
+++ b/artichoke-backend/src/extn/core/matchdata/trampoline.rs
@@ -1,0 +1,184 @@
+use std::convert::TryFrom;
+
+use crate::extn::core::matchdata::{args, CaptureAt, MatchData};
+use crate::extn::prelude::*;
+
+pub fn begin(interp: &mut Artichoke, value: Value, at: Value) -> Result<Value, Exception> {
+    let data = unsafe { MatchData::try_from_ruby(interp, &value) }?;
+    let borrow = data.borrow();
+    let capture = interp.try_convert(&at)?;
+    let begin = borrow.begin(interp, capture)?;
+    match begin.map(Int::try_from) {
+        Some(Ok(begin)) => Ok(interp.convert(begin)),
+        Some(Err(_)) => Err(Exception::from(ArgumentError::new(
+            interp,
+            "input string too long",
+        ))),
+        None => Ok(interp.convert(None::<Value>)),
+    }
+}
+
+pub fn captures(interp: &mut Artichoke, value: Value) -> Result<Value, Exception> {
+    let data = unsafe { MatchData::try_from_ruby(interp, &value) }?;
+    let borrow = data.borrow();
+    if let Some(captures) = borrow.captures(interp)? {
+        Ok(interp.convert_mut(captures))
+    } else {
+        Ok(interp.convert(None::<Value>))
+    }
+}
+
+pub fn element_reference(
+    interp: &mut Artichoke,
+    value: Value,
+    elem: Value,
+    len: Option<Value>,
+) -> Result<Value, Exception> {
+    let data = unsafe { MatchData::try_from_ruby(interp, &value) }?;
+    let borrow = data.borrow();
+    // TODO(GH-308): Once extracting a `Range` is safe, extract this conversion
+    // to a `TryConvert<&'a Value, CaptureAt<'a>>` impl.
+    let at = if let Some(len) = len {
+        let start = elem.implicitly_convert_to_int()?;
+        let len = len.implicitly_convert_to_int()?;
+        CaptureAt::StartLen(start, len)
+    } else if let Ok(index) = elem.implicitly_convert_to_int() {
+        CaptureAt::GroupIndex(index)
+    } else if let Ok(name) = elem.implicitly_convert_to_string() {
+        CaptureAt::GroupName(name)
+    } else {
+        // NOTE(lopopolo): Encapsulation is broken here by reaching into the
+        // inner regexp.
+        let captures_len = borrow.regexp.inner().captures_len(interp, None)?;
+        let rangelen = Int::try_from(captures_len)
+            .map_err(|_| ArgumentError::new(interp, "input string too long"))?;
+        match unsafe { args::is_range(interp, &elem, rangelen) } {
+            Ok(Some((start, len))) => CaptureAt::StartLen(start, len),
+            Ok(None) => return Ok(interp.convert(None::<Value>)),
+            Err(_) => {
+                let mut message = String::from("no implicit conversion of ");
+                message.push_str(elem.pretty_name());
+                message.push_str(" into Integer");
+                return Err(Exception::from(TypeError::new(interp, message)));
+            }
+        }
+    };
+    let matched = borrow.capture_at(interp, at)?;
+    Ok(interp.convert_mut(matched))
+}
+
+pub fn end(interp: &mut Artichoke, value: Value, at: Value) -> Result<Value, Exception> {
+    let data = unsafe { MatchData::try_from_ruby(interp, &value) }?;
+    let borrow = data.borrow();
+    let capture = interp.try_convert(&at)?;
+    let end = borrow.end(interp, capture)?;
+    match end.map(Int::try_from) {
+        Some(Ok(end)) => Ok(interp.convert(end)),
+        Some(Err(_)) => Err(Exception::from(ArgumentError::new(
+            interp,
+            "input string too long",
+        ))),
+        None => Ok(interp.convert(None::<Value>)),
+    }
+}
+
+pub fn length(interp: &mut Artichoke, value: Value) -> Result<Value, Exception> {
+    let data = unsafe { MatchData::try_from_ruby(interp, &value) }?;
+    let borrow = data.borrow();
+    let len = borrow.len(interp)?;
+    if let Ok(len) = Int::try_from(len) {
+        Ok(interp.convert(len))
+    } else {
+        Err(Exception::from(ArgumentError::new(
+            interp,
+            "input string too long",
+        )))
+    }
+}
+
+pub fn named_captures(interp: &mut Artichoke, value: Value) -> Result<Value, Exception> {
+    let data = unsafe { MatchData::try_from_ruby(interp, &value) }?;
+    let borrow = data.borrow();
+    let named_captures = borrow.named_captures(interp)?;
+    Ok(interp.convert_mut(named_captures))
+}
+
+pub fn names(interp: &mut Artichoke, value: Value) -> Result<Value, Exception> {
+    let data = unsafe { MatchData::try_from_ruby(interp, &value) }?;
+    let borrow = data.borrow();
+    let names = borrow.names(interp);
+    Ok(interp.convert_mut(names))
+}
+
+pub fn offset(interp: &mut Artichoke, value: Value, at: Value) -> Result<Value, Exception> {
+    let data = unsafe { MatchData::try_from_ruby(interp, &value) }?;
+    let borrow = data.borrow();
+    let capture = interp.try_convert(&at)?;
+    if let Some([begin, end]) = borrow.offset(interp, capture)? {
+        if let (Ok(begin), Ok(end)) = (Int::try_from(begin), Int::try_from(end)) {
+            // TODO: use a proper assoc 2-tuple
+            Ok(interp.convert_mut(&[begin, end][..]))
+        } else {
+            Err(Exception::from(ArgumentError::new(
+                interp,
+                "input string too long",
+            )))
+        }
+    } else {
+        // TODO: use a proper assoc 2-tuple
+        Ok(interp.convert_mut(&[None::<Value>, None::<Value>][..]))
+    }
+}
+
+pub fn post_match(interp: &mut Artichoke, value: Value) -> Result<Value, Exception> {
+    let data = unsafe { MatchData::try_from_ruby(interp, &value) }?;
+    let borrow = data.borrow();
+    let post = borrow.post();
+    Ok(interp.convert_mut(post))
+}
+
+pub fn pre_match(interp: &mut Artichoke, value: Value) -> Result<Value, Exception> {
+    let data = unsafe { MatchData::try_from_ruby(interp, &value) }?;
+    let borrow = data.borrow();
+    let pre = borrow.pre();
+    Ok(interp.convert_mut(pre))
+}
+
+pub fn regexp(interp: &mut Artichoke, value: Value) -> Result<Value, Exception> {
+    let data = unsafe { MatchData::try_from_ruby(interp, &value) }?;
+    let borrow = data.borrow();
+    let regexp = borrow.regexp();
+    // TODO(GH-614): MatchData#regexp needs to return an identical Regexp to the
+    // one used to create the match (same object ID).
+    //
+    // The `None` here should be replaced with the original `RBasic`.
+    //
+    // See: https://github.com/ruby/spec/pull/727
+    let regexp = regexp.clone().try_into_ruby(interp, None)?;
+    Ok(regexp)
+}
+
+pub fn string(interp: &mut Artichoke, value: Value) -> Result<Value, Exception> {
+    let data = unsafe { MatchData::try_from_ruby(interp, &value) }?;
+    let borrow = data.borrow();
+    let mut string = interp.convert_mut(borrow.string());
+    string.freeze()?;
+    Ok(string)
+}
+
+pub fn to_a(interp: &mut Artichoke, value: Value) -> Result<Value, Exception> {
+    let data = unsafe { MatchData::try_from_ruby(interp, &value) }?;
+    let borrow = data.borrow();
+    if let Some(ary) = borrow.to_a(interp)? {
+        Ok(interp.convert_mut(ary))
+    } else {
+        Ok(interp.convert(None::<Value>))
+    }
+}
+
+pub fn to_s(interp: &mut Artichoke, value: Value) -> Result<Value, Exception> {
+    let data = unsafe { MatchData::try_from_ruby(interp, &value) }?;
+    let borrow = data.borrow();
+    let display = borrow.to_s(interp)?;
+    Ok(interp.convert_mut(display))
+}

--- a/artichoke-backend/src/extn/core/mod.rs
+++ b/artichoke-backend/src/extn/core/mod.rs
@@ -49,7 +49,7 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     integer::mruby::init(interp)?;
     float::init(interp)?;
     kernel::init(interp)?;
-    matchdata::init(interp)?;
+    matchdata::mruby::init(interp)?;
     math::mruby::init(interp)?;
     method::init(interp)?;
     module::init(interp)?;

--- a/artichoke-backend/src/extn/core/regexp/backend/onig.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/onig.rs
@@ -241,12 +241,7 @@ impl RegexpType for Onig {
                 interp.set_global_variable(regexp::STRING_LEFT_OF_MATCH, &pre_match)?;
                 interp.set_global_variable(regexp::STRING_RIGHT_OF_MATCH, &post_match)?;
             }
-            let matchdata = MatchData::new(
-                haystack.into(),
-                Regexp::from(self.box_clone()),
-                0,
-                haystack.len(),
-            );
+            let matchdata = MatchData::new(haystack.into(), Regexp::from(self.box_clone()), ..);
             let matchdata = matchdata.try_into_ruby(&interp, None)?;
             interp.set_global_variable(regexp::LAST_MATCH, &matchdata)?;
             Ok(true)
@@ -342,18 +337,13 @@ impl RegexpType for Onig {
                 interp.set_global_variable(regexp::nth_match_group(group), &value)?;
             }
 
-            let mut matchdata = MatchData::new(
-                haystack.into(),
-                Regexp::from(self.box_clone()),
-                0,
-                haystack.len(),
-            );
+            let mut matchdata = MatchData::new(haystack.into(), Regexp::from(self.box_clone()), ..);
             if let Some(match_pos) = captures.pos(0) {
                 let pre_match = interp.convert_mut(&target[..match_pos.0]);
                 let post_match = interp.convert_mut(&target[match_pos.1..]);
                 interp.set_global_variable(regexp::STRING_LEFT_OF_MATCH, &pre_match)?;
                 interp.set_global_variable(regexp::STRING_RIGHT_OF_MATCH, &post_match)?;
-                matchdata.set_region(offset + match_pos.0, offset + match_pos.1);
+                matchdata.set_region(offset + match_pos.0..offset + match_pos.1);
             }
             let data = matchdata.try_into_ruby(interp, None)?;
             interp.set_global_variable(regexp::LAST_MATCH, &data)?;
@@ -394,12 +384,7 @@ impl RegexpType for Onig {
                 interp.set_global_variable(regexp::nth_match_group(group), &value)?;
             }
 
-            let matchdata = MatchData::new(
-                haystack.into(),
-                Regexp::from(self.box_clone()),
-                0,
-                haystack.len(),
-            );
+            let matchdata = MatchData::new(haystack.into(), Regexp::from(self.box_clone()), ..);
             let data = matchdata.try_into_ruby(interp, None)?;
             interp.set_global_variable(regexp::LAST_MATCH, &data)?;
             if let Some(match_pos) = captures.pos(0) {
@@ -525,12 +510,7 @@ impl RegexpType for Onig {
             )
         })?;
         regexp::clear_capture_globals(interp)?;
-        let mut matchdata = MatchData::new(
-            haystack.into(),
-            Regexp::from(self.box_clone()),
-            0,
-            haystack.len(),
-        );
+        let mut matchdata = MatchData::new(haystack.into(), Regexp::from(self.box_clone()), ..);
 
         let len = NonZeroUsize::new(self.regex.captures_len());
         if let Some(block) = block {
@@ -557,7 +537,7 @@ impl RegexpType for Onig {
 
                     let matched = interp.convert_mut(groups);
                     if let Some(pos) = captures.pos(0) {
-                        matchdata.set_region(pos.0, pos.1);
+                        matchdata.set_region(pos.0..pos.1);
                     }
                     let data = matchdata.clone().try_into_ruby(interp, None)?;
                     interp.set_global_variable(regexp::LAST_MATCH, &data)?;
@@ -573,7 +553,7 @@ impl RegexpType for Onig {
                 for pos in iter {
                     let scanned = &haystack[pos.0..pos.1];
                     let matched = interp.convert_mut(scanned);
-                    matchdata.set_region(pos.0, pos.1);
+                    matchdata.set_region(pos.0..pos.1);
                     let data = matchdata.clone().try_into_ruby(interp, None)?;
                     interp.set_global_variable(regexp::LAST_MATCH, &data)?;
                     let _ = block.yield_arg::<Value>(interp, &matched)?;
@@ -603,7 +583,7 @@ impl RegexpType for Onig {
                     }
                     collected.push(groups);
                 }
-                matchdata.set_region(last_pos.0, last_pos.1);
+                matchdata.set_region(last_pos.0..last_pos.1);
                 let data = matchdata.try_into_ruby(interp, None)?;
                 interp.set_global_variable(regexp::LAST_MATCH, &data)?;
 
@@ -630,7 +610,7 @@ impl RegexpType for Onig {
                     last_pos = pos;
                     collected.push(Vec::from(scanned.as_bytes()));
                 }
-                matchdata.set_region(last_pos.0, last_pos.1);
+                matchdata.set_region(last_pos.0..last_pos.1);
                 let data = matchdata.try_into_ruby(interp, None)?;
                 interp.set_global_variable(regexp::LAST_MATCH, &data)?;
 

--- a/artichoke-backend/src/extn/core/regexp/backend/regex/utf8.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/regex/utf8.rs
@@ -246,12 +246,7 @@ impl RegexpType for Utf8 {
                 interp.set_global_variable(regexp::STRING_LEFT_OF_MATCH, &pre_match)?;
                 interp.set_global_variable(regexp::STRING_RIGHT_OF_MATCH, &post_match)?;
             }
-            let matchdata = MatchData::new(
-                haystack.into(),
-                Regexp::from(self.box_clone()),
-                0,
-                haystack.len(),
-            );
+            let matchdata = MatchData::new(haystack.into(), Regexp::from(self.box_clone()), ..);
             let matchdata = matchdata.try_into_ruby(&interp, None)?;
             interp.set_global_variable(regexp::LAST_MATCH, &matchdata)?;
             Ok(true)
@@ -363,18 +358,13 @@ impl RegexpType for Utf8 {
                 interp.set_global_variable(regexp::nth_match_group(group), &value)?;
             }
 
-            let mut matchdata = MatchData::new(
-                haystack.into(),
-                Regexp::from(self.box_clone()),
-                0,
-                haystack.len(),
-            );
+            let mut matchdata = MatchData::new(haystack.into(), Regexp::from(self.box_clone()), ..);
             if let Some(match_pos) = captures.get(0) {
                 let pre_match = interp.convert_mut(&target[..match_pos.start()]);
                 let post_match = interp.convert_mut(&target[match_pos.end()..]);
                 interp.set_global_variable(regexp::STRING_LEFT_OF_MATCH, &pre_match)?;
                 interp.set_global_variable(regexp::STRING_RIGHT_OF_MATCH, &post_match)?;
-                matchdata.set_region(offset + match_pos.start(), offset + match_pos.end());
+                matchdata.set_region(offset + match_pos.start()..offset + match_pos.end());
             }
             let data = matchdata.try_into_ruby(interp, None)?;
             interp.set_global_variable(regexp::LAST_MATCH, &data)?;
@@ -432,12 +422,7 @@ impl RegexpType for Utf8 {
                 interp.set_global_variable(regexp::nth_match_group(group), &value)?;
             }
 
-            let matchdata = MatchData::new(
-                haystack.into(),
-                Regexp::from(self.box_clone()),
-                0,
-                haystack.len(),
-            );
+            let matchdata = MatchData::new(haystack.into(), Regexp::from(self.box_clone()), ..);
             let matchdata = matchdata.try_into_ruby(interp, None)?;
             interp.set_global_variable(regexp::LAST_MATCH, &matchdata)?;
             if let Some(match_pos) = captures.get(0) {
@@ -550,12 +535,7 @@ impl RegexpType for Utf8 {
             )
         })?;
         regexp::clear_capture_globals(interp)?;
-        let mut matchdata = MatchData::new(
-            haystack.into(),
-            Regexp::from(self.box_clone()),
-            0,
-            haystack.len(),
-        );
+        let mut matchdata = MatchData::new(haystack.into(), Regexp::from(self.box_clone()), ..);
 
         // regex crate always includes the zero group in the captures len.
         let len = self
@@ -595,7 +575,7 @@ impl RegexpType for Utf8 {
 
                     let matched = interp.convert_mut(groups);
                     if let Some(pos) = captures.get(0) {
-                        matchdata.set_region(pos.start(), pos.end());
+                        matchdata.set_region(pos.start()..pos.end());
                     }
                     let data = matchdata.clone().try_into_ruby(interp, None)?;
                     interp.set_global_variable(regexp::LAST_MATCH, &data)?;
@@ -611,7 +591,7 @@ impl RegexpType for Utf8 {
                 for pos in iter {
                     let scanned = &haystack[pos.start()..pos.end()];
                     let matched = interp.convert_mut(scanned);
-                    matchdata.set_region(pos.start(), pos.end());
+                    matchdata.set_region(pos.start()..pos.end());
                     let data = matchdata.clone().try_into_ruby(interp, None)?;
                     interp.set_global_variable(regexp::LAST_MATCH, &data)?;
                     let _ = block.yield_arg::<Value>(interp, &matched)?;
@@ -645,7 +625,7 @@ impl RegexpType for Utf8 {
                     }
                     collected.push(groups);
                 }
-                matchdata.set_region(last_pos.0, last_pos.1);
+                matchdata.set_region(last_pos.0..last_pos.1);
                 let data = matchdata.try_into_ruby(interp, None)?;
                 interp.set_global_variable(regexp::LAST_MATCH, &data)?;
                 let mut iter = collected.iter().enumerate();
@@ -671,7 +651,7 @@ impl RegexpType for Utf8 {
                     last_pos = (pos.start(), pos.end());
                     collected.push(Vec::from(scanned.as_bytes()));
                 }
-                matchdata.set_region(last_pos.0, last_pos.1);
+                matchdata.set_region(last_pos.0..last_pos.1);
                 let data = matchdata.try_into_ruby(interp, None)?;
                 interp.set_global_variable(regexp::LAST_MATCH, &data)?;
                 let last_matched = collected.last().map(Vec::as_slice);

--- a/artichoke-backend/src/extn/core/string/trampoline.rs
+++ b/artichoke-backend/src/extn/core/string/trampoline.rs
@@ -56,11 +56,11 @@ pub fn scan(
         let string = value.clone().try_into::<&[u8]>()?;
         if let Some(ref block) = block {
             let regex = Regexp::lazy(pattern_bytes.to_vec());
-            let matchdata = MatchData::new(string.to_vec(), regex, 0, string.len());
+            let matchdata = MatchData::new(string.to_vec(), regex, ..);
             let patlen = pattern_bytes.len();
             if let Some(pos) = string.find(pattern_bytes) {
                 let mut data = matchdata.clone();
-                data.set_region(pos, pos + patlen);
+                data.set_region(pos..pos + patlen);
                 let data = data.try_into_ruby(interp, None)?;
                 interp.set_global_variable(regexp::LAST_MATCH, &data)?;
 
@@ -73,7 +73,7 @@ pub fn scan(
                 let string = string.get(offset..).unwrap_or_default();
                 for pos in string.find_iter(pattern_bytes) {
                     let mut data = matchdata.clone();
-                    data.set_region(offset + pos, offset + pos + patlen);
+                    data.set_region(offset + pos..offset + pos + patlen);
                     let data = data.try_into_ruby(interp, None)?;
                     interp.set_global_variable(regexp::LAST_MATCH, &data)?;
 
@@ -99,8 +99,11 @@ pub fn scan(
             }
             if matches > 0 {
                 let regex = Regexp::lazy(pattern_bytes.to_vec());
-                let mut matchdata = MatchData::new(string.to_vec(), regex, 0, string.len());
-                matchdata.set_region(last_pos, last_pos + pattern_bytes.len());
+                let matchdata = MatchData::new(
+                    string.to_vec(),
+                    regex,
+                    last_pos..last_pos + pattern_bytes.len(),
+                );
                 let data = matchdata.try_into_ruby(interp, None)?;
                 interp.set_global_variable(regexp::LAST_MATCH, &data)?;
             } else {


### PR DESCRIPTION
`Regexp` and `MatchData` were the first two `extn` modules. `MatchData`
had mruby C trampolines as associated functions on the main type and one
module per trampoline. While `Regexp` was rewritten and updated to
support multiple backends, `MatchData` has aged.

This PR rewrites `MatchData` from scratch, incorporating the patterns
from GH-605 and GH-610 as well as the updates to `Regexp` in GH-607 and
GH-617.

Significant changes below (unordered):

- Unsafe `is_range` helper moved to private `matchdata::args` module.
- `Region` stores `start` and `end` as `Bound<usize>`.
- `Region` derives `Debug`, `Clone`, `Copy`, `Hash`, `PartialEq`, `Eq`.
- `Region::from_range(range: R)` where `R: RangeBounds<usize>`.
- `Region::offset` to compute offset into the haystack.
- `impl RangeBounds<usize> for Region`.
- Use new `Region` impl accepting a `RangeBounds<usize>` in `onig` and
  `utf8` `Regexp` backends.
- Fix bug in `String::scan` where a `MatchData` is instantiated with a
  full range and immediately calles `MatchData::set_region`.
- Add custom type `Capture` for parsing capture group index for
  `MatchData::begin`, `MatchData::end`, and `MatchData::offset`.
- Add `TryConvert<&'a Value, Capture<'a>>` for extracting capture index
  in trampoline.
- Add custom type `CaptureAt` for parsing capture group index for
  `MatchData::capture_at`.
- Add `TryConvert<&'a Value, CaptureAt<'a>>` for extracting capture index
  in trampoline.
- Improved index handling, see GH-600.
- `MatchData::offset` returns `Option<[usize; 2]>` in the success case.
- `MatchData::begin` and `MatchData::end` implemented with
  `MatchData::offset`.
- All `MatchData` Rust implementations are methods on `MatchData`.
- Added `#[inline]` annotations to `MatchData` methods where
  appropriate.
- Fix bug in `MatchData#offset`, `MatchData#begin`, and `MatchData#end`
  where negative indexes were wrapped with captures length instead of
  raising `IndexError`.
- Panic-free access to haystack in `MatchData::pre` and
  `MatchData::post`.
- Move mruby C trampolines to `matchdata::mruby` module.
- Fix long-standing TODOs about unwinding past `Value`s in `MatchData` C
  entrypoints due to passing references.
- Introduce `matchdata::trampoline` Rust trampolines for argument
  conversion and result boxing. See GH-605.
- Pass through a `&mut Artichoke` everywhere.