### PR TITLE
Output full line on recoverable parser error

### DIFF
--- a/src/repl.rs
+++ b/src/repl.rs
@@ -181,7 +181,7 @@ where
                     continue;
                 }
                 if parser_state.is_recoverable_error() {
-                    write!(error, "Could not parse input")?;
+                    writeln!(error, "Could not parse input")?;
                     buf.clear();
                     continue;
                 }


### PR DESCRIPTION
Audit uses of the `write!` macro. One use of `write!` in the REPL
frontend should be a `writeln!` instead.