### PR TITLE
Add interpreter-level APIs for manipulating Regexp global state

### DIFF
--- a/artichoke-backend/src/extn/core/regexp/backend/onig.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/onig.rs
@@ -225,11 +225,7 @@ impl RegexpType for Onig {
         })?;
         regexp::clear_capture_globals(interp)?;
         if let Some(captures) = self.regex.captures(haystack) {
-            interp
-                .0
-                .borrow_mut()
-                .regexp
-                .set_active_regexp_globals(captures.len());
+            interp.set_active_regexp_globals(captures.len());
             let value = interp.convert_mut(captures.at(0));
             interp.set_global_variable(regexp::LAST_MATCHED_STRING, &value)?;
 
@@ -331,11 +327,7 @@ impl RegexpType for Onig {
         };
 
         if let Some(captures) = self.regex.captures(target) {
-            interp
-                .0
-                .borrow_mut()
-                .regexp
-                .set_active_regexp_globals(captures.len());
+            interp.set_active_regexp_globals(captures.len());
 
             let value = interp.convert_mut(captures.at(0));
             interp.set_global_variable(regexp::LAST_MATCHED_STRING, &value)?;
@@ -382,11 +374,7 @@ impl RegexpType for Onig {
         })?;
         regexp::clear_capture_globals(interp)?;
         if let Some(captures) = self.regex.captures(haystack) {
-            interp
-                .0
-                .borrow_mut()
-                .regexp
-                .set_active_regexp_globals(captures.len());
+            interp.set_active_regexp_globals(captures.len());
 
             let value = interp.convert_mut(captures.at(0));
             interp.set_global_variable(regexp::LAST_MATCHED_STRING, &value)?;
@@ -527,11 +515,7 @@ impl RegexpType for Onig {
         let len = NonZeroUsize::new(self.regex.captures_len());
         if let Some(block) = block {
             if let Some(len) = len {
-                interp
-                    .0
-                    .borrow_mut()
-                    .regexp
-                    .set_active_regexp_globals(len.get());
+                interp.set_active_regexp_globals(len.get());
 
                 let mut iter = self.regex.captures_iter(haystack).peekable();
                 if iter.peek().is_none() {
@@ -580,11 +564,7 @@ impl RegexpType for Onig {
         } else {
             let mut last_pos = (0, 0);
             if let Some(len) = len {
-                interp
-                    .0
-                    .borrow_mut()
-                    .regexp
-                    .set_active_regexp_globals(len.get());
+                interp.set_active_regexp_globals(len.get());
 
                 let mut collected = vec![];
                 let mut iter = self.regex.captures_iter(haystack).peekable();

--- a/artichoke-backend/src/extn/core/regexp/backend/regex/utf8.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/regex/utf8.rs
@@ -219,11 +219,7 @@ impl RegexpType for Utf8 {
             // > capture group that corresponds to the full match.
             //
             // [docs]: https://docs.rs/regex/1.3.4/regex/struct.Captures.html#method.len
-            interp
-                .0
-                .borrow_mut()
-                .regexp
-                .set_active_regexp_globals(captures.len().checked_sub(1).unwrap_or_default());
+            interp.set_active_regexp_globals(captures.len().checked_sub(1).unwrap_or_default());
 
             let fullmatch = captures
                 .get(0)
@@ -340,11 +336,7 @@ impl RegexpType for Utf8 {
             // > capture group that corresponds to the full match.
             //
             // [docs]: https://docs.rs/regex/1.3.4/regex/struct.Captures.html#method.len
-            interp
-                .0
-                .borrow_mut()
-                .regexp
-                .set_active_regexp_globals(captures.len().checked_sub(1).unwrap_or_default());
+            interp.set_active_regexp_globals(captures.len().checked_sub(1).unwrap_or_default());
 
             let fullmatch = captures
                 .get(0)
@@ -407,11 +399,7 @@ impl RegexpType for Utf8 {
             // > capture group that corresponds to the full match.
             //
             // [docs]: https://docs.rs/regex/1.3.4/regex/struct.Captures.html#method.len
-            interp
-                .0
-                .borrow_mut()
-                .regexp
-                .set_active_regexp_globals(captures.len().checked_sub(1).unwrap_or_default());
+            interp.set_active_regexp_globals(captures.len().checked_sub(1).unwrap_or_default());
 
             let fullmatch = captures
                 .get(0)
@@ -548,11 +536,7 @@ impl RegexpType for Utf8 {
 
         // regex crate always includes the zero group in the captures len.
         let len = self.regex.captures_len().checked_sub(1);
-        interp
-            .0
-            .borrow_mut()
-            .regexp
-            .set_active_regexp_globals(len.unwrap_or_default());
+        interp.set_active_regexp_globals(len.unwrap_or_default());
         let len = len.and_then(NonZeroUsize::new);
         if let Some(block) = block {
             if let Some(len) = len {

--- a/artichoke-backend/src/extn/prelude.rs
+++ b/artichoke-backend/src/extn/prelude.rs
@@ -16,7 +16,7 @@
 
 pub use crate::class;
 pub use crate::convert::RustBackedValue;
-pub use crate::core::{Value as _, *};
+pub use crate::core::{Regexp as _, Value as _, *};
 pub use crate::def::{self, EnclosingRubyScope, NotDefinedError};
 pub use crate::exception;
 pub use crate::module;

--- a/artichoke-backend/src/lib.rs
+++ b/artichoke-backend/src/lib.rs
@@ -109,6 +109,7 @@ mod load;
 pub mod method;
 pub mod module;
 mod parser;
+mod regexp;
 pub mod state;
 pub mod string;
 pub mod sys;

--- a/artichoke-backend/src/regexp.rs
+++ b/artichoke-backend/src/regexp.rs
@@ -1,0 +1,12 @@
+use crate::core::Regexp;
+use crate::Artichoke;
+
+impl Regexp for Artichoke {
+    fn active_regexp_globals(&self) -> usize {
+        self.0.borrow().regexp.active_regexp_globals()
+    }
+
+    fn set_active_regexp_globals(&mut self, count: usize) {
+        self.0.borrow_mut().regexp.set_active_regexp_globals(count)
+    }
+}

--- a/artichoke-core/src/lib.rs
+++ b/artichoke-core/src/lib.rs
@@ -40,6 +40,7 @@ pub mod intern;
 pub mod io;
 pub mod load;
 pub mod parser;
+pub mod regexp;
 pub mod top_self;
 pub mod types;
 pub mod value;
@@ -66,6 +67,7 @@ pub mod prelude {
     pub use crate::io::Io;
     pub use crate::load::LoadSources;
     pub use crate::parser::{IncrementLinenoError, Parser};
+    pub use crate::regexp::Regexp;
     pub use crate::top_self::TopSelf;
     pub use crate::types::{Ruby, Rust};
     pub use crate::value::Value;

--- a/artichoke-core/src/regexp.rs
+++ b/artichoke-core/src/regexp.rs
@@ -1,0 +1,18 @@
+//! Track `Regexp` global state.
+
+/// Track the state of `Regexp` globals and global interpreter state.
+pub trait Regexp {
+    /// Retrieve the current number of set `Regexp` global variables.
+    ///
+    /// `Regexp` global variables like `$1` and `$7` are defined after certain
+    /// `Regexp` matching methods for each capturing group in the regular
+    /// expression.
+    fn active_regexp_globals(&self) -> usize;
+
+    /// Set the current number of set `Regexp` global variables.
+    ///
+    /// `Regexp` global variables like `$1` and `$7` are defined after certain
+    /// `Regexp` matching methods for each capturing group in the regular
+    /// expression.
+    fn set_active_regexp_globals(&mut self, count: usize);
+}


### PR DESCRIPTION
`regexp` module in `extn` no longer depends on the internals of the
Artichoke implementation.

This PR is required for GH-442.