### PR TITLE
Fix segfault in Artichoke::close

### DIFF
--- a/artichoke-backend/src/artichoke.rs
+++ b/artichoke-backend/src/artichoke.rs
@@ -1,5 +1,4 @@
 use std::ffi::c_void;
-use std::mem;
 use std::ops::{Deref, DerefMut};
 use std::ptr::NonNull;
 
@@ -67,8 +66,8 @@ impl Artichoke {
             //
             // Safety:
             //
-            // 1. The `Artichoke` struct is partially uninitialized with the
-            //    dangling `NonNull`.
+            // 1. Extract a `*mut sys::mrb_state` pointer from the `NonNull` mrb
+            //    field.
             // 2. Function safety conditions declare that `Artichoke` is not
             //    accessed inside the closure.
             // 3. Rust borrowing rules enforce that `Artichoke` is not accessed
@@ -83,8 +82,7 @@ impl Artichoke {
             // 9. Replace `self` with the new interpreter.
 
             // Step 1
-            let mrb = mem::replace(&mut self.mrb, NonNull::dangling());
-            let mrb = mrb.as_ptr();
+            let mrb = self.mrb.as_ptr();
 
             // Step 4
             (*mrb).ud = Box::into_raw(state) as *mut c_void;
@@ -96,7 +94,7 @@ impl Artichoke {
             let extracted = ffi::from_user_data(mrb)?;
 
             // Step 9
-            *self = extracted;
+            self.state = extracted.state;
             Ok(result)
         } else {
             Err(InterpreterExtractError)

--- a/artichoke-backend/src/convert/object.rs
+++ b/artichoke-backend/src/convert/object.rs
@@ -72,35 +72,33 @@ where
         // allocating with `mrb_data_object_alloc` below.
         let prior_gc_state = interp.disable_gc();
 
-        let obj = {
-            let state = interp.state.as_ref().ok_or(InterpreterExtractError)?;
-            let spec = state
-                .classes
-                .get::<Self>()
-                .ok_or_else(|| NotDefinedError::class(Self::ruby_type_name()))?;
+        let state = interp.state.as_ref().ok_or(InterpreterExtractError)?;
+        let spec = state
+            .classes
+            .get::<Self>()
+            .ok_or_else(|| NotDefinedError::class(Self::ruby_type_name()))?;
 
-            let data = Rc::new(RefCell::new(self));
-            let ptr = Rc::into_raw(data);
+        let data = Rc::new(RefCell::new(self));
+        let ptr = Rc::into_raw(data);
 
-            if let Some(mut slf) = slf {
-                unsafe {
-                    sys::mrb_sys_data_init(&mut slf, ptr as *mut c_void, spec.data_type());
-                }
-                slf
-            } else {
-                unsafe {
-                    let mrb = interp.mrb.as_mut();
-                    let mut rclass = spec
-                        .rclass(mrb)
-                        .ok_or_else(|| NotDefinedError::class(Self::ruby_type_name()))?;
-                    let alloc = sys::mrb_data_object_alloc(
-                        mrb,
-                        rclass.as_mut(),
-                        ptr as *mut c_void,
-                        spec.data_type(),
-                    );
-                    sys::mrb_sys_obj_value(alloc as *mut c_void)
-                }
+        let obj = if let Some(mut slf) = slf {
+            unsafe {
+                sys::mrb_sys_data_init(&mut slf, ptr as *mut c_void, spec.data_type());
+            }
+            slf
+        } else {
+            unsafe {
+                let mrb = interp.mrb.as_mut();
+                let mut rclass = spec
+                    .rclass(mrb)
+                    .ok_or_else(|| NotDefinedError::class(Self::ruby_type_name()))?;
+                let alloc = sys::mrb_data_object_alloc(
+                    mrb,
+                    rclass.as_mut(),
+                    ptr as *mut c_void,
+                    spec.data_type(),
+                );
+                sys::mrb_sys_obj_value(alloc as *mut c_void)
             }
         };
         if let GcState::Enabled = prior_gc_state {

--- a/artichoke-backend/src/state/mod.rs
+++ b/artichoke-backend/src/state/mod.rs
@@ -14,6 +14,7 @@ pub mod type_registry;
 use prng::Prng;
 use type_registry::TypeRegistry;
 
+/// Container for domain-specific interpreter state.
 #[derive(Debug)]
 pub struct State {
     pub parser: parser::State,
@@ -51,10 +52,5 @@ impl State {
             prng: Prng::default(),
         };
         Some(state)
-    }
-
-    /// Close a [`State`] and free underlying mruby structs and memory.
-    pub fn close(self, mrb: &mut sys::mrb_state) {
-        self.parser.close(mrb);
     }
 }

--- a/artichoke-backend/tests/leak_mrb_tt_data_rc.rs
+++ b/artichoke-backend/tests/leak_mrb_tt_data_rc.rs
@@ -48,7 +48,10 @@ unsafe extern "C" fn container_initialize(
     let container = Container { inner };
     let result = container.try_into_ruby(&mut guard, Some(slf));
     match result {
-        Ok(value) => value.inner(),
+        Ok(value) => {
+            drop(guard);
+            value.inner()
+        }
         Err(exception) => exception::raise(guard, exception),
     }
 }

--- a/artichoke-backend/tests/leak_mrb_tt_data_rc.rs
+++ b/artichoke-backend/tests/leak_mrb_tt_data_rc.rs
@@ -71,12 +71,10 @@ impl File for Container {
 
 #[test]
 fn rust_backed_mrb_value_smart_pointer_leak() {
-    // dummy interp, we will instantiate a fresh interp for each detector loop.
-    let mut interp = artichoke_backend::interpreter().unwrap();
-    leak::Detector::new("smart pointer", &mut interp)
+    leak::Looper::new("smart pointer")
         .with_iterations(ITERATIONS)
         .with_tolerance(LEAK_TOLERANCE)
-        .check_leaks(|_| {
+        .check_leaks(|| {
             let mut interp = artichoke_backend::interpreter().unwrap();
             interp
                 .def_file_for_type::<_, Container>("container")
@@ -87,5 +85,4 @@ fn rust_backed_mrb_value_smart_pointer_leak() {
             result.unwrap();
             interp.close();
         });
-    interp.close();
 }

--- a/artichoke-backend/tests/leak_mrb_tt_data_rc.rs
+++ b/artichoke-backend/tests/leak_mrb_tt_data_rc.rs
@@ -48,10 +48,7 @@ unsafe extern "C" fn container_initialize(
     let container = Container { inner };
     let result = container.try_into_ruby(&mut guard, Some(slf));
     match result {
-        Ok(value) => {
-            drop(guard);
-            value.inner()
-        }
+        Ok(value) => value.inner(),
         Err(exception) => exception::raise(guard, exception),
     }
 }


### PR DESCRIPTION
minimize the scope of unsafe code in the Guard pathway.

This PR triggered and led to fixing a lifetime issue causing a segfault: Ensure class and module specs are alive when running mrb_close.

The sometimes segfault on Windows is caused by `state.close()` consuming the
`State` before running the final gc in `mrb_close`. The gc relies on the class
specs free function to free Rust-defined data types. This data is not live
after the state is consumed.

The fix is to destructure the state, pulling apart the bits that need explicit
closes and those that must be kept alive. The class and module registries are
explicitly dropped last.

Regression introduced in GH-670.