### PR TITLE
Bump rubocop 0.83.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,3 +16,5 @@ Metrics:
   Enabled: false
 Style/Documentation:
   Enabled: false
+Style/SlicingWithRange:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,4 +17,4 @@ Metrics:
 Style/Documentation:
   Enabled: false
 Style/SlicingWithRange:
-  Enabled: false
+  Enabled: false # See GH-679.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,21 +66,26 @@ tasks by running:
 $ bundle exec rake --tasks
 rake doc               # Generate Rust API documentation
 rake doc:open          # Generate Rust API documentation and open it in a web browser
-rake lint:all          # Lint and format
-rake lint:clippy       # Run clippy
+rake lint              # Lint and format
+rake lint:clippy       # Run Clippy
 rake lint:deps         # Install linting dependencies
-rake lint:eslint       # Run eslint
+rake lint:eslint       # Run ESlint
 rake lint:format       # Format sources
 rake lint:links        # Check markdown links
-rake lint:restriction  # Lint with restriction pass (unenforced lints)
-rake lint:rubocop      # Run rubocop
+rake lint:restriction  # Lint with Clippy restriction pass (unenforced lints)
+rake lint:rubocop      # Run RuboCop
 rake spec              # Run enforced ruby/spec suite
-rake test              # Run Artichoke Rust tests
+rake test              # Run Artichoke unit tests
 ```
 
 To lint Ruby sources, Artichoke uses
 [RuboCop](https://github.com/rubocop-hq/rubocop). RuboCop runs as part of the
-`lint:all` task. To run RuboCop by itself, invoke the `lint:rubocop` task.
+`lint` task. To run RuboCop by itself, invoke the `lint:rubocop` task.
+
+```console
+$ bundle exec rake lint
+$ bundle exec rake lint:rubocop
+```
 
 ### Node.js
 
@@ -124,7 +129,7 @@ Once you [configure a development environment](#setup), run the following to
 lint sources:
 
 ```sh
-rake lint:all
+rake lint
 ```
 
 Merges will be blocked by CI if there are lint errors.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -179,26 +179,10 @@ If you need to pull in an updated version of a crate for a bugfix or a new
 feature, update the version number in `Cargo.toml`. See
 [GH-548](https://github.com/artichoke/artichoke/pull/548) for an example.
 
-To update Rust crate dependencies run the following command and check in the
-updated `Cargo.lock` file:
-
-```sh
-cargo update
-```
+Regular dependency bumps are handled by [@dependabot](https://dependabot.com/).
 
 ### Node.js Packages
 
 To see what packages are outdated, you can run `npm outdated`.
 
-To update Node.js package dependencies run the following command and check in
-the updated `package-lock.json` file:
-
-```sh
-npm update
-```
-
-If after running `npm update` there are still outdated packages reported by
-`npm outdated`, there has likely been a major release of a dependency. If you
-would like to update the dependency and deal with any breakage, please do;
-otherwise, please
-[file an issue](https://github.com/artichoke/artichoke/issues/new).
+Dependency bumps are handled by [@dependabot](https://dependabot.com/).

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,15 +2,13 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.0)
-    jaro_winkler (1.5.4)
     parallel (1.19.1)
-    parser (2.7.1.1)
+    parser (2.7.1.2)
       ast (~> 2.4.0)
     rainbow (3.0.0)
     rake (13.0.1)
     rexml (3.2.4)
-    rubocop (0.82.0)
-      jaro_winkler (~> 1.5.1)
+    rubocop (0.83.0)
       parallel (~> 1.10)
       parser (>= 2.7.0.1)
       rainbow (>= 2.2.2, < 4.0)

--- a/Rakefile
+++ b/Rakefile
@@ -2,13 +2,13 @@
 
 require 'fileutils'
 
-task default: 'lint:all'
+task default: :lint
+
+desc 'Lint and format'
+task lint: %i[lint:format lint:clippy lint:rubocop lint:eslint]
 
 namespace :lint do
-  desc 'Lint and format'
-  task all: %i[format clippy rubocop eslint]
-
-  desc 'Run clippy'
+  desc 'Run Clippy'
   task :clippy do
     roots = Dir.glob('**/{lib,main}.rs')
     roots.each do |root|
@@ -17,7 +17,7 @@ namespace :lint do
     sh 'cargo clippy'
   end
 
-  desc 'Run rubocop'
+  desc 'Run RuboCop'
   task :rubocop do
     sh 'rubocop -a'
   end
@@ -29,7 +29,7 @@ namespace :lint do
     sh 'node scripts/clang-format.js'
   end
 
-  desc 'Run eslint'
+  desc 'Run ESlint'
   task eslint: :deps do
     sh 'npx eslint --fix .'
   end
@@ -56,10 +56,10 @@ namespace :lint do
 
   desc 'Install linting dependencies'
   task :deps do
-    sh 'npm install'
+    sh 'npm ci'
   end
 
-  desc 'Lint with restriction pass (unenforced lints)'
+  desc 'Lint with Clippy restriction pass (unenforced lints)'
   task :restriction do
     sh 'cargo clippy -- ' \
       '-W clippy::dbg_macro ' \
@@ -92,7 +92,7 @@ task :spec do
   sh 'cargo run -q -p spec-runner -- spec-runner/enforced-specs.yaml'
 end
 
-desc 'Run Artichoke Rust tests'
+desc 'Run Artichoke unit tests'
 task :test do
   sh 'cargo test --workspace'
 end

--- a/artichoke-backend/src/extn/core/array/array.rb
+++ b/artichoke-backend/src/extn/core/array/array.rb
@@ -516,7 +516,7 @@ class Array
     if num.nil?
       return nil if empty?
 
-      while true # rubocop:disable Lint/LiteralAsCondition
+      while true
         idx = 0
         len = length
         while idx < len

--- a/artichoke-backend/src/extn/core/kernel/kernel.rb
+++ b/artichoke-backend/src/extn/core/kernel/kernel.rb
@@ -117,7 +117,13 @@ module Kernel
   def loop(&block)
     return to_enum :loop unless block
 
-    yield while true # rubocop:disable Style/InfiniteLoop, Lint/LiteralAsCondition
+    # RuboCop's `Style/InfiniteLoop` lint says:
+    #     Use `Kernel#loop` for infinite loops.
+    # Disable this lint since we are _implementing_ `Kernel#loop`.
+    #
+    # rubocop:disable Style/InfiniteLoop
+    yield while true
+    # rubocop:enable Style/InfiniteLoop
   rescue StopIteration => e
     e.result
   end

--- a/artichoke-backend/src/extn/core/kernel/kernel_test.rb
+++ b/artichoke-backend/src/extn/core/kernel/kernel_test.rb
@@ -45,6 +45,7 @@ end
 
 class Foo
   attr_accessor :bar, :baz
+
   def initialize(bar, baz)
     @bar = bar
     @baz = baz

--- a/artichoke-backend/src/extn/stdlib/forwardable/forwardable_test.rb
+++ b/artichoke-backend/src/extn/stdlib/forwardable/forwardable_test.rb
@@ -4,7 +4,9 @@ require 'forwardable'
 
 class RecordCollection
   attr_accessor :records
+
   extend Forwardable
+
   def_delegator :@records, :[], :record_number
 end
 


### PR DESCRIPTION
Upgrade RuboCop to 0.83.0 and fix warnings.
This PR disables the `Style/SlicingWithRange` cop because Artichoke does not yet support endless ranges: https://github.com/artichoke/artichoke/issues/441.

Rename `rake lint:all` to `rake lint`, update `CONTRIBUTING.md`.

Remove dependency update docs and mention dependabot.