### PR TITLE
Add Io trait for puts and print capabilities on the interpreter

### DIFF
--- a/artichoke-backend/README.md
+++ b/artichoke-backend/README.md
@@ -21,7 +21,8 @@ The `artichoke-backend` interpreter implements
 [`Eval` from `artichoke-core`](https://artichoke.github.io/artichoke/artichoke_core/eval/trait.Eval.html).
 
 ```rust
-use artichoke_backend::{Eval, ValueLike, exception::Exception};
+use artichoke_backend::prelude::core::*;
+use artichoke_backend::prelude::*;
 
 fn example() -> Result<(), Exception> {
     let mut interp = artichoke_backend::interpreter()?;
@@ -39,7 +40,8 @@ fn example() -> Result<(), Exception> {
 which enables calling Ruby functions from Rust.
 
 ```rust
-use artichoke_backend::{Eval, ValueLike, exception::Exception};
+use artichoke_backend::prelude::core::*;
+use artichoke_backend::prelude::*;
 
 fn example() -> Result<(), Exception> {
     let mut interp = artichoke_backend::interpreter()?;

--- a/artichoke-backend/src/constant.rs
+++ b/artichoke-backend/src/constant.rs
@@ -1,10 +1,11 @@
 use std::ffi::CString;
 
+use crate::core::DefineConstant;
 use crate::def::{ConstantNameError, NotDefinedError};
 use crate::exception::Exception;
 use crate::sys;
 use crate::value::Value;
-use crate::{Artichoke, DefineConstant};
+use crate::Artichoke;
 
 impl DefineConstant for Artichoke {
     type Value = Value;

--- a/artichoke-backend/src/convert.rs
+++ b/artichoke-backend/src/convert.rs
@@ -1,12 +1,13 @@
 use std::error;
 use std::fmt;
 
+use crate::core::{Convert, ConvertMut, TryConvert, TryConvertMut};
 use crate::exception::{Exception, RubyException};
 use crate::extn::core::exception::TypeError;
 use crate::sys;
 use crate::types::{Ruby, Rust};
 use crate::value::Value;
-use crate::{Artichoke, Convert, ConvertMut, TryConvert, TryConvertMut};
+use crate::Artichoke;
 
 mod array;
 mod boolean;

--- a/artichoke-backend/src/convert/array.rs
+++ b/artichoke-backend/src/convert/array.rs
@@ -1,11 +1,12 @@
 use std::iter::FromIterator;
 
 use crate::convert::{RustBackedValue, UnboxRubyError};
+use crate::core::{Convert, ConvertMut, TryConvert, TryConvertMut};
 use crate::exception::Exception;
 use crate::extn::core::array::{Array, InlineBuffer};
 use crate::types::{Int, Ruby, Rust};
 use crate::value::Value;
-use crate::{Artichoke, Convert, ConvertMut, TryConvert, TryConvertMut};
+use crate::Artichoke;
 
 impl ConvertMut<&[Value], Value> for Artichoke {
     fn convert_mut(&mut self, value: &[Value]) -> Value {

--- a/artichoke-backend/src/convert/boolean.rs
+++ b/artichoke-backend/src/convert/boolean.rs
@@ -1,9 +1,10 @@
 use crate::convert::UnboxRubyError;
+use crate::core::{Convert, TryConvert};
 use crate::exception::Exception;
 use crate::sys;
 use crate::types::{Ruby, Rust};
 use crate::value::Value;
-use crate::{Artichoke, Convert, TryConvert};
+use crate::Artichoke;
 
 impl Convert<bool, Value> for Artichoke {
     fn convert(&self, value: bool) -> Value {

--- a/artichoke-backend/src/convert/bytes.rs
+++ b/artichoke-backend/src/convert/bytes.rs
@@ -3,12 +3,13 @@ use std::ffi::{CStr, OsStr, OsString};
 use std::slice;
 
 use crate::convert::UnboxRubyError;
+use crate::core::{ConvertMut, TryConvert, TryConvertMut};
 use crate::exception::Exception;
 use crate::ffi;
 use crate::sys;
 use crate::types::{Ruby, Rust};
 use crate::value::Value;
-use crate::{Artichoke, ConvertMut, TryConvert, TryConvertMut};
+use crate::Artichoke;
 
 impl ConvertMut<Vec<u8>, Value> for Artichoke {
     fn convert_mut(&mut self, value: Vec<u8>) -> Value {

--- a/artichoke-backend/src/convert/fixnum.rs
+++ b/artichoke-backend/src/convert/fixnum.rs
@@ -1,11 +1,12 @@
 use std::convert::TryFrom;
 
 use crate::convert::{BoxIntoRubyError, UnboxRubyError};
+use crate::core::{Convert, TryConvert};
 use crate::exception::Exception;
 use crate::sys;
 use crate::types::{Int, Ruby, Rust};
 use crate::value::Value;
-use crate::{Artichoke, Convert, TryConvert};
+use crate::Artichoke;
 
 impl Convert<u8, Value> for Artichoke {
     #[inline]

--- a/artichoke-backend/src/convert/float.rs
+++ b/artichoke-backend/src/convert/float.rs
@@ -1,9 +1,10 @@
 use crate::convert::UnboxRubyError;
+use crate::core::{ConvertMut, TryConvert};
 use crate::exception::Exception;
 use crate::sys;
 use crate::types::{Fp, Ruby, Rust};
 use crate::value::Value;
-use crate::{Artichoke, ConvertMut, TryConvert};
+use crate::Artichoke;
 
 // TODO: when ,mruby is gone, float conversion should not allocate.
 impl ConvertMut<Fp, Value> for Artichoke {

--- a/artichoke-backend/src/convert/hash.rs
+++ b/artichoke-backend/src/convert/hash.rs
@@ -2,12 +2,13 @@ use std::collections::HashMap;
 use std::convert::TryFrom;
 
 use crate::convert::{RustBackedValue, UnboxRubyError};
+use crate::core::{ConvertMut, TryConvertMut};
 use crate::exception::Exception;
 use crate::extn::core::array::Array;
 use crate::sys;
 use crate::types::{Int, Ruby, Rust};
 use crate::value::Value;
-use crate::{Artichoke, ConvertMut, TryConvertMut};
+use crate::Artichoke;
 
 // TODO(GH-28): implement `PartialEq`, `Eq`, and `Hash` on `Value`.
 // TODO(GH-29): implement `Convert<HashMap<Value, Value>>`.

--- a/artichoke-backend/src/convert/nilable.rs
+++ b/artichoke-backend/src/convert/nilable.rs
@@ -1,11 +1,12 @@
 //! Converters for nilable primitive Ruby types. Excludes collection types
 //! Array and Hash.
 
+use crate::core::{Convert, ConvertMut, TryConvert};
 use crate::exception::Exception;
 use crate::sys;
 use crate::types::{Int, Ruby};
 use crate::value::Value;
-use crate::{Artichoke, Convert, ConvertMut, TryConvert};
+use crate::Artichoke;
 
 impl Convert<Option<Value>, Value> for Artichoke {
     fn convert(&self, value: Option<Value>) -> Value {

--- a/artichoke-backend/src/convert/string.rs
+++ b/artichoke-backend/src/convert/string.rs
@@ -1,10 +1,11 @@
 use std::str;
 
 use crate::convert::UnboxRubyError;
+use crate::core::{ConvertMut, TryConvert};
 use crate::exception::Exception;
 use crate::types::Rust;
 use crate::value::Value;
-use crate::{Artichoke, ConvertMut, TryConvert};
+use crate::Artichoke;
 
 impl ConvertMut<String, Value> for Artichoke {
     fn convert_mut(&mut self, value: String) -> Value {

--- a/artichoke-backend/src/def.rs
+++ b/artichoke-backend/src/def.rs
@@ -9,11 +9,12 @@ use std::rc::Rc;
 
 use crate::class;
 use crate::convert::RustBackedValue;
+use crate::core::ConvertMut;
 use crate::exception::{Exception, RubyException};
 use crate::extn::core::exception::{NameError, ScriptError};
 use crate::module;
 use crate::sys;
-use crate::{Artichoke, ConvertMut};
+use crate::Artichoke;
 
 /// Typedef for an mruby free function for an [`mrb_value`](sys::mrb_value) with
 /// `tt` [`MRB_TT_DATA`](sys::mrb_vtype::MRB_TT_DATA).

--- a/artichoke-backend/src/eval.rs
+++ b/artichoke-backend/src/eval.rs
@@ -1,12 +1,13 @@
 use std::ffi::OsStr;
 
+use crate::core::Eval;
 use crate::exception::Exception;
 use crate::exception_handler;
 use crate::extn::core::exception::Fatal;
 use crate::ffi;
 use crate::sys::{self, protect};
 use crate::value::Value;
-use crate::{Artichoke, Eval};
+use crate::Artichoke;
 
 impl Eval for Artichoke {
     type Value = Value;

--- a/artichoke-backend/src/exception.rs
+++ b/artichoke-backend/src/exception.rs
@@ -3,10 +3,11 @@ use std::error;
 use std::fmt;
 use std::hint;
 
+use crate::core::{TryConvertMut, Value as _};
 use crate::string;
 use crate::sys;
 use crate::value::Value;
-use crate::{Artichoke, TryConvertMut, ValueLike};
+use crate::Artichoke;
 
 #[derive(Debug)]
 pub struct Exception(Box<dyn RubyException>);

--- a/artichoke-backend/src/exception_handler.rs
+++ b/artichoke-backend/src/exception_handler.rs
@@ -1,7 +1,8 @@
+use crate::core::Value as _;
 use crate::exception::{CaughtException, Exception};
 use crate::gc::MrbGarbageCollection;
 use crate::value::Value;
-use crate::{Artichoke, ValueLike};
+use crate::Artichoke;
 
 /// Transform a `Exception` Ruby `Value` into an [`Exception`].
 ///

--- a/artichoke-backend/src/extn/core/kernel/require.rs
+++ b/artichoke-backend/src/extn/core/kernel/require.rs
@@ -7,7 +7,6 @@ use crate::extn::prelude::*;
 use crate::ffi;
 use crate::fs::RUBY_LOAD_PATH;
 use crate::state::parser::Context;
-use crate::Parser;
 
 const RUBY_EXTENSION: &str = "rb";
 

--- a/artichoke-backend/src/extn/core/numeric/mod.rs
+++ b/artichoke-backend/src/extn/core/numeric/mod.rs
@@ -57,7 +57,7 @@ pub enum Coercion {
 /// # Examples
 ///
 /// ```
-/// # use artichoke_backend::{Convert, ConvertMut};
+/// # use artichoke_backend::prelude::core::*;
 /// # use artichoke_backend::extn::core::numeric::{self, Coercion};
 /// # fn main() -> Result<(), Box<std::error::Error>> {
 /// # let mut interp = artichoke_backend::interpreter()?;

--- a/artichoke-backend/src/extn/prelude.rs
+++ b/artichoke-backend/src/extn/prelude.rs
@@ -1,25 +1,30 @@
-//! Prelude for [`extn`](crate::extn) development.
+//! A "prelude" for users of the `extn` module in the `artichoke-backend`
+//! crate.
 //!
-//! Include this module in a source with:
+//! This prelude is similar to the standard library's prelude in that you'll
+//! almost always want to import its entire contents, but unlike the standard
+//! library's prelude, you'll have to do so manually:
 //!
-//! ```rust,ignore
-//! use crate::extn::prelude::*;
 //! ```
+//! use artichoke_backend::extn::prelude::*;
+//! ```
+//!
+//! This prelude is most useful to include when developing functionality in the
+//! Artichoke standard library.
+//!
+//! The prelude may grow over time as additional items see ubiquitous use.
 
 pub use crate::class;
 pub use crate::convert::RustBackedValue;
+pub use crate::core::{Value as _, *};
 pub use crate::def::{self, EnclosingRubyScope, NotDefinedError};
-pub use crate::exception::{self, Exception, RubyException};
-pub use crate::extn::core::exception::*;
+pub use crate::exception;
 pub use crate::module;
+pub use crate::prelude::*;
 pub use crate::string;
 pub use crate::sys;
-pub use crate::types::{Fp, Int, Ruby};
+pub use crate::types::{Fp, Int};
 pub use crate::value::{Block, Value};
-pub use crate::{
-    Artichoke, Convert, ConvertMut, DefineConstant, Eval, File, Globals, Intern, LoadSources,
-    Parser, TryConvert, TryConvertMut, ValueLike, Warn,
-};
 
 /// Type alias for errors returned from `init` functions in
 /// [`extn`](crate::extn).

--- a/artichoke-backend/src/extn/stdlib/securerandom/mruby.rs
+++ b/artichoke-backend/src/extn/stdlib/securerandom/mruby.rs
@@ -1,6 +1,5 @@
 use crate::extn::prelude::*;
 use crate::extn::stdlib::securerandom::{self, trampoline};
-use crate::File;
 
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     interp.def_file_for_type::<_, SecureRandomFile>("securerandom.rb")?;

--- a/artichoke-backend/src/ffi.rs
+++ b/artichoke-backend/src/ffi.rs
@@ -11,11 +11,12 @@ use std::mem;
 use std::ptr::NonNull;
 use std::rc::Rc;
 
+use crate::core::ConvertMut;
 use crate::exception::{Exception, RubyException};
 use crate::extn::core::exception::{ArgumentError, Fatal};
 use crate::state::State;
 use crate::sys;
-use crate::{Artichoke, ConvertMut};
+use crate::Artichoke;
 
 /// Extract an [`Artichoke`] interpreter from the user data pointer on a
 /// [`sys::mrb_state`].

--- a/artichoke-backend/src/globals.rs
+++ b/artichoke-backend/src/globals.rs
@@ -1,9 +1,10 @@
 use std::borrow::Cow;
 
+use crate::core::{Convert, Globals, Intern};
 use crate::exception::Exception;
 use crate::sys;
 use crate::value::Value;
-use crate::{Artichoke, Convert, Globals, Intern};
+use crate::Artichoke;
 
 // TODO: Handle invalid variable names. For now this is delegated to mruby.
 

--- a/artichoke-backend/src/intern.rs
+++ b/artichoke-backend/src/intern.rs
@@ -1,7 +1,8 @@
 use std::borrow::Cow;
 
+use crate::core::Intern;
 use crate::sys;
-use crate::{Artichoke, Intern};
+use crate::Artichoke;
 
 impl Intern for Artichoke {
     type Symbol = sys::mrb_sym;

--- a/artichoke-backend/src/interpreter.rs
+++ b/artichoke-backend/src/interpreter.rs
@@ -5,13 +5,14 @@ use std::fmt;
 use std::ptr::NonNull;
 use std::rc::Rc;
 
+use crate::core::{ConvertMut, Eval};
 use crate::exception::{Exception, RubyException};
 use crate::extn;
 use crate::extn::core::exception::Fatal;
 use crate::gc::MrbGarbageCollection;
 use crate::state::State;
 use crate::sys;
-use crate::{Artichoke, ConvertMut, Eval};
+use crate::Artichoke;
 
 /// Create and initialize an [`Artichoke`] interpreter.
 ///

--- a/artichoke-backend/src/io.rs
+++ b/artichoke-backend/src/io.rs
@@ -2,10 +2,42 @@ use std::error;
 use std::fmt;
 use std::io;
 
+use crate::core::{ConvertMut, Io};
 use crate::exception::{Exception, RubyException};
 use crate::extn::core::exception;
+use crate::state::output::Output;
 use crate::sys;
-use crate::{Artichoke, ConvertMut};
+use crate::Artichoke;
+
+impl Io for Artichoke {
+    type Error = IOError;
+
+    /// Writes the given bytes to the interpreter stdout stream.
+    ///
+    /// This implementation delegates to the underlying output strategy.
+    ///
+    /// # Errors
+    ///
+    /// If the output stream encounters an error, an error is returned.
+    fn print<T: AsRef<[u8]>>(&mut self, message: T) -> Result<(), Self::Error> {
+        self.0.borrow_mut().output.write_stdout(message.as_ref())?;
+        Ok(())
+    }
+
+    /// Writes the given bytes to the interpreter stdout stream followed by a
+    /// newline.
+    ///
+    /// This implementation delegates to the underlying output strategy.
+    ///
+    /// # Errors
+    ///
+    /// If the output stream encounters an error, an error is returned.
+    fn puts<T: AsRef<[u8]>>(&mut self, message: T) -> Result<(), Self::Error> {
+        self.0.borrow_mut().output.write_stdout(message.as_ref())?;
+        self.0.borrow_mut().output.write_stdout(b"\n")?;
+        Ok(())
+    }
+}
 
 #[derive(Debug)]
 pub struct IOError {

--- a/artichoke-backend/src/lib.rs
+++ b/artichoke-backend/src/lib.rs
@@ -7,7 +7,7 @@
 
 //! # artichoke-backend
 //!
-//! `artichoke-backend` crate provides a Ruby interpreter. It currently is
+//! `artichoke-backend` crate provides a Ruby interpreter. It is currently
 //! implemented with [mruby](https://github.com/mruby/mruby) bindings exported
 //! by the [`sys`] module.
 //!
@@ -19,10 +19,11 @@
 //! ### Evaling Source Code
 //!
 //! The `artichoke-backend` interpreter implements
-//! [`Eval` from `artichoke-core`](crate::Eval).
+//! [`Eval` from `artichoke-core`](crate::prelude::core::Eval).
 //!
 //! ```rust
-//! use artichoke_backend::{Eval, ValueLike};
+//! use artichoke_backend::prelude::core::*;
+//! use artichoke_backend::prelude::*;
 //!
 //! let mut interp = artichoke_backend::interpreter().unwrap();
 //! let result = interp.eval(b"10 * 10").unwrap();
@@ -33,11 +34,12 @@
 //! ### Calling Functions on Ruby Objects
 //!
 //! [`Value`](value::Value)s returned by the `artichoke-backend` interpreter
-//! implement [`Value` from `artichoke-core`](crate::ValueLike), which enables
-//! calling Ruby functions from Rust.
+//! implement [`Value` from `artichoke-core`](crate::core::prelude::Value),
+//! which enables calling Ruby functions from Rust.
 //!
 //! ```rust
-//! use artichoke_backend::{Eval, ValueLike};
+//! use artichoke_backend::prelude::core::*;
+//! use artichoke_backend::prelude::*;
 //!
 //! let mut interp = artichoke_backend::interpreter().unwrap();
 //! let result = interp.eval(b"'ruby funcall'").unwrap();
@@ -118,24 +120,29 @@ mod warn;
 #[cfg(test)]
 mod test;
 
-pub use artichoke_core as core;
+pub use crate::interpreter::interpreter;
+pub use artichoke_core::prelude as core;
 
-pub use artichoke_core::constant::DefineConstant;
-pub use artichoke_core::convert::Convert;
-pub use artichoke_core::convert::ConvertMut;
-pub use artichoke_core::convert::TryConvert;
-pub use artichoke_core::convert::TryConvertMut;
-pub use artichoke_core::eval::Eval;
-pub use artichoke_core::file::File;
-pub use artichoke_core::globals::Globals;
-pub use artichoke_core::intern::Intern;
-pub use artichoke_core::load::LoadSources;
-pub use artichoke_core::parser::Parser;
-pub use artichoke_core::top_self::TopSelf;
-pub use artichoke_core::value::Value as ValueLike;
-pub use artichoke_core::warn::Warn;
+/// A "prelude" for users of the `artichoke-backend` crate.
+///
+/// This prelude is similar to the standard library's prelude in that you'll
+/// almost always want to import its entire contents, but unlike the standard
+/// library's prelude, you'll have to do so manually:
+///
+/// ```
+/// use artichoke_backend::prelude::*;
+/// ```
+///
+/// The prelude may grow over time as additional items see ubiquitous use.
+pub mod prelude {
+    pub use crate::core;
 
-pub use interpreter::interpreter;
+    pub use crate::exception::{raise, Exception, RubyException};
+    pub use crate::extn::core::exception::{Exception as _, *};
+    pub use crate::gc::MrbGarbageCollection;
+    pub use crate::interpreter::interpreter;
+    pub use crate::Artichoke;
+}
 
 /// Interpreter instance.
 ///

--- a/artichoke-backend/src/load.rs
+++ b/artichoke-backend/src/load.rs
@@ -1,9 +1,10 @@
 use std::borrow::Cow;
 use std::path::Path;
 
+use crate::core::{Eval, File, LoadSources};
 use crate::exception::Exception;
 use crate::fs::RUBY_LOAD_PATH;
-use crate::{Artichoke, Eval, File, LoadSources};
+use crate::Artichoke;
 
 impl LoadSources for Artichoke {
     type Artichoke = Self;

--- a/artichoke-backend/src/module.rs
+++ b/artichoke-backend/src/module.rs
@@ -6,11 +6,12 @@ use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::ptr::NonNull;
 
+use crate::core::Intern;
 use crate::def::{ConstantNameError, EnclosingRubyScope, Method, NotDefinedError};
 use crate::method;
 use crate::sys;
 use crate::value::Value;
-use crate::{Artichoke, Intern};
+use crate::Artichoke;
 
 #[derive(Debug, Clone)]
 pub struct Builder<'a> {

--- a/artichoke-backend/src/parser.rs
+++ b/artichoke-backend/src/parser.rs
@@ -1,6 +1,6 @@
 use std::ptr::NonNull;
 
-use crate::core::parser::{IncrementLinenoError, Parser};
+use crate::core::{IncrementLinenoError, Parser};
 use crate::state::parser::Context;
 use crate::Artichoke;
 

--- a/artichoke-backend/src/state/parser.rs
+++ b/artichoke-backend/src/state/parser.rs
@@ -4,7 +4,7 @@ use std::ffi::{CStr, CString};
 use std::fmt;
 use std::ptr::NonNull;
 
-use crate::core::parser::IncrementLinenoError;
+use crate::core::IncrementLinenoError;
 use crate::sys;
 
 /// Filename of the top eval context.

--- a/artichoke-backend/src/string.rs
+++ b/artichoke-backend/src/string.rs
@@ -11,10 +11,11 @@ use std::error;
 use std::fmt;
 use std::io;
 
+use crate::core::ConvertMut;
 use crate::exception::{Exception, RubyException};
 use crate::extn::core::exception::Fatal;
 use crate::sys;
-use crate::{Artichoke, ConvertMut};
+use crate::Artichoke;
 
 /// Write a UTF-8 debug representation of a byte slice into the given writer.
 ///

--- a/artichoke-backend/src/test/prelude.rs
+++ b/artichoke-backend/src/test/prelude.rs
@@ -1,23 +1,24 @@
-//! Prelude for writing tests.
+//! A "prelude" for writing tests in the `artichoke-backend` crate.
 //!
-//! Include this module in a test module with:
+//! This prelude is similar to the standard library's prelude in that you'll
+//! almost always want to import its entire contents, but unlike the standard
+//! library's prelude, you'll have to do so manually:
 //!
-//! ```rust,ignore
-//! use crate::test::prelude::*;
 //! ```
+//! use artichoke_backend::test::prelude::*;
+//! ```
+//!
+//! The prelude may grow over time as additional items see ubiquitous use.
 
 pub use crate::class;
 pub use crate::convert::RustBackedValue;
-pub use crate::def::{self, EnclosingRubyScope};
-pub use crate::exception::{self, Exception, RubyException};
-pub use crate::extn::core::exception::*;
-pub use crate::gc::MrbGarbageCollection;
+pub use crate::core::{Value as _, *};
+pub use crate::def::{self, EnclosingRubyScope, NotDefinedError};
+pub use crate::exception;
 pub use crate::module;
+pub use crate::prelude::*;
 pub use crate::state::parser::Context;
+pub use crate::string;
 pub use crate::sys;
-pub use crate::types::{Fp, Int, Ruby, Rust};
+pub use crate::types::{Fp, Int};
 pub use crate::value::{Block, Value};
-pub use crate::{
-    Artichoke, Convert, ConvertMut, DefineConstant, Eval, File, Globals, Intern, LoadSources,
-    Parser, TryConvert, TryConvertMut, ValueLike, Warn,
-};

--- a/artichoke-backend/src/top_self.rs
+++ b/artichoke-backend/src/top_self.rs
@@ -1,12 +1,14 @@
+use crate::core::TopSelf;
 use crate::sys;
 use crate::value::Value;
-use crate::{Artichoke, TopSelf};
+use crate::Artichoke;
 
 impl TopSelf for Artichoke {
     type Value = Value;
 
-    fn top_self(&self) -> Value {
+    fn top_self(&mut self) -> Value {
         let mrb = self.0.borrow().mrb;
-        Value::new(self, unsafe { sys::mrb_top_self(mrb) })
+        let top_self = unsafe { sys::mrb_top_self(mrb) };
+        Value::new(self, top_self)
     }
 }

--- a/artichoke-backend/src/types.rs
+++ b/artichoke-backend/src/types.rs
@@ -33,7 +33,7 @@ pub type Fp = f64;
 /// ```
 pub type Int = i64;
 
-pub use crate::core::types::{Ruby, Rust};
+pub use crate::core::{Ruby, Rust};
 
 /// Parse a [`Ruby`] type classifier from a [`sys::mrb_value`].
 ///

--- a/artichoke-backend/src/value.rs
+++ b/artichoke-backend/src/value.rs
@@ -2,14 +2,14 @@ use std::error;
 use std::fmt;
 use std::ptr;
 
-use crate::core::{self, value::Value as _};
+use crate::core::{Convert, ConvertMut, Intern, TryConvert, Value as ValueCore};
 use crate::exception::{Exception, RubyException};
 use crate::exception_handler;
 use crate::extn::core::exception::{ArgumentError, Fatal, TypeError};
 use crate::gc::MrbGarbageCollection;
 use crate::sys::{self, protect};
 use crate::types::{self, Int, Ruby};
-use crate::{Artichoke, Convert, ConvertMut, Intern, TryConvert};
+use crate::Artichoke;
 
 /// Max argument count for function calls including initialize and yield.
 pub const MRB_FUNCALL_ARGC_MAX: usize = 16;
@@ -198,7 +198,7 @@ impl Value {
     }
 }
 
-impl core::value::Value for Value {
+impl ValueCore for Value {
     type Artichoke = Artichoke;
     type Arg = Self;
     type Block = Self;

--- a/artichoke-backend/src/warn.rs
+++ b/artichoke-backend/src/warn.rs
@@ -1,12 +1,13 @@
 use std::fmt::Write;
 
+use crate::core::{ConvertMut, Value as _, Warn};
 use crate::def::NotDefinedError;
 use crate::exception::Exception;
 use crate::extn::core::exception::IOError;
 use crate::extn::core::warning::Warning;
 use crate::state::output::Output;
 use crate::value::Value;
-use crate::{Artichoke, ConvertMut, ValueLike, Warn};
+use crate::Artichoke;
 
 impl Warn for Artichoke {
     type Error = Exception;

--- a/artichoke-backend/tests/leak_funcall.rs
+++ b/artichoke-backend/tests/leak_funcall.rs
@@ -13,9 +13,8 @@
 //! If resident memory increases more than 10MB during the test, we likely are
 //! leaking memory.
 
-use artichoke_backend::gc::MrbGarbageCollection;
-use artichoke_backend::ConvertMut;
-use artichoke_backend::ValueLike as _;
+use artichoke_backend::prelude::core::*;
+use artichoke_backend::prelude::*;
 
 mod leak;
 

--- a/artichoke-backend/tests/leak_mrb_tt_data_rc.rs
+++ b/artichoke-backend/tests/leak_mrb_tt_data_rc.rs
@@ -18,14 +18,7 @@
 #[macro_use]
 extern crate artichoke_backend;
 
-use artichoke_backend::class;
-use artichoke_backend::convert::RustBackedValue;
-use artichoke_backend::def;
-use artichoke_backend::exception::{self, Exception};
-use artichoke_backend::gc::MrbGarbageCollection;
-use artichoke_backend::sys;
-use artichoke_backend::value::Value;
-use artichoke_backend::{Artichoke, Eval, File, LoadSources, ValueLike};
+use artichoke_backend::extn::prelude::*;
 
 mod leak;
 

--- a/artichoke-backend/tests/leak_unbounded_arena_growth.rs
+++ b/artichoke-backend/tests/leak_unbounded_arena_growth.rs
@@ -19,9 +19,8 @@
 //! This test fails before commit
 //! `a450ca7c458d0a4db6fdc60375d8c2c8482c85a7` with a fairly massive leak.
 
-use artichoke_backend::exception::RubyException;
-use artichoke_backend::gc::MrbGarbageCollection;
-use artichoke_backend::{Eval, ValueLike};
+use artichoke_backend::prelude::core::*;
+use artichoke_backend::prelude::*;
 
 mod leak;
 

--- a/artichoke-backend/tests/manual.rs
+++ b/artichoke-backend/tests/manual.rs
@@ -4,14 +4,7 @@
 #[macro_use]
 extern crate artichoke_backend;
 
-use artichoke_backend::class;
-use artichoke_backend::convert::RustBackedValue;
-use artichoke_backend::def;
-use artichoke_backend::exception::Exception;
-use artichoke_backend::sys;
-use artichoke_backend::types::Int;
-use artichoke_backend::value::Value;
-use artichoke_backend::{Artichoke, Convert, Eval, File, LoadSources, ValueLike};
+use artichoke_backend::extn::prelude::*;
 
 #[derive(Clone, Debug, Default)]
 struct Container {

--- a/artichoke-core/src/io.rs
+++ b/artichoke-core/src/io.rs
@@ -1,0 +1,30 @@
+//! I/O read and write APIs.
+
+use std::error;
+
+/// Make I/O external to the interpreter.
+pub trait Io {
+    /// Concrete error type for errors encountered when reading and writing.
+    type Error: error::Error;
+
+    /// Writes the given bytes to the interpreter stdout stream.
+    ///
+    /// # Errors
+    ///
+    /// If the output stream encounters an error, an error is returned.
+    fn print<T: AsRef<[u8]>>(&mut self, message: T) -> Result<(), Self::Error>;
+
+    /// Writes the given bytes to the interpreter stdout stream followed by a
+    /// newline.
+    ///
+    /// This default implementation uses two calls to [`Io::print`].
+    ///
+    /// # Errors
+    ///
+    /// If the output stream encounters an error, an error is returned.
+    fn puts<T: AsRef<[u8]>>(&mut self, message: T) -> Result<(), Self::Error> {
+        self.print(message.as_ref())?;
+        self.print("\n")?;
+        Ok(())
+    }
+}

--- a/artichoke-core/src/lib.rs
+++ b/artichoke-core/src/lib.rs
@@ -37,9 +37,37 @@ pub mod eval;
 pub mod file;
 pub mod globals;
 pub mod intern;
+pub mod io;
 pub mod load;
 pub mod parser;
 pub mod top_self;
 pub mod types;
 pub mod value;
 pub mod warn;
+
+/// A "prelude" for users of the `artichoke-core` crate.
+///
+/// This prelude is similar to the standard library's prelude in that you'll
+/// almost always want to import its entire contents, but unlike the standard
+/// library's prelude, you'll have to do so manually:
+///
+/// ```
+/// use artichoke_core::prelude::*;
+/// ```
+///
+/// The prelude may grow over time as additional items see ubiquitous use.
+pub mod prelude {
+    pub use crate::constant::DefineConstant;
+    pub use crate::convert::{Convert, ConvertMut, TryConvert, TryConvertMut};
+    pub use crate::eval::Eval;
+    pub use crate::file::File;
+    pub use crate::globals::Globals;
+    pub use crate::intern::Intern;
+    pub use crate::io::Io;
+    pub use crate::load::LoadSources;
+    pub use crate::parser::{IncrementLinenoError, Parser};
+    pub use crate::top_self::TopSelf;
+    pub use crate::types::{Ruby, Rust};
+    pub use crate::value::Value;
+    pub use crate::warn::Warn;
+}

--- a/artichoke-core/src/top_self.rs
+++ b/artichoke-core/src/top_self.rs
@@ -18,5 +18,5 @@ pub trait TopSelf {
     ///
     /// Top self is the root object that evaled code is executed within. Global
     /// methods, classes, and modules are defined in top self.
-    fn top_self(&self) -> Self::Value;
+    fn top_self(&mut self) -> Self::Value;
 }

--- a/spec-runner/src/main.rs
+++ b/spec-runner/src/main.rs
@@ -56,7 +56,7 @@
 #[macro_use]
 extern crate rust_embed;
 
-use artichoke_backend::LoadSources;
+use artichoke_backend::prelude::core::*;
 use std::error::Error;
 use std::ffi::OsStr;
 use std::fs;

--- a/spec-runner/src/mspec.rs
+++ b/spec-runner/src/mspec.rs
@@ -1,7 +1,7 @@
 //! Embedded `MSpec` framework.
 
-use artichoke_backend::exception::Exception;
-use artichoke_backend::{Artichoke, ConvertMut, Eval, LoadSources, TopSelf, ValueLike};
+use artichoke_backend::prelude::core::*;
+use artichoke_backend::prelude::*;
 
 /// Load `MSpec` sources into the Artichoke virtual filesystem.
 ///

--- a/spec-runner/src/rubyspec.rs
+++ b/spec-runner/src/rubyspec.rs
@@ -1,7 +1,7 @@
 //! Embedded copy of ruby/spec suites.
 
-use artichoke_backend::exception::Exception;
-use artichoke_backend::{Artichoke, LoadSources};
+use artichoke_backend::prelude::core::*;
+use artichoke_backend::prelude::*;
 
 /// Load ruby/spec sources into the Artichoke virtual filesystem.
 ///

--- a/src/backtrace.rs
+++ b/src/backtrace.rs
@@ -3,8 +3,7 @@
 use ansi_term::Style;
 use std::io;
 
-use crate::backend::exception::{Exception, RubyException};
-use crate::backend::Artichoke;
+use crate::prelude::*;
 
 /// Format an `Exception` backtrace into an [`io::Write`] suitable for
 /// displaying in a Ruby REPL.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,8 +27,9 @@
 //! You can create an interpreter and begin executing code on it:
 //!
 //! ```
-//! # use artichoke::backend::{Eval, ValueLike};
-//! # fn main() -> Result<(), artichoke::backend::exception::Exception> {
+//! # use artichoke::prelude::core::*;
+//! # use artichoke::prelude::*;
+//! # fn main() -> Result<(), Exception> {
 //! let mut interp = artichoke::interpreter()?;
 //! let result = interp.eval(b"2 + 5")?;
 //! # Ok(())
@@ -39,8 +40,9 @@
 //! Ruby boxed values and Rust native types:
 //!
 //! ```
-//! # use artichoke::backend::{ConvertMut, ValueLike};
-//! # fn main() -> Result<(), artichoke::backend::exception::Exception> {
+//! # use artichoke::prelude::core::*;
+//! # use artichoke::prelude::*;
+//! # fn main() -> Result<(), Exception> {
 //! let mut interp = artichoke::interpreter()?;
 //! let s = interp.convert_mut("💎");
 //! let codepoint = s.funcall::<u32>(&mut interp, "ord", &[] /* args */, None /* block */)?;
@@ -87,9 +89,24 @@ doc_comment::doctest!("../artichoke-core/README.md");
 doc_comment::doctest!("../spec-runner/README.md");
 
 pub use artichoke_backend as backend;
-pub use backend::interpreter;
+pub use backend::prelude::interpreter;
 
 pub mod backtrace;
 pub mod parser;
 pub mod repl;
 pub mod ruby;
+
+/// A "prelude" for users of the `artichoke-backend` crate.
+///
+/// This prelude is similar to the standard library's prelude in that you'll
+/// almost always want to import its entire contents, but unlike the standard
+/// library's prelude, you'll have to do so manually:
+///
+/// ```
+/// use artichoke::prelude::*;
+/// ```
+///
+/// The prelude may grow over time as additional items see ubiquitous use.
+pub mod prelude {
+    pub use artichoke_backend::prelude::*;
+}

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -10,12 +10,11 @@ use std::error;
 use std::fmt;
 use std::io;
 
-use crate::backend::exception::Exception;
-use crate::backend::gc::MrbGarbageCollection;
 use crate::backend::state::parser::Context;
-use crate::backend::{Artichoke, Eval, Parser as _, ValueLike};
 use crate::backtrace;
 use crate::parser::{Parser, State};
+use crate::prelude::core::{Eval, Parser as _, Value};
+use crate::prelude::*;
 
 const REPL_FILENAME: &[u8] = b"(airb)";
 

--- a/src/ruby.rs
+++ b/src/ruby.rs
@@ -8,13 +8,12 @@ use std::io;
 use std::path::{Path, PathBuf};
 use structopt::StructOpt;
 
-use crate::backend::exception::Exception;
-use crate::backend::extn::core::exception::{IOError, LoadError};
 use crate::backend::ffi;
 use crate::backend::state::parser::Context;
 use crate::backend::string;
-use crate::backend::{Artichoke, ConvertMut, Eval, Globals, Parser as _};
 use crate::backtrace;
+use crate::prelude::core::{ConvertMut, Eval, Globals, Parser};
+use crate::prelude::*;
 
 const INLINE_EVAL_SWITCH_FILENAME: &[u8] = b"-e";
 


### PR DESCRIPTION
This trait is similar to the `Warn` trait, except it allows writing to
stdout.

This change got tied up with introducing `prelude` modules in the core,
backend, and artchoke crates. Imports got reorganized in
artichoke-backend (again) which is why there is a lot of churn in this
commit.