### PR TITLE
Change RubyException::message and RubyException::name to return Cow

### DIFF
--- a/artichoke-backend/src/block.rs
+++ b/artichoke-backend/src/block.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::convert::TryFrom;
 use std::error;
 use std::fmt;
@@ -25,12 +26,12 @@ impl fmt::Display for NoBlockGiven {
 impl error::Error for NoBlockGiven {}
 
 impl RubyException for NoBlockGiven {
-    fn message(&self) -> &[u8] {
-        b"no block given"
+    fn message(&self) -> Cow<'_, [u8]> {
+        Cow::Borrowed(b"no block given")
     }
 
-    fn name(&self) -> String {
-        String::from("TypeError")
+    fn name(&self) -> Cow<'_, str> {
+        "TypeError".into()
     }
 
     fn vm_backtrace(&self, interp: &mut Artichoke) -> Option<Vec<Vec<u8>>> {

--- a/artichoke-backend/src/convert.rs
+++ b/artichoke-backend/src/convert.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::error;
 use std::fmt;
 
@@ -85,12 +86,12 @@ impl fmt::Display for UnboxRubyError {
 impl error::Error for UnboxRubyError {}
 
 impl RubyException for UnboxRubyError {
-    fn message(&self) -> &[u8] {
-        &b"Failed to convert from Ruby value to Rust type"[..]
+    fn message(&self) -> Cow<'_, [u8]> {
+        Cow::Borrowed(b"Failed to convert from Ruby value to Rust type")
     }
 
-    fn name(&self) -> String {
-        String::from("TypeError")
+    fn name(&self) -> Cow<'_, str> {
+        "TypeError".into()
     }
 
     fn vm_backtrace(&self, interp: &mut Artichoke) -> Option<Vec<Vec<u8>>> {
@@ -156,12 +157,12 @@ impl fmt::Display for BoxIntoRubyError {
 impl error::Error for BoxIntoRubyError {}
 
 impl RubyException for BoxIntoRubyError {
-    fn message(&self) -> &[u8] {
-        &b"Failed to convert from Rust type to Ruby value"[..]
+    fn message(&self) -> Cow<'_, [u8]> {
+        Cow::Borrowed(b"Failed to convert from Rust type to Ruby value")
     }
 
-    fn name(&self) -> String {
-        String::from("TypeError")
+    fn name(&self) -> Cow<'_, str> {
+        "TypeError".into()
     }
 
     fn vm_backtrace(&self, interp: &mut Artichoke) -> Option<Vec<Vec<u8>>> {

--- a/artichoke-backend/src/convert/bytes.rs
+++ b/artichoke-backend/src/convert/bytes.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::convert::TryFrom;
 use std::ffi::{CStr, OsStr, OsString};
 use std::slice;
@@ -27,6 +28,12 @@ impl ConvertMut<&[u8], Value> for Artichoke {
         // to worry about the lifetime of the slice passed into this converter.
         let string = unsafe { self.with_ffi_boundary(|mrb| sys::mrb_str_new(mrb, raw, len)) };
         Value::from(string.unwrap())
+    }
+}
+
+impl<'a> ConvertMut<Cow<'a, [u8]>, Value> for Artichoke {
+    fn convert_mut(&mut self, value: Cow<'a, [u8]>) -> Value {
+        self.convert_mut(value.as_ref())
     }
 }
 

--- a/artichoke-backend/src/convert/string.rs
+++ b/artichoke-backend/src/convert/string.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::str;
 
 use crate::convert::UnboxRubyError;
@@ -20,6 +21,12 @@ impl ConvertMut<&str, Value> for Artichoke {
         // Ruby `String`s are just bytes, so get a pointer to the underlying
         // `&[u8]` infallibly and convert that to a `Value`.
         self.convert_mut(value.as_bytes())
+    }
+}
+
+impl<'a> ConvertMut<Cow<'a, str>, Value> for Artichoke {
+    fn convert_mut(&mut self, value: Cow<'a, str>) -> Value {
+        self.convert_mut(value.as_ref())
     }
 }
 

--- a/artichoke-backend/src/def.rs
+++ b/artichoke-backend/src/def.rs
@@ -219,12 +219,12 @@ impl fmt::Display for ConstantNameError {
 impl error::Error for ConstantNameError {}
 
 impl RubyException for ConstantNameError {
-    fn message(&self) -> &[u8] {
-        &b"Invalid constant name contained a NUL byte"[..]
+    fn message(&self) -> Cow<'_, [u8]> {
+        Cow::Borrowed(b"Invalid constant name contained a NUL byte")
     }
 
-    fn name(&self) -> String {
-        String::from("NameError")
+    fn name(&self) -> Cow<'_, str> {
+        "NameError".into()
     }
 
     fn vm_backtrace(&self, interp: &mut Artichoke) -> Option<Vec<Vec<u8>>> {
@@ -363,12 +363,16 @@ impl fmt::Display for NotDefinedError {
 impl error::Error for NotDefinedError {}
 
 impl RubyException for NotDefinedError {
-    fn message(&self) -> &[u8] {
-        &b"Class-like not defined"[..]
+    fn message(&self) -> Cow<'_, [u8]> {
+        let mut message = String::from(self.item_type());
+        message.push(' ');
+        message.push_str(self.fqdn());
+        message.push_str(" not defined");
+        message.into_bytes().into()
     }
 
-    fn name(&self) -> String {
-        String::from("ScriptError")
+    fn name(&self) -> Cow<'_, str> {
+        "ScriptError".into()
     }
 
     fn vm_backtrace(&self, interp: &mut Artichoke) -> Option<Vec<Vec<u8>>> {

--- a/artichoke-backend/src/eval.rs
+++ b/artichoke-backend/src/eval.rs
@@ -180,14 +180,14 @@ mod tests {
     fn unparseable_code_returns_err_syntax_error() {
         let mut interp = crate::interpreter().unwrap();
         let err = interp.eval(b"'a").unwrap_err();
-        assert_eq!("SyntaxError", err.name().as_str());
+        assert_eq!("SyntaxError", err.name().as_ref());
     }
 
     #[test]
     fn interpreter_is_usable_after_syntax_error() {
         let mut interp = crate::interpreter().unwrap();
         let err = interp.eval(b"'a").unwrap_err();
-        assert_eq!("SyntaxError", err.name().as_str());
+        assert_eq!("SyntaxError", err.name().as_ref());
         // Ensure interpreter is usable after evaling unparseable code
         let result = interp.eval(b"'a' * 10 ").unwrap();
         let result = result.try_into_mut::<&str>(&mut interp).unwrap();
@@ -225,6 +225,6 @@ mod tests {
             .def_rb_source_file("fail.rb", &b"def bad; 'as'.scan(; end"[..])
             .unwrap();
         let err = interp.eval(b"require 'fail'").unwrap_err();
-        assert_eq!("SyntaxError", err.name().as_str());
+        assert_eq!("SyntaxError", err.name().as_ref());
     }
 }

--- a/artichoke-backend/src/exception_handler.rs
+++ b/artichoke-backend/src/exception_handler.rs
@@ -56,8 +56,8 @@ mod tests {
         let err = interp
             .eval(b"raise ArgumentError.new('waffles')")
             .unwrap_err();
-        assert_eq!("ArgumentError", err.name().as_str());
-        assert_eq!(&b"waffles"[..], err.message());
+        assert_eq!("ArgumentError", err.name().as_ref());
+        assert_eq!(&b"waffles"[..], err.message().as_ref());
         assert_eq!(
             Some(vec![Vec::from(&b"(eval):1"[..])]),
             err.vm_backtrace(&mut interp)
@@ -68,8 +68,8 @@ mod tests {
     fn return_exception_with_no_backtrace() {
         let mut interp = crate::interpreter().expect("init");
         let err = interp.eval(b"def bad; (; end").unwrap_err();
-        assert_eq!("SyntaxError", err.name().as_str());
-        assert_eq!(&b"syntax error"[..], err.message());
+        assert_eq!("SyntaxError", err.name().as_ref());
+        assert_eq!(&b"syntax error"[..], err.message().as_ref());
         assert_eq!(None, err.vm_backtrace(&mut interp));
     }
 

--- a/artichoke-backend/src/extn/core/env/backend/mod.rs
+++ b/artichoke-backend/src/extn/core/env/backend/mod.rs
@@ -59,13 +59,13 @@ impl error::Error for EnvArgumentError {}
 
 impl RubyException for EnvArgumentError {
     #[inline]
-    fn message(&self) -> &[u8] {
-        self.0.as_ref()
+    fn message(&self) -> Cow<'_, [u8]> {
+        Cow::Borrowed(self.0.as_ref())
     }
 
     #[inline]
-    fn name(&self) -> String {
-        String::from("ArgumentError")
+    fn name(&self) -> Cow<'_, str> {
+        "ArgumentError".into()
     }
 
     fn vm_backtrace(&self, interp: &mut Artichoke) -> Option<Vec<Vec<u8>>> {

--- a/artichoke-backend/src/extn/core/kernel/mod.rs
+++ b/artichoke-backend/src/extn/core/kernel/mod.rs
@@ -78,7 +78,7 @@ mod tests {
             let err = interp.eval(b"require 'non-existent-source'").unwrap_err();
             assert_eq!(
                 &b"cannot load such file -- non-existent-source"[..],
-                err.message()
+                err.message().as_ref()
             );
             let expected = vec![Vec::from(&b"(eval):1"[..])];
             assert_eq!(Some(expected), err.vm_backtrace(&mut interp),);
@@ -115,7 +115,10 @@ mod tests {
         fn directory_err() {
             let mut interp = crate::interpreter().unwrap();
             let err = interp.eval(b"require '/src'").unwrap_err();
-            assert_eq!(&b"cannot load such file -- /src"[..], err.message());
+            assert_eq!(
+                &b"cannot load such file -- /src"[..],
+                err.message().as_ref()
+            );
             let expected = vec![Vec::from(&b"(eval):1"[..])];
             assert_eq!(Some(expected), err.vm_backtrace(&mut interp));
         }

--- a/artichoke-backend/src/extn/core/math/mod.rs
+++ b/artichoke-backend/src/extn/core/math/mod.rs
@@ -484,12 +484,12 @@ impl fmt::Display for DomainError {
 impl error::Error for DomainError {}
 
 impl RubyException for DomainError {
-    fn message(&self) -> &[u8] {
-        self.0.as_ref().as_bytes()
+    fn message(&self) -> Cow<'_, [u8]> {
+        self.0.as_ref().as_bytes().into()
     }
 
-    fn name(&self) -> String {
-        String::from("DomainError")
+    fn name(&self) -> Cow<'_, str> {
+        "DomainError".into()
     }
 
     fn vm_backtrace(&self, interp: &mut Artichoke) -> Option<Vec<Vec<u8>>> {

--- a/artichoke-backend/src/ffi.rs
+++ b/artichoke-backend/src/ffi.rs
@@ -3,6 +3,7 @@
 //! These functions are unsafe. Use them carefully.
 
 use bstr::{ByteSlice, ByteVec};
+use std::borrow::Cow;
 use std::error;
 use std::ffi::{OsStr, OsString};
 use std::fmt;
@@ -72,12 +73,12 @@ impl fmt::Display for InterpreterExtractError {
 impl error::Error for InterpreterExtractError {}
 
 impl RubyException for InterpreterExtractError {
-    fn message(&self) -> &[u8] {
-        &b"Failed to extract Artichoke Ruby interpreter from mrb_state"[..]
+    fn message(&self) -> Cow<'_, [u8]> {
+        Cow::Borrowed(b"Failed to extract Artichoke Ruby interpreter from mrb_state")
     }
 
-    fn name(&self) -> String {
-        String::from("fatal")
+    fn name(&self) -> Cow<'_, str> {
+        "fatal".into()
     }
 
     fn vm_backtrace(&self, interp: &mut Artichoke) -> Option<Vec<Vec<u8>>> {
@@ -152,12 +153,12 @@ impl fmt::Display for ConvertBytesError {
 impl error::Error for ConvertBytesError {}
 
 impl RubyException for ConvertBytesError {
-    fn message(&self) -> &[u8] {
-        &b"invalid byte sequence"[..]
+    fn message(&self) -> Cow<'_, [u8]> {
+        Cow::Borrowed(b"invalid byte sequence")
     }
 
-    fn name(&self) -> String {
-        String::from("ArgumentError")
+    fn name(&self) -> Cow<'_, str> {
+        "ArgumentError".into()
     }
 
     fn vm_backtrace(&self, interp: &mut Artichoke) -> Option<Vec<Vec<u8>>> {

--- a/artichoke-backend/src/interpreter.rs
+++ b/artichoke-backend/src/interpreter.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::error;
 use std::fmt;
 use std::ptr::NonNull;
@@ -96,12 +97,12 @@ impl fmt::Display for InterpreterAllocError {
 impl error::Error for InterpreterAllocError {}
 
 impl RubyException for InterpreterAllocError {
-    fn message(&self) -> &[u8] {
-        &b"Failed to allocate Artichoke Ruby interpreter"[..]
+    fn message(&self) -> Cow<'_, [u8]> {
+        Cow::Borrowed(b"Failed to allocate Artichoke Ruby interpreter")
     }
 
-    fn name(&self) -> String {
-        String::from("fatal")
+    fn name(&self) -> Cow<'_, str> {
+        "fatal".into()
     }
 
     fn vm_backtrace(&self, interp: &mut Artichoke) -> Option<Vec<Vec<u8>>> {
@@ -145,6 +146,6 @@ mod tests {
     #[test]
     fn open_close() {
         let interp = super::interpreter().unwrap();
-        drop(interp);
+        interp.close();
     }
 }

--- a/artichoke-backend/src/parser.rs
+++ b/artichoke-backend/src/parser.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use crate::class_registry::ClassRegistry;
 use crate::core::{ConvertMut, IncrementLinenoError, Parser};
 use crate::exception::{Exception, RubyException};
@@ -74,12 +76,12 @@ impl Parser for Artichoke {
 }
 
 impl RubyException for IncrementLinenoError {
-    fn message(&self) -> &[u8] {
-        b"parser exceeded maximum line count"
+    fn message(&self) -> Cow<'_, [u8]> {
+        Cow::Borrowed(b"parser exceeded maximum line count")
     }
 
-    fn name(&self) -> String {
-        String::from("ScriptError")
+    fn name(&self) -> Cow<'_, str> {
+        "ScriptError".into()
     }
 
     fn vm_backtrace(&self, interp: &mut Artichoke) -> Option<Vec<Vec<u8>>> {

--- a/artichoke-backend/src/string.rs
+++ b/artichoke-backend/src/string.rs
@@ -7,6 +7,7 @@
 //! Artichoke aims to support ASCII, UTF-8, maybe UTF-8, and binary encodings.
 
 use bstr::ByteSlice;
+use std::borrow::Cow;
 use std::error;
 use std::fmt;
 use std::io;
@@ -111,13 +112,13 @@ impl error::Error for WriteError {
 
 impl RubyException for WriteError {
     #[inline]
-    fn message(&self) -> &[u8] {
-        &b"Unable to write message into destination"[..]
+    fn message(&self) -> Cow<'_, [u8]> {
+        Cow::Borrowed(b"Unable to write message into destination")
     }
 
     #[inline]
-    fn name(&self) -> String {
-        String::from("fatal")
+    fn name(&self) -> Cow<'_, str> {
+        "fatal".into()
     }
 
     fn vm_backtrace(&self, interp: &mut Artichoke) -> Option<Vec<Vec<u8>>> {
@@ -189,13 +190,13 @@ impl error::Error for IoWriteError {
 
 impl RubyException for IoWriteError {
     #[inline]
-    fn message(&self) -> &[u8] {
-        &b"Unable to write message"[..]
+    fn message(&self) -> Cow<'_, [u8]> {
+        Cow::Borrowed(b"Unable to write message")
     }
 
     #[inline]
-    fn name(&self) -> String {
-        String::from("fatal")
+    fn name(&self) -> Cow<'_, str> {
+        "fatal".into()
     }
 
     fn vm_backtrace(&self, interp: &mut Artichoke) -> Option<Vec<Vec<u8>>> {


### PR DESCRIPTION
This allows e.g. impls of Display to be used to satisfy these APIs when
implementing the trait.

In the common case, it makes the API more flexible while still avoiding allocations.

This commit adds ConvertMut impls for `Cow<'_, [u8]>` and `Cow<'_, str>`.