### PR TITLE
Remove some build deps from artichoke-backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,7 +55,6 @@ dependencies = [
  "rand",
  "rand_pcg",
  "regex",
- "rustc_version",
  "smallvec",
  "target-lexicon",
  "uuid",
@@ -698,15 +697,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
-name = "rustc_version"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
-dependencies = [
- "semver",
-]
-
-[[package]]
 name = "rustyline"
 version = "6.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -738,21 +728,6 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
-
-[[package]]
-name = "semver"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-dependencies = [
- "semver-parser 0.7.0",
-]
-
-[[package]]
-name = "semver-parser"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "semver-parser"
@@ -1003,7 +978,7 @@ dependencies = [
  "proc-macro2",
  "pulldown-cmark",
  "regex",
- "semver-parser 0.9.0",
+ "semver-parser",
  "syn",
  "toml",
  "url",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,13 +41,11 @@ dependencies = [
  "cc",
  "chrono",
  "dtoa",
- "git2",
  "hex",
  "itoa",
  "libc",
  "libm",
  "log",
- "num_cpus",
  "once_cell",
  "onig",
  "quickcheck",
@@ -127,9 +125,6 @@ name = "cc"
 version = "1.0.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bbb73db36c1246e9034e307d0fba23f9a2e251faa47ade70c1bd252220c8311"
-dependencies = [
- "jobserver",
-]
 
 [[package]]
 name = "cexpr"
@@ -213,21 +208,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "git2"
-version = "0.13.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11e4b2082980e751c4bf4273e9cbb4a02c655729c8ee8a79f66cad03c8f4d31e"
-dependencies = [
- "bitflags",
- "libc",
- "libgit2-sys",
- "log",
- "openssl-probe",
- "openssl-sys",
- "url",
-]
-
-[[package]]
 name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -284,15 +264,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
 
 [[package]]
-name = "jobserver"
-version = "0.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c71313ebb9439f74b00d9d2dcec36440beaf57a6aa0623068441dd7cd81a7f2"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -311,20 +282,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9457b06509d27052635f90d6466700c65095fdf75409b3fbdd903e988b886f49"
 
 [[package]]
-name = "libgit2-sys"
-version = "0.12.6+1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf81b43f9b45ab07897a780c9b7b26b1504497e469c7a78162fc29e3b8b1c1b3"
-dependencies = [
- "cc",
- "libc",
- "libssh2-sys",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
-]
-
-[[package]]
 name = "libloading"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -339,32 +296,6 @@ name = "libm"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
-
-[[package]]
-name = "libssh2-sys"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d45f516b9b19ea6c940b9f36d36734062a153a2b4cc9ef31d82c54bb9780f525"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
-name = "libz-sys"
-version = "1.0.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eb5e43362e38e2bca2fd5f5134c4d4564a23a5c28e9b95411652021a8675ebe"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "linked-hash-map"
@@ -436,16 +367,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_cpus"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
-dependencies = [
- "hermit-abi",
- "libc",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -469,25 +390,6 @@ source = "git+https://github.com/artichoke/rust-onig?rev=ec266cae185ef4119008ea0
 dependencies = [
  "cc",
  "pkg-config",
-]
-
-[[package]]
-name = "openssl-probe"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.55"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7717097d810a0f2e2323f9e5d11e71608355e24828410b55b9d4f18aa5f9a5d8"
-dependencies = [
- "autocfg",
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
 ]
 
 [[package]]
@@ -955,12 +857,6 @@ checksum = "9fde2f6a4bea1d6e007c4ad38c6839fa71cbb63b6dbf5b595aa38dc9b1093c11"
 dependencies = [
  "rand",
 ]
-
-[[package]]
-name = "vcpkg"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fc439f2794e98976c88a2a2dafce96b930fe8010b0a256b3c2199a773933168"
 
 [[package]]
 name = "vec_map"

--- a/Rakefile
+++ b/Rakefile
@@ -10,7 +10,7 @@ task lint: %i[lint:format lint:clippy lint:rubocop lint:eslint]
 namespace :lint do
   desc 'Run Clippy'
   task :clippy do
-    roots = Dir.glob('**/{lib,main}.rs')
+    roots = Dir.glob('**/{build,lib,main}.rs')
     roots.each do |root|
       FileUtils.touch(root)
     end

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -42,8 +42,6 @@ quickcheck_macros = "0.9"
 bindgen = { version = "0.54.0", default-features = false, features = ["runtime"] }
 cc = "1.0"
 chrono = "0.4"
-git2 = "0.13"
-num_cpus = "1"
 target-lexicon = "0.10.0"
 
 [features]

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -40,11 +40,10 @@ quickcheck_macros = "0.9"
 
 [build-dependencies]
 bindgen = { version = "0.54.0", default-features = false, features = ["runtime"] }
-cc = { version = "1.0", features = ["parallel"] }
+cc = "1.0"
 chrono = "0.4"
 git2 = "0.13"
 num_cpus = "1"
-rustc_version = "0.2.3"
 target-lexicon = "0.10.0"
 
 [features]

--- a/artichoke-backend/build.rs
+++ b/artichoke-backend/build.rs
@@ -370,7 +370,7 @@ mod release {
         emit("RUBY_DESCRIPTION", description);
         emit(
             "ARTICHOKE_COMPILER_VERSION",
-            compiler_version().unwrap_or_else(|| String::new()),
+            compiler_version().unwrap_or_else(String::new),
         );
     }
 
@@ -388,7 +388,7 @@ mod release {
         // 2019-04-06 18:30:21 -0700
         // $ git rev-list --count db318759dad41686be679c87c349fcb5ff0a396c
         // 1
-        let time = 1554600621;
+        let time = 1_554_600_621;
         Some(Utc.timestamp(time, 0))
     }
 

--- a/artichoke-backend/build.rs
+++ b/artichoke-backend/build.rs
@@ -329,7 +329,9 @@ mod release {
     use chrono::prelude::*;
     use git2::Repository;
     use std::env;
+    use std::ffi::OsString;
     use std::fmt;
+    use std::process::Command;
     use std::str;
     use target_lexicon::Triple;
 
@@ -438,17 +440,9 @@ mod release {
     }
 
     fn compiler_version() -> Option<String> {
-        let metadata = rustc_version::version_meta().ok()?;
-        let compiler_version = if let Some(mut commit) = metadata.commit_hash {
-            commit.truncate(7);
-            format!(
-                "Rust {} (rev {}) on {}",
-                metadata.semver, commit, metadata.host
-            )
-        } else {
-            format!("Rust {} on {}", metadata.semver, metadata.host)
-        };
-        Some(compiler_version)
+        let cmd = env::var_os("RUSTC").unwrap_or_else(|| OsString::from("rustc"));
+        let compiler_version = Command::new(cmd).arg("-V").output().ok()?;
+        String::from_utf8(compiler_version.stdout).ok()
     }
 }
 

--- a/deny.toml
+++ b/deny.toml
@@ -24,9 +24,7 @@ multiple-versions = "deny"
 highlight = "all"
 allow = []
 deny = []
-skip = [
-  { name = "semver-parser", version = "< 0.9" },
-]
+skip = []
 skip-tree = []
 
 [sources]


### PR DESCRIPTION
Remove:

- num_cpus
- git2
- rustc_version
- jobserver (combination of the above removals and not enabling cc's `parallel` feature)

This change hardcodes some repo metadata into the build script and reduces the number of external subprocesses which can fail.

Previous work on the build script made resolving compiler version and revision count optional in the build script but Artichoke would still fail to build. This PR adds zeroed defaults when emitting the env vars to the compiler.