### PR TITLE
Add interpreter-level APIs for accessing the interpreter global PRNG

### DIFF
--- a/artichoke-backend/src/extn/core/random/backend/default.rs
+++ b/artichoke-backend/src/extn/core/random/backend/default.rs
@@ -11,28 +11,23 @@ impl RandType for Default {
         self
     }
 
-    fn bytes(&mut self, interp: &mut Artichoke, buf: &mut [u8]) {
-        let mut borrow = interp.0.borrow_mut();
-        borrow.prng.bytes(buf);
+    fn bytes(&mut self, interp: &mut Artichoke, buf: &mut [u8]) -> Result<(), Exception> {
+        interp.prng_fill_bytes(buf)
     }
 
-    fn seed(&self, interp: &Artichoke) -> u64 {
-        let borrow = interp.0.borrow();
-        borrow.prng.seed()
+    fn seed(&self, interp: &Artichoke) -> Result<u64, Exception> {
+        interp.prng_seed()
     }
 
-    fn internal_state(&self, interp: &Artichoke) -> InternalState {
-        let borrow = interp.0.borrow();
-        borrow.prng.internal_state()
+    fn internal_state(&self, interp: &Artichoke) -> Result<InternalState, Exception> {
+        interp.prng_internal_state()
     }
 
-    fn rand_int(&mut self, interp: &mut Artichoke, max: Int) -> Int {
-        let mut borrow = interp.0.borrow_mut();
-        borrow.prng.rand_int(max)
+    fn rand_int(&mut self, interp: &mut Artichoke, max: Int) -> Result<Int, Exception> {
+        interp.rand_int(max)
     }
 
-    fn rand_float(&mut self, interp: &mut Artichoke, max: Option<Fp>) -> Fp {
-        let mut borrow = interp.0.borrow_mut();
-        borrow.prng.rand_float(max)
+    fn rand_float(&mut self, interp: &mut Artichoke, max: Option<Fp>) -> Result<Fp, Exception> {
+        interp.rand_float(max)
     }
 }

--- a/artichoke-backend/src/extn/core/random/backend/mod.rs
+++ b/artichoke-backend/src/extn/core/random/backend/mod.rs
@@ -11,23 +11,23 @@ pub trait RandType {
     fn as_debug(&self) -> &dyn fmt::Debug;
 
     /// Completely fill a buffer with random bytes.
-    fn bytes(&mut self, interp: &mut Artichoke, buf: &mut [u8]);
+    fn bytes(&mut self, interp: &mut Artichoke, buf: &mut [u8]) -> Result<(), Exception>;
 
     /// Return the value this backend was seeded with.
-    fn seed(&self, interp: &Artichoke) -> u64;
+    fn seed(&self, interp: &Artichoke) -> Result<u64, Exception>;
 
     /// Return true if this and `other` would return the same sequence of random
     /// data.
-    fn internal_state(&self, interp: &Artichoke) -> InternalState;
+    fn internal_state(&self, interp: &Artichoke) -> Result<InternalState, Exception>;
 
     /// Return a random `Integer` between 0 and `max` -- `[0, max)`.
-    fn rand_int(&mut self, interp: &mut Artichoke, max: Int) -> Int;
+    fn rand_int(&mut self, interp: &mut Artichoke, max: Int) -> Result<Int, Exception>;
 
     /// Return a random `Float` between 0 and `max` -- `[0, max)`.
     ///
     /// If `max` is `None`, return a random `Float between 0 and 1.0 --
     /// `[0, 1.0)`.
-    fn rand_float(&mut self, interp: &mut Artichoke, max: Option<Fp>) -> Fp;
+    fn rand_float(&mut self, interp: &mut Artichoke, max: Option<Fp>) -> Result<Fp, Exception>;
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/artichoke-backend/src/extn/core/random/backend/rand.rs
+++ b/artichoke-backend/src/extn/core/random/backend/rand.rs
@@ -80,28 +80,29 @@ where
         self
     }
 
-    fn bytes(&mut self, interp: &mut Artichoke, buf: &mut [u8]) {
+    fn bytes(&mut self, interp: &mut Artichoke, buf: &mut [u8]) -> Result<(), Exception> {
         let _ = interp;
         self.bytes(buf);
+        Ok(())
     }
 
-    fn seed(&self, interp: &Artichoke) -> u64 {
+    fn seed(&self, interp: &Artichoke) -> Result<u64, Exception> {
         let _ = interp;
-        self.seed()
+        Ok(self.seed())
     }
 
-    fn internal_state(&self, interp: &Artichoke) -> InternalState {
+    fn internal_state(&self, interp: &Artichoke) -> Result<InternalState, Exception> {
         let _ = interp;
-        self.internal_state()
+        Ok(self.internal_state())
     }
 
-    fn rand_int(&mut self, interp: &mut Artichoke, max: Int) -> Int {
+    fn rand_int(&mut self, interp: &mut Artichoke, max: Int) -> Result<Int, Exception> {
         let _ = interp;
-        self.rand_int(max)
+        Ok(self.rand_int(max))
     }
 
-    fn rand_float(&mut self, interp: &mut Artichoke, max: Option<Fp>) -> Fp {
+    fn rand_float(&mut self, interp: &mut Artichoke, max: Option<Fp>) -> Result<Fp, Exception> {
         let _ = interp;
-        self.rand_float(max)
+        Ok(self.rand_float(max))
     }
 }

--- a/artichoke-backend/src/extn/core/random/trampoline.rs
+++ b/artichoke-backend/src/extn/core/random/trampoline.rs
@@ -15,7 +15,7 @@ pub fn initialize(
 pub fn equal(interp: &mut Artichoke, rand: Value, other: Value) -> Result<Value, Exception> {
     let rand = unsafe { Random::try_from_ruby(interp, &rand)? };
     let borrow = rand.borrow();
-    let eql = borrow.eql(interp, other);
+    let eql = borrow.eql(interp, other)?;
     Ok(interp.convert(eql))
 }
 
@@ -38,7 +38,7 @@ pub fn rand(interp: &mut Artichoke, rand: Value, max: Option<Value>) -> Result<V
 pub fn seed(interp: &mut Artichoke, rand: Value) -> Result<Value, Exception> {
     let rand = unsafe { Random::try_from_ruby(interp, &rand)? };
     let borrow = rand.borrow();
-    let seed = borrow.seed(interp);
+    let seed = borrow.seed(interp)?;
     Ok(interp.convert(seed))
 }
 

--- a/artichoke-backend/src/lib.rs
+++ b/artichoke-backend/src/lib.rs
@@ -109,6 +109,7 @@ mod load;
 pub mod method;
 pub mod module;
 mod parser;
+mod prng;
 mod regexp;
 pub mod state;
 pub mod string;

--- a/artichoke-backend/src/lib.rs
+++ b/artichoke-backend/src/lib.rs
@@ -109,6 +109,7 @@ mod load;
 pub mod method;
 pub mod module;
 mod parser;
+#[cfg(feature = "core-random")]
 mod prng;
 mod regexp;
 pub mod state;

--- a/artichoke-backend/src/prng.rs
+++ b/artichoke-backend/src/prng.rs
@@ -1,0 +1,43 @@
+use crate::core::Prng;
+use crate::exception::Exception;
+use crate::extn::core::random::backend::InternalState;
+use crate::types::{Fp, Int};
+use crate::Artichoke;
+
+impl Prng for Artichoke {
+    type Error = Exception;
+    type InternalState = InternalState;
+    type Int = Int;
+    type Float = Fp;
+
+    fn prng_fill_bytes(&mut self, buf: &mut [u8]) -> Result<(), Self::Error> {
+        let mut borrow = self.0.borrow_mut();
+        borrow.prng.bytes(buf);
+        Ok(())
+    }
+
+    fn prng_seed(&self) -> Result<u64, Self::Error> {
+        let borrow = self.0.borrow();
+        Ok(borrow.prng.seed())
+    }
+
+    fn prng_reseed(&mut self, seed: Option<u64>) -> Result<(), Self::Error> {
+        self.0.borrow_mut().prng.reseed(seed);
+        Ok(())
+    }
+
+    fn prng_internal_state(&self) -> Result<Self::InternalState, Self::Error> {
+        let borrow = self.0.borrow();
+        Ok(borrow.prng.internal_state())
+    }
+
+    fn rand_int(&mut self, max: Self::Int) -> Result<Self::Int, Self::Error> {
+        let mut borrow = self.0.borrow_mut();
+        Ok(borrow.prng.rand_int(max))
+    }
+
+    fn rand_float(&mut self, max: Option<Self::Float>) -> Result<Self::Float, Self::Error> {
+        let mut borrow = self.0.borrow_mut();
+        Ok(borrow.prng.rand_float(max))
+    }
+}

--- a/artichoke-core/src/lib.rs
+++ b/artichoke-core/src/lib.rs
@@ -40,6 +40,7 @@ pub mod intern;
 pub mod io;
 pub mod load;
 pub mod parser;
+pub mod prng;
 pub mod regexp;
 pub mod top_self;
 pub mod types;
@@ -67,6 +68,7 @@ pub mod prelude {
     pub use crate::io::Io;
     pub use crate::load::LoadSources;
     pub use crate::parser::{IncrementLinenoError, Parser};
+    pub use crate::prng::Prng;
     pub use crate::regexp::Regexp;
     pub use crate::top_self::TopSelf;
     pub use crate::types::{Ruby, Rust};

--- a/artichoke-core/src/prng.rs
+++ b/artichoke-core/src/prng.rs
@@ -1,0 +1,72 @@
+//! Interpreter global psuedorandom number generator.
+
+use std::error;
+
+/// Interpreter global psuedorandom number generator.
+///
+/// Implementors of this trait back the `Random::DEFAULT` PRNG.
+pub trait Prng {
+    /// Concrete type for PRNG errors.
+    type Error: error::Error;
+
+    /// Cocnrete type representing the internal state of all PRNG backends.
+    type InternalState;
+
+    /// Conrete type for integer input and output.
+    type Int;
+
+    /// Concrete type for floating point input and output.
+    type Float;
+
+    /// Completely fill a buffer with random bytes.
+    ///
+    /// # Errors
+    ///
+    /// If the PRNG is inaccessible, an error is returned.
+    ///
+    /// If the PRNG encounters an error, an error is returned.
+    fn prng_fill_bytes(&mut self, buf: &mut [u8]) -> Result<(), Self::Error>;
+
+    /// Return the value this PRNG was seeded with.
+    ///
+    /// # Errors
+    ///
+    /// If the PRNG is inaccessible, an error is returned.
+    fn prng_seed(&self) -> Result<u64, Self::Error>;
+
+    /// Reseed the PRNG with a new seed.
+    ///
+    /// # Errors
+    ///
+    /// If the PRNG is inaccessible, an error is returned.
+    fn prng_reseed(&mut self, seed: Option<u64>) -> Result<(), Self::Error>;
+
+    /// Return true if this and `other` would return the same sequence of random
+    /// data.
+    ///
+    /// # Errors
+    ///
+    /// If the PRNG is inaccessible, an error is returned.
+    fn prng_internal_state(&self) -> Result<Self::InternalState, Self::Error>;
+
+    /// Return a random `Integer` between 0 and `max` -- `[0, max)`.
+    ///
+    /// # Errors
+    ///
+    /// If the PRNG is inaccessible, an error is returned.
+    ///
+    /// If the PRNG encounters an error, an error is returned.
+    fn rand_int(&mut self, max: Self::Int) -> Result<Self::Int, Self::Error>;
+
+    /// Return a random `Float` between 0 and `max` -- `[0, max)`.
+    ///
+    /// If `max` is `None`, return a random `Float between 0 and 1.0 --
+    /// `[0, 1.0)`.
+    ///
+    /// # Errors
+    ///
+    /// If the PRNG is inaccessible, an error is returned.
+    ///
+    /// If the PRNG encounters an error, an error is returned.
+    fn rand_float(&mut self, max: Option<Self::Float>) -> Result<Self::Float, Self::Error>;
+}


### PR DESCRIPTION
`random` module in `extn` no longer depends on the internals of the
Artichoke implementation.

This PR is required for GH-442.