### PR TITLE
Use BString struct fields where possible to get better debug impls

### DIFF
--- a/artichoke-backend/src/exception.rs
+++ b/artichoke-backend/src/exception.rs
@@ -1,3 +1,4 @@
+use bstr::BString;
 use std::error;
 use std::fmt;
 use std::hint;
@@ -132,16 +133,16 @@ impl error::Error for &dyn RubyException {}
 pub(crate) struct CaughtException {
     value: Value,
     name: String,
-    message: Vec<u8>,
+    message: BString,
 }
 
 impl CaughtException {
     /// Construct a new `CaughtException`.
-    pub fn new(value: Value, name: &str, message: &[u8]) -> Self {
+    pub fn new(value: Value, name: String, message: Vec<u8>) -> Self {
         Self {
             value,
-            name: name.to_owned(),
-            message: message.to_vec(),
+            name,
+            message: message.into(),
         }
     }
 }

--- a/artichoke-backend/src/exception_handler.rs
+++ b/artichoke-backend/src/exception_handler.rs
@@ -38,7 +38,7 @@ pub fn last_error(interp: &Artichoke, exception: Value) -> Result<Exception, Exc
     let classname = class.funcall::<&str>("name", &[], None)?;
     let message = exception.funcall::<&[u8]>("message", &[], None)?;
 
-    let exception = CaughtException::new(exception, classname, message);
+    let exception = CaughtException::new(exception, String::from(classname), message.to_vec());
     debug!("Extracted exception from interpreter: {}", exception);
     Ok(Exception::from(exception))
 }

--- a/artichoke-backend/src/extn/core/exception/mod.rs
+++ b/artichoke-backend/src/extn/core/exception/mod.rs
@@ -265,7 +265,7 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
 
 macro_rules! ruby_exception_impl {
     ($exception:ident) => {
-        #[derive(Debug, Clone)]
+        #[derive(Clone)]
         pub struct $exception {
             message: Cow<'static, [u8]>,
         }
@@ -342,6 +342,14 @@ macro_rules! ruby_exception_impl {
                 let spec = borrow.class_spec::<Self>()?;
                 let value = spec.new_instance(interp, &[message])?;
                 Some(value.inner())
+            }
+        }
+
+        impl fmt::Debug for $exception {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.debug_struct(stringify!($exception))
+                    .field("message", &bstr::B(self.message.as_ref()))
+                    .finish()
             }
         }
 

--- a/artichoke-backend/src/extn/core/matchdata/mod.rs
+++ b/artichoke-backend/src/extn/core/matchdata/mod.rs
@@ -9,6 +9,7 @@
 //! [matchdata]: https://ruby-doc.org/core-2.6.3/MatchData.html
 //! [rubyspec]: https://github.com/ruby/spec
 
+use bstr::BString;
 use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::ops::{Bound, RangeBounds};
@@ -118,7 +119,7 @@ impl ConvertMut<CaptureMatch, Value> for Artichoke {
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub struct MatchData {
-    haystack: Vec<u8>,
+    haystack: BString,
     regexp: Regexp,
     region: Region,
 }
@@ -137,7 +138,7 @@ impl MatchData {
     {
         let region = Region::from_range(bounds);
         Self {
-            haystack,
+            haystack: haystack.into(),
             regexp,
             region,
         }

--- a/artichoke-backend/src/state/output.rs
+++ b/artichoke-backend/src/state/output.rs
@@ -1,3 +1,4 @@
+use bstr::BString;
 use std::fmt;
 use std::io::{self, Write};
 
@@ -58,8 +59,8 @@ impl Output for Process {
 
 #[derive(Default, Debug, Clone, Hash, PartialEq, Eq)]
 pub struct Captured {
-    stdout: Vec<u8>,
-    stderr: Vec<u8>,
+    stdout: BString,
+    stderr: BString,
 }
 
 impl Captured {


### PR DESCRIPTION
`&BStr` and `BString` come with conventional UTF-8 decoding debug impls, which means we can replace private `Vec<u8>` struct fields with `BString` to get a more usable `fmt::Debug` derived impl for free with no loss of functionality or other code changes because of the `Deref` and `DerefMut` impls to `Vec`.