### PR TITLE
Fixes to build and linter

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Fetch cargo-audit
+      - name: Fetch cargo-deny
         run: |
           curl -sL "$RELEASE" | sudo tar xvz -C /usr/local/bin/ --strip-components=1
         env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,8 +67,6 @@ jobs:
   rust:
     name: Lint and format Rust
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
     env:
       RUSTFLAGS: -D warnings
       RUST_BACKTRACE: 1
@@ -105,8 +103,6 @@ jobs:
   ruby:
     name: Lint and format Ruby
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -125,8 +121,6 @@ jobs:
   c:
     name: Lint and format C
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -152,8 +146,6 @@ jobs:
   text:
     name: Lint and format text
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -162,4 +154,7 @@ jobs:
         run: npx prettier --check '**/*'
 
       - name: Format markdown with prettier
-        run: npx prettier --prose-wrap always --check '**/*.md' '*.md'
+        run: npx prettier --prose-wrap always --check '**/*.md'
+
+      - name: Format YAML with prettier
+        run: npx prettier --prose-wrap always --check '**/*.{yaml,yml}'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,16 +39,16 @@ requires configuring several dependencies.
 ### Rust Toolchain
 
 Artichoke depends on Rust and several compiler plugins for linting and
-formatting. The specific version of Rust Artichoke requires is specified in the
-[toolchain file](rust-toolchain).
+formatting. The specific version of Rust that Artichoke requires is specified in
+the [toolchain file](rust-toolchain).
 
 Toolchain requirements are documented in [`BUILD.md`](BUILD.md#rust-toolchain).
 
 ### C Toolchain
 
-Some artichoke dependencies, like the mruby [`sys`](artichoke-backend/src/sys)
-and [`onig`](https://crates.io/crates/onig), build C static libraries and
-require a C compiler.
+Some Artichoke dependencies, like the mruby [`sys`](artichoke-backend/src/sys)
+module and the [`onig`](https://crates.io/crates/onig) crate, build C static
+libraries and require a C compiler.
 
 Toolchain requirements are documented in [`BUILD.md`](BUILD.md#c-toolchain).
 
@@ -67,6 +67,7 @@ $ bundle exec rake --tasks
 rake doc               # Generate Rust API documentation
 rake doc:open          # Generate Rust API documentation and open it in a web browser
 rake lint:all          # Lint and format
+rake lint:clippy       # Run clippy
 rake lint:deps         # Install linting dependencies
 rake lint:eslint       # Run eslint
 rake lint:format       # Format sources
@@ -74,6 +75,7 @@ rake lint:links        # Check markdown links
 rake lint:restriction  # Lint with restriction pass (unenforced lints)
 rake lint:rubocop      # Run rubocop
 rake spec              # Run enforced ruby/spec suite
+rake test              # Run Artichoke Rust tests
 ```
 
 To lint Ruby sources, Artichoke uses
@@ -129,7 +131,7 @@ Merges will be blocked by CI if there are lint errors.
 
 ### Testing
 
-A PR must have tests for it to be merged. The
+A PR must have new or existing tests for it to be merged. The
 [Rust book chapter on testing](https://doc.rust-lang.org/book/ch11-00-testing.html)
 is a good place to start. If you'd like to see some examples in Artichoke, take
 a look at the `Value` tests in
@@ -138,11 +140,11 @@ a look at the `Value` tests in
 To run tests:
 
 ```sh
-cargo test --workspace
+rake test
 ```
 
-If you are only working on one package, it can speed up iteration time to only
-build and run tests for that package:
+If you are only working on one crate, it can speed up iteration time to only
+build and run tests for that crate:
 
 ```sh
 cargo test -p artichoke-backend

--- a/Rakefile
+++ b/Rakefile
@@ -1,10 +1,21 @@
 # frozen_string_literal: true
 
+require 'fileutils'
+
 task default: 'lint:all'
 
 namespace :lint do
   desc 'Lint and format'
-  task all: %i[format rubocop eslint]
+  task all: %i[format clippy rubocop eslint]
+
+  desc 'Run clippy'
+  task :clippy do
+    roots = Dir.glob('**/{lib,main}.rs')
+    roots.each do |root|
+      FileUtils.touch(root)
+    end
+    sh 'cargo clippy'
+  end
 
   desc 'Run rubocop'
   task :rubocop do
@@ -14,8 +25,7 @@ namespace :lint do
   desc 'Format sources'
   task format: :deps do
     sh 'cargo fmt -- --color=auto'
-    sh "npx prettier --write '**/*'"
-    sh "npx prettier --prose-wrap always --write '**/*.md' '*.md'"
+    sh 'npm run fmt:all'
     sh 'node scripts/clang-format.js'
   end
 
@@ -80,4 +90,9 @@ end
 desc 'Run enforced ruby/spec suite'
 task :spec do
   sh 'cargo run -q -p spec-runner -- spec-runner/enforced-specs.yaml'
+end
+
+desc 'Run Artichoke Rust tests'
+task :test do
+  sh 'cargo test --workspace'
 end

--- a/package.json
+++ b/package.json
@@ -31,6 +31,9 @@
     }
   },
   "scripts": {
-    "eslint-check": "eslint --print-config package.json | eslint-config-prettier-check"
+    "fmt": "npx prettier --write '**/*'",
+    "fmt:all": "npm run fmt && npm run fmt:md && npm run fmt:yaml",
+    "fmt:md": "npx prettier --prose-wrap always --write '**/*.md'",
+    "fmt:yaml": "npx prettier --prose-wrap always --write '**/*.{yaml,yml}'"
   }
 }


### PR DESCRIPTION
- Remove `strategy.fail-fast` configution in GitHub Actions workflows
  where there is no matrix.
- Check YAML formatting in CI.
- Update text formatting CI job with Prettier 2.0-style globs.
- Clean up some copy in `CONTRIBUTING.md`.
- Add `rake lint:clippy`. This rake task touches all lib and binary
  source roots to force a clippy run. Fixes GH-638.
- Add `rake test`. Now that the Cargo workspace in this repo is not
  virtual, I always forget to add the `--workspace` argument when
  invoking `cargo test`. `rake test` is short to type and does the right
  thing.
- Move prettier formatting script definitions to `package.json` npm
  scripts. Invoke `npm run fmt:all` from `Rakefile`.