### PR TITLE
Add a Value::nil constructor and Default impl for Value

### DIFF
--- a/artichoke-backend/src/block.rs
+++ b/artichoke-backend/src/block.rs
@@ -1,0 +1,112 @@
+use std::convert::TryFrom;
+use std::fmt;
+
+use crate::exception::Exception;
+use crate::exception_handler;
+use crate::extn::core::exception::{Fatal, TypeError};
+use crate::gc::MrbGarbageCollection;
+use crate::sys::{self, protect};
+use crate::types::{self, Ruby};
+use crate::value::Value;
+use crate::Artichoke;
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+struct NoBlockGiven(Ruby);
+
+impl From<sys::mrb_value> for NoBlockGiven {
+    fn from(value: sys::mrb_value) -> Self {
+        Self(types::ruby_from_mrb_value(value))
+    }
+}
+
+impl From<Ruby> for NoBlockGiven {
+    fn from(ruby_type: Ruby) -> Self {
+        Self(ruby_type)
+    }
+}
+
+impl NoBlockGiven {
+    pub fn new(ruby_type: Ruby) -> Self {
+        Self(ruby_type)
+    }
+
+    pub fn ruby_type(self) -> Ruby {
+        self.0
+    }
+}
+
+#[derive(Clone, Copy)]
+pub struct Block(sys::mrb_value);
+
+impl From<sys::mrb_value> for Option<Block> {
+    fn from(value: sys::mrb_value) -> Self {
+        Block::new(value)
+    }
+}
+
+impl TryFrom<sys::mrb_value> for Block {
+    type Error = NoBlockGiven;
+
+    fn try_from(value: sys::mrb_value) -> Result<Self, Self::Error> {
+        if let Some(block) = value.into() {
+            Ok(block)
+        } else {
+            Err(NoBlockGiven::from(value))
+        }
+    }
+}
+
+impl fmt::Debug for Block {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "proc")
+    }
+}
+
+impl Block {
+    #[must_use]
+    pub fn new(block: sys::mrb_value) -> Option<Self> {
+        if let Ruby::Nil = types::ruby_from_mrb_value(block) {
+            None
+        } else {
+            Some(Self(block))
+        }
+    }
+
+    #[inline]
+    #[must_use]
+    pub fn inner(&self) -> sys::mrb_value {
+        self.0
+    }
+
+    pub fn yield_arg(&self, interp: &mut Artichoke, arg: &Value) -> Result<Value, Exception> {
+        let mut arena = interp.create_arena_savepoint();
+
+        let result = unsafe {
+            arena
+                .interp()
+                .with_ffi_boundary(|mrb| protect::block_yield(mrb, self.inner(), arg.inner()))?
+        };
+        match result {
+            Ok(value) => {
+                let value = Value::new(&arena, value);
+                if value.is_unreachable() {
+                    // Unreachable values are internal to the mruby interpreter
+                    // and interacting with them via the C API is unspecified
+                    // and may result in a segfault.
+                    //
+                    // See: https://github.com/mruby/mruby/issues/4460
+                    Err(Exception::from(Fatal::new(
+                        arena.interp(),
+                        "Unreachable Ruby value",
+                    )))
+                } else {
+                    Ok(value)
+                }
+            }
+            Err(exception) => {
+                let exception = Value::new(&arena, exception);
+                Err(exception_handler::last_error(&mut arena, exception)?)
+            }
+        }
+    }
+}

--- a/artichoke-backend/src/block.rs
+++ b/artichoke-backend/src/block.rs
@@ -147,7 +147,7 @@ impl Block {
         };
         match result {
             Ok(value) => {
-                let value = Value::new(&arena, value);
+                let value = Value::from(value);
                 if value.is_unreachable() {
                     // Unreachable values are internal to the mruby interpreter
                     // and interacting with them via the C API is unspecified
@@ -163,7 +163,7 @@ impl Block {
                 }
             }
             Err(exception) => {
-                let exception = Value::new(&arena, exception);
+                let exception = Value::from(exception);
                 Err(exception_handler::last_error(&mut arena, exception)?)
             }
         }

--- a/artichoke-backend/src/block.rs
+++ b/artichoke-backend/src/block.rs
@@ -3,6 +3,7 @@ use std::error;
 use std::fmt;
 
 use crate::class_registry::ClassRegistry;
+use crate::core::ConvertMut;
 use crate::exception::{Exception, RubyException};
 use crate::exception_handler;
 use crate::extn::core::exception::{Fatal, TypeError};
@@ -13,7 +14,7 @@ use crate::value::Value;
 use crate::Artichoke;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-struct NoBlockGiven(Ruby);
+pub struct NoBlockGiven(Ruby);
 
 impl fmt::Display for NoBlockGiven {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -23,7 +24,7 @@ impl fmt::Display for NoBlockGiven {
 
 impl error::Error for NoBlockGiven {}
 
-impl RubyException for IOError {
+impl RubyException for NoBlockGiven {
     fn message(&self) -> &[u8] {
         b"no block given"
     }
@@ -38,7 +39,7 @@ impl RubyException for IOError {
     }
 
     fn as_mrb_value(&self, interp: &mut Artichoke) -> Option<sys::mrb_value> {
-        let message = interp.convert_mut(self.inner.to_string());
+        let message = interp.convert_mut(self.message());
         let value = interp
             .new_instance::<TypeError>(&[message])
             .ok()

--- a/artichoke-backend/src/block.rs
+++ b/artichoke-backend/src/block.rs
@@ -85,10 +85,12 @@ impl From<Ruby> for NoBlockGiven {
 }
 
 impl NoBlockGiven {
+    #[must_use]
     pub fn new(ruby_type: Ruby) -> Self {
         Self(ruby_type)
     }
 
+    #[must_use]
     pub fn ruby_type(self) -> Ruby {
         self.0
     }

--- a/artichoke-backend/src/class_registry.rs
+++ b/artichoke-backend/src/class_registry.rs
@@ -82,7 +82,7 @@ impl ClassRegistry for Artichoke {
             let mrb = self.mrb.as_mut();
             if let Some(mut rclass) = spec.rclass(mrb) {
                 let class = sys::mrb_sys_class_value(rclass.as_mut());
-                Ok(Some(Value::new(self, class)))
+                Ok(Some(Value::from(class)))
             } else {
                 Ok(None)
             }
@@ -136,7 +136,7 @@ impl ClassRegistry for Artichoke {
             let mrb = self.mrb.as_mut();
             if let Some(mut rclass) = spec.rclass(mrb) {
                 let value = sys::mrb_obj_new(mrb, rclass.as_mut(), arglen, args.as_ptr());
-                Ok(Some(Value::new(self, value)))
+                Ok(Some(Value::from(value)))
             } else {
                 Ok(None)
             }

--- a/artichoke-backend/src/convert/boolean.rs
+++ b/artichoke-backend/src/convert/boolean.rs
@@ -9,9 +9,9 @@ use crate::Artichoke;
 impl Convert<bool, Value> for Artichoke {
     fn convert(&self, value: bool) -> Value {
         if value {
-            Value::new(self, unsafe { sys::mrb_sys_true_value() })
+            Value::from(unsafe { sys::mrb_sys_true_value() })
         } else {
-            Value::new(self, unsafe { sys::mrb_sys_false_value() })
+            Value::from(unsafe { sys::mrb_sys_false_value() })
         }
     }
 }

--- a/artichoke-backend/src/convert/bytes.rs
+++ b/artichoke-backend/src/convert/bytes.rs
@@ -26,7 +26,7 @@ impl ConvertMut<&[u8], Value> for Artichoke {
         // `mrb_str_new` copies the `char *` to the mruby heap so we do not have
         // to worry about the lifetime of the slice passed into this converter.
         let string = unsafe { self.with_ffi_boundary(|mrb| sys::mrb_str_new(mrb, raw, len)) };
-        Value::new(self, string.unwrap())
+        Value::from(string.unwrap())
     }
 }
 

--- a/artichoke-backend/src/convert/fixnum.rs
+++ b/artichoke-backend/src/convert/fixnum.rs
@@ -35,7 +35,7 @@ impl TryConvert<u64, Value> for Artichoke {
     fn try_convert(&self, value: u64) -> Result<Value, Self::Error> {
         if let Ok(value) = Int::try_from(value) {
             let fixnum = unsafe { sys::mrb_sys_fixnum_value(value) };
-            Ok(Value::new(self, fixnum))
+            Ok(Value::from(fixnum))
         } else {
             Err(Exception::from(BoxIntoRubyError::new(
                 Rust::UnsignedInt,
@@ -83,7 +83,7 @@ impl Convert<Int, Value> for Artichoke {
     #[inline]
     fn convert(&self, value: Int) -> Value {
         let fixnum = unsafe { sys::mrb_sys_fixnum_value(value) };
-        Value::new(self, fixnum)
+        Value::from(fixnum)
     }
 }
 

--- a/artichoke-backend/src/convert/float.rs
+++ b/artichoke-backend/src/convert/float.rs
@@ -10,7 +10,7 @@ use crate::Artichoke;
 impl ConvertMut<Fp, Value> for Artichoke {
     fn convert_mut(&mut self, value: Fp) -> Value {
         let float = unsafe { self.with_ffi_boundary(|mrb| sys::mrb_sys_float_value(mrb, value)) };
-        Value::new(self, float.unwrap())
+        Value::from(float.unwrap())
     }
 }
 

--- a/artichoke-backend/src/convert/hash.rs
+++ b/artichoke-backend/src/convert/hash.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::convert::TryFrom;
 
 use crate::convert::{RustBackedValue, UnboxRubyError};
-use crate::core::{Convert, ConvertMut, TryConvertMut};
+use crate::core::{ConvertMut, TryConvertMut};
 use crate::exception::Exception;
 use crate::extn::core::array::Array;
 use crate::sys;

--- a/artichoke-backend/src/convert/hash.rs
+++ b/artichoke-backend/src/convert/hash.rs
@@ -69,7 +69,7 @@ impl ConvertMut<Option<HashMap<Vec<u8>, Option<Vec<u8>>>>, Value> for Artichoke 
             }
             Value::new(self, hash)
         } else {
-            self.convert(None::<Value>)
+            Value::nil()
         }
     }
 }

--- a/artichoke-backend/src/convert/hash.rs
+++ b/artichoke-backend/src/convert/hash.rs
@@ -23,7 +23,7 @@ impl ConvertMut<Vec<(Value, Value)>, Value> for Artichoke {
             let val = val.inner();
             let _ = unsafe { self.with_ffi_boundary(|mrb| sys::mrb_hash_set(mrb, hash, key, val)) };
         }
-        Value::new(self, hash)
+        Value::from(hash)
     }
 }
 
@@ -37,7 +37,7 @@ impl ConvertMut<Vec<(Vec<u8>, Vec<Int>)>, Value> for Artichoke {
             let val = self.convert_mut(val).inner();
             let _ = unsafe { self.with_ffi_boundary(|mrb| sys::mrb_hash_set(mrb, hash, key, val)) };
         }
-        Value::new(self, hash)
+        Value::from(hash)
     }
 }
 
@@ -51,7 +51,7 @@ impl ConvertMut<HashMap<Vec<u8>, Vec<u8>>, Value> for Artichoke {
             let val = self.convert_mut(val).inner();
             let _ = unsafe { self.with_ffi_boundary(|mrb| sys::mrb_hash_set(mrb, hash, key, val)) };
         }
-        Value::new(self, hash)
+        Value::from(hash)
     }
 }
 
@@ -67,7 +67,7 @@ impl ConvertMut<Option<HashMap<Vec<u8>, Option<Vec<u8>>>>, Value> for Artichoke 
                 let _ =
                     unsafe { self.with_ffi_boundary(|mrb| sys::mrb_hash_set(mrb, hash, key, val)) };
             }
-            Value::new(self, hash)
+            Value::from(hash)
         } else {
             Value::nil()
         }
@@ -82,7 +82,7 @@ impl TryConvertMut<Value, Vec<(Value, Value)>> for Artichoke {
             let hash = value.inner();
             let keys = unsafe { self.with_ffi_boundary(|mrb| sys::mrb_hash_keys(mrb, hash))? };
 
-            let keys = Value::new(self, keys);
+            let keys = Value::from(keys);
             let array = unsafe { Array::try_from_ruby(self, &keys) }?;
             let borrow = array.borrow();
 
@@ -91,7 +91,7 @@ impl TryConvertMut<Value, Vec<(Value, Value)>> for Artichoke {
                 let value = unsafe {
                     self.with_ffi_boundary(|mrb| sys::mrb_hash_get(mrb, hash, key.inner()))?
                 };
-                pairs.push((key, Value::new(self, value)))
+                pairs.push((key, Value::from(value)))
             }
             Ok(pairs)
         } else {

--- a/artichoke-backend/src/convert/nilable.rs
+++ b/artichoke-backend/src/convert/nilable.rs
@@ -1,19 +1,16 @@
-//! Converters for nilable primitive Ruby types. Excludes collection types
-//! Array and Hash.
+//! Converters for nilable primitive Ruby types.
+//!
+//! Excludes collection types Array and Hash.
 
-use crate::core::{Convert, ConvertMut, TryConvert, TryConvertMut};
+use crate::core::{Convert, ConvertMut, TryConvert, TryConvertMut, Value as _};
 use crate::exception::Exception;
-use crate::types::{Int, Ruby};
+use crate::types::Int;
 use crate::value::Value;
 use crate::Artichoke;
 
 impl Convert<Option<Value>, Value> for Artichoke {
     fn convert(&self, value: Option<Value>) -> Value {
-        if let Some(value) = value {
-            value
-        } else {
-            Value::nil()
-        }
+        Value::from(value)
     }
 }
 
@@ -61,7 +58,7 @@ impl ConvertMut<Option<&str>, Value> for Artichoke {
 
 impl Convert<Value, Option<Value>> for Artichoke {
     fn convert(&self, value: Value) -> Option<Value> {
-        if let Ruby::Nil = value.ruby_type() {
+        if value.is_nil() {
             None
         } else {
             Some(value)
@@ -69,11 +66,11 @@ impl Convert<Value, Option<Value>> for Artichoke {
     }
 }
 
-impl<'a> TryConvert<Value, Option<bool>> for Artichoke {
+impl TryConvert<Value, Option<bool>> for Artichoke {
     type Error = Exception;
 
     fn try_convert(&self, value: Value) -> Result<Option<bool>, Self::Error> {
-        if let Ruby::Nil = value.ruby_type() {
+        if value.is_nil() {
             Ok(None)
         } else {
             self.try_convert(value).map(Some)
@@ -81,11 +78,11 @@ impl<'a> TryConvert<Value, Option<bool>> for Artichoke {
     }
 }
 
-impl<'a> TryConvertMut<Value, Option<Vec<u8>>> for Artichoke {
+impl TryConvertMut<Value, Option<Vec<u8>>> for Artichoke {
     type Error = Exception;
 
     fn try_convert_mut(&mut self, value: Value) -> Result<Option<Vec<u8>>, Self::Error> {
-        if let Ruby::Nil = value.ruby_type() {
+        if value.is_nil() {
             Ok(None)
         } else {
             self.try_convert_mut(value).map(Some)
@@ -97,7 +94,7 @@ impl<'a> TryConvertMut<Value, Option<&'a [u8]>> for Artichoke {
     type Error = Exception;
 
     fn try_convert_mut(&mut self, value: Value) -> Result<Option<&'a [u8]>, Self::Error> {
-        if let Ruby::Nil = value.ruby_type() {
+        if value.is_nil() {
             Ok(None)
         } else {
             self.try_convert_mut(value).map(Some)
@@ -105,11 +102,11 @@ impl<'a> TryConvertMut<Value, Option<&'a [u8]>> for Artichoke {
     }
 }
 
-impl<'a> TryConvertMut<Value, Option<String>> for Artichoke {
+impl TryConvertMut<Value, Option<String>> for Artichoke {
     type Error = Exception;
 
     fn try_convert_mut(&mut self, value: Value) -> Result<Option<String>, Self::Error> {
-        if let Ruby::Nil = value.ruby_type() {
+        if value.is_nil() {
             Ok(None)
         } else {
             self.try_convert_mut(value).map(Some)
@@ -121,7 +118,7 @@ impl<'a> TryConvertMut<Value, Option<&'a str>> for Artichoke {
     type Error = Exception;
 
     fn try_convert_mut(&mut self, value: Value) -> Result<Option<&'a str>, Self::Error> {
-        if let Ruby::Nil = value.ruby_type() {
+        if value.is_nil() {
             Ok(None)
         } else {
             self.try_convert_mut(value).map(Some)
@@ -129,11 +126,11 @@ impl<'a> TryConvertMut<Value, Option<&'a str>> for Artichoke {
     }
 }
 
-impl<'a> TryConvert<Value, Option<Int>> for Artichoke {
+impl TryConvert<Value, Option<Int>> for Artichoke {
     type Error = Exception;
 
     fn try_convert(&self, value: Value) -> Result<Option<Int>, Self::Error> {
-        if let Ruby::Nil = value.ruby_type() {
+        if value.is_nil() {
             Ok(None)
         } else {
             self.try_convert(value).map(Some)

--- a/artichoke-backend/src/convert/nilable.rs
+++ b/artichoke-backend/src/convert/nilable.rs
@@ -3,7 +3,6 @@
 
 use crate::core::{Convert, ConvertMut, TryConvert, TryConvertMut};
 use crate::exception::Exception;
-use crate::sys;
 use crate::types::{Int, Ruby};
 use crate::value::Value;
 use crate::Artichoke;

--- a/artichoke-backend/src/convert/nilable.rs
+++ b/artichoke-backend/src/convert/nilable.rs
@@ -13,7 +13,7 @@ impl Convert<Option<Value>, Value> for Artichoke {
         if let Some(value) = value {
             value
         } else {
-            Value::new(self, unsafe { sys::mrb_sys_nil_value() })
+            Value::nil()
         }
     }
 }
@@ -23,7 +23,7 @@ impl Convert<Option<Int>, Value> for Artichoke {
         if let Some(value) = value {
             self.convert(value)
         } else {
-            Value::new(self, unsafe { sys::mrb_sys_nil_value() })
+            Value::nil()
         }
     }
 }
@@ -39,7 +39,7 @@ impl ConvertMut<Option<&[u8]>, Value> for Artichoke {
         if let Some(value) = value {
             self.convert_mut(value)
         } else {
-            Value::new(self, unsafe { sys::mrb_sys_nil_value() })
+            Value::nil()
         }
     }
 }
@@ -55,7 +55,7 @@ impl ConvertMut<Option<&str>, Value> for Artichoke {
         if let Some(value) = value {
             self.convert_mut(value)
         } else {
-            Value::new(self, unsafe { sys::mrb_sys_nil_value() })
+            Value::nil()
         }
     }
 }

--- a/artichoke-backend/src/convert/object.rs
+++ b/artichoke-backend/src/convert/object.rs
@@ -199,7 +199,7 @@ mod tests {
             let borrow = container.borrow();
             guard.convert_mut(borrow.inner.as_bytes())
         } else {
-            guard.convert(None::<Value>)
+            Value::nil()
         };
         result.inner()
     }

--- a/artichoke-backend/src/convert/object.rs
+++ b/artichoke-backend/src/convert/object.rs
@@ -104,7 +104,7 @@ where
         if let GcState::Enabled = prior_gc_state {
             interp.enable_gc();
         }
-        Ok(Value::new(interp, obj))
+        Ok(Value::from(obj))
     }
 
     /// Try to extract a Rust object from the [`Value`].
@@ -194,7 +194,7 @@ mod tests {
         let mut interp = unwrap_interpreter!(mrb);
         let mut guard = Guard::new(&mut interp);
 
-        let value = Value::new(&guard, slf);
+        let value = Value::from(slf);
         let result = if let Ok(container) = Container::try_from_ruby(&mut guard, &value) {
             let borrow = container.borrow();
             guard.convert_mut(borrow.inner.as_bytes())

--- a/artichoke-backend/src/eval.rs
+++ b/artichoke-backend/src/eval.rs
@@ -29,7 +29,7 @@ impl Eval for Artichoke {
         };
         match result {
             Ok(value) => {
-                let value = Value::new(self, value);
+                let value = Value::from(value);
                 if value.is_unreachable() {
                     // Unreachable values are internal to the mruby interpreter
                     // and interacting with them via the C API is unspecified
@@ -44,7 +44,7 @@ impl Eval for Artichoke {
                 }
             }
             Err(exception) => {
-                let exception = Value::new(self, exception);
+                let exception = Value::from(exception);
                 debug!(
                     "Failed eval raised exception: {:?}",
                     bstr::B(&exception.inspect(self))

--- a/artichoke-backend/src/eval.rs
+++ b/artichoke-backend/src/eval.rs
@@ -116,7 +116,7 @@ mod tests {
             let result = if let Ok(value) = guard.eval(b"__FILE__") {
                 value
             } else {
-                guard.convert(None::<Value>)
+                Value::nil()
             };
             result.inner()
         }

--- a/artichoke-backend/src/extn/core/array/ffi.rs
+++ b/artichoke-backend/src/extn/core/array/ffi.rs
@@ -92,7 +92,7 @@ unsafe extern "C" fn artichoke_ary_splat(
 ) -> sys::mrb_value {
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let value = Value::new(&guard, value);
+    let value = Value::from(value);
     let result = if Array::try_from_ruby(&mut guard, &value).is_ok() {
         Ok(value)
     } else {
@@ -115,8 +115,8 @@ unsafe extern "C" fn artichoke_ary_concat(
 ) -> sys::mrb_value {
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let ary = Value::new(&guard, ary);
-    let other = Value::new(&guard, other);
+    let ary = Value::from(ary);
+    let other = Value::from(other);
     let result = if let Ok(array) = Array::try_from_ruby(&mut guard, &ary) {
         let mut borrow = array.borrow_mut();
         let prior_gc_state = guard.disable_gc();
@@ -146,7 +146,7 @@ unsafe extern "C" fn artichoke_ary_pop(
 ) -> sys::mrb_value {
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let ary = Value::new(&guard, ary);
+    let ary = Value::from(ary);
     let result = if let Ok(array) = Array::try_from_ruby(&mut guard, &ary) {
         let mut borrow = array.borrow_mut();
         let prior_gc_state = guard.disable_gc();
@@ -177,8 +177,8 @@ unsafe extern "C" fn artichoke_ary_push(
 ) -> sys::mrb_value {
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let ary = Value::new(&guard, ary);
-    let value = Value::new(&guard, value);
+    let ary = Value::from(ary);
+    let value = Value::from(value);
     let result = if let Ok(array) = Array::try_from_ruby(&mut guard, &ary) {
         let idx = array.borrow().len();
         let mut borrow = array.borrow_mut();
@@ -210,7 +210,7 @@ unsafe extern "C" fn artichoke_ary_ref(
 ) -> sys::mrb_value {
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let ary = Value::new(&guard, ary);
+    let ary = Value::from(ary);
     let offset = usize::try_from(offset).unwrap_or_default();
     let result = if let Ok(array) = Array::try_from_ruby(&mut guard, &ary) {
         let borrow = array.borrow();
@@ -239,8 +239,8 @@ unsafe extern "C" fn artichoke_ary_set(
 ) -> sys::mrb_value {
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let ary = Value::new(&guard, ary);
-    let value = Value::new(&guard, value);
+    let ary = Value::from(ary);
+    let value = Value::from(value);
     let result = if let Ok(array) = Array::try_from_ruby(&mut guard, &ary) {
         let offset = if let Ok(offset) = usize::try_from(offset) {
             offset
@@ -288,7 +288,7 @@ unsafe extern "C" fn artichoke_ary_shift(
 ) -> sys::mrb_value {
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let array = Value::new(&guard, ary);
+    let array = Value::from(ary);
     let result = if let Ok(array) = Array::try_from_ruby(&mut guard, &array) {
         let mut borrow = array.borrow_mut();
         let prior_gc_state = guard.disable_gc();
@@ -319,8 +319,8 @@ unsafe extern "C" fn artichoke_ary_unshift(
 ) -> sys::mrb_value {
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let array = Value::new(&guard, ary);
-    let value = Value::new(&guard, value);
+    let array = Value::from(ary);
+    let value = Value::from(value);
     if let Ok(array) = Array::try_from_ruby(&mut guard, &array) {
         let mut borrow = array.borrow_mut();
         let prior_gc_state = guard.disable_gc();
@@ -341,7 +341,7 @@ unsafe extern "C" fn artichoke_ary_len(
 ) -> sys::mrb_int {
     let mut interp = unwrap_interpreter!(mrb, or_else = 0);
     let mut guard = Guard::new(&mut interp);
-    let ary = Value::new(&guard, ary);
+    let ary = Value::from(ary);
     if let Ok(array) = Array::try_from_ruby(&mut guard, &ary) {
         let borrow = array.borrow();
         Int::try_from(borrow.0.len()).unwrap_or_default()
@@ -358,7 +358,7 @@ unsafe extern "C" fn artichoke_ary_set_len(
 ) {
     let mut interp = unwrap_interpreter!(mrb, or_else = ());
     let mut guard = Guard::new(&mut interp);
-    let ary = Value::new(&guard, ary);
+    let ary = Value::from(ary);
     if let Ok(array) = Array::try_from_ruby(&mut guard, &ary) {
         let len = usize::try_from(len).unwrap_or_default();
         let mut borrow = array.borrow_mut();
@@ -373,7 +373,7 @@ unsafe extern "C" fn artichoke_ary_ptr(
 ) -> *mut sys::mrb_value {
     let mut interp = unwrap_interpreter!(mrb, or_else = ptr::null_mut());
     let mut guard = Guard::new(&mut interp);
-    let ary = Value::new(&guard, ary);
+    let ary = Value::from(ary);
     if let Ok(array) = Array::try_from_ruby(&mut guard, &ary) {
         let mut borrow = array.borrow_mut();
         borrow.0.as_mut_ptr()
@@ -389,7 +389,7 @@ unsafe extern "C" fn artichoke_ary_check(
 ) -> sys::mrb_bool {
     let mut interp = unwrap_interpreter!(mrb, or_else = 0);
     let mut guard = Guard::new(&mut interp);
-    let ary = Value::new(&guard, ary);
+    let ary = Value::from(ary);
     if Array::try_from_ruby(&mut guard, &ary).is_ok() {
         1
     } else {
@@ -401,7 +401,7 @@ unsafe extern "C" fn artichoke_ary_check(
 unsafe extern "C" fn artichoke_gc_mark_ary(mrb: *mut sys::mrb_state, ary: sys::mrb_value) {
     let mut interp = unwrap_interpreter!(mrb, or_else = ());
     let mut guard = Guard::new(&mut interp);
-    let array = Value::new(&guard, ary);
+    let array = Value::from(ary);
     if let Ok(array) = Array::try_from_ruby(&mut guard, &array) {
         let borrow = array.borrow();
         borrow.gc_mark(&mut guard);
@@ -415,7 +415,7 @@ unsafe extern "C" fn artichoke_gc_mark_ary_size(
 ) -> usize {
     let mut interp = unwrap_interpreter!(mrb, or_else = 0);
     let mut guard = Guard::new(&mut interp);
-    let array = Value::new(&guard, ary);
+    let array = Value::from(ary);
     if let Ok(array) = Array::try_from_ruby(&mut guard, &array) {
         let borrow = array.borrow();
         borrow.real_children()

--- a/artichoke-backend/src/extn/core/array/ffi.rs
+++ b/artichoke-backend/src/extn/core/array/ffi.rs
@@ -156,7 +156,7 @@ unsafe extern "C" fn artichoke_ary_pop(
         }
         result
     } else {
-        Ok(guard.convert(None::<Value>))
+        Ok(Value::nil())
     };
     match result {
         Ok(value) => {
@@ -221,7 +221,7 @@ unsafe extern "C" fn artichoke_ary_ref(
         }
         result
     } else {
-        Ok(guard.convert(None::<Value>))
+        Ok(Value::nil())
     };
     match result {
         Ok(value) => value.inner(),
@@ -299,7 +299,7 @@ unsafe extern "C" fn artichoke_ary_shift(
         }
         result
     } else {
-        Ok(guard.convert(None::<Value>))
+        Ok(Value::nil())
     };
     match result {
         Ok(value) => {

--- a/artichoke-backend/src/extn/core/array/inline_buffer.rs
+++ b/artichoke-backend/src/extn/core/array/inline_buffer.rs
@@ -95,7 +95,7 @@ impl ArrayType for InlineBuffer {
 
     fn gc_mark(&self, interp: &mut Artichoke) {
         for elem in self.0.iter().copied() {
-            let value = Value::new(interp, elem);
+            let value = Value::from(elem);
             interp.mark_value(&value);
         }
     }
@@ -209,11 +209,7 @@ impl InlineBuffer {
 
     #[must_use]
     pub fn as_vec(&self, interp: &Artichoke) -> Vec<Value> {
-        self.0
-            .iter()
-            .copied()
-            .map(|value| Value::new(interp, value))
-            .collect()
+        self.0.iter().copied().map(Value::from).collect()
     }
 
     #[must_use]
@@ -251,7 +247,7 @@ impl InlineBuffer {
 
     pub fn get(&self, interp: &Artichoke, index: usize) -> Result<Option<Value>, Exception> {
         let elem = self.0.get(index);
-        Ok(elem.copied().map(|elem| Value::new(interp, elem)))
+        Ok(elem.copied().map(Value::from))
     }
 
     pub fn slice(&self, interp: &Artichoke, start: usize, len: usize) -> Result<Self, Exception> {
@@ -366,7 +362,7 @@ impl InlineBuffer {
 
     pub fn pop(&mut self, interp: &Artichoke) -> Result<Value, Exception> {
         let value = self.0.pop();
-        Ok(interp.convert(value.map(|value| Value::new(interp, value))))
+        Ok(interp.convert(value.map(Value::from)))
     }
 
     pub fn reverse(&mut self, interp: &Artichoke) -> Result<(), Exception> {

--- a/artichoke-backend/src/extn/core/array/inline_buffer.rs
+++ b/artichoke-backend/src/extn/core/array/inline_buffer.rs
@@ -274,7 +274,7 @@ impl InlineBuffer {
             idx if idx < buflen => self.0[index] = elem.inner(),
             idx if idx == buflen => self.0.push(elem.inner()),
             idx => {
-                let nil = interp.convert(None::<Value>).inner();
+                let nil = Value::nil().inner();
                 self.0.reserve(idx + 1 - buflen);
                 for _ in buflen..idx {
                     self.0.push(nil);
@@ -297,7 +297,7 @@ impl InlineBuffer {
         let drained = cmp::min(buflen.checked_sub(start).unwrap_or_default(), drain);
         match start {
             idx if idx > buflen => {
-                let nil = interp.convert(None::<Value>).inner();
+                let nil = Value::nil().inner();
                 self.0.reserve(start + 1 - buflen);
                 for _ in buflen..start {
                     self.0.push(nil);
@@ -328,7 +328,7 @@ impl InlineBuffer {
         let drained = cmp::min(buflen.checked_sub(start).unwrap_or_default(), drain);
         match start {
             idx if idx > buflen => {
-                let nil = interp.convert(None::<Value>).inner();
+                let nil = Value::nil().inner();
                 for _ in buflen..idx {
                     self.0.push(nil);
                 }

--- a/artichoke-backend/src/extn/core/array/inline_buffer.rs
+++ b/artichoke-backend/src/extn/core/array/inline_buffer.rs
@@ -209,6 +209,7 @@ impl InlineBuffer {
 
     #[must_use]
     pub fn as_vec(&self, interp: &Artichoke) -> Vec<Value> {
+        let _ = interp;
         self.0.iter().copied().map(Value::from).collect()
     }
 
@@ -246,6 +247,7 @@ impl InlineBuffer {
     }
 
     pub fn get(&self, interp: &Artichoke, index: usize) -> Result<Option<Value>, Exception> {
+        let _ = interp;
         let elem = self.0.get(index);
         Ok(elem.copied().map(Value::from))
     }

--- a/artichoke-backend/src/extn/core/array/inline_buffer.rs
+++ b/artichoke-backend/src/extn/core/array/inline_buffer.rs
@@ -63,7 +63,7 @@ impl FromIterator<Option<Value>> for InlineBuffer {
     {
         Self(SmallVec::from_iter(iter.into_iter().map(|elem| {
             elem.as_ref()
-                .map_or_else(|| unsafe { sys::mrb_sys_nil_value() }, Value::inner)
+                .map_or_else(|| Value::nil().inner(), Value::inner)
         })))
     }
 }
@@ -75,7 +75,7 @@ impl<'a> FromIterator<&'a Option<Value>> for InlineBuffer {
     {
         Self(SmallVec::from_iter(iter.into_iter().map(|elem| {
             elem.as_ref()
-                .map_or_else(|| unsafe { sys::mrb_sys_nil_value() }, Value::inner)
+                .map_or_else(|| Value::nil().inner(), Value::inner)
         })))
     }
 }

--- a/artichoke-backend/src/extn/core/array/mod.rs
+++ b/artichoke-backend/src/extn/core/array/mod.rs
@@ -80,7 +80,7 @@ impl Array {
                     }
                     InlineBuffer::from(buffer)
                 } else {
-                    let default = second.unwrap_or_else(|| interp.convert(None::<Value>));
+                    let default = second.unwrap_or_else(Value::nil);
                     let mut buffer = Vec::with_capacity(len);
                     for _ in 0..len {
                         buffer.push(default.inner());
@@ -108,7 +108,7 @@ impl Array {
         len: Option<Value>,
     ) -> Result<Value, Exception> {
         let (index, len) = match args::element_reference(interp, index, len, self.0.len())? {
-            args::ElementReference::Empty => return Ok(interp.convert(None::<Value>)),
+            args::ElementReference::Empty => return Ok(Value::nil()),
             args::ElementReference::Index(index) => (index, None),
             args::ElementReference::StartLen(index, len) => (index, Some(len)),
         };
@@ -122,11 +122,11 @@ impl Array {
             if let Some(start) = idx {
                 start
             } else {
-                return Ok(interp.convert(None::<Value>));
+                return Ok(Value::nil());
             }
         };
         if start > self.0.len() {
-            return Ok(interp.convert(None::<Value>));
+            return Ok(Value::nil());
         }
         if let Some(len) = len {
             let result = self.0.slice(interp, start, len)?;

--- a/artichoke-backend/src/extn/core/array/mruby.rs
+++ b/artichoke-backend/src/extn/core/array/mruby.rs
@@ -38,7 +38,7 @@ unsafe extern "C" fn ary_pop(mrb: *mut sys::mrb_state, ary: sys::mrb_value) -> s
     mrb_get_args!(mrb, none);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let array = Value::new(&guard, ary);
+    let array = Value::from(ary);
     let result = array::trampoline::pop(&mut guard, array);
     match result {
         Ok(value) => {
@@ -54,7 +54,7 @@ unsafe extern "C" fn ary_len(mrb: *mut sys::mrb_state, ary: sys::mrb_value) -> s
     mrb_get_args!(mrb, none);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let ary = Value::new(&guard, ary);
+    let ary = Value::from(ary);
     let result = array::trampoline::len(&mut guard, ary).and_then(|len| {
         if let Ok(len) = sys::mrb_int::try_from(len) {
             Ok(len)
@@ -75,8 +75,8 @@ unsafe extern "C" fn ary_concat(mrb: *mut sys::mrb_state, ary: sys::mrb_value) -
     let other = mrb_get_args!(mrb, optional = 1);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let array = Value::new(&guard, ary);
-    let other = other.map(|other| Value::new(&guard, other));
+    let array = Value::from(ary);
+    let other = other.map(Value::from);
     let result = array::trampoline::concat(&mut guard, array, other);
     match result {
         Ok(value) => {
@@ -95,9 +95,9 @@ unsafe extern "C" fn ary_initialize(
     let (first, second, block) = mrb_get_args!(mrb, optional = 2, &block);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let array = Value::new(&guard, ary);
-    let first = first.map(|first| Value::new(&guard, first));
-    let second = second.map(|second| Value::new(&guard, second));
+    let array = Value::from(ary);
+    let first = first.map(Value::from);
+    let second = second.map(Value::from);
     let result = array::trampoline::initialize(&mut guard, array, first, second, block);
     match result {
         Ok(value) => {
@@ -116,8 +116,8 @@ unsafe extern "C" fn ary_initialize_copy(
     let other = mrb_get_args!(mrb, required = 1);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let array = Value::new(&guard, ary);
-    let other = Value::new(&guard, other);
+    let array = Value::from(ary);
+    let other = Value::from(other);
     let result = array::trampoline::initialize_copy(&mut guard, array, other);
     match result {
         Ok(value) => {
@@ -136,7 +136,7 @@ unsafe extern "C" fn ary_reverse_bang(
     mrb_get_args!(mrb, none);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let array = Value::new(&guard, ary);
+    let array = Value::from(ary);
     let result = array::trampoline::reverse_bang(&mut guard, array);
     match result {
         Ok(value) => {
@@ -155,9 +155,9 @@ unsafe extern "C" fn ary_element_reference(
     let (elem, len) = mrb_get_args!(mrb, required = 1, optional = 1);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let elem = Value::new(&guard, elem);
-    let len = len.map(|len| Value::new(&guard, len));
-    let array = Value::new(&guard, ary);
+    let elem = Value::from(elem);
+    let len = len.map(Value::from);
+    let array = Value::from(ary);
     let result = array::trampoline::element_reference(&mut guard, array, elem, len);
     match result {
         Ok(value) => value.inner(),
@@ -172,10 +172,10 @@ unsafe extern "C" fn ary_element_assignment(
     let (first, second, third) = mrb_get_args!(mrb, required = 2, optional = 1);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let first = Value::new(&guard, first);
-    let second = Value::new(&guard, second);
-    let third = third.map(|third| Value::new(&guard, third));
-    let array = Value::new(&guard, ary);
+    let first = Value::from(first);
+    let second = Value::from(second);
+    let third = third.map(Value::from);
+    let array = Value::from(ary);
     let result = array::trampoline::element_assignment(&mut guard, array, first, second, third);
     match result {
         Ok(value) => {

--- a/artichoke-backend/src/extn/core/array/trampoline.rs
+++ b/artichoke-backend/src/extn/core/array/trampoline.rs
@@ -42,7 +42,7 @@ pub fn element_assignment(
     let array = unsafe { Array::try_from_ruby(interp, &ary) }?;
     // TODO: properly handle self-referential sets.
     if ary == first || ary == second || Some(ary) == third {
-        return Ok(interp.convert(None::<Value>));
+        return Ok(Value::nil());
     }
     let mut borrow = array.borrow_mut();
     let prior_gc_state = interp.disable_gc();

--- a/artichoke-backend/src/extn/core/env/mruby.rs
+++ b/artichoke-backend/src/extn/core/env/mruby.rs
@@ -56,8 +56,8 @@ unsafe extern "C" fn artichoke_env_element_reference(
     let name = mrb_get_args!(mrb, required = 1);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let obj = Value::new(&guard, slf);
-    let name = Value::new(&guard, name);
+    let obj = Value::from(slf);
+    let name = Value::from(name);
     let result = env::element_reference(&mut guard, obj, &name);
     match result {
         Ok(value) => value.inner(),
@@ -73,9 +73,9 @@ unsafe extern "C" fn artichoke_env_element_assignment(
     let (name, value) = mrb_get_args!(mrb, required = 2);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let obj = Value::new(&guard, slf);
-    let name = Value::new(&guard, name);
-    let value = Value::new(&guard, value);
+    let obj = Value::from(slf);
+    let name = Value::from(name);
+    let value = Value::from(value);
     let result = env::element_assignment(&mut guard, obj, &name, value);
     match result {
         Ok(value) => value.inner(),
@@ -91,7 +91,7 @@ unsafe extern "C" fn artichoke_env_to_h(
     mrb_get_args!(mrb, none);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let obj = Value::new(&guard, slf);
+    let obj = Value::from(slf);
     let result = env::to_h(&mut guard, obj);
     match result {
         Ok(value) => value.inner(),

--- a/artichoke-backend/src/extn/core/integer/mruby.rs
+++ b/artichoke-backend/src/extn/core/integer/mruby.rs
@@ -30,8 +30,8 @@ unsafe extern "C" fn artichoke_integer_chr(
     let encoding = mrb_get_args!(mrb, optional = 1);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let value = Value::new(&guard, slf);
-    let encoding = encoding.map(|encoding| Value::new(&guard, encoding));
+    let value = Value::from(slf);
+    let encoding = encoding.map(Value::from);
     let result = trampoline::chr(&mut guard, value, encoding);
     match result {
         Ok(value) => value.inner(),
@@ -46,8 +46,8 @@ unsafe extern "C" fn artichoke_integer_element_reference(
     let bit = mrb_get_args!(mrb, required = 1);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let value = Value::new(&guard, slf);
-    let bit = Value::new(&guard, bit);
+    let value = Value::from(slf);
+    let bit = Value::from(bit);
     let result = trampoline::element_reference(&mut guard, value, bit);
     match result {
         Ok(value) => value.inner(),
@@ -62,8 +62,8 @@ unsafe extern "C" fn artichoke_integer_div(
     let denominator = mrb_get_args!(mrb, required = 1);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let value = Value::new(&guard, slf);
-    let denominator = Value::new(&guard, denominator);
+    let value = Value::from(slf);
+    let denominator = Value::from(denominator);
     let result = trampoline::div(&mut guard, value, denominator);
     match result {
         Ok(value) => value.inner(),

--- a/artichoke-backend/src/extn/core/kernel/mruby.rs
+++ b/artichoke-backend/src/extn/core/kernel/mruby.rs
@@ -56,8 +56,8 @@ unsafe extern "C" fn artichoke_kernel_integer(
     let (arg, base) = mrb_get_args!(mrb, required = 1, optional = 1);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let arg = Value::new(&guard, arg);
-    let base = base.map(|base| Value::new(&guard, base));
+    let arg = Value::from(arg);
+    let base = base.map(Value::from);
     let result = trampoline::integer(&mut guard, arg, base);
     match result {
         Ok(value) => value.inner(),
@@ -72,7 +72,7 @@ unsafe extern "C" fn artichoke_kernel_load(
     let file = mrb_get_args!(mrb, required = 1);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let file = Value::new(&guard, file);
+    let file = Value::from(file);
     let result = trampoline::load(&mut guard, file);
     match result {
         Ok(value) => value.inner(),
@@ -87,11 +87,7 @@ unsafe extern "C" fn artichoke_kernel_p(
     let args = mrb_get_args!(mrb, *args);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let args = args
-        .iter()
-        .copied()
-        .map(|arg| Value::new(&guard, arg))
-        .collect::<Vec<_>>();
+    let args = args.iter().copied().map(Value::from).collect::<Vec<_>>();
     let result = trampoline::p(&mut guard, args);
     match result {
         Ok(value) => value.inner(),
@@ -106,11 +102,7 @@ unsafe extern "C" fn artichoke_kernel_print(
     let args = mrb_get_args!(mrb, *args);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let args = args
-        .iter()
-        .copied()
-        .map(|arg| Value::new(&guard, arg))
-        .collect::<Vec<_>>();
+    let args = args.iter().copied().map(Value::from).collect::<Vec<_>>();
     let result = trampoline::print(&mut guard, args);
     match result {
         Ok(value) => value.inner(),
@@ -125,11 +117,7 @@ unsafe extern "C" fn artichoke_kernel_puts(
     let args = mrb_get_args!(mrb, *args);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let args = args
-        .iter()
-        .copied()
-        .map(|arg| Value::new(&guard, arg))
-        .collect::<Vec<_>>();
+    let args = args.iter().copied().map(Value::from).collect::<Vec<_>>();
     let result = trampoline::puts(&mut guard, args);
     match result {
         Ok(value) => value.inner(),
@@ -144,7 +132,7 @@ unsafe extern "C" fn artichoke_kernel_require(
     let file = mrb_get_args!(mrb, required = 1);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let file = Value::new(&guard, file);
+    let file = Value::from(file);
     let result = trampoline::require(&mut guard, file);
     match result {
         Ok(value) => value.inner(),
@@ -159,7 +147,7 @@ unsafe extern "C" fn artichoke_kernel_require_relative(
     let file = mrb_get_args!(mrb, required = 1);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let file = Value::new(&guard, file);
+    let file = Value::from(file);
     let result = trampoline::require_relative(&mut guard, file);
     match result {
         Ok(value) => value.inner(),

--- a/artichoke-backend/src/extn/core/kernel/mruby.rs
+++ b/artichoke-backend/src/extn/core/kernel/mruby.rs
@@ -87,7 +87,7 @@ unsafe extern "C" fn artichoke_kernel_p(
     let args = mrb_get_args!(mrb, *args);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let args = args.iter().copied().map(Value::from).collect::<Vec<_>>();
+    let args = args.iter().copied().map(Value::from);
     let result = trampoline::p(&mut guard, args);
     match result {
         Ok(value) => value.inner(),
@@ -102,7 +102,7 @@ unsafe extern "C" fn artichoke_kernel_print(
     let args = mrb_get_args!(mrb, *args);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let args = args.iter().copied().map(Value::from).collect::<Vec<_>>();
+    let args = args.iter().copied().map(Value::from);
     let result = trampoline::print(&mut guard, args);
     match result {
         Ok(value) => value.inner(),
@@ -117,7 +117,7 @@ unsafe extern "C" fn artichoke_kernel_puts(
     let args = mrb_get_args!(mrb, *args);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let args = args.iter().copied().map(Value::from).collect::<Vec<_>>();
+    let args = args.iter().copied().map(Value::from);
     let result = trampoline::puts(&mut guard, args);
     match result {
         Ok(value) => value.inner(),

--- a/artichoke-backend/src/extn/core/kernel/trampoline.rs
+++ b/artichoke-backend/src/extn/core/kernel/trampoline.rs
@@ -70,10 +70,10 @@ where
         interp.puts(display)?;
     }
 
-    match args {
-        0 => Ok(Value::nil()),
-        1 => Ok(interp.convert(args[0].to_owned())),
-        _ => Ok(interp.convert_mut(args)),
+    match args.as_slice() {
+        [] => Ok(Value::nil()),
+        [first] => Ok(*first),
+        [args @ ..] => Ok(interp.convert_mut(args)),
     }
 }
 

--- a/artichoke-backend/src/extn/core/kernel/trampoline.rs
+++ b/artichoke-backend/src/extn/core/kernel/trampoline.rs
@@ -49,13 +49,14 @@ where
         Ok(())
     }
 
-    let mut args = args.into_iter().peekable();
-    if args.peek().is_none() {
-        interp.print(b"\n")?;
-    } else {
+    let mut args = args.into_iter();
+    if let Some(first) = args.next() {
+        puts_foreach(interp, &first)?;
         for value in args {
             puts_foreach(interp, &value)?;
         }
+    } else {
+        interp.print(b"\n")?;
     }
     Ok(Value::nil())
 }
@@ -64,16 +65,22 @@ pub fn p<T>(interp: &mut Artichoke, args: T) -> Result<Value, Exception>
 where
     T: IntoIterator<Item = Value>,
 {
-    let args = args.into_iter().collect::<Vec<_>>();
-    for value in &args {
-        let display = value.inspect(interp);
+    let mut args = args.into_iter().peekable();
+    if let Some(first) = args.next() {
+        let display = first.inspect(interp);
         interp.puts(display)?;
-    }
-
-    match args.as_slice() {
-        [] => Ok(Value::nil()),
-        [first] => Ok(*first),
-        [args @ ..] => Ok(interp.convert_mut(args)),
+        if args.peek().is_none() {
+            return Ok(first);
+        }
+        let mut result = vec![first];
+        for value in args {
+            let display = value.inspect(interp);
+            interp.puts(display)?;
+            result.push(value)
+        }
+        Ok(interp.convert_mut(result))
+    } else {
+        return Ok(Value::nil());
     }
 }
 

--- a/artichoke-backend/src/extn/core/kernel/trampoline.rs
+++ b/artichoke-backend/src/extn/core/kernel/trampoline.rs
@@ -80,7 +80,7 @@ where
         }
         Ok(interp.convert_mut(result))
     } else {
-        return Ok(Value::nil());
+        Ok(Value::nil())
     }
 }
 

--- a/artichoke-backend/src/extn/core/kernel/trampoline.rs
+++ b/artichoke-backend/src/extn/core/kernel/trampoline.rs
@@ -27,7 +27,7 @@ where
         let display = value.to_s(interp);
         interp.print(display)?;
     }
-    Ok(interp.convert(None::<Value>))
+    Ok(Value::nil())
 }
 
 pub fn puts<T>(interp: &mut Artichoke, args: T) -> Result<Value, Exception>
@@ -57,7 +57,7 @@ where
             puts_foreach(interp, &value)?;
         }
     }
-    Ok(interp.convert(None::<Value>))
+    Ok(Value::nil())
 }
 
 pub fn p<T>(interp: &mut Artichoke, args: T) -> Result<Value, Exception>
@@ -70,8 +70,8 @@ where
         interp.puts(display)?;
     }
 
-    match args.len() {
-        0 => Ok(interp.convert(None::<Value>)),
+    match args {
+        0 => Ok(Value::nil()),
         1 => Ok(interp.convert(args[0].to_owned())),
         _ => Ok(interp.convert_mut(args)),
     }

--- a/artichoke-backend/src/extn/core/matchdata/mod.rs
+++ b/artichoke-backend/src/extn/core/matchdata/mod.rs
@@ -109,7 +109,7 @@ pub enum CaptureMatch {
 impl ConvertMut<CaptureMatch, Value> for Artichoke {
     fn convert_mut(&mut self, value: CaptureMatch) -> Value {
         match value {
-            CaptureMatch::None => self.convert(None::<Value>),
+            CaptureMatch::None => Value::nil(),
             CaptureMatch::Single(capture) => self.convert_mut(capture),
             CaptureMatch::Range(captures) => self.convert_mut(captures),
         }

--- a/artichoke-backend/src/extn/core/matchdata/mruby.rs
+++ b/artichoke-backend/src/extn/core/matchdata/mruby.rs
@@ -62,8 +62,8 @@ unsafe extern "C" fn artichoke_matchdata_begin(
     let begin = mrb_get_args!(mrb, required = 1);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let value = Value::new(&guard, slf);
-    let begin = Value::new(&guard, begin);
+    let value = Value::from(slf);
+    let begin = Value::from(begin);
     let result = trampoline::begin(&mut guard, value, begin);
     match result {
         Ok(result) => result.inner(),
@@ -78,7 +78,7 @@ unsafe extern "C" fn artichoke_matchdata_captures(
     mrb_get_args!(mrb, none);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let value = Value::new(&guard, slf);
+    let value = Value::from(slf);
     let result = trampoline::captures(&mut guard, value);
     match result {
         Ok(result) => result.inner(),
@@ -93,9 +93,9 @@ unsafe extern "C" fn artichoke_matchdata_element_reference(
     let (elem, len) = mrb_get_args!(mrb, required = 1, optional = 1);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let value = Value::new(&guard, slf);
-    let elem = Value::new(&guard, elem);
-    let len = len.map(|len| Value::new(&guard, len));
+    let value = Value::from(slf);
+    let elem = Value::from(elem);
+    let len = len.map(Value::from);
     let result = trampoline::element_reference(&mut guard, value, elem, len);
     match result {
         Ok(result) => result.inner(),
@@ -110,8 +110,8 @@ unsafe extern "C" fn artichoke_matchdata_end(
     let end = mrb_get_args!(mrb, required = 1);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let value = Value::new(&guard, slf);
-    let end = Value::new(&guard, end);
+    let value = Value::from(slf);
+    let end = Value::from(end);
     let result = trampoline::end(&mut guard, value, end);
     match result {
         Ok(result) => result.inner(),
@@ -126,7 +126,7 @@ unsafe extern "C" fn artichoke_matchdata_length(
     mrb_get_args!(mrb, none);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let value = Value::new(&guard, slf);
+    let value = Value::from(slf);
     let result = trampoline::length(&mut guard, value);
     match result {
         Ok(result) => result.inner(),
@@ -141,7 +141,7 @@ unsafe extern "C" fn artichoke_matchdata_named_captures(
     mrb_get_args!(mrb, none);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let value = Value::new(&guard, slf);
+    let value = Value::from(slf);
     let result = trampoline::named_captures(&mut guard, value);
     match result {
         Ok(result) => result.inner(),
@@ -156,7 +156,7 @@ unsafe extern "C" fn artichoke_matchdata_names(
     mrb_get_args!(mrb, none);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let value = Value::new(&guard, slf);
+    let value = Value::from(slf);
     let result = trampoline::names(&mut guard, value);
     match result {
         Ok(result) => result.inner(),
@@ -171,8 +171,8 @@ unsafe extern "C" fn artichoke_matchdata_offset(
     let offset = mrb_get_args!(mrb, required = 1);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let value = Value::new(&guard, slf);
-    let offset = Value::new(&guard, offset);
+    let value = Value::from(slf);
+    let offset = Value::from(offset);
     let result = trampoline::offset(&mut guard, value, offset);
     match result {
         Ok(result) => result.inner(),
@@ -187,7 +187,7 @@ unsafe extern "C" fn artichoke_matchdata_post_match(
     mrb_get_args!(mrb, none);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let value = Value::new(&guard, slf);
+    let value = Value::from(slf);
     let result = trampoline::post_match(&mut guard, value);
     match result {
         Ok(result) => result.inner(),
@@ -202,7 +202,7 @@ unsafe extern "C" fn artichoke_matchdata_pre_match(
     mrb_get_args!(mrb, none);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let value = Value::new(&guard, slf);
+    let value = Value::from(slf);
     let result = trampoline::pre_match(&mut guard, value);
     match result {
         Ok(result) => result.inner(),
@@ -217,7 +217,7 @@ unsafe extern "C" fn artichoke_matchdata_regexp(
     mrb_get_args!(mrb, none);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let value = Value::new(&guard, slf);
+    let value = Value::from(slf);
     let result = trampoline::regexp(&mut guard, value);
     match result {
         Ok(result) => result.inner(),
@@ -232,7 +232,7 @@ unsafe extern "C" fn artichoke_matchdata_string(
     mrb_get_args!(mrb, none);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let value = Value::new(&guard, slf);
+    let value = Value::from(slf);
     let result = trampoline::string(&mut guard, value);
     match result {
         Ok(result) => result.inner(),
@@ -247,7 +247,7 @@ unsafe extern "C" fn artichoke_matchdata_to_a(
     mrb_get_args!(mrb, none);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let value = Value::new(&guard, slf);
+    let value = Value::from(slf);
     let result = trampoline::to_a(&mut guard, value);
     match result {
         Ok(result) => result.inner(),
@@ -262,7 +262,7 @@ unsafe extern "C" fn artichoke_matchdata_to_s(
     mrb_get_args!(mrb, none);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let value = Value::new(&guard, slf);
+    let value = Value::from(slf);
     let result = trampoline::to_s(&mut guard, value);
     match result {
         Ok(result) => result.inner(),

--- a/artichoke-backend/src/extn/core/matchdata/trampoline.rs
+++ b/artichoke-backend/src/extn/core/matchdata/trampoline.rs
@@ -15,7 +15,7 @@ pub fn begin(interp: &mut Artichoke, value: Value, at: Value) -> Result<Value, E
             interp,
             "input string too long",
         ))),
-        None => Ok(interp.convert(None::<Value>)),
+        None => Ok(Value::nil()),
     }
 }
 
@@ -25,7 +25,7 @@ pub fn captures(interp: &mut Artichoke, value: Value) -> Result<Value, Exception
     if let Some(captures) = borrow.captures(interp)? {
         Ok(interp.convert_mut(captures))
     } else {
-        Ok(interp.convert(None::<Value>))
+        Ok(Value::nil())
     }
 }
 
@@ -54,7 +54,7 @@ pub fn element_reference(
         if let Some(protect::Range { start, len }) = elem.is_range(interp, rangelen)? {
             CaptureAt::StartLen(start, len)
         } else {
-            return Ok(interp.convert(None::<Value>));
+            return Ok(Value::nil());
         }
     };
     let matched = borrow.capture_at(interp, at)?;
@@ -72,7 +72,7 @@ pub fn end(interp: &mut Artichoke, value: Value, at: Value) -> Result<Value, Exc
             interp,
             "input string too long",
         ))),
-        None => Ok(interp.convert(None::<Value>)),
+        None => Ok(Value::nil()),
     }
 }
 
@@ -166,7 +166,7 @@ pub fn to_a(interp: &mut Artichoke, value: Value) -> Result<Value, Exception> {
     if let Some(ary) = borrow.to_a(interp)? {
         Ok(interp.convert_mut(ary))
     } else {
-        Ok(interp.convert(None::<Value>))
+        Ok(Value::nil())
     }
 }
 

--- a/artichoke-backend/src/extn/core/math/mruby.rs
+++ b/artichoke-backend/src/extn/core/math/mruby.rs
@@ -57,7 +57,7 @@ unsafe extern "C" fn artichoke_math_acos(
     let value = mrb_get_args!(mrb, required = 1);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let value = Value::new(&guard, value);
+    let value = Value::from(value);
     let result = math::acos(&mut guard, value).map(|result| guard.convert_mut(result));
     match result {
         Ok(value) => value.inner(),
@@ -72,7 +72,7 @@ unsafe extern "C" fn artichoke_math_acosh(
     let value = mrb_get_args!(mrb, required = 1);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let value = Value::new(&guard, value);
+    let value = Value::from(value);
     let result = math::acosh(&mut guard, value).map(|result| guard.convert_mut(result));
     match result {
         Ok(value) => value.inner(),
@@ -87,7 +87,7 @@ unsafe extern "C" fn artichoke_math_asin(
     let value = mrb_get_args!(mrb, required = 1);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let value = Value::new(&guard, value);
+    let value = Value::from(value);
     let result = math::asin(&mut guard, value).map(|result| guard.convert_mut(result));
     match result {
         Ok(value) => value.inner(),
@@ -102,7 +102,7 @@ unsafe extern "C" fn artichoke_math_asinh(
     let value = mrb_get_args!(mrb, required = 1);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let value = Value::new(&guard, value);
+    let value = Value::from(value);
     let result = math::asinh(&mut guard, value).map(|result| guard.convert_mut(result));
     match result {
         Ok(value) => value.inner(),
@@ -117,7 +117,7 @@ unsafe extern "C" fn artichoke_math_atan(
     let value = mrb_get_args!(mrb, required = 1);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let value = Value::new(&guard, value);
+    let value = Value::from(value);
     let result = math::atan(&mut guard, value).map(|result| guard.convert_mut(result));
     match result {
         Ok(value) => value.inner(),
@@ -132,8 +132,8 @@ unsafe extern "C" fn artichoke_math_atan2(
     let (value, other) = mrb_get_args!(mrb, required = 2);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let value = Value::new(&guard, value);
-    let other = Value::new(&guard, other);
+    let value = Value::from(value);
+    let other = Value::from(other);
     let result = math::atan2(&mut guard, value, other).map(|result| guard.convert_mut(result));
     match result {
         Ok(value) => value.inner(),
@@ -148,7 +148,7 @@ unsafe extern "C" fn artichoke_math_atanh(
     let value = mrb_get_args!(mrb, required = 1);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let value = Value::new(&guard, value);
+    let value = Value::from(value);
     let result = math::atanh(&mut guard, value).map(|result| guard.convert_mut(result));
     match result {
         Ok(value) => value.inner(),
@@ -163,7 +163,7 @@ unsafe extern "C" fn artichoke_math_cbrt(
     let value = mrb_get_args!(mrb, required = 1);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let value = Value::new(&guard, value);
+    let value = Value::from(value);
     let result = math::cbrt(&mut guard, value).map(|result| guard.convert_mut(result));
     match result {
         Ok(value) => value.inner(),
@@ -178,7 +178,7 @@ unsafe extern "C" fn artichoke_math_cos(
     let value = mrb_get_args!(mrb, required = 1);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let value = Value::new(&guard, value);
+    let value = Value::from(value);
     let result = math::cos(&mut guard, value).map(|result| guard.convert_mut(result));
     match result {
         Ok(value) => value.inner(),
@@ -193,7 +193,7 @@ unsafe extern "C" fn artichoke_math_cosh(
     let value = mrb_get_args!(mrb, required = 1);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let value = Value::new(&guard, value);
+    let value = Value::from(value);
     let result = math::cosh(&mut guard, value).map(|result| guard.convert_mut(result));
     match result {
         Ok(value) => value.inner(),
@@ -208,7 +208,7 @@ unsafe extern "C" fn artichoke_math_erf(
     let value = mrb_get_args!(mrb, required = 1);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let value = Value::new(&guard, value);
+    let value = Value::from(value);
     let result = math::erf(&mut guard, value).map(|result| guard.convert_mut(result));
     match result {
         Ok(value) => value.inner(),
@@ -223,7 +223,7 @@ unsafe extern "C" fn artichoke_math_erfc(
     let value = mrb_get_args!(mrb, required = 1);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let value = Value::new(&guard, value);
+    let value = Value::from(value);
     let result = math::erfc(&mut guard, value).map(|result| guard.convert_mut(result));
     match result {
         Ok(value) => value.inner(),
@@ -238,7 +238,7 @@ unsafe extern "C" fn artichoke_math_exp(
     let value = mrb_get_args!(mrb, required = 1);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let value = Value::new(&guard, value);
+    let value = Value::from(value);
     let result = math::exp(&mut guard, value).map(|result| guard.convert_mut(result));
     match result {
         Ok(value) => value.inner(),
@@ -253,7 +253,7 @@ unsafe extern "C" fn artichoke_math_frexp(
     let value = mrb_get_args!(mrb, required = 1);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let value = Value::new(&guard, value);
+    let value = Value::from(value);
     let result = math::frexp(&mut guard, value).map(|(fraction, exponent)| {
         let fraction = guard.convert_mut(fraction);
         let exponent = guard.convert(exponent);
@@ -272,7 +272,7 @@ unsafe extern "C" fn artichoke_math_gamma(
     let value = mrb_get_args!(mrb, required = 1);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let value = Value::new(&guard, value);
+    let value = Value::from(value);
     let result = math::gamma(&mut guard, value).map(|result| guard.convert_mut(result));
     match result {
         Ok(value) => value.inner(),
@@ -287,8 +287,8 @@ unsafe extern "C" fn artichoke_math_hypot(
     let (value, other) = mrb_get_args!(mrb, required = 2);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let value = Value::new(&guard, value);
-    let other = Value::new(&guard, other);
+    let value = Value::from(value);
+    let other = Value::from(other);
     let result = math::hypot(&mut guard, value, other).map(|result| guard.convert_mut(result));
     match result {
         Ok(value) => value.inner(),
@@ -303,8 +303,8 @@ unsafe extern "C" fn artichoke_math_ldexp(
     let (fraction, exponent) = mrb_get_args!(mrb, required = 2);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let fraction = Value::new(&guard, fraction);
-    let exponent = Value::new(&guard, exponent);
+    let fraction = Value::from(fraction);
+    let exponent = Value::from(exponent);
     let result =
         math::ldexp(&mut guard, fraction, exponent).map(|result| guard.convert_mut(result));
     match result {
@@ -320,7 +320,7 @@ unsafe extern "C" fn artichoke_math_lgamma(
     let value = mrb_get_args!(mrb, required = 1);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let value = Value::new(&guard, value);
+    let value = Value::from(value);
     let result = math::lgamma(&mut guard, value).map(|(result, sign)| {
         let result = guard.convert_mut(result);
         let sign = guard.convert(sign);
@@ -339,8 +339,8 @@ unsafe extern "C" fn artichoke_math_log(
     let (value, base) = mrb_get_args!(mrb, required = 1, optional = 1);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let value = Value::new(&guard, value);
-    let base = base.map(|base| Value::new(&guard, base));
+    let value = Value::from(value);
+    let base = base.map(Value::from);
     let result = math::log(&mut guard, value, base).map(|result| guard.convert_mut(result));
     match result {
         Ok(value) => value.inner(),
@@ -355,7 +355,7 @@ unsafe extern "C" fn artichoke_math_log10(
     let value = mrb_get_args!(mrb, required = 1);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let value = Value::new(&guard, value);
+    let value = Value::from(value);
     let result = math::log10(&mut guard, value).map(|result| guard.convert_mut(result));
     match result {
         Ok(value) => value.inner(),
@@ -370,7 +370,7 @@ unsafe extern "C" fn artichoke_math_log2(
     let value = mrb_get_args!(mrb, required = 1);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let value = Value::new(&guard, value);
+    let value = Value::from(value);
     let result = math::log2(&mut guard, value).map(|result| guard.convert_mut(result));
     match result {
         Ok(value) => value.inner(),
@@ -385,7 +385,7 @@ unsafe extern "C" fn artichoke_math_sin(
     let value = mrb_get_args!(mrb, required = 1);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let value = Value::new(&guard, value);
+    let value = Value::from(value);
     let result = math::sin(&mut guard, value).map(|result| guard.convert_mut(result));
     match result {
         Ok(value) => value.inner(),
@@ -400,7 +400,7 @@ unsafe extern "C" fn artichoke_math_sinh(
     let value = mrb_get_args!(mrb, required = 1);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let value = Value::new(&guard, value);
+    let value = Value::from(value);
     let result = math::sinh(&mut guard, value).map(|result| guard.convert_mut(result));
     match result {
         Ok(value) => value.inner(),
@@ -415,7 +415,7 @@ unsafe extern "C" fn artichoke_math_sqrt(
     let value = mrb_get_args!(mrb, required = 1);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let value = Value::new(&guard, value);
+    let value = Value::from(value);
     let result = math::sqrt(&mut guard, value).map(|result| guard.convert_mut(result));
     match result {
         Ok(value) => value.inner(),
@@ -430,7 +430,7 @@ unsafe extern "C" fn artichoke_math_tan(
     let value = mrb_get_args!(mrb, required = 1);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let value = Value::new(&guard, value);
+    let value = Value::from(value);
     let result = math::tan(&mut guard, value).map(|result| guard.convert_mut(result));
     match result {
         Ok(value) => value.inner(),
@@ -445,7 +445,7 @@ unsafe extern "C" fn artichoke_math_tanh(
     let value = mrb_get_args!(mrb, required = 1);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let value = Value::new(&guard, value);
+    let value = Value::from(value);
     let result = math::tanh(&mut guard, value).map(|result| guard.convert_mut(result));
     match result {
         Ok(value) => value.inner(),

--- a/artichoke-backend/src/extn/core/random/mruby.rs
+++ b/artichoke-backend/src/extn/core/random/mruby.rs
@@ -49,8 +49,8 @@ unsafe extern "C" fn artichoke_random_initialize(
     let seed = mrb_get_args!(mrb, optional = 1);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let slf = Value::new(&guard, slf);
-    let seed = seed.map(|seed| Value::new(&guard, seed));
+    let slf = Value::from(slf);
+    let seed = seed.map(Value::from);
     let result = trampoline::initialize(&mut guard, seed, slf);
     match result {
         Ok(value) => value.inner(),
@@ -66,8 +66,8 @@ unsafe extern "C" fn artichoke_random_eq(
     let other = mrb_get_args!(mrb, required = 1);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let rand = Value::new(&guard, slf);
-    let other = Value::new(&guard, other);
+    let rand = Value::from(slf);
+    let other = Value::from(other);
     let result = trampoline::equal(&mut guard, rand, other);
     match result {
         Ok(value) => value.inner(),
@@ -83,8 +83,8 @@ unsafe extern "C" fn artichoke_random_bytes(
     let size = mrb_get_args!(mrb, required = 1);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let rand = Value::new(&guard, slf);
-    let size = Value::new(&guard, size);
+    let rand = Value::from(slf);
+    let size = Value::from(size);
     let result = trampoline::bytes(&mut guard, rand, size);
     match result {
         Ok(value) => value.inner(),
@@ -100,8 +100,8 @@ unsafe extern "C" fn artichoke_random_rand(
     let max = mrb_get_args!(mrb, optional = 1);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let rand = Value::new(&guard, slf);
-    let max = max.map(|max| Value::new(&guard, max));
+    let rand = Value::from(slf);
+    let max = max.map(Value::from);
     let result = trampoline::rand(&mut guard, rand, max);
     match result {
         Ok(value) => value.inner(),
@@ -117,7 +117,7 @@ unsafe extern "C" fn artichoke_random_seed(
     mrb_get_args!(mrb, none);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let rand = Value::new(&guard, slf);
+    let rand = Value::from(slf);
     let result = trampoline::seed(&mut guard, rand);
     match result {
         Ok(value) => value.inner(),
@@ -148,7 +148,7 @@ unsafe extern "C" fn artichoke_random_self_srand(
     let number = mrb_get_args!(mrb, optional = 1);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let number = number.map(|number| Value::new(&guard, number));
+    let number = number.map(Value::from);
     let result = trampoline::srand(&mut guard, number);
     match result {
         Ok(value) => value.inner(),
@@ -164,7 +164,7 @@ unsafe extern "C" fn artichoke_random_self_urandom(
     let size = mrb_get_args!(mrb, required = 1);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let size = Value::new(&guard, size);
+    let size = Value::from(size);
     let result = trampoline::urandom(&mut guard, size);
     match result {
         Ok(value) => value.inner(),

--- a/artichoke-backend/src/extn/core/regexp/backend/onig.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/onig.rs
@@ -313,7 +313,7 @@ impl RegexpType for Onig {
             if let Some(pos) = pos {
                 pos
             } else {
-                return Ok(interp.convert(None::<Value>));
+                return Ok(Value::nil());
             }
         };
         let offset = haystack.chars().take(pos).map(char::len_utf8).sum();
@@ -323,7 +323,7 @@ impl RegexpType for Onig {
             interp.unset_global_variable(regexp::LAST_MATCH)?;
             interp.unset_global_variable(regexp::STRING_LEFT_OF_MATCH)?;
             interp.unset_global_variable(regexp::STRING_RIGHT_OF_MATCH)?;
-            return Ok(interp.convert(None::<Value>));
+            return Ok(Value::nil());
         };
 
         if let Some(captures) = self.regex.captures(target) {
@@ -357,7 +357,7 @@ impl RegexpType for Onig {
             interp.unset_global_variable(regexp::LAST_MATCH)?;
             interp.unset_global_variable(regexp::STRING_LEFT_OF_MATCH)?;
             interp.unset_global_variable(regexp::STRING_RIGHT_OF_MATCH)?;
-            Ok(interp.convert(None::<Value>))
+            Ok(Value::nil())
         }
     }
 

--- a/artichoke-backend/src/extn/core/regexp/backend/regex/utf8.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/regex/utf8.rs
@@ -317,7 +317,7 @@ impl RegexpType for Utf8 {
             if let Some(pos) = pos {
                 pos
             } else {
-                return Ok(interp.convert(None::<Value>));
+                return Ok(Value::nil());
             }
         };
         let offset = haystack.chars().take(pos).map(char::len_utf8).sum();
@@ -327,7 +327,7 @@ impl RegexpType for Utf8 {
             interp.unset_global_variable(regexp::LAST_MATCH)?;
             interp.unset_global_variable(regexp::STRING_LEFT_OF_MATCH)?;
             interp.unset_global_variable(regexp::STRING_RIGHT_OF_MATCH)?;
-            return Ok(interp.convert(None::<Value>));
+            return Ok(Value::nil());
         };
         if let Some(captures) = self.regex.captures(target) {
             // per the [docs] for `captures.len()`:
@@ -376,7 +376,7 @@ impl RegexpType for Utf8 {
             interp.unset_global_variable(regexp::LAST_MATCH)?;
             interp.unset_global_variable(regexp::STRING_LEFT_OF_MATCH)?;
             interp.unset_global_variable(regexp::STRING_RIGHT_OF_MATCH)?;
-            Ok(interp.convert(None::<Value>))
+            Ok(Value::nil())
         }
     }
 

--- a/artichoke-backend/src/extn/core/regexp/mod.rs
+++ b/artichoke-backend/src/extn/core/regexp/mod.rs
@@ -345,7 +345,7 @@ impl Regexp {
             self.0.match_(interp, pattern, pos, block)
         } else {
             interp.unset_global_variable(LAST_MATCH)?;
-            Ok(interp.convert(None::<Value>))
+            Ok(Value::nil())
         }
     }
 

--- a/artichoke-backend/src/extn/core/regexp/mruby.rs
+++ b/artichoke-backend/src/extn/core/regexp/mruby.rs
@@ -91,7 +91,7 @@ unsafe extern "C" fn union(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sy
     let args = mrb_get_args!(mrb, *args);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let args = args.iter().copied().map(Value::from).collect::<Vec<_>>();
+    let args = args.iter().copied().map(Value::from);
     let result = regexp::trampoline::union(&mut guard, args);
     match result {
         Ok(result) => result.inner(),

--- a/artichoke-backend/src/extn/core/regexp/mruby.rs
+++ b/artichoke-backend/src/extn/core/regexp/mruby.rs
@@ -52,10 +52,10 @@ unsafe extern "C" fn initialize(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -
     let (pattern, options, encoding) = mrb_get_args!(mrb, required = 1, optional = 2);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let into = Value::new(&guard, slf);
-    let pattern = Value::new(&guard, pattern);
-    let options = options.map(|options| Value::new(&guard, options));
-    let encoding = encoding.map(|encoding| Value::new(&guard, encoding));
+    let into = Value::from(slf);
+    let pattern = Value::from(pattern);
+    let options = options.map(Value::from);
+    let encoding = encoding.map(Value::from);
     let result = regexp::trampoline::initialize(&mut guard, pattern, options, encoding, Some(into));
     match result {
         Ok(value) => value.inner(),
@@ -79,7 +79,7 @@ unsafe extern "C" fn escape(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> s
     let pattern = mrb_get_args!(mrb, required = 1);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let pattern = Value::new(&guard, pattern);
+    let pattern = Value::from(pattern);
     let result = regexp::trampoline::escape(&mut guard, pattern);
     match result {
         Ok(result) => result.inner(),
@@ -91,11 +91,7 @@ unsafe extern "C" fn union(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sy
     let args = mrb_get_args!(mrb, *args);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let args = args
-        .iter()
-        .copied()
-        .map(|arg| Value::new(&guard, arg))
-        .collect::<Vec<_>>();
+    let args = args.iter().copied().map(Value::from).collect::<Vec<_>>();
     let result = regexp::trampoline::union(&mut guard, args);
     match result {
         Ok(result) => result.inner(),
@@ -107,9 +103,9 @@ unsafe extern "C" fn match_q(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> s
     let (pattern, pos) = mrb_get_args!(mrb, required = 1, optional = 1);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let value = Value::new(&guard, slf);
-    let pattern = Value::new(&guard, pattern);
-    let pos = pos.map(|pos| Value::new(&guard, pos));
+    let value = Value::from(slf);
+    let pattern = Value::from(pattern);
+    let pos = pos.map(Value::from);
     let result = regexp::trampoline::is_match(&mut guard, value, pattern, pos);
     match result {
         Ok(result) => result.inner(),
@@ -121,9 +117,9 @@ unsafe extern "C" fn match_(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sy
     let (pattern, pos, block) = mrb_get_args!(mrb, required = 1, optional = 1, &block);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let value = Value::new(&guard, slf);
-    let pattern = Value::new(&guard, pattern);
-    let pos = pos.map(|pos| Value::new(&guard, pos));
+    let value = Value::from(slf);
+    let pattern = Value::from(pattern);
+    let pos = pos.map(Value::from);
     let result = regexp::trampoline::match_(&mut guard, value, pattern, pos, block);
     match result {
         Ok(result) => result.inner(),
@@ -135,8 +131,8 @@ unsafe extern "C" fn eql(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::
     let other = mrb_get_args!(mrb, required = 1);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let value = Value::new(&guard, slf);
-    let other = Value::new(&guard, other);
+    let value = Value::from(slf);
+    let other = Value::from(other);
     let result = regexp::trampoline::eql(&mut guard, value, other);
     match result {
         Ok(result) => result.inner(),
@@ -148,8 +144,8 @@ unsafe extern "C" fn case_compare(mrb: *mut sys::mrb_state, slf: sys::mrb_value)
     let pattern = mrb_get_args!(mrb, required = 1);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let value = Value::new(&guard, slf);
-    let pattern = Value::new(&guard, pattern);
+    let value = Value::from(slf);
+    let pattern = Value::from(pattern);
     let result = regexp::trampoline::case_compare(&mut guard, value, pattern);
     match result {
         Ok(result) => result.inner(),
@@ -164,8 +160,8 @@ unsafe extern "C" fn match_operator(
     let pattern = mrb_get_args!(mrb, required = 1);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let value = Value::new(&guard, slf);
-    let pattern = Value::new(&guard, pattern);
+    let value = Value::from(slf);
+    let pattern = Value::from(pattern);
     let result = regexp::trampoline::match_operator(&mut guard, value, pattern);
     match result {
         Ok(result) => result.inner(),
@@ -177,7 +173,7 @@ unsafe extern "C" fn casefold(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> 
     mrb_get_args!(mrb, none);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let value = Value::new(&guard, slf);
+    let value = Value::from(slf);
     let result = regexp::trampoline::is_casefold(&mut guard, value);
     match result {
         Ok(result) => result.inner(),
@@ -192,7 +188,7 @@ unsafe extern "C" fn fixed_encoding(
     mrb_get_args!(mrb, none);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let value = Value::new(&guard, slf);
+    let value = Value::from(slf);
     let result = regexp::trampoline::is_fixed_encoding(&mut guard, value);
     match result {
         Ok(result) => result.inner(),
@@ -204,7 +200,7 @@ unsafe extern "C" fn hash(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys:
     mrb_get_args!(mrb, none);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let value = Value::new(&guard, slf);
+    let value = Value::from(slf);
     let result = regexp::trampoline::hash(&mut guard, value);
     match result {
         Ok(result) => result.inner(),
@@ -216,7 +212,7 @@ unsafe extern "C" fn inspect(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> s
     mrb_get_args!(mrb, none);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let value = Value::new(&guard, slf);
+    let value = Value::from(slf);
     let result = regexp::trampoline::inspect(&mut guard, value);
     match result {
         Ok(result) => result.inner(),
@@ -231,7 +227,7 @@ unsafe extern "C" fn named_captures(
     mrb_get_args!(mrb, none);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let value = Value::new(&guard, slf);
+    let value = Value::from(slf);
     let result = regexp::trampoline::named_captures(&mut guard, value);
     match result {
         Ok(result) => result.inner(),
@@ -243,7 +239,7 @@ unsafe extern "C" fn names(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys
     mrb_get_args!(mrb, none);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let value = Value::new(&guard, slf);
+    let value = Value::from(slf);
     let result = regexp::trampoline::names(&mut guard, value);
     match result {
         Ok(result) => result.inner(),
@@ -255,7 +251,7 @@ unsafe extern "C" fn options(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> s
     mrb_get_args!(mrb, none);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let value = Value::new(&guard, slf);
+    let value = Value::from(slf);
     let result = regexp::trampoline::options(&mut guard, value);
     match result {
         Ok(result) => result.inner(),
@@ -267,7 +263,7 @@ unsafe extern "C" fn source(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sy
     mrb_get_args!(mrb, none);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let value = Value::new(&guard, slf);
+    let value = Value::from(slf);
     let result = regexp::trampoline::source(&mut guard, value);
     match result {
         Ok(result) => result.inner(),
@@ -279,7 +275,7 @@ unsafe extern "C" fn to_s(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys:
     mrb_get_args!(mrb, none);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let value = Value::new(&guard, slf);
+    let value = Value::from(slf);
     let result = regexp::trampoline::to_s(&mut guard, value);
     match result {
         Ok(result) => result.inner(),

--- a/artichoke-backend/src/extn/core/regexp/trampoline.rs
+++ b/artichoke-backend/src/extn/core/regexp/trampoline.rs
@@ -98,7 +98,7 @@ pub fn match_operator(
             interp,
             "string too long",
         ))),
-        None => Ok(interp.convert(None::<Value>)),
+        None => Ok(Value::nil()),
     }
 }
 

--- a/artichoke-backend/src/extn/core/string/mruby.rs
+++ b/artichoke-backend/src/extn/core/string/mruby.rs
@@ -22,7 +22,7 @@ unsafe extern "C" fn artichoke_string_ord(
 ) -> sys::mrb_value {
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let value = Value::new(&guard, slf);
+    let value = Value::from(slf);
     let result = trampoline::ord(&mut guard, value);
     match result {
         Ok(value) => value.inner(),
@@ -37,8 +37,8 @@ unsafe extern "C" fn artichoke_string_scan(
     let (pattern, block) = mrb_get_args!(mrb, required = 1, &block);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let value = Value::new(&guard, slf);
-    let pattern = Value::new(&guard, pattern);
+    let value = Value::from(slf);
+    let pattern = Value::from(pattern);
     let result = trampoline::scan(&mut guard, value, pattern, block);
     match result {
         Ok(result) => result.inner(),

--- a/artichoke-backend/src/extn/core/time/mruby.rs
+++ b/artichoke-backend/src/extn/core/time/mruby.rs
@@ -54,7 +54,7 @@ unsafe extern "C" fn artichoke_time_day(
     mrb_get_args!(mrb, none);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let time = Value::new(&guard, slf);
+    let time = Value::from(slf);
     let result = trampoline::day(&mut guard, time);
     match result {
         Ok(value) => value.inner(),
@@ -70,7 +70,7 @@ unsafe extern "C" fn artichoke_time_hour(
     mrb_get_args!(mrb, none);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let time = Value::new(&guard, slf);
+    let time = Value::from(slf);
     let result = trampoline::hour(&mut guard, time);
     match result {
         Ok(value) => value.inner(),
@@ -86,7 +86,7 @@ unsafe extern "C" fn artichoke_time_minute(
     mrb_get_args!(mrb, none);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let time = Value::new(&guard, slf);
+    let time = Value::from(slf);
     let result = trampoline::minute(&mut guard, time);
     match result {
         Ok(value) => value.inner(),
@@ -102,7 +102,7 @@ unsafe extern "C" fn artichoke_time_month(
     mrb_get_args!(mrb, none);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let time = Value::new(&guard, slf);
+    let time = Value::from(slf);
     let result = trampoline::month(&mut guard, time);
     match result {
         Ok(value) => value.inner(),
@@ -118,7 +118,7 @@ unsafe extern "C" fn artichoke_time_nanosecond(
     mrb_get_args!(mrb, none);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let time = Value::new(&guard, slf);
+    let time = Value::from(slf);
     let result = trampoline::nanosecond(&mut guard, time);
     match result {
         Ok(value) => value.inner(),
@@ -134,7 +134,7 @@ unsafe extern "C" fn artichoke_time_second(
     mrb_get_args!(mrb, none);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let time = Value::new(&guard, slf);
+    let time = Value::from(slf);
     let result = trampoline::second(&mut guard, time);
     match result {
         Ok(value) => value.inner(),
@@ -150,7 +150,7 @@ unsafe extern "C" fn artichoke_time_microsecond(
     mrb_get_args!(mrb, none);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let time = Value::new(&guard, slf);
+    let time = Value::from(slf);
     let result = trampoline::microsecond(&mut guard, time);
     match result {
         Ok(value) => value.inner(),
@@ -166,7 +166,7 @@ unsafe extern "C" fn artichoke_time_weekday(
     mrb_get_args!(mrb, none);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let time = Value::new(&guard, slf);
+    let time = Value::from(slf);
     let result = trampoline::weekday(&mut guard, time);
     match result {
         Ok(value) => value.inner(),
@@ -182,7 +182,7 @@ unsafe extern "C" fn artichoke_time_year_day(
     mrb_get_args!(mrb, none);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let time = Value::new(&guard, slf);
+    let time = Value::from(slf);
     let result = trampoline::year_day(&mut guard, time);
     match result {
         Ok(value) => value.inner(),
@@ -198,7 +198,7 @@ unsafe extern "C" fn artichoke_time_year(
     mrb_get_args!(mrb, none);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let time = Value::new(&guard, slf);
+    let time = Value::from(slf);
     let result = trampoline::year(&mut guard, time);
     match result {
         Ok(value) => value.inner(),

--- a/artichoke-backend/src/extn/prelude.rs
+++ b/artichoke-backend/src/extn/prelude.rs
@@ -14,6 +14,7 @@
 //!
 //! The prelude may grow over time as additional items see ubiquitous use.
 
+pub use crate::block::Block;
 pub use crate::class;
 pub use crate::class_registry::ClassRegistry;
 pub use crate::convert::RustBackedValue;
@@ -26,7 +27,7 @@ pub use crate::prelude::*;
 pub use crate::string;
 pub use crate::sys;
 pub use crate::types::{Fp, Int};
-pub use crate::value::{Block, Value};
+pub use crate::value::Value;
 
 /// Type alias for errors returned from `init` functions in
 /// [`extn`](crate::extn).

--- a/artichoke-backend/src/extn/stdlib/securerandom/mruby.rs
+++ b/artichoke-backend/src/extn/stdlib/securerandom/mruby.rs
@@ -57,9 +57,7 @@ unsafe extern "C" fn artichoke_securerandom_alphanumeric(
     let len = mrb_get_args!(mrb, optional = 1);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let len = len
-        .map(|len| Value::new(&guard, len))
-        .and_then(|len| guard.convert(len));
+    let len = len.map(Value::from).and_then(|len| guard.convert(len));
     let result = trampoline::alphanumeric(&mut guard, len);
     match result {
         Ok(value) => value.inner(),
@@ -75,9 +73,7 @@ unsafe extern "C" fn artichoke_securerandom_base64(
     let len = mrb_get_args!(mrb, optional = 1);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let len = len
-        .map(|len| Value::new(&guard, len))
-        .and_then(|len| guard.convert(len));
+    let len = len.map(Value::from).and_then(|len| guard.convert(len));
     let result = trampoline::base64(&mut guard, len);
     match result {
         Ok(value) => value.inner(),
@@ -93,9 +89,7 @@ unsafe extern "C" fn artichoke_securerandom_hex(
     let len = mrb_get_args!(mrb, optional = 1);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let len = len
-        .map(|len| Value::new(&guard, len))
-        .and_then(|len| guard.convert(len));
+    let len = len.map(Value::from).and_then(|len| guard.convert(len));
     let result = trampoline::hex(&mut guard, len);
     match result {
         Ok(value) => value.inner(),
@@ -111,9 +105,7 @@ unsafe extern "C" fn artichoke_securerandom_random_bytes(
     let len = mrb_get_args!(mrb, optional = 1);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let len = len
-        .map(|len| Value::new(&guard, len))
-        .and_then(|len| guard.convert(len));
+    let len = len.map(Value::from).and_then(|len| guard.convert(len));
     let result = trampoline::random_bytes(&mut guard, len);
     match result {
         Ok(value) => value.inner(),
@@ -129,9 +121,7 @@ unsafe extern "C" fn artichoke_securerandom_random_number(
     let max = mrb_get_args!(mrb, optional = 1);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let max = max
-        .map(|max| Value::new(&guard, max))
-        .and_then(|max| guard.convert(max));
+    let max = max.map(Value::from).and_then(|max| guard.convert(max));
     let result = trampoline::random_number(&mut guard, max);
     match result {
         Ok(value) => value.inner(),

--- a/artichoke-backend/src/globals.rs
+++ b/artichoke-backend/src/globals.rs
@@ -60,6 +60,6 @@ impl Globals for Artichoke {
         // NOTE: This implementation is not compliant with the spec laid out in
         // the trait documentation. This implementation always returns `Some(_)`
         // even if the global is unset.
-        Ok(Some(Value::new(self, value)))
+        Ok(Some(Value::from(value)))
     }
 }

--- a/artichoke-backend/src/globals.rs
+++ b/artichoke-backend/src/globals.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use crate::core::{Convert, Globals, Intern};
+use crate::core::{Globals, Intern};
 use crate::exception::Exception;
 use crate::sys;
 use crate::value::Value;

--- a/artichoke-backend/src/globals.rs
+++ b/artichoke-backend/src/globals.rs
@@ -40,7 +40,7 @@ impl Globals for Artichoke {
         T: Into<Cow<'static, [u8]>>,
     {
         let sym = self.intern_symbol(name.into());
-        let nil = self.convert(None::<Value>);
+        let nil = Value::nil();
         unsafe {
             let mrb = self.mrb.as_mut();
             sys::mrb_gv_set(mrb, sym, nil.inner());

--- a/artichoke-backend/src/lib.rs
+++ b/artichoke-backend/src/lib.rs
@@ -97,6 +97,7 @@ extern crate log;
 pub mod macros;
 
 mod artichoke;
+pub mod block;
 pub mod class;
 pub mod class_registry;
 mod constant;

--- a/artichoke-backend/src/macros.rs
+++ b/artichoke-backend/src/macros.rs
@@ -151,7 +151,7 @@ macro_rules! mrb_get_args {
             2 | 1 => {
                 let req1 = req1.assume_init();
                 let block = block.assume_init();
-                (req1, $crate::value::Block::new(block))
+                (req1, $crate::block::Block::new(block))
             }
             _ => unreachable!("mrb_get_args should have raised"),
         }
@@ -175,7 +175,7 @@ macro_rules! mrb_get_args {
                 let req1 = req1.assume_init();
                 let opt1 = opt1.assume_init();
                 let block = block.assume_init();
-                (req1, Some(opt1), $crate::value::Block::new(block))
+                (req1, Some(opt1), $crate::block::Block::new(block))
             }
             2 => {
                 let req1 = req1.assume_init();
@@ -185,12 +185,12 @@ macro_rules! mrb_get_args {
                     None
                 };
                 let block = block.assume_init();
-                (req1, opt1, $crate::value::Block::new(block))
+                (req1, opt1, $crate::block::Block::new(block))
             }
             1 => {
                 let req1 = req1.assume_init();
                 let block = block.assume_init();
-                (req1, None, $crate::value::Block::new(block))
+                (req1, None, $crate::block::Block::new(block))
             }
             _ => unreachable!("mrb_get_args should have raised"),
         }
@@ -241,7 +241,7 @@ macro_rules! mrb_get_args {
             None
         };
         let block = block.assume_init();
-        (opt1, opt2, $crate::value::Block::new(block))
+        (opt1, opt2, $crate::block::Block::new(block))
     }};
     ($mrb:expr, required = 2, optional = 1) => {{
         let mut req1 = std::mem::MaybeUninit::<$crate::sys::mrb_value>::uninit();

--- a/artichoke-backend/src/module_registry.rs
+++ b/artichoke-backend/src/module_registry.rs
@@ -75,7 +75,7 @@ impl ModuleRegistry for Artichoke {
             let mrb = self.mrb.as_mut();
             if let Some(mut rclass) = spec.rclass(mrb) {
                 let module = sys::mrb_sys_module_value(rclass.as_mut());
-                Ok(Some(Value::new(self, module)))
+                Ok(Some(Value::from(module)))
             } else {
                 Ok(None)
             }

--- a/artichoke-backend/src/sys/mod.rs
+++ b/artichoke-backend/src/sys/mod.rs
@@ -29,6 +29,12 @@ mod ffi_tests;
 pub use self::args::*;
 pub use self::ffi::*;
 
+impl Default for mrb_value {
+    fn default() -> Self {
+        unsafe { mrb_sys_nil_value() }
+    }
+}
+
 /// Version metadata `String` for embedded mruby.
 #[must_use]
 pub fn mrb_sys_mruby_version(verbose: bool) -> String {

--- a/artichoke-backend/src/test/prelude.rs
+++ b/artichoke-backend/src/test/prelude.rs
@@ -10,6 +10,7 @@
 //!
 //! The prelude may grow over time as additional items see ubiquitous use.
 
+pub use crate::block::Block;
 pub use crate::class;
 pub use crate::class_registry::ClassRegistry;
 pub use crate::convert::RustBackedValue;
@@ -24,4 +25,4 @@ pub use crate::state::parser::Context;
 pub use crate::string;
 pub use crate::sys;
 pub use crate::types::{Fp, Int};
-pub use crate::value::{Block, Value};
+pub use crate::value::Value;

--- a/artichoke-backend/src/top_self.rs
+++ b/artichoke-backend/src/top_self.rs
@@ -11,6 +11,6 @@ impl TopSelf for Artichoke {
             let mrb = self.mrb.as_mut();
             sys::mrb_top_self(mrb)
         };
-        Value::new(self, top_self)
+        Value::from(top_self)
     }
 }

--- a/artichoke-backend/src/types.rs
+++ b/artichoke-backend/src/types.rs
@@ -144,7 +144,6 @@ mod tests {
 
     #[test]
     fn parse_nil_ruby_type() {
-        let interp = crate::interpreter().unwrap();
         let nil = Value::nil();
         assert_eq!(Ruby::Nil, types::ruby_from_mrb_value(nil.inner()));
     }

--- a/artichoke-backend/src/types.rs
+++ b/artichoke-backend/src/types.rs
@@ -145,7 +145,7 @@ mod tests {
     #[test]
     fn parse_nil_ruby_type() {
         let interp = crate::interpreter().unwrap();
-        let nil = interp.convert(None::<Value>);
+        let nil = Value::nil();
         assert_eq!(Ruby::Nil, types::ruby_from_mrb_value(nil.inner()));
     }
 

--- a/artichoke-backend/src/value.rs
+++ b/artichoke-backend/src/value.rs
@@ -16,7 +16,7 @@ use crate::Artichoke;
 pub const MRB_FUNCALL_ARGC_MAX: usize = 16;
 
 /// Boxed Ruby value in the [`Artichoke`] interpreter.
-#[derive(Clone, Copy)]
+#[derive(Default, Clone, Copy)]
 pub struct Value(sys::mrb_value);
 
 impl From<sys::mrb_value> for Value {

--- a/artichoke-backend/src/value.rs
+++ b/artichoke-backend/src/value.rs
@@ -462,7 +462,7 @@ mod tests {
     fn to_s_nil() {
         let mut interp = crate::interpreter().unwrap();
 
-        let value = interp.convert(None::<Value>);
+        let value = Value::nil();
         let string = value.to_s(&mut interp);
         assert_eq!(string, b"");
     }
@@ -471,7 +471,7 @@ mod tests {
     fn inspect_nil() {
         let mut interp = crate::interpreter().unwrap();
 
-        let value = interp.convert(None::<Value>);
+        let value = Value::nil();
         let debug = value.inspect(&mut interp);
         assert_eq!(debug, b"nil");
     }
@@ -571,7 +571,7 @@ mod tests {
     #[test]
     fn funcall() {
         let mut interp = crate::interpreter().unwrap();
-        let nil = interp.convert(None::<Value>);
+        let nil = Value::nil();
         let nil_is_nil = nil
             .funcall(&mut interp, "nil?", &[], None)
             .and_then(|value| value.try_into::<bool>(&interp))
@@ -592,7 +592,7 @@ mod tests {
     #[test]
     fn funcall_different_types() {
         let mut interp = crate::interpreter().unwrap();
-        let nil = interp.convert(None::<Value>);
+        let nil = Value::nil();
         let s = interp.convert_mut("foo");
         let eql = nil
             .funcall(&mut interp, "==", &[s], None)
@@ -604,7 +604,7 @@ mod tests {
     #[test]
     fn funcall_type_error() {
         let mut interp = crate::interpreter().unwrap();
-        let nil = interp.convert(None::<Value>);
+        let nil = Value::nil();
         let s = interp.convert_mut("foo");
         let err = s
             .funcall(&mut interp, "+", &[nil], None)
@@ -617,7 +617,7 @@ mod tests {
     #[test]
     fn funcall_method_not_exists() {
         let mut interp = crate::interpreter().unwrap();
-        let nil = interp.convert(None::<Value>);
+        let nil = Value::nil();
         let s = interp.convert_mut("foo");
         let err = nil
             .funcall(&mut interp, "garbage_method_name", &[s], None)

--- a/artichoke-backend/src/value.rs
+++ b/artichoke-backend/src/value.rs
@@ -26,6 +26,22 @@ impl From<sys::mrb_value> for Value {
     }
 }
 
+impl From<Option<sys::mrb_value>> for Value {
+    fn from(value: Option<sys::mrb_value>) -> Self {
+        if let Some(value) = value {
+            Self::from(value)
+        } else {
+            Self::nil()
+        }
+    }
+}
+
+impl From<Option<Value>> for Value {
+    fn from(value: Option<Value>) -> Self {
+        value.unwrap_or_else(Value::nil)
+    }
+}
+
 impl fmt::Debug for Value {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Value")

--- a/artichoke-backend/src/value.rs
+++ b/artichoke-backend/src/value.rs
@@ -20,6 +20,7 @@ pub const MRB_FUNCALL_ARGC_MAX: usize = 16;
 pub struct Value(sys::mrb_value);
 
 impl From<sys::mrb_value> for Value {
+    /// Construct a new [`Value`] from a [`sys::mrb_value`].
     fn from(value: sys::mrb_value) -> Self {
         Self(value)
     }
@@ -42,13 +43,16 @@ impl PartialEq for Value {
 }
 
 impl Value {
-    /// Construct a new [`Value`] from an interpreter and [`sys::mrb_value`].
+    /// Create a new, empty Ruby value.
+    ///
+    /// Alias for `Value::default`.
+    #[inline]
     #[must_use]
-    pub fn new(interp: &Artichoke, value: sys::mrb_value) -> Self {
-        let _ = interp;
-        Self::from(value)
+    pub fn new() -> Self {
+        Self::default()
     }
 
+    /// Create a `nil` Ruby Value.
     #[inline]
     #[must_use]
     pub fn nil() -> Self {
@@ -128,7 +132,7 @@ impl Value {
         match result {
             Ok(range) => Ok(range),
             Err(exception) => {
-                let exception = Self::new(&arena, exception);
+                let exception = Self::from(exception);
                 Err(exception_handler::last_error(&mut arena, exception)?)
             }
         }
@@ -260,7 +264,7 @@ impl ValueCore for Value {
         };
         match result {
             Ok(value) => {
-                let value = Self::new(&arena, value);
+                let value = Self::from(value);
                 if value.is_unreachable() {
                     // Unreachable values are internal to the mruby interpreter
                     // and interacting with them via the C API is unspecified
@@ -276,7 +280,7 @@ impl ValueCore for Value {
                 }
             }
             Err(exception) => {
-                let exception = Self::new(&arena, exception);
+                let exception = Self::from(exception);
                 Err(exception_handler::last_error(&mut arena, exception)?)
             }
         }

--- a/artichoke-backend/src/value.rs
+++ b/artichoke-backend/src/value.rs
@@ -49,6 +49,12 @@ impl Value {
         Self::from(value)
     }
 
+    #[inline]
+    #[must_use]
+    pub fn nil() -> Self {
+        Self::default()
+    }
+
     /// The [`sys::mrb_value`] that this [`Value`] wraps.
     // TODO(GH-251): make `Value::inner` pub(crate).
     #[inline]
@@ -66,7 +72,6 @@ impl Value {
 
     #[must_use]
     pub fn pretty_name<'a>(&self, interp: &mut Artichoke) -> &'a str {
-        let _ = interp;
         match self.try_into(interp) {
             Ok(Some(true)) => "true",
             Ok(Some(false)) => "false",

--- a/artichoke-backend/tests/leak_mrb_tt_data_rc.rs
+++ b/artichoke-backend/tests/leak_mrb_tt_data_rc.rs
@@ -43,7 +43,7 @@ unsafe extern "C" fn container_initialize(
     let inner = mrb_get_args!(mrb, required = 1);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let inner = Value::new(&guard, inner);
+    let inner = Value::from(inner);
     let inner = inner.try_into_mut::<String>(&mut guard).unwrap_or_default();
     let container = Container { inner };
     let result = container.try_into_ruby(&mut guard, Some(slf));

--- a/artichoke-backend/tests/manual.rs
+++ b/artichoke-backend/tests/manual.rs
@@ -24,7 +24,7 @@ unsafe extern "C" fn container_initialize(
     let inner = mrb_get_args!(mrb, required = 1);
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let inner = Value::new(&guard, inner);
+    let inner = Value::from(inner);
     let inner = inner.try_into::<Int>(&mut guard).unwrap_or_default();
     let container = Box::new(Container { inner });
     let result = container
@@ -40,7 +40,7 @@ unsafe extern "C" fn container_value(
 ) -> sys::mrb_value {
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let value = Value::new(&guard, slf);
+    let value = Value::from(slf);
     let result = if let Ok(data) = Box::<Container>::try_from_ruby(&mut guard, &value) {
         let borrow = data.borrow();
         guard.interp().convert(borrow.inner)


### PR DESCRIPTION
This PR changes the constructors for `Value`:

- Add a `Default` impl for `Value` that returns a `nil` Ruby value.
- Add `Value::nil` that returns a `nil` Ruby value.
- Add `Value::new` with no args that is an alias to `Value::default`.
- Add a `From<sys::mrb_value>` impl for `Value`.

To help with this, this PR also adds a `Default` impl for `sys::mrb_value` which calls `sys::mrb_sys_nil_value`.

This PR replaces all calls to `Value::new` with `Value::from`. All calls to `interp.convert(None::<Value>)` have been rewritten to use the `Value::nil` constructor which is clearer and able to be inlined.

Removing the interpreter arg from the constructor avoids the need to eagerly collect iterators into `Vec`s in some parts of `extn`.

`Block` has been extracted to its own module for readability with some additional conversion APIs added.

This PR completes the work that started in GH-631 to make `Value` a thin wrapper around the underlying FFI type.