### PR TITLE
Convert filename argument in LoadSources from &[u8] to AsRef<Path>

### DIFF
--- a/artichoke-backend/src/eval.rs
+++ b/artichoke-backend/src/eval.rs
@@ -120,7 +120,7 @@ mod tests {
         fn eval_context_is_a_stack() {
             let mut interp = crate::interpreter().unwrap();
             interp
-                .def_file_for_type::<NestedEval>(b"nested_eval.rb")
+                .def_file_for_type::<_, NestedEval>("nested_eval.rb")
                 .unwrap();
             let code = br#"require 'nested_eval'; NestedEval.file"#;
             let result = interp.eval(code).unwrap();
@@ -176,7 +176,7 @@ mod tests {
     fn file_magic_constant() {
         let mut interp = crate::interpreter().unwrap();
         interp
-            .def_rb_source_file(b"source.rb", &b"def file; __FILE__; end"[..])
+            .def_rb_source_file("source.rb", &b"def file; __FILE__; end"[..])
             .unwrap();
         let result = interp.eval(b"require 'source'; file").unwrap();
         let result = result.try_into::<&str>(&interp).unwrap();
@@ -187,7 +187,7 @@ mod tests {
     fn file_not_persistent() {
         let mut interp = crate::interpreter().unwrap();
         interp
-            .def_rb_source_file(b"source.rb", &b"def file; __FILE__; end"[..])
+            .def_rb_source_file("source.rb", &b"def file; __FILE__; end"[..])
             .unwrap();
         let result = interp.eval(b"require 'source'; __FILE__").unwrap();
         let result = result.try_into::<&str>(&interp).unwrap();
@@ -198,7 +198,7 @@ mod tests {
     fn return_syntax_error() {
         let mut interp = crate::interpreter().unwrap();
         interp
-            .def_rb_source_file(b"fail.rb", &b"def bad; 'as'.scan(; end"[..])
+            .def_rb_source_file("fail.rb", &b"def bad; 'as'.scan(; end"[..])
             .unwrap();
         let err = interp.eval(b"require 'fail'").unwrap_err();
         assert_eq!("SyntaxError", err.name().as_str());

--- a/artichoke-backend/src/extn/core/kernel/mod.rs
+++ b/artichoke-backend/src/extn/core/kernel/mod.rs
@@ -61,7 +61,7 @@ mod tests {
         fn integration_test() {
             let mut interp = crate::interpreter().unwrap();
             interp
-                .def_file_for_type::<IntegrationTest>(b"file.rb")
+                .def_file_for_type::<_, IntegrationTest>("file.rb")
                 .unwrap();
             let result = interp.eval(b"require 'file'").unwrap();
             let require_result = result.try_into::<bool>(&interp).unwrap();
@@ -88,7 +88,7 @@ mod tests {
         fn absolute_path() {
             let mut interp = crate::interpreter().unwrap();
             interp
-                .def_rb_source_file(b"/foo/bar/source.rb", &b"# a source file"[..])
+                .def_rb_source_file("/foo/bar/source.rb", &b"# a source file"[..])
                 .unwrap();
             let result = interp.eval(b"require '/foo/bar/source.rb'").unwrap();
             assert!(result.try_into::<bool>(&interp).unwrap());
@@ -100,10 +100,10 @@ mod tests {
         fn relative_with_dotted_path() {
             let mut interp = crate::interpreter().unwrap();
             interp
-                .def_rb_source_file(b"/foo/bar/source.rb", &b"require_relative '../bar.rb'"[..])
+                .def_rb_source_file("/foo/bar/source.rb", &b"require_relative '../bar.rb'"[..])
                 .unwrap();
             interp
-                .def_rb_source_file(b"/foo/bar.rb", &b"# a source file"[..])
+                .def_rb_source_file("/foo/bar.rb", &b"# a source file"[..])
                 .unwrap();
             let result = interp.eval(b"require '/foo/bar/source.rb'").unwrap();
             assert!(result.try_into::<bool>(&interp).unwrap());
@@ -124,10 +124,10 @@ mod tests {
         fn path_defined_as_source_then_extension_file() {
             let mut interp = crate::interpreter().unwrap();
             interp
-                .def_rb_source_file(b"foo.rb", &b"module Foo; RUBY = 3; end"[..])
+                .def_rb_source_file("foo.rb", &b"module Foo; RUBY = 3; end"[..])
                 .unwrap();
             interp
-                .def_file_for_type::<HybridRustAndRuby>(b"foo.rb")
+                .def_file_for_type::<_, HybridRustAndRuby>("foo.rb")
                 .unwrap();
             let result = interp.eval(b"require 'foo'").unwrap();
             let result = result.try_into::<bool>(&interp).unwrap();
@@ -144,10 +144,10 @@ mod tests {
         fn path_defined_as_extension_file_then_source() {
             let mut interp = crate::interpreter().unwrap();
             interp
-                .def_file_for_type::<HybridRustAndRuby>(b"foo.rb")
+                .def_file_for_type::<_, HybridRustAndRuby>("foo.rb")
                 .unwrap();
             interp
-                .def_rb_source_file(b"foo.rb", &b"module Foo; RUBY = 3; end"[..])
+                .def_rb_source_file("foo.rb", &b"module Foo; RUBY = 3; end"[..])
                 .unwrap();
             let result = interp.eval(b"require 'foo'").unwrap();
             let result = result.try_into::<bool>(&interp).unwrap();

--- a/artichoke-backend/src/extn/core/thread/mod.rs
+++ b/artichoke-backend/src/extn/core/thread/mod.rs
@@ -11,7 +11,7 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     interp.0.borrow_mut().def_class::<Thread>(spec);
     let spec = class::Spec::new("Mutex", None, None)?;
     interp.0.borrow_mut().def_class::<Mutex>(spec);
-    interp.def_rb_source_file(b"thread.rb", &include_bytes!("thread.rb")[..])?;
+    interp.def_rb_source_file("thread.rb", &include_bytes!("thread.rb")[..])?;
     // Thread is loaded by default, so eval it on interpreter initialization
     // https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/UnneededRequireStatement
     let _ = interp.eval(&b"require 'thread'"[..])?;

--- a/artichoke-backend/src/extn/stdlib/abbrev/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/abbrev/mod.rs
@@ -3,7 +3,7 @@ use crate::extn::prelude::*;
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     let spec = module::Spec::new(interp, "Abbrev", None)?;
     interp.0.borrow_mut().def_module::<Abbrev>(spec);
-    interp.def_rb_source_file(b"abbrev.rb", &include_bytes!("vendor/abbrev.rb")[..])?;
+    interp.def_rb_source_file("abbrev.rb", &include_bytes!("vendor/abbrev.rb")[..])?;
     Ok(())
 }
 

--- a/artichoke-backend/src/extn/stdlib/cmath/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/cmath/mod.rs
@@ -3,7 +3,7 @@ use crate::extn::prelude::*;
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     let spec = module::Spec::new(interp, "CMath", None)?;
     interp.0.borrow_mut().def_module::<CMath>(spec);
-    interp.def_rb_source_file(b"cmath.rb", &include_bytes!("vendor/cmath.rb")[..])?;
+    interp.def_rb_source_file("cmath.rb", &include_bytes!("vendor/cmath.rb")[..])?;
     Ok(())
 }
 

--- a/artichoke-backend/src/extn/stdlib/delegate/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/delegate/mod.rs
@@ -5,7 +5,7 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     interp.0.borrow_mut().def_class::<Delegator>(spec);
     let spec = class::Spec::new("SimpleDelegator", None, None)?;
     interp.0.borrow_mut().def_class::<SimpleDelegator>(spec);
-    interp.def_rb_source_file(b"delegate.rb", &include_bytes!("vendor/delegate.rb")[..])?;
+    interp.def_rb_source_file("delegate.rb", &include_bytes!("vendor/delegate.rb")[..])?;
     Ok(())
 }
 

--- a/artichoke-backend/src/extn/stdlib/forwardable/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/forwardable/mod.rs
@@ -4,11 +4,11 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     let spec = module::Spec::new(interp, "Forwardable", None)?;
     interp.0.borrow_mut().def_module::<Forwardable>(spec);
     interp.def_rb_source_file(
-        b"forwardable.rb",
+        "forwardable.rb",
         &include_bytes!("vendor/forwardable.rb")[..],
     )?;
     interp.def_rb_source_file(
-        b"forwardable/impl.rb",
+        "forwardable/impl.rb",
         &include_bytes!("vendor/forwardable/impl.rb")[..],
     )?;
     Ok(())

--- a/artichoke-backend/src/extn/stdlib/json/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/json/mod.rs
@@ -6,26 +6,26 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     // NOTE(lopopolo): This setup of the JSON gem in the vfs does not include
     // any of the `json/add` sources for serializing "extra" types like `Time`
     // and `BigDecimal`, not all of which Artichoke supports.
-    interp.def_rb_source_file(b"json.rb", &include_bytes!("vendor/json.rb")[..])?;
+    interp.def_rb_source_file("json.rb", &include_bytes!("vendor/json.rb")[..])?;
     interp.def_rb_source_file(
-        b"json/common.rb",
+        "json/common.rb",
         &include_bytes!("vendor/json/common.rb")[..],
     )?;
     interp.def_rb_source_file(
-        b"json/generic_object.rb",
+        "json/generic_object.rb",
         &include_bytes!("vendor/json/generic_object.rb")[..],
     )?;
     interp.def_rb_source_file(
-        b"json/version.rb",
+        "json/version.rb",
         &include_bytes!("vendor/json/version.rb")[..],
     )?;
-    interp.def_rb_source_file(b"json/pure.rb", &include_bytes!("vendor/json/pure.rb")[..])?;
+    interp.def_rb_source_file("json/pure.rb", &include_bytes!("vendor/json/pure.rb")[..])?;
     interp.def_rb_source_file(
-        b"json/pure/generator.rb",
+        "json/pure/generator.rb",
         &include_bytes!("vendor/json/pure/generator.rb")[..],
     )?;
     interp.def_rb_source_file(
-        b"json/pure/parser.rb",
+        "json/pure/parser.rb",
         &include_bytes!("vendor/json/pure/parser.rb")[..],
     )?;
     Ok(())

--- a/artichoke-backend/src/extn/stdlib/monitor/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/monitor/mod.rs
@@ -3,7 +3,7 @@ use crate::extn::prelude::*;
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     let spec = class::Spec::new("Monitor", None, None)?;
     interp.0.borrow_mut().def_class::<Monitor>(spec);
-    interp.def_rb_source_file(b"monitor.rb", &include_bytes!("vendor/monitor.rb")[..])?;
+    interp.def_rb_source_file("monitor.rb", &include_bytes!("vendor/monitor.rb")[..])?;
     Ok(())
 }
 

--- a/artichoke-backend/src/extn/stdlib/ostruct/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/ostruct/mod.rs
@@ -3,7 +3,7 @@ use crate::extn::prelude::*;
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     let spec = class::Spec::new("OpenStruct", None, None)?;
     interp.0.borrow_mut().def_class::<OpenStruct>(spec);
-    interp.def_rb_source_file(b"ostruct.rb", &include_bytes!("vendor/ostruct.rb")[..])?;
+    interp.def_rb_source_file("ostruct.rb", &include_bytes!("vendor/ostruct.rb")[..])?;
     Ok(())
 }
 

--- a/artichoke-backend/src/extn/stdlib/securerandom/mruby.rs
+++ b/artichoke-backend/src/extn/stdlib/securerandom/mruby.rs
@@ -3,7 +3,7 @@ use crate::extn::stdlib::securerandom::{self, trampoline};
 use crate::File;
 
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
-    interp.def_file_for_type::<SecureRandomFile>(&b"securerandom.rb"[..])?;
+    interp.def_file_for_type::<_, SecureRandomFile>("securerandom.rb")?;
     Ok(())
 }
 

--- a/artichoke-backend/src/extn/stdlib/set/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/set/mod.rs
@@ -5,7 +5,7 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     interp.0.borrow_mut().def_class::<Set>(spec);
     let spec = class::Spec::new("SortedSet", None, None)?;
     interp.0.borrow_mut().def_class::<SortedSet>(spec);
-    interp.def_rb_source_file(b"set.rb", &include_bytes!("vendor/set.rb")[..])?;
+    interp.def_rb_source_file("set.rb", &include_bytes!("vendor/set.rb")[..])?;
     Ok(())
 }
 

--- a/artichoke-backend/src/extn/stdlib/shellwords/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/shellwords/mod.rs
@@ -3,10 +3,7 @@ use crate::extn::prelude::*;
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     let spec = module::Spec::new(interp, "Shellwords", None)?;
     interp.0.borrow_mut().def_module::<Shellwords>(spec);
-    interp.def_rb_source_file(
-        b"shellwords.rb",
-        &include_bytes!("vendor/shellwords.rb")[..],
-    )?;
+    interp.def_rb_source_file("shellwords.rb", &include_bytes!("vendor/shellwords.rb")[..])?;
     Ok(())
 }
 

--- a/artichoke-backend/src/extn/stdlib/strscan/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/strscan/mod.rs
@@ -3,7 +3,7 @@ use crate::extn::prelude::*;
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     let spec = class::Spec::new("StringScanner", None, None)?;
     interp.0.borrow_mut().def_class::<StringScanner>(spec);
-    interp.def_rb_source_file(b"strscan.rb", &include_bytes!("strscan.rb")[..])?;
+    interp.def_rb_source_file("strscan.rb", &include_bytes!("strscan.rb")[..])?;
     Ok(())
 }
 

--- a/artichoke-backend/src/extn/stdlib/time/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/time/mod.rs
@@ -3,6 +3,6 @@ use crate::extn::prelude::*;
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     // time package does not define any additional types; it provides extension
     // methods on the `Time` core class.
-    interp.def_rb_source_file(b"time.rb", &include_bytes!("vendor/time.rb")[..])?;
+    interp.def_rb_source_file("time.rb", &include_bytes!("vendor/time.rb")[..])?;
     Ok(())
 }

--- a/artichoke-backend/src/extn/stdlib/uri/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/uri/mod.rs
@@ -10,31 +10,25 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     let spec = module::Spec::new(interp, "URI", None)?;
     interp.0.borrow_mut().def_module::<Uri>(spec);
 
-    interp.def_rb_source_file(b"uri.rb", &include_bytes!("vendor/uri.rb")[..])?;
+    interp.def_rb_source_file("uri.rb", &include_bytes!("vendor/uri.rb")[..])?;
+    interp.def_rb_source_file("uri/common.rb", &include_bytes!("vendor/uri/common.rb")[..])?;
+    interp.def_rb_source_file("uri/file.rb", &include_bytes!("vendor/uri/file.rb")[..])?;
+    interp.def_rb_source_file("uri/ftp.rb", &include_bytes!("vendor/uri/ftp.rb")[..])?;
     interp.def_rb_source_file(
-        b"uri/common.rb",
-        &include_bytes!("vendor/uri/common.rb")[..],
-    )?;
-    interp.def_rb_source_file(b"uri/file.rb", &include_bytes!("vendor/uri/file.rb")[..])?;
-    interp.def_rb_source_file(b"uri/ftp.rb", &include_bytes!("vendor/uri/ftp.rb")[..])?;
-    interp.def_rb_source_file(
-        b"uri/generic.rb",
+        "uri/generic.rb",
         &include_bytes!("vendor/uri/generic.rb")[..],
     )?;
-    interp.def_rb_source_file(b"uri/http.rb", &include_bytes!("vendor/uri/http.rb")[..])?;
-    interp.def_rb_source_file(b"uri/https.rb", &include_bytes!("vendor/uri/https.rb")[..])?;
-    interp.def_rb_source_file(b"uri/ldap.rb", &include_bytes!("vendor/uri/ldap.rb")[..])?;
-    interp.def_rb_source_file(b"uri/ldaps.rb", &include_bytes!("vendor/uri/ldaps.rb")[..])?;
+    interp.def_rb_source_file("uri/http.rb", &include_bytes!("vendor/uri/http.rb")[..])?;
+    interp.def_rb_source_file("uri/https.rb", &include_bytes!("vendor/uri/https.rb")[..])?;
+    interp.def_rb_source_file("uri/ldap.rb", &include_bytes!("vendor/uri/ldap.rb")[..])?;
+    interp.def_rb_source_file("uri/ldaps.rb", &include_bytes!("vendor/uri/ldaps.rb")[..])?;
+    interp.def_rb_source_file("uri/mailto.rb", &include_bytes!("vendor/uri/mailto.rb")[..])?;
     interp.def_rb_source_file(
-        b"uri/mailto.rb",
-        &include_bytes!("vendor/uri/mailto.rb")[..],
-    )?;
-    interp.def_rb_source_file(
-        b"uri/rfc2396_parser.rb",
+        "uri/rfc2396_parser.rb",
         &include_bytes!("vendor/uri/rfc2396_parser.rb")[..],
     )?;
     interp.def_rb_source_file(
-        b"uri/rfc3986_parser.rb",
+        "uri/rfc3986_parser.rb",
         &include_bytes!("vendor/uri/rfc3986_parser.rb")[..],
     )?;
 

--- a/artichoke-backend/tests/leak_mrb_tt_data_rc.rs
+++ b/artichoke-backend/tests/leak_mrb_tt_data_rc.rs
@@ -85,7 +85,9 @@ fn rust_backed_mrb_value_smart_pointer_leak() {
         .check_leaks_with_finalizer(
             |_| {
                 let mut interp = artichoke_backend::interpreter().unwrap();
-                interp.def_file_for_type::<Container>(b"container").unwrap();
+                interp
+                    .def_file_for_type::<_, Container>("container")
+                    .unwrap();
 
                 let code = b"require 'container'; Container.new('a' * 1024 * 1024)";
                 let result = interp.eval(code);

--- a/artichoke-backend/tests/manual.rs
+++ b/artichoke-backend/tests/manual.rs
@@ -73,7 +73,7 @@ impl File for Container {
 fn define_rust_backed_ruby_class() {
     let mut interp = artichoke_backend::interpreter().unwrap();
     interp
-        .def_file_for_type::<Container>(b"container.rb")
+        .def_file_for_type::<_, Container>("container.rb")
         .unwrap();
 
     let _ = interp.eval(b"require 'container'").unwrap();

--- a/artichoke-core/src/load.rs
+++ b/artichoke-core/src/load.rs
@@ -2,6 +2,7 @@
 
 use std::borrow::Cow;
 use std::error;
+use std::path::Path;
 
 use crate::file::File;
 
@@ -21,7 +22,7 @@ pub trait LoadSources {
     /// added to the filesystem and [`File::require`] will dynamically define
     /// Ruby items when invoked via `Kernel#require`.
     ///
-    /// If filename is a relative path, the Ruby source is added to the
+    /// If `path` is a relative path, the Ruby source is added to the
     /// filesystem relative to `RUBY_LOAD_PATH`. If the path is absolute, the
     /// file is placed directly on the filesystem. Anscestor directories are
     /// created automatically.
@@ -29,13 +30,14 @@ pub trait LoadSources {
     /// # Errors
     ///
     /// If writes to the underlying filesystem fail, an error is returned.
-    fn def_file_for_type<T>(&mut self, filename: &[u8]) -> Result<(), Self::Error>
+    fn def_file_for_type<P, T>(&mut self, path: P) -> Result<(), Self::Error>
     where
+        P: AsRef<Path>,
         T: File<Artichoke = Self::Artichoke, Error = Self::Exception>;
 
     /// Add a Ruby source to the virtual filesystem.
     ///
-    /// If filename is a relative path, the Ruby source is added to the
+    /// If `path` is a relative path, the Ruby source is added to the
     /// filesystem relative to `RUBY_LOAD_PATH`. If the path is absolute, the
     /// file is placed directly on the filesystem. Anscestor directories are
     /// created automatically.
@@ -43,7 +45,8 @@ pub trait LoadSources {
     /// # Errors
     ///
     /// If writes to the underlying filesystem fail, an error is returned.
-    fn def_rb_source_file<T>(&mut self, filename: &[u8], contents: T) -> Result<(), Self::Error>
+    fn def_rb_source_file<P, T>(&mut self, path: P, contents: T) -> Result<(), Self::Error>
     where
+        P: AsRef<Path>,
         T: Into<Cow<'static, [u8]>>;
 }

--- a/spec-runner/src/main.rs
+++ b/spec-runner/src/main.rs
@@ -125,7 +125,7 @@ pub fn try_main(config: &Path) -> Result<bool, Box<dyn Error>> {
             .any(|component| component == OsStr::new("shared"));
         if is_fixture || is_shared {
             if let Some(contents) = mspec::Sources::get(&name) {
-                interp.def_rb_source_file(name.as_bytes(), contents)?;
+                interp.def_rb_source_file(path, contents)?;
             }
             continue;
         }

--- a/spec-runner/src/mspec.rs
+++ b/spec-runner/src/mspec.rs
@@ -11,7 +11,7 @@ use artichoke_backend::{Artichoke, ConvertMut, Eval, LoadSources, TopSelf, Value
 pub fn init(interp: &mut Artichoke) -> Result<(), Exception> {
     for source in Sources::iter() {
         if let Some(content) = Sources::get(&source) {
-            interp.def_rb_source_file(source.as_bytes(), content)?;
+            interp.def_rb_source_file(source.as_ref(), content)?;
         }
     }
     Ok(())
@@ -31,10 +31,10 @@ pub fn run<'a, T>(interp: &mut Artichoke, specs: T) -> Result<bool, Exception>
 where
     T: IntoIterator<Item = &'a str>,
 {
-    interp.def_rb_source_file(b"/src/spec_helper.rb", &b""[..])?;
-    interp.def_rb_source_file(b"/src/lib/spec_helper.rb", &b""[..])?;
+    interp.def_rb_source_file("/src/spec_helper.rb", &b""[..])?;
+    interp.def_rb_source_file("/src/lib/spec_helper.rb", &b""[..])?;
     interp.def_rb_source_file(
-        b"/src/test/spec_runner",
+        "/src/test/spec_runner",
         &include_bytes!("spec_runner.rb")[..],
     )?;
     interp.eval(b"require '/src/test/spec_runner'")?;

--- a/spec-runner/src/rubyspec.rs
+++ b/spec-runner/src/rubyspec.rs
@@ -11,7 +11,7 @@ use artichoke_backend::{Artichoke, LoadSources};
 pub fn init(interp: &mut Artichoke) -> Result<(), Exception> {
     for source in Specs::iter() {
         if let Some(content) = Specs::get(&source) {
-            interp.def_rb_source_file(source.as_bytes(), content)?;
+            interp.def_rb_source_file(source.as_ref(), content)?;
         }
     }
     Ok(())


### PR DESCRIPTION
In practice these APIs are called when a `Path` is already in context
which requires marshalling to bytes only to undo that by marshalling
back to `Path`.

Converting the filename argument to be a `Path` (and renaming it to
`path`) documents the intent that this argument will load from the
filesystem. It also pushes conversions to callers _only if they are
necessary_.

This PR is required to address GH-442, which will be lifting direct
access to the VFS out of `Kernel#require` into APIs in the `LoadSources`
trait.