### PR TITLE
Remove Artichoke parameter from $exception::new for all Exceptions in Core

### DIFF
--- a/artichoke-backend/src/block.rs
+++ b/artichoke-backend/src/block.rs
@@ -151,10 +151,7 @@ impl Block {
                     // and may result in a segfault.
                     //
                     // See: https://github.com/mruby/mruby/issues/4460
-                    Err(Exception::from(Fatal::new(
-                        arena.interp(),
-                        "Unreachable Ruby value",
-                    )))
+                    Err(Fatal::from("Unreachable Ruby value").into())
                 } else {
                     Ok(value)
                 }

--- a/artichoke-backend/src/convert/boxing.rs
+++ b/artichoke-backend/src/convert/boxing.rs
@@ -103,7 +103,7 @@ where
         if value.ruby_type() != Ruby::Data {
             let mut message = String::from("uninitialized ");
             message.push_str(Self::RUBY_TYPE);
-            return Err(Exception::from(TypeError::new(interp, message)));
+            return Err(TypeError::from(message).into());
         }
 
         let state = interp.state.as_ref().ok_or(InterpreterExtractError)?;
@@ -122,7 +122,7 @@ where
             let mut message = String::from("Could not extract ");
             message.push_str(Self::RUBY_TYPE);
             message.push_str(" from receiver");
-            return Err(Exception::from(TypeError::new(interp, message)));
+            return Err(TypeError::from(message).into());
         }
 
         // Copy data pointer out of the `mrb_value` box.
@@ -132,7 +132,7 @@ where
             // `#initialize`. These objects will return a NULL pointer.
             let mut message = String::from("uninitialized ");
             message.push_str(Self::RUBY_TYPE);
-            return Err(Exception::from(TypeError::new(interp, message)));
+            return Err(TypeError::from(message).into());
         }
 
         // Move the data pointer into a `Box`.

--- a/artichoke-backend/src/eval.rs
+++ b/artichoke-backend/src/eval.rs
@@ -38,7 +38,7 @@ impl Eval for Artichoke {
                     //
                     // See: https://github.com/mruby/mruby/issues/4460
                     error!("Fatal eval returned unreachable value");
-                    Err(Exception::from(Fatal::new(self, "Unreachable Ruby value")))
+                    Err(Fatal::from("Unreachable Ruby value").into())
                 } else {
                     trace!("Sucessful eval");
                     Ok(value)
@@ -60,7 +60,7 @@ impl Eval for Artichoke {
 
     fn eval_file(&mut self, file: &Path) -> Result<Self::Value, Self::Error> {
         let context = Context::new(ffi::os_str_to_bytes(file.as_os_str())?.to_vec())
-            .ok_or_else(|| ArgumentError::new(self, "path name contains null byte"))?;
+            .ok_or_else(|| ArgumentError::from("path name contains null byte"))?;
         self.push_context(context)?;
         let code = self.read_source_file_contents(file)?.into_owned();
         let result = self.eval(code.as_slice());

--- a/artichoke-backend/src/extn/core/array/args.rs
+++ b/artichoke-backend/src/extn/core/array/args.rs
@@ -27,8 +27,8 @@ pub fn element_reference(
     } else if let Ok(index) = elem.implicitly_convert_to_int(interp) {
         Ok(ElementReference::Index(index))
     } else {
-        let rangelen = Int::try_from(ary_len)
-            .map_err(|_| Fatal::new(interp, "Range length exceeds Integer max"))?;
+        let rangelen =
+            Int::try_from(ary_len).map_err(|_| Fatal::from("Range length exceeds Integer max"))?;
         if let Some(protect::Range { start, len }) = elem.is_range(interp, rangelen)? {
             if let Ok(len) = usize::try_from(len) {
                 Ok(ElementReference::StartLen(start, len))
@@ -64,7 +64,7 @@ pub fn element_assignment(
                 string::format_int_into(&mut message, start)?;
                 message.push_str(" too small for array; minimum: -");
                 string::format_int_into(&mut message, len)?;
-                return Err(Exception::from(IndexError::new(interp, message)));
+                return Err(IndexError::from(message).into());
             }
         };
         let slice_len = second.implicitly_convert_to_int(interp)?;
@@ -74,7 +74,7 @@ pub fn element_assignment(
             let mut message = String::from("negative length (");
             string::format_int_into(&mut message, slice_len)?;
             message.push(')');
-            Err(Exception::from(IndexError::new(interp, message)))
+            Err(IndexError::from(message).into())
         }
     } else if let Ok(index) = first.implicitly_convert_to_int(interp) {
         if let Ok(index) = usize::try_from(index) {
@@ -91,12 +91,12 @@ pub fn element_assignment(
                 string::format_int_into(&mut message, index)?;
                 message.push_str(" too small for array; minimum: -");
                 string::format_int_into(&mut message, len)?;
-                Err(Exception::from(IndexError::new(interp, message)))
+                Err(IndexError::from(message).into())
             }
         }
     } else {
-        let rangelen = Int::try_from(len)
-            .map_err(|_| Fatal::new(interp, "Range length exceeds Integer max"))?;
+        let rangelen =
+            Int::try_from(len).map_err(|_| Fatal::from("Range length exceeds Integer max"))?;
         if let Some(protect::Range { start, len }) = first.is_range(interp, rangelen)? {
             let start = usize::try_from(start).unwrap_or_else(|_| {
                 unimplemented!("should throw RangeError (-11..1 out of range)")
@@ -116,7 +116,7 @@ pub fn element_assignment(
                 message.push_str("..");
                 string::format_int_into(&mut message, end)?;
                 message.push_str(" out of range");
-                return Err(Exception::from(RangeError::new(interp, message)));
+                return Err(RangeError::from(message).into());
             }
             match (usize::try_from(start), usize::try_from(end)) {
                 (Ok(start), Ok(end)) => Ok((start, end.checked_sub(start), second)),
@@ -132,7 +132,7 @@ pub fn element_assignment(
                         string::format_int_into(&mut message, start)?;
                         message.push_str(" too small for array; minimum: -");
                         string::format_int_into(&mut message, len)?;
-                        Err(Exception::from(IndexError::new(interp, message)))
+                        Err(IndexError::from(message).into())
                     }
                 }
                 (Ok(start), Err(_)) => Ok((start, None, second)),
@@ -141,7 +141,7 @@ pub fn element_assignment(
                     string::format_int_into(&mut message, start)?;
                     message.push_str(" too small for array; minimum: -");
                     string::format_int_into(&mut message, len)?;
-                    Err(Exception::from(IndexError::new(interp, message)))
+                    Err(IndexError::from(message).into())
                 }
             }
         }

--- a/artichoke-backend/src/extn/core/array/mod.rs
+++ b/artichoke-backend/src/extn/core/array/mod.rs
@@ -169,12 +169,12 @@ impl Array {
                     message.push_str(first.pretty_name(interp));
                     message.push_str("#to_ary gives ");
                     message.push_str(other.pretty_name(interp));
-                    return Err(Exception::from(TypeError::new(interp, message)));
+                    return Err(TypeError::from(message).into());
                 }
             } else {
                 let len = first.implicitly_convert_to_int(interp)?;
-                let len = usize::try_from(len)
-                    .map_err(|_| ArgumentError::new(interp, "negative array size"))?;
+                let len =
+                    usize::try_from(len).map_err(|_| ArgumentError::from("negative array size"))?;
                 if let Some(block) = block {
                     if second.is_some() {
                         interp.warn(&b"warning: block supersedes default value argument"[..])?;
@@ -182,7 +182,7 @@ impl Array {
                     let mut buffer = Vec::with_capacity(len);
                     for idx in 0..len {
                         let idx = Int::try_from(idx).map_err(|_| {
-                            RangeError::new(interp, "bignum too big to convert into `long'")
+                            RangeError::from("bignum too big to convert into `long'")
                         })?;
                         let idx = interp.convert(idx);
                         let elem = block.yield_arg(interp, &idx)?;
@@ -196,10 +196,10 @@ impl Array {
                 }
             }
         } else if second.is_some() {
-            return Err(Exception::from(Fatal::new(
-                interp,
+            return Err(Fatal::from(
                 "default cannot be set if first arg is missing in Array#initialize",
-            )));
+            )
+            .into());
         } else {
             InlineBuffer::default()
         };
@@ -267,7 +267,7 @@ impl Array {
                     message.push_str(elem.pretty_name(interp));
                     message.push_str("#to_ary gives ");
                     message.push_str(other.pretty_name(interp));
-                    return Err(Exception::from(TypeError::new(interp, message)));
+                    return Err(TypeError::from(message).into());
                 }
             } else {
                 self.0.set_with_drain(start, drain, elem);
@@ -310,13 +310,13 @@ impl Array {
                 message.push_str(other.pretty_name(interp));
                 message.push_str("#to_ary gives ");
                 message.push_str(other.pretty_name(interp));
-                return Err(Exception::from(TypeError::new(interp, message)));
+                return Err(TypeError::from(message).into());
             }
         } else {
             let mut message = String::from("no implicit conversion of ");
             message.push_str(other.pretty_name(interp));
             message.push_str(" into Array");
-            return Err(Exception::from(TypeError::new(interp, message)));
+            return Err(TypeError::from(message).into());
         };
         Ok(())
     }

--- a/artichoke-backend/src/extn/core/array/mruby.rs
+++ b/artichoke-backend/src/extn/core/array/mruby.rs
@@ -59,7 +59,7 @@ unsafe extern "C" fn ary_len(mrb: *mut sys::mrb_state, ary: sys::mrb_value) -> s
         if let Ok(len) = sys::mrb_int::try_from(len) {
             Ok(len)
         } else {
-            Err(Fatal::new(&guard, "Array length does not fit in mruby Integer max").into())
+            Err(Fatal::from("Array length does not fit in mruby Integer max").into())
         }
     });
     match result {

--- a/artichoke-backend/src/extn/core/array/trampoline.rs
+++ b/artichoke-backend/src/extn/core/array/trampoline.rs
@@ -4,10 +4,7 @@ use crate::gc::{MrbGarbageCollection, State as GcState};
 
 pub fn clear(interp: &mut Artichoke, mut ary: Value) -> Result<Value, Exception> {
     if ary.is_frozen(interp) {
-        return Err(Exception::from(FrozenError::new(
-            interp,
-            "can't modify frozen Array",
-        )));
+        return Err(FrozenError::from("can't modify frozen Array").into());
     }
     let mut array = unsafe { Array::unbox_from_value(&mut ary, interp)? };
     array.clear();
@@ -33,10 +30,7 @@ pub fn element_assignment(
     third: Option<Value>,
 ) -> Result<Value, Exception> {
     if ary.is_frozen(interp) {
-        return Err(Exception::from(FrozenError::new(
-            interp,
-            "can't modify frozen Array",
-        )));
+        return Err(FrozenError::from("can't modify frozen Array").into());
     }
     // TODO: properly handle self-referential sets.
     if ary == first || ary == second || Some(ary) == third {
@@ -56,10 +50,7 @@ pub fn element_assignment(
 
 pub fn pop(interp: &mut Artichoke, mut ary: Value) -> Result<Value, Exception> {
     if ary.is_frozen(interp) {
-        return Err(Exception::from(FrozenError::new(
-            interp,
-            "can't modify frozen Array",
-        )));
+        return Err(FrozenError::from("can't modify frozen Array").into());
     }
     let mut array = unsafe { Array::unbox_from_value(&mut ary, interp)? };
     let result = array.pop();
@@ -72,10 +63,7 @@ pub fn concat(
     other: Option<Value>,
 ) -> Result<Value, Exception> {
     if ary.is_frozen(interp) {
-        return Err(Exception::from(FrozenError::new(
-            interp,
-            "can't modify frozen Array",
-        )));
+        return Err(FrozenError::from("can't modify frozen Array").into());
     }
     if let Some(other) = other {
         let mut array = unsafe { Array::unbox_from_value(&mut ary, interp)? };
@@ -86,10 +74,7 @@ pub fn concat(
 
 pub fn push(interp: &mut Artichoke, mut ary: Value, value: Value) -> Result<Value, Exception> {
     if ary.is_frozen(interp) {
-        return Err(Exception::from(FrozenError::new(
-            interp,
-            "can't modify frozen Array",
-        )));
+        return Err(FrozenError::from("can't modify frozen Array").into());
     }
     let mut array = unsafe { Array::unbox_from_value(&mut ary, interp)? };
     array.push(value);
@@ -98,10 +83,7 @@ pub fn push(interp: &mut Artichoke, mut ary: Value, value: Value) -> Result<Valu
 
 pub fn reverse_bang(interp: &mut Artichoke, mut ary: Value) -> Result<Value, Exception> {
     if ary.is_frozen(interp) {
-        return Err(Exception::from(FrozenError::new(
-            interp,
-            "can't modify frozen Array",
-        )));
+        return Err(FrozenError::from("can't modify frozen Array").into());
     }
     let mut array = unsafe { Array::unbox_from_value(&mut ary, interp)? };
     array.reverse();

--- a/artichoke-backend/src/extn/core/exception/mod.rs
+++ b/artichoke-backend/src/extn/core/exception/mod.rs
@@ -38,7 +38,7 @@
 //! - `SystemStackError`
 //! - `fatal` -- impossible to rescue
 
-use bstr::BStr;
+use bstr::{BStr, ByteSlice};
 use std::borrow::Cow;
 use std::error;
 use std::fmt;
@@ -258,30 +258,62 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
 
 macro_rules! ruby_exception_impl {
     ($exception:ident) => {
-        #[derive(Default, Debug, Clone)]
+        #[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
         pub struct $exception {
             message: Cow<'static, BStr>,
         }
 
         impl $exception {
-            pub fn new<S>(interp: &Artichoke, message: S) -> Self
-            where
-                S: Into<Cow<'static, str>>,
-            {
-                let _ = interp;
-                let message = match message.into() {
+            pub fn new() -> Self {
+                // `Exception`s initialized via `raise RuntimeError` or
+                // `RuntimeError.new` have `message` equal to the `Exception`
+                // class name.
+                let message = Cow::Borrowed(stringify!($exception).as_bytes().into());
+                Self { message }
+            }
+        }
+
+        impl From<String> for $exception {
+            fn from(message: String) -> Self {
+                let message = Cow::Owned(message.into_bytes().into());
+                Self { message }
+            }
+        }
+
+        impl From<&'static str> for $exception {
+            fn from(message: &'static str) -> Self {
+                let message = Cow::Borrowed(message.as_bytes().into());
+                Self { message }
+            }
+        }
+
+        impl From<Cow<'static, str>> for $exception {
+            fn from(message: Cow<'static, str>) -> Self {
+                let message = match message {
                     Cow::Borrowed(s) => Cow::Borrowed(s.as_bytes().into()),
                     Cow::Owned(s) => Cow::Owned(s.into_bytes().into()),
                 };
                 Self { message }
             }
+        }
 
-            pub fn new_raw<S>(interp: &Artichoke, message: S) -> Self
-            where
-                S: Into<Cow<'static, [u8]>>,
-            {
-                let _ = interp;
-                let message = match message.into() {
+        impl From<Vec<u8>> for $exception {
+            fn from(message: Vec<u8>) -> Self {
+                let message = Cow::Owned(message.into());
+                Self { message }
+            }
+        }
+
+        impl From<&'static [u8]> for $exception {
+            fn from(message: &'static [u8]) -> Self {
+                let message = message.as_bstr().into();
+                Self { message }
+            }
+        }
+
+        impl From<Cow<'static, [u8]>> for $exception {
+            fn from(message: Cow<'static, [u8]>) -> Self {
+                let message = match message {
                     Cow::Borrowed(s) => Cow::Borrowed(s.into()),
                     Cow::Owned(s) => Cow::Owned(s.into()),
                 };

--- a/artichoke-backend/src/extn/core/exception/mod.rs
+++ b/artichoke-backend/src/extn/core/exception/mod.rs
@@ -264,6 +264,7 @@ macro_rules! ruby_exception_impl {
         }
 
         impl $exception {
+            #[must_use]
             pub fn new() -> Self {
                 // `Exception`s initialized via `raise RuntimeError` or
                 // `RuntimeError.new` have `message` equal to the `Exception`

--- a/artichoke-backend/src/extn/core/exception/mod.rs
+++ b/artichoke-backend/src/extn/core/exception/mod.rs
@@ -428,7 +428,7 @@ mod tests {
     unsafe extern "C" fn run_run(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {
         let mut interp = unwrap_interpreter!(mrb);
         let guard = Guard::new(&mut interp);
-        let exc = RuntimeError::new(&guard, "something went wrong");
+        let exc = RuntimeError::from("something went wrong");
         exception::raise(guard, exc)
     }
 

--- a/artichoke-backend/src/extn/core/integer/mod.rs
+++ b/artichoke-backend/src/extn/core/integer/mod.rs
@@ -84,9 +84,7 @@ impl Integer {
             let mut message = b"encoding parameter of Integer#chr (given ".to_vec();
             message.extend(encoding.inspect(interp));
             message.extend(b") not supported");
-            Err(Exception::from(NotImplementedError::new_raw(
-                interp, message,
-            )))
+            Err(NotImplementedError::from(message).into())
         } else {
             // When no encoding is supplied, MRI assumes the encoding is
             // either ASCII or ASCII-8BIT.
@@ -127,7 +125,7 @@ impl Integer {
                     let mut message = String::new();
                     string::format_int_into(&mut message, self.as_i64())?;
                     message.push_str(" out of char range");
-                    Err(Exception::from(RangeError::new(&interp, message)))
+                    Err(RangeError::from(message).into())
                 }
             }
         }
@@ -148,10 +146,7 @@ impl Integer {
                 let denom = denominator.try_into::<Int>(interp)?;
                 let value = self.as_i64();
                 if denom == 0 {
-                    Err(Exception::from(ZeroDivisionError::new(
-                        interp,
-                        "divided by 0",
-                    )))
+                    Err(ZeroDivisionError::from("divided by 0").into())
                 } else if value < 0 && (value % denom) != 0 {
                     Ok(((value / denom) - 1).into())
                 } else {
@@ -166,13 +161,10 @@ impl Integer {
                 let x = interp.convert(self);
                 let coerced = numeric::coerce(interp, x, denominator)?;
                 match coerced {
-                    Coercion::Float(_, denom) if denom == 0.0 => Err(Exception::from(
-                        ZeroDivisionError::new(interp, "divided by 0"),
-                    )),
-                    Coercion::Integer(_, 0) => Err(Exception::from(ZeroDivisionError::new(
-                        interp,
-                        "divided by 0",
-                    ))),
+                    Coercion::Float(_, denom) if denom == 0.0 => {
+                        Err(ZeroDivisionError::from("divided by 0").into())
+                    }
+                    Coercion::Integer(_, 0) => Err(ZeroDivisionError::from("divided by 0").into()),
                     Coercion::Float(numer, denom) => Ok((numer / denom).into()),
                     Coercion::Integer(numer, denom) if numer < 0 && (numer % denom) != 0 => {
                         Ok(((numer / denom) - 1).into())

--- a/artichoke-backend/src/extn/core/kernel/integer.rs
+++ b/artichoke-backend/src/extn/core/kernel/integer.rs
@@ -136,7 +136,7 @@ impl<'a> ParseState<'a> {
         Self::Initial(arg)
     }
 
-    fn set_sign(self, interp: &mut Artichoke, sign: Sign) -> Result<Self, Exception> {
+    fn set_sign(self, sign: Sign) -> Result<Self, Exception> {
         match self {
             Self::Sign(arg, _) | Self::Accumulate(arg, _, _) => {
                 let mut message = String::from(r#"invalid value for Integer(): ""#);
@@ -167,7 +167,7 @@ impl<'a> ParseState<'a> {
         }
     }
 
-    fn parse(self, interp: &mut Artichoke) -> Result<(String, Option<Radix>), Exception> {
+    fn parse(self) -> Result<(String, Option<Radix>), Exception> {
         match self {
             Self::Accumulate(arg, sign, mut digits) => {
                 let (mut src, radix) = match digits.as_bytes() {
@@ -225,11 +225,7 @@ impl<'a> ParseState<'a> {
     }
 }
 
-pub fn method<'a>(
-    interp: &mut Artichoke,
-    arg: IntegerString<'a>,
-    radix: Option<Radix>,
-) -> Result<Int, Exception> {
+pub fn method<'a>(arg: IntegerString<'a>, radix: Option<Radix>) -> Result<Int, Exception> {
     let mut state = ParseState::new(arg);
     let mut chars = arg
         .inner()
@@ -262,14 +258,14 @@ pub fn method<'a>(
         }
 
         state = match current {
-            '+' => state.set_sign(interp, Sign::Pos)?,
-            '-' => state.set_sign(interp, Sign::Neg)?,
+            '+' => state.set_sign(Sign::Pos)?,
+            '-' => state.set_sign(Sign::Neg)?,
             digit => state.collect_digit(digit),
         };
         prev = Some(current);
     }
 
-    let (src, src_radix) = state.parse(interp)?;
+    let (src, src_radix) = state.parse()?;
 
     let parsed_int = match (radix, src_radix) {
         (Some(x), Some(y)) if x == y => Int::from_str_radix(src.as_str(), x.as_u32()).ok(),

--- a/artichoke-backend/src/extn/core/kernel/integer.rs
+++ b/artichoke-backend/src/extn/core/kernel/integer.rs
@@ -10,6 +10,11 @@ use crate::extn::prelude::*;
 pub struct Radix(NonZeroU32);
 
 impl Radix {
+    #[must_use]
+    pub fn new() -> Self {
+        Self(unsafe { NonZeroU32::new_unchecked(10) })
+    }
+
     #[inline]
     #[must_use]
     pub fn as_u32(self) -> u32 {
@@ -31,9 +36,9 @@ impl TryConvertMut<Option<Value>, Option<Radix>> for Artichoke {
                 }
                 let mut message = String::from("invalid radix ");
                 string::format_int_into(&mut message, radix)?;
-                Err(Exception::from(ArgumentError::new(self, message)))
+                Err(ArgumentError::from(message).into())
             } else {
-                Err(Exception::from(ArgumentError::new(self, "invalid radix")))
+                Err(ArgumentError::from("invalid radix").into())
             }
         } else {
             Ok(None)
@@ -85,7 +90,7 @@ impl<'a> TryConvertMut<&'a Value, IntegerString<'a>> for Artichoke {
             let mut message = String::from("can't convert ");
             message.push_str(value.pretty_name(self));
             message.push_str(" into Integer");
-            TypeError::new(self, message)
+            TypeError::from(message)
         })?;
         if let Some(converted) = IntegerString::from_slice(arg) {
             Ok(converted)
@@ -93,7 +98,7 @@ impl<'a> TryConvertMut<&'a Value, IntegerString<'a>> for Artichoke {
             let mut message = String::from(r#"invalid value for Integer(): ""#);
             string::format_unicode_debug_into(&mut message, arg)?;
             message.push('"');
-            Err(ArgumentError::new(self, message).into())
+            Err(ArgumentError::from(message).into())
         }
     }
 }
@@ -137,7 +142,7 @@ impl<'a> ParseState<'a> {
                 let mut message = String::from(r#"invalid value for Integer(): ""#);
                 string::format_unicode_debug_into(&mut message, arg.into())?;
                 message.push('"');
-                Err(ArgumentError::new(interp, message).into())
+                Err(ArgumentError::from(message).into())
             }
             Self::Initial(arg) => Ok(ParseState::Sign(arg, sign)),
         }
@@ -195,7 +200,7 @@ impl<'a> ParseState<'a> {
                             let mut message = String::from(r#"invalid value for Integer(): ""#);
                             string::format_unicode_debug_into(&mut message, arg.into())?;
                             message.push('"');
-                            return Err(ArgumentError::new(interp, message).into());
+                            return Err(ArgumentError::from(message).into());
                         } else if '0' == first {
                             digits.drain(..1);
                             (digits, Some(Radix(unsafe { NonZeroU32::new_unchecked(8) })))
@@ -214,7 +219,7 @@ impl<'a> ParseState<'a> {
                 let mut message = String::from(r#"invalid value for Integer(): ""#);
                 string::format_unicode_debug_into(&mut message, arg.into())?;
                 message.push('"');
-                Err(ArgumentError::new(interp, message).into())
+                Err(ArgumentError::from(message).into())
             }
         }
     }
@@ -249,7 +254,7 @@ pub fn method<'a>(
                 let mut message = String::from(r#"invalid value for Integer(): ""#);
                 string::format_unicode_debug_into(&mut message, arg.into())?;
                 message.push('"');
-                return Err(ArgumentError::new(interp, message).into());
+                return Err(ArgumentError::from(message).into());
             } else {
                 prev = Some(current);
                 continue;
@@ -280,6 +285,6 @@ pub fn method<'a>(
         let mut message = String::from(r#"invalid value for Integer(): ""#);
         string::format_unicode_debug_into(&mut message, arg.into())?;
         message.push('"');
-        Err(ArgumentError::new(interp, message).into())
+        Err(ArgumentError::from(message).into())
     }
 }

--- a/artichoke-backend/src/extn/core/kernel/integer.rs
+++ b/artichoke-backend/src/extn/core/kernel/integer.rs
@@ -9,10 +9,16 @@ use crate::extn::prelude::*;
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Radix(NonZeroU32);
 
+impl Default for Radix {
+    fn default() -> Self {
+        Self(unsafe { NonZeroU32::new_unchecked(10) })
+    }
+}
+
 impl Radix {
     #[must_use]
     pub fn new() -> Self {
-        Self(unsafe { NonZeroU32::new_unchecked(10) })
+        Self::default()
     }
 
     #[inline]
@@ -225,7 +231,7 @@ impl<'a> ParseState<'a> {
     }
 }
 
-pub fn method<'a>(arg: IntegerString<'a>, radix: Option<Radix>) -> Result<Int, Exception> {
+pub fn method(arg: IntegerString<'_>, radix: Option<Radix>) -> Result<Int, Exception> {
     let mut state = ParseState::new(arg);
     let mut chars = arg
         .inner()

--- a/artichoke-backend/src/extn/core/kernel/require.rs
+++ b/artichoke-backend/src/extn/core/kernel/require.rs
@@ -13,10 +13,7 @@ const RUBY_EXTENSION: &str = "rb";
 pub fn load(interp: &mut Artichoke, filename: Value) -> Result<bool, Exception> {
     let filename = filename.implicitly_convert_to_string(interp)?;
     if filename.find_byte(b'\0').is_some() {
-        return Err(Exception::from(ArgumentError::new(
-            interp,
-            "path name contains null byte",
-        )));
+        return Err(ArgumentError::from("path name contains null byte").into());
     }
     let file = ffi::bytes_to_os_str(filename)?;
     let pathbuf;
@@ -28,10 +25,10 @@ pub fn load(interp: &mut Artichoke, filename: Value) -> Result<bool, Exception> 
     if !interp.source_is_file(path)? {
         let mut message = b"cannot load such file -- ".to_vec();
         message.extend_from_slice(filename);
-        return Err(LoadError::new_raw(interp, message).into());
+        return Err(LoadError::from(message).into());
     }
     let context = Context::new(ffi::os_str_to_bytes(path.as_os_str())?.to_vec())
-        .ok_or_else(|| ArgumentError::new(interp, "path name contains null byte"))?;
+        .ok_or_else(|| ArgumentError::from("path name contains null byte"))?;
     interp.push_context(context)?;
     let result = interp.load_source(path);
     let _ = interp.pop_context()?;
@@ -45,10 +42,7 @@ pub fn require(
 ) -> Result<bool, Exception> {
     let filename = filename.implicitly_convert_to_string(interp)?;
     if filename.find_byte(b'\0').is_some() {
-        return Err(Exception::from(ArgumentError::new(
-            interp,
-            "path name contains null byte",
-        )));
+        return Err(ArgumentError::from("path name contains null byte").into());
     }
     let file = ffi::bytes_to_os_str(filename)?;
     let path = Path::new(file);
@@ -75,7 +69,7 @@ pub fn require(
     };
     if interp.source_is_file(&path)? {
         let context = Context::new(ffi::os_str_to_bytes(path.as_os_str())?.to_vec())
-            .ok_or_else(|| ArgumentError::new(interp, "path name contains null byte"))?;
+            .ok_or_else(|| ArgumentError::from("path name contains null byte"))?;
         interp.push_context(context)?;
         let result = interp.require_source(&path);
         let _ = interp.pop_context()?;
@@ -84,7 +78,7 @@ pub fn require(
     if let Some(path) = alternate {
         if interp.source_is_file(&path)? {
             let context = Context::new(ffi::os_str_to_bytes(path.as_os_str())?.to_vec())
-                .ok_or_else(|| ArgumentError::new(interp, "path name contains null byte"))?;
+                .ok_or_else(|| ArgumentError::from("path name contains null byte"))?;
             interp.push_context(context)?;
             let result = interp.require_source(&path);
             let _ = interp.pop_context()?;
@@ -93,18 +87,39 @@ pub fn require(
     }
     let mut message = b"cannot load such file -- ".to_vec();
     message.extend_from_slice(filename);
-    Err(LoadError::new_raw(interp, message).into())
+    Err(LoadError::from(message).into())
 }
 
 #[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct RelativePath(PathBuf);
 
-impl RelativePath {
-    pub fn new<T>(path: T) -> Self
-    where
-        T: Into<PathBuf>,
-    {
+impl From<PathBuf> for RelativePath {
+    fn from(path: PathBuf) -> Self {
+        Self(path)
+    }
+}
+
+impl From<&Path> for RelativePath {
+    fn from(path: &Path) -> Self {
         Self(path.into())
+    }
+}
+
+impl From<String> for RelativePath {
+    fn from(path: String) -> Self {
+        Self(path.into())
+    }
+}
+
+impl From<&str> for RelativePath {
+    fn from(path: &str) -> Self {
+        Self(path.into())
+    }
+}
+
+impl RelativePath {
+    pub fn new() -> Self {
+        Self::from(RUBY_LOAD_PATH)
     }
 
     pub fn join<P: AsRef<Path>>(&self, path: P) -> PathBuf {
@@ -114,13 +129,13 @@ impl RelativePath {
     pub fn try_from_interp(interp: &mut Artichoke) -> Result<Self, Exception> {
         let context = interp
             .peek_context()?
-            .ok_or_else(|| Fatal::new(interp, "relative require with no context stack"))?;
+            .ok_or_else(|| Fatal::from("relative require with no context stack"))?;
         let path = ffi::bytes_to_os_str(context.filename())?;
         let path = Path::new(path);
         if let Some(base) = path.parent() {
-            Ok(Self::new(base))
+            Ok(Self::from(base))
         } else {
-            Ok(Self::new("/"))
+            Ok(Self::from("/"))
         }
     }
 }

--- a/artichoke-backend/src/extn/core/kernel/require.rs
+++ b/artichoke-backend/src/extn/core/kernel/require.rs
@@ -118,6 +118,7 @@ impl From<&str> for RelativePath {
 }
 
 impl RelativePath {
+    #[must_use]
     pub fn new() -> Self {
         Self::from(RUBY_LOAD_PATH)
     }

--- a/artichoke-backend/src/extn/core/kernel/trampoline.rs
+++ b/artichoke-backend/src/extn/core/kernel/trampoline.rs
@@ -10,7 +10,7 @@ pub fn integer(
     let base = base.and_then(|base| interp.convert(base));
     let arg = interp.try_convert_mut(&arg)?;
     let base = interp.try_convert_mut(base)?;
-    let integer = kernel::integer::method(interp, arg, base)?;
+    let integer = kernel::integer::method(arg, base)?;
     Ok(interp.convert(integer))
 }
 

--- a/artichoke-backend/src/extn/core/matchdata/mod.rs
+++ b/artichoke-backend/src/extn/core/matchdata/mod.rs
@@ -271,6 +271,11 @@ impl MatchData {
         }
     }
 
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.len().unwrap_or_default() > 0
+    }
+
     #[inline]
     pub fn len(&self) -> Result<usize, Exception> {
         let haystack = self.matched_region();
@@ -284,6 +289,7 @@ impl MatchData {
     }
 
     #[inline]
+    #[must_use]
     pub fn names(&self) -> Vec<Vec<u8>> {
         self.regexp.names()
     }

--- a/artichoke-backend/src/extn/core/matchdata/mod.rs
+++ b/artichoke-backend/src/extn/core/matchdata/mod.rs
@@ -225,7 +225,7 @@ impl MatchData {
                     let mut message = String::from("undefined group name reference: \"");
                     string::format_unicode_debug_into(&mut message, name)?;
                     message.push('"');
-                    Err(Exception::from(IndexError::new(interp, message)))
+                    Err(IndexError::from(message).into())
                 }
             }
             CaptureAt::StartLen(start, len) => {
@@ -323,7 +323,7 @@ impl MatchData {
                         let mut message = String::from("index ");
                         string::format_int_into(&mut message, index)?;
                         message.push_str(" out of matches");
-                        return Err(Exception::from(IndexError::new(interp, message)));
+                        return Err(IndexError::from(message).into());
                     }
                 }
             }

--- a/artichoke-backend/src/extn/core/matchdata/mod.rs
+++ b/artichoke-backend/src/extn/core/matchdata/mod.rs
@@ -164,25 +164,17 @@ impl MatchData {
     }
 
     #[inline]
-    pub fn begin(
-        &self,
-        interp: &mut Artichoke,
-        capture: Capture<'_>,
-    ) -> Result<Option<usize>, Exception> {
-        if let Some([begin, _]) = self.offset(interp, capture)? {
+    pub fn begin(&self, capture: Capture<'_>) -> Result<Option<usize>, Exception> {
+        if let Some([begin, _]) = self.offset(capture)? {
             Ok(Some(begin))
         } else {
             Ok(None)
         }
     }
 
-    pub fn capture_at(
-        &self,
-        interp: &mut Artichoke,
-        at: CaptureAt<'_>,
-    ) -> Result<CaptureMatch, Exception> {
+    pub fn capture_at(&self, at: CaptureAt<'_>) -> Result<CaptureMatch, Exception> {
         let haystack = self.matched_region();
-        let captures = if let Some(captures) = self.regexp.inner().captures(interp, haystack)? {
+        let captures = if let Some(captures) = self.regexp.inner().captures(haystack)? {
             captures
         } else {
             return Ok(CaptureMatch::None);
@@ -213,7 +205,7 @@ impl MatchData {
                 }
             }
             CaptureAt::GroupName(name) => {
-                let indexes = self.regexp.inner().capture_indexes_for_name(interp, name)?;
+                let indexes = self.regexp.inner().capture_indexes_for_name(name)?;
                 if let Some(indexes) = indexes {
                     let capture = indexes
                         .iter()
@@ -256,12 +248,9 @@ impl MatchData {
         }
     }
 
-    pub fn captures(
-        &self,
-        interp: &mut Artichoke,
-    ) -> Result<Option<Vec<Option<Vec<u8>>>>, Exception> {
+    pub fn captures(&self) -> Result<Option<Vec<Option<Vec<u8>>>>, Exception> {
         let haystack = self.matched_region();
-        let captures = self.regexp.inner().captures(interp, haystack)?;
+        let captures = self.regexp.inner().captures(haystack)?;
         if let Some(mut captures) = captures {
             // Panic safety:
             //
@@ -274,12 +263,8 @@ impl MatchData {
     }
 
     #[inline]
-    pub fn end(
-        &self,
-        interp: &mut Artichoke,
-        capture: Capture<'_>,
-    ) -> Result<Option<usize>, Exception> {
-        if let Some([_, end]) = self.offset(interp, capture)? {
+    pub fn end(&self, capture: Capture<'_>) -> Result<Option<usize>, Exception> {
+        if let Some([_, end]) = self.offset(capture)? {
             Ok(Some(end))
         } else {
             Ok(None)
@@ -287,36 +272,27 @@ impl MatchData {
     }
 
     #[inline]
-    pub fn len(&self, interp: &mut Artichoke) -> Result<usize, Exception> {
+    pub fn len(&self) -> Result<usize, Exception> {
         let haystack = self.matched_region();
-        self.regexp.inner().captures_len(interp, Some(haystack))
+        self.regexp.inner().captures_len(Some(haystack))
     }
 
     #[inline]
-    pub fn named_captures(
-        &self,
-        interp: &mut Artichoke,
-    ) -> Result<Option<HashMap<Vec<u8>, NilableString>>, Exception> {
+    pub fn named_captures(&self) -> Result<Option<HashMap<Vec<u8>, NilableString>>, Exception> {
         let haystack = self.matched_region();
-        self.regexp
-            .inner()
-            .named_captures_for_haystack(interp, haystack)
+        self.regexp.inner().named_captures_for_haystack(haystack)
     }
 
     #[inline]
-    pub fn names(&self, interp: &mut Artichoke) -> Vec<Vec<u8>> {
-        self.regexp.names(interp)
+    pub fn names(&self) -> Vec<Vec<u8>> {
+        self.regexp.names()
     }
 
-    pub fn offset(
-        &self,
-        interp: &mut Artichoke,
-        capture: Capture<'_>,
-    ) -> Result<Option<[usize; 2]>, Exception> {
+    pub fn offset(&self, capture: Capture<'_>) -> Result<Option<[usize; 2]>, Exception> {
         let haystack = self.matched_region();
         let index = match capture {
             Capture::GroupIndex(index) => {
-                let captures_len = self.regexp.inner().captures_len(interp, Some(haystack))?;
+                let captures_len = self.regexp.inner().captures_len(Some(haystack))?;
                 match usize::try_from(index) {
                     Ok(idx) if idx < captures_len => idx,
                     _ => {
@@ -328,7 +304,7 @@ impl MatchData {
                 }
             }
             Capture::GroupName(name) => {
-                let indexes = self.regexp.inner().capture_indexes_for_name(interp, name)?;
+                let indexes = self.regexp.inner().capture_indexes_for_name(name)?;
                 if let Some(index) = indexes.and_then(|indexes| indexes.last().copied()) {
                     index
                 } else {
@@ -336,7 +312,7 @@ impl MatchData {
                 }
             }
         };
-        if let Some((begin, end)) = self.regexp.inner().pos(interp, haystack, index)? {
+        if let Some((begin, end)) = self.regexp.inner().pos(haystack, index)? {
             let begin = if let Some(Ok(haystack)) = haystack.get(..begin).map(str::from_utf8) {
                 haystack.chars().count()
             } else {
@@ -398,14 +374,14 @@ impl MatchData {
     }
 
     #[inline]
-    pub fn to_a(&self, interp: &mut Artichoke) -> Result<Option<Vec<NilableString>>, Exception> {
+    pub fn to_a(&self) -> Result<Option<Vec<NilableString>>, Exception> {
         let haystack = self.matched_region();
-        self.regexp.inner().captures(interp, haystack)
+        self.regexp.inner().captures(haystack)
     }
 
     #[inline]
-    pub fn to_s(&self, interp: &mut Artichoke) -> Result<Option<&[u8]>, Exception> {
+    pub fn to_s(&self) -> Result<Option<&[u8]>, Exception> {
         let haystack = self.matched_region();
-        self.regexp.inner().capture0(interp, haystack)
+        self.regexp.inner().capture0(haystack)
     }
 }

--- a/artichoke-backend/src/extn/core/matchdata/trampoline.rs
+++ b/artichoke-backend/src/extn/core/matchdata/trampoline.rs
@@ -9,7 +9,7 @@ use crate::sys::protect;
 pub fn begin(interp: &mut Artichoke, mut value: Value, at: Value) -> Result<Value, Exception> {
     let data = unsafe { MatchData::unbox_from_value(&mut value, interp)? };
     let capture = interp.try_convert_mut(&at)?;
-    let begin = data.begin(interp, capture)?;
+    let begin = data.begin(capture)?;
     match begin.map(Int::try_from) {
         Some(Ok(begin)) => Ok(interp.convert(begin)),
         Some(Err(_)) => Err(ArgumentError::from("input string too long").into()),
@@ -19,7 +19,7 @@ pub fn begin(interp: &mut Artichoke, mut value: Value, at: Value) -> Result<Valu
 
 pub fn captures(interp: &mut Artichoke, mut value: Value) -> Result<Value, Exception> {
     let data = unsafe { MatchData::unbox_from_value(&mut value, interp)? };
-    if let Some(captures) = data.captures(interp)? {
+    if let Some(captures) = data.captures()? {
         interp.try_convert_mut(captures)
     } else {
         Ok(Value::nil())
@@ -44,7 +44,7 @@ pub fn element_reference(
     } else {
         // NOTE(lopopolo): Encapsulation is broken here by reaching into the
         // inner regexp.
-        let captures_len = data.regexp.inner().captures_len(interp, None)?;
+        let captures_len = data.regexp.inner().captures_len(None)?;
         let rangelen = Int::try_from(captures_len)
             .map_err(|_| ArgumentError::from("input string too long"))?;
         if let Some(protect::Range { start, len }) = elem.is_range(interp, rangelen)? {
@@ -53,14 +53,14 @@ pub fn element_reference(
             return Ok(Value::nil());
         }
     };
-    let matched = data.capture_at(interp, at)?;
+    let matched = data.capture_at(at)?;
     interp.try_convert_mut(matched)
 }
 
 pub fn end(interp: &mut Artichoke, mut value: Value, at: Value) -> Result<Value, Exception> {
     let data = unsafe { MatchData::unbox_from_value(&mut value, interp)? };
     let capture = interp.try_convert_mut(&at)?;
-    let end = data.end(interp, capture)?;
+    let end = data.end(capture)?;
     match end.map(Int::try_from) {
         Some(Ok(end)) => Ok(interp.convert(end)),
         Some(Err(_)) => Err(ArgumentError::from("input string too long").into()),
@@ -70,7 +70,7 @@ pub fn end(interp: &mut Artichoke, mut value: Value, at: Value) -> Result<Value,
 
 pub fn length(interp: &mut Artichoke, mut value: Value) -> Result<Value, Exception> {
     let data = unsafe { MatchData::unbox_from_value(&mut value, interp)? };
-    let len = data.len(interp)?;
+    let len = data.len()?;
     if let Ok(len) = Int::try_from(len) {
         Ok(interp.convert(len))
     } else {
@@ -80,20 +80,20 @@ pub fn length(interp: &mut Artichoke, mut value: Value) -> Result<Value, Excepti
 
 pub fn named_captures(interp: &mut Artichoke, mut value: Value) -> Result<Value, Exception> {
     let data = unsafe { MatchData::unbox_from_value(&mut value, interp)? };
-    let named_captures = data.named_captures(interp)?;
+    let named_captures = data.named_captures()?;
     interp.try_convert_mut(named_captures)
 }
 
 pub fn names(interp: &mut Artichoke, mut value: Value) -> Result<Value, Exception> {
     let data = unsafe { MatchData::unbox_from_value(&mut value, interp)? };
-    let names = data.names(interp);
+    let names = data.names();
     interp.try_convert_mut(names)
 }
 
 pub fn offset(interp: &mut Artichoke, mut value: Value, at: Value) -> Result<Value, Exception> {
     let data = unsafe { MatchData::unbox_from_value(&mut value, interp)? };
     let capture = interp.try_convert_mut(&at)?;
-    if let Some([begin, end]) = data.offset(interp, capture)? {
+    if let Some([begin, end]) = data.offset(capture)? {
         if let (Ok(begin), Ok(end)) = (Int::try_from(begin), Int::try_from(end)) {
             let ary = Array::assoc(interp.convert(begin), interp.convert(end));
             Array::alloc_value(ary, interp)
@@ -141,7 +141,7 @@ pub fn string(interp: &mut Artichoke, mut value: Value) -> Result<Value, Excepti
 
 pub fn to_a(interp: &mut Artichoke, mut value: Value) -> Result<Value, Exception> {
     let data = unsafe { MatchData::unbox_from_value(&mut value, interp)? };
-    if let Some(ary) = data.to_a(interp)? {
+    if let Some(ary) = data.to_a()? {
         interp.try_convert_mut(ary)
     } else {
         Ok(Value::nil())
@@ -150,6 +150,6 @@ pub fn to_a(interp: &mut Artichoke, mut value: Value) -> Result<Value, Exception
 
 pub fn to_s(interp: &mut Artichoke, mut value: Value) -> Result<Value, Exception> {
     let data = unsafe { MatchData::unbox_from_value(&mut value, interp)? };
-    let display = data.to_s(interp)?;
+    let display = data.to_s()?;
     Ok(interp.convert_mut(display))
 }

--- a/artichoke-backend/src/extn/core/matchdata/trampoline.rs
+++ b/artichoke-backend/src/extn/core/matchdata/trampoline.rs
@@ -12,10 +12,7 @@ pub fn begin(interp: &mut Artichoke, mut value: Value, at: Value) -> Result<Valu
     let begin = data.begin(interp, capture)?;
     match begin.map(Int::try_from) {
         Some(Ok(begin)) => Ok(interp.convert(begin)),
-        Some(Err(_)) => Err(Exception::from(ArgumentError::new(
-            interp,
-            "input string too long",
-        ))),
+        Some(Err(_)) => Err(ArgumentError::from("input string too long").into()),
         None => Ok(Value::nil()),
     }
 }
@@ -49,7 +46,7 @@ pub fn element_reference(
         // inner regexp.
         let captures_len = data.regexp.inner().captures_len(interp, None)?;
         let rangelen = Int::try_from(captures_len)
-            .map_err(|_| ArgumentError::new(interp, "input string too long"))?;
+            .map_err(|_| ArgumentError::from("input string too long"))?;
         if let Some(protect::Range { start, len }) = elem.is_range(interp, rangelen)? {
             CaptureAt::StartLen(start, len)
         } else {
@@ -66,10 +63,7 @@ pub fn end(interp: &mut Artichoke, mut value: Value, at: Value) -> Result<Value,
     let end = data.end(interp, capture)?;
     match end.map(Int::try_from) {
         Some(Ok(end)) => Ok(interp.convert(end)),
-        Some(Err(_)) => Err(Exception::from(ArgumentError::new(
-            interp,
-            "input string too long",
-        ))),
+        Some(Err(_)) => Err(ArgumentError::from("input string too long").into()),
         None => Ok(Value::nil()),
     }
 }
@@ -80,10 +74,7 @@ pub fn length(interp: &mut Artichoke, mut value: Value) -> Result<Value, Excepti
     if let Ok(len) = Int::try_from(len) {
         Ok(interp.convert(len))
     } else {
-        Err(Exception::from(ArgumentError::new(
-            interp,
-            "input string too long",
-        )))
+        Err(ArgumentError::from("input string too long").into())
     }
 }
 
@@ -107,10 +98,7 @@ pub fn offset(interp: &mut Artichoke, mut value: Value, at: Value) -> Result<Val
             let ary = Array::assoc(interp.convert(begin), interp.convert(end));
             Array::alloc_value(ary, interp)
         } else {
-            Err(Exception::from(ArgumentError::new(
-                interp,
-                "input string too long",
-            )))
+            Err(ArgumentError::from("input string too long").into())
         }
     } else {
         let ary = Array::assoc(Value::nil(), Value::nil());

--- a/artichoke-backend/src/extn/core/math/mod.rs
+++ b/artichoke-backend/src/extn/core/math/mod.rs
@@ -19,10 +19,7 @@ fn value_to_float(interp: &mut Artichoke, value: Value) -> Result<Fp, Exception>
     match value.ruby_type() {
         Ruby::Float => value.try_into(interp),
         Ruby::Fixnum => value.try_into::<Integer>(interp).map(Integer::as_f64),
-        Ruby::Nil => Err(Exception::from(TypeError::new(
-            interp,
-            "can't convert nil into Float",
-        ))),
+        Ruby::Nil => Err(TypeError::from("can't convert nil into Float").into()),
         _ => {
             // TODO: This should use `numeric::coerce`
             let class_of_numeric = interp
@@ -43,19 +40,19 @@ fn value_to_float(interp: &mut Artichoke, value: Value) -> Result<Fp, Exception>
                         message.push_str("#to_f gives ");
                         message.push_str(coerced.pretty_name(interp));
                         message.push(')');
-                        Err(Exception::from(TypeError::new(interp, message)))
+                        Err(TypeError::from(message).into())
                     }
                 } else {
                     let mut message = String::from("can't convert ");
                     message.push_str(value.pretty_name(interp));
                     message.push_str(" into Float");
-                    Err(Exception::from(TypeError::new(interp, message)))
+                    Err(TypeError::from(message).into())
                 }
             } else {
                 let mut message = String::from("can't convert ");
                 message.push_str(value.pretty_name(interp));
                 message.push_str(" into Float");
-                Err(Exception::from(TypeError::new(interp, message)))
+                Err(TypeError::from(message).into())
             }
         }
     }
@@ -68,9 +65,7 @@ pub fn acos(interp: &mut Artichoke, value: Value) -> Result<Fp, Exception> {
     }
     let result = value.acos();
     if result.is_nan() {
-        Err(Exception::from(DomainError::new(
-            r#"Numerical argument is out of domain - "acos""#,
-        )))
+        Err(DomainError::from(r#"Numerical argument is out of domain - "acos""#).into())
     } else {
         Ok(result)
     }
@@ -83,9 +78,7 @@ pub fn acosh(interp: &mut Artichoke, value: Value) -> Result<Fp, Exception> {
     }
     let result = value.acosh();
     if result.is_nan() {
-        Err(Exception::from(DomainError::new(
-            r#"Numerical argument is out of domain - "acosh""#,
-        )))
+        Err(DomainError::from(r#"Numerical argument is out of domain - "acosh""#).into())
     } else {
         Ok(result)
     }
@@ -98,9 +91,7 @@ pub fn asin(interp: &mut Artichoke, value: Value) -> Result<Fp, Exception> {
     }
     let result = value.asin();
     if result.is_nan() {
-        Err(Exception::from(DomainError::new(
-            r#"Numerical argument is out of domain - "asin""#,
-        )))
+        Err(DomainError::from(r#"Numerical argument is out of domain - "asin""#).into())
     } else {
         Ok(result)
     }
@@ -132,9 +123,7 @@ pub fn atanh(interp: &mut Artichoke, value: Value) -> Result<Fp, Exception> {
     }
     let result = value.atanh();
     if result.is_nan() {
-        Err(Exception::from(DomainError::new(
-            r#"Numerical argument is out of domain - "atanh""#,
-        )))
+        Err(DomainError::from(r#"Numerical argument is out of domain - "atanh""#).into())
     } else {
         Ok(result)
     }
@@ -161,8 +150,7 @@ pub fn cosh(interp: &mut Artichoke, value: Value) -> Result<Fp, Exception> {
 #[cfg(not(feature = "core-math-extra"))]
 pub fn erf(interp: &mut Artichoke, value: Value) -> Result<Fp, Exception> {
     let _ = value;
-    Err(Exception::from(NotImplementedError::new(
-        interp,
+    Err(Exception::from(NotImplementedError::from(
         "enable 'core-math-extra' feature when building Artichoke",
     )))
 }
@@ -177,8 +165,7 @@ pub fn erf(interp: &mut Artichoke, value: Value) -> Result<Fp, Exception> {
 #[cfg(not(feature = "core-math-extra"))]
 pub fn erfc(interp: &mut Artichoke, value: Value) -> Result<Fp, Exception> {
     let _ = value;
-    Err(Exception::from(NotImplementedError::new(
-        interp,
+    Err(Exception::from(NotImplementedError::from(
         "enable 'core-math-extra' feature when building Artichoke",
     )))
 }
@@ -199,8 +186,7 @@ pub fn exp(interp: &mut Artichoke, value: Value) -> Result<Fp, Exception> {
 #[cfg(not(feature = "core-math-extra"))]
 pub fn frexp(interp: &mut Artichoke, value: Value) -> Result<(Fp, Int), Exception> {
     let _ = value;
-    Err(Exception::from(NotImplementedError::new(
-        interp,
+    Err(Exception::from(NotImplementedError::from(
         "enable 'core-math-extra' feature when building Artichoke",
     )))
 }
@@ -215,8 +201,7 @@ pub fn frexp(interp: &mut Artichoke, value: Value) -> Result<(Fp, Int), Exceptio
 #[cfg(not(feature = "core-math-extra"))]
 pub fn gamma(interp: &mut Artichoke, value: Value) -> Result<Fp, Exception> {
     let _ = value;
-    Err(Exception::from(NotImplementedError::new(
-        interp,
+    Err(Exception::from(NotImplementedError::from(
         "enable 'core-math-extra' feature when building Artichoke",
     )))
 }
@@ -258,9 +243,7 @@ pub fn gamma(interp: &mut Artichoke, value: Value) -> Result<Fp, Exception> {
     ];
     if value.is_infinite() {
         if value.is_sign_negative() {
-            Err(Exception::from(DomainError::new(
-                r#"Numerical argument is out of domain - "gamma""#,
-            )))
+            Err(DomainError::from(r#"Numerical argument is out of domain - "gamma""#).into())
         } else {
             Ok(float::Float::INFINITY)
         }
@@ -272,9 +255,7 @@ pub fn gamma(interp: &mut Artichoke, value: Value) -> Result<Fp, Exception> {
         }
     } else if (value - value.floor()).abs() < f64::EPSILON {
         if value.is_sign_negative() {
-            Err(Exception::from(DomainError::new(
-                r#"Numerical argument is out of domain - "gamma""#,
-            )))
+            Err(DomainError::from(r#"Numerical argument is out of domain - "gamma""#).into())
         } else {
             // TODO: use `approx_unchecked_to` once stabilized instead of `as`
             // cast.
@@ -307,8 +288,7 @@ pub fn hypot(interp: &mut Artichoke, value: Value, other: Value) -> Result<Fp, E
 pub fn ldexp(interp: &mut Artichoke, fraction: Value, exponent: Value) -> Result<Fp, Exception> {
     let _ = fraction;
     let _ = exponent;
-    Err(Exception::from(NotImplementedError::new(
-        interp,
+    Err(Exception::from(NotImplementedError::from(
         "enable 'core-math-extra' feature when building Artichoke",
     )))
 }
@@ -321,10 +301,7 @@ pub fn ldexp(interp: &mut Artichoke, fraction: Value, exponent: Value) -> Result
     let exponent = exponent.implicitly_convert_to_int(interp).or_else(|err| {
         if let Ok(exponent) = exponent.try_into::<Fp>(interp) {
             if exponent.is_nan() {
-                Err(Exception::from(RangeError::new(
-                    interp,
-                    "float NaN out of range of integer",
-                )))
+                Err(RangeError::from("float NaN out of range of integer").into())
             } else {
                 // TODO: use `approx_unchecked_to` once stabilized.
                 #[allow(clippy::cast_possible_truncation)]
@@ -340,20 +317,19 @@ pub fn ldexp(interp: &mut Artichoke, fraction: Value, exponent: Value) -> Result
         let mut message = String::from("integer ");
         string::format_int_into(&mut message, exponent)?;
         message.push_str("too small to convert to `int'");
-        Err(Exception::from(RangeError::new(interp, message)))
+        Err(RangeError::from(message).into())
     } else {
         let mut message = String::from("integer ");
         string::format_int_into(&mut message, exponent)?;
         message.push_str("too big to convert to `int'");
-        Err(Exception::from(RangeError::new(interp, message)))
+        Err(RangeError::from(message).into())
     }
 }
 
 #[cfg(not(feature = "core-math-extra"))]
 pub fn lgamma(interp: &mut Artichoke, value: Value) -> Result<(Fp, Int), Exception> {
     let _ = value;
-    Err(Exception::from(NotImplementedError::new(
-        interp,
+    Err(Exception::from(NotImplementedError::from(
         "enable 'core-math-extra' feature when building Artichoke",
     )))
 }
@@ -362,9 +338,7 @@ pub fn lgamma(interp: &mut Artichoke, value: Value) -> Result<(Fp, Int), Excepti
 pub fn lgamma(interp: &mut Artichoke, value: Value) -> Result<(Fp, Int), Exception> {
     let value = value_to_float(interp, value)?;
     if value.is_infinite() && value.is_sign_negative() {
-        Err(Exception::from(DomainError::new(
-            r#"Numerical argument is out of domain - "lgamma""#,
-        )))
+        Err(DomainError::from(r#"Numerical argument is out of domain - "lgamma""#).into())
     } else {
         let (result, sign) = libm::lgamma_r(value);
         Ok((result, Int::from(sign)))
@@ -386,9 +360,7 @@ pub fn log(interp: &mut Artichoke, value: Value, base: Option<Value>) -> Result<
         value.ln()
     };
     if result.is_nan() {
-        Err(Exception::from(DomainError::new(
-            r#"Numerical argument is out of domain - "log""#,
-        )))
+        Err(DomainError::from(r#"Numerical argument is out of domain - "log""#).into())
     } else {
         Ok(result)
     }
@@ -401,9 +373,7 @@ pub fn log10(interp: &mut Artichoke, value: Value) -> Result<Fp, Exception> {
     }
     let result = value.log10();
     if result.is_nan() {
-        Err(Exception::from(DomainError::new(
-            r#"Numerical argument is out of domain - "log10""#,
-        )))
+        Err(DomainError::from(r#"Numerical argument is out of domain - "log10""#).into())
     } else {
         Ok(result)
     }
@@ -416,9 +386,7 @@ pub fn log2(interp: &mut Artichoke, value: Value) -> Result<Fp, Exception> {
     }
     let result = value.log2();
     if result.is_nan() {
-        Err(Exception::from(DomainError::new(
-            r#"Numerical argument is out of domain - "log2""#,
-        )))
+        Err(DomainError::from(r#"Numerical argument is out of domain - "log2""#).into())
     } else {
         Ok(result)
     }
@@ -443,9 +411,7 @@ pub fn sqrt(interp: &mut Artichoke, value: Value) -> Result<Fp, Exception> {
     }
     let result = value.sqrt();
     if result.is_nan() {
-        Err(Exception::from(DomainError::new(
-            r#"Numerical argument is out of domain - "sqrt""#,
-        )))
+        Err(DomainError::from(r#"Numerical argument is out of domain - "sqrt""#).into())
     } else {
         Ok(result)
     }
@@ -464,14 +430,31 @@ pub fn tanh(interp: &mut Artichoke, value: Value) -> Result<Fp, Exception> {
 }
 
 #[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
-struct DomainError(Cow<'static, str>);
+pub struct DomainError(Cow<'static, str>);
+
+impl From<String> for DomainError {
+    fn from(message: String) -> Self {
+        Self(message.into())
+    }
+}
+
+impl From<&'static str> for DomainError {
+    fn from(message: &'static str) -> Self {
+        Self(message.into())
+    }
+}
+
+impl From<Cow<'static, str>> for DomainError {
+    fn from(message: Cow<'static, str>) -> Self {
+        Self(message)
+    }
+}
 
 impl DomainError {
-    pub fn new<T>(name: T) -> Self
-    where
-        T: Into<Cow<'static, str>>,
-    {
-        Self(name.into())
+    pub fn new() -> Self {
+        // [2.6.3] > Math::DomainError.new.message
+        // => "Math::DomainError"
+        Self::from("Math::DomainError")
     }
 }
 

--- a/artichoke-backend/src/extn/core/math/mod.rs
+++ b/artichoke-backend/src/extn/core/math/mod.rs
@@ -149,6 +149,7 @@ pub fn cosh(interp: &mut Artichoke, value: Value) -> Result<Fp, Exception> {
 
 #[cfg(not(feature = "core-math-extra"))]
 pub fn erf(interp: &mut Artichoke, value: Value) -> Result<Fp, Exception> {
+    let _ = interp;
     let _ = value;
     Err(Exception::from(NotImplementedError::from(
         "enable 'core-math-extra' feature when building Artichoke",
@@ -164,6 +165,7 @@ pub fn erf(interp: &mut Artichoke, value: Value) -> Result<Fp, Exception> {
 
 #[cfg(not(feature = "core-math-extra"))]
 pub fn erfc(interp: &mut Artichoke, value: Value) -> Result<Fp, Exception> {
+    let _ = interp;
     let _ = value;
     Err(Exception::from(NotImplementedError::from(
         "enable 'core-math-extra' feature when building Artichoke",
@@ -185,6 +187,7 @@ pub fn exp(interp: &mut Artichoke, value: Value) -> Result<Fp, Exception> {
 
 #[cfg(not(feature = "core-math-extra"))]
 pub fn frexp(interp: &mut Artichoke, value: Value) -> Result<(Fp, Int), Exception> {
+    let _ = interp;
     let _ = value;
     Err(Exception::from(NotImplementedError::from(
         "enable 'core-math-extra' feature when building Artichoke",
@@ -200,6 +203,7 @@ pub fn frexp(interp: &mut Artichoke, value: Value) -> Result<(Fp, Int), Exceptio
 
 #[cfg(not(feature = "core-math-extra"))]
 pub fn gamma(interp: &mut Artichoke, value: Value) -> Result<Fp, Exception> {
+    let _ = interp;
     let _ = value;
     Err(Exception::from(NotImplementedError::from(
         "enable 'core-math-extra' feature when building Artichoke",
@@ -286,6 +290,7 @@ pub fn hypot(interp: &mut Artichoke, value: Value, other: Value) -> Result<Fp, E
 
 #[cfg(not(feature = "core-math-extra"))]
 pub fn ldexp(interp: &mut Artichoke, fraction: Value, exponent: Value) -> Result<Fp, Exception> {
+    let _ = interp;
     let _ = fraction;
     let _ = exponent;
     Err(Exception::from(NotImplementedError::from(
@@ -328,6 +333,7 @@ pub fn ldexp(interp: &mut Artichoke, fraction: Value, exponent: Value) -> Result
 
 #[cfg(not(feature = "core-math-extra"))]
 pub fn lgamma(interp: &mut Artichoke, value: Value) -> Result<(Fp, Int), Exception> {
+    let _ = interp;
     let _ = value;
     Err(Exception::from(NotImplementedError::from(
         "enable 'core-math-extra' feature when building Artichoke",

--- a/artichoke-backend/src/extn/core/math/mod.rs
+++ b/artichoke-backend/src/extn/core/math/mod.rs
@@ -451,6 +451,7 @@ impl From<Cow<'static, str>> for DomainError {
 }
 
 impl DomainError {
+    #[must_use]
     pub fn new() -> Self {
         // [2.6.3] > Math::DomainError.new.message
         // => "Math::DomainError"

--- a/artichoke-backend/src/extn/core/numeric/mod.rs
+++ b/artichoke-backend/src/extn/core/numeric/mod.rs
@@ -83,10 +83,7 @@ pub fn coerce(interp: &mut Artichoke, x: Value, y: Value) -> Result<Coercion, Ex
         depth: u8,
     ) -> Result<Coercion, Exception> {
         if depth > MAX_COERCE_DEPTH {
-            return Err(Exception::from(SystemStackError::new(
-                interp,
-                "stack level too deep",
-            )));
+            return Err(SystemStackError::from("stack level too deep").into());
         }
         match (x.ruby_type(), y.ruby_type()) {
             (Ruby::Float, Ruby::Float) => {
@@ -114,19 +111,16 @@ pub fn coerce(interp: &mut Artichoke, x: Value, y: Value) -> Result<Coercion, Ex
                         let coerced = y.funcall(interp, "coerce", &[x], None)?;
                         let coerced: Vec<Value> = interp
                             .try_convert_mut(coerced)
-                            .map_err(|_| TypeError::new(interp, "coerce must return [x, y]"))?;
+                            .map_err(|_| TypeError::from("coerce must return [x, y]"))?;
                         let mut coerced = coerced.into_iter();
                         let y = coerced
                             .next()
-                            .ok_or_else(|| TypeError::new(interp, "coerce must return [x, y]"))?;
+                            .ok_or_else(|| TypeError::from("coerce must return [x, y]"))?;
                         let x = coerced
                             .next()
-                            .ok_or_else(|| TypeError::new(interp, "coerce must return [x, y]"))?;
+                            .ok_or_else(|| TypeError::from("coerce must return [x, y]"))?;
                         if coerced.next().is_some() {
-                            Err(Exception::from(TypeError::new(
-                                interp,
-                                "coerce must return [x, y]",
-                            )))
+                            Err(TypeError::from("coerce must return [x, y]").into())
                         } else {
                             do_coerce(interp, x, y, depth + 1)
                         }
@@ -134,12 +128,12 @@ pub fn coerce(interp: &mut Artichoke, x: Value, y: Value) -> Result<Coercion, Ex
                         let mut message = String::from("can't convert ");
                         message.push_str(y.pretty_name(interp));
                         message.push_str(" into Float");
-                        Err(Exception::from(TypeError::new(interp, message)))
+                        Err(TypeError::from(message).into())
                     }
                 } else {
                     let mut message = String::from(y.pretty_name(interp));
                     message.push_str(" can't be coerced into Float");
-                    Err(Exception::from(TypeError::new(interp, message)))
+                    Err(TypeError::from(message).into())
                 }
             }
         }

--- a/artichoke-backend/src/extn/core/random/mod.rs
+++ b/artichoke-backend/src/extn/core/random/mod.rs
@@ -55,7 +55,7 @@ pub fn srand(interp: &mut Artichoke, seed: Seed) -> Result<Int, Exception> {
     Ok(old_seed as Int)
 }
 
-pub fn urandom(interp: &mut Artichoke, size: Int) -> Result<Vec<u8>, Exception> {
+pub fn urandom(size: Int) -> Result<Vec<u8>, Exception> {
     match usize::try_from(size) {
         Ok(0) => Ok(Vec::new()),
         Ok(len) => {

--- a/artichoke-backend/src/extn/core/random/mod.rs
+++ b/artichoke-backend/src/extn/core/random/mod.rs
@@ -62,13 +62,10 @@ pub fn urandom(interp: &mut Artichoke, size: Int) -> Result<Vec<u8>, Exception> 
             let mut buf = vec![0; len];
             let mut rng = rand::thread_rng();
             rng.try_fill_bytes(&mut buf)
-                .map_err(|err| RuntimeError::new(interp, err.to_string()))?;
+                .map_err(|err| RuntimeError::from(err.to_string()))?;
             Ok(buf)
         }
-        Err(_) => Err(Exception::from(ArgumentError::new(
-            interp,
-            "negative string size (or size too big)",
-        ))),
+        Err(_) => Err(ArgumentError::from("negative string size (or size too big)").into()),
     }
 }
 
@@ -128,10 +125,7 @@ impl Random {
                 self.inner_mut().bytes(interp, &mut buf)?;
                 Ok(buf)
             }
-            Err(_) => Err(Exception::from(ArgumentError::new(
-                interp,
-                "negative string size (or size too big)",
-            ))),
+            Err(_) => Err(ArgumentError::from("negative string size (or size too big)").into()),
         }
     }
 
@@ -143,15 +137,12 @@ impl Random {
         match max {
             RandomNumberMax::Float(max) if !max.is_finite() => {
                 // NOTE: MRI returns `Errno::EDOM` exception class.
-                Err(Exception::from(ArgumentError::new(
-                    interp,
-                    "Numerical argument out of domain",
-                )))
+                Err(ArgumentError::from("Numerical argument out of domain").into())
             }
             RandomNumberMax::Float(max) if max < 0.0 => {
                 let mut message = b"invalid argument - ".to_vec();
                 string::write_float_into(&mut message, max)?;
-                Err(Exception::from(ArgumentError::new_raw(interp, message)))
+                Err(ArgumentError::from(message).into())
             }
             RandomNumberMax::Float(max) if max == 0.0 => {
                 let number = self.inner_mut().rand_float(interp, None)?;
@@ -164,7 +155,7 @@ impl Random {
             RandomNumberMax::Integer(max) if max < 1 => {
                 let mut message = String::from("invalid argument - ");
                 string::format_int_into(&mut message, max)?;
-                Err(Exception::from(ArgumentError::new(interp, message)))
+                Err(ArgumentError::from(message).into())
             }
             RandomNumberMax::Integer(max) => {
                 let number = self.inner_mut().rand_int(interp, max)?;
@@ -227,7 +218,7 @@ impl TryConvertMut<Option<Value>, RandomNumberMax> for Artichoke {
                     let max = max.implicitly_convert_to_int(self).map_err(|_| {
                         let mut message = b"invalid argument - ".to_vec();
                         message.extend(max.inspect(self));
-                        ArgumentError::new_raw(self, message)
+                        ArgumentError::from(message)
                     })?;
                     Ok(RandomNumberMax::Integer(max))
                 }

--- a/artichoke-backend/src/extn/core/random/trampoline.rs
+++ b/artichoke-backend/src/extn/core/random/trampoline.rs
@@ -55,6 +55,6 @@ pub fn srand(interp: &mut Artichoke, seed: Option<Value>) -> Result<Value, Excep
 
 pub fn urandom(interp: &mut Artichoke, size: Value) -> Result<Value, Exception> {
     let size = size.implicitly_convert_to_int(interp)?;
-    let buf = random::urandom(interp, size)?;
+    let buf = random::urandom(size)?;
     Ok(interp.convert_mut(buf))
 }

--- a/artichoke-backend/src/extn/core/regexp/backend/lazy.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/lazy.rs
@@ -7,31 +7,32 @@ use crate::extn::prelude::*;
 
 use super::{NameToCaptureLocations, NilableString};
 
-#[derive(Debug)]
+#[derive(Default, Debug)]
 pub struct Lazy {
     literal: Config,
     encoding: Encoding,
     regexp: OnceCell<Regexp>,
 }
 
-impl Lazy {
-    #[must_use]
-    pub fn new(literal: Config) -> Self {
+impl From<Config> for Lazy {
+    fn from(config: Config) -> Self {
         Self {
-            literal,
+            literal: config,
             encoding: Encoding::default(),
             regexp: OnceCell::new(),
         }
     }
+}
 
-    pub fn regexp(&self, interp: &mut Artichoke) -> Result<&Regexp, Exception> {
+impl Lazy {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn regexp(&self) -> Result<&Regexp, Exception> {
         self.regexp.get_or_try_init(|| {
-            Regexp::new(
-                interp,
-                self.literal.clone(),
-                self.literal.clone(),
-                self.encoding,
-            )
+            Regexp::new(self.literal.clone(), self.literal.clone(), self.encoding)
         })
     }
 }
@@ -45,7 +46,7 @@ impl fmt::Display for Lazy {
 
 impl Clone for Lazy {
     fn clone(&self) -> Self {
-        Self::new(self.literal.clone())
+        self.literal.clone().into()
     }
 }
 
@@ -54,38 +55,20 @@ impl RegexpType for Lazy {
         Box::new(self.clone())
     }
 
-    fn captures(
-        &self,
-        interp: &mut Artichoke,
-        haystack: &[u8],
-    ) -> Result<Option<Vec<NilableString>>, Exception> {
-        self.regexp(interp)?.inner().captures(interp, haystack)
+    fn captures(&self, haystack: &[u8]) -> Result<Option<Vec<NilableString>>, Exception> {
+        self.regexp()?.inner().captures(haystack)
     }
 
-    fn capture_indexes_for_name(
-        &self,
-        interp: &mut Artichoke,
-        name: &[u8],
-    ) -> Result<Option<Vec<usize>>, Exception> {
-        self.regexp(interp)?
-            .inner()
-            .capture_indexes_for_name(interp, name)
+    fn capture_indexes_for_name(&self, name: &[u8]) -> Result<Option<Vec<usize>>, Exception> {
+        self.regexp()?.inner().capture_indexes_for_name(name)
     }
 
-    fn captures_len(
-        &self,
-        interp: &mut Artichoke,
-        haystack: Option<&[u8]>,
-    ) -> Result<usize, Exception> {
-        self.regexp(interp)?.inner().captures_len(interp, haystack)
+    fn captures_len(&self, haystack: Option<&[u8]>) -> Result<usize, Exception> {
+        self.regexp()?.inner().captures_len(haystack)
     }
 
-    fn capture0<'a>(
-        &self,
-        interp: &mut Artichoke,
-        haystack: &'a [u8],
-    ) -> Result<Option<&'a [u8]>, Exception> {
-        self.regexp(interp)?.inner().capture0(interp, haystack)
+    fn capture0<'a>(&self, haystack: &'a [u8]) -> Result<Option<&'a [u8]>, Exception> {
+        self.regexp()?.inner().capture0(haystack)
     }
 
     fn debug(&self) -> String {
@@ -117,29 +100,24 @@ impl RegexpType for Lazy {
         &self.encoding
     }
 
-    fn inspect(&self, interp: &mut Artichoke) -> Vec<u8> {
-        self.regexp(interp)
-            .map(|regexp| regexp.inner().inspect(interp))
+    fn inspect(&self) -> Vec<u8> {
+        self.regexp()
+            .map(|regexp| regexp.inner().inspect())
             .unwrap_or_default()
     }
 
-    fn string(&self, interp: &mut Artichoke) -> &[u8] {
-        self.regexp(interp)
-            .map(|regexp| regexp.inner().string(interp))
+    fn string(&self) -> &[u8] {
+        self.regexp()
+            .map(|regexp| regexp.inner().string())
             .unwrap_or_default()
     }
 
     fn case_match(&self, interp: &mut Artichoke, haystack: &[u8]) -> Result<bool, Exception> {
-        self.regexp(interp)?.inner().case_match(interp, haystack)
+        self.regexp()?.inner().case_match(interp, haystack)
     }
 
-    fn is_match(
-        &self,
-        interp: &mut Artichoke,
-        haystack: &[u8],
-        pos: Option<Int>,
-    ) -> Result<bool, Exception> {
-        self.regexp(interp)?.inner().is_match(interp, haystack, pos)
+    fn is_match(&self, haystack: &[u8], pos: Option<Int>) -> Result<bool, Exception> {
+        self.regexp()?.inner().is_match(haystack, pos)
     }
 
     fn match_(
@@ -149,9 +127,7 @@ impl RegexpType for Lazy {
         pos: Option<Int>,
         block: Option<Block>,
     ) -> Result<Value, Exception> {
-        self.regexp(interp)?
-            .inner()
-            .match_(interp, haystack, pos, block)
+        self.regexp()?.inner().match_(interp, haystack, pos, block)
     }
 
     fn match_operator(
@@ -159,38 +135,28 @@ impl RegexpType for Lazy {
         interp: &mut Artichoke,
         haystack: &[u8],
     ) -> Result<Option<usize>, Exception> {
-        self.regexp(interp)?
-            .inner()
-            .match_operator(interp, haystack)
+        self.regexp()?.inner().match_operator(interp, haystack)
     }
 
-    fn named_captures(&self, interp: &mut Artichoke) -> Result<NameToCaptureLocations, Exception> {
-        self.regexp(interp)?.inner().named_captures(interp)
+    fn named_captures(&self) -> Result<NameToCaptureLocations, Exception> {
+        self.regexp()?.inner().named_captures()
     }
 
     fn named_captures_for_haystack(
         &self,
-        interp: &mut Artichoke,
         haystack: &[u8],
     ) -> Result<Option<HashMap<Vec<u8>, NilableString>>, Exception> {
-        self.regexp(interp)?
-            .inner()
-            .named_captures_for_haystack(interp, haystack)
+        self.regexp()?.inner().named_captures_for_haystack(haystack)
     }
 
-    fn names(&self, interp: &mut Artichoke) -> Vec<Vec<u8>> {
-        self.regexp(interp)
-            .map(|regexp| regexp.inner().names(interp))
+    fn names(&self) -> Vec<Vec<u8>> {
+        self.regexp()
+            .map(|regexp| regexp.inner().names())
             .unwrap_or_default()
     }
 
-    fn pos(
-        &self,
-        interp: &mut Artichoke,
-        haystack: &[u8],
-        at: usize,
-    ) -> Result<Option<(usize, usize)>, Exception> {
-        self.regexp(interp)?.inner().pos(interp, haystack, at)
+    fn pos(&self, haystack: &[u8], at: usize) -> Result<Option<(usize, usize)>, Exception> {
+        self.regexp()?.inner().pos(haystack, at)
     }
 
     fn scan(
@@ -199,6 +165,6 @@ impl RegexpType for Lazy {
         haystack: &[u8],
         block: Option<Block>,
     ) -> Result<Scan, Exception> {
-        self.regexp(interp)?.inner().scan(interp, haystack, block)
+        self.regexp()?.inner().scan(interp, haystack, block)
     }
 }

--- a/artichoke-backend/src/extn/core/regexp/backend/mod.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/mod.rs
@@ -49,42 +49,21 @@ pub trait RegexpType {
 
     fn encoding(&self) -> &Encoding;
 
-    fn inspect(&self, interp: &mut Artichoke) -> Vec<u8>;
+    fn inspect(&self) -> Vec<u8>;
 
-    fn string(&self, interp: &mut Artichoke) -> &[u8];
+    fn string(&self) -> &[u8];
 
-    fn captures(
-        &self,
-        interp: &mut Artichoke,
-        haystack: &[u8],
-    ) -> Result<Option<Vec<NilableString>>, Exception>;
+    fn captures(&self, haystack: &[u8]) -> Result<Option<Vec<NilableString>>, Exception>;
 
-    fn capture_indexes_for_name(
-        &self,
-        interp: &mut Artichoke,
-        name: &[u8],
-    ) -> Result<Option<Vec<usize>>, Exception>;
+    fn capture_indexes_for_name(&self, name: &[u8]) -> Result<Option<Vec<usize>>, Exception>;
 
-    fn captures_len(
-        &self,
-        interp: &mut Artichoke,
-        haystack: Option<&[u8]>,
-    ) -> Result<usize, Exception>;
+    fn captures_len(&self, haystack: Option<&[u8]>) -> Result<usize, Exception>;
 
-    fn capture0<'a>(
-        &self,
-        interp: &mut Artichoke,
-        haystack: &'a [u8],
-    ) -> Result<Option<&'a [u8]>, Exception>;
+    fn capture0<'a>(&self, haystack: &'a [u8]) -> Result<Option<&'a [u8]>, Exception>;
 
     fn case_match(&self, interp: &mut Artichoke, haystack: &[u8]) -> Result<bool, Exception>;
 
-    fn is_match(
-        &self,
-        interp: &mut Artichoke,
-        haystack: &[u8],
-        pos: Option<Int>,
-    ) -> Result<bool, Exception>;
+    fn is_match(&self, haystack: &[u8], pos: Option<Int>) -> Result<bool, Exception>;
 
     fn match_(
         &self,
@@ -100,22 +79,16 @@ pub trait RegexpType {
         haystack: &[u8],
     ) -> Result<Option<usize>, Exception>;
 
-    fn named_captures(&self, interp: &mut Artichoke) -> Result<NameToCaptureLocations, Exception>;
+    fn named_captures(&self) -> Result<NameToCaptureLocations, Exception>;
 
     fn named_captures_for_haystack(
         &self,
-        interp: &mut Artichoke,
         haystack: &[u8],
     ) -> Result<Option<HashMap<Vec<u8>, NilableString>>, Exception>;
 
-    fn names(&self, interp: &mut Artichoke) -> Vec<Vec<u8>>;
+    fn names(&self) -> Vec<Vec<u8>>;
 
-    fn pos(
-        &self,
-        interp: &mut Artichoke,
-        haystack: &[u8],
-        at: usize,
-    ) -> Result<Option<(usize, usize)>, Exception>;
+    fn pos(&self, haystack: &[u8], at: usize) -> Result<Option<(usize, usize)>, Exception>;
 
     fn scan(
         &self,

--- a/artichoke-backend/src/extn/core/regexp/backend/onig.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/onig.rs
@@ -38,12 +38,7 @@ pub struct Onig {
 }
 
 impl Onig {
-    pub fn new(
-        interp: &mut Artichoke,
-        literal: Config,
-        derived: Config,
-        encoding: Encoding,
-    ) -> Result<Self, Exception> {
+    pub fn new(literal: Config, derived: Config, encoding: Encoding) -> Result<Self, Exception> {
         let pattern = str::from_utf8(derived.pattern.as_slice()).map_err(|_| {
             ArgumentError::from("Oniguruma backend for Regexp only supports UTF-8 patterns")
         })?;
@@ -76,11 +71,7 @@ impl RegexpType for Onig {
         Box::new(self.clone())
     }
 
-    fn captures(
-        &self,
-        interp: &mut Artichoke,
-        haystack: &[u8],
-    ) -> Result<Option<Vec<NilableString>>, Exception> {
+    fn captures(&self, haystack: &[u8]) -> Result<Option<Vec<NilableString>>, Exception> {
         let haystack = str::from_utf8(haystack).map_err(|_| {
             ArgumentError::from("Oniguruma backend for Regexp only supports UTF-8 haystacks")
         })?;
@@ -99,12 +90,7 @@ impl RegexpType for Onig {
         }
     }
 
-    fn capture_indexes_for_name(
-        &self,
-        interp: &mut Artichoke,
-        name: &[u8],
-    ) -> Result<Option<Vec<usize>>, Exception> {
-        let _ = interp;
+    fn capture_indexes_for_name(&self, name: &[u8]) -> Result<Option<Vec<usize>>, Exception> {
         let mut result = None;
         self.regex.foreach_name(|group, group_indexes| {
             if name == group.as_bytes() {
@@ -127,11 +113,7 @@ impl RegexpType for Onig {
         Ok(result)
     }
 
-    fn captures_len(
-        &self,
-        interp: &mut Artichoke,
-        haystack: Option<&[u8]>,
-    ) -> Result<usize, Exception> {
+    fn captures_len(&self, haystack: Option<&[u8]>) -> Result<usize, Exception> {
         let result = if let Some(haystack) = haystack {
             let haystack = str::from_utf8(haystack).map_err(|_| {
                 ArgumentError::from("Oniguruma backend for Regexp only supports UTF-8 haystacks")
@@ -146,11 +128,7 @@ impl RegexpType for Onig {
         Ok(result)
     }
 
-    fn capture0<'a>(
-        &self,
-        interp: &mut Artichoke,
-        haystack: &'a [u8],
-    ) -> Result<Option<&'a [u8]>, Exception> {
+    fn capture0<'a>(&self, haystack: &'a [u8]) -> Result<Option<&'a [u8]>, Exception> {
         let haystack = str::from_utf8(haystack).map_err(|_| {
             ArgumentError::from("Oniguruma backend for Regexp only supports UTF-8 haystacks")
         })?;
@@ -191,8 +169,7 @@ impl RegexpType for Onig {
         &self.encoding
     }
 
-    fn inspect(&self, interp: &mut Artichoke) -> Vec<u8> {
-        let _ = interp;
+    fn inspect(&self) -> Vec<u8> {
         // pattern length + 2x '/' + mix + encoding
         let mut inspect = Vec::with_capacity(self.literal.pattern.len() + 2 + 4);
         inspect.push(b'/');
@@ -207,8 +184,7 @@ impl RegexpType for Onig {
         inspect
     }
 
-    fn string(&self, interp: &mut Artichoke) -> &[u8] {
-        let _ = interp;
+    fn string(&self) -> &[u8] {
         self.derived.pattern.as_slice()
     }
 
@@ -245,12 +221,7 @@ impl RegexpType for Onig {
         }
     }
 
-    fn is_match(
-        &self,
-        interp: &mut Artichoke,
-        haystack: &[u8],
-        pos: Option<Int>,
-    ) -> Result<bool, Exception> {
+    fn is_match(&self, haystack: &[u8], pos: Option<Int>) -> Result<bool, Exception> {
         let haystack = str::from_utf8(haystack).map_err(|_| {
             ArgumentError::from("Oniguruma backend for Regexp only supports UTF-8 haystacks")
         })?;
@@ -389,8 +360,7 @@ impl RegexpType for Onig {
         }
     }
 
-    fn named_captures(&self, interp: &mut Artichoke) -> Result<NameToCaptureLocations, Exception> {
-        let _ = interp;
+    fn named_captures(&self) -> Result<NameToCaptureLocations, Exception> {
         // Use a Vec of key-value pairs because insertion order matters for spec
         // compliance.
         let mut map = vec![];
@@ -410,7 +380,6 @@ impl RegexpType for Onig {
 
     fn named_captures_for_haystack(
         &self,
-        interp: &mut Artichoke,
         haystack: &[u8],
     ) -> Result<Option<HashMap<Vec<u8>, NilableString>>, Exception> {
         let haystack = str::from_utf8(haystack).map_err(|_| {
@@ -438,8 +407,7 @@ impl RegexpType for Onig {
         }
     }
 
-    fn names(&self, interp: &mut Artichoke) -> Vec<Vec<u8>> {
-        let _ = interp;
+    fn names(&self) -> Vec<Vec<u8>> {
         let mut names = vec![];
         let mut capture_names = Vec::<(Vec<u8>, Vec<u32>)>::new();
         self.regex.foreach_name(|group, group_indexes| {
@@ -459,12 +427,7 @@ impl RegexpType for Onig {
         names
     }
 
-    fn pos(
-        &self,
-        interp: &mut Artichoke,
-        haystack: &[u8],
-        at: usize,
-    ) -> Result<Option<(usize, usize)>, Exception> {
+    fn pos(&self, haystack: &[u8], at: usize) -> Result<Option<(usize, usize)>, Exception> {
         let haystack = str::from_utf8(haystack).map_err(|_| {
             ArgumentError::from("Oniguruma backend for Regexp only supports UTF-8 haystacks")
         })?;

--- a/artichoke-backend/src/extn/core/regexp/backend/onig.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/onig.rs
@@ -45,25 +45,14 @@ impl Onig {
         encoding: Encoding,
     ) -> Result<Self, Exception> {
         let pattern = str::from_utf8(derived.pattern.as_slice()).map_err(|_| {
-            ArgumentError::new(
-                interp,
-                "Oniguruma backend for Regexp only supports UTF-8 patterns",
-            )
+            ArgumentError::from("Oniguruma backend for Regexp only supports UTF-8 patterns")
         })?;
         let regex = match Regex::with_options(pattern, derived.options.into(), Syntax::ruby()) {
             Ok(regex) => regex,
             Err(err) if literal.options.literal => {
-                return Err(Exception::from(SyntaxError::new(
-                    interp,
-                    err.description().to_owned(),
-                )))
+                return Err(SyntaxError::from(err.description().to_owned()).into())
             }
-            Err(err) => {
-                return Err(Exception::from(RegexpError::new(
-                    interp,
-                    err.description().to_owned(),
-                )))
-            }
+            Err(err) => return Err(RegexpError::from(err.description().to_owned()).into()),
         };
         let regexp = Self {
             literal,
@@ -93,10 +82,7 @@ impl RegexpType for Onig {
         haystack: &[u8],
     ) -> Result<Option<Vec<NilableString>>, Exception> {
         let haystack = str::from_utf8(haystack).map_err(|_| {
-            ArgumentError::new(
-                interp,
-                "Oniguruma backend for Regexp only supports UTF-8 haystacks",
-            )
+            ArgumentError::from("Oniguruma backend for Regexp only supports UTF-8 haystacks")
         })?;
         if let Some(captures) = self.regex.captures(haystack) {
             let mut result = Vec::with_capacity(captures.len());
@@ -148,10 +134,7 @@ impl RegexpType for Onig {
     ) -> Result<usize, Exception> {
         let result = if let Some(haystack) = haystack {
             let haystack = str::from_utf8(haystack).map_err(|_| {
-                ArgumentError::new(
-                    interp,
-                    "Oniguruma backend for Regexp only supports UTF-8 haystacks",
-                )
+                ArgumentError::from("Oniguruma backend for Regexp only supports UTF-8 haystacks")
             })?;
             self.regex
                 .captures(haystack)
@@ -169,10 +152,7 @@ impl RegexpType for Onig {
         haystack: &'a [u8],
     ) -> Result<Option<&'a [u8]>, Exception> {
         let haystack = str::from_utf8(haystack).map_err(|_| {
-            ArgumentError::new(
-                interp,
-                "Oniguruma backend for Regexp only supports UTF-8 haystacks",
-            )
+            ArgumentError::from("Oniguruma backend for Regexp only supports UTF-8 haystacks")
         })?;
         let result = self
             .regex
@@ -234,10 +214,7 @@ impl RegexpType for Onig {
 
     fn case_match(&self, interp: &mut Artichoke, haystack: &[u8]) -> Result<bool, Exception> {
         let haystack = str::from_utf8(haystack).map_err(|_| {
-            ArgumentError::new(
-                interp,
-                "Oniguruma backend for Regexp only supports UTF-8 haystacks",
-            )
+            ArgumentError::from("Oniguruma backend for Regexp only supports UTF-8 haystacks")
         })?;
         regexp::clear_capture_globals(interp)?;
         if let Some(captures) = self.regex.captures(haystack) {
@@ -275,10 +252,7 @@ impl RegexpType for Onig {
         pos: Option<Int>,
     ) -> Result<bool, Exception> {
         let haystack = str::from_utf8(haystack).map_err(|_| {
-            ArgumentError::new(
-                interp,
-                "Oniguruma backend for Regexp only supports UTF-8 haystacks",
-            )
+            ArgumentError::from("Oniguruma backend for Regexp only supports UTF-8 haystacks")
         })?;
         let haystack_char_len = haystack.chars().count();
         let pos = pos.unwrap_or_default();
@@ -311,10 +285,7 @@ impl RegexpType for Onig {
         block: Option<Block>,
     ) -> Result<Value, Exception> {
         let haystack = str::from_utf8(haystack).map_err(|_| {
-            ArgumentError::new(
-                interp,
-                "Oniguruma backend for Regexp only supports UTF-8 haystacks",
-            )
+            ArgumentError::from("Oniguruma backend for Regexp only supports UTF-8 haystacks")
         })?;
         regexp::clear_capture_globals(interp)?;
         let haystack_char_len = haystack.chars().count();
@@ -383,10 +354,7 @@ impl RegexpType for Onig {
         haystack: &[u8],
     ) -> Result<Option<usize>, Exception> {
         let haystack = str::from_utf8(haystack).map_err(|_| {
-            ArgumentError::new(
-                interp,
-                "Oniguruma backend for Regexp only supports UTF-8 haystacks",
-            )
+            ArgumentError::from("Oniguruma backend for Regexp only supports UTF-8 haystacks")
         })?;
         regexp::clear_capture_globals(interp)?;
         if let Some(captures) = self.regex.captures(haystack) {
@@ -446,10 +414,7 @@ impl RegexpType for Onig {
         haystack: &[u8],
     ) -> Result<Option<HashMap<Vec<u8>, NilableString>>, Exception> {
         let haystack = str::from_utf8(haystack).map_err(|_| {
-            ArgumentError::new(
-                interp,
-                "Oniguruma backend for Regexp only supports UTF-8 haystacks",
-            )
+            ArgumentError::from("Oniguruma backend for Regexp only supports UTF-8 haystacks")
         })?;
         if let Some(captures) = self.regex.captures(haystack) {
             let mut map = HashMap::with_capacity(captures.len());
@@ -501,10 +466,7 @@ impl RegexpType for Onig {
         at: usize,
     ) -> Result<Option<(usize, usize)>, Exception> {
         let haystack = str::from_utf8(haystack).map_err(|_| {
-            ArgumentError::new(
-                interp,
-                "Oniguruma backend for Regexp only supports UTF-8 haystacks",
-            )
+            ArgumentError::from("Oniguruma backend for Regexp only supports UTF-8 haystacks")
         })?;
         let pos = self
             .regex
@@ -520,10 +482,7 @@ impl RegexpType for Onig {
         block: Option<Block>,
     ) -> Result<Scan, Exception> {
         let haystack = str::from_utf8(haystack).map_err(|_| {
-            ArgumentError::new(
-                interp,
-                "Oniguruma backend for Regexp only supports UTF-8 haystacks",
-            )
+            ArgumentError::from("Oniguruma backend for Regexp only supports UTF-8 haystacks")
         })?;
         regexp::clear_capture_globals(interp)?;
         let mut matchdata = MatchData::new(haystack.into(), Regexp::from(self.box_clone()), ..);

--- a/artichoke-backend/src/extn/core/regexp/backend/regex/utf8.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/regex/utf8.rs
@@ -28,10 +28,7 @@ impl Utf8 {
         encoding: Encoding,
     ) -> Result<Self, Exception> {
         let pattern = str::from_utf8(derived.pattern.as_slice()).map_err(|_| {
-            ArgumentError::new(
-                interp,
-                "regex crate utf8 backend for Regexp only supports UTF-8 patterns",
-            )
+            ArgumentError::from("regex crate utf8 backend for Regexp only supports UTF-8 patterns")
         })?;
         let mut builder = RegexBuilder::new(pattern);
         builder.case_insensitive(derived.options.ignore_case);
@@ -40,9 +37,9 @@ impl Utf8 {
         let regex = match builder.build() {
             Ok(regex) => regex,
             Err(err) if literal.options.literal => {
-                return Err(Exception::from(SyntaxError::new(interp, err.to_string())));
+                return Err(SyntaxError::from(err.to_string()).into());
             }
-            Err(err) => return Err(Exception::from(RegexpError::new(interp, err.to_string()))),
+            Err(err) => return Err(RegexpError::from(err.to_string()).into()),
         };
         let regexp = Self {
             literal,
@@ -72,10 +69,7 @@ impl RegexpType for Utf8 {
         haystack: &[u8],
     ) -> Result<Option<Vec<NilableString>>, Exception> {
         let haystack = str::from_utf8(haystack).map_err(|_| {
-            ArgumentError::new(
-                interp,
-                "regex crate utf8 backend for Regexp only supports UTF-8 haystacks",
-            )
+            ArgumentError::from("regex crate utf8 backend for Regexp only supports UTF-8 haystacks")
         })?;
         if let Some(captures) = self.regex.captures(haystack) {
             let mut result = Vec::with_capacity(captures.len());
@@ -118,8 +112,7 @@ impl RegexpType for Utf8 {
     ) -> Result<usize, Exception> {
         let result = if let Some(haystack) = haystack {
             let haystack = str::from_utf8(haystack).map_err(|_| {
-                ArgumentError::new(
-                    interp,
+                ArgumentError::from(
                     "regex crate utf8 backend for Regexp only supports UTF-8 haystacks",
                 )
             })?;
@@ -139,10 +132,7 @@ impl RegexpType for Utf8 {
         haystack: &'a [u8],
     ) -> Result<Option<&'a [u8]>, Exception> {
         let haystack = str::from_utf8(haystack).map_err(|_| {
-            ArgumentError::new(
-                interp,
-                "regex crate utf8 backend for Regexp only supports UTF-8 haystacks",
-            )
+            ArgumentError::from("regex crate utf8 backend for Regexp only supports UTF-8 haystacks")
         })?;
         let result = self
             .regex
@@ -206,10 +196,7 @@ impl RegexpType for Utf8 {
 
     fn case_match(&self, interp: &mut Artichoke, haystack: &[u8]) -> Result<bool, Exception> {
         let haystack = str::from_utf8(haystack).map_err(|_| {
-            ArgumentError::new(
-                interp,
-                "regex crate utf8 backend for Regexp only supports UTF-8 haystack",
-            )
+            ArgumentError::from("regex crate utf8 backend for Regexp only supports UTF-8 haystack")
         })?;
         regexp::clear_capture_globals(interp)?;
         if let Some(captures) = self.regex.captures(haystack) {
@@ -263,10 +250,7 @@ impl RegexpType for Utf8 {
         pos: Option<Int>,
     ) -> Result<bool, Exception> {
         let haystack = str::from_utf8(haystack).map_err(|_| {
-            ArgumentError::new(
-                interp,
-                "regex crate utf8 backend for Regexp only supports UTF-8 haystack",
-            )
+            ArgumentError::from("regex crate utf8 backend for Regexp only supports UTF-8 haystack")
         })?;
         let haystack_char_len = haystack.chars().count();
         let pos = pos.unwrap_or_default();
@@ -299,10 +283,7 @@ impl RegexpType for Utf8 {
         block: Option<Block>,
     ) -> Result<Value, Exception> {
         let haystack = str::from_utf8(haystack).map_err(|_| {
-            ArgumentError::new(
-                interp,
-                "regex crate utf8 backend for Regexp only supports UTF-8 haystacks",
-            )
+            ArgumentError::from("regex crate utf8 backend for Regexp only supports UTF-8 haystacks")
         })?;
         regexp::clear_capture_globals(interp)?;
         let haystack_char_len = haystack.chars().count();
@@ -386,10 +367,7 @@ impl RegexpType for Utf8 {
         haystack: &[u8],
     ) -> Result<Option<usize>, Exception> {
         let haystack = str::from_utf8(haystack).map_err(|_| {
-            ArgumentError::new(
-                interp,
-                "regex crate utf8 backend for Regexp only supports UTF-8 haystacks",
-            )
+            ArgumentError::from("regex crate utf8 backend for Regexp only supports UTF-8 haystacks")
         })?;
         regexp::clear_capture_globals(interp)?;
         if let Some(captures) = self.regex.captures(haystack) {
@@ -458,10 +436,7 @@ impl RegexpType for Utf8 {
         haystack: &[u8],
     ) -> Result<Option<HashMap<Vec<u8>, NilableString>>, Exception> {
         let haystack = str::from_utf8(haystack).map_err(|_| {
-            ArgumentError::new(
-                interp,
-                "regex crate utf8 backend for Regexp only supports UTF-8 haystacks",
-            )
+            ArgumentError::from("regex crate utf8 backend for Regexp only supports UTF-8 haystacks")
         })?;
         if let Some(captures) = self.regex.captures(haystack) {
             let mut map = HashMap::with_capacity(captures.len());
@@ -506,10 +481,7 @@ impl RegexpType for Utf8 {
         at: usize,
     ) -> Result<Option<(usize, usize)>, Exception> {
         let haystack = str::from_utf8(haystack).map_err(|_| {
-            ArgumentError::new(
-                interp,
-                "regex crate utf8 backend for Regexp only supports UTF-8 haystacks",
-            )
+            ArgumentError::from("regex crate utf8 backend for Regexp only supports UTF-8 haystacks")
         })?;
         let pos = self
             .regex
@@ -526,10 +498,7 @@ impl RegexpType for Utf8 {
         block: Option<Block>,
     ) -> Result<Scan, Exception> {
         let haystack = str::from_utf8(haystack).map_err(|_| {
-            ArgumentError::new(
-                interp,
-                "regex crate utf8 backend for Regexp only supports UTF-8 haystacks",
-            )
+            ArgumentError::from("regex crate utf8 backend for Regexp only supports UTF-8 haystacks")
         })?;
         regexp::clear_capture_globals(interp)?;
         let mut matchdata = MatchData::new(haystack.into(), Regexp::from(self.box_clone()), ..);

--- a/artichoke-backend/src/extn/core/regexp/mod.rs
+++ b/artichoke-backend/src/extn/core/regexp/mod.rs
@@ -201,11 +201,7 @@ impl Regexp {
         if let Ok(pattern) = str::from_utf8(pattern) {
             Ok(syntax::escape(pattern))
         } else {
-            // drop(bytes);
-            Err(Exception::from(ArgumentError::new(
-                interp,
-                "invalid encoding (non UTF-8)",
-            )))
+            Err(ArgumentError::from("invalid encoding (non UTF-8)").into())
         }
     }
 
@@ -225,10 +221,7 @@ impl Regexp {
                     pattern
                 } else {
                     // drop(bytes);
-                    return Err(Exception::from(ArgumentError::new(
-                        interp,
-                        "invalid encoding (non UTF-8)",
-                    )));
+                    return Err(ArgumentError::from("invalid encoding (non UTF-8)").into());
                 };
                 Ok(syntax::escape(pattern).into_bytes())
             }
@@ -380,10 +373,7 @@ impl Regexp {
                 if let Ok(idx) = Int::try_from(idx) {
                     fixnums.push(idx);
                 } else {
-                    return Err(Exception::from(ArgumentError::new(
-                        interp,
-                        "string too long",
-                    )));
+                    return Err(ArgumentError::from("string too long").into());
                 }
             }
             converted.push((name, fixnums));

--- a/artichoke-backend/src/extn/core/regexp/trampoline.rs
+++ b/artichoke-backend/src/extn/core/regexp/trampoline.rs
@@ -17,7 +17,7 @@ pub fn initialize(
 
 pub fn escape(interp: &mut Artichoke, pattern: Value) -> Result<Value, Exception> {
     let pattern = pattern.implicitly_convert_to_string(interp)?;
-    let pattern = Regexp::escape(interp, pattern)?;
+    let pattern = Regexp::escape(pattern)?;
     Ok(interp.convert_mut(pattern))
 }
 
@@ -42,7 +42,7 @@ pub fn is_match(
     } else {
         None
     };
-    let is_match = regexp.is_match(interp, pattern, pos)?;
+    let is_match = regexp.is_match(pattern, pos)?;
     Ok(interp.convert(is_match))
 }
 
@@ -96,55 +96,55 @@ pub fn match_operator(
 
 pub fn is_casefold(interp: &mut Artichoke, mut regexp: Value) -> Result<Value, Exception> {
     let regexp = unsafe { Regexp::unbox_from_value(&mut regexp, interp)? };
-    let is_casefold = regexp.is_casefold(interp);
+    let is_casefold = regexp.is_casefold();
     Ok(interp.convert(is_casefold))
 }
 
 pub fn is_fixed_encoding(interp: &mut Artichoke, mut regexp: Value) -> Result<Value, Exception> {
     let regexp = unsafe { Regexp::unbox_from_value(&mut regexp, interp)? };
-    let is_fixed_encoding = regexp.is_fixed_encoding(interp);
+    let is_fixed_encoding = regexp.is_fixed_encoding();
     Ok(interp.convert(is_fixed_encoding))
 }
 
 pub fn hash(interp: &mut Artichoke, mut regexp: Value) -> Result<Value, Exception> {
     let regexp = unsafe { Regexp::unbox_from_value(&mut regexp, interp)? };
-    let hash = regexp.hash(interp);
+    let hash = regexp.hash();
     #[allow(clippy::cast_possible_wrap)]
     Ok(interp.convert(hash as Int))
 }
 
 pub fn inspect(interp: &mut Artichoke, mut regexp: Value) -> Result<Value, Exception> {
     let regexp = unsafe { Regexp::unbox_from_value(&mut regexp, interp)? };
-    let inspect = regexp.inspect(interp);
+    let inspect = regexp.inspect();
     Ok(interp.convert_mut(inspect))
 }
 
 pub fn named_captures(interp: &mut Artichoke, mut regexp: Value) -> Result<Value, Exception> {
     let regexp = unsafe { Regexp::unbox_from_value(&mut regexp, interp)? };
-    let named_captures = regexp.named_captures(interp)?;
+    let named_captures = regexp.named_captures()?;
     interp.try_convert_mut(named_captures)
 }
 
 pub fn names(interp: &mut Artichoke, mut regexp: Value) -> Result<Value, Exception> {
     let regexp = unsafe { Regexp::unbox_from_value(&mut regexp, interp)? };
-    let names = regexp.names(interp);
+    let names = regexp.names();
     interp.try_convert_mut(names)
 }
 
 pub fn options(interp: &mut Artichoke, mut regexp: Value) -> Result<Value, Exception> {
     let regexp = unsafe { Regexp::unbox_from_value(&mut regexp, interp)? };
-    let opts = regexp.options(interp);
+    let opts = regexp.options();
     Ok(interp.convert(opts))
 }
 
 pub fn source(interp: &mut Artichoke, mut regexp: Value) -> Result<Value, Exception> {
     let regexp = unsafe { Regexp::unbox_from_value(&mut regexp, interp)? };
-    let source = regexp.source(interp);
+    let source = regexp.source();
     Ok(interp.convert_mut(source))
 }
 
 pub fn to_s(interp: &mut Artichoke, mut regexp: Value) -> Result<Value, Exception> {
     let regexp = unsafe { Regexp::unbox_from_value(&mut regexp, interp)? };
-    let s = regexp.string(interp);
+    let s = regexp.string();
     Ok(interp.convert_mut(s))
 }

--- a/artichoke-backend/src/extn/core/regexp/trampoline.rs
+++ b/artichoke-backend/src/extn/core/regexp/trampoline.rs
@@ -89,10 +89,7 @@ pub fn match_operator(
     let pos = regexp.match_operator(interp, pattern)?;
     match pos.map(Int::try_from) {
         Some(Ok(pos)) => Ok(interp.convert(pos)),
-        Some(Err(_)) => Err(Exception::from(ArgumentError::new(
-            interp,
-            "string too long",
-        ))),
+        Some(Err(_)) => Err(ArgumentError::from("string too long").into()),
         None => Ok(Value::nil()),
     }
 }

--- a/artichoke-backend/src/extn/core/string/trampoline.rs
+++ b/artichoke-backend/src/extn/core/string/trampoline.rs
@@ -16,12 +16,7 @@ pub fn ord(interp: &mut Artichoke, value: Value) -> Result<Value, Exception> {
                 [a, b] => u32::from_le_bytes([*a, *b, 0, 0]),
                 [a, b, c] => u32::from_le_bytes([*a, *b, *c, 0]),
                 [a, b, c, d] => u32::from_le_bytes([*a, *b, *c, *d]),
-                _ => {
-                    return Err(Exception::from(ArgumentError::new(
-                        interp,
-                        "Unicode out of range",
-                    )))
-                }
+                _ => return Err(ArgumentError::from("Unicode out of range").into()),
             }
         } else {
             // All `char`s are valid `u32`s
@@ -29,7 +24,7 @@ pub fn ord(interp: &mut Artichoke, value: Value) -> Result<Value, Exception> {
             ch as u32
         }
     } else {
-        return Err(Exception::from(ArgumentError::new(interp, "empty string")));
+        return Err(ArgumentError::from("empty string").into());
     };
     Ok(interp.convert(ord))
 }
@@ -44,7 +39,7 @@ pub fn scan(
         let mut message = String::from("wrong argument type ");
         message.push_str(pattern.pretty_name(interp));
         message.push_str(" (expected Regexp)");
-        Err(Exception::from(TypeError::new(interp, message)))
+        Err(TypeError::from(message).into())
     } else if let Ok(regexp) = unsafe { Regexp::unbox_from_value(&mut pattern, interp) } {
         let haystack = value.try_into_mut::<&[u8]>(interp)?;
         let scan = regexp.inner().scan(interp, haystack, block)?;
@@ -112,6 +107,6 @@ pub fn scan(
         let mut message = String::from("wrong argument type ");
         message.push_str(pattern.pretty_name(interp));
         message.push_str(" (expected Regexp)");
-        Err(Exception::from(TypeError::new(interp, message)))
+        Err(TypeError::from(message).into())
     }
 }

--- a/artichoke-backend/src/extn/stdlib/securerandom/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/securerandom/mod.rs
@@ -165,9 +165,10 @@ pub fn alphanumeric(len: Option<Int>) -> Result<String, Exception> {
     Ok(string)
 }
 
+#[must_use]
 pub fn uuid() -> String {
     let uuid = Uuid::new_v4();
     let mut buf = Uuid::encode_buffer();
     let enc = uuid.to_hyphenated().encode_lower(&mut buf);
-    enc.to_owned()
+    String::from(enc)
 }

--- a/artichoke-backend/src/extn/stdlib/securerandom/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/securerandom/mod.rs
@@ -27,7 +27,7 @@ mod tests {
 #[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct SecureRandom;
 
-pub fn random_bytes(interp: &mut Artichoke, len: Option<Int>) -> Result<Vec<u8>, Exception> {
+pub fn random_bytes(len: Option<Int>) -> Result<Vec<u8>, Exception> {
     let len = if let Some(len) = len {
         match usize::try_from(len) {
             Ok(0) => return Ok(Vec::new()),
@@ -106,10 +106,7 @@ impl ConvertMut<RandomNumber, Value> for Artichoke {
     }
 }
 
-pub fn random_number(
-    interp: &mut Artichoke,
-    max: RandomNumberMax,
-) -> Result<RandomNumber, ArgumentError> {
+pub fn random_number(max: RandomNumberMax) -> Result<RandomNumber, ArgumentError> {
     let mut rng = rand::thread_rng();
     match max {
         RandomNumberMax::Float(max) if !max.is_finite() => {
@@ -140,18 +137,18 @@ pub fn random_number(
 }
 
 #[inline]
-pub fn hex(interp: &mut Artichoke, len: Option<Int>) -> Result<String, Exception> {
-    let bytes = random_bytes(interp, len)?;
+pub fn hex(len: Option<Int>) -> Result<String, Exception> {
+    let bytes = random_bytes(len)?;
     Ok(hex::encode(bytes))
 }
 
 #[inline]
-pub fn base64(interp: &mut Artichoke, len: Option<Int>) -> Result<String, Exception> {
-    let bytes = random_bytes(interp, len)?;
+pub fn base64(len: Option<Int>) -> Result<String, Exception> {
+    let bytes = random_bytes(len)?;
     Ok(base64::encode(bytes))
 }
 
-pub fn alphanumeric(interp: &mut Artichoke, len: Option<Int>) -> Result<String, Exception> {
+pub fn alphanumeric(len: Option<Int>) -> Result<String, Exception> {
     let len = if let Some(len) = len {
         match usize::try_from(len) {
             Ok(0) => return Ok(String::new()),
@@ -168,8 +165,7 @@ pub fn alphanumeric(interp: &mut Artichoke, len: Option<Int>) -> Result<String, 
     Ok(string)
 }
 
-pub fn uuid(interp: &mut Artichoke) -> String {
-    let _ = interp;
+pub fn uuid() -> String {
     let uuid = Uuid::new_v4();
     let mut buf = Uuid::encode_buffer();
     let enc = uuid.to_hyphenated().encode_lower(&mut buf);

--- a/artichoke-backend/src/extn/stdlib/securerandom/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/securerandom/mod.rs
@@ -33,10 +33,7 @@ pub fn random_bytes(interp: &mut Artichoke, len: Option<Int>) -> Result<Vec<u8>,
             Ok(0) => return Ok(Vec::new()),
             Ok(len) => len,
             Err(_) => {
-                return Err(Exception::from(ArgumentError::new(
-                    interp,
-                    "negative string size (or size too big)",
-                )))
+                return Err(ArgumentError::from("negative string size (or size too big)").into())
             }
         }
     } else {
@@ -45,7 +42,7 @@ pub fn random_bytes(interp: &mut Artichoke, len: Option<Int>) -> Result<Vec<u8>,
     let mut rng = rand::thread_rng();
     let mut bytes = vec![0; len];
     rng.try_fill_bytes(&mut bytes)
-        .map_err(|err| RuntimeError::new(interp, err.to_string()))?;
+        .map_err(|err| RuntimeError::from(err.to_string()))?;
     Ok(bytes)
 }
 
@@ -83,7 +80,7 @@ impl TryConvertMut<Option<Value>, RandomNumberMax> for Artichoke {
                     let max = max.implicitly_convert_to_int(self).map_err(|_| {
                         let mut message = b"invalid argument - ".to_vec();
                         message.extend(max.inspect(self).as_slice());
-                        ArgumentError::new_raw(self, message)
+                        ArgumentError::from(message)
                     })?;
                     Ok(RandomNumberMax::Integer(max))
                 }
@@ -117,10 +114,7 @@ pub fn random_number(
     match max {
         RandomNumberMax::Float(max) if !max.is_finite() => {
             // NOTE: MRI returns `Errno::EDOM` exception class.
-            Err(ArgumentError::new(
-                interp,
-                "Numerical argument out of domain",
-            ))
+            Err(ArgumentError::from("Numerical argument out of domain"))
         }
         RandomNumberMax::Float(max) if max <= 0.0 => {
             let number = rng.gen_range(0.0, 1.0);
@@ -163,10 +157,7 @@ pub fn alphanumeric(interp: &mut Artichoke, len: Option<Int>) -> Result<String, 
             Ok(0) => return Ok(String::new()),
             Ok(len) => len,
             Err(_) => {
-                return Err(Exception::from(ArgumentError::new(
-                    interp,
-                    "negative string size (or size too big)",
-                )))
+                return Err(ArgumentError::from("negative string size (or size too big)").into())
             }
         }
     } else {

--- a/artichoke-backend/src/extn/stdlib/securerandom/trampoline.rs
+++ b/artichoke-backend/src/extn/stdlib/securerandom/trampoline.rs
@@ -5,9 +5,9 @@ use crate::extn::stdlib::securerandom;
 pub fn alphanumeric(interp: &mut Artichoke, len: Option<Value>) -> Result<Value, Exception> {
     let alpha = if let Some(len) = len {
         let len = len.implicitly_convert_to_int(interp)?;
-        securerandom::alphanumeric(interp, Some(len))?
+        securerandom::alphanumeric(Some(len))?
     } else {
-        securerandom::alphanumeric(interp, None)?
+        securerandom::alphanumeric(None)?
     };
     Ok(interp.convert_mut(alpha))
 }
@@ -16,9 +16,9 @@ pub fn alphanumeric(interp: &mut Artichoke, len: Option<Value>) -> Result<Value,
 pub fn base64(interp: &mut Artichoke, len: Option<Value>) -> Result<Value, Exception> {
     let base64 = if let Some(len) = len {
         let len = len.implicitly_convert_to_int(interp)?;
-        securerandom::base64(interp, Some(len))?
+        securerandom::base64(Some(len))?
     } else {
-        securerandom::base64(interp, None)?
+        securerandom::base64(None)?
     };
     Ok(interp.convert_mut(base64))
 }
@@ -27,9 +27,9 @@ pub fn base64(interp: &mut Artichoke, len: Option<Value>) -> Result<Value, Excep
 pub fn hex(interp: &mut Artichoke, len: Option<Value>) -> Result<Value, Exception> {
     let hex = if let Some(len) = len {
         let len = len.implicitly_convert_to_int(interp)?;
-        securerandom::hex(interp, Some(len))?
+        securerandom::hex(Some(len))?
     } else {
-        securerandom::hex(interp, None)?
+        securerandom::hex(None)?
     };
     Ok(interp.convert_mut(hex))
 }
@@ -38,9 +38,9 @@ pub fn hex(interp: &mut Artichoke, len: Option<Value>) -> Result<Value, Exceptio
 pub fn random_bytes(interp: &mut Artichoke, len: Option<Value>) -> Result<Value, Exception> {
     let bytes = if let Some(len) = len {
         let len = len.implicitly_convert_to_int(interp)?;
-        securerandom::random_bytes(interp, Some(len))?
+        securerandom::random_bytes(Some(len))?
     } else {
-        securerandom::random_bytes(interp, None)?
+        securerandom::random_bytes(None)?
     };
     Ok(interp.convert_mut(bytes))
 }
@@ -48,12 +48,12 @@ pub fn random_bytes(interp: &mut Artichoke, len: Option<Value>) -> Result<Value,
 #[inline]
 pub fn random_number(interp: &mut Artichoke, max: Option<Value>) -> Result<Value, Exception> {
     let max = interp.try_convert_mut(max)?;
-    let num = securerandom::random_number(interp, max)?;
+    let num = securerandom::random_number(max)?;
     Ok(interp.convert_mut(num))
 }
 
 #[inline]
 pub fn uuid(interp: &mut Artichoke) -> Result<Value, Exception> {
-    let uuid = securerandom::uuid(interp);
+    let uuid = securerandom::uuid();
     Ok(interp.convert_mut(uuid))
 }

--- a/artichoke-backend/src/value.rs
+++ b/artichoke-backend/src/value.rs
@@ -152,8 +152,7 @@ impl Value {
             if let Some(int) = int {
                 int
             } else {
-                return Err(TypeError::new(
-                    interp,
+                return Err(TypeError::from(
                     "no implicit conversion from nil to integer",
                 ));
             }
@@ -169,19 +168,19 @@ impl Value {
                     message.push_str("#to_int gives ");
                     message.push_str(maybe.pretty_name(interp));
                     message.push(')');
-                    return Err(TypeError::new(interp, message));
+                    return Err(TypeError::from(message));
                 }
             } else {
                 let mut message = String::from("no implicit conversion of ");
                 message.push_str(self.pretty_name(interp));
                 message.push_str(" into Integer");
-                return Err(TypeError::new(interp, message));
+                return Err(TypeError::from(message));
             }
         } else {
             let mut message = String::from("no implicit conversion of ");
             message.push_str(self.pretty_name(interp));
             message.push_str(" into Integer");
-            return Err(TypeError::new(interp, message));
+            return Err(TypeError::from(message));
         };
         Ok(int)
     }
@@ -201,19 +200,19 @@ impl Value {
                     message.push_str("#to_str gives ");
                     message.push_str(maybe.pretty_name(interp));
                     message.push(')');
-                    return Err(TypeError::new(interp, message));
+                    return Err(TypeError::from(message));
                 }
             } else {
                 let mut message = String::from("no implicit conversion of ");
                 message.push_str(self.pretty_name(interp));
                 message.push_str(" into String");
-                return Err(TypeError::new(interp, message));
+                return Err(TypeError::from(message));
             }
         } else {
             let mut message = String::from("no implicit conversion of ");
             message.push_str(self.pretty_name(interp));
             message.push_str(" into String");
-            return Err(TypeError::new(interp, message));
+            return Err(TypeError::from(message));
         };
         Ok(string)
     }
@@ -280,10 +279,7 @@ impl ValueCore for Value {
                     // and may result in a segfault.
                     //
                     // See: https://github.com/mruby/mruby/issues/4460
-                    Err(Exception::from(Fatal::new(
-                        arena.interp(),
-                        "Unreachable Ruby value",
-                    )))
+                    Err(Fatal::from("Unreachable Ruby value").into())
                 } else {
                     Ok(value)
                 }

--- a/artichoke-backend/src/warn.rs
+++ b/artichoke-backend/src/warn.rs
@@ -18,17 +18,17 @@ impl Warn for Artichoke {
         if let Err(err) = state.output.write_stderr(b"rb warning: ") {
             let mut message = String::from("Failed to write warning to $stderr: ");
             let _ = write!(&mut message, "{}", err);
-            return Err(IOError::new(self, message).into());
+            return Err(IOError::from(message).into());
         }
         if let Err(err) = state.output.write_stderr(message) {
             let mut message = String::from("Failed to write warning to $stderr: ");
             let _ = write!(&mut message, "{}", err);
-            return Err(IOError::new(self, message).into());
+            return Err(IOError::from(message).into());
         }
         if let Err(err) = state.output.write_stderr(b"\n") {
             let mut message = String::from("Failed to write warning to $stderr: ");
             let _ = write!(&mut message, "{}", err);
-            return Err(IOError::new(self, message).into());
+            return Err(IOError::from(message).into());
         }
         let warning = self
             .module_of::<Warning>()?

--- a/src/ruby.rs
+++ b/src/ruby.rs
@@ -72,7 +72,7 @@ where
         let mut program = vec![];
         input
             .read_to_end(&mut program)
-            .map_err(|_| IOError::new(&interp, "Could not read program from STDIN"))?;
+            .map_err(|_| IOError::from("Could not read program from STDIN"))?;
         if let Err(ref exc) = interp.eval(program.as_slice()) {
             backtrace::format_cli_trace_into(error, &mut interp, exc)?;
             return Ok(Err(()));
@@ -151,10 +151,9 @@ fn setup_fixture_hack<P: AsRef<Path>>(interp: &mut Artichoke, fixture: P) -> Res
     let data = if let Ok(data) = std::fs::read(fixture.as_ref()) {
         data
     } else {
-        return Err(Exception::from(LoadError::new(
-            &interp,
-            load_error(fixture.as_ref(), "No such file or directory")?,
-        )));
+        return Err(
+            LoadError::from(load_error(fixture.as_ref(), "No such file or directory")?).into(),
+        );
     };
     let value = interp.convert_mut(data);
     interp.set_global_variable(&b"$fixture"[..], &value)?;


### PR DESCRIPTION
`extn::core::exception` implements all `Exception` descendants in Ruby Core using macros because there are a bunch of them.

These macros define the inherent methods:

```rust
impl $excepton {
    pub fn new<T: Into<Cow<'static, str>>>(interp: &Artchoke, msg: T)` {}

    pub fn new_raw<T: Into<Cow<'static, [u8]>>>(interp: &Artchoke, msg: T)` {}
}
```

The interp parameters were present since the initial implementation of these structs. When `Artichoke` was clone-able, each exception struct owned a copy of the `Rc`-wrapped interpreter to resolve its classname. 042bc4b3484c9e89890b3f3114053f56141a67bb removed this struct member in favor of a `stringified` class name, but did not refactor the constructor or any call sites.

This PR changes the inherent impl to:

```rust
impl $exception {
    pub fn new() -> Self {
        Self(stringify!($exception).into())
    }
}
```

This matches the behavior of MRI when raising an `Exception` with no message or calling `Exception.new` with no message:

```console
[2.6.3] > raise RuntimeError
Traceback (most recent call last):
        4: from /usr/local/var/rbenv/versions/2.6.3/bin/irb:23:in `<main>'
        3: from /usr/local/var/rbenv/versions/2.6.3/bin/irb:23:in `load'
        2: from /usr/local/var/rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
        1: from (irb):2
RuntimeError (RuntimeError)
[2.6.3] > RuntimeError.new.message
=> "RuntimeError"
```

Constructs with an explicit message have been reworked to `From` impls for owned, borrowed, and `Cow` types. This removes some of the ugliness in the `new_raw` constructor.

Removing the unused `interp` parameter from the error constructors allows culling of significant unnecessary proliferation of the interp parameter into `extn` backend implementations. This change removes most `interp` params from `Regexp` and `MatchData` backends, limiting the parameter to the trampolines. Some APIs, like `SecureRandom` now are `interp`-free which improves the ergonomics of invoking them from Rust.