### PR TITLE
Remove caching from GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,33 +23,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Set toolchain versions
-        run: |
-          echo "::set-output name=rust::$(cat rust-toolchain)"
-        id: toolchain_versions
-
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-
-      - name: Cache cargo registry
-        uses: actions/cache@v1
-        with:
-          path: ~/.cargo/registry
-          key: cargo-registry-${{ github.workflow }}-${{ github.job_id }}-${{ runner.os }}-rust-${{ steps.toolchain_versions.outputs.rust }}-${{ hashFiles('**/Cargo.toml') }}
-
-      - name: Cache cargo index
-        uses: actions/cache@v1
-        with:
-          path: ~/.cargo/git
-          key: cargo-index-${{ github.workflow }}-${{ github.job_id }}-${{ runner.os }}-rust-${{ steps.toolchain_versions.outputs.rust }}-${{ hashFiles('**/Cargo.toml') }}
-
-      - name: Cache cargo build
-        uses: actions/cache@v1
-        with:
-          path: target
-          key: cargo-build-target-${{ github.workflow }}-${{ github.job_id }}-${{ runner.os }}-rust-${{ steps.toolchain_versions.outputs.rust }}-${{ hashFiles('**/Cargo.toml') }}
 
       - name: Install Ruby toolchain
         uses: ruby/setup-ruby@v1
@@ -93,34 +70,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Set toolchain versions
-        run: |
-          echo "::set-output name=rust::$(cat rust-toolchain)"
-        id: toolchain_versions
-
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           components: rustfmt, clippy
-
-      - name: Cache cargo registry
-        uses: actions/cache@v1
-        with:
-          path: ~/.cargo/registry
-          key: cargo-registry-${{ github.workflow }}-${{ github.job_id }}-${{ runner.os }}-rust-${{ steps.toolchain_versions.outputs.rust }}-${{ hashFiles('**/Cargo.toml') }}
-
-      - name: Cache cargo index
-        uses: actions/cache@v1
-        with:
-          path: ~/.cargo/git
-          key: cargo-index-${{ github.workflow }}-${{ github.job_id }}-${{ runner.os }}-rust-${{ steps.toolchain_versions.outputs.rust }}-${{ hashFiles('**/Cargo.toml') }}
-
-      - name: Cache cargo build
-        uses: actions/cache@v1
-        with:
-          path: target
-          key: cargo-build-target-${{ github.workflow }}-${{ github.job_id }}-${{ runner.os }}-rust-${{ steps.toolchain_versions.outputs.rust }}-${{ hashFiles('**/Cargo.toml') }}
 
       - name: Install Ruby toolchain
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/fuzz.yaml
+++ b/.github/workflows/fuzz.yaml
@@ -23,24 +23,6 @@ jobs:
           profile: minimal
           override: true
 
-      - name: Cache cargo registry
-        uses: actions/cache@v1
-        with:
-          path: ~/.cargo/registry
-          key: cargo-registry-${{ github.workflow }}-${{ github.job_id }}-${{ runner.os }}-rust-${{ hashFiles('**/Cargo.toml') }}
-
-      - name: Cache cargo index
-        uses: actions/cache@v1
-        with:
-          path: ~/.cargo/git
-          key: cargo-index-${{ github.workflow }}-${{ github.job_id }}-${{ runner.os }}-rust-${{ hashFiles('**/Cargo.toml') }}
-
-      - name: Cache cargo build
-        uses: actions/cache@v1
-        with:
-          path: target
-          key: cargo-build-target-${{ github.workflow }}-${{ github.job_id }}-${{ runner.os }}-rust-${{ hashFiles('**/Cargo.toml') }}
-
       - name: Install Ruby toolchain
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/rustdoc.yaml
+++ b/.github/workflows/rustdoc.yaml
@@ -20,11 +20,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Set toolchain versions
-        run: |
-          echo "::set-output name=rust::$(cat rust-toolchain)"
-        id: toolchain_versions
-
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -32,24 +27,6 @@ jobs:
           profile: minimal
           override: true
           components: rustfmt, rust-src
-
-      - name: Cache cargo registry
-        uses: actions/cache@v1
-        with:
-          path: ~/.cargo/registry
-          key: cargo-registry-${{ github.workflow }}-${{ github.job_id }}-${{ runner.os }}-rust-${{ hashFiles('**/Cargo.toml') }}
-
-      - name: Cache cargo index
-        uses: actions/cache@v1
-        with:
-          path: ~/.cargo/git
-          key: cargo-index-${{ github.workflow }}-${{ github.job_id }}-${{ runner.os }}-rust-${{ hashFiles('**/Cargo.toml') }}
-
-      - name: Cache cargo build
-        uses: actions/cache@v1
-        with:
-          path: target
-          key: cargo-build-target-${{ github.workflow }}-${{ github.job_id }}-${{ runner.os }}-rust-${{ hashFiles('**/Cargo.toml') }}
 
       - name: Install Ruby toolchain
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
It turns out not to be faster. Cache creation and download time on the
target directory is longer than the savings in compile time.

The real slowness is installing LLVM on Windows.