### PR TITLE
Fallible artichoke backend build steps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,6 +41,7 @@ dependencies = [
  "cc",
  "chrono",
  "dtoa",
+ "git2",
  "hex",
  "itoa",
  "libc",
@@ -213,6 +214,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "git2"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cfb93ca10f2934069c3aaafb753fbe0663f08ee009a01b6d62e062391447b15"
+dependencies = [
+ "bitflags",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "openssl-probe",
+ "openssl-sys",
+ "url",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -296,6 +312,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea0c0405123bba743ee3f91f49b1c7cfb684eef0da0a50110f758ccf24cdff0"
 
 [[package]]
+name = "libgit2-sys"
+version = "0.12.3+1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7637dc15e7f05a16011723e0448655081fc01a374bcd368e2c9b9c7f5c5ab3ea"
+dependencies = [
+ "cc",
+ "libc",
+ "libssh2-sys",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libloading"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -310,6 +340,32 @@ name = "libm"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
+
+[[package]]
+name = "libssh2-sys"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb70f29dc7c31d32c97577f13f41221af981b31248083e347b7f2c39225a6bc"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb5e43362e38e2bca2fd5f5134c4d4564a23a5c28e9b95411652021a8675ebe"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "linked-hash-map"
@@ -415,6 +471,25 @@ dependencies = [
  "bindgen",
  "cc",
  "pkg-config",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7717097d810a0f2e2323f9e5d11e71608355e24828410b55b9d4f18aa5f9a5d8"
+dependencies = [
+ "autocfg",
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -906,6 +981,12 @@ checksum = "9fde2f6a4bea1d6e007c4ad38c6839fa71cbb63b6dbf5b595aa38dc9b1093c11"
 dependencies = [
  "rand",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fc439f2794e98976c88a2a2dafce96b930fe8010b0a256b3c2199a773933168"
 
 [[package]]
 name = "vec_map"

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -41,6 +41,7 @@ quickcheck_macros = "0.9"
 bindgen = { version = "0.53.1", default-features = false, features = ["runtime"] }
 cc = { version = "1.0", features = ["parallel"] }
 chrono = "0.4"
+git2 = "0.13"
 num_cpus = "1"
 rustc_version = "0.2.3"
 target-lexicon = "0.10.0"

--- a/artichoke-backend/build.rs
+++ b/artichoke-backend/build.rs
@@ -359,7 +359,9 @@ mod release {
         emit("RUBY_PLATFORM", platform);
         emit("RUBY_COPYRIGHT", copyright);
         emit("RUBY_DESCRIPTION", description);
-        emit("ARTICHOKE_COMPILER_VERSION", compiler_version());
+        if let Some(compiler_version) = compiler_version() {
+            emit("ARTICHOKE_COMPILER_VERSION", compiler_version);
+        }
     }
 
     fn emit<T>(env: &str, value: T)
@@ -430,9 +432,9 @@ mod release {
         }
     }
 
-    fn compiler_version() -> String {
-        let metadata = rustc_version::version_meta().unwrap();
-        if let Some(mut commit) = metadata.commit_hash {
+    fn compiler_version() -> Option<String> {
+        let metadata = rustc_version::version_meta().ok()?;
+        let compiler_version = if let Some(mut commit) = metadata.commit_hash {
             commit.truncate(7);
             format!(
                 "Rust {} (rev {}) on {}",
@@ -440,7 +442,8 @@ mod release {
             )
         } else {
             format!("Rust {} on {}", metadata.semver, metadata.host)
-        }
+        };
+        Some(compiler_version)
     }
 }
 


### PR DESCRIPTION
Prevent the artichoke-backend build from failing if:

- Artichoke is not being built in a copy of its git repository.
- `rustc` version metadata cannot be read.

This PR replaces the subprocess calls to `git` with calls using the `libgit2` bindings.

Followup to GH-637.