### PR TITLE
Take mutable reference to an interpreter in RustBackedValue

### DIFF
--- a/artichoke-backend/src/convert/array.rs
+++ b/artichoke-backend/src/convert/array.rs
@@ -5,7 +5,7 @@ use crate::exception::Exception;
 use crate::extn::core::array::{Array, InlineBuffer};
 use crate::types::{Int, Ruby, Rust};
 use crate::value::Value;
-use crate::{Artichoke, Convert, ConvertMut, TryConvert};
+use crate::{Artichoke, Convert, ConvertMut, TryConvert, TryConvertMut};
 
 impl ConvertMut<&[Value], Value> for Artichoke {
     fn convert_mut(&mut self, value: &[Value]) -> Value {
@@ -180,10 +180,10 @@ impl ConvertMut<Vec<Vec<Option<&str>>>, Value> for Artichoke {
     }
 }
 
-impl TryConvert<Value, Vec<Value>> for Artichoke {
+impl TryConvertMut<Value, Vec<Value>> for Artichoke {
     type Error = Exception;
 
-    fn try_convert(&self, value: Value) -> Result<Vec<Value>, Self::Error> {
+    fn try_convert_mut(&mut self, value: Value) -> Result<Vec<Value>, Self::Error> {
         if let Ruby::Data = value.ruby_type() {
             let array = unsafe { Array::try_from_ruby(self, &value) }?;
             let borrow = array.borrow();
@@ -194,10 +194,10 @@ impl TryConvert<Value, Vec<Value>> for Artichoke {
     }
 }
 
-impl TryConvert<Value, Vec<Vec<u8>>> for Artichoke {
+impl TryConvertMut<Value, Vec<Vec<u8>>> for Artichoke {
     type Error = Exception;
 
-    fn try_convert(&self, value: Value) -> Result<Vec<Vec<u8>>, Self::Error> {
+    fn try_convert_mut(&mut self, value: Value) -> Result<Vec<Vec<u8>>, Self::Error> {
         if let Ruby::Data = value.ruby_type() {
             let array = unsafe { Array::try_from_ruby(self, &value) }?;
             let borrow = array.borrow();
@@ -213,10 +213,10 @@ impl TryConvert<Value, Vec<Vec<u8>>> for Artichoke {
     }
 }
 
-impl TryConvert<Value, Vec<Option<Vec<u8>>>> for Artichoke {
+impl TryConvertMut<Value, Vec<Option<Vec<u8>>>> for Artichoke {
     type Error = Exception;
 
-    fn try_convert(&self, value: Value) -> Result<Vec<Option<Vec<u8>>>, Self::Error> {
+    fn try_convert_mut(&mut self, value: Value) -> Result<Vec<Option<Vec<u8>>>, Self::Error> {
         if let Ruby::Data = value.ruby_type() {
             let array = unsafe { Array::try_from_ruby(self, &value) }?;
             let borrow = array.borrow();
@@ -232,10 +232,10 @@ impl TryConvert<Value, Vec<Option<Vec<u8>>>> for Artichoke {
     }
 }
 
-impl<'a> TryConvert<Value, Vec<&'a [u8]>> for Artichoke {
+impl<'a> TryConvertMut<Value, Vec<&'a [u8]>> for Artichoke {
     type Error = Exception;
 
-    fn try_convert(&self, value: Value) -> Result<Vec<&'a [u8]>, Self::Error> {
+    fn try_convert_mut(&mut self, value: Value) -> Result<Vec<&'a [u8]>, Self::Error> {
         if let Ruby::Data = value.ruby_type() {
             let array = unsafe { Array::try_from_ruby(self, &value) }?;
             let borrow = array.borrow();
@@ -251,10 +251,10 @@ impl<'a> TryConvert<Value, Vec<&'a [u8]>> for Artichoke {
     }
 }
 
-impl<'a> TryConvert<Value, Vec<Option<&'a [u8]>>> for Artichoke {
+impl<'a> TryConvertMut<Value, Vec<Option<&'a [u8]>>> for Artichoke {
     type Error = Exception;
 
-    fn try_convert(&self, value: Value) -> Result<Vec<Option<&'a [u8]>>, Self::Error> {
+    fn try_convert_mut(&mut self, value: Value) -> Result<Vec<Option<&'a [u8]>>, Self::Error> {
         if let Ruby::Data = value.ruby_type() {
             let array = unsafe { Array::try_from_ruby(self, &value) }?;
             let borrow = array.borrow();
@@ -270,10 +270,10 @@ impl<'a> TryConvert<Value, Vec<Option<&'a [u8]>>> for Artichoke {
     }
 }
 
-impl TryConvert<Value, Vec<String>> for Artichoke {
+impl TryConvertMut<Value, Vec<String>> for Artichoke {
     type Error = Exception;
 
-    fn try_convert(&self, value: Value) -> Result<Vec<String>, Self::Error> {
+    fn try_convert_mut(&mut self, value: Value) -> Result<Vec<String>, Self::Error> {
         if let Ruby::Data = value.ruby_type() {
             let array = unsafe { Array::try_from_ruby(self, &value) }?;
             let borrow = array.borrow();
@@ -289,10 +289,10 @@ impl TryConvert<Value, Vec<String>> for Artichoke {
     }
 }
 
-impl TryConvert<Value, Vec<Option<String>>> for Artichoke {
+impl TryConvertMut<Value, Vec<Option<String>>> for Artichoke {
     type Error = Exception;
 
-    fn try_convert(&self, value: Value) -> Result<Vec<Option<String>>, Self::Error> {
+    fn try_convert_mut(&mut self, value: Value) -> Result<Vec<Option<String>>, Self::Error> {
         if let Ruby::Data = value.ruby_type() {
             let array = unsafe { Array::try_from_ruby(self, &value) }?;
             let borrow = array.borrow();
@@ -308,10 +308,10 @@ impl TryConvert<Value, Vec<Option<String>>> for Artichoke {
     }
 }
 
-impl<'a> TryConvert<Value, Vec<&'a str>> for Artichoke {
+impl<'a> TryConvertMut<Value, Vec<&'a str>> for Artichoke {
     type Error = Exception;
 
-    fn try_convert(&self, value: Value) -> Result<Vec<&'a str>, Self::Error> {
+    fn try_convert_mut(&mut self, value: Value) -> Result<Vec<&'a str>, Self::Error> {
         if let Ruby::Data = value.ruby_type() {
             let array = unsafe { Array::try_from_ruby(self, &value) }?;
             let borrow = array.borrow();
@@ -327,10 +327,10 @@ impl<'a> TryConvert<Value, Vec<&'a str>> for Artichoke {
     }
 }
 
-impl<'a> TryConvert<Value, Vec<Option<&'a str>>> for Artichoke {
+impl<'a> TryConvertMut<Value, Vec<Option<&'a str>>> for Artichoke {
     type Error = Exception;
 
-    fn try_convert(&self, value: Value) -> Result<Vec<Option<&'a str>>, Self::Error> {
+    fn try_convert_mut(&mut self, value: Value) -> Result<Vec<Option<&'a str>>, Self::Error> {
         if let Ruby::Data = value.ruby_type() {
             let array = unsafe { Array::try_from_ruby(self, &value) }?;
             let borrow = array.borrow();
@@ -346,10 +346,10 @@ impl<'a> TryConvert<Value, Vec<Option<&'a str>>> for Artichoke {
     }
 }
 
-impl TryConvert<Value, Vec<Int>> for Artichoke {
+impl TryConvertMut<Value, Vec<Int>> for Artichoke {
     type Error = Exception;
 
-    fn try_convert(&self, value: Value) -> Result<Vec<Int>, Self::Error> {
+    fn try_convert_mut(&mut self, value: Value) -> Result<Vec<Int>, Self::Error> {
         if let Ruby::Data = value.ruby_type() {
             let array = unsafe { Array::try_from_ruby(self, &value) }?;
             let borrow = array.borrow();
@@ -376,7 +376,7 @@ mod tests {
         let mut interp = crate::interpreter().unwrap();
         // get a Ruby value that can't be converted to a primitive type.
         let value = interp.eval(b"Object.new").unwrap();
-        let result = value.try_into::<Vec<Value>>(&interp);
+        let result = value.try_into_mut::<Vec<Value>>(&mut interp);
         assert!(result.is_err());
     }
 
@@ -397,7 +397,7 @@ mod tests {
         if empty != arr.is_empty() {
             return false;
         }
-        let recovered: Vec<Int> = interp.try_convert(value).unwrap();
+        let recovered: Vec<Int> = interp.try_convert_mut(value).unwrap();
         if recovered != arr {
             return false;
         }
@@ -415,7 +415,7 @@ mod tests {
         if empty != arr.is_empty() {
             return false;
         }
-        let recovered: Vec<Int> = interp.try_convert(value).unwrap();
+        let recovered: Vec<Int> = interp.try_convert_mut(value).unwrap();
         if recovered != arr {
             return false;
         }
@@ -439,7 +439,7 @@ mod tests {
         if empty != arr.is_empty() {
             return false;
         }
-        let recovered: Vec<String> = interp.try_convert(value).unwrap();
+        let recovered: Vec<String> = interp.try_convert_mut(value).unwrap();
         if recovered != arr {
             return false;
         }
@@ -457,7 +457,7 @@ mod tests {
         if empty != arr.is_empty() {
             return false;
         }
-        let recovered: Vec<String> = interp.try_convert(value).unwrap();
+        let recovered: Vec<String> = interp.try_convert_mut(value).unwrap();
         if recovered != arr {
             return false;
         }
@@ -481,7 +481,7 @@ mod tests {
         if empty != arr.is_empty() {
             return false;
         }
-        let recovered: Vec<Option<Vec<u8>>> = interp.try_convert(value).unwrap();
+        let recovered: Vec<Option<Vec<u8>>> = interp.try_convert_mut(value).unwrap();
         if recovered != arr {
             return false;
         }
@@ -499,7 +499,7 @@ mod tests {
         if empty != arr.is_empty() {
             return false;
         }
-        let recovered: Vec<Option<Vec<u8>>> = interp.try_convert(value).unwrap();
+        let recovered: Vec<Option<Vec<u8>>> = interp.try_convert_mut(value).unwrap();
         if recovered != arr {
             return false;
         }
@@ -508,9 +508,9 @@ mod tests {
 
     #[quickcheck]
     fn roundtrip_err(i: i64) -> bool {
-        let interp = crate::interpreter().unwrap();
+        let mut interp = crate::interpreter().unwrap();
         let value = interp.convert(i);
-        let value = value.try_into::<Vec<Value>>(&interp);
+        let value = value.try_into_mut::<Vec<Value>>(&mut interp);
         value.is_err()
     }
 }

--- a/artichoke-backend/src/convert/hash.rs
+++ b/artichoke-backend/src/convert/hash.rs
@@ -7,7 +7,7 @@ use crate::extn::core::array::Array;
 use crate::sys;
 use crate::types::{Int, Ruby, Rust};
 use crate::value::Value;
-use crate::{Artichoke, ConvertMut, TryConvert};
+use crate::{Artichoke, ConvertMut, TryConvertMut};
 
 // TODO(GH-28): implement `PartialEq`, `Eq`, and `Hash` on `Value`.
 // TODO(GH-29): implement `Convert<HashMap<Value, Value>>`.
@@ -72,10 +72,10 @@ impl ConvertMut<Option<HashMap<Vec<u8>, Option<Vec<u8>>>>, Value> for Artichoke 
     }
 }
 
-impl TryConvert<Value, Vec<(Value, Value)>> for Artichoke {
+impl TryConvertMut<Value, Vec<(Value, Value)>> for Artichoke {
     type Error = Exception;
 
-    fn try_convert(&self, value: Value) -> Result<Vec<(Value, Value)>, Self::Error> {
+    fn try_convert_mut(&mut self, value: Value) -> Result<Vec<(Value, Value)>, Self::Error> {
         if let Ruby::Hash = value.ruby_type() {
             let mrb = self.0.borrow().mrb;
             let hash = value.inner();
@@ -117,7 +117,9 @@ mod tests {
         if len != hash.len() {
             return false;
         }
-        let recovered = value.try_into::<Vec<(Value, Value)>>(&interp).unwrap();
+        let recovered = value
+            .try_into_mut::<Vec<(Value, Value)>>(&mut interp)
+            .unwrap();
         if recovered.len() != hash.len() {
             return false;
         }

--- a/artichoke-backend/src/exception.rs
+++ b/artichoke-backend/src/exception.rs
@@ -6,7 +6,7 @@ use std::hint;
 use crate::string;
 use crate::sys;
 use crate::value::Value;
-use crate::{Artichoke, ValueLike};
+use crate::{Artichoke, TryConvertMut, ValueLike};
 
 #[derive(Debug)]
 pub struct Exception(Box<dyn RubyException>);
@@ -169,7 +169,9 @@ impl RubyException for CaughtException {
     }
 
     fn vm_backtrace(&self, interp: &mut Artichoke) -> Option<Vec<Vec<u8>>> {
-        self.value.funcall(interp, "backtrace", &[], None).ok()
+        let backtrace = self.value.funcall(interp, "backtrace", &[], None).ok()?;
+        let backtrace = interp.try_convert_mut(backtrace).ok()?;
+        Some(backtrace)
     }
 
     fn as_mrb_value(&self, interp: &mut Artichoke) -> Option<sys::mrb_value> {

--- a/artichoke-backend/src/extn/core/array/trampoline.rs
+++ b/artichoke-backend/src/extn/core/array/trampoline.rs
@@ -128,7 +128,7 @@ pub fn reverse_bang(interp: &mut Artichoke, ary: Value) -> Result<Value, Excepti
     Ok(ary)
 }
 
-pub fn len(interp: &Artichoke, ary: Value) -> Result<usize, Exception> {
+pub fn len(interp: &mut Artichoke, ary: Value) -> Result<usize, Exception> {
     let array = unsafe { Array::try_from_ruby(interp, &ary) }?;
     let borrow = array.borrow();
     Ok(borrow.len())
@@ -144,7 +144,11 @@ pub fn initialize(
     Array::initialize(interp, first, second, block, ary)
 }
 
-pub fn initialize_copy(interp: &Artichoke, ary: Value, from: Value) -> Result<Value, Exception> {
+pub fn initialize_copy(
+    interp: &mut Artichoke,
+    ary: Value,
+    from: Value,
+) -> Result<Value, Exception> {
     let from = unsafe { Array::try_from_ruby(interp, &from) }?;
     let borrow = from.borrow();
     let result = borrow.clone();

--- a/artichoke-backend/src/extn/core/env/mod.rs
+++ b/artichoke-backend/src/extn/core/env/mod.rs
@@ -25,20 +25,26 @@ impl fmt::Debug for Environ {
 }
 
 #[cfg(feature = "core-env-system")]
-pub fn initialize(interp: &Artichoke, into: Option<sys::mrb_value>) -> Result<Value, Exception> {
+pub fn initialize(
+    interp: &mut Artichoke,
+    into: Option<sys::mrb_value>,
+) -> Result<Value, Exception> {
     use backend::system::System;
 
     let obj = Environ(Box::new(System::new()));
-    let result = obj.try_into_ruby(&interp, into)?;
+    let result = obj.try_into_ruby(interp, into)?;
     Ok(result)
 }
 
 #[cfg(not(feature = "core-env-system"))]
-pub fn initialize(interp: &Artichoke, into: Option<sys::mrb_value>) -> Result<Value, Exception> {
+pub fn initialize(
+    interp: &mut Artichoke,
+    into: Option<sys::mrb_value>,
+) -> Result<Value, Exception> {
     use backend::memory::Memory;
 
     let obj = Environ(Box::new(Memory::new()));
-    let result = obj.try_into_ruby(&interp, into)?;
+    let result = obj.try_into_ruby(interp, into)?;
     Ok(result)
 }
 

--- a/artichoke-backend/src/extn/core/env/mruby.rs
+++ b/artichoke-backend/src/extn/core/env/mruby.rs
@@ -41,8 +41,8 @@ unsafe extern "C" fn artichoke_env_initialize(
     slf: sys::mrb_value,
 ) -> sys::mrb_value {
     mrb_get_args!(mrb, none);
-    let interp = unwrap_interpreter!(mrb);
-    let result = env::initialize(&interp, Some(slf));
+    let mut interp = unwrap_interpreter!(mrb);
+    let result = env::initialize(&mut interp, Some(slf));
     match result {
         Ok(value) => value.inner(),
         Err(exception) => exception::raise(interp, exception),

--- a/artichoke-backend/src/extn/core/kernel/trampoline.rs
+++ b/artichoke-backend/src/extn/core/kernel/trampoline.rs
@@ -32,7 +32,7 @@ pub fn puts(interp: &mut Artichoke, args: Vec<Value>) -> Result<Value, Exception
         // TODO(GH-310): Use `Value::implicitly_convert_to_array` when
         // implemented so `Value`s that respond to `to_ary` are converted
         // and iterated over.
-        if let Ok(array) = value.try_into::<Vec<Value>>(interp) {
+        if let Ok(array) = value.try_into_mut::<Vec<_>>(interp) {
             for value in &array {
                 puts_foreach(interp, value);
             }

--- a/artichoke-backend/src/extn/core/numeric/mod.rs
+++ b/artichoke-backend/src/extn/core/numeric/mod.rs
@@ -117,7 +117,7 @@ pub fn coerce(interp: &mut Artichoke, x: Value, y: Value) -> Result<Coercion, Ex
                     if y.respond_to(interp, "coerce")? {
                         let coerced = y.funcall::<Value>(interp, "coerce", &[x], None)?;
                         let coerced: Vec<Value> = interp
-                            .try_convert(coerced)
+                            .try_convert_mut(coerced)
                             .map_err(|_| TypeError::new(interp, "coerce must return [x, y]"))?;
                         let mut coerced = coerced.into_iter();
                         let y = coerced

--- a/artichoke-backend/src/extn/core/time/mruby.rs
+++ b/artichoke-backend/src/extn/core/time/mruby.rs
@@ -37,8 +37,8 @@ unsafe extern "C" fn artichoke_time_self_now(
     _slf: sys::mrb_value,
 ) -> sys::mrb_value {
     mrb_get_args!(mrb, none);
-    let interp = unwrap_interpreter!(mrb);
-    let result = trampoline::now(&interp);
+    let mut interp = unwrap_interpreter!(mrb);
+    let result = trampoline::now(&mut interp);
     match result {
         Ok(value) => value.inner(),
         Err(exception) => exception::raise(interp, exception),
@@ -51,9 +51,9 @@ unsafe extern "C" fn artichoke_time_day(
     slf: sys::mrb_value,
 ) -> sys::mrb_value {
     mrb_get_args!(mrb, none);
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let time = Value::new(&interp, slf);
-    let result = trampoline::day(&interp, time);
+    let result = trampoline::day(&mut interp, time);
     match result {
         Ok(value) => value.inner(),
         Err(exception) => exception::raise(interp, exception),
@@ -66,9 +66,9 @@ unsafe extern "C" fn artichoke_time_hour(
     slf: sys::mrb_value,
 ) -> sys::mrb_value {
     mrb_get_args!(mrb, none);
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let time = Value::new(&interp, slf);
-    let result = trampoline::hour(&interp, time);
+    let result = trampoline::hour(&mut interp, time);
     match result {
         Ok(value) => value.inner(),
         Err(exception) => exception::raise(interp, exception),
@@ -81,9 +81,9 @@ unsafe extern "C" fn artichoke_time_minute(
     slf: sys::mrb_value,
 ) -> sys::mrb_value {
     mrb_get_args!(mrb, none);
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let time = Value::new(&interp, slf);
-    let result = trampoline::minute(&interp, time);
+    let result = trampoline::minute(&mut interp, time);
     match result {
         Ok(value) => value.inner(),
         Err(exception) => exception::raise(interp, exception),
@@ -96,9 +96,9 @@ unsafe extern "C" fn artichoke_time_month(
     slf: sys::mrb_value,
 ) -> sys::mrb_value {
     mrb_get_args!(mrb, none);
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let time = Value::new(&interp, slf);
-    let result = trampoline::month(&interp, time);
+    let result = trampoline::month(&mut interp, time);
     match result {
         Ok(value) => value.inner(),
         Err(exception) => exception::raise(interp, exception),
@@ -111,9 +111,9 @@ unsafe extern "C" fn artichoke_time_nanosecond(
     slf: sys::mrb_value,
 ) -> sys::mrb_value {
     mrb_get_args!(mrb, none);
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let time = Value::new(&interp, slf);
-    let result = trampoline::nanosecond(&interp, time);
+    let result = trampoline::nanosecond(&mut interp, time);
     match result {
         Ok(value) => value.inner(),
         Err(exception) => exception::raise(interp, exception),
@@ -126,9 +126,9 @@ unsafe extern "C" fn artichoke_time_second(
     slf: sys::mrb_value,
 ) -> sys::mrb_value {
     mrb_get_args!(mrb, none);
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let time = Value::new(&interp, slf);
-    let result = trampoline::second(&interp, time);
+    let result = trampoline::second(&mut interp, time);
     match result {
         Ok(value) => value.inner(),
         Err(exception) => exception::raise(interp, exception),
@@ -141,9 +141,9 @@ unsafe extern "C" fn artichoke_time_microsecond(
     slf: sys::mrb_value,
 ) -> sys::mrb_value {
     mrb_get_args!(mrb, none);
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let time = Value::new(&interp, slf);
-    let result = trampoline::microsecond(&interp, time);
+    let result = trampoline::microsecond(&mut interp, time);
     match result {
         Ok(value) => value.inner(),
         Err(exception) => exception::raise(interp, exception),
@@ -156,9 +156,9 @@ unsafe extern "C" fn artichoke_time_weekday(
     slf: sys::mrb_value,
 ) -> sys::mrb_value {
     mrb_get_args!(mrb, none);
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let time = Value::new(&interp, slf);
-    let result = trampoline::weekday(&interp, time);
+    let result = trampoline::weekday(&mut interp, time);
     match result {
         Ok(value) => value.inner(),
         Err(exception) => exception::raise(interp, exception),
@@ -171,9 +171,9 @@ unsafe extern "C" fn artichoke_time_year_day(
     slf: sys::mrb_value,
 ) -> sys::mrb_value {
     mrb_get_args!(mrb, none);
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let time = Value::new(&interp, slf);
-    let result = trampoline::year_day(&interp, time);
+    let result = trampoline::year_day(&mut interp, time);
     match result {
         Ok(value) => value.inner(),
         Err(exception) => exception::raise(interp, exception),
@@ -186,9 +186,9 @@ unsafe extern "C" fn artichoke_time_year(
     slf: sys::mrb_value,
 ) -> sys::mrb_value {
     mrb_get_args!(mrb, none);
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let time = Value::new(&interp, slf);
-    let result = trampoline::year(&interp, time);
+    let result = trampoline::year(&mut interp, time);
     match result {
         Ok(value) => value.inner(),
         Err(exception) => exception::raise(interp, exception),

--- a/artichoke-backend/src/extn/core/time/trampoline.rs
+++ b/artichoke-backend/src/extn/core/time/trampoline.rs
@@ -2,76 +2,76 @@ use crate::extn::core::time::backend::MakeTime;
 use crate::extn::core::time::{self, Time};
 use crate::extn::prelude::*;
 
-pub fn now(interp: &Artichoke) -> Result<Value, Exception> {
+pub fn now(interp: &mut Artichoke) -> Result<Value, Exception> {
     let now = Time(Box::new(time::factory().now(interp)));
-    let result = now.try_into_ruby(&interp, None)?;
+    let result = now.try_into_ruby(interp, None)?;
     Ok(result)
 }
 
-pub fn day(interp: &Artichoke, time: Value) -> Result<Value, Exception> {
+pub fn day(interp: &mut Artichoke, time: Value) -> Result<Value, Exception> {
     let time = unsafe { Time::try_from_ruby(interp, &time) }?;
     let day = time.borrow().inner().day();
     let result = interp.convert(day);
     Ok(result)
 }
 
-pub fn hour(interp: &Artichoke, time: Value) -> Result<Value, Exception> {
+pub fn hour(interp: &mut Artichoke, time: Value) -> Result<Value, Exception> {
     let time = unsafe { Time::try_from_ruby(interp, &time) }?;
     let hour = time.borrow().inner().hour();
     let result = interp.convert(hour);
     Ok(result)
 }
 
-pub fn minute(interp: &Artichoke, time: Value) -> Result<Value, Exception> {
+pub fn minute(interp: &mut Artichoke, time: Value) -> Result<Value, Exception> {
     let time = unsafe { Time::try_from_ruby(interp, &time) }?;
     let minute = time.borrow().inner().minute();
     let result = interp.convert(minute);
     Ok(result)
 }
 
-pub fn month(interp: &Artichoke, time: Value) -> Result<Value, Exception> {
+pub fn month(interp: &mut Artichoke, time: Value) -> Result<Value, Exception> {
     let time = unsafe { Time::try_from_ruby(interp, &time) }?;
     let month = time.borrow().inner().month();
     let result = interp.convert(month);
     Ok(result)
 }
 
-pub fn nanosecond(interp: &Artichoke, time: Value) -> Result<Value, Exception> {
+pub fn nanosecond(interp: &mut Artichoke, time: Value) -> Result<Value, Exception> {
     let time = unsafe { Time::try_from_ruby(interp, &time) }?;
     let nanosecond = time.borrow().inner().nanosecond();
     let result = interp.convert(nanosecond);
     Ok(result)
 }
 
-pub fn second(interp: &Artichoke, time: Value) -> Result<Value, Exception> {
+pub fn second(interp: &mut Artichoke, time: Value) -> Result<Value, Exception> {
     let time = unsafe { Time::try_from_ruby(interp, &time) }?;
     let second = time.borrow().inner().second();
     let result = interp.convert(second);
     Ok(result)
 }
 
-pub fn microsecond(interp: &Artichoke, time: Value) -> Result<Value, Exception> {
+pub fn microsecond(interp: &mut Artichoke, time: Value) -> Result<Value, Exception> {
     let time = unsafe { Time::try_from_ruby(interp, &time) }?;
     let microsecond = time.borrow().inner().microsecond();
     let result = interp.convert(microsecond);
     Ok(result)
 }
 
-pub fn weekday(interp: &Artichoke, time: Value) -> Result<Value, Exception> {
+pub fn weekday(interp: &mut Artichoke, time: Value) -> Result<Value, Exception> {
     let time = unsafe { Time::try_from_ruby(interp, &time) }?;
     let weekday = time.borrow().inner().weekday();
     let result = interp.convert(weekday);
     Ok(result)
 }
 
-pub fn year_day(interp: &Artichoke, time: Value) -> Result<Value, Exception> {
+pub fn year_day(interp: &mut Artichoke, time: Value) -> Result<Value, Exception> {
     let time = unsafe { Time::try_from_ruby(interp, &time) }?;
     let year_day = time.borrow().inner().year_day();
     let result = interp.convert(year_day);
     Ok(result)
 }
 
-pub fn year(interp: &Artichoke, time: Value) -> Result<Value, Exception> {
+pub fn year(interp: &mut Artichoke, time: Value) -> Result<Value, Exception> {
     let time = unsafe { Time::try_from_ruby(interp, &time) }?;
     let year = time.borrow().inner().year();
     let result = interp.convert(year);

--- a/artichoke-backend/src/value.rs
+++ b/artichoke-backend/src/value.rs
@@ -607,8 +607,9 @@ mod tests {
         assert!(!string_is_nil);
         let delim = interp.convert_mut("");
         let split = s
-            .funcall::<Vec<&str>>(&mut interp, "split", &[delim], None)
+            .funcall::<Value>(&mut interp, "split", &[delim], None)
             .unwrap();
+        let split: Vec<&str> = interp.try_convert_mut(split).unwrap();
         assert_eq!(split, vec!["f", "o", "o"])
     }
 

--- a/artichoke-backend/tests/leak_mrb_tt_data_rc.rs
+++ b/artichoke-backend/tests/leak_mrb_tt_data_rc.rs
@@ -48,11 +48,11 @@ unsafe extern "C" fn container_initialize(
     slf: sys::mrb_value,
 ) -> sys::mrb_value {
     let inner = mrb_get_args!(mrb, required = 1);
-    let interp = unwrap_interpreter!(mrb);
+    let mut interp = unwrap_interpreter!(mrb);
     let inner = Value::new(&interp, inner);
     let inner = inner.try_into::<String>(&interp).unwrap_or_default();
     let container = Container { inner };
-    let result = container.try_into_ruby(&interp, Some(slf));
+    let result = container.try_into_ruby(&mut interp, Some(slf));
     match result {
         Ok(value) => value.inner(),
         Err(exception) => exception::raise(interp, exception),

--- a/artichoke-backend/tests/manual.rs
+++ b/artichoke-backend/tests/manual.rs
@@ -30,20 +30,20 @@ impl Container {
         slf: sys::mrb_value,
     ) -> sys::mrb_value {
         let inner = mrb_get_args!(mrb, required = 1);
-        let interp = unwrap_interpreter!(mrb);
+        let mut interp = unwrap_interpreter!(mrb);
         let inner = Value::new(&interp, inner);
         let inner = inner.try_into::<Int>(&interp).unwrap_or_default();
         let container = Box::new(Self { inner });
         container
-            .try_into_ruby(&interp, Some(slf))
+            .try_into_ruby(&mut interp, Some(slf))
             .unwrap_or_else(|_| interp.convert(None::<Value>))
             .inner()
     }
 
     unsafe extern "C" fn value(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
-        let interp = unwrap_interpreter!(mrb);
+        let mut interp = unwrap_interpreter!(mrb);
         let value = Value::new(&interp, slf);
-        if let Ok(data) = Box::<Self>::try_from_ruby(&interp, &value) {
+        if let Ok(data) = Box::<Self>::try_from_ruby(&mut interp, &value) {
             let borrow = data.borrow();
             interp.convert(borrow.inner).inner()
         } else {

--- a/artichoke-backend/tests/obj_new_borrow_mut.rs
+++ b/artichoke-backend/tests/obj_new_borrow_mut.rs
@@ -34,7 +34,7 @@ unsafe extern "C" fn initialize(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -
 
 #[test]
 fn obj_new_borrow_mut() {
-    let interp = artichoke_backend::interpreter().expect("init");
+    let mut interp = artichoke_backend::interpreter().expect("init");
     let spec = class::Spec::new("Obj", None, None).unwrap();
     class::Builder::for_spec(&interp, &spec)
         .add_method("initialize", initialize, sys::mrb_args_none())
@@ -42,5 +42,5 @@ fn obj_new_borrow_mut() {
         .define()
         .unwrap();
     interp.0.borrow_mut().def_class::<Obj>(spec);
-    let _ = Obj.try_into_ruby(&interp, None).unwrap();
+    let _ = Obj.try_into_ruby(&mut interp, None).unwrap();
 }

--- a/artichoke-core/src/value.rs
+++ b/artichoke-core/src/value.rs
@@ -2,7 +2,7 @@
 
 use std::error;
 
-use crate::convert::TryConvert;
+use crate::convert::{TryConvert, TryConvertMut};
 
 /// A boxed Ruby value owned by the interpreter.
 ///
@@ -40,7 +40,8 @@ where
     where
         Self::Artichoke: TryConvert<Self, T, Error = Self::Error>;
 
-    /// Consume `self` and try to convert `self` to type `T`.
+    /// Consume `self` and try to convert `self` to type `T` using a
+    /// [`TryConvert`] conversion.
     ///
     /// # Errors
     ///
@@ -50,6 +51,19 @@ where
         Self::Artichoke: TryConvert<Self, T, Error = Self::Error>,
     {
         interp.try_convert(self)
+    }
+
+    /// Consume `self` and try to convert `self` to type `T` using a
+    /// [`TryConvertMut`] conversion.
+    ///
+    /// # Errors
+    ///
+    /// If a [`TryConvertMut`] conversion fails, then an error is returned.
+    fn try_into_mut<T>(self, interp: &mut Self::Artichoke) -> Result<T, Self::Error>
+    where
+        Self::Artichoke: TryConvertMut<Self, T, Error = Self::Error>,
+    {
+        interp.try_convert_mut(self)
     }
 
     /// Call `#freeze` on this [`Value`].


### PR DESCRIPTION
To prepare for closing out GH-442, the data converters need access to a
raw interpreter, which will require exclusive access.

This PR takes care of the last stragglers in the extn trampolines that
did not take `&mut Artichoke`.

This PR introduces `TryConvertMut` implementations from `Value` to a
Rust type. This introduces a split in APIs that perform conversions
automatically based on a type parameter. This PR introduces
`Value::try_into_mut` but does not introduce the corresponding
`Value::funcall_mut`.