### PR TITLE
Move VFS access to LoadSources trait

### DIFF
--- a/artichoke-backend/src/extn/core/kernel/require.rs
+++ b/artichoke-backend/src/extn/core/kernel/require.rs
@@ -54,22 +54,22 @@ pub fn require(
     let file = ffi::bytes_to_os_str(filename)?;
     let path = Path::new(file);
 
-    let is_rb = path
-        .extension()
-        .filter(|ext| ext == &RUBY_EXTENSION)
-        .is_some();
     let (path, alternate) = if path.is_relative() {
         let mut path = if let Some(ref base) = base {
             base.join(path)
         } else {
             Path::new(RUBY_LOAD_PATH).join(path)
         };
-        if !is_rb {
+        let is_rb = path
+            .extension()
+            .filter(|ext| ext == &RUBY_EXTENSION)
+            .is_some();
+        if is_rb {
+            (path, None)
+        } else {
             let alternate = path.clone();
             path.set_extension(RUBY_EXTENSION);
             (path, Some(alternate))
-        } else {
-            (path, None)
         }
     } else {
         (path.to_owned(), None)

--- a/artichoke-backend/src/extn/core/kernel/trampoline.rs
+++ b/artichoke-backend/src/extn/core/kernel/trampoline.rs
@@ -15,7 +15,8 @@ pub fn integer(
 }
 
 pub fn load(interp: &mut Artichoke, path: Value) -> Result<Value, Exception> {
-    kernel::require::load(interp, path)
+    let success = kernel::require::load(interp, path)?;
+    Ok(interp.convert(success))
 }
 
 pub fn print<T>(interp: &mut Artichoke, args: T) -> Result<Value, Exception>
@@ -80,10 +81,12 @@ where
 }
 
 pub fn require(interp: &mut Artichoke, path: Value) -> Result<Value, Exception> {
-    kernel::require::require(interp, path, None)
+    let success = kernel::require::require(interp, path, None)?;
+    Ok(interp.convert(success))
 }
 
 pub fn require_relative(interp: &mut Artichoke, path: Value) -> Result<Value, Exception> {
     let relative_base = RelativePath::try_from_interp(interp)?;
-    kernel::require::require(interp, path, Some(relative_base))
+    let success = kernel::require::require(interp, path, Some(relative_base))?;
+    Ok(interp.convert(success))
 }

--- a/artichoke-backend/src/load.rs
+++ b/artichoke-backend/src/load.rs
@@ -1,23 +1,14 @@
 use std::borrow::Cow;
-use std::error;
-use std::fmt;
 use std::path::Path;
 
-use crate::core::load::State;
-use crate::exception::{Exception, RubyException};
-use crate::extn::core::exception::Fatal;
-use crate::fs::{ExtensionHook, RUBY_LOAD_PATH};
-use crate::sys;
-use crate::{Artichoke, ConvertMut, File, LoadSources};
+use crate::exception::Exception;
+use crate::fs::RUBY_LOAD_PATH;
+use crate::{Artichoke, Eval, File, LoadSources};
 
 impl LoadSources for Artichoke {
     type Artichoke = Self;
-
     type Error = Exception;
-
     type Exception = Exception;
-
-    type Extension = ExtensionHook;
 
     fn def_file_for_type<P, T>(&mut self, path: P) -> Result<(), Self::Error>
     where
@@ -68,119 +59,55 @@ impl LoadSources for Artichoke {
         Ok(is_file)
     }
 
-    fn source_require_state<P>(&self, path: P) -> Result<State, Self::Error>
+    fn load_source<P>(&mut self, path: P) -> Result<bool, Self::Error>
     where
         P: AsRef<Path>,
     {
-        let is_required = self.0.borrow().vfs.is_required(path.as_ref());
-        if is_required {
-            Ok(State::Required)
-        } else {
-            Ok(State::Default)
-        }
-    }
-
-    fn set_source_require_state<P>(&mut self, path: P, next: State) -> Result<(), Self::Error>
-    where
-        P: AsRef<Path>,
-    {
-        let current = self.source_require_state(path.as_ref())?;
-        match (current, next) {
-            (State::Default, State::Default) | (State::Required, State::Required) => {
-                // no transition. this is a no-op.
-            }
-            (State::Default, State::Required) => {
-                self.0.borrow_mut().vfs.mark_required(path.as_ref())?;
-            }
-            _ => return Err(StateTransitionError::new(current, next).into()),
-        }
-        Ok(())
-    }
-
-    fn source_extension_hook<P>(&self, path: P) -> Result<Option<Self::Extension>, Self::Error>
-    where
-        P: AsRef<Path>,
-    {
+        // Load Rust `File` first because an File may define classes and
+        // modules with `LoadSources` and Ruby files can require arbitrary
+        // other files, including some child sources that may depend on these
+        // module definitions.
         let hook = self.0.borrow().vfs.get_extension(path.as_ref());
-        Ok(hook)
+        if let Some(hook) = hook {
+            // dynamic, Rust-backed `File` require
+            hook(self)?;
+        }
+        let contents = self.read_source_file_contents(path.as_ref())?.into_owned();
+        self.eval(contents.as_ref())?;
+        trace!(r#"Successful load of {}"#, path.as_ref().display());
+        Ok(true)
     }
 
-    fn read_source_file<P>(&self, path: P) -> Result<Cow<'_, [u8]>, Self::Error>
+    fn require_source<P>(&mut self, path: P) -> Result<bool, Self::Error>
+    where
+        P: AsRef<Path>,
+    {
+        // If a file is already required, short circuit.
+        if self.0.borrow().vfs.is_required(path.as_ref()) {
+            return Ok(false);
+        }
+        // Require Rust `File` first because an File may define classes and
+        // modules with `LoadSources` and Ruby files can require arbitrary
+        // other files, including some child sources that may depend on these
+        // module definitions.
+        let hook = self.0.borrow().vfs.get_extension(path.as_ref());
+        if let Some(hook) = hook {
+            // dynamic, Rust-backed `File` require
+            hook(self)?;
+        }
+        let contents = self.read_source_file_contents(path.as_ref())?.into_owned();
+        self.eval(contents.as_ref())?;
+        self.0.borrow_mut().vfs.mark_required(path.as_ref())?;
+        trace!(r#"Successful require of {}"#, path.as_ref().display());
+        Ok(true)
+    }
+
+    fn read_source_file_contents<P>(&self, path: P) -> Result<Cow<'_, [u8]>, Self::Error>
     where
         P: AsRef<Path>,
     {
         let borrow = self.0.borrow();
         let contents = borrow.vfs.read_file(path.as_ref())?;
         Ok(contents.to_vec().into())
-    }
-}
-
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
-pub struct StateTransitionError {
-    pub current: State,
-    pub next: State,
-}
-
-impl StateTransitionError {
-    pub fn new(current: State, next: State) -> Self {
-        Self { current, next }
-    }
-}
-
-impl fmt::Display for StateTransitionError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "Invalid state transition: cannot un-require a source file"
-        )
-    }
-}
-
-impl error::Error for StateTransitionError {}
-
-impl RubyException for StateTransitionError {
-    fn message(&self) -> &[u8] {
-        &b"Invalid state transition: cannot un-require a source file"[..]
-    }
-
-    fn name(&self) -> String {
-        String::from("fatal")
-    }
-
-    fn vm_backtrace(&self, interp: &mut Artichoke) -> Option<Vec<Vec<u8>>> {
-        let _ = interp;
-        None
-    }
-
-    fn as_mrb_value(&self, interp: &mut Artichoke) -> Option<sys::mrb_value> {
-        let message = interp.convert_mut(self.message());
-        let borrow = interp.0.borrow();
-        let spec = borrow.class_spec::<Fatal>()?;
-        let value = spec.new_instance(interp, &[message])?;
-        Some(value.inner())
-    }
-}
-
-impl From<StateTransitionError> for Exception {
-    fn from(exception: StateTransitionError) -> Self {
-        Self::from(Box::<dyn RubyException>::from(exception))
-    }
-}
-
-impl From<Box<StateTransitionError>> for Exception {
-    fn from(exception: Box<StateTransitionError>) -> Self {
-        Self::from(Box::<dyn RubyException>::from(exception))
-    }
-}
-
-impl From<StateTransitionError> for Box<dyn RubyException> {
-    fn from(exception: StateTransitionError) -> Box<dyn RubyException> {
-        Box::new(exception)
-    }
-}
-
-impl From<Box<StateTransitionError>> for Box<dyn RubyException> {
-    fn from(exception: Box<StateTransitionError>) -> Box<dyn RubyException> {
-        exception
     }
 }

--- a/artichoke-backend/src/load.rs
+++ b/artichoke-backend/src/load.rs
@@ -1,9 +1,14 @@
 use std::borrow::Cow;
+use std::error;
+use std::fmt;
 use std::path::Path;
 
-use crate::exception::Exception;
-use crate::fs::RUBY_LOAD_PATH;
-use crate::{Artichoke, File, LoadSources};
+use crate::core::load::State;
+use crate::exception::{Exception, RubyException};
+use crate::extn::core::exception::Fatal;
+use crate::fs::{ExtensionHook, RUBY_LOAD_PATH};
+use crate::sys;
+use crate::{Artichoke, ConvertMut, File, LoadSources};
 
 impl LoadSources for Artichoke {
     type Artichoke = Self;
@@ -11,6 +16,8 @@ impl LoadSources for Artichoke {
     type Error = Exception;
 
     type Exception = Exception;
+
+    type Extension = ExtensionHook;
 
     fn def_file_for_type<P, T>(&mut self, path: P) -> Result<(), Self::Error>
     where
@@ -51,5 +58,129 @@ impl LoadSources for Artichoke {
             path.display()
         );
         Ok(())
+    }
+
+    fn source_is_file<P>(&self, path: P) -> Result<bool, Self::Error>
+    where
+        P: AsRef<Path>,
+    {
+        let is_file = self.0.borrow().vfs.is_file(path.as_ref());
+        Ok(is_file)
+    }
+
+    fn source_require_state<P>(&self, path: P) -> Result<State, Self::Error>
+    where
+        P: AsRef<Path>,
+    {
+        let is_required = self.0.borrow().vfs.is_required(path.as_ref());
+        if is_required {
+            Ok(State::Required)
+        } else {
+            Ok(State::Default)
+        }
+    }
+
+    fn set_source_require_state<P>(&mut self, path: P, next: State) -> Result<(), Self::Error>
+    where
+        P: AsRef<Path>,
+    {
+        let current = self.source_require_state(path.as_ref())?;
+        match (current, next) {
+            (State::Default, State::Default) | (State::Required, State::Required) => {
+                // no transition. this is a no-op.
+            }
+            (State::Default, State::Required) => {
+                self.0.borrow_mut().vfs.mark_required(path.as_ref())?;
+            }
+            _ => return Err(StateTransitionError::new(current, next).into()),
+        }
+        Ok(())
+    }
+
+    fn source_extension_hook<P>(&self, path: P) -> Result<Option<Self::Extension>, Self::Error>
+    where
+        P: AsRef<Path>,
+    {
+        let hook = self.0.borrow().vfs.get_extension(path.as_ref());
+        Ok(hook)
+    }
+
+    fn read_source_file<P>(&self, path: P) -> Result<Cow<'_, [u8]>, Self::Error>
+    where
+        P: AsRef<Path>,
+    {
+        let borrow = self.0.borrow();
+        let contents = borrow.vfs.read_file(path.as_ref())?;
+        Ok(contents.to_vec().into())
+    }
+}
+
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub struct StateTransitionError {
+    pub current: State,
+    pub next: State,
+}
+
+impl StateTransitionError {
+    pub fn new(current: State, next: State) -> Self {
+        Self { current, next }
+    }
+}
+
+impl fmt::Display for StateTransitionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Invalid state transition: cannot un-require a source file"
+        )
+    }
+}
+
+impl error::Error for StateTransitionError {}
+
+impl RubyException for StateTransitionError {
+    fn message(&self) -> &[u8] {
+        &b"Invalid state transition: cannot un-require a source file"[..]
+    }
+
+    fn name(&self) -> String {
+        String::from("fatal")
+    }
+
+    fn vm_backtrace(&self, interp: &mut Artichoke) -> Option<Vec<Vec<u8>>> {
+        let _ = interp;
+        None
+    }
+
+    fn as_mrb_value(&self, interp: &mut Artichoke) -> Option<sys::mrb_value> {
+        let message = interp.convert_mut(self.message());
+        let borrow = interp.0.borrow();
+        let spec = borrow.class_spec::<Fatal>()?;
+        let value = spec.new_instance(interp, &[message])?;
+        Some(value.inner())
+    }
+}
+
+impl From<StateTransitionError> for Exception {
+    fn from(exception: StateTransitionError) -> Self {
+        Self::from(Box::<dyn RubyException>::from(exception))
+    }
+}
+
+impl From<Box<StateTransitionError>> for Exception {
+    fn from(exception: Box<StateTransitionError>) -> Self {
+        Self::from(Box::<dyn RubyException>::from(exception))
+    }
+}
+
+impl From<StateTransitionError> for Box<dyn RubyException> {
+    fn from(exception: StateTransitionError) -> Box<dyn RubyException> {
+        Box::new(exception)
+    }
+}
+
+impl From<Box<StateTransitionError>> for Box<dyn RubyException> {
+    fn from(exception: Box<StateTransitionError>) -> Box<dyn RubyException> {
+        exception
     }
 }

--- a/artichoke-core/src/load.rs
+++ b/artichoke-core/src/load.rs
@@ -18,6 +18,9 @@ pub trait LoadSources {
     /// Concrete type for errors returned by `File::require`.
     type Exception: error::Error;
 
+    /// Concrete type for extension hooks defined by `File::require`.
+    type Extension;
+
     /// Add a Rust extension hook to the virtual filesystem. A stub Ruby file is
     /// added to the filesystem and [`File::require`] will dynamically define
     /// Ruby items when invoked via `Kernel#require`.
@@ -28,6 +31,8 @@ pub trait LoadSources {
     /// created automatically.
     ///
     /// # Errors
+    ///
+    /// If the underlying filesystem is inaccessible, an error is returned.
     ///
     /// If writes to the underlying filesystem fail, an error is returned.
     fn def_file_for_type<P, T>(&mut self, path: P) -> Result<(), Self::Error>
@@ -44,9 +49,128 @@ pub trait LoadSources {
     ///
     /// # Errors
     ///
+    /// If the underlying filesystem is inaccessible, an error is returned.
+    ///
     /// If writes to the underlying filesystem fail, an error is returned.
     fn def_rb_source_file<P, T>(&mut self, path: P, contents: T) -> Result<(), Self::Error>
     where
         P: AsRef<Path>,
         T: Into<Cow<'static, [u8]>>;
+
+    /// Test for a source file at a path.
+    ///
+    /// Query the underlying virtual filesystem to check if `path` points to a
+    /// source file.
+    ///
+    /// This function returns `false` if `path` does not exist in the virtual
+    /// filesystem.
+    ///
+    /// # Errors
+    ///
+    /// If the underlying filesystem is inaccessible, an error is returned.
+    fn source_is_file<P>(&self, path: P) -> Result<bool, Self::Error>
+    where
+        P: AsRef<Path>;
+
+    /// Retrieve the require state for a source file.
+    ///
+    /// Query the underlying virtual filesystem for the [`State`] of the source
+    /// file at `path`.
+    ///
+    /// # Errors
+    ///
+    /// If the underlying filesystem is inaccessible, an error is returned.
+    ///
+    /// If reads to the underlying filesystem fail, an error is returned.
+    ///
+    /// If `path` does not point to a source file, an error is returned.
+    fn source_require_state<P>(&self, path: P) -> Result<State, Self::Error>
+    where
+        P: AsRef<Path>;
+
+    /// Set the require state for a source file.
+    ///
+    /// Write the source require [`State`] into the underlying virtual
+    /// filesystem for the source file at `path`.
+    ///
+    /// # Errors
+    ///
+    /// If an invalid state transition occurs, an error is returned.
+    ///
+    /// If the underlying filesystem is inaccessible, an error is returned.
+    ///
+    /// If writes to the underlying filesystem fail, an error is returned.
+    ///
+    /// If `path` does not point to a source file, an error is returned.
+    fn set_source_require_state<P>(&mut self, path: P, next: State) -> Result<(), Self::Error>
+    where
+        P: AsRef<Path>;
+
+    /// Retrieve the extension hook for a source file.
+    ///
+    /// Query the underlying virtual filesystem for the optional extension hook
+    /// of the source file at `path`.
+    ///
+    /// # Errors
+    ///
+    /// If the underlying filesystem is inaccessible, an error is returned.
+    ///
+    /// If reads to the underlying filesystem fail, an error is returned.
+    ///
+    /// If `path` does not point to a source file, an error is returned.
+    fn source_extension_hook<P>(&self, path: P) -> Result<Option<Self::Extension>, Self::Error>
+    where
+        P: AsRef<Path>;
+
+    /// Retrieve file contents for a source file.
+    ///
+    /// Query the underlying virtual filesystem for the file contents of the
+    /// source file at `path`.
+    ///
+    /// # Errors
+    ///
+    /// If the underlying filesystem is inaccessible, an error is returned.
+    ///
+    /// If reads to the underlying filesystem fail, an error is returned.
+    ///
+    /// If `path` does not point to a source file, an error is returned.
+    fn read_source_file<P>(&self, path: P) -> Result<Cow<'_, [u8]>, Self::Error>
+    where
+        P: AsRef<Path>;
+}
+
+/// States in a source file's `require` lifecycle.
+///
+/// Source files are by default un-required.
+///
+/// When `Kernel#require` is invoked with a path that resolves to a source file,
+/// it's `require` state transitions to `Required`.
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub enum State {
+    /// Default require state, the feature has not been required.
+    Default,
+    /// The feature has been loaded by `Kernel#require`.
+    Required,
+}
+
+impl Default for State {
+    #[inline]
+    fn default() -> Self {
+        Self::Default
+    }
+}
+
+impl State {
+    /// Create a new, default `State`.
+    #[inline]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Whether this state represents that `Kernel#require` has loaded the feature.
+    ///
+    /// Returns `true` if `self == State::Required`.
+    pub fn is_required(self) -> bool {
+        matches!(self, Self::Required)
+    }
 }


### PR DESCRIPTION
Lift access to the `vfs` on the `State` to the interpreter level.

This PR adds high level APIs for requiring and loading sources to the `LoadSources` trait. This significantly simplifies the implmentation of `Kernel#load` and `Kernel#require`.

This PR is required for progress on GH-442, which is made easier by removing access to the `State` from `extn`.