### PR TITLE
Add interpreter parameter to implicit conversions on Value

### DIFF
--- a/artichoke-backend/src/extn/core/array/mod.rs
+++ b/artichoke-backend/src/extn/core/array/mod.rs
@@ -62,7 +62,7 @@ impl Array {
                     return Err(Exception::from(TypeError::new(interp, message)));
                 }
             } else {
-                let len = first.implicitly_convert_to_int()?;
+                let len = first.implicitly_convert_to_int(interp)?;
                 let len = usize::try_from(len)
                     .map_err(|_| ArgumentError::new(interp, "negative array size"))?;
                 if let Some(block) = block {
@@ -103,7 +103,7 @@ impl Array {
 
     fn element_reference(
         &self,
-        interp: &Artichoke,
+        interp: &mut Artichoke,
         index: Value,
         len: Option<Value>,
     ) -> Result<Value, Exception> {
@@ -141,7 +141,7 @@ impl Array {
 
     fn element_assignment(
         &mut self,
-        interp: &Artichoke,
+        interp: &mut Artichoke,
         first: Value,
         second: Value,
         third: Option<Value>,

--- a/artichoke-backend/src/extn/core/array/mruby.rs
+++ b/artichoke-backend/src/extn/core/array/mruby.rs
@@ -144,11 +144,11 @@ unsafe extern "C" fn ary_element_reference(
     ary: sys::mrb_value,
 ) -> sys::mrb_value {
     let (elem, len) = mrb_get_args!(mrb, required = 1, optional = 1);
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let elem = Value::new(&interp, elem);
     let len = len.map(|len| Value::new(&interp, len));
     let array = Value::new(&interp, ary);
-    let result = array::trampoline::element_reference(&interp, array, elem, len);
+    let result = array::trampoline::element_reference(&mut interp, array, elem, len);
     match result {
         Ok(value) => value.inner(),
         Err(exception) => exception::raise(interp, exception),
@@ -160,12 +160,12 @@ unsafe extern "C" fn ary_element_assignment(
     ary: sys::mrb_value,
 ) -> sys::mrb_value {
     let (first, second, third) = mrb_get_args!(mrb, required = 2, optional = 1);
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let first = Value::new(&interp, first);
     let second = Value::new(&interp, second);
     let third = third.map(|third| Value::new(&interp, third));
     let array = Value::new(&interp, ary);
-    let result = array::trampoline::element_assignment(&interp, array, first, second, third);
+    let result = array::trampoline::element_assignment(&mut interp, array, first, second, third);
     match result {
         Ok(value) => {
             let basic = sys::mrb_sys_basic_ptr(ary);

--- a/artichoke-backend/src/extn/core/array/trampoline.rs
+++ b/artichoke-backend/src/extn/core/array/trampoline.rs
@@ -16,7 +16,7 @@ pub fn clear(interp: &Artichoke, ary: Value) -> Result<Value, Exception> {
 }
 
 pub fn element_reference(
-    interp: &Artichoke,
+    interp: &mut Artichoke,
     ary: Value,
     first: Value,
     second: Option<Value>,
@@ -27,7 +27,7 @@ pub fn element_reference(
 }
 
 pub fn element_assignment(
-    interp: &Artichoke,
+    interp: &mut Artichoke,
     ary: Value,
     first: Value,
     second: Value,

--- a/artichoke-backend/src/extn/core/env/mod.rs
+++ b/artichoke-backend/src/extn/core/env/mod.rs
@@ -48,7 +48,7 @@ pub fn element_reference(
     name: &Value,
 ) -> Result<Value, Exception> {
     let obj = unsafe { Environ::try_from_ruby(interp, &obj) }?;
-    let name = name.implicitly_convert_to_string()?;
+    let name = name.implicitly_convert_to_string(interp)?;
     let env = obj.borrow();
     let result = env.0.get(interp, name)?;
     let mut result = interp.convert_mut(result.as_ref().map(Cow::as_ref));
@@ -63,8 +63,8 @@ pub fn element_assignment(
     value: Value,
 ) -> Result<Value, Exception> {
     let obj = unsafe { Environ::try_from_ruby(interp, &obj) }?;
-    let name = name.implicitly_convert_to_string()?;
-    let env_value = value.implicitly_convert_to_nilable_string()?;
+    let name = name.implicitly_convert_to_string(interp)?;
+    let env_value = value.implicitly_convert_to_nilable_string(interp)?;
     obj.borrow_mut().0.put(interp, name, env_value)?;
     // Return original object, even if we converted it to a `String`.
     Ok(value)

--- a/artichoke-backend/src/extn/core/integer/mod.rs
+++ b/artichoke-backend/src/extn/core/integer/mod.rs
@@ -133,9 +133,8 @@ impl Integer {
         }
     }
 
-    pub fn bit(self, interp: &Artichoke, bit: Value) -> Result<Self, Exception> {
-        let _ = interp;
-        let bit = bit.implicitly_convert_to_int()?;
+    #[inline]
+    pub fn bit(self, bit: Int) -> Result<Self, Exception> {
         if let Ok(bit) = u32::try_from(bit) {
             Ok(self.as_i64().checked_shr(bit).map_or(0, |v| v & 1).into())
         } else {

--- a/artichoke-backend/src/extn/core/integer/trampoline.rs
+++ b/artichoke-backend/src/extn/core/integer/trampoline.rs
@@ -17,7 +17,8 @@ pub fn element_reference(
     bit: Value,
 ) -> Result<Value, Exception> {
     let value = value.try_into::<Integer>()?;
-    let bit = value.bit(interp, bit)?;
+    let bit = bit.implicitly_convert_to_int(interp)?;
+    let bit = value.bit(bit)?;
     Ok(interp.convert(bit))
 }
 

--- a/artichoke-backend/src/extn/core/kernel/integer.rs
+++ b/artichoke-backend/src/extn/core/kernel/integer.rs
@@ -5,7 +5,11 @@ use std::str::{self, FromStr};
 
 use crate::extn::prelude::*;
 
-pub fn method(interp: &Artichoke, arg: Value, radix: Option<Value>) -> Result<Value, Exception> {
+pub fn method(
+    interp: &mut Artichoke,
+    arg: Value,
+    radix: Option<Value>,
+) -> Result<Value, Exception> {
     #[derive(Debug, Clone, Copy)]
     enum Sign {
         Pos,
@@ -18,7 +22,7 @@ pub fn method(interp: &Artichoke, arg: Value, radix: Option<Value>) -> Result<Va
         Accumulate(Sign, String),
     }
     let radix = if let Some(radix) = radix {
-        radix.implicitly_convert_to_int().ok()
+        radix.implicitly_convert_to_int(interp).ok()
     } else {
         None
     };

--- a/artichoke-backend/src/extn/core/kernel/integer.rs
+++ b/artichoke-backend/src/extn/core/kernel/integer.rs
@@ -32,7 +32,7 @@ pub fn method(
         Some(Err(_)) => return Err(Exception::from(ArgumentError::new(interp, "invalid radix"))),
         None => None,
     };
-    let arg = arg.implicitly_convert_to_string().map_err(|_| {
+    let arg = arg.implicitly_convert_to_string(interp).map_err(|_| {
         let mut message = String::from("can't convert ");
         message.push_str(arg.pretty_name());
         message.push_str(" into Integer");

--- a/artichoke-backend/src/extn/core/kernel/mod.rs
+++ b/artichoke-backend/src/extn/core/kernel/mod.rs
@@ -46,12 +46,10 @@ pub struct Kernel;
 impl Kernel {
     unsafe extern "C" fn integer(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {
         let (arg, base) = mrb_get_args!(mrb, required = 1, optional = 1);
-        let interp = unwrap_interpreter!(mrb);
-        let result = integer::method(
-            &interp,
-            Value::new(&interp, arg),
-            base.map(|base| Value::new(&interp, base)),
-        );
+        let mut interp = unwrap_interpreter!(mrb);
+        let arg = Value::new(&interp, arg);
+        let base = base.map(|base| Value::new(&interp, base));
+        let result = integer::method(&mut interp, arg, base);
         match result {
             Ok(value) => value.inner(),
             Err(exception) => exception::raise(interp, exception),

--- a/artichoke-backend/src/extn/core/kernel/require.rs
+++ b/artichoke-backend/src/extn/core/kernel/require.rs
@@ -13,7 +13,7 @@ use crate::Parser;
 const RUBY_EXTENSION: &str = "rb";
 
 pub fn load(interp: &mut Artichoke, filename: Value) -> Result<Value, Exception> {
-    let filename = filename.implicitly_convert_to_string()?;
+    let filename = filename.implicitly_convert_to_string(interp)?;
     if filename.find_byte(b'\0').is_some() {
         return Err(Exception::from(ArgumentError::new(
             interp,
@@ -68,7 +68,7 @@ pub fn require(
     filename: Value,
     base: Option<&Path>,
 ) -> Result<Value, Exception> {
-    let filename = filename.implicitly_convert_to_string()?;
+    let filename = filename.implicitly_convert_to_string(interp)?;
     if filename.find_byte(b'\0').is_some() {
         return Err(Exception::from(ArgumentError::new(
             interp,

--- a/artichoke-backend/src/extn/core/matchdata/mod.rs
+++ b/artichoke-backend/src/extn/core/matchdata/mod.rs
@@ -83,7 +83,7 @@ impl<'a> TryConvertMut<&'a Value, Capture<'a>> for Artichoke {
     type Error = TypeError;
 
     fn try_convert_mut(&mut self, value: &'a Value) -> Result<Capture<'a>, Self::Error> {
-        if let Ok(name) = value.implicitly_convert_to_string() {
+        if let Ok(name) = value.implicitly_convert_to_string(self) {
             Ok(Capture::GroupName(name))
         } else {
             let idx = value.implicitly_convert_to_int(self)?;

--- a/artichoke-backend/src/extn/core/matchdata/mod.rs
+++ b/artichoke-backend/src/extn/core/matchdata/mod.rs
@@ -79,14 +79,14 @@ pub enum Capture<'a> {
     GroupName(&'a [u8]),
 }
 
-impl<'a> TryConvert<&'a Value, Capture<'a>> for Artichoke {
+impl<'a> TryConvertMut<&'a Value, Capture<'a>> for Artichoke {
     type Error = TypeError;
 
-    fn try_convert(&self, value: &'a Value) -> Result<Capture<'a>, Self::Error> {
+    fn try_convert_mut(&mut self, value: &'a Value) -> Result<Capture<'a>, Self::Error> {
         if let Ok(name) = value.implicitly_convert_to_string() {
             Ok(Capture::GroupName(name))
         } else {
-            let idx = value.implicitly_convert_to_int()?;
+            let idx = value.implicitly_convert_to_int(self)?;
             Ok(Capture::GroupIndex(idx))
         }
     }

--- a/artichoke-backend/src/extn/core/matchdata/trampoline.rs
+++ b/artichoke-backend/src/extn/core/matchdata/trampoline.rs
@@ -6,7 +6,7 @@ use crate::extn::prelude::*;
 pub fn begin(interp: &mut Artichoke, value: Value, at: Value) -> Result<Value, Exception> {
     let data = unsafe { MatchData::try_from_ruby(interp, &value) }?;
     let borrow = data.borrow();
-    let capture = interp.try_convert(&at)?;
+    let capture = interp.try_convert_mut(&at)?;
     let begin = borrow.begin(interp, capture)?;
     match begin.map(Int::try_from) {
         Some(Ok(begin)) => Ok(interp.convert(begin)),
@@ -39,10 +39,10 @@ pub fn element_reference(
     // TODO(GH-308): Once extracting a `Range` is safe, extract this conversion
     // to a `TryConvert<&'a Value, CaptureAt<'a>>` impl.
     let at = if let Some(len) = len {
-        let start = elem.implicitly_convert_to_int()?;
-        let len = len.implicitly_convert_to_int()?;
+        let start = elem.implicitly_convert_to_int(interp)?;
+        let len = len.implicitly_convert_to_int(interp)?;
         CaptureAt::StartLen(start, len)
-    } else if let Ok(index) = elem.implicitly_convert_to_int() {
+    } else if let Ok(index) = elem.implicitly_convert_to_int(interp) {
         CaptureAt::GroupIndex(index)
     } else if let Ok(name) = elem.implicitly_convert_to_string() {
         CaptureAt::GroupName(name)
@@ -70,7 +70,7 @@ pub fn element_reference(
 pub fn end(interp: &mut Artichoke, value: Value, at: Value) -> Result<Value, Exception> {
     let data = unsafe { MatchData::try_from_ruby(interp, &value) }?;
     let borrow = data.borrow();
-    let capture = interp.try_convert(&at)?;
+    let capture = interp.try_convert_mut(&at)?;
     let end = borrow.end(interp, capture)?;
     match end.map(Int::try_from) {
         Some(Ok(end)) => Ok(interp.convert(end)),
@@ -113,7 +113,7 @@ pub fn names(interp: &mut Artichoke, value: Value) -> Result<Value, Exception> {
 pub fn offset(interp: &mut Artichoke, value: Value, at: Value) -> Result<Value, Exception> {
     let data = unsafe { MatchData::try_from_ruby(interp, &value) }?;
     let borrow = data.borrow();
-    let capture = interp.try_convert(&at)?;
+    let capture = interp.try_convert_mut(&at)?;
     if let Some([begin, end]) = borrow.offset(interp, capture)? {
         if let (Ok(begin), Ok(end)) = (Int::try_from(begin), Int::try_from(end)) {
             // TODO: use a proper assoc 2-tuple

--- a/artichoke-backend/src/extn/core/matchdata/trampoline.rs
+++ b/artichoke-backend/src/extn/core/matchdata/trampoline.rs
@@ -44,7 +44,7 @@ pub fn element_reference(
         CaptureAt::StartLen(start, len)
     } else if let Ok(index) = elem.implicitly_convert_to_int(interp) {
         CaptureAt::GroupIndex(index)
-    } else if let Ok(name) = elem.implicitly_convert_to_string() {
+    } else if let Ok(name) = elem.implicitly_convert_to_string(interp) {
         CaptureAt::GroupName(name)
     } else {
         // NOTE(lopopolo): Encapsulation is broken here by reaching into the

--- a/artichoke-backend/src/extn/core/random/mod.rs
+++ b/artichoke-backend/src/extn/core/random/mod.rs
@@ -25,21 +25,21 @@ impl Seed {
     }
 }
 
-impl TryConvert<Value, Seed> for Artichoke {
+impl TryConvertMut<Value, Seed> for Artichoke {
     type Error = TypeError;
 
-    fn try_convert(&self, value: Value) -> Result<Seed, Self::Error> {
+    fn try_convert_mut(&mut self, value: Value) -> Result<Seed, Self::Error> {
         let optional: Option<Value> = self.convert(value);
-        self.try_convert(optional)
+        self.try_convert_mut(optional)
     }
 }
 
-impl TryConvert<Option<Value>, Seed> for Artichoke {
+impl TryConvertMut<Option<Value>, Seed> for Artichoke {
     type Error = TypeError;
 
-    fn try_convert(&self, value: Option<Value>) -> Result<Seed, Self::Error> {
+    fn try_convert_mut(&mut self, value: Option<Value>) -> Result<Seed, Self::Error> {
         if let Some(value) = value {
-            let seed = value.implicitly_convert_to_int()?;
+            let seed = value.implicitly_convert_to_int(self)?;
             Ok(Seed::New(seed))
         } else {
             Ok(Seed::None)
@@ -205,19 +205,19 @@ pub enum RandomNumberMax {
     None,
 }
 
-impl TryConvert<Value, RandomNumberMax> for Artichoke {
+impl TryConvertMut<Value, RandomNumberMax> for Artichoke {
     type Error = Exception;
 
-    fn try_convert(&self, max: Value) -> Result<RandomNumberMax, Self::Error> {
+    fn try_convert_mut(&mut self, max: Value) -> Result<RandomNumberMax, Self::Error> {
         let optional: Option<Value> = self.try_convert(max)?;
-        self.try_convert(optional)
+        self.try_convert_mut(optional)
     }
 }
 
-impl TryConvert<Option<Value>, RandomNumberMax> for Artichoke {
+impl TryConvertMut<Option<Value>, RandomNumberMax> for Artichoke {
     type Error = Exception;
 
-    fn try_convert(&self, max: Option<Value>) -> Result<RandomNumberMax, Self::Error> {
+    fn try_convert_mut(&mut self, max: Option<Value>) -> Result<RandomNumberMax, Self::Error> {
         if let Some(max) = max {
             match max.ruby_type() {
                 Ruby::Fixnum => {
@@ -229,7 +229,7 @@ impl TryConvert<Option<Value>, RandomNumberMax> for Artichoke {
                     Ok(RandomNumberMax::Float(max))
                 }
                 _ => {
-                    let max = max.implicitly_convert_to_int().map_err(|_| {
+                    let max = max.implicitly_convert_to_int(self).map_err(|_| {
                         let mut message = b"invalid argument - ".to_vec();
                         message.extend(max.inspect().as_slice());
                         ArgumentError::new_raw(self, message)

--- a/artichoke-backend/src/extn/core/random/trampoline.rs
+++ b/artichoke-backend/src/extn/core/random/trampoline.rs
@@ -6,7 +6,7 @@ pub fn initialize(
     seed: Option<Value>,
     into: Value,
 ) -> Result<Value, Exception> {
-    let seed = interp.try_convert(seed)?;
+    let seed = interp.try_convert_mut(seed)?;
     let rand = Random::initialize(interp, seed)?;
     let rand = rand.try_into_ruby(interp, Some(into.inner()))?;
     Ok(rand)
@@ -22,7 +22,7 @@ pub fn equal(interp: &mut Artichoke, rand: Value, other: Value) -> Result<Value,
 pub fn bytes(interp: &mut Artichoke, rand: Value, size: Value) -> Result<Value, Exception> {
     let rand = unsafe { Random::try_from_ruby(interp, &rand)? };
     let mut borrow = rand.borrow_mut();
-    let size = size.implicitly_convert_to_int()?;
+    let size = size.implicitly_convert_to_int(interp)?;
     let buf = borrow.bytes(interp, size)?;
     Ok(interp.convert_mut(buf))
 }
@@ -30,7 +30,7 @@ pub fn bytes(interp: &mut Artichoke, rand: Value, size: Value) -> Result<Value, 
 pub fn rand(interp: &mut Artichoke, rand: Value, max: Option<Value>) -> Result<Value, Exception> {
     let rand = unsafe { Random::try_from_ruby(interp, &rand)? };
     let mut borrow = rand.borrow_mut();
-    let max = interp.try_convert(max)?;
+    let max = interp.try_convert_mut(max)?;
     let num = borrow.rand(interp, max)?;
     Ok(interp.convert_mut(num))
 }
@@ -48,13 +48,13 @@ pub fn new_seed(interp: &mut Artichoke) -> Result<Value, Exception> {
 }
 
 pub fn srand(interp: &mut Artichoke, seed: Option<Value>) -> Result<Value, Exception> {
-    let seed = interp.try_convert(seed)?;
+    let seed = interp.try_convert_mut(seed)?;
     let old_seed = random::srand(interp, seed)?;
     Ok(interp.convert(old_seed))
 }
 
 pub fn urandom(interp: &mut Artichoke, size: Value) -> Result<Value, Exception> {
-    let size = size.implicitly_convert_to_int()?;
+    let size = size.implicitly_convert_to_int(interp)?;
     let buf = random::urandom(interp, size)?;
     Ok(interp.convert_mut(buf))
 }

--- a/artichoke-backend/src/extn/core/regexp/trampoline.rs
+++ b/artichoke-backend/src/extn/core/regexp/trampoline.rs
@@ -35,7 +35,7 @@ pub fn is_match(
     let borrow = regexp.borrow();
     let pattern = pattern.implicitly_convert_to_nilable_string()?;
     let pos = if let Some(pos) = pos {
-        Some(pos.implicitly_convert_to_int()?)
+        Some(pos.implicitly_convert_to_int(interp)?)
     } else {
         None
     };
@@ -54,7 +54,7 @@ pub fn match_(
     let borrow = regexp.borrow();
     let pattern = pattern.implicitly_convert_to_nilable_string()?;
     let pos = if let Some(pos) = pos {
-        Some(pos.implicitly_convert_to_int()?)
+        Some(pos.implicitly_convert_to_int(interp)?)
     } else {
         None
     };

--- a/artichoke-backend/src/extn/core/regexp/trampoline.rs
+++ b/artichoke-backend/src/extn/core/regexp/trampoline.rs
@@ -16,6 +16,7 @@ pub fn initialize(
 }
 
 pub fn escape(interp: &mut Artichoke, pattern: Value) -> Result<Value, Exception> {
+    let pattern = pattern.implicitly_convert_to_string(interp)?;
     let pattern = Regexp::escape(interp, pattern)?;
     Ok(interp.convert_mut(pattern))
 }
@@ -33,7 +34,7 @@ pub fn is_match(
 ) -> Result<Value, Exception> {
     let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }?;
     let borrow = regexp.borrow();
-    let pattern = pattern.implicitly_convert_to_nilable_string()?;
+    let pattern = pattern.implicitly_convert_to_nilable_string(interp)?;
     let pos = if let Some(pos) = pos {
         Some(pos.implicitly_convert_to_int(interp)?)
     } else {
@@ -52,7 +53,7 @@ pub fn match_(
 ) -> Result<Value, Exception> {
     let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }?;
     let borrow = regexp.borrow();
-    let pattern = pattern.implicitly_convert_to_nilable_string()?;
+    let pattern = pattern.implicitly_convert_to_nilable_string(interp)?;
     let pos = if let Some(pos) = pos {
         Some(pos.implicitly_convert_to_int(interp)?)
     } else {
@@ -86,7 +87,7 @@ pub fn match_operator(
 ) -> Result<Value, Exception> {
     let regexp = unsafe { Regexp::try_from_ruby(interp, &regexp) }?;
     let borrow = regexp.borrow();
-    let pattern = pattern.implicitly_convert_to_nilable_string()?;
+    let pattern = pattern.implicitly_convert_to_nilable_string(interp)?;
     let pos = borrow.match_operator(interp, pattern)?;
     match pos.map(Int::try_from) {
         Some(Ok(pos)) => Ok(interp.convert(pos)),

--- a/artichoke-backend/src/extn/core/string/trampoline.rs
+++ b/artichoke-backend/src/extn/core/string/trampoline.rs
@@ -52,7 +52,7 @@ pub fn scan(
             Scan::Collected(collected) => Ok(interp.convert_mut(collected)),
             Scan::Patterns(patterns) => Ok(interp.convert_mut(patterns)),
         }
-    } else if let Ok(pattern_bytes) = pattern.implicitly_convert_to_string() {
+    } else if let Ok(pattern_bytes) = pattern.implicitly_convert_to_string(interp) {
         let string = value.clone().try_into::<&[u8]>()?;
         if let Some(ref block) = block {
             let regex = Regexp::lazy(pattern_bytes.to_vec());

--- a/artichoke-backend/src/extn/stdlib/securerandom/trampoline.rs
+++ b/artichoke-backend/src/extn/stdlib/securerandom/trampoline.rs
@@ -3,31 +3,51 @@ use crate::extn::stdlib::securerandom;
 
 #[inline]
 pub fn alphanumeric(interp: &mut Artichoke, len: Option<Value>) -> Result<Value, Exception> {
-    let alpha = securerandom::alphanumeric(interp, len)?;
+    let alpha = if let Some(len) = len {
+        let len = len.implicitly_convert_to_int(interp)?;
+        securerandom::alphanumeric(interp, Some(len))?
+    } else {
+        securerandom::alphanumeric(interp, None)?
+    };
     Ok(interp.convert_mut(alpha))
 }
 
 #[inline]
 pub fn base64(interp: &mut Artichoke, len: Option<Value>) -> Result<Value, Exception> {
-    let base64 = securerandom::base64(interp, len)?;
+    let base64 = if let Some(len) = len {
+        let len = len.implicitly_convert_to_int(interp)?;
+        securerandom::base64(interp, Some(len))?
+    } else {
+        securerandom::base64(interp, None)?
+    };
     Ok(interp.convert_mut(base64))
 }
 
 #[inline]
 pub fn hex(interp: &mut Artichoke, len: Option<Value>) -> Result<Value, Exception> {
-    let hex = securerandom::hex(interp, len)?;
+    let hex = if let Some(len) = len {
+        let len = len.implicitly_convert_to_int(interp)?;
+        securerandom::hex(interp, Some(len))?
+    } else {
+        securerandom::hex(interp, None)?
+    };
     Ok(interp.convert_mut(hex))
 }
 
 #[inline]
 pub fn random_bytes(interp: &mut Artichoke, len: Option<Value>) -> Result<Value, Exception> {
-    let bytes = securerandom::random_bytes(interp, len)?;
+    let bytes = if let Some(len) = len {
+        let len = len.implicitly_convert_to_int(interp)?;
+        securerandom::random_bytes(interp, Some(len))?
+    } else {
+        securerandom::random_bytes(interp, None)?
+    };
     Ok(interp.convert_mut(bytes))
 }
 
 #[inline]
 pub fn random_number(interp: &mut Artichoke, max: Option<Value>) -> Result<Value, Exception> {
-    let max = interp.try_convert(max)?;
+    let max = interp.try_convert_mut(max)?;
     let num = securerandom::random_number(interp, max)?;
     Ok(interp.convert_mut(num))
 }

--- a/artichoke-backend/src/value.rs
+++ b/artichoke-backend/src/value.rs
@@ -115,13 +115,13 @@ impl Value {
         debug
     }
 
-    pub fn implicitly_convert_to_int(&self) -> Result<Int, TypeError> {
+    pub fn implicitly_convert_to_int(&self, interp: &mut Artichoke) -> Result<Int, TypeError> {
         let int = if let Ok(int) = self.clone().try_into::<Option<Int>>() {
             if let Some(int) = int {
                 int
             } else {
                 return Err(TypeError::new(
-                    &self.interp,
+                    interp,
                     "no implicit conversion from nil to integer",
                 ));
             }
@@ -138,19 +138,19 @@ impl Value {
                     message.push_str("#to_int gives ");
                     message.push_str(gives_pretty_name);
                     message.push(')');
-                    return Err(TypeError::new(&self.interp, message));
+                    return Err(TypeError::new(interp, message));
                 }
             } else {
                 let mut message = String::from("no implicit conversion of ");
                 message.push_str(self.pretty_name());
                 message.push_str(" into Integer");
-                return Err(TypeError::new(&self.interp, message));
+                return Err(TypeError::new(interp, message));
             }
         } else {
             let mut message = String::from("no implicit conversion of ");
             message.push_str(self.pretty_name());
             message.push_str(" into Integer");
-            return Err(TypeError::new(&self.interp, message));
+            return Err(TypeError::new(interp, message));
         };
         Ok(int)
     }


### PR DESCRIPTION
Add a `&mut Artichoke` parameter to `Value::implicitly_convert_to_int`, `Value::implicitly_convert_to_string`, and `Value::implicitly_convert_to_nilable_string`.

These API changes are required to address GH-442.

The `&mut` part of the additional parameter is required because these implicit conversions bottom out in `Value::funcall`, which will require mutability to move the interpreter back into the `mrb_state`.

The changes introduced in GH-605 limited the scope of these changes mostly to trampolines (or functions that act as trampolines) and polymorphic functions that haven't been migrated to sum types parsed using `TryConvert` yet.

This change refactors `implicitly_convert_to_nilable_string` to be a wrapper around `implicitly_convert_to_string` with a `nil` check.

The arg conversion function in `Math` was refactored to use a match statement on `Value::ruby_type`.

Some API functions changed the types of their arguments from `Value` or `Option<Value>` to an unboxed type and pushed the unboxing out to the trampoline, like what is happening in `securerandom`.