### PR TITLE
Allow building when there is no commit info for rustc

### DIFF
--- a/artichoke-backend/build.rs
+++ b/artichoke-backend/build.rs
@@ -460,12 +460,15 @@ mod release {
 
     fn compiler_version() -> String {
         let metadata = rustc_version::version_meta().unwrap();
-        let mut commit = metadata.commit_hash.unwrap();
-        commit.truncate(7);
-        format!(
-            "Rust {} (rev {}) on {}",
-            metadata.semver, commit, metadata.host
-        )
+        if let Some(mut commit) = metadata.commit_hash {
+            commit.truncate(7);
+            format!(
+                "Rust {} (rev {}) on {}",
+                metadata.semver, commit, metadata.host
+            )
+        } else {
+            format!("Rust {} on {}", metadata.semver, metadata.host)
+        }
     }
 }
 


### PR DESCRIPTION
I was trying to build artichoke on my machine. However even though my rustc version matches the one in toolchain file, I was still getting an error:

```
thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', artichoke-backend/build.rs:463:26
stack backtrace:
   0: <std::sys_common::backtrace::_print::DisplayBacktrace as core::fmt::Display>::fmt
   1: core::fmt::write
   2: std::io::Write::write_fmt
   3: std::panicking::default_hook::{{closure}}
   4: std::panicking::default_hook
   5: std::panicking::rust_panic_with_hook
   6: rust_begin_unwind
   7: core::panicking::panic_fmt
   8: core::panicking::panic
   9: core::option::Option<T>::unwrap
             at /build/rust/src/rustc-1.42.0-src/src/libcore/macros/mod.rs:10
  10: build_script_build::release::compiler_version
             at artichoke-backend/build.rs:463
  11: build_script_build::release::build
             at artichoke-backend/build.rs:359
  12: build_script_build::main
             at artichoke-backend/build.rs:561
  13: std::rt::lang_start::{{closure}}
             at /build/rust/src/rustc-1.42.0-src/src/libstd/rt.rs:67
  14: std::panicking::try::do_call
  15: __rust_maybe_catch_panic
  16: std::rt::lang_start_internal
  17: std::rt::lang_start
             at /build/rust/src/rustc-1.42.0-src/src/libstd/rt.rs:67
  18: main
  19: __libc_start_main
  20: _start
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```

Upon closer inspection I think this is because I have rust installed via package manager, not by rustup, and because of that I don't have info about commit hash of my rustc. I don't see why this would be blocking (i.e. why would I need specific version + installed via rustup), so I propose a fix to skip checking for commit hash when this information is not available.

**Some additional context**

```
> rustc --version 
rustc 1.42.0
```

```
> uname -a
Linux brzask 5.5.13-arch2-1 #1 SMP PREEMPT Mon, 30 Mar 2020 20:42:41 +0000 x86_64 GNU/Linux
```