### PR TITLE
Make onig an optional dependency

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,6 +61,29 @@ jobs:
       - name: Test
         run: cargo test --workspace
 
+  build-features:
+    name: Build (non-default features)
+    runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: -D warnings
+      RUST_BACKTRACE: 1
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+
+      - name: Install Ruby toolchain
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ".ruby-version"
+
+      - name: Install Bison
+        run: sudo apt install bison
+
       - name: Compile artichoke with no default features
         run: cargo build --verbose --no-default-features
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,12 +42,14 @@ default = [
   "core-env-system",
   "core-math-extra",
   "core-random",
+  "core-regexp-oniguruma",
   "native-filesystem-access",
   "stdlib-securerandom"
 ]
 core-env-system = ["artichoke-backend/core-env-system"]
 core-math-extra = ["artichoke-backend/core-math-extra"]
 core-random = ["artichoke-backend/core-random"]
+core-regexp-oniguruma = ["artichoke-backend/core-regexp-oniguruma"]
 native-filesystem-access = ["artichoke-backend/native-filesystem-access"]
 output-strategy-capture = ["artichoke-backend/output-strategy-capture"]
 output-strategy-null = ["artichoke-backend/output-strategy-null"]

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -32,6 +32,7 @@ path = "../artichoke-core"
 git = "https://github.com/artichoke/rust-onig"
 rev = "ec266cae185ef4119008ea0b4799b9abd7161436"
 default-features = false
+optional = true
 
 [dev-dependencies]
 libc = "0.2"
@@ -49,11 +50,13 @@ default = [
   "core-env-system",
   "core-math-extra",
   "core-random",
+  "core-regexp-oniguruma",
   "stdlib-securerandom"
 ]
 core-env-system = []
 core-math-extra = ["libm"]
 core-random = ["rand", "rand_pcg"]
+core-regexp-oniguruma = ["onig"]
 native-filesystem-access = []
 output-strategy-capture = []
 output-strategy-null = ["output-strategy-capture"]

--- a/artichoke-backend/src/extn/core/regexp/backend/lazy.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/lazy.rs
@@ -100,8 +100,8 @@ impl RegexpType for Lazy {
         let _ = string::format_unicode_debug_into(&mut pattern, self.literal.pattern.as_slice());
         debug.push_str(pattern.replace("/", r"\/").as_str());
         debug.push('/');
-        debug.push_str(self.literal.options.modifier_string().as_str());
-        debug.push_str(self.encoding.string());
+        debug.push_str(self.literal.options.as_display_modifier());
+        debug.push_str(self.encoding.modifier_string());
         debug
     }
 

--- a/artichoke-backend/src/extn/core/regexp/backend/mod.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/mod.rs
@@ -6,6 +6,7 @@ use crate::extn::core::regexp::{Config, Encoding};
 use crate::extn::prelude::*;
 
 pub mod lazy;
+#[cfg(feature = "core-regexp-oniguruma")]
 pub mod onig;
 pub mod regex;
 

--- a/artichoke-backend/src/extn/core/regexp/backend/onig.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/onig.rs
@@ -194,8 +194,8 @@ impl RegexpType for Onig {
         let _ = string::format_unicode_debug_into(&mut pattern, self.literal.pattern.as_slice());
         debug.push_str(pattern.replace("/", r"\/").as_str());
         debug.push('/');
-        debug.push_str(self.literal.options.modifier_string().as_str());
-        debug.push_str(self.encoding.string());
+        debug.push_str(self.literal.options.as_display_modifier());
+        debug.push_str(self.encoding.modifier_string());
         debug
     }
 
@@ -222,8 +222,8 @@ impl RegexpType for Onig {
             inspect.extend(self.literal.pattern.iter());
         }
         inspect.push(b'/');
-        inspect.extend(self.literal.options.modifier_string().as_bytes());
-        inspect.extend(self.encoding.string().as_bytes());
+        inspect.extend(self.literal.options.as_display_modifier().as_bytes());
+        inspect.extend(self.encoding.modifier_string().as_bytes());
         inspect
     }
 

--- a/artichoke-backend/src/extn/core/regexp/backend/regex/utf8.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/regex/utf8.rs
@@ -166,8 +166,8 @@ impl RegexpType for Utf8 {
         let _ = string::format_unicode_debug_into(&mut pattern, self.literal.pattern.as_slice());
         debug.push_str(pattern.replace("/", r"\/").as_str());
         debug.push('/');
-        debug.push_str(self.literal.options.modifier_string().as_str());
-        debug.push_str(self.encoding.string());
+        debug.push_str(self.literal.options.as_display_modifier());
+        debug.push_str(self.encoding.modifier_string());
         debug
     }
 
@@ -194,8 +194,8 @@ impl RegexpType for Utf8 {
             inspect.extend(self.literal.pattern.iter());
         }
         inspect.push(b'/');
-        inspect.extend(self.literal.options.modifier_string().as_bytes());
-        inspect.extend(self.encoding.string().as_bytes());
+        inspect.extend(self.literal.options.as_display_modifier().as_bytes());
+        inspect.extend(self.encoding.modifier_string().as_bytes());
         inspect
     }
 

--- a/artichoke-backend/src/extn/core/regexp/enc.rs
+++ b/artichoke-backend/src/extn/core/regexp/enc.rs
@@ -48,7 +48,7 @@ impl Hash for Encoding {
 
 impl PartialEq for Encoding {
     fn eq(&self, other: &Self) -> bool {
-        use Encoding::*;
+        use Encoding::{Fixed, No, None};
         match (self, other) {
             (No, No) | (No, None) | (None, No) | (None, None) | (Fixed, Fixed) => true,
             _ => false,

--- a/artichoke-backend/src/extn/core/regexp/enc.rs
+++ b/artichoke-backend/src/extn/core/regexp/enc.rs
@@ -1,39 +1,37 @@
 //! Parse encoding parameter to `Regexp#initialize` and `Regexp::compile`.
 
+use bstr::ByteSlice;
+use std::error;
+use std::fmt;
 use std::hash::{Hash, Hasher};
 
 use crate::extn::core::regexp;
 use crate::extn::prelude::*;
 
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
-pub enum Error {
-    InvalidEncoding,
+#[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub struct InvalidEncodingError;
+
+impl fmt::Display for InvalidEncodingError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Invalid Regexp encoding")
+    }
 }
 
+impl error::Error for InvalidEncodingError {}
+
+/// The encoding of a Regexp literal.
+///
+/// Regexps are assumed to use the source encoding but literals may override
+/// the encoding with a Regexp modifier.
+///
+/// See [`Regexp encoding][regexp-encoding].
+///
+/// [regexp-encoding]: https://ruby-doc.org/core-2.6.3/Regexp.html#class-Regexp-label-Encoding
 #[derive(Debug, Clone, Copy)]
 pub enum Encoding {
     Fixed,
     No,
     None,
-}
-
-impl Encoding {
-    #[must_use]
-    pub fn flags(self) -> Int {
-        match self {
-            Self::Fixed => regexp::FIXEDENCODING,
-            Self::No => regexp::NOENCODING,
-            Self::None => 0,
-        }
-    }
-
-    #[must_use]
-    pub fn string(self) -> &'static str {
-        match self {
-            Self::Fixed | Self::None => "",
-            Self::No => "n",
-        }
-    }
 }
 
 impl Default for Encoding {
@@ -44,18 +42,15 @@ impl Default for Encoding {
 
 impl Hash for Encoding {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.string().hash(state);
+        self.modifier_string().hash(state);
     }
 }
 
 impl PartialEq for Encoding {
     fn eq(&self, other: &Self) -> bool {
+        use Encoding::*;
         match (self, other) {
-            (Self::No, Self::No)
-            | (Self::No, Self::None)
-            | (Self::None, Self::No)
-            | (Self::None, Self::None)
-            | (Self::Fixed, Self::Fixed) => true,
+            (No, No) | (No, None) | (None, No) | (None, None) | (Fixed, Fixed) => true,
             _ => false,
         }
     }
@@ -63,34 +58,83 @@ impl PartialEq for Encoding {
 
 impl Eq for Encoding {}
 
-pub fn parse(interp: &mut Artichoke, value: &Value) -> Result<Encoding, Error> {
-    if let Ok(encoding) = value.try_into::<Int>(interp) {
-        // Only deal with Encoding opts
-        let encoding = encoding & !regexp::ALL_REGEXP_OPTS;
-        if encoding == regexp::FIXEDENCODING {
-            Ok(Encoding::Fixed)
-        } else if encoding == regexp::NOENCODING {
-            Ok(Encoding::No)
-        } else if encoding == 0 {
-            Ok(Encoding::default())
-        } else {
-            Err(Error::InvalidEncoding)
+impl From<Encoding> for Int {
+    /// Convert an `Encoding` to its bitflag representation.
+    fn from(enc: Encoding) -> Self {
+        match enc {
+            Encoding::Fixed => regexp::FIXEDENCODING,
+            Encoding::No => regexp::NOENCODING,
+            Encoding::None => 0,
         }
-    } else if let Ok(encoding) = value.try_into_mut::<&str>(interp) {
-        if encoding.contains('u') && encoding.contains('n') {
-            return Err(Error::InvalidEncoding);
+    }
+}
+
+impl From<&Encoding> for Int {
+    /// Convert an `Encoding` to its bitflag representation.
+    fn from(enc: &Encoding) -> Self {
+        Self::from(*enc)
+    }
+}
+
+impl fmt::Display for Encoding {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.modifier_string())
+    }
+}
+
+impl Encoding {
+    /// Convert an `Encoding` to its bitflag representation.
+    ///
+    /// Alias for the corresponding `Into<Int>` implementation.
+    #[must_use]
+    pub fn bitflags(self) -> Int {
+        self.into()
+    }
+
+    /// Serialize the encoding flags to a string suitable for a `Regexp` display
+    /// or debug implementation.
+    ///
+    /// See also [`Regexp#inspect`][regexp-inspect].
+    ///
+    /// [regexp-inspect]: https://ruby-doc.org/core-2.7.1/Regexp.html#method-i-inspect
+    #[must_use]
+    pub fn modifier_string(self) -> &'static str {
+        match self {
+            Self::Fixed | Self::None => "",
+            Self::No => "n",
         }
-        let mut enc = None;
-        for flag in encoding.chars() {
-            match flag {
-                'u' | 's' | 'e' if enc.is_none() => enc = Some(Encoding::Fixed),
-                'n' if enc.is_none() => enc = Some(Encoding::No),
-                'i' | 'm' | 'x' | 'o' => continue,
-                _ => return Err(Error::InvalidEncoding),
+    }
+}
+
+impl TryConvertMut<Value, Encoding> for Artichoke {
+    type Error = InvalidEncodingError;
+
+    fn try_convert_mut(&mut self, value: Value) -> Result<Encoding, Self::Error> {
+        if let Ok(encoding) = value.try_into::<Int>(self) {
+            // Only deal with Encoding opts
+            let encoding = encoding & !regexp::ALL_REGEXP_OPTS;
+            match encoding {
+                regexp::FIXEDENCODING => Ok(Encoding::Fixed),
+                regexp::NOENCODING => Ok(Encoding::No),
+                0 => Ok(Encoding::default()),
+                _ => Err(InvalidEncodingError),
             }
+        } else if let Ok(encoding) = value.try_into_mut::<&[u8]>(self) {
+            if encoding.find_byte(b'u').is_some() && encoding.find_byte(b'n').is_some() {
+                return Err(InvalidEncodingError);
+            }
+            let mut enc = None;
+            for &flag in encoding {
+                match flag {
+                    b'u' | b's' | b'e' if enc.is_none() => enc = Some(Encoding::Fixed),
+                    b'n' if enc.is_none() => enc = Some(Encoding::No),
+                    b'i' | b'm' | b'x' | b'o' => continue,
+                    _ => return Err(InvalidEncodingError),
+                }
+            }
+            Ok(enc.unwrap_or_default())
+        } else {
+            Ok(Encoding::default())
         }
-        Ok(enc.unwrap_or_default())
-    } else {
-        Ok(Encoding::default())
     }
 }

--- a/artichoke-backend/src/extn/core/regexp/mod.rs
+++ b/artichoke-backend/src/extn/core/regexp/mod.rs
@@ -19,6 +19,7 @@ pub mod backend;
 pub mod enc;
 pub mod mruby;
 pub mod opts;
+pub mod pattern;
 pub mod syntax;
 pub mod trampoline;
 
@@ -181,10 +182,10 @@ impl Regexp {
                 options: options.unwrap_or_default(),
             }
         };
-        let (pattern, options) =
-            opts::parse_pattern(literal_config.pattern.as_slice(), literal_config.options);
+        let pattern = pattern::parse(&literal_config.pattern, literal_config.options);
+        let options = pattern.options();
         let derived_config = Config {
-            pattern: pattern.into(),
+            pattern: pattern.into_pattern().into(),
             options,
         };
         Self::new(
@@ -252,9 +253,10 @@ impl Regexp {
         };
 
         let derived_config = {
-            let (pattern, options) = opts::parse_pattern(pattern.as_slice(), Options::default());
+            let pattern = pattern::parse(&pattern, Options::default());
+            let options = pattern.options();
             Config {
-                pattern: pattern.into(),
+                pattern: pattern.into_pattern().into(),
                 options,
             }
         };
@@ -316,14 +318,7 @@ impl Regexp {
     pub fn is_fixed_encoding(&self, interp: &mut Artichoke) -> bool {
         let _ = interp;
         match self.0.encoding() {
-            Encoding::No => {
-                let bits = self.0.literal_config().options.flags().bits();
-                if let Ok(opts) = Int::try_from(bits) {
-                    (opts & NOENCODING) != 0
-                } else {
-                    false
-                }
-            }
+            Encoding::No => false,
             Encoding::Fixed => true,
             Encoding::None => false,
         }
@@ -403,9 +398,8 @@ impl Regexp {
     #[must_use]
     pub fn options(&self, interp: &mut Artichoke) -> Int {
         let _ = interp;
-        let opts =
-            Int::try_from(self.0.literal_config().options.flags().bits()).unwrap_or_default();
-        opts | self.0.encoding().flags()
+        let opts = self.0.literal_config().options;
+        Int::from(opts) | Int::from(self.0.encoding())
     }
 
     #[inline]
@@ -451,28 +445,26 @@ impl TryConvertMut<(Option<Value>, Option<Value>), (Option<opts::Options>, Optio
     ) -> Result<(Option<opts::Options>, Option<enc::Encoding>), Self::Error> {
         let (options, encoding) = value;
         if let Some(encoding) = encoding {
-            let encoding = match enc::parse(self, &encoding) {
-                Ok(encoding) => Some(encoding),
-                Err(enc::Error::InvalidEncoding) => {
-                    let mut warning = Vec::from(&b"encoding option is ignored -- "[..]);
-                    warning.extend(encoding.to_s(self));
-                    self.warn(warning.as_slice())?;
-                    None
-                }
+            let encoding = if let Ok(encoding) = self.try_convert_mut(encoding) {
+                Some(encoding)
+            } else {
+                let mut warning = Vec::from(&b"encoding option is ignored -- "[..]);
+                warning.extend(encoding.to_s(self));
+                self.warn(warning.as_slice())?;
+                None
             };
-            let options = options.map(|options| opts::parse(self, &options));
+            let options = options.map(|options| self.convert_mut(options));
             Ok((options, encoding))
         } else if let Some(options) = options {
-            let encoding = match enc::parse(self, &options) {
-                Ok(encoding) => Some(encoding),
-                Err(enc::Error::InvalidEncoding) => {
-                    let mut warning = Vec::from(&b"encoding option is ignored -- "[..]);
-                    warning.extend(options.to_s(self));
-                    self.warn(warning.as_slice())?;
-                    None
-                }
+            let encoding = if let Ok(encoding) = self.try_convert_mut(options) {
+                Some(encoding)
+            } else {
+                let mut warning = Vec::from(&b"encoding option is ignored -- "[..]);
+                warning.extend(options.to_s(self));
+                self.warn(warning.as_slice())?;
+                None
             };
-            let options = opts::parse(self, &options);
+            let options = self.convert_mut(options);
             Ok((Some(options), encoding))
         } else {
             Ok((None, None))

--- a/artichoke-backend/src/extn/core/regexp/mod.rs
+++ b/artichoke-backend/src/extn/core/regexp/mod.rs
@@ -318,9 +318,8 @@ impl Regexp {
     pub fn is_fixed_encoding(&self, interp: &mut Artichoke) -> bool {
         let _ = interp;
         match self.0.encoding() {
-            Encoding::No => false,
+            Encoding::No | Encoding::None => false,
             Encoding::Fixed => true,
-            Encoding::None => false,
         }
     }
 

--- a/artichoke-backend/src/extn/core/regexp/opts.rs
+++ b/artichoke-backend/src/extn/core/regexp/opts.rs
@@ -1,20 +1,57 @@
 //! Parse options parameter to `Regexp#initialize` and `Regexp::compile`.
 
-use onig::RegexOptions;
+use bstr::ByteSlice;
+use std::fmt;
 
 use crate::extn::core::regexp;
 use crate::extn::prelude::*;
 
+/// Configuration options for Ruby Regexps.
+///
+/// Options can be supplied either as an `Integer` object to `Regexp::new` or
+/// inline in Regexp literals like `/artichoke/i`.
 #[allow(clippy::struct_excessive_bools)]
-#[derive(Debug, Clone, Copy, Default, Hash, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq)]
 pub struct Options {
+    /// Multiline mode.
     pub multiline: bool,
+    /// Case-insensitive mode.
     pub ignore_case: bool,
+    /// Extended mode with insignificant whitespace.
     pub extended: bool,
+    /// Whether the Regexp was parsed as a literal, e.g. `'/artichoke/i`.
+    ///
+    /// This enables Ruby parsers to inject whether a Regexp is a literal to
+    /// the core library. Literal Regexps have some special behavior regrding
+    /// capturing groups and report parse failures differently.
     pub literal: bool,
 }
 
+impl From<Options> for Int {
+    /// Convert an `Options` to its bitflag representation.
+    fn from(opts: Options) -> Self {
+        let mut bits = 0;
+        if opts.multiline {
+            bits |= regexp::MULTILINE;
+        }
+        if opts.ignore_case {
+            bits |= regexp::IGNORECASE;
+        }
+        if opts.extended {
+            bits |= regexp::EXTENDED;
+        }
+        bits
+    }
+}
+
+impl fmt::Display for Options {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.as_display_modifier())
+    }
+}
+
 impl Options {
+    /// An options instance that has only case insensitive mode enabled.
     #[must_use]
     pub fn ignore_case() -> Self {
         let mut opts = Self::default();
@@ -22,26 +59,22 @@ impl Options {
         opts
     }
 
+    /// Convert an `Options` to its bitflag representation.
+    ///
+    /// Alias for the corresponding `Into<Int>` implementation.
     #[must_use]
-    pub fn flags(self) -> RegexOptions {
-        let mut bits = RegexOptions::REGEX_OPTION_NONE;
-        if self.multiline {
-            bits |= RegexOptions::REGEX_OPTION_MULTILINE;
-        }
-        if self.ignore_case {
-            bits |= RegexOptions::REGEX_OPTION_IGNORECASE;
-        }
-        if self.extended {
-            bits |= RegexOptions::REGEX_OPTION_EXTEND;
-        }
-        bits
+    pub fn bitflags(self) -> Int {
+        self.into()
     }
 
-    // TODO: This function should return a &'static str but linking fails under
-    // the wasm32-unknown-emscripten build if this function does not return an
-    // owned String.
+    /// Serialize the option flags to a string suitable for a `Regexp` display
+    /// or debug implementation.
+    ///
+    /// See also [`Regexp#inspect`][regexp-inspect].
+    ///
+    /// [regexp-inspect]: https://ruby-doc.org/core-2.7.1/Regexp.html#method-i-inspect
     #[must_use]
-    pub fn modifier_string(self) -> String {
+    pub fn as_display_modifier(self) -> &'static str {
         match (self.multiline, self.ignore_case, self.extended) {
             (true, true, true) => "mix",
             (true, true, false) => "mi",
@@ -52,14 +85,12 @@ impl Options {
             (false, false, true) => "x",
             (false, false, false) => "",
         }
-        .to_owned()
     }
 
-    // TODO: This function should return a &'static str but linking fails under
-    // the wasm32-unknown-emscripten build if this function does not return an
-    // owned String.
+    /// Serialize the option flags to a string suitable for including in a raw
+    /// pattern for configuring an underlying Regexp backend.
     #[must_use]
-    fn onig_string(self) -> String {
+    pub fn as_inline_modifier(self) -> &'static str {
         match (self.multiline, self.ignore_case, self.extended) {
             (true, true, true) => "mix",
             (true, true, false) => "mi-x",
@@ -70,136 +101,36 @@ impl Options {
             (false, false, true) => "x-mi",
             (false, false, false) => "-mix",
         }
-        .to_owned()
     }
 }
 
-#[must_use]
-pub fn parse(interp: &mut Artichoke, value: &Value) -> Options {
-    // If options is an Integer, it should be one or more of the constants
-    // Regexp::EXTENDED, Regexp::IGNORECASE, and Regexp::MULTILINE, logically
-    // or-ed together. Otherwise, if options is not nil or false, the regexp
-    // will be case insensitive.
-    if let Ok(options) = value.try_into::<Int>(interp) {
-        Options {
-            multiline: options & regexp::MULTILINE > 0,
-            ignore_case: options & regexp::IGNORECASE > 0,
-            extended: options & regexp::EXTENDED > 0,
-            literal: options & regexp::LITERAL > 0,
-        }
-    } else if let Ok(options) = value.try_into::<Option<bool>>(interp) {
-        match options {
-            Some(false) | None => Options::default(),
-            _ => Options::ignore_case(),
-        }
-    } else if let Ok(options) = value.try_into_mut::<Option<&str>>(interp) {
-        if let Some(options) = options {
+impl ConvertMut<Value, Options> for Artichoke {
+    fn convert_mut(&mut self, value: Value) -> Options {
+        // If options is an Integer, it should be one or more of the constants
+        // Regexp::EXTENDED, Regexp::IGNORECASE, and Regexp::MULTILINE, logically
+        // or-ed together. Otherwise, if options is not nil or false, the regexp
+        // will be case insensitive.
+        if let Ok(options) = value.implicitly_convert_to_int(self) {
             Options {
-                multiline: options.contains('m'),
-                ignore_case: options.contains('i'),
-                extended: options.contains('x'),
+                multiline: options & regexp::MULTILINE > 0,
+                ignore_case: options & regexp::IGNORECASE > 0,
+                extended: options & regexp::EXTENDED > 0,
+                literal: options & regexp::LITERAL > 0,
+            }
+        } else if let Ok(options) = value.try_into::<Option<bool>>(self) {
+            match options {
+                Some(false) | None => Options::default(),
+                _ => Options::ignore_case(),
+            }
+        } else if let Ok(options) = value.try_into_mut::<&[u8]>(self) {
+            Options {
+                multiline: options.find_byte(b'm').is_some(),
+                ignore_case: options.find_byte(b'i').is_some(),
+                extended: options.find_byte(b'x').is_some(),
                 literal: false,
             }
         } else {
-            Options::default()
-        }
-    } else {
-        Options::ignore_case()
-    }
-}
-
-// TODO(GH-26): Add tests for `parse_pattern`.
-#[must_use]
-pub fn parse_pattern(pattern: &[u8], mut opts: Options) -> (Vec<u8>, Options) {
-    let orig_opts = opts;
-    let mut chars = pattern.iter().copied();
-    let mut enabled = true;
-    let mut pat_buf = Vec::new();
-    let mut pointer = 0;
-    match chars.next() {
-        None => {
-            pat_buf.extend(b"(?".to_vec());
-            pat_buf.extend(opts.onig_string().into_bytes());
-            pat_buf.push(b':');
-            pat_buf.push(b')');
-            return (pat_buf, opts);
-        }
-        Some(token) if token != b'(' => {
-            pat_buf.extend(b"(?".to_vec());
-            pat_buf.extend(opts.onig_string().into_bytes());
-            pat_buf.push(b':');
-            pat_buf.extend(pattern);
-            pat_buf.push(b')');
-            return (pat_buf, opts);
-        }
-        _ => (),
-    };
-    pointer += 1;
-    match chars.next() {
-        None => {
-            pat_buf.extend(b"(?".to_vec());
-            pat_buf.extend(opts.onig_string().into_bytes());
-            pat_buf.push(b':');
-            pat_buf.extend(pattern);
-            pat_buf.push(b')');
-            return (pat_buf, opts);
-        }
-        Some(token) if token != b'?' => {
-            pat_buf.extend(b"(?".to_vec());
-            pat_buf.extend(opts.onig_string().into_bytes());
-            pat_buf.push(b':');
-            pat_buf.extend(pattern);
-            pat_buf.push(b')');
-            return (pat_buf, opts);
-        }
-        _ => (),
-    };
-    pointer += 1;
-    for token in chars {
-        pointer += 1;
-        match token {
-            b'-' => enabled = false,
-            b'i' => {
-                opts.ignore_case = enabled;
-            }
-            b'm' => {
-                opts.multiline = enabled;
-            }
-            b'x' => {
-                opts.extended = enabled;
-            }
-            b':' => break,
-            _ => {
-                pat_buf.extend(b"(?".to_vec());
-                pat_buf.extend(opts.onig_string().into_bytes());
-                pat_buf.push(b':');
-                pat_buf.extend(pattern);
-                pat_buf.push(b')');
-                return (pat_buf, opts);
-            }
+            Options::ignore_case()
         }
     }
-    let mut chars = pattern[pointer..].iter().copied();
-    let mut nest = 1;
-    while let Some(token) = chars.next() {
-        if token == b'(' {
-            nest += 1;
-        } else if token == b')' {
-            nest -= 1;
-            if nest == 0 && chars.next().is_some() {
-                pat_buf.extend(b"(?".to_vec());
-                pat_buf.extend(orig_opts.onig_string().into_bytes());
-                pat_buf.push(b':');
-                pat_buf.extend(pattern);
-                pat_buf.push(b')');
-                return (pat_buf, orig_opts);
-            }
-            break;
-        }
-    }
-    pat_buf.extend(b"(?".to_vec());
-    pat_buf.extend(opts.onig_string().into_bytes());
-    pat_buf.push(b':');
-    pat_buf.extend(&pattern[pointer..]);
-    (pat_buf, opts)
 }

--- a/artichoke-backend/src/extn/core/regexp/pattern.rs
+++ b/artichoke-backend/src/extn/core/regexp/pattern.rs
@@ -1,0 +1,281 @@
+//! Regexp pattern parsers.
+
+use std::iter;
+
+use crate::extn::core::regexp::Options;
+
+/// A Regexp pattern including its derived `Options`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Pattern {
+    pattern: Vec<u8>,
+    options: Options,
+}
+
+impl Pattern {
+    /// Return the pattern as a byte slice.
+    pub fn pattern(&self) -> &[u8] {
+        self.pattern.as_slice()
+    }
+
+    /// Consume self and return the inner pattern byte vector.
+    pub fn into_pattern(self) -> Vec<u8> {
+        self.pattern
+    }
+
+    /// Return the `Options` parsed when constructing this `Pattern`.
+    pub fn options(&self) -> Options {
+        self.options
+    }
+}
+
+#[inline]
+fn build_pattern<T>(pattern: T, options: Options) -> Pattern
+where
+    T: IntoIterator<Item = u8>,
+{
+    let iter = pattern.into_iter();
+    let hint = iter.size_hint();
+    let modifiers = options.as_inline_modifier();
+    let mut parsed = Vec::with_capacity(2 + modifiers.len() + 2 + hint.1.unwrap_or(hint.0));
+    parsed.extend(b"(?");
+    parsed.extend(modifiers.as_bytes());
+    parsed.push(b':');
+    parsed.extend(iter);
+    parsed.push(b')');
+    Pattern {
+        pattern: parsed,
+        options,
+    }
+}
+
+// TODO(GH-26): Add tests for `parse_pattern`.
+#[must_use]
+pub fn parse<T: AsRef<[u8]>>(pattern: T, options: Options) -> Pattern {
+    let pattern = pattern.as_ref();
+    let mut chars = pattern.iter().copied();
+
+    match chars.next() {
+        Some(b'(') => {}
+        Some(_) => return build_pattern(pattern.iter().copied(), options),
+        None => return build_pattern(iter::empty(), options),
+    }
+    match chars.next() {
+        Some(b'?') => {}
+        Some(_) => return build_pattern(pattern.iter().copied(), options),
+        None => return build_pattern(iter::once(b'('), options),
+    }
+
+    let orignal_options = options;
+    let mut options = options;
+    let mut enable_literal_option = true;
+    let mut cursor = 2;
+    let mut chars = chars.zip(2..);
+
+    while let Some((token, _)) = chars.next() {
+        match token {
+            b'-' => enable_literal_option = false,
+            b'i' => {
+                options.ignore_case = enable_literal_option;
+            }
+            b'm' => {
+                options.multiline = enable_literal_option;
+            }
+            b'x' => {
+                options.extended = enable_literal_option;
+            }
+            b':' => break,
+            _ => return build_pattern(pattern.iter().copied(), options),
+        }
+    }
+
+    let mut chars = chars.peekable();
+    if let Some((_, idx)) = chars.peek() {
+        cursor = *idx;
+    }
+
+    let mut nest = 1;
+    while let Some((token, _)) = chars.next() {
+        if token == b'(' {
+            nest += 1;
+        } else if token == b')' {
+            nest -= 1;
+            if nest == 0 && chars.next().is_some() {
+                return build_pattern(pattern.iter().copied(), orignal_options);
+            }
+            break;
+        }
+    }
+
+    let slice = pattern.get(cursor..).unwrap_or_default();
+    let modifiers = options.as_inline_modifier();
+    let mut parsed = Vec::with_capacity(2 + modifiers.len() + 1 + slice.len());
+    parsed.extend(b"(?");
+    parsed.extend(modifiers.as_bytes());
+    parsed.push(b':');
+    parsed.extend_from_slice(slice);
+    Pattern {
+        pattern: parsed,
+        options,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bstr::BString;
+
+    use crate::extn::core::regexp::Options;
+
+    #[test]
+    fn parse_literal_string_pattern() {
+        let opts = Options::default();
+        let parsed = super::parse("foo", opts);
+        assert_eq!(
+            BString::from("(?-mix:foo)"),
+            BString::from(parsed.into_pattern())
+        );
+    }
+
+    // The below tests are extracted from `Regexp#to_s` ruby/specs.
+
+    #[test]
+    fn parse_options_if_included_and_expand() {
+        let mut opts = Options::default();
+        opts.multiline = true;
+        opts.extended = true;
+        opts.ignore_case = true;
+        let parsed = super::parse("abc", opts);
+        assert_eq!(
+            BString::from("(?mix:abc)"),
+            BString::from(parsed.into_pattern()),
+        );
+    }
+
+    #[test]
+    fn parse_non_included_options_and_embed_expanded_modifiers_prefixed_by_a_minus_sign() {
+        let mut opts = Options::default();
+        opts.ignore_case = true;
+        let parsed = super::parse("abc", opts);
+        assert_eq!(
+            BString::from("(?i-mx:abc)"),
+            BString::from(parsed.into_pattern()),
+        );
+    }
+
+    #[test]
+    fn parse_patterns_with_no_enabled_options_and_expand_with_all_modifiers_excluded() {
+        let opts = Options::default();
+        let parsed = super::parse("abc", opts);
+        assert_eq!(
+            BString::from("(?-mix:abc)"),
+            BString::from(parsed.into_pattern()),
+        );
+    }
+
+    #[test]
+    fn embeds_the_pattern_after_the_options_after_parsing() {
+        let mut opts = Options::default();
+        opts.multiline = true;
+        opts.extended = true;
+        opts.ignore_case = true;
+        let parsed = super::parse("ab+c", opts);
+        assert_eq!(
+            BString::from("(?mix:ab+c)"),
+            BString::from(parsed.into_pattern()),
+        );
+        let opts = Options::default();
+        let parsed = super::parse("xyz", opts);
+        assert_eq!(
+            BString::from("(?-mix:xyz)"),
+            BString::from(parsed.into_pattern()),
+        );
+    }
+
+    #[test]
+    fn parse_groups_with_options() {
+        let opts = Options::default();
+        let parsed = super::parse("(?ix:foo)(?m:bar)", opts);
+        assert_eq!(
+            BString::from("(?-mix:(?ix:foo)(?m:bar))"),
+            BString::from(parsed.into_pattern()),
+        );
+        let mut opts = Options::default();
+        opts.multiline = true;
+        let parsed = super::parse("(?ix:foo)bar", opts);
+        assert_eq!(
+            BString::from("(?m-ix:(?ix:foo)bar)"),
+            BString::from(parsed.into_pattern()),
+        );
+    }
+
+    #[test]
+    fn parse_a_single_group_with_options_as_the_main_regexp() {
+        let opts = Options::default();
+        let parsed = super::parse("(?i:nothing outside this group)", opts);
+        assert_eq!(
+            BString::from("(?i-mx:nothing outside this group)"),
+            BString::from(parsed.into_pattern())
+        );
+    }
+
+    #[test]
+    fn parse_uncaptured_groups() {
+        let mut opts = Options::default();
+        opts.ignore_case = true;
+        opts.extended = true;
+        let parsed = super::parse("whatever(?:0d)", opts);
+        assert_eq!(
+            BString::from("(?ix-m:whatever(?:0d))"),
+            BString::from(parsed.into_pattern()),
+        );
+    }
+
+    #[test]
+    fn parse_lookahead_groups() {
+        let opts = Options::default();
+        let parsed = super::parse("(?=5)", opts);
+        assert_eq!(
+            BString::from("(?-mix:(?=5))"),
+            BString::from(parsed.into_pattern())
+        );
+        let opts = Options::default();
+        let parsed = super::parse("(?!5)", opts);
+        assert_eq!(
+            BString::from("(?-mix:(?!5))"),
+            BString::from(parsed.into_pattern())
+        );
+    }
+
+    #[test]
+    fn parse_to_fully_expanded_options_inline() {
+        let mut opts = Options::default();
+        opts.ignore_case = true;
+        opts.extended = true;
+        let parsed = super::parse("ab+c", opts);
+        assert_eq!(
+            BString::from("(?ix-m:ab+c)"),
+            BString::from(parsed.into_pattern()),
+        );
+        let opts = Options::default();
+        let parsed = super::parse("(?i:.)", opts);
+        assert_eq!(
+            BString::from("(?i-mx:.)"),
+            BString::from(parsed.into_pattern()),
+        );
+        let opts = Options::default();
+        let parsed = super::parse("(?:.)", opts);
+        assert_eq!(
+            BString::from("(?-mix:.)"),
+            BString::from(parsed.into_pattern()),
+        );
+    }
+
+    #[test]
+    fn parse_abusive_options_literals() {
+        let opts = Options::default();
+        let parsed = super::parse("(?mmmmix-miiiix:)", opts);
+        assert_eq!(
+            BString::from("(?-mix:)"),
+            BString::from(parsed.into_pattern()),
+        );
+    }
+}

--- a/artichoke-backend/src/extn/core/regexp/pattern.rs
+++ b/artichoke-backend/src/extn/core/regexp/pattern.rs
@@ -13,22 +13,26 @@ pub struct Pattern {
 
 impl Pattern {
     /// Return the pattern as a byte slice.
+    #[must_use]
     pub fn pattern(&self) -> &[u8] {
         self.pattern.as_slice()
     }
 
     /// Consume self and return the inner pattern byte vector.
+    #[must_use]
     pub fn into_pattern(self) -> Vec<u8> {
         self.pattern
     }
 
     /// Return the `Options` parsed when constructing this `Pattern`.
+    #[must_use]
     pub fn options(&self) -> Options {
         self.options
     }
 }
 
 #[inline]
+#[must_use]
 fn build_pattern<T>(pattern: T, options: Options) -> Pattern
 where
     T: IntoIterator<Item = u8>,
@@ -48,7 +52,6 @@ where
     }
 }
 
-// TODO(GH-26): Add tests for `parse_pattern`.
 #[must_use]
 pub fn parse<T: AsRef<[u8]>>(pattern: T, options: Options) -> Pattern {
     let pattern = pattern.as_ref();


### PR DESCRIPTION
This PR adds a cargo feature to `artichoke` and `artichoke-backend` called `core-regexp-oniguruma`.

`core-regexp-oniguruma` is enabled by default. When the feature is enabled, `onig` dependency is built and the core `Regexp` implementation is a hybrid of the Rust `regex` crate and oniguruma.

Disabling this feature builds the core `Regexp` backend such that only the Rust `regex` crate powers it. Disabling this feature should make building for Wasm targets easier since Rust `regex` is pure Rust and the C `onig` dependency is excluded.

This PR opportunistically gives some love to the rest of the `Regexp` Rust implementation, refactoring to use more Rust idioms, iterators, and trait implementations; increase readability and performance; and add tests.

Fixes GH-489.
Fixes GH-26.