### PR TITLE
Treat a single dash '-' programfile argument to CLI as 'read from stdin'

### DIFF
--- a/src/ruby.rs
+++ b/src/ruby.rs
@@ -66,7 +66,7 @@ where
         Ok(Ok(()))
     } else if !opt.commands.is_empty() {
         execute_inline_eval(error, opt.commands, opt.fixture.as_deref())
-    } else if let Some(programfile) = opt.programfile {
+    } else if let Some(programfile) = opt.programfile.filter(|file| file != Path::new("-")) {
         execute_program_file(error, programfile.as_path(), opt.fixture.as_deref())
     } else {
         let mut interp = crate::interpreter()?;


### PR DESCRIPTION
Fixes GH-653.

    $ ./target/debug/artichoke - <<EOF
    puts "export RUBY_ENGINE=#{begin; Object.const_get(:RUBY_ENGINE); rescue NameError; 'ruby'; end};"
    puts "export RUBY_VERSION=#{RUBY_VERSION};"
    begin; require 'rubygems'; puts "export GEM_ROOT=#{Gem.default_dir.inspect};"; rescue LoadError; end
    EOF
    export RUBY_ENGINE=artichoke-mruby;
    export RUBY_VERSION=2.6.3;

Artichoke does not support `defined?`, so to get the chruby script to
execute, I had to replace it with `Object.const_get`.

cc @deepj