### PR TITLE
Implement Kernel#p as a trampoline method similar to Kernel#puts

### DIFF
--- a/artichoke-backend/src/extn/core/kernel/kernel_test.rb
+++ b/artichoke-backend/src/extn/core/kernel/kernel_test.rb
@@ -4,6 +4,9 @@
 # https://ruby-doc.org/core-2.6.3/Kernel.html
 def spec
   throw_catch
+  kernel_p_no_args
+  kernel_p_one_arg
+  kernel_p_array_args
 
   true
 end
@@ -38,6 +41,35 @@ def throw_catch
     456
   end
   raise unless result == 123
+end
+
+class Foo
+  attr_accessor :a, :b
+  def initialize(a, b)
+    @a = a
+    @b = b
+  end
+end
+
+# https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-p
+def kernel_p_no_args
+  result = p
+  raise if result
+end
+
+def kernel_p_one_arg
+  f = Foo.new(1, 2)
+  result = p(f)
+  raise unless result
+end
+
+def kernel_p_array_args
+  f = Foo.new(1, 2)
+  g = Foo.new(3, 4)
+  result = p(f,g)
+  raise unless result
+  raise unless result.is_a?(Array)
+  raise unless result.length == 2
 end
 
 spec if $PROGRAM_NAME == __FILE__

--- a/artichoke-backend/src/extn/core/kernel/kernel_test.rb
+++ b/artichoke-backend/src/extn/core/kernel/kernel_test.rb
@@ -44,30 +44,30 @@ def throw_catch
 end
 
 class Foo
-  attr_accessor :a, :b
-  def initialize(a, b)
-    @a = a
-    @b = b
+  attr_accessor :bar, :baz
+  def initialize(bar, baz)
+    @bar = bar
+    @baz = baz
   end
 end
 
 # https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-p
 def kernel_p_no_args
   result = p
-  raise if result
+  raise unless result.nil?
 end
 
 def kernel_p_one_arg
   f = Foo.new(1, 2)
   result = p(f)
-  raise unless result
+  raise unless result.equal?(f)
 end
 
 def kernel_p_array_args
   f = Foo.new(1, 2)
   g = Foo.new(3, 4)
-  result = p(f,g)
-  raise unless result
+  result = p(f, g)
+  raise unless result == [f, g]
   raise unless result.is_a?(Array)
   raise unless result.length == 2
 end

--- a/artichoke-backend/src/extn/core/kernel/mruby.rs
+++ b/artichoke-backend/src/extn/core/kernel/mruby.rs
@@ -17,6 +17,7 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
         .add_method("load", artichoke_kernel_load, sys::mrb_args_rest())?
         .add_method("print", artichoke_kernel_print, sys::mrb_args_rest())?
         .add_method("puts", artichoke_kernel_puts, sys::mrb_args_rest())?
+        .add_method("p", artichoke_kernel_p, sys::mrb_args_rest())?
         .define()?;
     interp.0.borrow_mut().def_module::<kernel::Kernel>(spec);
     let _ = interp.eval(&include_bytes!("kernel.rb")[..])?;
@@ -91,6 +92,24 @@ unsafe extern "C" fn artichoke_kernel_print(
         .map(|arg| Value::new(&interp, arg))
         .collect::<Vec<_>>();
     let result = trampoline::print(&mut interp, args);
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => exception::raise(interp, exception),
+    }
+}
+
+unsafe extern "C" fn artichoke_kernel_p(
+    mrb: *mut sys::mrb_state,
+    _slf: sys::mrb_value,
+) -> sys::mrb_value {
+    let args = mrb_get_args!(mrb, *args);
+    let mut interp = unwrap_interpreter!(mrb);
+    let args = args
+        .iter()
+        .copied()
+        .map(|arg| Value::new(&interp, arg))
+        .collect::<Vec<_>>();
+    let result = trampoline::p(&mut interp, args);
     match result {
         Ok(value) => value.inner(),
         Err(exception) => exception::raise(interp, exception),

--- a/artichoke-backend/src/extn/core/kernel/trampoline.rs
+++ b/artichoke-backend/src/extn/core/kernel/trampoline.rs
@@ -54,6 +54,20 @@ pub fn puts(interp: &mut Artichoke, args: Vec<Value>) -> Result<Value, Exception
     Ok(interp.convert(None::<Value>))
 }
 
+pub fn p(interp: &mut Artichoke, args: Vec<Value>) -> Result<Value, Exception> {
+    for value in &args {
+        let display = value.inspect(interp);
+        let mut borrow = interp.0.borrow_mut();
+        borrow.output.puts(display);
+    }
+
+    match args.len() {
+        0 => Ok(interp.convert(None::<Value>)),
+        1 => Ok(interp.convert(args[0].to_owned())),
+        _ => Ok(interp.convert_mut(args)),
+    }
+}
+
 pub fn require(interp: &mut Artichoke, path: Value) -> Result<Value, Exception> {
     kernel::require::require(interp, path, None)
 }

--- a/artichoke-backend/src/extn/core/kernel/trampoline.rs
+++ b/artichoke-backend/src/extn/core/kernel/trampoline.rs
@@ -54,7 +54,11 @@ pub fn puts(interp: &mut Artichoke, args: Vec<Value>) -> Result<Value, Exception
     Ok(interp.convert(None::<Value>))
 }
 
-pub fn p(interp: &mut Artichoke, args: Vec<Value>) -> Result<Value, Exception> {
+pub fn p<T>(interp: &mut Artichoke, args: T) -> Result<Value, Exception>
+where
+    T: IntoIterator<Item = Value>,
+{
+    let args = args.into_iter().collect::<Vec<_>>();
     for value in &args {
         let display = value.inspect(interp);
         let mut borrow = interp.0.borrow_mut();


### PR DESCRIPTION
Fixes #440 

I've taken a stab at implementing the `p` method in the `trampoline` of the `Kernel` module. Looking at the implementation of MRI it looks like this method is used to debug Ruby objects from C so I felt the the trampoline was a good place for it.

I also wasn't sure on how to get this under test. For the time being I added it to the `Kernel` module integration tests. I ran it against the Rubyspec tests but there were quite a few prerequisites required to run.

Let me know what you think. I'm a Rust beginner and new to working with interpreters in general, so I'm totally willing to re-work this in pure Ruby as well if the trampoline isn't a good place for this.

