### PR TITLE
Add &mut Artichoke parameter to all Value methods

### DIFF
--- a/artichoke-backend/src/extn/core/array/args.rs
+++ b/artichoke-backend/src/extn/core/array/args.rs
@@ -40,7 +40,7 @@ pub fn element_reference(
             Ok(None) => Ok(ElementReference::Empty),
             Err(_) => {
                 let mut message = String::from("no implicit conversion of ");
-                message.push_str(elem.pretty_name());
+                message.push_str(elem.pretty_name(interp));
                 message.push_str(" into Integer");
                 Err(Exception::from(TypeError::new(interp, message)))
             }
@@ -156,7 +156,7 @@ pub fn element_assignment(
             }
             Err(_) => {
                 let mut message = String::from("no implicit conversion of ");
-                message.push_str(first.pretty_name());
+                message.push_str(first.pretty_name(interp));
                 message.push_str(" into Integer");
                 Err(Exception::from(TypeError::new(interp, message)))
             }

--- a/artichoke-backend/src/extn/core/array/ffi.rs
+++ b/artichoke-backend/src/extn/core/array/ffi.rs
@@ -106,13 +106,13 @@ unsafe extern "C" fn artichoke_ary_concat(
     ary: sys::mrb_value,
     other: sys::mrb_value,
 ) -> sys::mrb_value {
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let ary = Value::new(&interp, ary);
     let other = Value::new(&interp, other);
     let result = if let Ok(array) = Array::try_from_ruby(&interp, &ary) {
         let mut borrow = array.borrow_mut();
         let gc_was_enabled = interp.disable_gc();
-        let result = borrow.concat(&interp, other);
+        let result = borrow.concat(&mut interp, other);
         if gc_was_enabled {
             interp.enable_gc();
         }

--- a/artichoke-backend/src/extn/core/array/mod.rs
+++ b/artichoke-backend/src/extn/core/array/mod.rs
@@ -54,11 +54,11 @@ impl Array {
                     other.borrow().0.clone()
                 } else {
                     let mut message = String::from("can't convert ");
-                    message.push_str(first.pretty_name());
+                    message.push_str(first.pretty_name(interp));
                     message.push_str(" to Array (");
-                    message.push_str(first.pretty_name());
+                    message.push_str(first.pretty_name(interp));
                     message.push_str("#to_ary gives ");
-                    message.push_str(other.pretty_name());
+                    message.push_str(other.pretty_name(interp));
                     return Err(Exception::from(TypeError::new(interp, message)));
                 }
             } else {
@@ -157,11 +157,11 @@ impl Array {
                     self.0.set_slice(interp, start, drain, &other.borrow().0)?;
                 } else {
                     let mut message = String::from("can't convert ");
-                    message.push_str(elem.pretty_name());
+                    message.push_str(elem.pretty_name(interp));
                     message.push_str(" to Array (");
-                    message.push_str(elem.pretty_name());
+                    message.push_str(elem.pretty_name(interp));
                     message.push_str("#to_ary gives ");
-                    message.push_str(other.pretty_name());
+                    message.push_str(other.pretty_name(interp));
                     return Err(Exception::from(TypeError::new(interp, message)));
                 }
             } else {
@@ -214,7 +214,7 @@ impl Array {
         Ok(())
     }
 
-    pub fn concat(&mut self, interp: &Artichoke, other: Value) -> Result<(), Exception> {
+    pub fn concat(&mut self, interp: &mut Artichoke, other: Value) -> Result<(), Exception> {
         if let Ok(other) = unsafe { Self::try_from_ruby(interp, &other) } {
             self.0.concat(interp, &other.borrow().0)?;
         } else if other.respond_to("to_ary")? {
@@ -223,16 +223,16 @@ impl Array {
                 self.0.concat(interp, &other.borrow().0)?;
             } else {
                 let mut message = String::from("can't convert ");
-                message.push_str(other.pretty_name());
+                message.push_str(other.pretty_name(interp));
                 message.push_str(" to Array (");
-                message.push_str(other.pretty_name());
+                message.push_str(other.pretty_name(interp));
                 message.push_str("#to_ary gives ");
-                message.push_str(other.pretty_name());
+                message.push_str(other.pretty_name(interp));
                 return Err(Exception::from(TypeError::new(interp, message)));
             }
         } else {
             let mut message = String::from("no implicit conversion of ");
-            message.push_str(other.pretty_name());
+            message.push_str(other.pretty_name(interp));
             message.push_str(" into Array");
             return Err(Exception::from(TypeError::new(interp, message)));
         };

--- a/artichoke-backend/src/extn/core/array/mruby.rs
+++ b/artichoke-backend/src/extn/core/array/mruby.rs
@@ -68,10 +68,10 @@ unsafe extern "C" fn ary_len(mrb: *mut sys::mrb_state, ary: sys::mrb_value) -> s
 
 unsafe extern "C" fn ary_concat(mrb: *mut sys::mrb_state, ary: sys::mrb_value) -> sys::mrb_value {
     let other = mrb_get_args!(mrb, optional = 1);
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let array = Value::new(&interp, ary);
     let other = other.map(|other| Value::new(&interp, other));
-    let result = array::trampoline::concat(&interp, array, other);
+    let result = array::trampoline::concat(&mut interp, array, other);
     match result {
         Ok(value) => {
             let basic = sys::mrb_sys_basic_ptr(ary);

--- a/artichoke-backend/src/extn/core/array/trampoline.rs
+++ b/artichoke-backend/src/extn/core/array/trampoline.rs
@@ -70,7 +70,11 @@ pub fn pop(interp: &Artichoke, ary: Value) -> Result<Value, Exception> {
     result
 }
 
-pub fn concat(interp: &Artichoke, ary: Value, other: Option<Value>) -> Result<Value, Exception> {
+pub fn concat(
+    interp: &mut Artichoke,
+    ary: Value,
+    other: Option<Value>,
+) -> Result<Value, Exception> {
     if ary.is_frozen() {
         return Err(Exception::from(FrozenError::new(
             interp,

--- a/artichoke-backend/src/extn/core/kernel/integer.rs
+++ b/artichoke-backend/src/extn/core/kernel/integer.rs
@@ -34,7 +34,7 @@ pub fn method(
     };
     let arg = arg.implicitly_convert_to_string(interp).map_err(|_| {
         let mut message = String::from("can't convert ");
-        message.push_str(arg.pretty_name());
+        message.push_str(arg.pretty_name(interp));
         message.push_str(" into Integer");
         TypeError::new(interp, message)
     })?;

--- a/artichoke-backend/src/extn/core/matchdata/trampoline.rs
+++ b/artichoke-backend/src/extn/core/matchdata/trampoline.rs
@@ -57,7 +57,7 @@ pub fn element_reference(
             Ok(None) => return Ok(interp.convert(None::<Value>)),
             Err(_) => {
                 let mut message = String::from("no implicit conversion of ");
-                message.push_str(elem.pretty_name());
+                message.push_str(elem.pretty_name(interp));
                 message.push_str(" into Integer");
                 return Err(Exception::from(TypeError::new(interp, message)));
             }

--- a/artichoke-backend/src/extn/core/math/mod.rs
+++ b/artichoke-backend/src/extn/core/math/mod.rs
@@ -44,23 +44,23 @@ fn value_to_float(interp: &mut Artichoke, value: Value) -> Result<Float, Excepti
                         coerced.try_into::<Float>()
                     } else {
                         let mut message = String::from("can't convert ");
-                        message.push_str(value.pretty_name());
+                        message.push_str(value.pretty_name(interp));
                         message.push_str(" into Float (");
-                        message.push_str(value.pretty_name());
+                        message.push_str(value.pretty_name(interp));
                         message.push_str("#to_f gives ");
-                        message.push_str(coerced.pretty_name());
+                        message.push_str(coerced.pretty_name(interp));
                         message.push(')');
                         Err(Exception::from(TypeError::new(interp, message)))
                     }
                 } else {
                     let mut message = String::from("can't convert ");
-                    message.push_str(value.pretty_name());
+                    message.push_str(value.pretty_name(interp));
                     message.push_str(" into Float");
                     Err(Exception::from(TypeError::new(interp, message)))
                 }
             } else {
                 let mut message = String::from("can't convert ");
-                message.push_str(value.pretty_name());
+                message.push_str(value.pretty_name(interp));
                 message.push_str(" into Float");
                 Err(Exception::from(TypeError::new(interp, message)))
             }

--- a/artichoke-backend/src/extn/core/numeric/mod.rs
+++ b/artichoke-backend/src/extn/core/numeric/mod.rs
@@ -132,12 +132,12 @@ pub fn coerce(interp: &mut Artichoke, x: Value, y: Value) -> Result<Coercion, Ex
                         }
                     } else {
                         let mut message = String::from("can't convert ");
-                        message.push_str(y.pretty_name());
+                        message.push_str(y.pretty_name(interp));
                         message.push_str(" into Float");
                         Err(Exception::from(TypeError::new(interp, message)))
                     }
                 } else {
-                    let mut message = String::from(y.pretty_name());
+                    let mut message = String::from(y.pretty_name(interp));
                     message.push_str(" can't be coerced into Float");
                     Err(Exception::from(TypeError::new(interp, message)))
                 }

--- a/artichoke-backend/src/extn/core/string/trampoline.rs
+++ b/artichoke-backend/src/extn/core/string/trampoline.rs
@@ -42,7 +42,7 @@ pub fn scan(
 ) -> Result<Value, Exception> {
     if let Ruby::Symbol = pattern.ruby_type() {
         let mut message = String::from("wrong argument type ");
-        message.push_str(pattern.pretty_name());
+        message.push_str(pattern.pretty_name(interp));
         message.push_str(" (expected Regexp)");
         Err(Exception::from(TypeError::new(interp, message)))
     } else if let Ok(regexp) = unsafe { Regexp::try_from_ruby(interp, &pattern) } {
@@ -113,7 +113,7 @@ pub fn scan(
         }
     } else {
         let mut message = String::from("wrong argument type ");
-        message.push_str(pattern.pretty_name());
+        message.push_str(pattern.pretty_name(interp));
         message.push_str(" (expected Regexp)");
         Err(Exception::from(TypeError::new(interp, message)))
     }

--- a/artichoke-backend/src/gc.rs
+++ b/artichoke-backend/src/gc.rs
@@ -253,7 +253,7 @@ mod tests {
             let arena = interp.create_arena_savepoint();
             let result = interp.eval(b"'gc test'");
             let value = result.unwrap();
-            assert!(!value.is_dead());
+            assert!(!value.is_dead(&mut interp));
             arena.restore();
             interp.incremental_gc();
         }

--- a/artichoke-backend/tests/leak_unbounded_arena_growth.rs
+++ b/artichoke-backend/tests/leak_unbounded_arena_growth.rs
@@ -69,16 +69,16 @@ end
         || interp.clone().full_gc(),
     );
 
-    // Value::to_s_debug
+    // Value::inspect
     let interp = artichoke_backend::interpreter().expect("init");
-    let expected = format!(r#"String<\"{}\">"#, "a".repeat(1024 * 1024));
-    leak::Detector::new("to_s_debug", ITERATIONS, 3 * LEAK_TOLERANCE).check_leaks_with_finalizer(
+    let expected = format!(r#""{}""#, "a".repeat(1024 * 1024)).into_bytes();
+    leak::Detector::new("inspect", ITERATIONS, 3 * LEAK_TOLERANCE).check_leaks_with_finalizer(
         |_| {
             let mut interp = interp.clone();
             let arena = interp.create_arena_savepoint();
             let result = interp.eval(b"'a' * 1024 * 1024").expect("eval");
             arena.restore();
-            assert_eq!(result.to_s_debug(), expected);
+            assert_eq!(result.inspect(), expected);
             drop(result);
             interp.incremental_gc();
         },


### PR DESCRIPTION
Add `&mut Artichoke` parameter to all methods on `Value` that are on the
bare `impl` block.

Most of the updates in `extn` and elsewhere came from the change to
`Value::pretty_name`'s signature.

This commit refactors `Value::pretty_name` to minimize conversions.

This PR removes:

- `impl fmt::Display for Value`
- `Value::protect`
- `Value::to_s_debug`

`Value` now requires an interpreter to print out anything useful about
itself, so the `fmt::Debug` implementation only includes info about the
`Ruby` type of the value using a simple `debug_struct` formatter.

Follow up to GH-621 and required for GH-442.