### PR TITLE
Rename types::Float alias to types::Fp

### DIFF
--- a/artichoke-backend/src/convert/float.rs
+++ b/artichoke-backend/src/convert/float.rs
@@ -1,23 +1,23 @@
 use crate::convert::UnboxRubyError;
 use crate::exception::Exception;
 use crate::sys;
-use crate::types::{Float, Ruby, Rust};
+use crate::types::{Fp, Ruby, Rust};
 use crate::value::Value;
 use crate::{Artichoke, ConvertMut, TryConvert};
 
 // TODO: when ,mruby is gone, float conversion should not allocate.
-impl ConvertMut<Float, Value> for Artichoke {
-    fn convert_mut(&mut self, value: Float) -> Value {
+impl ConvertMut<Fp, Value> for Artichoke {
+    fn convert_mut(&mut self, value: Fp) -> Value {
         let mrb = self.0.borrow().mrb;
         let float = unsafe { sys::mrb_sys_float_value(mrb, value) };
         Value::new(self, float)
     }
 }
 
-impl TryConvert<Value, Float> for Artichoke {
+impl TryConvert<Value, Fp> for Artichoke {
     type Error = Exception;
 
-    fn try_convert(&self, value: Value) -> Result<Float, Self::Error> {
+    fn try_convert(&self, value: Value) -> Result<Fp, Self::Error> {
         if let Ruby::Float = value.ruby_type() {
             let value = value.inner();
             Ok(unsafe { sys::mrb_sys_float_to_cdouble(value) })
@@ -38,39 +38,39 @@ mod tests {
         let mut interp = crate::interpreter().unwrap();
         // get a Ruby Value that can't be converted to a primitive type.
         let value = interp.eval(b"Object.new").unwrap();
-        let result = value.try_into::<Float>(&interp);
+        let result = value.try_into::<Fp>(&interp);
         assert!(result.is_err());
     }
 
     #[quickcheck]
-    fn convert_to_float(f: Float) -> bool {
+    fn convert_to_float(f: Fp) -> bool {
         let mut interp = crate::interpreter().unwrap();
         let value = interp.convert_mut(f);
         value.ruby_type() == Ruby::Float
     }
 
     #[quickcheck]
-    fn float_with_value(f: Float) -> bool {
+    fn float_with_value(f: Fp) -> bool {
         let mut interp = crate::interpreter().unwrap();
         let value = interp.convert_mut(f);
         let inner = value.inner();
         let cdouble = unsafe { sys::mrb_sys_float_to_cdouble(inner) };
-        (cdouble - f).abs() < Float::EPSILON
+        (cdouble - f).abs() < Fp::EPSILON
     }
 
     #[quickcheck]
-    fn roundtrip(f: Float) -> bool {
+    fn roundtrip(f: Fp) -> bool {
         let mut interp = crate::interpreter().unwrap();
         let value = interp.convert_mut(f);
-        let value = value.try_into::<Float>(&interp).unwrap();
-        (value - f).abs() < std::f64::EPSILON
+        let value = value.try_into::<Fp>(&interp).unwrap();
+        (value - f).abs() < Fp::EPSILON
     }
 
     #[quickcheck]
     fn roundtrip_err(b: bool) -> bool {
         let interp = crate::interpreter().unwrap();
         let value = interp.convert(b);
-        let value = value.try_into::<Float>(&interp);
+        let value = value.try_into::<Fp>(&interp);
         value.is_err()
     }
 }

--- a/artichoke-backend/src/extn/core/float/mod.rs
+++ b/artichoke-backend/src/extn/core/float/mod.rs
@@ -1,6 +1,5 @@
 use crate::extn::core::numeric::{self, Coercion, Outcome};
 use crate::extn::prelude::*;
-use crate::types;
 
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     if interp.0.borrow().class_spec::<Float>().is_some() {
@@ -42,7 +41,7 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct Float(types::Float);
+pub struct Float(Fp);
 
 impl ConvertMut<Float, Value> for Artichoke {
     #[inline]
@@ -61,14 +60,14 @@ impl TryConvert<Value, Float> for Artichoke {
     }
 }
 
-impl From<types::Float> for Float {
+impl From<Fp> for Float {
     #[inline]
-    fn from(flt: types::Float) -> Self {
+    fn from(flt: Fp) -> Self {
         Self(flt)
     }
 }
 
-impl From<Float> for types::Float {
+impl From<Float> for Fp {
     #[inline]
     fn from(flt: Float) -> Self {
         flt.as_f64()
@@ -82,9 +81,9 @@ impl From<Float> for Outcome {
     }
 }
 
-impl From<types::Float> for Outcome {
+impl From<Fp> for Outcome {
     #[inline]
-    fn from(flt: types::Float) -> Self {
+    fn from(flt: Fp) -> Self {
         Self::Float(flt)
     }
 }
@@ -94,40 +93,40 @@ impl Float {
     /// floating point.
     ///
     /// Usually defaults to 15.
-    pub const DIG: Int = types::Float::DIGITS as Int;
+    pub const DIG: Int = Fp::DIGITS as Int;
 
     /// The difference between 1 and the smallest double-precision floating
     /// point number greater than 1.
     ///
     /// Usually defaults to 2.2204460492503131e-16.
-    pub const EPSILON: types::Float = types::Float::EPSILON;
+    pub const EPSILON: Fp = Fp::EPSILON;
 
     /// An expression representing positive infinity.
-    pub const INFINITY: types::Float = types::Float::INFINITY;
+    pub const INFINITY: Fp = Fp::INFINITY;
 
     /// The minimum number of significant decimal digits in a double-precision
     /// floating point.
     ///
     /// Usually defaults to 15.
-    pub const MANT_DIG: Int = types::Float::MANTISSA_DIGITS as Int;
+    pub const MANT_DIG: Int = Fp::MANTISSA_DIGITS as Int;
 
     /// The largest possible integer in a double-precision floating point
     /// number.
     ///
     /// Usually defaults to 1.7976931348623157e+308.
-    pub const MAX: types::Float = types::Float::MAX;
+    pub const MAX: Fp = Fp::MAX;
 
     /// The largest positive exponent in a double-precision floating point where
     /// 10 raised to this power minus 1.
     ///
     /// Usually defaults to 308.
-    pub const MAX_10_EXP: Int = types::Float::MAX_10_EXP as Int;
+    pub const MAX_10_EXP: Int = Fp::MAX_10_EXP as Int;
 
     /// The largest possible exponent value in a double-precision floating
     /// point.
     ///
     /// Usually defaults to 1024.
-    pub const MAX_EXP: Int = types::Float::MAX_EXP as Int;
+    pub const MAX_EXP: Int = Fp::MAX_EXP as Int;
 
     /// The smallest positive normalized number in a double-precision floating
     /// point.
@@ -137,31 +136,31 @@ impl Float {
     /// If the platform supports denormalized numbers, there are numbers between
     /// zero and [`Float::MIN`]. `0.0.next_float` returns the smallest positive
     /// floating point number including denormalized numbers.
-    pub const MIN: types::Float = types::Float::MIN;
+    pub const MIN: Fp = Fp::MIN;
 
     /// The smallest negative exponent in a double-precision floating point
     /// where 10 raised to this power minus 1.
     ///
     /// Usually defaults to -307.
-    pub const MIN_10_EXP: Int = types::Float::MIN_10_EXP as Int;
+    pub const MIN_10_EXP: Int = Fp::MIN_10_EXP as Int;
 
     /// The smallest possible exponent value in a double-precision floating
     /// point.
     ///
     /// Usually defaults to -1021.
-    pub const MIN_EXP: Int = types::Float::MIN_EXP as Int;
+    pub const MIN_EXP: Int = Fp::MIN_EXP as Int;
 
     /// An expression representing a value which is "not a number".
-    pub const NAN: types::Float = types::Float::NAN;
+    pub const NAN: Fp = Fp::NAN;
 
-    pub const NEG_INFINITY: types::Float = types::Float::NEG_INFINITY;
+    pub const NEG_INFINITY: Fp = Fp::NEG_INFINITY;
 
     /// The base of the floating point, or number of unique digits used to
     /// represent the number.
     ///
     /// Usually defaults to 2 on most systems, which would represent a base-10
     /// decimal.
-    pub const RADIX: Int = types::Float::RADIX as Int;
+    pub const RADIX: Int = Fp::RADIX as Int;
 
     /// Represents the rounding mode for floating point addition.
     ///
@@ -194,7 +193,7 @@ impl Float {
 
     #[inline]
     #[must_use]
-    pub fn new(num: types::Float) -> Self {
+    pub fn new(num: Fp) -> Self {
         Self(num)
     }
 

--- a/artichoke-backend/src/extn/core/integer/mod.rs
+++ b/artichoke-backend/src/extn/core/integer/mod.rs
@@ -159,7 +159,7 @@ impl Integer {
                 }
             }
             Ruby::Float => {
-                let denom = denominator.try_into::<Float>(interp)?;
+                let denom = denominator.try_into::<Fp>(interp)?;
                 Ok((self.as_f64() / denom).into())
             }
             _ => {

--- a/artichoke-backend/src/extn/core/math/mod.rs
+++ b/artichoke-backend/src/extn/core/math/mod.rs
@@ -9,13 +9,13 @@ use crate::extn::prelude::*;
 
 pub mod mruby;
 
-pub const E: Float = f64::consts::E;
-pub const PI: Float = f64::consts::PI;
+pub const E: Fp = f64::consts::E;
+pub const PI: Fp = f64::consts::PI;
 
 #[derive(Debug)]
 pub struct Math;
 
-fn value_to_float(interp: &mut Artichoke, value: Value) -> Result<Float, Exception> {
+fn value_to_float(interp: &mut Artichoke, value: Value) -> Result<Fp, Exception> {
     match value.ruby_type() {
         Ruby::Float => value.try_into(interp),
         Ruby::Fixnum => value.try_into::<Integer>(interp).map(Integer::as_f64),
@@ -38,7 +38,7 @@ fn value_to_float(interp: &mut Artichoke, value: Value) -> Result<Float, Excepti
                 if value.respond_to(interp, "to_f")? {
                     let coerced = value.funcall::<Value>(interp, "to_f", &[], None)?;
                     if let Ruby::Float = coerced.ruby_type() {
-                        coerced.try_into::<Float>(interp)
+                        coerced.try_into::<Fp>(interp)
                     } else {
                         let mut message = String::from("can't convert ");
                         message.push_str(value.pretty_name(interp));
@@ -65,7 +65,7 @@ fn value_to_float(interp: &mut Artichoke, value: Value) -> Result<Float, Excepti
     }
 }
 
-pub fn acos(interp: &mut Artichoke, value: Value) -> Result<Float, Exception> {
+pub fn acos(interp: &mut Artichoke, value: Value) -> Result<Fp, Exception> {
     let value = value_to_float(interp, value)?;
     if value.is_nan() {
         return Ok(value);
@@ -80,7 +80,7 @@ pub fn acos(interp: &mut Artichoke, value: Value) -> Result<Float, Exception> {
     }
 }
 
-pub fn acosh(interp: &mut Artichoke, value: Value) -> Result<Float, Exception> {
+pub fn acosh(interp: &mut Artichoke, value: Value) -> Result<Fp, Exception> {
     let value = value_to_float(interp, value)?;
     if value.is_nan() {
         return Ok(value);
@@ -95,7 +95,7 @@ pub fn acosh(interp: &mut Artichoke, value: Value) -> Result<Float, Exception> {
     }
 }
 
-pub fn asin(interp: &mut Artichoke, value: Value) -> Result<Float, Exception> {
+pub fn asin(interp: &mut Artichoke, value: Value) -> Result<Fp, Exception> {
     let value = value_to_float(interp, value)?;
     if value.is_nan() {
         return Ok(value);
@@ -110,26 +110,26 @@ pub fn asin(interp: &mut Artichoke, value: Value) -> Result<Float, Exception> {
     }
 }
 
-pub fn asinh(interp: &mut Artichoke, value: Value) -> Result<Float, Exception> {
+pub fn asinh(interp: &mut Artichoke, value: Value) -> Result<Fp, Exception> {
     let value = value_to_float(interp, value)?;
     let result = value.asinh();
     Ok(result)
 }
 
-pub fn atan(interp: &mut Artichoke, value: Value) -> Result<Float, Exception> {
+pub fn atan(interp: &mut Artichoke, value: Value) -> Result<Fp, Exception> {
     let value = value_to_float(interp, value)?;
     let result = value.atan();
     Ok(result)
 }
 
-pub fn atan2(interp: &mut Artichoke, value: Value, other: Value) -> Result<Float, Exception> {
+pub fn atan2(interp: &mut Artichoke, value: Value, other: Value) -> Result<Fp, Exception> {
     let value = value_to_float(interp, value)?;
     let other = value_to_float(interp, other)?;
     let result = value.atan2(other);
     Ok(result)
 }
 
-pub fn atanh(interp: &mut Artichoke, value: Value) -> Result<Float, Exception> {
+pub fn atanh(interp: &mut Artichoke, value: Value) -> Result<Fp, Exception> {
     let value = value_to_float(interp, value)?;
     if value.is_nan() {
         return Ok(value);
@@ -144,26 +144,26 @@ pub fn atanh(interp: &mut Artichoke, value: Value) -> Result<Float, Exception> {
     }
 }
 
-pub fn cbrt(interp: &mut Artichoke, value: Value) -> Result<Float, Exception> {
+pub fn cbrt(interp: &mut Artichoke, value: Value) -> Result<Fp, Exception> {
     let value = value_to_float(interp, value)?;
     let result = value.cbrt();
     Ok(result)
 }
 
-pub fn cos(interp: &mut Artichoke, value: Value) -> Result<Float, Exception> {
+pub fn cos(interp: &mut Artichoke, value: Value) -> Result<Fp, Exception> {
     let value = value_to_float(interp, value)?;
     let result = value.cos();
     Ok(result)
 }
 
-pub fn cosh(interp: &mut Artichoke, value: Value) -> Result<Float, Exception> {
+pub fn cosh(interp: &mut Artichoke, value: Value) -> Result<Fp, Exception> {
     let value = value_to_float(interp, value)?;
     let result = value.cosh();
     Ok(result)
 }
 
 #[cfg(not(feature = "core-math-extra"))]
-pub fn erf(interp: &mut Artichoke, value: Value) -> Result<Float, Exception> {
+pub fn erf(interp: &mut Artichoke, value: Value) -> Result<Fp, Exception> {
     let _ = value;
     Err(Exception::from(NotImplementedError::new(
         interp,
@@ -172,14 +172,14 @@ pub fn erf(interp: &mut Artichoke, value: Value) -> Result<Float, Exception> {
 }
 
 #[cfg(feature = "core-math-extra")]
-pub fn erf(interp: &mut Artichoke, value: Value) -> Result<Float, Exception> {
+pub fn erf(interp: &mut Artichoke, value: Value) -> Result<Fp, Exception> {
     let value = value_to_float(interp, value)?;
     let result = libm::erf(value);
     Ok(result)
 }
 
 #[cfg(not(feature = "core-math-extra"))]
-pub fn erfc(interp: &mut Artichoke, value: Value) -> Result<Float, Exception> {
+pub fn erfc(interp: &mut Artichoke, value: Value) -> Result<Fp, Exception> {
     let _ = value;
     Err(Exception::from(NotImplementedError::new(
         interp,
@@ -188,20 +188,20 @@ pub fn erfc(interp: &mut Artichoke, value: Value) -> Result<Float, Exception> {
 }
 
 #[cfg(feature = "core-math-extra")]
-pub fn erfc(interp: &mut Artichoke, value: Value) -> Result<Float, Exception> {
+pub fn erfc(interp: &mut Artichoke, value: Value) -> Result<Fp, Exception> {
     let value = value_to_float(interp, value)?;
     let result = libm::erfc(value);
     Ok(result)
 }
 
-pub fn exp(interp: &mut Artichoke, value: Value) -> Result<Float, Exception> {
+pub fn exp(interp: &mut Artichoke, value: Value) -> Result<Fp, Exception> {
     let value = value_to_float(interp, value)?;
     let result = value.exp();
     Ok(result)
 }
 
 #[cfg(not(feature = "core-math-extra"))]
-pub fn frexp(interp: &mut Artichoke, value: Value) -> Result<(Float, Int), Exception> {
+pub fn frexp(interp: &mut Artichoke, value: Value) -> Result<(Fp, Int), Exception> {
     let _ = value;
     Err(Exception::from(NotImplementedError::new(
         interp,
@@ -210,14 +210,14 @@ pub fn frexp(interp: &mut Artichoke, value: Value) -> Result<(Float, Int), Excep
 }
 
 #[cfg(feature = "core-math-extra")]
-pub fn frexp(interp: &mut Artichoke, value: Value) -> Result<(Float, Int), Exception> {
+pub fn frexp(interp: &mut Artichoke, value: Value) -> Result<(Fp, Int), Exception> {
     let value = value_to_float(interp, value)?;
     let (fraction, exponent) = libm::frexp(value);
     Ok((fraction, exponent.into()))
 }
 
 #[cfg(not(feature = "core-math-extra"))]
-pub fn gamma(interp: &mut Artichoke, value: Value) -> Result<Float, Exception> {
+pub fn gamma(interp: &mut Artichoke, value: Value) -> Result<Fp, Exception> {
     let _ = value;
     Err(Exception::from(NotImplementedError::new(
         interp,
@@ -226,7 +226,7 @@ pub fn gamma(interp: &mut Artichoke, value: Value) -> Result<Float, Exception> {
 }
 
 #[cfg(feature = "core-math-extra")]
-pub fn gamma(interp: &mut Artichoke, value: Value) -> Result<Float, Exception> {
+pub fn gamma(interp: &mut Artichoke, value: Value) -> Result<Fp, Exception> {
     use crate::extn::core::float;
     use std::convert::TryFrom;
     use std::num::FpCategory;
@@ -300,7 +300,7 @@ pub fn gamma(interp: &mut Artichoke, value: Value) -> Result<Float, Exception> {
     }
 }
 
-pub fn hypot(interp: &mut Artichoke, value: Value, other: Value) -> Result<Float, Exception> {
+pub fn hypot(interp: &mut Artichoke, value: Value, other: Value) -> Result<Fp, Exception> {
     let value = value_to_float(interp, value)?;
     let other = value_to_float(interp, other)?;
     let result = value.hypot(other);
@@ -308,7 +308,7 @@ pub fn hypot(interp: &mut Artichoke, value: Value, other: Value) -> Result<Float
 }
 
 #[cfg(not(feature = "core-math-extra"))]
-pub fn ldexp(interp: &mut Artichoke, fraction: Value, exponent: Value) -> Result<Float, Exception> {
+pub fn ldexp(interp: &mut Artichoke, fraction: Value, exponent: Value) -> Result<Fp, Exception> {
     let _ = fraction;
     let _ = exponent;
     Err(Exception::from(NotImplementedError::new(
@@ -318,12 +318,12 @@ pub fn ldexp(interp: &mut Artichoke, fraction: Value, exponent: Value) -> Result
 }
 
 #[cfg(feature = "core-math-extra")]
-pub fn ldexp(interp: &mut Artichoke, fraction: Value, exponent: Value) -> Result<Float, Exception> {
+pub fn ldexp(interp: &mut Artichoke, fraction: Value, exponent: Value) -> Result<Fp, Exception> {
     use std::convert::TryFrom;
 
     let fraction = value_to_float(interp, fraction)?;
     let exponent = exponent.implicitly_convert_to_int(interp).or_else(|err| {
-        if let Ok(exponent) = exponent.try_into::<Float>(interp) {
+        if let Ok(exponent) = exponent.try_into::<Fp>(interp) {
             if exponent.is_nan() {
                 Err(Exception::from(RangeError::new(
                     interp,
@@ -354,7 +354,7 @@ pub fn ldexp(interp: &mut Artichoke, fraction: Value, exponent: Value) -> Result
 }
 
 #[cfg(not(feature = "core-math-extra"))]
-pub fn lgamma(interp: &mut Artichoke, value: Value) -> Result<(Float, Int), Exception> {
+pub fn lgamma(interp: &mut Artichoke, value: Value) -> Result<(Fp, Int), Exception> {
     let _ = value;
     Err(Exception::from(NotImplementedError::new(
         interp,
@@ -363,7 +363,7 @@ pub fn lgamma(interp: &mut Artichoke, value: Value) -> Result<(Float, Int), Exce
 }
 
 #[cfg(feature = "core-math-extra")]
-pub fn lgamma(interp: &mut Artichoke, value: Value) -> Result<(Float, Int), Exception> {
+pub fn lgamma(interp: &mut Artichoke, value: Value) -> Result<(Fp, Int), Exception> {
     let value = value_to_float(interp, value)?;
     if value.is_infinite() && value.is_sign_negative() {
         Err(Exception::from(DomainError::new(
@@ -375,7 +375,7 @@ pub fn lgamma(interp: &mut Artichoke, value: Value) -> Result<(Float, Int), Exce
     }
 }
 
-pub fn log(interp: &mut Artichoke, value: Value, base: Option<Value>) -> Result<Float, Exception> {
+pub fn log(interp: &mut Artichoke, value: Value, base: Option<Value>) -> Result<Fp, Exception> {
     let value = value_to_float(interp, value)?;
     if value.is_nan() {
         return Ok(value);
@@ -398,7 +398,7 @@ pub fn log(interp: &mut Artichoke, value: Value, base: Option<Value>) -> Result<
     }
 }
 
-pub fn log10(interp: &mut Artichoke, value: Value) -> Result<Float, Exception> {
+pub fn log10(interp: &mut Artichoke, value: Value) -> Result<Fp, Exception> {
     let value = value_to_float(interp, value)?;
     if value.is_nan() {
         return Ok(value);
@@ -413,7 +413,7 @@ pub fn log10(interp: &mut Artichoke, value: Value) -> Result<Float, Exception> {
     }
 }
 
-pub fn log2(interp: &mut Artichoke, value: Value) -> Result<Float, Exception> {
+pub fn log2(interp: &mut Artichoke, value: Value) -> Result<Fp, Exception> {
     let value = value_to_float(interp, value)?;
     if value.is_nan() {
         return Ok(value);
@@ -428,19 +428,19 @@ pub fn log2(interp: &mut Artichoke, value: Value) -> Result<Float, Exception> {
     }
 }
 
-pub fn sin(interp: &mut Artichoke, value: Value) -> Result<Float, Exception> {
+pub fn sin(interp: &mut Artichoke, value: Value) -> Result<Fp, Exception> {
     let value = value_to_float(interp, value)?;
     let result = value.sin();
     Ok(result)
 }
 
-pub fn sinh(interp: &mut Artichoke, value: Value) -> Result<Float, Exception> {
+pub fn sinh(interp: &mut Artichoke, value: Value) -> Result<Fp, Exception> {
     let value = value_to_float(interp, value)?;
     let result = value.sinh();
     Ok(result)
 }
 
-pub fn sqrt(interp: &mut Artichoke, value: Value) -> Result<Float, Exception> {
+pub fn sqrt(interp: &mut Artichoke, value: Value) -> Result<Fp, Exception> {
     let value = value_to_float(interp, value)?;
     if value.is_nan() {
         return Ok(value);
@@ -455,13 +455,13 @@ pub fn sqrt(interp: &mut Artichoke, value: Value) -> Result<Float, Exception> {
     }
 }
 
-pub fn tan(interp: &mut Artichoke, value: Value) -> Result<Float, Exception> {
+pub fn tan(interp: &mut Artichoke, value: Value) -> Result<Fp, Exception> {
     let value = value_to_float(interp, value)?;
     let result = value.tan();
     Ok(result)
 }
 
-pub fn tanh(interp: &mut Artichoke, value: Value) -> Result<Float, Exception> {
+pub fn tanh(interp: &mut Artichoke, value: Value) -> Result<Fp, Exception> {
     let value = value_to_float(interp, value)?;
     let result = value.tanh();
     Ok(result)

--- a/artichoke-backend/src/extn/core/numeric/mod.rs
+++ b/artichoke-backend/src/extn/core/numeric/mod.rs
@@ -17,7 +17,7 @@ pub struct Numeric;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Outcome {
-    Float(Float),
+    Float(Fp),
     Integer(Int),
     // TODO: Complex? Rational?
 }
@@ -35,7 +35,7 @@ const MAX_COERCE_DEPTH: u8 = 15;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Coercion {
-    Float(Float, Float),
+    Float(Fp, Fp),
     Integer(Int, Int),
     // TODO: Complex? Rational?
 }

--- a/artichoke-backend/src/extn/core/random/backend/default.rs
+++ b/artichoke-backend/src/extn/core/random/backend/default.rs
@@ -31,7 +31,7 @@ impl RandType for Default {
         borrow.prng.rand_int(max)
     }
 
-    fn rand_float(&mut self, interp: &mut Artichoke, max: Option<Float>) -> Float {
+    fn rand_float(&mut self, interp: &mut Artichoke, max: Option<Fp>) -> Fp {
         let mut borrow = interp.0.borrow_mut();
         borrow.prng.rand_float(max)
     }

--- a/artichoke-backend/src/extn/core/random/backend/mod.rs
+++ b/artichoke-backend/src/extn/core/random/backend/mod.rs
@@ -27,7 +27,7 @@ pub trait RandType {
     ///
     /// If `max` is `None`, return a random `Float between 0 and 1.0 --
     /// `[0, 1.0)`.
-    fn rand_float(&mut self, interp: &mut Artichoke, max: Option<Float>) -> Float;
+    fn rand_float(&mut self, interp: &mut Artichoke, max: Option<Fp>) -> Fp;
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/artichoke-backend/src/extn/core/random/backend/rand.rs
+++ b/artichoke-backend/src/extn/core/random/backend/rand.rs
@@ -66,7 +66,7 @@ where
     }
 
     #[inline]
-    pub fn rand_float(&mut self, max: Option<Float>) -> Float {
+    pub fn rand_float(&mut self, max: Option<Fp>) -> Fp {
         let max = max.unwrap_or(1.0);
         self.rng.gen_range(0.0, max)
     }
@@ -100,7 +100,7 @@ where
         self.rand_int(max)
     }
 
-    fn rand_float(&mut self, interp: &mut Artichoke, max: Option<Float>) -> Float {
+    fn rand_float(&mut self, interp: &mut Artichoke, max: Option<Fp>) -> Fp {
         let _ = interp;
         self.rand_float(max)
     }

--- a/artichoke-backend/src/extn/core/random/mod.rs
+++ b/artichoke-backend/src/extn/core/random/mod.rs
@@ -200,7 +200,7 @@ impl fmt::Debug for Random {
 #[allow(clippy::module_name_repetitions)]
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
 pub enum RandomNumberMax {
-    Float(Float),
+    Float(Fp),
     Integer(Int),
     None,
 }
@@ -246,8 +246,8 @@ impl TryConvertMut<Option<Value>, RandomNumberMax> for Artichoke {
 #[allow(clippy::module_name_repetitions)]
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
 pub enum RandomNumber {
+    Float(Fp),
     Integer(Int),
-    Float(Float),
 }
 
 impl ConvertMut<RandomNumber, Value> for Artichoke {

--- a/artichoke-backend/src/extn/prelude.rs
+++ b/artichoke-backend/src/extn/prelude.rs
@@ -14,7 +14,7 @@ pub use crate::extn::core::exception::*;
 pub use crate::module;
 pub use crate::string;
 pub use crate::sys;
-pub use crate::types::{Float, Int, Ruby};
+pub use crate::types::{Fp, Int, Ruby};
 pub use crate::value::{Block, Value};
 pub use crate::{
     Artichoke, Convert, ConvertMut, DefineConstant, Eval, File, Globals, Intern, LoadSources,

--- a/artichoke-backend/src/extn/stdlib/securerandom/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/securerandom/mod.rs
@@ -51,7 +51,7 @@ pub fn random_bytes(interp: &mut Artichoke, len: Option<Int>) -> Result<Vec<u8>,
 
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
 pub enum RandomNumberMax {
-    Float(Float),
+    Float(Fp),
     Integer(Int),
     None,
 }
@@ -96,8 +96,8 @@ impl TryConvertMut<Option<Value>, RandomNumberMax> for Artichoke {
 
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
 pub enum RandomNumber {
+    Float(Fp),
     Integer(Int),
-    Float(Float),
 }
 
 impl ConvertMut<RandomNumber, Value> for Artichoke {

--- a/artichoke-backend/src/state/prng.rs
+++ b/artichoke-backend/src/state/prng.rs
@@ -1,6 +1,6 @@
 use crate::extn::core::random::backend::rand::{Rand, Rng};
 use crate::extn::core::random::backend::InternalState;
-use crate::types::{Float, Int};
+use crate::types::{Fp, Int};
 
 #[derive(Debug)]
 pub struct Prng {
@@ -44,7 +44,7 @@ impl Prng {
     }
 
     #[inline]
-    pub fn rand_float(&mut self, max: Option<Float>) -> Float {
+    pub fn rand_float(&mut self, max: Option<Fp>) -> Fp {
         self.random.rand_float(max)
     }
 }

--- a/artichoke-backend/src/test/prelude.rs
+++ b/artichoke-backend/src/test/prelude.rs
@@ -15,7 +15,7 @@ pub use crate::gc::MrbGarbageCollection;
 pub use crate::module;
 pub use crate::state::parser::Context;
 pub use crate::sys;
-pub use crate::types::{Float, Int, Ruby, Rust};
+pub use crate::types::{Fp, Int, Ruby, Rust};
 pub use crate::value::{Block, Value};
 pub use crate::{
     Artichoke, Convert, ConvertMut, DefineConstant, Eval, File, Globals, Intern, LoadSources,

--- a/artichoke-backend/src/types.rs
+++ b/artichoke-backend/src/types.rs
@@ -2,19 +2,18 @@ use crate::sys;
 
 /// Artichoke native floating point type.
 ///
-/// `Float` is the backend to the [`Float`](crate::extn::core::float::Float)
-/// class.
+/// `Fp` is the backend to the [`Float`](crate::extn::core::float::Float) class.
 ///
-/// The `Float` type alias is for the `f64` floating point primitive.
+/// The `Fp` type alias is for the `f64` floating point primitive.
 ///
 /// ```
 /// # use std::any::TypeId;
 /// # use std::mem;
-/// # use artichoke_backend::types::Float;
-/// assert_eq!(mem::size_of::<f64>(), mem::size_of::<Float>());
-/// assert_eq!(TypeId::of::<f64>(), TypeId::of::<Float>());
+/// # use artichoke_backend::types::Fp;
+/// assert_eq!(mem::size_of::<f64>(), mem::size_of::<Fp>());
+/// assert_eq!(TypeId::of::<f64>(), TypeId::of::<Fp>());
 /// ```
-pub type Float = f64;
+pub type Fp = f64;
 
 /// Artichoke native integer type.
 ///


### PR DESCRIPTION
There was confusion where both the primitive alias and `Float` class
implementation were in scope.