### PR TITLE
Fail doc builds on warnings

### DIFF
--- a/.github/workflows/rustdoc.yaml
+++ b/.github/workflows/rustdoc.yaml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       RUSTFLAGS: -D warnings
+      RUSTDOCFLAGS: -D warnings
       RUST_BACKTRACE: 1
 
     steps:

--- a/Rakefile
+++ b/Rakefile
@@ -79,11 +79,13 @@ end
 
 desc 'Generate Rust API documentation'
 task :doc do
+  ENV['RUSTDOCFLAGS'] = '-D warnings'
   sh 'rustup run --install nightly cargo doc --workspace --no-deps'
 end
 
 desc 'Generate Rust API documentation and open it in a web browser'
 task :'doc:open' do
+  ENV['RUSTDOCFLAGS'] = '-D warnings'
   sh 'rustup run --install nightly cargo doc --workspace --no-deps --open'
 end
 

--- a/artichoke-backend/src/artichoke.rs
+++ b/artichoke-backend/src/artichoke.rs
@@ -8,18 +8,9 @@ use crate::sys;
 
 /// Interpreter instance.
 ///
-/// The interpreter [`State`](state::State) is wrapped in an `Rc<RefCell<_>>`.
-///
-/// The [`Rc`] enables the State to be cloned so it can be stored in the
-/// [`sys::mrb_state`],
-/// [extracted in `extern "C"` functions](ffi::from_user_data), and used in
-/// [`Value`](value::Value) instances.
-///
-/// The [`RefCell`] enables mutable access to the underlying
-/// [`State`](state::State), even across an FFI boundary.
-///
 /// Functionality is added to the interpreter via traits, for example,
-/// [garbage collection](gc::MrbGarbageCollection) or [eval](eval::Eval).
+/// [garbage collection](crate::prelude::gc::MrbGarbageCollection) or
+/// [eval](crate::prelude::Eval).
 #[derive(Debug)]
 pub struct Artichoke {
     /// Underlying mruby interpreter.

--- a/artichoke-backend/src/artichoke.rs
+++ b/artichoke-backend/src/artichoke.rs
@@ -9,8 +9,8 @@ use crate::sys;
 /// Interpreter instance.
 ///
 /// Functionality is added to the interpreter via traits, for example,
-/// [garbage collection](crate::prelude::gc::MrbGarbageCollection) or
-/// [eval](crate::prelude::Eval).
+/// [garbage collection](crate::gc::MrbGarbageCollection) or
+/// [eval](crate::core::Eval).
 #[derive(Debug)]
 pub struct Artichoke {
     /// Underlying mruby interpreter.

--- a/artichoke-backend/src/class_registry.rs
+++ b/artichoke-backend/src/class_registry.rs
@@ -42,9 +42,9 @@ pub trait ClassRegistry {
 impl ClassRegistry for Artichoke {
     /// Create a class definition bound to a Rust type `T`.
     ///
-    /// Class definitions have the same lifetime as the [`State`] because the
-    /// class def owns the `mrb_data_type` for the type, which must be
-    /// long-lived.
+    /// Class definitions have the same lifetime as the
+    /// [`State`](crate::state::State) because the class def owns the
+    /// `mrb_data_type` for the type, which must be long-lived.
     fn def_class<T>(&mut self, spec: class::Spec) -> Result<(), Exception>
     where
         T: Any,

--- a/artichoke-backend/src/ffi.rs
+++ b/artichoke-backend/src/ffi.rs
@@ -26,7 +26,7 @@ use crate::Artichoke;
 /// # Safety
 ///
 /// This function assumes that the user data pointer was created with
-/// [Box::into_raw`] and that the pointer is to a non-free'd
+/// [`Box::into_raw`] and that the pointer is to a non-free'd
 /// [`Box`]`<`[`State`]`>`.
 pub unsafe fn from_user_data(
     mrb: *mut sys::mrb_state,

--- a/artichoke-backend/src/ffi.rs
+++ b/artichoke-backend/src/ffi.rs
@@ -20,14 +20,14 @@ use crate::Artichoke;
 /// Extract an [`Artichoke`] interpreter from the user data pointer on a
 /// [`sys::mrb_state`].
 ///
-/// Calling this function will increase the [`Rc::strong_count`] on the
-/// [`Artichoke`] interpreter by one.
+/// Calling this function will move the [`State`] out of the [`sys::mrb_state`]
+/// into the [`Artichoke`] interpreter.
 ///
 /// # Safety
 ///
 /// This function assumes that the user data pointer was created with
-/// [`Rc::into_raw`] and that the pointer is to a non-free'd
-/// [`Rc`]`<`[`RefCell`]`<`[`State`]`>>`.
+/// [Box::into_raw`] and that the pointer is to a non-free'd
+/// [`Box`]`<`[`State`]`>`.
 pub unsafe fn from_user_data(
     mrb: *mut sys::mrb_state,
 ) -> Result<Artichoke, InterpreterExtractError> {

--- a/artichoke-backend/src/fs.rs
+++ b/artichoke-backend/src/fs.rs
@@ -29,7 +29,7 @@ pub const RUBY_LOAD_PATH: &str = "/src/lib";
 ///
 /// This signature is equivalent to the signature for `File::require` as defined
 /// by the `artichoke-backend` implementation of
-/// [`LoadSources`](crate::LoadSources).
+/// [`LoadSources`](crate::core::LoadSources).
 pub type ExtensionHook = fn(&mut Artichoke) -> Result<(), Exception>;
 
 #[cfg(test)]
@@ -153,8 +153,8 @@ impl Entry {
 ///   MRI C extension rubygem).
 ///
 /// Sources in `Virtual` are only writable via the
-/// [`LoadSources`](crate::LoadSources) trait. Sources can only be completely
-/// replaced.
+/// [`LoadSources`](crate::core::LoadSources) trait. Sources can only be
+/// completely replaced.
 ///
 /// These APIs are consumed primarily by the `Kernel::require` implementation in
 /// [`extn::core::kernel::require`](crate::extn::core::kernel::require).

--- a/artichoke-backend/src/lib.rs
+++ b/artichoke-backend/src/lib.rs
@@ -4,6 +4,7 @@
 #![warn(intra_doc_link_resolution_failure)]
 #![warn(missing_debug_implementations)]
 #![warn(rust_2018_idioms)]
+#![cfg_attr(doc, deny(warnings))]
 
 //! # artichoke-backend
 //!

--- a/artichoke-backend/src/lib.rs
+++ b/artichoke-backend/src/lib.rs
@@ -38,8 +38,8 @@
 //! ### Calling Functions on Ruby Objects
 //!
 //! [`Value`](value::Value)s returned by the `artichoke-backend` interpreter
-//! implement [`Value` from `artichoke-core`](crate::core::prelude::Value),
-//! which enables calling Ruby functions from Rust.
+//! implement [`Value` from `artichoke-core`](crate::core::Value), which enables
+//! calling Ruby functions from Rust.
 //!
 //! ```rust
 //! use artichoke_backend::prelude::core::*;

--- a/artichoke-backend/src/lib.rs
+++ b/artichoke-backend/src/lib.rs
@@ -4,7 +4,6 @@
 #![warn(intra_doc_link_resolution_failure)]
 #![warn(missing_debug_implementations)]
 #![warn(rust_2018_idioms)]
-#![cfg_attr(doc, deny(warnings))]
 
 //! # artichoke-backend
 //!

--- a/artichoke-backend/src/state/mod.rs
+++ b/artichoke-backend/src/state/mod.rs
@@ -33,8 +33,8 @@ impl State {
     /// The state is comprised of several components:
     ///
     /// - [`Class`](crate::class_registry::ClassRegistry) and
-    ///   [`Module`](crate::module_registry::ModModuleRegistry) registries.
-    /// - `Regexp` [global state](Regexp).
+    ///   [`Module`](crate::module_registry::ModuleRegistry) registries.
+    /// - `Regexp` [global state](regexp::State).
     /// - [In-memory virtual filesystem](fs::Virtual).
     /// - [Ruby parser and file context](parser::State).
     /// - [Intepreter-level PRNG](Prng) (behind the `core-random` feature).

--- a/artichoke-backend/src/sys/mod.rs
+++ b/artichoke-backend/src/sys/mod.rs
@@ -1,4 +1,4 @@
-#![deny(missing_docs, intra_doc_link_resolution_failure)]
+#![warn(missing_docs, intra_doc_link_resolution_failure)]
 
 //! Rust bindings for mruby, customized for Artichoke.
 //!

--- a/artichoke-core/src/lib.rs
+++ b/artichoke-core/src/lib.rs
@@ -4,6 +4,7 @@
 #![warn(missing_debug_implementations)]
 #![warn(rust_2018_idioms)]
 #![forbid(unsafe_code)]
+#![cfg_attr(doc, deny(warnings))]
 
 //! # artichoke-core
 //!

--- a/artichoke-core/src/lib.rs
+++ b/artichoke-core/src/lib.rs
@@ -4,7 +4,6 @@
 #![warn(missing_debug_implementations)]
 #![warn(rust_2018_idioms)]
 #![forbid(unsafe_code)]
-#![cfg_attr(doc, deny(warnings))]
 
 //! # artichoke-core
 //!

--- a/spec-runner/src/main.rs
+++ b/spec-runner/src/main.rs
@@ -3,7 +3,6 @@
 #![deny(missing_docs, intra_doc_link_resolution_failure)]
 #![warn(rust_2018_idioms)]
 #![forbid(unsafe_code)]
-#![cfg_attr(doc, deny(warnings))]
 
 //! `spec-runner` is the ruby/spec runner for Artichoke.
 //!

--- a/spec-runner/src/main.rs
+++ b/spec-runner/src/main.rs
@@ -1,6 +1,6 @@
-#![deny(clippy::all)]
-#![deny(clippy::pedantic)]
-#![deny(missing_docs, intra_doc_link_resolution_failure)]
+#![warn(clippy::all)]
+#![warn(clippy::pedantic)]
+#![warn(missing_docs, intra_doc_link_resolution_failure)]
 #![warn(rust_2018_idioms)]
 #![forbid(unsafe_code)]
 

--- a/spec-runner/src/main.rs
+++ b/spec-runner/src/main.rs
@@ -3,6 +3,7 @@
 #![deny(missing_docs, intra_doc_link_resolution_failure)]
 #![warn(rust_2018_idioms)]
 #![forbid(unsafe_code)]
+#![cfg_attr(doc, deny(warnings))]
 
 //! `spec-runner` is the ruby/spec runner for Artichoke.
 //!

--- a/src/bin/airb.rs
+++ b/src/bin/airb.rs
@@ -3,7 +3,6 @@
 #![deny(intra_doc_link_resolution_failure)]
 #![warn(missing_debug_implementations)]
 #![warn(rust_2018_idioms)]
-#![cfg_attr(doc, deny(warnings))]
 
 //! `airb` is the Artichoke implementation of `irb` and is an interactive Ruby shell
 //! and [REPL](https://en.wikipedia.org/wiki/Read%E2%80%93eval%E2%80%93print_loop).

--- a/src/bin/airb.rs
+++ b/src/bin/airb.rs
@@ -1,6 +1,6 @@
 #![warn(clippy::all)]
 #![warn(clippy::pedantic)]
-#![deny(intra_doc_link_resolution_failure)]
+#![warn(missing_docs, intra_doc_link_resolution_failure)]
 #![warn(missing_debug_implementations)]
 #![warn(rust_2018_idioms)]
 

--- a/src/bin/airb.rs
+++ b/src/bin/airb.rs
@@ -3,6 +3,7 @@
 #![deny(intra_doc_link_resolution_failure)]
 #![warn(missing_debug_implementations)]
 #![warn(rust_2018_idioms)]
+#![cfg_attr(doc, deny(warnings))]
 
 //! `airb` is the Artichoke implementation of `irb` and is an interactive Ruby shell
 //! and [REPL](https://en.wikipedia.org/wiki/Read%E2%80%93eval%E2%80%93print_loop).

--- a/src/bin/artichoke.rs
+++ b/src/bin/artichoke.rs
@@ -3,7 +3,6 @@
 #![deny(intra_doc_link_resolution_failure)]
 #![warn(missing_debug_implementations)]
 #![warn(rust_2018_idioms)]
-#![cfg_attr(doc, deny(warnings))]
 
 //! `artichoke` is the `ruby` binary frontend to Artichoke.
 //!

--- a/src/bin/artichoke.rs
+++ b/src/bin/artichoke.rs
@@ -1,6 +1,6 @@
 #![warn(clippy::all)]
 #![warn(clippy::pedantic)]
-#![deny(intra_doc_link_resolution_failure)]
+#![warn(missing_docs, intra_doc_link_resolution_failure)]
 #![warn(missing_debug_implementations)]
 #![warn(rust_2018_idioms)]
 

--- a/src/bin/artichoke.rs
+++ b/src/bin/artichoke.rs
@@ -3,6 +3,7 @@
 #![deny(intra_doc_link_resolution_failure)]
 #![warn(missing_debug_implementations)]
 #![warn(rust_2018_idioms)]
+#![cfg_attr(doc, deny(warnings))]
 
 //! `artichoke` is the `ruby` binary frontend to Artichoke.
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,6 @@
 #![warn(missing_docs, intra_doc_link_resolution_failure)]
 #![warn(missing_debug_implementations)]
 #![warn(rust_2018_idioms)]
-#![cfg_attr(doc, deny(warnings))]
 
 //! Artichoke Ruby
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 #![warn(missing_docs, intra_doc_link_resolution_failure)]
 #![warn(missing_debug_implementations)]
 #![warn(rust_2018_idioms)]
+#![cfg_attr(doc, deny(warnings))]
 
 //! Artichoke Ruby
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@
 //! - A Rust and Ruby implementation of Ruby Core and Standard Library using
 //!   high-quality Rust dependencies and modern Ruby.
 //! - Support for injecting Rust code and types into the interpreter with a
-//!   rubygems-style [`File`](backend::File) API.
+//!   rubygems-style [`File`](backend::prelude::core::File) API.
 //! - The ability to disable parts of the interpreter VM or library functions at
 //!   compile time. For example, deny access to the system environ by disabling
 //!   the `core-env-system` feature.


### PR DESCRIPTION
with many of the refactors stemming from GH-442, doc links have been broken.

Enforcement of doc link resolution warnings was accidentally removed in https://github.com/artichoke/artichoke/commit/2fcb2dbd6edac6e05950b4e1e9972533642dfffc. `cargo doc` does not respect `RUSTFLAGS`.

This PR adds `RUSTDOCFLAGS="-D warnings"` and fixes up the broken links.