### PR TITLE
Implement base64 standard library

### DIFF
--- a/artichoke-backend/src/extn/stdlib/base64/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/base64/mod.rs
@@ -1,0 +1,12 @@
+use crate::extn::prelude::*;
+
+pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
+    let spec = crate::module::Spec::new(interp, "Base64", None)?;
+    interp.def_module::<Base64>(spec)?;
+    interp.def_rb_source_file("base64.rb", &include_bytes!("vendor/base64.rb")[..])?;
+
+    Ok(())
+}
+
+#[derive(Debug)]
+pub struct Base64;

--- a/artichoke-backend/src/extn/stdlib/base64/vendor/base64.rb
+++ b/artichoke-backend/src/extn/stdlib/base64/vendor/base64.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+#
+# = base64.rb: methods for base64-encoding and -decoding strings
+#
+
+# The Base64 module provides for the encoding (#encode64, #strict_encode64,
+# #urlsafe_encode64) and decoding (#decode64, #strict_decode64,
+# #urlsafe_decode64) of binary data using a Base64 representation.
+#
+# == Example
+#
+# A simple encoding and decoding.
+#
+#     require "base64"
+#
+#     enc   = Base64.encode64('Send reinforcements')
+#                         # -> "U2VuZCByZWluZm9yY2VtZW50cw==\n"
+#     plain = Base64.decode64(enc)
+#                         # -> "Send reinforcements"
+#
+# The purpose of using base64 to encode data is that it translates any
+# binary data into purely printable characters.
+
+module Base64
+  module_function
+
+  # Returns the Base64-encoded version of +bin+.
+  # This method complies with RFC 2045.
+  # Line feeds are added to every 60 encoded characters.
+  #
+  #    require 'base64'
+  #    Base64.encode64("Now is the time for all good coders\nto learn Ruby")
+  #
+  # <i>Generates:</i>
+  #
+  #    Tm93IGlzIHRoZSB0aW1lIGZvciBhbGwgZ29vZCBjb2RlcnMKdG8gbGVhcm4g
+  #    UnVieQ==
+  def encode64(bin)
+    [bin].pack("m")
+  end
+
+  # Returns the Base64-decoded version of +str+.
+  # This method complies with RFC 2045.
+  # Characters outside the base alphabet are ignored.
+  #
+  #   require 'base64'
+  #   str = 'VGhpcyBpcyBsaW5lIG9uZQpUaGlzIG' +
+  #         'lzIGxpbmUgdHdvClRoaXMgaXMgbGlu' +
+  #         'ZSB0aHJlZQpBbmQgc28gb24uLi4K'
+  #   puts Base64.decode64(str)
+  #
+  # <i>Generates:</i>
+  #
+  #    This is line one
+  #    This is line two
+  #    This is line three
+  #    And so on...
+  def decode64(str)
+    str.unpack1("m")
+  end
+
+  # Returns the Base64-encoded version of +bin+.
+  # This method complies with RFC 4648.
+  # No line feeds are added.
+  def strict_encode64(bin)
+    [bin].pack("m0")
+  end
+
+  # Returns the Base64-decoded version of +str+.
+  # This method complies with RFC 4648.
+  # ArgumentError is raised if +str+ is incorrectly padded or contains
+  # non-alphabet characters.  Note that CR or LF are also rejected.
+  def strict_decode64(str)
+    str.unpack1("m0")
+  end
+
+  # Returns the Base64-encoded version of +bin+.
+  # This method complies with ``Base 64 Encoding with URL and Filename Safe
+  # Alphabet'' in RFC 4648.
+  # The alphabet uses '-' instead of '+' and '_' instead of '/'.
+  # Note that the result can still contain '='.
+  # You can remove the padding by setting +padding+ as false.
+  def urlsafe_encode64(bin, padding: true)
+    str = strict_encode64(bin).tr("+/", "-_")
+    str = str.delete("=") unless padding
+    str
+  end
+
+  # Returns the Base64-decoded version of +str+.
+  # This method complies with ``Base 64 Encoding with URL and Filename Safe
+  # Alphabet'' in RFC 4648.
+  # The alphabet uses '-' instead of '+' and '_' instead of '/'.
+  #
+  # The padding character is optional.
+  # This method accepts both correctly-padded and unpadded input.
+  # Note that it still rejects incorrectly-padded input.
+  def urlsafe_decode64(str)
+    # NOTE: RFC 4648 does say nothing about unpadded input, but says that
+    # "the excess pad characters MAY also be ignored", so it is inferred that
+    # unpadded input is also acceptable.
+    str = str.tr("-_", "+/")
+    if !str.end_with?("=") && str.length % 4 != 0
+      str = str.ljust((str.length + 3) & ~3, "=")
+    end
+    strict_decode64(str)
+  end
+end

--- a/artichoke-backend/src/extn/stdlib/base64/vendor/base64.rb
+++ b/artichoke-backend/src/extn/stdlib/base64/vendor/base64.rb
@@ -22,8 +22,6 @@
 # binary data into purely printable characters.
 
 module Base64
-  module_function
-
   # Returns the Base64-encoded version of +bin+.
   # This method complies with RFC 2045.
   # Line feeds are added to every 60 encoded characters.
@@ -104,4 +102,11 @@ module Base64
     end
     strict_decode64(str)
   end
+
+  module_function :encode64
+  module_function :decode64
+  module_function :strict_encode64
+  module_function :strict_decode64
+  module_function :urlsafe_encode64
+  module_function :urlsafe_decode64
 end

--- a/artichoke-backend/src/extn/stdlib/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/mod.rs
@@ -1,6 +1,7 @@
 use crate::extn::prelude::*;
 
 pub mod abbrev;
+pub mod base64;
 pub mod cmath;
 pub mod delegate;
 pub mod forwardable;
@@ -17,6 +18,7 @@ pub mod uri;
 
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     abbrev::init(interp)?;
+    base64::init(interp)?;
     cmath::init(interp)?;
     delegate::init(interp)?;
     forwardable::init(interp)?;

--- a/spec-runner/enforced-specs.yaml
+++ b/spec-runner/enforced-specs.yaml
@@ -79,3 +79,4 @@ library:
   - suite: uri
     skip:
       - parse
+  - suite: base64


### PR DESCRIPTION
close https://github.com/artichoke/artichoke/issues/75

Hi!
I added base64 standard library.

```sh
$ bundle exec rake spec | grep Base64
cargo run -q -p spec-runner -- spec-runner/enforced-specs.yaml
rb warning: encoding option is ignored -- N
rb warning: flags ignored when initializing from Regexp
rb warning: encoding option is ignored -- N
rb warning: flags ignored when initializing from Regexp
Base64#encode64: ..
Base64#decode64: .
Base64#urlsafe_encode64: ...
Base64#urlsafe_decode64: ...
```