### PR TITLE
Rubocop 0.84

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,18 +3,21 @@ GEM
   specs:
     ast (2.4.0)
     parallel (1.19.1)
-    parser (2.7.1.2)
+    parser (2.7.1.3)
       ast (~> 2.4.0)
     rainbow (3.0.0)
     rake (13.0.1)
     rexml (3.2.4)
-    rubocop (0.83.0)
+    rubocop (0.84.0)
       parallel (~> 1.10)
       parser (>= 2.7.0.1)
       rainbow (>= 2.2.2, < 4.0)
       rexml
+      rubocop-ast (>= 0.0.3)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 2.0)
+    rubocop-ast (0.0.3)
+      parser (>= 2.7.0.1)
     rubocop-rake (0.5.1)
       rubocop
     ruby-progressbar (1.10.1)

--- a/artichoke-backend/src/extn/core/array/array.rb
+++ b/artichoke-backend/src/extn/core/array/array.rb
@@ -3,14 +3,10 @@
 module Artichoke
   class Array
     def self.reachable?(src, dest, reachable_objects = nil)
-      unless src.is_a?(::Array)
-        raise ArgumentError, 'reachable requires an Array src'
-      end
+      raise ArgumentError, 'reachable requires an Array src' unless src.is_a?(::Array)
 
       reachable_objects ||= ::Hash.new { |h, k| h[k] = [] }
-      unless reachable_objects.key?(src.object_id)
-        reachable_objects[src.object_id] << src.class
-      end
+      reachable_objects[src.object_id] << src.class unless reachable_objects.key?(src.object_id)
       return true if reachable_objects[dest.object_id].include?(dest.class)
 
       if dest.equal?(nil) || dest.equal?(true) || dest.equal?(false) || dest.is_a?(::Integer) || dest.is_a?(::Float)
@@ -30,9 +26,7 @@ module Artichoke
         end
       end
       dest.instance_variables.each do |iv|
-        if reachable?(src, dest.instance_variable_get(iv), reachable_objects)
-          return true
-        end
+        return true if reachable?(src, dest.instance_variable_get(iv), reachable_objects)
       end
       false
     end
@@ -64,9 +58,7 @@ class Array
   end
 
   def &(other)
-    unless other.is_a?(Array)
-      raise TypeError, "can't convert #{other.class} into Array"
-    end
+    raise TypeError, "can't convert #{other.class} into Array" unless other.is_a?(Array)
 
     hash = {}
     array = []
@@ -103,12 +95,8 @@ class Array
   def +(other)
     ary = other.to_ary if other.respond_to?(:to_ary)
     classname = other.class
-    if other.nil? || other.equal?(false) || other.equal?(true)
-      classname = other.inspect
-    end
-    unless ary.is_a?(Array)
-      raise TypeError, "no implicit conversion of #{classname} into #{self.class}"
-    end
+    classname = other.inspect if other.nil? || other.equal?(false) || other.equal?(true)
+    raise TypeError, "no implicit conversion of #{classname} into #{self.class}" unless ary.is_a?(Array)
 
     dup.concat(ary)
   end
@@ -116,12 +104,8 @@ class Array
   def -(other)
     ary = other.to_ary if other.respond_to?(:to_ary)
     classname = other.class
-    if other.nil? || other.equal?(false) || other.equal?(true)
-      classname = other.inspect
-    end
-    unless ary.is_a?(Array)
-      raise TypeError, "no implicit conversion of #{classname} into #{self.class}"
-    end
+    classname = other.inspect if other.nil? || other.equal?(false) || other.equal?(true)
+    raise TypeError, "no implicit conversion of #{classname} into #{self.class}" unless ary.is_a?(Array)
 
     hash = {}
     array = []
@@ -162,9 +146,7 @@ class Array
 
       unless cmp.is_a?(Numeric)
         classname = other.class
-        if other.nil? || other.equal?(false) || other.equal?(true) || other.is_a?(Numeric)
-          classname = other.inspect
-        end
+        classname = other.inspect if other.nil? || other.equal?(false) || other.equal?(true) || other.is_a?(Numeric)
         raise ArgumentError, "Comparison of #{self.class} with #{classname} failed"
       end
 
@@ -476,9 +458,7 @@ class Array
 
           other
         else
-          unless other.is_a?(Array)
-            raise TypeError, "no implicit conversion of #{classname} into Array"
-          end
+          raise TypeError, "no implicit conversion of #{classname} into Array" unless other.is_a?(Array)
         end
       self[length, 0] = ary
       idx += 1
@@ -716,17 +696,13 @@ class Array
   end
 
   def fetch(index, default = (not_set = true), &block)
-    if !index.nil? && !not_set && block
-      warn 'block supersedes default value argument'
-    end
+    warn 'block supersedes default value argument' if !index.nil? && !not_set && block
 
     idx = index
     idx += size if idx.negative?
     if idx.negative? || size <= idx
       return block.call(index) if block
-      if not_set
-        raise IndexError, "index #{idx} outside of array bounds: #{-size}...#{size}"
-      end
+      raise IndexError, "index #{idx} outside of array bounds: #{-size}...#{size}" if not_set
 
       return default
     end
@@ -734,9 +710,7 @@ class Array
   end
 
   def fill(arg0 = nil, arg1 = nil, arg2 = nil, &block)
-    if arg0.nil? && arg1.nil? && arg2.nil? && !block
-      raise ArgumentError, 'wrong number of arguments (0 for 1..3)'
-    end
+    raise ArgumentError, 'wrong number of arguments (0 for 1..3)' if arg0.nil? && arg1.nil? && arg2.nil? && !block
 
     beg = len = 0
     if block
@@ -963,9 +937,7 @@ class Array
 
   def join(separator = $,) # rubocop:disable Style/SpecialGlobalVars
     classname = separator.class
-    if separator.equal?(true) || separator.equal?(false)
-      classname = separator.inspect
-    end
+    classname = separator.inspect if separator.equal?(true) || separator.equal?(false)
 
     separator = '' if separator.nil?
     sep = String.try_convert(separator)
@@ -1158,9 +1130,7 @@ class Array
 
   def replace(other)
     classname = other.class
-    if other.equal?(true) || other.equal?(false) || other.nil?
-      classname = other.inspect
-    end
+    classname = other.inspect if other.equal?(true) || other.equal?(false) || other.nil?
     ary =
       if other.is_a?(Array)
         other
@@ -1172,9 +1142,7 @@ class Array
 
         other
       else
-        unless other.is_a?(Array)
-          raise TypeError, "no implicit conversion of #{classname} into Array"
-        end
+        raise TypeError, "no implicit conversion of #{classname} into Array" unless other.is_a?(Array)
       end
     self[0, length] = ary
     self
@@ -1315,9 +1283,7 @@ class Array
       case arg
       when Range
         start = range.begin
-        unless start.is_a?(Integer)
-          raise TypeError, "No implicit conversion of #{start.class} into Integer"
-        end
+        raise TypeError, "No implicit conversion of #{start.class} into Integer" unless start.is_a?(Integer)
 
         len = range.size
         return nil if start.abs > length
@@ -1340,12 +1306,8 @@ class Array
     when 2
       start = args[0]
       len = args[1]
-      unless start.is_a?(Integer)
-        raise TypeError, "No implicit conversion of #{start.class} into Integer"
-      end
-      unless len.is_a?(Integer)
-        raise TypeError, "No implicit conversion of #{len.class} into Integer"
-      end
+      raise TypeError, "No implicit conversion of #{start.class} into Integer" unless start.is_a?(Integer)
+      raise TypeError, "No implicit conversion of #{len.class} into Integer" unless len.is_a?(Integer)
 
       return nil if start.abs > length
 
@@ -1430,17 +1392,11 @@ class Array
       item = block.call(item) if block
 
       classname = item.class
-      if item.equal?(true) || item.equal?(false) || item.nil?
-        classname = item.inspect
-      end
-      unless item.respond_to?(:to_i)
-        raise TypeError, "#{classname} can't be coerced into Integer"
-      end
+      classname = item.inspect if item.equal?(true) || item.equal?(false) || item.nil?
+      raise TypeError, "#{classname} can't be coerced into Integer" unless item.respond_to?(:to_i)
 
       item = item.to_i
-      unless item.is_a?(Integer)
-        raise TypeError, "#{classname} can't be coerced into Integer"
-      end
+      raise TypeError, "#{classname} can't be coerced into Integer" unless item.is_a?(Integer)
 
       sum += item
       idx += 1
@@ -1479,9 +1435,7 @@ class Array
           raise TypeError, "wrong element type #{v.class} at #{idx} (expected array)"
         end
 
-      unless v.length == 2
-        raise ArgumentError, "wrong array length at #{idx} (expected 2, was #{v.length})"
-      end
+      raise ArgumentError, "wrong array length at #{idx} (expected 2, was #{v.length})" unless v.length == 2
 
       key, value = *v
       h[key] = value
@@ -1559,12 +1513,8 @@ class Array
         ary.concat(self[selector])
       else
         classname = selector.class
-        if selector.equal?(true) || selector.equal?(false) || selector.nil?
-          classname = selector.inspect
-        end
-        unless selector.respond_to?(:to_int)
-          raise TypeError, "No implicit conversion from #{classname} to Integer"
-        end
+        classname = selector.inspect if selector.equal?(true) || selector.equal?(false) || selector.nil?
+        raise TypeError, "No implicit conversion from #{classname} to Integer" unless selector.respond_to?(:to_int)
 
         selector = selector.to_int
         unless selector.is_a?(Integer)
@@ -1583,9 +1533,7 @@ class Array
   end
 
   def |(other)
-    unless other.is_a?(Array)
-      raise TypeError, "can't convert #{other.class} into Array"
-    end
+    raise TypeError, "can't convert #{other.class} into Array" unless other.is_a?(Array)
 
     ary = self + other
     ary.uniq! || ary

--- a/artichoke-backend/src/extn/core/array/inline_buffer_test.rb
+++ b/artichoke-backend/src/extn/core/array/inline_buffer_test.rb
@@ -95,7 +95,6 @@ def inline_set
   raise unless a == [1, 2, 3, 'a']
 end
 
-# rubocop:disable Style/GuardClause
 def inline_set_sparse
   # to inline
   a = [1, 2, 3]
@@ -105,39 +104,26 @@ def inline_set_sparse
   # to dynamic
   a = [1, 2, 3]
   a[20] = 'a'
-  unless a == [1, 2, 3, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 'a']
-    raise
-  end
+  raise unless a == [1, 2, 3, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 'a']
 end
-# rubocop:enable Style/GuardClause
 
-# rubocop:disable Style/GuardClause
 def dynamic_set
   a = (1..25).map.to_a
   a[0] = 'a'
-  unless a == ['a', 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25]
-    raise
-  end
+  raise unless a == ['a', 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25]
 
   a = (1..25).map.to_a
   a[10] = 'a'
-  unless a == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 'a', 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25]
-    raise
-  end
+  raise unless a == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 'a', 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25]
 
   a = (1..25).map.to_a
   a[-1] = 'a'
-  unless a == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 'a']
-    raise
-  end
+  raise unless a == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 'a']
 
   a = (1..25).map.to_a
   a[25] = 'a'
-  unless a == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 'a']
-    raise
-  end
+  raise unless a == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 'a']
 end
-# rubocop:enable Style/GuardClause
 
 # rubocop:disable Style/GuardClause
 def dynamic_set_sparse
@@ -195,25 +181,18 @@ def inline_set_with_drain
   raise unless a == [1, 2, 3, 4, 5, 6, 7, 'a']
 end
 
-# rubocop:disable Style/GuardClause
 def dynamic_set_with_drain
   a = (1..25).map.to_a
   a[0, 0] = 'a'
-  unless a == ['a', 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25]
-    raise
-  end
+  raise unless a == ['a', 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25]
 
   a = (1..25).map.to_a
   a[1, 0] = 'a'
-  unless a == [1, 'a', 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25]
-    raise
-  end
+  raise unless a == [1, 'a', 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25]
 
   a = (1..25).map.to_a
   a[25, 0] = 'a'
-  unless a == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 'a']
-    raise
-  end
+  raise unless a == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 'a']
 
   a = (1..25).map.to_a
   a[27, 0] = 'a'
@@ -233,15 +212,11 @@ def dynamic_set_with_drain
 
   a = (1..25).map.to_a
   a[1, 1] = 'a'
-  unless a == [1, 'a', 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25]
-    raise
-  end
+  raise unless a == [1, 'a', 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25]
 
   a = (1..25).map.to_a
   a[1, 2] = 'a'
-  unless a == [1, 'a', 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25]
-    raise
-  end
+  raise unless a == [1, 'a', 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25]
 
   a = (1..25).map.to_a
   a[1, 24] = 'a'
@@ -253,17 +228,12 @@ def dynamic_set_with_drain
 
   a = (1..25).map.to_a
   a[20, 100] = 'a'
-  unless a == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 'a']
-    raise
-  end
+  raise unless a == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 'a']
 
   a = (1..25).map.to_a
   a[25, 100] = 'a'
-  unless a == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 'a']
-    raise
-  end
+  raise unless a == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 'a']
 end
-# rubocop:enable Style/GuardClause
 
 def inline_set_slice
   a = [1, 2, 3]
@@ -316,9 +286,7 @@ def inline_set_slice
 
   a = [1, 2, 3]
   a[0, 100] = (1..25).map.to_a
-  unless a == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25]
-    raise
-  end
+  raise unless a == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25]
 
   a = [1, 2, 3]
   a[0, 0] = %w[a b c d e]
@@ -332,21 +300,15 @@ end
 def dynamic_set_slice
   a = (1..25).map.to_a
   a[0, 0] = []
-  unless a == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25]
-    raise
-  end
+  raise unless a == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25]
 
   a = (1..25).map.to_a
   a[0, 0] = %w[a]
-  unless a == ['a', 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25]
-    raise
-  end
+  raise unless a == ['a', 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25]
 
   a = (1..25).map.to_a
   a[0, 0] = %w[a]
-  unless a == ['a', 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25]
-    raise
-  end
+  raise unless a == ['a', 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25]
 
   a = (1..25).map.to_a
   a[0, 25] = %w[a]
@@ -405,9 +367,7 @@ def concat
   a = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
   b = %w[a b c d e f g h i j]
   a.concat(b)
-  unless a == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j']
-    raise
-  end
+  raise unless a == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j']
   raise unless b == %w[a b c d e f g h i j]
 end
 

--- a/artichoke-backend/src/extn/core/comparable/comparable.rb
+++ b/artichoke-backend/src/extn/core/comparable/comparable.rb
@@ -6,16 +6,12 @@ module Comparable
 
     if cmp.nil?
       classname = other.class
-      if other.nil? || other.equal?(false) || other.equal?(true) || other.is_a?(Numeric)
-        classname = other.inspect
-      end
+      classname = other.inspect if other.nil? || other.equal?(false) || other.equal?(true) || other.is_a?(Numeric)
       raise ArgumentError, "Comparison of #{self.class} with #{classname} failed"
     end
     unless cmp.is_a?(Numeric)
       classname = other.class
-      if other.nil? || other.equal?(false) || other.equal?(true) || other.is_a?(Numeric)
-        classname = other.inspect
-      end
+      classname = other.inspect if other.nil? || other.equal?(false) || other.equal?(true) || other.is_a?(Numeric)
       raise ArgumentError, "Comparison of #{self.class} with #{classname} failed"
     end
 
@@ -29,16 +25,12 @@ module Comparable
 
     if cmp.nil?
       classname = other.class
-      if other.nil? || other.equal?(false) || other.equal?(true) || other.is_a?(Numeric)
-        classname = other.inspect
-      end
+      classname = other.inspect if other.nil? || other.equal?(false) || other.equal?(true) || other.is_a?(Numeric)
       raise ArgumentError, "Comparison of #{self.class} with #{classname} failed"
     end
     unless cmp.is_a?(Numeric)
       classname = other.class
-      if other.nil? || other.equal?(false) || other.equal?(true) || other.is_a?(Numeric)
-        classname = other.inspect
-      end
+      classname = other.inspect if other.nil? || other.equal?(false) || other.equal?(true) || other.is_a?(Numeric)
       raise ArgumentError, "Comparison of #{self.class} with #{classname} failed"
     end
 
@@ -56,9 +48,7 @@ module Comparable
 
     unless cmp.is_a?(Numeric)
       classname = other.class
-      if other.nil? || other.equal?(false) || other.equal?(true) || other.is_a?(Numeric)
-        classname = other.inspect
-      end
+      classname = other.inspect if other.nil? || other.equal?(false) || other.equal?(true) || other.is_a?(Numeric)
       raise ArgumentError, "Comparison of #{self.class} with #{classname} failed"
     end
 
@@ -74,16 +64,12 @@ module Comparable
 
     if cmp.nil?
       classname = other.class
-      if other.nil? || other.equal?(false) || other.equal?(true) || other.is_a?(Numeric)
-        classname = other.inspect
-      end
+      classname = other.inspect if other.nil? || other.equal?(false) || other.equal?(true) || other.is_a?(Numeric)
       raise ArgumentError, "Comparison of #{self.class} with #{classname} failed"
     end
     unless cmp.is_a?(Numeric)
       classname = other.class
-      if other.nil? || other.equal?(false) || other.equal?(true) || other.is_a?(Numeric)
-        classname = other.inspect
-      end
+      classname = other.inspect if other.nil? || other.equal?(false) || other.equal?(true) || other.is_a?(Numeric)
       raise ArgumentError, "Comparison of #{self.class} with #{classname} failed"
     end
 
@@ -97,16 +83,12 @@ module Comparable
 
     if cmp.nil?
       classname = other.class
-      if other.nil? || other.equal?(false) || other.equal?(true) || other.is_a?(Numeric)
-        classname = other.inspect
-      end
+      classname = other.inspect if other.nil? || other.equal?(false) || other.equal?(true) || other.is_a?(Numeric)
       raise ArgumentError, "Comparison of #{self.class} with #{classname} failed"
     end
     unless cmp.is_a?(Numeric)
       classname = other.class
-      if other.nil? || other.equal?(false) || other.equal?(true) || other.is_a?(Numeric)
-        classname = other.inspect
-      end
+      classname = other.inspect if other.nil? || other.equal?(false) || other.equal?(true) || other.is_a?(Numeric)
       raise ArgumentError, "Comparison of #{self.class} with #{classname} failed"
     end
 
@@ -119,16 +101,12 @@ module Comparable
     cmp = (self <=> min)
     if cmp.nil?
       classname = other.class
-      if other.nil? || other.equal?(false) || other.equal?(true) || other.is_a?(Numeric)
-        classname = other.inspect
-      end
+      classname = other.inspect if other.nil? || other.equal?(false) || other.equal?(true) || other.is_a?(Numeric)
       raise ArgumentError, "Comparison of #{self.class} with #{classname} failed"
     end
     unless cmp.is_a?(Numeric)
       classname = other.class
-      if other.nil? || other.equal?(false) || other.equal?(true) || other.is_a?(Numeric)
-        classname = other.inspect
-      end
+      classname = other.inspect if other.nil? || other.equal?(false) || other.equal?(true) || other.is_a?(Numeric)
       raise ArgumentError, "Comparison of #{self.class} with #{classname} failed"
     end
 
@@ -137,16 +115,12 @@ module Comparable
     cmp = (self <=> max)
     if cmp.nil?
       classname = other.class
-      if other.nil? || other.equal?(false) || other.equal?(true) || other.is_a?(Numeric)
-        classname = other.inspect
-      end
+      classname = other.inspect if other.nil? || other.equal?(false) || other.equal?(true) || other.is_a?(Numeric)
       raise ArgumentError, "Comparison of #{self.class} with #{classname} failed"
     end
     unless cmp.is_a?(Numeric)
       classname = other.class
-      if other.nil? || other.equal?(false) || other.equal?(true) || other.is_a?(Numeric)
-        classname = other.inspect
-      end
+      classname = other.inspect if other.nil? || other.equal?(false) || other.equal?(true) || other.is_a?(Numeric)
       raise ArgumentError, "Comparison of #{self.class} with #{classname} failed"
     end
 
@@ -157,23 +131,17 @@ module Comparable
 
   def clamp(min, max)
     paramcmp = (min <=> max)
-    if paramcmp.nil? || paramcmp.positive?
-      raise ArgumentError, 'min argument must be smaller than max argument'
-    end
+    raise ArgumentError, 'min argument must be smaller than max argument' if paramcmp.nil? || paramcmp.positive?
 
     cmp = (self <=> min)
     if cmp.nil?
       classname = other.class
-      if other.nil? || other.equal?(false) || other.equal?(true) || other.is_a?(Numeric)
-        classname = other.inspect
-      end
+      classname = other.inspect if other.nil? || other.equal?(false) || other.equal?(true) || other.is_a?(Numeric)
       raise ArgumentError, "Comparison of #{self.class} with #{classname} failed"
     end
     unless cmp.is_a?(Numeric)
       classname = other.class
-      if other.nil? || other.equal?(false) || other.equal?(true) || other.is_a?(Numeric)
-        classname = other.inspect
-      end
+      classname = other.inspect if other.nil? || other.equal?(false) || other.equal?(true) || other.is_a?(Numeric)
       raise ArgumentError, "Comparison of #{self.class} with #{classname} failed"
     end
 
@@ -182,16 +150,12 @@ module Comparable
     cmp = (self <=> max)
     if cmp.nil?
       classname = other.class
-      if other.nil? || other.equal?(false) || other.equal?(true) || other.is_a?(Numeric)
-        classname = other.inspect
-      end
+      classname = other.inspect if other.nil? || other.equal?(false) || other.equal?(true) || other.is_a?(Numeric)
       raise ArgumentError, "Comparison of #{self.class} with #{classname} failed"
     end
     unless cmp.is_a?(Numeric)
       classname = other.class
-      if other.nil? || other.equal?(false) || other.equal?(true) || other.is_a?(Numeric)
-        classname = other.inspect
-      end
+      classname = other.inspect if other.nil? || other.equal?(false) || other.equal?(true) || other.is_a?(Numeric)
       raise ArgumentError, "Comparison of #{self.class} with #{classname} failed"
     end
 

--- a/artichoke-backend/src/extn/core/enumerable/enumerable.rb
+++ b/artichoke-backend/src/extn/core/enumerable/enumerable.rb
@@ -568,23 +568,15 @@ module Enumerable
     if blk
       each do |v|
         v = blk.call(v)
-        unless v.is_a? Array
-          raise TypeError, "wrong element type #{v.class} (expected Array)"
-        end
-        if v.size != 2
-          raise ArgumentError, "element has wrong array length (expected 2, was #{v.size})"
-        end
+        raise TypeError, "wrong element type #{v.class} (expected Array)" unless v.is_a? Array
+        raise ArgumentError, "element has wrong array length (expected 2, was #{v.size})" if v.size != 2
 
         h[v[0]] = v[1]
       end
     else
       each do |v|
-        unless v.is_a? Array
-          raise TypeError, "wrong element type #{v.class} (expected Array)"
-        end
-        if v.size != 2
-          raise ArgumentError, "element has wrong array length (expected 2, was #{v.size})"
-        end
+        raise TypeError, "wrong element type #{v.class} (expected Array)" unless v.is_a? Array
+        raise ArgumentError, "element has wrong array length (expected 2, was #{v.size})" if v.size != 2
 
         h[v[0]] = v[1]
       end
@@ -613,9 +605,7 @@ module Enumerable
   def zip(*arg, &block)
     result = block ? nil : []
     arg = arg.map do |a|
-      unless a.respond_to?(:to_a)
-        raise TypeError, "wrong argument type #{a.class} (must respond to :to_a)"
-      end
+      raise TypeError, "wrong argument type #{a.class} (must respond to :to_a)" unless a.respond_to?(:to_a)
 
       a.to_a
     end

--- a/artichoke-backend/src/extn/core/enumerator/enumerator.rb
+++ b/artichoke-backend/src/extn/core/enumerator/enumerator.rb
@@ -531,9 +531,7 @@ class Enumerator
   class Generator
     include Enumerable
     def initialize(&block)
-      unless block.is_a? Proc
-        raise TypeError, "wrong argument type #{self.class} (expected Proc)"
-      end
+      raise TypeError, "wrong argument type #{self.class} (expected Proc)" unless block.is_a? Proc
 
       @proc = block
     end
@@ -661,9 +659,7 @@ module Enumerable
   # use Enumerator to use infinite sequence
   def zip(*args, &block)
     args = args.map do |a|
-      unless a.respond_to?(:each)
-        raise TypeError, "wrong argument type #{a.class} (must respond to :each)"
-      end
+      raise TypeError, "wrong argument type #{a.class} (must respond to :each)" unless a.respond_to?(:each)
 
       a.to_enum(:each)
     end

--- a/artichoke-backend/src/extn/core/env/env.rb
+++ b/artichoke-backend/src/extn/core/env/env.rb
@@ -80,9 +80,7 @@ class << ENV
   end
 
   def fetch(name, default = (not_set = true))
-    if !not_set && block_given?
-      warn 'warning: block supersedes default value argument'
-    end
+    warn 'warning: block supersedes default value argument' if !not_set && block_given?
 
     name =
       if name.is_a?(String)
@@ -271,9 +269,7 @@ class << ENV
       pairs = h.each_pair.map do |name, value|
         tx = yield(name, value)
         if tx.is_a?(Array)
-          if tx.length != 2
-            raise ArgumentError, "element has wrong array length (expected 2, was #{tx.length})"
-          end
+          raise ArgumentError, "element has wrong array length (expected 2, was #{tx.length})" if tx.length != 2
 
           tx
         elsif tx.respond_to?(:to_ary)

--- a/artichoke-backend/src/extn/core/hash/hash.rb
+++ b/artichoke-backend/src/extn/core/hash/hash.rb
@@ -14,9 +14,7 @@ class Hash
       elsif o.respond_to?(:to_a)
         h = new
         o.to_a.each do |i|
-          unless i.respond_to?(:to_a)
-            raise ArgumentError, "wrong element type #{i.class} (expected array)"
-          end
+          raise ArgumentError, "wrong element type #{i.class} (expected array)" unless i.respond_to?(:to_a)
 
           k, v = nil
           case i.size
@@ -43,9 +41,7 @@ class Hash
   end
 
   def <(other)
-    unless other.is_a?(Hash)
-      raise TypeError, "can't convert #{other.class} to Hash"
-    end
+    raise TypeError, "can't convert #{other.class} to Hash" unless other.is_a?(Hash)
 
     (size < other.size) && all? do |key, val|
       other.key?(key) && (other[key] == val)
@@ -53,9 +49,7 @@ class Hash
   end
 
   def <=(other)
-    unless other.is_a?(Hash)
-      raise TypeError, "can't convert #{other.class} to Hash"
-    end
+    raise TypeError, "can't convert #{other.class} to Hash" unless other.is_a?(Hash)
 
     (size <= other.size) && all? do |key, val|
       other.key?(key) && (other[key] == val)
@@ -75,9 +69,7 @@ class Hash
   end
 
   def >(other)
-    unless other.is_a?(Hash)
-      raise TypeError, "can't convert #{other.class} to Hash"
-    end
+    raise TypeError, "can't convert #{other.class} to Hash" unless other.is_a?(Hash)
 
     (size > other.size) && other.all? do |key, val|
       key?(key) && (self[key] == val)
@@ -85,9 +77,7 @@ class Hash
   end
 
   def >=(other)
-    unless other.is_a?(Hash)
-      raise TypeError, "can't convert #{other.class} to Hash"
-    end
+    raise TypeError, "can't convert #{other.class} to Hash" unless other.is_a?(Hash)
 
     (size >= other.size) && other.all? do |key, val|
       key?(key) && (self[key] == val)
@@ -247,9 +237,7 @@ class Hash
   end
 
   def merge(other, &block)
-    unless other.is_a?(Hash)
-      raise TypeError, "Hash required (#{other.class} given)"
-    end
+    raise TypeError, "Hash required (#{other.class} given)" unless other.is_a?(Hash)
 
     h = dup
     if block
@@ -267,9 +255,7 @@ class Hash
   end
 
   def merge!(other, &block)
-    unless other.is_a?(Hash)
-      raise TypeError, "Hash required (#{other.class} given)"
-    end
+    raise TypeError, "Hash required (#{other.class} given)" unless other.is_a?(Hash)
 
     if block
       other.each_key do |k|
@@ -305,9 +291,7 @@ class Hash
   end
 
   def replace(hash)
-    unless hash.is_a?(Hash)
-      raise TypeError, "Hash required (#{hash.class} given)"
-    end
+    raise TypeError, "Hash required (#{hash.class} given)" unless hash.is_a?(Hash)
 
     clear
     hash.each_key { |k| self[k] = hash[k] }

--- a/artichoke-backend/src/extn/core/integer/integer.rb
+++ b/artichoke-backend/src/extn/core/integer/integer.rb
@@ -12,9 +12,7 @@ class Integer
     end
 
     classname = mask.class
-    if mask.nil? || mask.equal?(false) || mask.equal?(true)
-      classname = mask.inspect
-    end
+    classname = mask.inspect if mask.nil? || mask.equal?(false) || mask.equal?(true)
     raise TypeError, "no implicit conversion of #{classname} into #{self.class}"
   end
 
@@ -25,9 +23,7 @@ class Integer
     end
 
     classname = mask.class
-    if mask.nil? || mask.equal?(false) || mask.equal?(true)
-      classname = mask.inspect
-    end
+    classname = mask.inspect if mask.nil? || mask.equal?(false) || mask.equal?(true)
     raise TypeError, "no implicit conversion of #{classname} into #{self.class}"
   end
 
@@ -46,9 +42,7 @@ class Integer
     end
 
     classname = mask.class
-    if mask.nil? || mask.equal?(false) || mask.equal?(true)
-      classname = mask.inspect
-    end
+    classname = mask.inspect if mask.nil? || mask.equal?(false) || mask.equal?(true)
     raise TypeError, "no implicit conversion of #{classname} into #{self.class}"
   end
 

--- a/artichoke-backend/src/extn/core/kernel/kernel.rb
+++ b/artichoke-backend/src/extn/core/kernel/kernel.rb
@@ -62,9 +62,7 @@ module Kernel
   end
 
   def Integer(arg, base = nil, exception: true) # rubocop:disable Naming/MethodName
-    if base&.positive? && arg.is_a?(Numeric)
-      raise ArgumentError, 'base specified for non string value'
-    end
+    raise ArgumentError, 'base specified for non string value' if base&.positive? && arg.is_a?(Numeric)
 
     classname = arg.class
     classname = arg.inspect if arg.nil? || arg.equal?(false) || arg.equal?(true)
@@ -148,9 +146,7 @@ module Kernel
   def singleton_method(name)
     m = method(name)
     sc = (class << self; self; end)
-    if m.owner != sc
-      raise NameError, "undefined method '#{name}' for class '#{sc}'"
-    end
+    raise NameError, "undefined method '#{name}' for class '#{sc}'" if m.owner != sc
 
     m
   end

--- a/artichoke-backend/src/extn/core/range/range.rb
+++ b/artichoke-backend/src/extn/core/range/range.rb
@@ -4,9 +4,7 @@ class Range
   include Enumerable
 
   def cover?(*args)
-    unless args.length == 1
-      raise ArgumentError, "wrong number of arguments (given #{args.length}, expected 1)"
-    end
+    raise ArgumentError, "wrong number of arguments (given #{args.length}, expected 1)" unless args.length == 1
 
     range_begin = self.begin
     range_end = self.end
@@ -96,9 +94,7 @@ class Range
   def first(*args)
     return self.begin if args.empty?
 
-    unless args.length == 1
-      raise ArgumentError, "wrong number of arguments (given #{args.length}, expected 1)"
-    end
+    raise ArgumentError, "wrong number of arguments (given #{args.length}, expected 1)" unless args.length == 1
 
     n = args[0].to_i
     raise ArgumentError, 'negative array size (or size too big)' unless n >= 0
@@ -122,16 +118,12 @@ class Range
   def last(*args)
     return self.end if args.empty?
 
-    if args.length > 1
-      raise ArgumentError, "wrong number of arguments (given #{args.length}, expected 0..1)"
-    end
+    raise ArgumentError, "wrong number of arguments (given #{args.length}, expected 0..1)" if args.length > 1
 
     arg = args[0]
     classname = arg.class
     classname = arg.inspect if arg.nil? || arg.equal?(false) || arg.equal?(true)
-    unless arg.respond_to?(:to_int)
-      raise TypeError, "no implicit conversion of #{classname} into Integer"
-    end
+    raise TypeError, "no implicit conversion of #{classname} into Integer" unless arg.respond_to?(:to_int)
 
     n = arg.to_int
     unless n.is_a?(Integer)

--- a/artichoke-backend/src/extn/core/string/string.rb
+++ b/artichoke-backend/src/extn/core/string/string.rb
@@ -113,9 +113,7 @@ class String
 
   def =~(other)
     return other.match(self)&.begin(0) if other.is_a?(Regexp)
-    if other.is_a?(String)
-      raise TypeError, "type mismatch: #{other.class} given"
-    end
+    raise TypeError, "type mismatch: #{other.class} given" if other.is_a?(String)
     return other =~ self if other.respond_to?(:=~)
 
     nil
@@ -123,9 +121,7 @@ class String
 
   alias __old_element_reference []
   def [](*args)
-    if args.empty? || args.length > 2
-      raise ArgumentError, 'wrong number of arguments (given 0, expected 1..2)'
-    end
+    raise ArgumentError, 'wrong number of arguments (given 0, expected 1..2)' if args.empty? || args.length > 2
 
     element =
       if (regexp = args[0]).is_a?(Regexp)
@@ -276,9 +272,7 @@ class String
   end
 
   def delete_prefix(prefix)
-    unless prefix.is_a?(String)
-      raise TypeError, "no implicit conversion of #{prefix.class} into String"
-    end
+    raise TypeError, "no implicit conversion of #{prefix.class} into String" unless prefix.is_a?(String)
 
     return self[prefix.length..-1] if start_with?(prefix)
 
@@ -291,9 +285,7 @@ class String
   end
 
   def delete_suffix(suffix)
-    unless suffix.is_a?(String)
-      raise TypeError, "no implicit conversion of #{suffix.class} into String"
-    end
+    raise TypeError, "no implicit conversion of #{suffix.class} into String" unless suffix.is_a?(String)
 
     return self[0..-suffix.length] if end_with?(suffix)
 
@@ -699,9 +691,7 @@ class String
   def tr(from_str, to_str)
     # TODO: Support character ranges c1-c2
     # TODO: Support backslash escapes
-    if to_str.length.positive?
-      to_str = to_str.rjust(from_str.length, to_str[-1])
-    end
+    to_str = to_str.rjust(from_str.length, to_str[-1]) if to_str.length.positive?
 
     gsub(Regexp.compile("[#{from_str}]")) do |char|
       to_str[from_str.index(char)] || ''
@@ -747,9 +737,7 @@ class String
 
   def upto(max, exclusive = false, &block)
     return to_enum(:upto, max, exclusive) unless block
-    unless max.is_a?(String)
-      raise TypeError, "no implicit conversion of #{max.class} into String"
-    end
+    raise TypeError, "no implicit conversion of #{max.class} into String" unless max.is_a?(String)
 
     len = length
     maxlen = max.length

--- a/artichoke-backend/src/extn/core/string/string_test.rb
+++ b/artichoke-backend/src/extn/core/string/string_test.rb
@@ -19,20 +19,14 @@ def string_match_operator
   raise unless match.nil?
 end
 
-# rubocop:disable Style/GuardClause
 def string_element_reference_regexp
   raise unless 'hello there'[/[aeiou](.)\1/] == 'ell'
   raise unless 'hello there'[/[aeiou](.)\1/, 0] == 'ell'
   raise unless 'hello there'[/[aeiou](.)\1/, 1] == 'l'
   raise unless 'hello there'[/[aeiou](.)\1/, 2].nil?
-  unless 'hello there'[/(?<vowel>[aeiou])(?<non_vowel>[^aeiou])/, 'non_vowel'] == 'l'
-    raise
-  end
-  unless 'hello there'[/(?<vowel>[aeiou])(?<non_vowel>[^aeiou])/, 'vowel'] == 'e'
-    raise
-  end
+  raise unless 'hello there'[/(?<vowel>[aeiou])(?<non_vowel>[^aeiou])/, 'non_vowel'] == 'l'
+  raise unless 'hello there'[/(?<vowel>[aeiou])(?<non_vowel>[^aeiou])/, 'vowel'] == 'e'
 end
-# rubocop:enable Style/GuardClause
 
 def string_scan
   s = 'abababa'

--- a/artichoke-backend/src/extn/core/thread/thread.rb
+++ b/artichoke-backend/src/extn/core/thread/thread.rb
@@ -124,16 +124,12 @@ class Thread
     if @__unwind_with_exception.nil?
       @terminated_with_exception = true
       @value = e
-      if self.class.abort_on_exception || abort_on_exception
-        self.class.__mark_unwind(e)
-      end
+      self.class.__mark_unwind(e) if self.class.abort_on_exception || abort_on_exception
     end
   ensure
     @alive = false unless root
     self.class.__pop_stack unless root
-    if self.class.current == self.class.main && !@__unwind_with_exception.nil?
-      __raise__ @__unwind_with_exception
-    end
+    __raise__ @__unwind_with_exception if self.class.current == self.class.main && !@__unwind_with_exception.nil?
   end
 
   def [](sym)
@@ -176,9 +172,7 @@ class Thread
   alias terminate exit
 
   def fetch(*args)
-    unless [1, 2].include?(args.length)
-      __raise__ ArgumentError, 'Thread#fetch requires 1 or 2 arguments'
-    end
+    __raise__ ArgumentError, 'Thread#fetch requires 1 or 2 arguments' unless [1, 2].include?(args.length)
 
     key = args[0]
     if @fiber_locals.key?(key)

--- a/artichoke-backend/src/extn/stdlib/strscan/strscan.rb
+++ b/artichoke-backend/src/extn/stdlib/strscan/strscan.rb
@@ -247,9 +247,7 @@ class StringScanner
   end
 
   def scan_full(pattern, advance_pointer_p, return_string_p)
-    unless pattern.is_a?(Regexp)
-      raise TypeError, "wrong argument type #{pattern.class} (expected Regexp)"
-    end
+    raise TypeError, "wrong argument type #{pattern.class} (expected Regexp)" unless pattern.is_a?(Regexp)
 
     previous_charpos = @charpos
     match = pattern.match(@string[@charpos..-1])
@@ -340,9 +338,7 @@ class StringScanner
   end
 
   def unscan
-    if @previous_charpos.nil?
-      raise ScanError, 'unscan failed: previous match record not exist'
-    end
+    raise ScanError, 'unscan failed: previous match record not exist' if @previous_charpos.nil?
 
     @charpos = @previous_charpos
     @previous_charpos = nil

--- a/artichoke-backend/src/extn/stdlib/strscan/strscan_test.rb
+++ b/artichoke-backend/src/extn/stdlib/strscan/strscan_test.rb
@@ -77,9 +77,7 @@ def test_index
   raise unless s.pre_match == ''
 
   s.reset
-  unless s.scan(/(?<wday>\w+) (?<month>\w+) (?<day>\d+) /) == 'Fri Dec 12 '
-    raise
-  end
+  raise unless s.scan(/(?<wday>\w+) (?<month>\w+) (?<day>\d+) /) == 'Fri Dec 12 '
   raise unless s[0] == 'Fri Dec 12 '
   raise unless s[1] == 'Fri'
   raise unless s[2] == 'Dec'

--- a/artichoke-backend/src/extn/stdlib/uri/uri_test.rb
+++ b/artichoke-backend/src/extn/stdlib/uri/uri_test.rb
@@ -25,9 +25,7 @@ end
 
 def basic_example
   uri = URI('http://foo.com/posts?id=30&limit=5#time=1305298413')
-  unless uri.inspect == '#<URI::HTTP http://foo.com/posts?id=30&limit=5#time=1305298413>'
-    raise
-  end
+  raise unless uri.inspect == '#<URI::HTTP http://foo.com/posts?id=30&limit=5#time=1305298413>'
   raise unless uri.scheme == 'http'
   raise unless uri.host == 'foo.com'
   raise unless uri.path == '/posts'
@@ -63,47 +61,25 @@ def uri_decode_www_form
   raise unless Hash[ary] == { 'a' => '2', 'b' => '3' }
 end
 
-# rubocop:disable Style/GuardClause
 def uri_encode_www_form
-  unless URI.encode_www_form([%w[q ruby], %w[lang en]]) == 'q=ruby&lang=en'
-    raise
-  end
-  unless URI.encode_www_form('q' => 'ruby', 'lang' => 'en') == 'q=ruby&lang=en'
-    raise
-  end
-  unless URI.encode_www_form('q' => %w[ruby perl], 'lang' => 'en') == 'q=ruby&q=perl&lang=en'
-    raise
-  end
-  unless URI.encode_www_form([%w[q ruby], %w[q perl], %w[lang en]]) == 'q=ruby&q=perl&lang=en'
-    raise
-  end
+  raise unless URI.encode_www_form([%w[q ruby], %w[lang en]]) == 'q=ruby&lang=en'
+  raise unless URI.encode_www_form('q' => 'ruby', 'lang' => 'en') == 'q=ruby&lang=en'
+  raise unless URI.encode_www_form('q' => %w[ruby perl], 'lang' => 'en') == 'q=ruby&q=perl&lang=en'
+  raise unless URI.encode_www_form([%w[q ruby], %w[q perl], %w[lang en]]) == 'q=ruby&q=perl&lang=en'
 end
-# rubocop:enable Style/GuardClause
 
 def uri_extract
   uris = URI.extract('text here http://foo.example.org/bla and here mailto:test@example.com and here also.')
   raise unless uris == ['http://foo.example.org/bla', 'mailto:test@example.com']
 end
 
-# rubocop:disable Style/GuardClause
 def uri_join
-  unless URI.join('http://example.com/', 'main.rbx').inspect == '#<URI::HTTP http://example.com/main.rbx>'
-    raise
-  end
-  unless URI.join('http://example.com/', 'foo').inspect == '#<URI::HTTP http://example.com/foo>'
-    raise
-  end
-  unless URI.join('http://example.com/', '/foo', '/bar').inspect == '#<URI::HTTP http://example.com/bar>'
-    raise
-  end
-  unless URI.join('http://example.com/', '/foo', 'bar').inspect == '#<URI::HTTP http://example.com/bar>'
-    raise
-  end
-  unless URI.join('http://example.com/', '/foo/', 'bar').inspect == '#<URI::HTTP http://example.com/foo/bar>'
-    raise
-  end
+  raise unless URI.join('http://example.com/', 'main.rbx').inspect == '#<URI::HTTP http://example.com/main.rbx>'
+  raise unless URI.join('http://example.com/', 'foo').inspect == '#<URI::HTTP http://example.com/foo>'
+  raise unless URI.join('http://example.com/', '/foo', '/bar').inspect == '#<URI::HTTP http://example.com/bar>'
+  raise unless URI.join('http://example.com/', '/foo', 'bar').inspect == '#<URI::HTTP http://example.com/bar>'
+  raise unless URI.join('http://example.com/', '/foo/', 'bar').inspect == '#<URI::HTTP http://example.com/foo/bar>'
 end
-# rubocop:enable Style/GuardClause
 
 def uri_parse
   uri = URI.parse('http://www.ruby-lang.org/')

--- a/spec-runner/src/spec_runner.rb
+++ b/spec-runner/src/spec_runner.rb
@@ -102,9 +102,7 @@ class SpecCollector
     elsif state.exception.is_a?(RuntimeError)
       skipped = true if state.message =~ /invalid UTF-8/
     end
-    if state.it == 'does not add a URI method to Object instances'
-      skipped = true
-    end
+    skipped = true if state.it == 'does not add a URI method to Object instances'
     skipped = true if state.it == 'is multi-byte character sensitive'
     skipped = true if state.it =~ /UTF-8/
     skipped = true if state.it =~ /\\u/


### PR DESCRIPTION
Update RuboCop to 0.84 and apply all autocorrects.

All autocorrects come from RuboCop increasing the default max line length to 120.

Obsoletes GH-685.