### PR TITLE
Quality improvements and small refactors

### DIFF
--- a/artichoke-backend/src/block.rs
+++ b/artichoke-backend/src/block.rs
@@ -13,7 +13,7 @@ use crate::types::{self, Ruby};
 use crate::value::Value;
 use crate::Artichoke;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct NoBlockGiven(Ruby);
 
 impl fmt::Display for NoBlockGiven {
@@ -96,7 +96,7 @@ impl NoBlockGiven {
     }
 }
 
-#[derive(Clone, Copy)]
+#[derive(Default, Debug, Clone, Copy)]
 pub struct Block(sys::mrb_value);
 
 impl From<sys::mrb_value> for Option<Block> {
@@ -114,12 +114,6 @@ impl TryFrom<sys::mrb_value> for Block {
         } else {
             Err(NoBlockGiven::from(value))
         }
-    }
-}
-
-impl fmt::Debug for Block {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "proc")
     }
 }
 

--- a/artichoke-backend/src/convert.rs
+++ b/artichoke-backend/src/convert.rs
@@ -120,14 +120,12 @@ impl From<Box<UnboxRubyError>> for Exception {
     }
 }
 
-#[allow(clippy::use_self)]
 impl From<UnboxRubyError> for Box<dyn RubyException> {
     fn from(exception: UnboxRubyError) -> Box<dyn RubyException> {
         Box::new(exception)
     }
 }
 
-#[allow(clippy::use_self)]
 impl From<Box<UnboxRubyError>> for Box<dyn RubyException> {
     fn from(exception: Box<UnboxRubyError>) -> Box<dyn RubyException> {
         exception
@@ -193,14 +191,12 @@ impl From<Box<BoxIntoRubyError>> for Exception {
     }
 }
 
-#[allow(clippy::use_self)]
 impl From<BoxIntoRubyError> for Box<dyn RubyException> {
     fn from(exception: BoxIntoRubyError) -> Box<dyn RubyException> {
         Box::new(exception)
     }
 }
 
-#[allow(clippy::use_self)]
 impl From<Box<BoxIntoRubyError>> for Box<dyn RubyException> {
     fn from(exception: Box<BoxIntoRubyError>) -> Box<dyn RubyException> {
         exception

--- a/artichoke-backend/src/convert/object.rs
+++ b/artichoke-backend/src/convert/object.rs
@@ -182,7 +182,7 @@ mod tests {
 
     use crate::test::prelude::*;
 
-    #[derive(Debug, Default, Clone)]
+    #[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
     struct Container {
         inner: String,
     }
@@ -210,7 +210,7 @@ mod tests {
         }
     }
 
-    #[derive(Debug, Default, Clone, Copy)]
+    #[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
     // this struct is stack allocated
     struct Other {
         _inner: bool,

--- a/artichoke-backend/src/def.rs
+++ b/artichoke-backend/src/def.rs
@@ -197,7 +197,7 @@ impl Hash for EnclosingRubyScope {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ConstantNameError(Cow<'static, str>);
 
 impl ConstantNameError {
@@ -253,21 +253,19 @@ impl From<Box<ConstantNameError>> for Exception {
     }
 }
 
-#[allow(clippy::use_self)]
 impl From<ConstantNameError> for Box<dyn RubyException> {
     fn from(exception: ConstantNameError) -> Box<dyn RubyException> {
         Box::new(exception)
     }
 }
 
-#[allow(clippy::use_self)]
 impl From<Box<ConstantNameError>> for Box<dyn RubyException> {
     fn from(exception: Box<ConstantNameError>) -> Box<dyn RubyException> {
         exception
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum NotDefinedError {
     EnclosingScope(Cow<'static, str>),
     Super(Cow<'static, str>),
@@ -399,14 +397,12 @@ impl From<Box<NotDefinedError>> for Exception {
     }
 }
 
-#[allow(clippy::use_self)]
 impl From<NotDefinedError> for Box<dyn RubyException> {
     fn from(exception: NotDefinedError) -> Box<dyn RubyException> {
         Box::new(exception)
     }
 }
 
-#[allow(clippy::use_self)]
 impl From<Box<NotDefinedError>> for Box<dyn RubyException> {
     fn from(exception: Box<NotDefinedError>) -> Box<dyn RubyException> {
         exception

--- a/artichoke-backend/src/eval.rs
+++ b/artichoke-backend/src/eval.rs
@@ -1,4 +1,4 @@
-use bstr::BStr;
+use bstr::ByteSlice;
 use std::ffi::OsStr;
 use std::path::Path;
 
@@ -47,8 +47,7 @@ impl Eval for Artichoke {
             Err(exception) => {
                 let exception = Value::from(exception);
                 let debug = exception.inspect(self);
-                let loggable = <&BStr>::from(debug.as_slice());
-                debug!("Failed eval raised exception: {:?}", loggable);
+                debug!("Failed eval raised exception: {:?}", debug.as_bstr());
                 Err(exception_handler::last_error(self, exception)?)
             }
         }

--- a/artichoke-backend/src/exception.rs
+++ b/artichoke-backend/src/exception.rs
@@ -182,7 +182,6 @@ impl RubyException for CaughtException {
     }
 }
 
-#[allow(clippy::use_self)]
 impl From<CaughtException> for Box<dyn RubyException> {
     fn from(exc: CaughtException) -> Self {
         Box::new(exc)

--- a/artichoke-backend/src/extn/core/array/args.rs
+++ b/artichoke-backend/src/extn/core/array/args.rs
@@ -3,7 +3,7 @@ use std::convert::TryFrom;
 use crate::extn::prelude::*;
 use crate::sys::protect;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum ElementReference {
     Empty,
     Index(Int),

--- a/artichoke-backend/src/extn/core/array/inline_buffer.rs
+++ b/artichoke-backend/src/extn/core/array/inline_buffer.rs
@@ -287,7 +287,7 @@ impl InlineBuffer {
 
 #[cfg(test)]
 mod tests {
-    use bstr::BStr;
+    use bstr::ByteSlice;
 
     use crate::test::prelude::*;
 
@@ -301,8 +301,10 @@ mod tests {
         if let Err(exc) = result {
             let backtrace = exc.vm_backtrace(&mut interp);
             let backtrace = bstr::join("\n", backtrace.unwrap_or_default());
-            let loggable = <&BStr>::from(backtrace.as_slice());
-            panic!("InlineBuffer tests failed with backtrace:\n{:?}", loggable);
+            panic!(
+                "InlineBuffer tests failed with backtrace:\n{:?}",
+                backtrace.as_bstr()
+            );
         }
     }
 }

--- a/artichoke-backend/src/extn/core/env/backend/memory.rs
+++ b/artichoke-backend/src/extn/core/env/backend/memory.rs
@@ -6,7 +6,7 @@ use std::fmt;
 use crate::extn::core::env::backend::EnvType;
 use crate::extn::prelude::*;
 
-#[derive(Debug, Default, Clone)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 pub struct Memory {
     store: HashMap<Vec<u8>, Vec<u8>>,
 }

--- a/artichoke-backend/src/extn/core/env/backend/system.rs
+++ b/artichoke-backend/src/extn/core/env/backend/system.rs
@@ -7,7 +7,7 @@ use crate::extn::core::env::backend::EnvType;
 use crate::extn::prelude::*;
 use crate::ffi;
 
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct System;
 
 impl System {

--- a/artichoke-backend/src/extn/core/env/mod.rs
+++ b/artichoke-backend/src/extn/core/env/mod.rs
@@ -10,17 +10,17 @@ use backend::EnvType;
 
 pub struct Environ(Box<dyn EnvType>);
 
-impl RustBackedValue for Environ {
-    fn ruby_type_name() -> &'static str {
-        "Artichoke::Environ"
-    }
-}
-
 impl fmt::Debug for Environ {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Environ")
             .field("backend", self.0.as_debug())
             .finish()
+    }
+}
+
+impl RustBackedValue for Environ {
+    fn ruby_type_name() -> &'static str {
+        "Artichoke::Environ"
     }
 }
 

--- a/artichoke-backend/src/extn/core/exception/mod.rs
+++ b/artichoke-backend/src/extn/core/exception/mod.rs
@@ -289,28 +289,24 @@ macro_rules! ruby_exception_impl {
             }
         }
 
-        #[allow(clippy::use_self)]
         impl From<$exception> for exception::Exception {
             fn from(exception: $exception) -> exception::Exception {
                 exception::Exception::from(Box::<dyn RubyException>::from(exception))
             }
         }
 
-        #[allow(clippy::use_self)]
         impl From<Box<$exception>> for exception::Exception {
             fn from(exception: Box<$exception>) -> exception::Exception {
                 exception::Exception::from(Box::<dyn RubyException>::from(exception))
             }
         }
 
-        #[allow(clippy::use_self)]
         impl From<$exception> for Box<dyn RubyException> {
             fn from(exception: $exception) -> Box<dyn RubyException> {
                 Box::new(exception)
             }
         }
 
-        #[allow(clippy::use_self)]
         impl From<Box<$exception>> for Box<dyn RubyException> {
             fn from(exception: Box<$exception>) -> Box<dyn RubyException> {
                 exception

--- a/artichoke-backend/src/extn/core/float/mod.rs
+++ b/artichoke-backend/src/extn/core/float/mod.rs
@@ -40,7 +40,7 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     Ok(())
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
+#[derive(Default, Debug, Clone, Copy, PartialEq, PartialOrd)]
 pub struct Float(Fp);
 
 impl ConvertMut<Float, Value> for Artichoke {

--- a/artichoke-backend/src/extn/core/integer/mod.rs
+++ b/artichoke-backend/src/extn/core/integer/mod.rs
@@ -7,7 +7,7 @@ use crate::extn::prelude::*;
 pub mod mruby;
 pub mod trampoline;
 
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Integer(Int);
 
 impl Convert<Integer, Value> for Artichoke {

--- a/artichoke-backend/src/extn/core/kernel/require.rs
+++ b/artichoke-backend/src/extn/core/kernel/require.rs
@@ -96,7 +96,7 @@ pub fn require(
     Err(LoadError::new_raw(interp, message).into())
 }
 
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct RelativePath(PathBuf);
 
 impl RelativePath {

--- a/artichoke-backend/src/extn/core/math/mod.rs
+++ b/artichoke-backend/src/extn/core/math/mod.rs
@@ -463,7 +463,7 @@ pub fn tanh(interp: &mut Artichoke, value: Value) -> Result<Fp, Exception> {
     Ok(result)
 }
 
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 struct DomainError(Cow<'static, str>);
 
 impl DomainError {
@@ -516,14 +516,12 @@ impl From<Box<DomainError>> for Exception {
     }
 }
 
-#[allow(clippy::use_self)]
 impl From<DomainError> for Box<dyn RubyException> {
     fn from(exception: DomainError) -> Box<dyn RubyException> {
         Box::new(exception)
     }
 }
 
-#[allow(clippy::use_self)]
 impl From<Box<DomainError>> for Box<dyn RubyException> {
     fn from(exception: Box<DomainError>) -> Box<dyn RubyException> {
         exception

--- a/artichoke-backend/src/extn/core/numeric/mod.rs
+++ b/artichoke-backend/src/extn/core/numeric/mod.rs
@@ -15,7 +15,7 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
 #[derive(Debug)]
 pub struct Numeric;
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
 pub enum Outcome {
     Float(Fp),
     Integer(Int),
@@ -33,7 +33,7 @@ impl ConvertMut<Outcome, Value> for Artichoke {
 
 const MAX_COERCE_DEPTH: u8 = 15;
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
 pub enum Coercion {
     Float(Fp, Fp),
     Integer(Int, Int),

--- a/artichoke-backend/src/extn/core/random/backend/default.rs
+++ b/artichoke-backend/src/extn/core/random/backend/default.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use crate::extn::core::random::backend::{InternalState, RandType};
 use crate::extn::prelude::*;
 
-#[derive(Default, Debug, Clone, Copy)]
+#[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Default;
 
 impl RandType for Default {

--- a/artichoke-backend/src/extn/core/random/mod.rs
+++ b/artichoke-backend/src/extn/core/random/mod.rs
@@ -70,7 +70,16 @@ pub fn urandom(interp: &mut Artichoke, size: Int) -> Result<Vec<u8>, Exception> 
         ))),
     }
 }
+
 pub struct Random(Box<dyn backend::RandType>);
+
+impl fmt::Debug for Random {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Random")
+            .field("backend", self.0.as_debug())
+            .finish()
+    }
+}
 
 impl Random {
     #[must_use]
@@ -185,14 +194,6 @@ impl Random {
 impl RustBackedValue for Random {
     fn ruby_type_name() -> &'static str {
         "Random"
-    }
-}
-
-impl fmt::Debug for Random {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Random")
-            .field("backend", self.0.as_debug())
-            .finish()
     }
 }
 

--- a/artichoke-backend/src/extn/core/regexp/enc.rs
+++ b/artichoke-backend/src/extn/core/regexp/enc.rs
@@ -8,7 +8,7 @@ use std::hash::{Hash, Hasher};
 use crate::extn::core::regexp;
 use crate::extn::prelude::*;
 
-#[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct InvalidEncodingError;
 
 impl fmt::Display for InvalidEncodingError {

--- a/artichoke-backend/src/extn/core/regexp/mod.rs
+++ b/artichoke-backend/src/extn/core/regexp/mod.rs
@@ -427,7 +427,7 @@ impl From<Box<dyn RegexpType>> for Regexp {
     }
 }
 
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Config {
     pattern: BString,
     options: opts::Options,

--- a/artichoke-backend/src/extn/core/regexp/opts.rs
+++ b/artichoke-backend/src/extn/core/regexp/opts.rs
@@ -11,7 +11,7 @@ use crate::extn::prelude::*;
 /// Options can be supplied either as an `Integer` object to `Regexp::new` or
 /// inline in Regexp literals like `/artichoke/i`.
 #[allow(clippy::struct_excessive_bools)]
-#[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Options {
     /// Multiline mode.
     pub multiline: bool,

--- a/artichoke-backend/src/extn/core/time/backend/chrono.rs
+++ b/artichoke-backend/src/extn/core/time/backend/chrono.rs
@@ -5,18 +5,31 @@ use crate::extn::core::time::backend::{MakeTime, TimeType};
 use crate::Artichoke;
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Chrono<T: 'static + TimeZone>(DateTime<T>);
+pub struct Chrono<T: TimeZone>(DateTime<T>);
 
-#[derive(Debug, Clone, Copy)]
+impl<T> Copy for Chrono<T>
+where
+    T: TimeZone,
+    T::Offset: Copy,
+{
+}
+
+#[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Factory;
 
-impl<T: TimeZone> Chrono<T> {
+impl<T> Chrono<T>
+where
+    T: TimeZone,
+{
     fn new(time: DateTime<T>) -> Self {
         Self(time)
     }
 }
 
-impl<T: 'static + TimeZone + fmt::Debug> TimeType for Chrono<T> {
+impl<T> TimeType for Chrono<T>
+where
+    T: TimeZone + fmt::Debug,
+{
     fn as_debug(&self) -> &dyn fmt::Debug {
         self
     }

--- a/artichoke-backend/src/extn/core/time/mod.rs
+++ b/artichoke-backend/src/extn/core/time/mod.rs
@@ -16,6 +16,14 @@ pub fn factory() -> impl MakeTime {
 
 pub struct Time(Box<dyn TimeType>);
 
+impl fmt::Debug for Time {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Time")
+            .field("backend", self.0.as_debug())
+            .finish()
+    }
+}
+
 impl Time {
     fn inner(&self) -> &dyn TimeType {
         self.0.as_ref()
@@ -25,13 +33,5 @@ impl Time {
 impl RustBackedValue for Time {
     fn ruby_type_name() -> &'static str {
         "Time"
-    }
-}
-
-impl fmt::Debug for Time {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Time")
-            .field("backend", self.0.as_debug())
-            .finish()
     }
 }

--- a/artichoke-backend/src/extn/stdlib/securerandom/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/securerandom/mod.rs
@@ -24,7 +24,7 @@ mod tests {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct SecureRandom;
 
 pub fn random_bytes(interp: &mut Artichoke, len: Option<Int>) -> Result<Vec<u8>, Exception> {

--- a/artichoke-backend/src/ffi.rs
+++ b/artichoke-backend/src/ffi.rs
@@ -57,7 +57,7 @@ pub unsafe fn from_user_data(
 }
 
 /// Failed to extract Artichoke interpreter at an FFI boundary.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct InterpreterExtractError;
 
 impl fmt::Display for InterpreterExtractError {
@@ -104,14 +104,12 @@ impl From<Box<InterpreterExtractError>> for Exception {
     }
 }
 
-#[allow(clippy::use_self)]
 impl From<InterpreterExtractError> for Box<dyn RubyException> {
     fn from(exception: InterpreterExtractError) -> Box<dyn RubyException> {
         Box::new(exception)
     }
 }
 
-#[allow(clippy::use_self)]
 impl From<Box<InterpreterExtractError>> for Box<dyn RubyException> {
     fn from(exception: Box<InterpreterExtractError>) -> Box<dyn RubyException> {
         exception
@@ -142,7 +140,7 @@ pub fn os_string_to_bytes(value: OsString) -> Result<Vec<u8>, ConvertBytesError>
     Vec::from_os_string(value).map_err(|_| ConvertBytesError)
 }
 
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ConvertBytesError;
 
 impl fmt::Display for ConvertBytesError {
@@ -189,14 +187,12 @@ impl From<Box<ConvertBytesError>> for Exception {
     }
 }
 
-#[allow(clippy::use_self)]
 impl From<ConvertBytesError> for Box<dyn RubyException> {
     fn from(exception: ConvertBytesError) -> Box<dyn RubyException> {
         Box::new(exception)
     }
 }
 
-#[allow(clippy::use_self)]
 impl From<Box<ConvertBytesError>> for Box<dyn RubyException> {
     fn from(exception: Box<ConvertBytesError>) -> Box<dyn RubyException> {
         exception

--- a/artichoke-backend/src/fs.rs
+++ b/artichoke-backend/src/fs.rs
@@ -41,14 +41,14 @@ pub const RUBY_LOAD_PATH: &str = "/src/lib";
 pub type ExtensionHook = fn(&mut Artichoke) -> Result<(), Exception>;
 
 #[must_use]
-#[cfg(all(feature = "native-filesystem-access", not(test), not(doctest)))]
+#[cfg(all(feature = "native-filesystem-access", not(any(test, doctest))))]
 pub fn filesystem() -> Box<dyn Filesystem> {
     let fs = hybrid::Hybrid::default();
     Box::new(fs)
 }
 
 #[must_use]
-#[cfg(all(not(feature = "native-filesystem-access"), not(test), not(doctest)))]
+#[cfg(not(any(feature = "native-filesystem-access", test, doctest)))]
 pub fn filesystem() -> Box<dyn Filesystem> {
     let fs = memory::Memory::default();
     Box::new(fs)

--- a/artichoke-backend/src/interpreter.rs
+++ b/artichoke-backend/src/interpreter.rs
@@ -69,7 +69,7 @@ pub fn interpreter() -> Result<Artichoke, Exception> {
     Ok(interp)
 }
 
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[allow(clippy::module_name_repetitions)]
 pub struct InterpreterAllocError;
 
@@ -114,14 +114,12 @@ impl From<Box<InterpreterAllocError>> for Exception {
     }
 }
 
-#[allow(clippy::use_self)]
 impl From<InterpreterAllocError> for Box<dyn RubyException> {
     fn from(exception: InterpreterAllocError) -> Box<dyn RubyException> {
         Box::new(exception)
     }
 }
 
-#[allow(clippy::use_self)]
 impl From<Box<InterpreterAllocError>> for Box<dyn RubyException> {
     fn from(exception: Box<InterpreterAllocError>) -> Box<dyn RubyException> {
         exception

--- a/artichoke-backend/src/io.rs
+++ b/artichoke-backend/src/io.rs
@@ -113,14 +113,12 @@ impl From<Box<IOError>> for Exception {
     }
 }
 
-#[allow(clippy::use_self)]
 impl From<IOError> for Box<dyn RubyException> {
     fn from(exception: IOError) -> Box<dyn RubyException> {
         Box::new(exception)
     }
 }
 
-#[allow(clippy::use_self)]
 impl From<Box<IOError>> for Box<dyn RubyException> {
     fn from(exception: Box<IOError>) -> Box<dyn RubyException> {
         exception

--- a/artichoke-backend/src/parser.rs
+++ b/artichoke-backend/src/parser.rs
@@ -109,14 +109,12 @@ impl From<Box<IncrementLinenoError>> for Exception {
     }
 }
 
-#[allow(clippy::use_self)]
 impl From<IncrementLinenoError> for Box<dyn RubyException> {
     fn from(exception: IncrementLinenoError) -> Box<dyn RubyException> {
         Box::new(exception)
     }
 }
 
-#[allow(clippy::use_self)]
 impl From<Box<IncrementLinenoError>> for Box<dyn RubyException> {
     fn from(exception: Box<IncrementLinenoError>) -> Box<dyn RubyException> {
         exception

--- a/artichoke-backend/src/state/output.rs
+++ b/artichoke-backend/src/state/output.rs
@@ -33,7 +33,7 @@ pub trait Output: Send + Sync {
     }
 }
 
-#[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Process;
 
 impl Process {
@@ -57,7 +57,7 @@ impl Output for Process {
     }
 }
 
-#[derive(Default, Debug, Clone, Hash, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Captured {
     stdout: BString,
     stderr: BString,
@@ -117,7 +117,7 @@ impl<'a> Output for &'a mut Captured {
     }
 }
 
-#[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Null;
 
 impl Null {

--- a/artichoke-backend/src/state/parser.rs
+++ b/artichoke-backend/src/state/parser.rs
@@ -137,7 +137,7 @@ fn reset_context_filename(mrb: &mut sys::mrb_state, context: &mut sys::mrbc_cont
 ///
 /// Parser [`State`] maintains a stack of `Context`s and
 /// [`eval`](crate::eval::Eval) calls XXX to set the `__FILE__` magic constant.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Context {
     /// Value of the `__FILE__` magic constant that also appears in stack
     /// frames.

--- a/artichoke-backend/src/string.rs
+++ b/artichoke-backend/src/string.rs
@@ -146,7 +146,6 @@ impl From<Box<WriteError>> for Exception {
     }
 }
 
-#[allow(clippy::use_self)]
 impl From<WriteError> for Box<dyn RubyException> {
     #[inline]
     fn from(exception: WriteError) -> Box<dyn RubyException> {
@@ -154,7 +153,6 @@ impl From<WriteError> for Box<dyn RubyException> {
     }
 }
 
-#[allow(clippy::use_self)]
 impl From<Box<WriteError>> for Box<dyn RubyException> {
     #[inline]
     fn from(exception: Box<WriteError>) -> Box<dyn RubyException> {
@@ -226,7 +224,6 @@ impl From<Box<IoWriteError>> for Exception {
     }
 }
 
-#[allow(clippy::use_self)]
 impl From<IoWriteError> for Box<dyn RubyException> {
     #[inline]
     fn from(exception: IoWriteError) -> Box<dyn RubyException> {
@@ -234,7 +231,6 @@ impl From<IoWriteError> for Box<dyn RubyException> {
     }
 }
 
-#[allow(clippy::use_self)]
 impl From<Box<IoWriteError>> for Box<dyn RubyException> {
     #[inline]
     fn from(exception: Box<IoWriteError>) -> Box<dyn RubyException> {

--- a/artichoke-backend/src/value.rs
+++ b/artichoke-backend/src/value.rs
@@ -346,7 +346,7 @@ impl ConvertMut<Value, Value> for Artichoke {
 }
 
 /// Argument count exceeds maximum allowed by the VM.
-#[derive(Debug, Clone, Copy)]
+#[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ArgCountError {
     /// Number of arguments given.
     pub given: usize,
@@ -415,14 +415,12 @@ impl From<Box<ArgCountError>> for Exception {
     }
 }
 
-#[allow(clippy::use_self)]
 impl From<ArgCountError> for Box<dyn RubyException> {
     fn from(exception: ArgCountError) -> Box<dyn RubyException> {
         Box::new(exception)
     }
 }
 
-#[allow(clippy::use_self)]
 impl From<Box<ArgCountError>> for Box<dyn RubyException> {
     fn from(exception: Box<ArgCountError>) -> Box<dyn RubyException> {
         exception

--- a/artichoke-backend/tests/manual.rs
+++ b/artichoke-backend/tests/manual.rs
@@ -6,7 +6,7 @@ extern crate artichoke_backend;
 
 use artichoke_backend::extn::prelude::*;
 
-#[derive(Clone, Debug, Default)]
+#[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 struct Container {
     inner: i64,
 }

--- a/artichoke-core/src/parser.rs
+++ b/artichoke-core/src/parser.rs
@@ -63,7 +63,7 @@ pub trait Parser {
 ///
 /// Errors include overflows of the interpreters line counter.
 #[non_exhaustive]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum IncrementLinenoError {
     /// An overflow occurred when incrementing the line number.
     ///

--- a/artichoke-core/src/types.rs
+++ b/artichoke-core/src/types.rs
@@ -3,7 +3,7 @@
 use std::fmt;
 
 /// Classes of Rust types.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Rust {
     /// Rust `bool` type.
     Bool,
@@ -49,7 +49,7 @@ impl fmt::Display for Rust {
 }
 
 /// Classes of Ruby types.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Ruby {
     /// Ruby `Array` type.
     Array,

--- a/spec-runner/src/main.rs
+++ b/spec-runner/src/main.rs
@@ -74,7 +74,7 @@ mod mspec;
 mod rubyspec;
 
 /// CLI specification for `spec-runner`.
-#[derive(Debug, StructOpt)]
+#[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, StructOpt)]
 #[structopt(name = "spec-runner", about = "ruby/spec runner for Artichoke.")]
 struct Opt {
     /// Path to YAML config file.

--- a/spec-runner/src/mspec.rs
+++ b/spec-runner/src/mspec.rs
@@ -20,7 +20,7 @@ pub fn init(interp: &mut Artichoke) -> Result<(), Exception> {
 }
 
 /// `MSpec` source code.
-#[derive(RustEmbed)]
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord, RustEmbed)]
 #[folder = "vendor/mspec/lib"]
 pub struct Sources;
 

--- a/spec-runner/src/rubyspec.rs
+++ b/spec-runner/src/rubyspec.rs
@@ -18,6 +18,6 @@ pub fn init(interp: &mut Artichoke) -> Result<(), Exception> {
 }
 
 /// ruby/spec source code.
-#[derive(RustEmbed)]
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord, RustEmbed)]
 #[folder = "vendor/spec"]
 pub struct Specs;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -14,7 +14,7 @@ use crate::backend::Artichoke;
 ///
 /// This enum only encapsulates whether artichoke can parse the code. It may
 /// still have syntactic or semantic errors.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum State {
     /// Internal parser error. This is a fatal error.
     ParseError,

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -30,7 +30,7 @@ mod filename_test {
 /// Failed to initialize parser during REPL boot.
 ///
 /// The parser is needed to properly enter and exit multi-line editing mode.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 struct ParserAllocError;
 
 impl fmt::Display for ParserAllocError {
@@ -42,7 +42,7 @@ impl fmt::Display for ParserAllocError {
 impl error::Error for ParserAllocError {}
 
 /// Parser processed too many lines of input.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 struct ParserLineCountError;
 
 impl fmt::Display for ParserLineCountError {
@@ -56,7 +56,7 @@ impl error::Error for ParserLineCountError {}
 /// Internal fatal parser error.
 ///
 /// This is usually an unknown FFI to Rust translation.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 struct ParserInternalError;
 
 impl fmt::Display for ParserInternalError {
@@ -84,7 +84,7 @@ impl error::Error for UnhandledReadlineError {
 }
 
 /// Configuration for the REPL readline prompt.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct PromptConfig {
     /// Basic prompt for start of a new expression.
     pub simple: String,

--- a/src/ruby.rs
+++ b/src/ruby.rs
@@ -29,7 +29,7 @@ mod filename_test {
     }
 }
 
-#[derive(Debug, StructOpt)]
+#[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, StructOpt)]
 #[structopt(name = "artichoke", about = "Artichoke is a Ruby made with Rust.")]
 struct Opt {
     /// print the copyright


### PR DESCRIPTION
Derive more common Rust traits:

https://rust-lang.github.io/api-guidelines/interoperability.html#types-eagerly-implement-common-traits-c-common-traits

Make better and more use of `bstr::ByteSlice` APIs.

Remove lint `allow`s for deactivated clippy lints.