### PR TITLE
Remove CI dependency on chocolatey

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,8 +37,13 @@ jobs:
         run: sudo apt install bison
         if: matrix.os == 'ubuntu-latest'
 
+      # avoid choco because it takes forever to initialize on first use
+      # instead, install directly from GitHub releases
       - name: Install Bison
-        run: choco install winflexbison3 --no-progress
+        run: |
+          (New-Object System.Net.WebClient).DownloadFile("https://github.com/lexxmark/winflexbison/releases/download/v2.5.22/win_flex_bison-2.5.22.zip","win_flex_bison.zip");
+          Expand-Archive .\win_flex_bison.zip .\win_flex_bison;
+          echo "::add-path::./win_flex_bison"
         if: matrix.os == 'windows-latest'
 
       - name: Compile

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,10 +33,6 @@ jobs:
         with:
           ruby-version: ".ruby-version"
 
-      - name: Install Clang
-        run: choco install llvm --no-progress
-        if: matrix.os == 'windows-latest'
-
       - name: Install Bison
         run: sudo apt install bison
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,7 +43,13 @@ jobs:
         run: |
           (New-Object System.Net.WebClient).DownloadFile("https://github.com/lexxmark/winflexbison/releases/download/v2.5.22/win_flex_bison-2.5.22.zip","win_flex_bison.zip");
           Expand-Archive .\win_flex_bison.zip .\win_flex_bison;
-          echo "::add-path::./win_flex_bison"
+          echo "::add-path::${{ github.workspace }}/win_flex_bison"
+        if: matrix.os == 'windows-latest'
+
+      - name: Check Bison
+        run: |
+          win_bison.exe --version
+          win_bison --version
         if: matrix.os == 'windows-latest'
 
       - name: Compile


### PR DESCRIPTION
https://github.com/actions/virtual-environments/issues/104 added llvm to the windows base image but did not stop `choco install llvm` from taking 5 minutes per CI run.

This PR removes the llvm install build step.

Removing this first `choco` invocation caused the `winflexbison3` install step, which normally takes 15 seconds, to take almost 3 minutes. It appears that chocolatey does quite a bit of initialization or cache warming on first launch.

Replace `choco install winflexbison3` with a tarball install of a recent release from GitHub.

This PR reduces windows build times from 15 minutes to 10.5 minutes.