### PR TITLE
Kernel#Integer rewrite

### DIFF
--- a/artichoke-backend/src/extn/core/kernel/kernel.rb
+++ b/artichoke-backend/src/extn/core/kernel/kernel.rb
@@ -69,9 +69,7 @@ module Kernel
     classname = arg.class
     classname = arg.inspect if arg.nil? || arg.equal?(false) || arg.equal?(true)
 
-    if arg.nil?
-      raise TypeError, "can't convert #{classname} into Integer"
-    end
+    raise TypeError, "can't convert #{classname} into Integer" if arg.nil?
 
     if arg&.respond_to?(:to_int)
       ret = arg.to_int
@@ -83,6 +81,7 @@ module Kernel
       if arg.respond_to?(:to_i)
         ret = arg.to_i
         return ret if ret.is_a?(Numeric)
+
         raise TypeError, "can't convert #{classname} to Integer (#{arg.class}#to_i gives #{ret.class})"
       end
     elsif !arg.is_a?(String) && arg && arg.respond_to?(:to_i)

--- a/artichoke-backend/src/extn/core/kernel/kernel.rb
+++ b/artichoke-backend/src/extn/core/kernel/kernel.rb
@@ -69,16 +69,22 @@ module Kernel
     classname = arg.class
     classname = arg.inspect if arg.nil? || arg.equal?(false) || arg.equal?(true)
 
+    if arg.nil?
+      raise TypeError, "can't convert #{classname} into Integer"
+    end
+
     if arg&.respond_to?(:to_int)
       ret = arg.to_int
 
       # uncritically return the value of to_int even if it is not an Integer
       return ret if ret.is_a?(Numeric)
-      return ret if ret&.scan(/\D/)&.empty? && ret&.to_i.nil?
+      return ret if !ret.nil? && ret.scan(/\D/)&.empty? && ret.to_i.nil?
 
-      ret = arg.to_i
-
-      return ret if ret.is_a?(Numeric)
+      if arg.respond_to?(:to_i)
+        ret = arg.to_i
+        return ret if ret.is_a?(Numeric)
+        raise TypeError, "can't convert #{classname} to Integer (#{arg.class}#to_i gives #{ret.class})"
+      end
     elsif !arg.is_a?(String) && arg && arg.respond_to?(:to_i)
       ret = arg.to_i
 

--- a/artichoke-backend/src/extn/core/kernel/trampoline.rs
+++ b/artichoke-backend/src/extn/core/kernel/trampoline.rs
@@ -8,6 +8,7 @@ pub fn integer(
     arg: Value,
     base: Option<Value>,
 ) -> Result<Value, Exception> {
+    let base = base.and_then(|base| interp.convert(base));
     let arg = interp.try_convert_mut(&arg)?;
     let base = interp.try_convert_mut(base)?;
     let integer = kernel::integer::method(interp, arg, base)?;

--- a/spec-runner/enforced-specs.yaml
+++ b/spec-runner/enforced-specs.yaml
@@ -47,6 +47,9 @@ core:
       - element_set # missing Errno::EINVAL implementation
       - store # missing Errno::EINVAL implementation
       - values_at # Hash#values_at is not implemented
+  - suite: kernel
+    specs:
+      - Integer
   - suite: matchdata
   - suite: math
     skip:

--- a/spec-runner/src/spec_runner.rb
+++ b/spec-runner/src/spec_runner.rb
@@ -81,6 +81,9 @@ class SpecCollector
       skipped = true if state.message =~ /'tainted\?'/
       skipped = true if state.message =~ /'untrust'/
       skipped = true if state.message =~ /'untrusted\?'/
+      skipped = true if state.message =~ /undefined method 'Rational'/
+    elsif state.exception.is_a?(NameError)
+      skipped = true if state.message =~ /uninitialized constant Bignum/
     elsif state.exception.is_a?(SpecExpectationNotMetError)
       skipped = true if state.it =~ /encoding/
       skipped = true if state.it =~ /ASCII/

--- a/spec-runner/vendor/spec/core/kernel/fixtures/classes.rb
+++ b/spec-runner/vendor/spec/core/kernel/fixtures/classes.rb
@@ -425,19 +425,19 @@ module KernelSpecs
     def f3_call_lineno; method(:f4).source_location[1] + 1; end
   end
 
-  CustomRangeInteger = Struct.new(:value) do
-    def to_int; value; end
-    def <=>(other); to_int <=> other.to_int; end
-    def -(other); self.class.new(to_int - other.to_int); end
-    def +(other); self.class.new(to_int + other.to_int); end
-  end
+  # CustomRangeInteger = Struct.new(:value) do
+  #   def to_int; value; end
+  #   def <=>(other); to_int <=> other.to_int; end
+  #   def -(other); self.class.new(to_int - other.to_int); end
+  #   def +(other); self.class.new(to_int + other.to_int); end
+  # end
 
-  CustomRangeFloat = Struct.new(:value) do
-    def to_f; value; end
-    def <=>(other); to_f <=> other.to_f; end
-    def -(other); to_f - other.to_f; end
-    def +(other); self.class.new(to_f + other.to_f); end
-  end
+  # CustomRangeFloat = Struct.new(:value) do
+  #   def to_f; value; end
+  #   def <=>(other); to_f <=> other.to_f; end
+  #   def -(other); to_f - other.to_f; end
+  #   def +(other); self.class.new(to_f + other.to_f); end
+  # end
 end
 
 class EvalSpecs


### PR DESCRIPTION
Fix a regression in ruby/spec compliance of `Kernel#Integer`

This is the fourth iteration of this standard library function (third near-complete rewrite).

Refactoring the `Kernel` `extn` module to use trampolines introduced a
regression in parsing the `base` parameter. `base` is an optional
parameter that is also `nil`able. This PR flattens the `nil`able `Value`
into `Option<Value>`.

This PR rewrites the state machine used in parsing the numeric
`String`s. State transitions are moved into the `ParseState`. Each
transition consumes the state and returns a new state. Fallible
transitions are clearly marked by their return types and the main parse
loop is readable by high level operation. Extracting the `src` `String`
and parsed radix now consumes the `ParseState`.

`match` arms are significantly simplified. `ParseState::parse` uses
slice patterns to avoid allocations and transiting through `collect`.

Default and `new` methods make constructing the state machine easier to
scan when reading the source.

Add `Kernel#Integer` to `enforced-specs.yaml`

All `Kernel#Integer` specs pass apart from 4 that reference either
`Bignum` or `Rational`.

The `Kernel` specs define two fixture classes as subclasses of
`Struct.new`. Artichoke does not support `Struct`. These fixtures, which
we do not use yet, are commented out.

Artichoke passes 1685 specs now 🎉 💎

<img width="1202" alt="Screen Shot 2020-05-02 at 12 07 16 PM" src="https://user-images.githubusercontent.com/860434/80875355-9bb7e480-8c6f-11ea-81b5-2ffaf54f84ac.png">
