### PR TITLE
Improve reliability of setup program lang actions

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -34,11 +34,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Install Node toolchain
-        uses: actions/setup-node@v1
-        with:
-          node-version: "12.x"
-
       - name: Install Nodejs toolchain
         run: npm ci
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,9 +29,9 @@ jobs:
           profile: minimal
 
       - name: Install Ruby toolchain
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "2.6"
+          ruby-version: ".ruby-version"
 
       - name: Install Clang
         run: sudo apt install clang
@@ -83,9 +83,9 @@ jobs:
           components: rustfmt, clippy
 
       - name: Install Ruby toolchain
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "2.6"
+          ruby-version: ".ruby-version"
 
       - name: Install Clang
         run: sudo apt install clang
@@ -112,12 +112,9 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Ruby toolchain
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "2.6"
-
-      - name: Install bundler
-        run: gem install bundler
+          ruby-version: ".ruby-version"
 
       - name: Install gems
         run: bundle install
@@ -134,11 +131,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Install Node toolchain
-        uses: actions/setup-node@v1
-        with:
-          node-version: "12.x"
-
       - name: Install Nodejs toolchain
         run: npm ci
 
@@ -154,11 +146,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Install Node toolchain
-        uses: actions/setup-node@v1
-        with:
-          node-version: "12.x"
-
       - name: Lint and check formatting with eslint
         run: npx eslint .
 
@@ -170,22 +157,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-
-      - name: Install Ruby toolchain
-        uses: actions/setup-ruby@v1
-        with:
-          ruby-version: "2.6"
-
-      - name: Install bundler
-        run: gem install bundler
-
-      - name: Install gems
-        run: bundle install
-
-      - name: Install Node toolchain
-        uses: actions/setup-node@v1
-        with:
-          node-version: "12.x"
 
       - name: Lint and check formatting with prettier
         run: npx prettier --check '**/*'

--- a/.github/workflows/fuzz.yaml
+++ b/.github/workflows/fuzz.yaml
@@ -21,9 +21,9 @@ jobs:
           override: true
 
       - name: Install Ruby toolchain
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "2.6"
+          ruby-version: ".ruby-version"
 
       - name: Install Clang
         run: sudo apt install clang

--- a/.github/workflows/rustdoc.yaml
+++ b/.github/workflows/rustdoc.yaml
@@ -29,9 +29,9 @@ jobs:
           components: rustfmt, rust-src
 
       - name: Install Ruby toolchain
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "2.6"
+          ruby-version: ".ruby-version"
 
       - name: Install Clang
         run: sudo apt install clang


### PR DESCRIPTION
Remove actions/setup-node. Artichoke build just depends on some recent
node, not a specific node. The runner images already include node 12, so
this build step is redundant and introduces flakiness by depending on
npm infrastructure.

Replace actions/setup-ruby with ruby/setup-ruby. The official Ruby
action is speedier, has no external dependencies, and supports reading
an exact Ruby version out of the `.ruby-version` file in Artichoke root.