### PR TITLE
Update rust-onig and bindgen to latest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,9 +90,9 @@ checksum = "53d1ccbaf7d9ec9537465a97bf19edc1a4e158ecb49fc16178202238c569cc42"
 
 [[package]]
 name = "bindgen"
-version = "0.53.2"
+version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bb26d6a69a335b8cb0e7c7e9775cd5666611dc50a37177c3f2cedcfc040e8c8"
+checksum = "66c0bb6167449588ff70803f4127f0684f9063097eca5016f37eb52b92c2cf36"
 dependencies = [
  "bitflags",
  "cexpr",
@@ -454,8 +454,8 @@ checksum = "0b631f7e854af39a1739f401cf34a8a013dfe09eac4fa4dba91e9768bd28168d"
 
 [[package]]
 name = "onig"
-version = "5.0.0"
-source = "git+https://github.com/artichoke/rust-onig?rev=11bc679d45b6799df2866cb4c90e1d542c4ba4c0#11bc679d45b6799df2866cb4c90e1d542c4ba4c0"
+version = "6.0.0"
+source = "git+https://github.com/artichoke/rust-onig?rev=ec266cae185ef4119008ea0b4799b9abd7161436#ec266cae185ef4119008ea0b4799b9abd7161436"
 dependencies = [
  "bitflags",
  "lazy_static",
@@ -465,10 +465,9 @@ dependencies = [
 
 [[package]]
 name = "onig_sys"
-version = "69.2.0"
-source = "git+https://github.com/artichoke/rust-onig?rev=11bc679d45b6799df2866cb4c90e1d542c4ba4c0#11bc679d45b6799df2866cb4c90e1d542c4ba4c0"
+version = "69.5.0"
+source = "git+https://github.com/artichoke/rust-onig?rev=ec266cae185ef4119008ea0b4799b9abd7161436#ec266cae185ef4119008ea0b4799b9abd7161436"
 dependencies = [
- "bindgen",
  "cc",
  "pkg-config",
 ]

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -30,7 +30,8 @@ path = "../artichoke-core"
 
 [dependencies.onig]
 git = "https://github.com/artichoke/rust-onig"
-rev = "11bc679d45b6799df2866cb4c90e1d542c4ba4c0"
+rev = "ec266cae185ef4119008ea0b4799b9abd7161436"
+default-features = false
 
 [dev-dependencies]
 libc = "0.2"
@@ -38,7 +39,7 @@ quickcheck = { version = "0.9", default-features = false }
 quickcheck_macros = "0.9"
 
 [build-dependencies]
-bindgen = { version = "0.53.1", default-features = false, features = ["runtime"] }
+bindgen = { version = "0.54.0", default-features = false, features = ["runtime"] }
 cc = { version = "1.0", features = ["parallel"] }
 chrono = "0.4"
 git2 = "0.13"


### PR DESCRIPTION
This PR pulls in the latest rust-onig fork which syncs master as of
rust-onig/rust-onig@742dc25ab7750c21493b666b90bdee7656d0b221. This patch
level removed most of my patches except the one that adds bindgen
support for wasm32 targets.

The fork also updates the bindgen dep, which we propagate to
artichoke-backend as well.