### PR TITLE
Add favicon and Artichoke logo to rustdocs

### DIFF
--- a/artichoke-backend/src/lib.rs
+++ b/artichoke-backend/src/lib.rs
@@ -86,6 +86,8 @@
 //! `HashMap<String, Option<Vec<u8>>>` using an `artichoke-backend` interpreter.
 
 #![doc(html_root_url = "https://artichoke.github.io/artichoke/artichoke_backend")]
+#![doc(html_favicon_url = "https://www.artichokeruby.org/favicon.ico")]
+#![doc(html_logo_url = "https://www.artichokeruby.org/artichoke-logo.svg")]
 
 #[macro_use]
 extern crate log;

--- a/artichoke-core/src/lib.rs
+++ b/artichoke-core/src/lib.rs
@@ -30,6 +30,8 @@
 //! and [interning `Symbol`s](intern::Intern).
 
 #![doc(html_root_url = "https://artichoke.github.io/artichoke/artichoke_core")]
+#![doc(html_favicon_url = "https://www.artichokeruby.org/favicon.ico")]
+#![doc(html_logo_url = "https://www.artichokeruby.org/artichoke-logo.svg")]
 
 pub mod constant;
 pub mod convert;

--- a/spec-runner/README.md
+++ b/spec-runner/README.md
@@ -25,7 +25,7 @@ core:
     specs:
       - any
       - append
-      - array
+      - drop
   - suite: comparable
   - suite: string
     specs:

--- a/spec-runner/src/main.rs
+++ b/spec-runner/src/main.rs
@@ -23,7 +23,7 @@
 //!     specs:
 //!       - any
 //!       - append
-//!       - array
+//!       - drop
 //!   - suite: comparable
 //!   - suite: string
 //!     specs:
@@ -52,6 +52,9 @@
 //! ARGS:
 //!     <config>    Path to YAML config file
 //! ```
+
+#![doc(html_favicon_url = "https://www.artichokeruby.org/favicon.ico")]
+#![doc(html_logo_url = "https://www.artichokeruby.org/artichoke-logo.svg")]
 
 #[macro_use]
 extern crate rust_embed;

--- a/src/bin/airb.rs
+++ b/src/bin/airb.rs
@@ -5,7 +5,7 @@
 #![warn(rust_2018_idioms)]
 
 //! `airb` is the Artichoke implementation of `irb` and is an interactive Ruby shell
-//! and [REPL](https://en.wikipedia.org/wiki/Read%E2%80%93eval%E2%80%93print_loop).
+//! and [REPL][repl].
 //!
 //! `airb` is a readline enabled shell, although it does not persist history.
 //!
@@ -14,6 +14,11 @@
 //! ```shell
 //! cargo run --bin airb
 //! ```
+//!
+//! [repl]: https://en.wikipedia.org/wiki/Read%E2%80%93eval%E2%80%93print_loop
+
+#![doc(html_favicon_url = "https://www.artichokeruby.org/favicon.ico")]
+#![doc(html_logo_url = "https://www.artichokeruby.org/artichoke-logo.svg")]
 
 use artichoke::repl;
 use std::io::{self, Write};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,6 +79,8 @@
 //! [stdlib-mod-securerandom]: https://ruby-doc.org/stdlib-2.6.3/libdoc/securerandom/rdoc/SecureRandom.html
 
 #![doc(html_root_url = "https://docs.rs/artichoke/0.1.0-pre.0")]
+#![doc(html_favicon_url = "https://www.artichokeruby.org/favicon.ico")]
+#![doc(html_logo_url = "https://www.artichokeruby.org/artichoke-logo.svg")]
 
 #[cfg(doctest)]
 doc_comment::doctest!("../README.md");


### PR DESCRIPTION
Set `html_favicon_url` and `html_logo_url` rustdoc attributes in source code
to favicon and logo hosted at www.artichokeruby.org.

https://doc.rust-lang.org/rustdoc/the-doc-attribute.html#at-the-crate-level