### PR TITLE
Add a bunch more constructors and From impls

### DIFF
--- a/artichoke-backend/src/block.rs
+++ b/artichoke-backend/src/block.rs
@@ -73,6 +73,12 @@ impl From<Box<NoBlockGiven>> for Box<dyn RubyException> {
     }
 }
 
+impl From<Value> for NoBlockGiven {
+    fn from(value: Value) -> Self {
+        Self(value.ruby_type())
+    }
+}
+
 impl From<sys::mrb_value> for NoBlockGiven {
     fn from(value: sys::mrb_value) -> Self {
         Self(types::ruby_from_mrb_value(value))
@@ -85,10 +91,16 @@ impl From<Ruby> for NoBlockGiven {
     }
 }
 
+impl Default for NoBlockGiven {
+    fn default() -> Self {
+        Self(Ruby::Nil)
+    }
+}
+
 impl NoBlockGiven {
     #[must_use]
-    pub fn new(ruby_type: Ruby) -> Self {
-        Self(ruby_type)
+    pub fn new() -> Self {
+        Self::default()
     }
 
     #[must_use]
@@ -102,7 +114,11 @@ pub struct Block(sys::mrb_value);
 
 impl From<sys::mrb_value> for Option<Block> {
     fn from(value: sys::mrb_value) -> Self {
-        Block::new(value)
+        if let Ruby::Nil = types::ruby_from_mrb_value(value) {
+            None
+        } else {
+            Some(Block(value))
+        }
     }
 }
 
@@ -126,6 +142,11 @@ impl Block {
         } else {
             Some(Self(block))
         }
+    }
+
+    #[must_use]
+    pub unsafe fn new_unchecked(block: sys::mrb_value) -> Self {
+        Self(block)
     }
 
     #[inline]

--- a/artichoke-backend/src/block.rs
+++ b/artichoke-backend/src/block.rs
@@ -135,6 +135,7 @@ impl TryFrom<sys::mrb_value> for Block {
 }
 
 impl Block {
+    /// Construct a `Block` from a Ruby value.
     #[must_use]
     pub fn new(block: sys::mrb_value) -> Option<Self> {
         if let Ruby::Nil = types::ruby_from_mrb_value(block) {
@@ -144,6 +145,11 @@ impl Block {
         }
     }
 
+    /// Construct a `Block` from a Ruby value.
+    ///
+    /// # Safety
+    ///
+    /// The block must not be `nil`.
     #[must_use]
     pub unsafe fn new_unchecked(block: sys::mrb_value) -> Self {
         Self(block)

--- a/artichoke-backend/src/class.rs
+++ b/artichoke-backend/src/class.rs
@@ -163,7 +163,7 @@ impl Spec {
                 enclosing_scope: enclosing_scope.map(Box::new),
             })
         } else {
-            Err(ConstantNameError::new(name))
+            Err(name.into())
         }
     }
 

--- a/artichoke-backend/src/constant.rs
+++ b/artichoke-backend/src/constant.rs
@@ -19,7 +19,7 @@ impl DefineConstant for Artichoke {
         value: Self::Value,
     ) -> Result<(), Self::Error> {
         let name =
-            CString::new(constant).map_err(|_| ConstantNameError::new(String::from(constant)))?;
+            CString::new(constant).map_err(|_| ConstantNameError::from(String::from(constant)))?;
         unsafe {
             let mrb = self.mrb.as_mut();
             sys::mrb_define_global_const(mrb, name.as_ptr() as *const i8, value.inner());
@@ -36,7 +36,7 @@ impl DefineConstant for Artichoke {
         T: 'static,
     {
         let name =
-            CString::new(constant).map_err(|_| ConstantNameError::new(String::from(constant)))?;
+            CString::new(constant).map_err(|_| ConstantNameError::from(String::from(constant)))?;
         let state = self.state.as_mut().ok_or(InterpreterExtractError)?;
         unsafe {
             let mrb = self.mrb.as_mut();
@@ -64,7 +64,7 @@ impl DefineConstant for Artichoke {
         T: 'static,
     {
         let name =
-            CString::new(constant).map_err(|_| ConstantNameError::new(String::from(constant)))?;
+            CString::new(constant).map_err(|_| ConstantNameError::from(String::from(constant)))?;
         let state = self.state.as_mut().ok_or(InterpreterExtractError)?;
         unsafe {
             let mrb = self.mrb.as_mut();

--- a/artichoke-backend/src/convert.rs
+++ b/artichoke-backend/src/convert.rs
@@ -60,7 +60,7 @@ where
 }
 
 /// Failed to convert from boxed Ruby value to a Rust type.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct UnboxRubyError {
     pub from: Ruby,
     pub into: Rust,
@@ -134,7 +134,7 @@ impl From<Box<UnboxRubyError>> for Box<dyn RubyException> {
 }
 
 /// Failed to convert from Rust type to a boxed Ruby value.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct BoxIntoRubyError {
     pub from: Rust,
     pub into: Ruby,

--- a/artichoke-backend/src/def.rs
+++ b/artichoke-backend/src/def.rs
@@ -220,6 +220,7 @@ impl From<Cow<'static, str>> for ConstantNameError {
 }
 
 impl ConstantNameError {
+    #[must_use]
     pub fn new() -> Self {
         Self::default()
     }

--- a/artichoke-backend/src/def.rs
+++ b/artichoke-backend/src/def.rs
@@ -201,12 +201,27 @@ impl Hash for EnclosingRubyScope {
 #[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ConstantNameError(Cow<'static, str>);
 
-impl ConstantNameError {
-    pub fn new<T>(name: T) -> Self
-    where
-        T: Into<Cow<'static, str>>,
-    {
+impl From<&'static str> for ConstantNameError {
+    fn from(name: &'static str) -> Self {
         Self(name.into())
+    }
+}
+
+impl From<String> for ConstantNameError {
+    fn from(name: String) -> Self {
+        Self(name.into())
+    }
+}
+
+impl From<Cow<'static, str>> for ConstantNameError {
+    fn from(name: Cow<'static, str>) -> Self {
+        Self(name)
+    }
+}
+
+impl ConstantNameError {
+    pub fn new() -> Self {
+        Self::default()
     }
 }
 

--- a/artichoke-backend/src/exception.rs
+++ b/artichoke-backend/src/exception.rs
@@ -57,7 +57,10 @@ impl From<Box<dyn RubyException>> for Exception {
 /// Because this precondition must hold for all frames between the caller and
 /// the closest [`sys::mrb_protect`] landing pad, this function should only be
 /// called in the entrypoint into Rust from mruby.
-pub unsafe fn raise(mut guard: Guard<'_>, exception: impl RubyException + fmt::Debug) -> ! {
+pub unsafe fn raise<T>(mut guard: Guard<'_>, exception: T) -> !
+where
+    T: RubyException + fmt::Debug,
+{
     let exc = exception.as_mrb_value(&mut guard);
     let mrb = guard.mrb.as_mut() as *mut _;
     drop(guard);

--- a/artichoke-backend/src/extn/core/env/backend/memory.rs
+++ b/artichoke-backend/src/extn/core/env/backend/memory.rs
@@ -12,6 +12,7 @@ pub struct Memory {
 }
 
 impl Memory {
+    /// Constructs a new, default ENV `Memory` backend.
     #[must_use]
     pub fn new() -> Self {
         Self::default()

--- a/artichoke-backend/src/extn/core/env/backend/mod.rs
+++ b/artichoke-backend/src/extn/core/env/backend/mod.rs
@@ -45,7 +45,7 @@ impl EnvArgumentError {
     #[inline]
     #[must_use]
     pub fn new() -> Self {
-        Self::default()
+        Self::from("ArgumentError")
     }
 }
 

--- a/artichoke-backend/src/extn/core/env/backend/system.rs
+++ b/artichoke-backend/src/extn/core/env/backend/system.rs
@@ -12,6 +12,7 @@ use crate::ffi;
 pub struct System;
 
 impl System {
+    /// Constructs a new, default ENV `System` backend.
     #[must_use]
     pub fn new() -> Self {
         Self::default()

--- a/artichoke-backend/src/extn/core/float/mod.rs
+++ b/artichoke-backend/src/extn/core/float/mod.rs
@@ -193,8 +193,8 @@ impl Float {
 
     #[inline]
     #[must_use]
-    pub fn new(num: Fp) -> Self {
-        Self(num)
+    pub fn new() -> Self {
+        Self::default()
     }
 
     #[inline]

--- a/artichoke-backend/src/extn/core/integer/mod.rs
+++ b/artichoke-backend/src/extn/core/integer/mod.rs
@@ -34,10 +34,17 @@ impl From<Int> for Integer {
     }
 }
 
-impl From<Integer> for Int {
+impl From<Integer> for i64 {
     #[inline]
     fn from(int: Integer) -> Self {
         int.as_i64()
+    }
+}
+
+impl From<Integer> for f64 {
+    #[inline]
+    fn from(int: Integer) -> Self {
+        int.as_f64()
     }
 }
 
@@ -56,10 +63,11 @@ impl From<Int> for Outcome {
 }
 
 impl Integer {
+    /// Constructs a new, default `Integer`.
     #[inline]
     #[must_use]
-    pub fn new(int: Int) -> Self {
-        Self(int)
+    pub fn new() -> Self {
+        Self::default()
     }
 
     #[inline]

--- a/artichoke-backend/src/extn/core/kernel/integer.rs
+++ b/artichoke-backend/src/extn/core/kernel/integer.rs
@@ -4,7 +4,7 @@ use std::error;
 use std::fmt;
 use std::iter::Iterator;
 use std::num::NonZeroU32;
-use std::str::{self, FromStr, Utf8Error};
+use std::str::{self, FromStr};
 
 use crate::extn::prelude::*;
 
@@ -17,12 +17,22 @@ impl Default for Radix {
     }
 }
 
+impl From<Radix> for u32 {
+    fn from(radix: Radix) -> Self {
+        radix.as_u32()
+    }
+}
+
 impl Radix {
+    /// Construct a new, default `Radix`.
+    ///
+    /// Default `Radix` is 10.
     #[must_use]
     pub fn new() -> Self {
         Self::default()
     }
 
+    /// Extract the `Radix` as the underlying `u32`.
     #[inline]
     #[must_use]
     pub fn as_u32(self) -> u32 {
@@ -36,17 +46,13 @@ impl TryConvertMut<Option<Value>, Option<Radix>> for Artichoke {
     fn try_convert_mut(&mut self, value: Option<Value>) -> Result<Option<Radix>, Self::Error> {
         if let Some(value) = value {
             let num = value.implicitly_convert_to_int(self)?;
-            if let Ok(radix) = u32::try_from(num) {
-                if let Some(radix) = NonZeroU32::new(radix) {
-                    if (2..=36).contains(&radix.get()) {
-                        return Ok(Some(Radix(radix)));
-                    }
-                }
+            let radix = u32::try_from(num).map_err(|_| ArgumentError::from("invalid radix"))?;
+            if (2..=36).contains(&radix) {
+                Ok(NonZeroU32::new(radix).map(Radix))
+            } else {
                 let mut message = String::from("invalid radix ");
                 string::format_int_into(&mut message, radix)?;
                 Err(ArgumentError::from(message).into())
-            } else {
-                Err(ArgumentError::from("invalid radix").into())
             }
         } else {
             Ok(None)
@@ -65,11 +71,11 @@ impl<'a> From<&'a str> for IntegerString<'a> {
 }
 
 impl<'a> TryFrom<&'a [u8]> for IntegerString<'a> {
-    type Error = NonNulUtf8Error;
+    type Error = Utf8Error;
 
     fn try_from(to_parse: &'a [u8]) -> Result<Self, Self::Error> {
         if to_parse.find_byte(b'\0').is_some() {
-            return Err(NonNulUtf8Error::NulByte);
+            return Err(Utf8Error::NulByte);
         }
         let to_parse = str::from_utf8(to_parse)?;
         Ok(to_parse.into())
@@ -77,12 +83,12 @@ impl<'a> TryFrom<&'a [u8]> for IntegerString<'a> {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum NonNulUtf8Error {
+pub enum Utf8Error {
     NulByte,
-    InvalidUtf8(Utf8Error),
+    InvalidUtf8(str::Utf8Error),
 }
 
-impl error::Error for NonNulUtf8Error {
+impl error::Error for Utf8Error {
     fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match self {
             Self::NulByte => None,
@@ -91,7 +97,7 @@ impl error::Error for NonNulUtf8Error {
     }
 }
 
-impl fmt::Display for NonNulUtf8Error {
+impl fmt::Display for Utf8Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::NulByte => write!(f, "String contained forbidden NUL byte"),
@@ -100,8 +106,8 @@ impl fmt::Display for NonNulUtf8Error {
     }
 }
 
-impl From<Utf8Error> for NonNulUtf8Error {
-    fn from(err: Utf8Error) -> Self {
+impl From<str::Utf8Error> for Utf8Error {
+    fn from(err: str::Utf8Error) -> Self {
         Self::InvalidUtf8(err)
     }
 }
@@ -153,27 +159,27 @@ impl<'a> TryConvertMut<&'a Value, IntegerString<'a>> for Artichoke {
     }
 }
 
-impl<'a> Into<&'a [u8]> for IntegerString<'a> {
+impl<'a> From<IntegerString<'a>> for &'a [u8] {
     #[inline]
-    fn into(self) -> &'a [u8] {
-        self.as_bytes()
+    fn from(string: IntegerString<'a>) -> &'a [u8] {
+        string.as_bytes()
     }
 }
 
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 enum Sign {
-    Pos,
-    Neg,
+    Positive,
+    Negative,
 }
 
 impl Default for Sign {
     #[inline]
     fn default() -> Self {
-        Self::Pos
+        Self::Positive
     }
 }
 
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 enum ParseState<'a> {
     Initial(IntegerString<'a>),
     Sign(IntegerString<'a>, Sign),
@@ -218,60 +224,53 @@ impl<'a> ParseState<'a> {
     }
 
     fn parse(self) -> Result<(String, Option<Radix>), Exception> {
-        match self {
-            Self::Accumulate(arg, sign, mut digits) => {
-                let (mut src, radix) = match digits.as_bytes() {
-                    [b'0', b'b', ..] | [b'0', b'B', ..] => {
-                        digits.drain(..2);
-                        (digits, Some(Radix(unsafe { NonZeroU32::new_unchecked(2) })))
-                    }
-                    [b'0', b'o', ..] | [b'0', b'O', ..] => {
-                        digits.drain(..2);
-                        (digits, Some(Radix(unsafe { NonZeroU32::new_unchecked(8) })))
-                    }
-                    [b'0', b'd', ..] | [b'0', b'D', ..] => {
-                        digits.drain(..2);
-                        (
-                            digits,
-                            Some(Radix(unsafe { NonZeroU32::new_unchecked(10) })),
-                        )
-                    }
-                    [b'0', b'x', ..] | [b'0', b'X', ..] => {
-                        digits.drain(..2);
-                        (
-                            digits,
-                            Some(Radix(unsafe { NonZeroU32::new_unchecked(16) })),
-                        )
-                    }
-                    [x, y, ..] => {
-                        let first = char::from(*x);
-                        let next = char::from(*y);
-                        if !next.is_numeric() && !next.is_alphabetic() {
-                            let mut message = String::from(r#"invalid value for Integer(): ""#);
-                            string::format_unicode_debug_into(&mut message, arg.into())?;
-                            message.push('"');
-                            return Err(ArgumentError::from(message).into());
-                        } else if '0' == first {
-                            digits.drain(..1);
-                            (digits, Some(Radix(unsafe { NonZeroU32::new_unchecked(8) })))
-                        } else {
-                            (digits, None)
-                        }
-                    }
-                    _ => (digits, None),
-                };
-                if let Sign::Neg = sign {
-                    src.insert(0, '-');
-                }
-                Ok((src, radix))
-            }
+        let (arg, sign, mut digits) = match self {
+            Self::Accumulate(arg, sign, digits) => (arg, sign, digits),
             Self::Initial(arg) | Self::Sign(arg, _) => {
                 let mut message = String::from(r#"invalid value for Integer(): ""#);
                 string::format_unicode_debug_into(&mut message, arg.into())?;
                 message.push('"');
-                Err(ArgumentError::from(message).into())
+                return Err(ArgumentError::from(message).into());
             }
+        };
+        let radix = match digits.as_bytes() {
+            [b'0', b'b', ..] | [b'0', b'B', ..] => {
+                digits.drain(..2);
+                Some(Radix(unsafe { NonZeroU32::new_unchecked(2) }))
+            }
+            [b'0', b'o', ..] | [b'0', b'O', ..] => {
+                digits.drain(..2);
+                Some(Radix(unsafe { NonZeroU32::new_unchecked(8) }))
+            }
+            [b'0', b'd', ..] | [b'0', b'D', ..] => {
+                digits.drain(..2);
+                Some(Radix(unsafe { NonZeroU32::new_unchecked(10) }))
+            }
+            [b'0', b'x', ..] | [b'0', b'X', ..] => {
+                digits.drain(..2);
+                Some(Radix(unsafe { NonZeroU32::new_unchecked(16) }))
+            }
+            [x, y, ..] => {
+                let first = char::from(*x);
+                let next = char::from(*y);
+                if !next.is_numeric() && !next.is_alphabetic() {
+                    let mut message = String::from(r#"invalid value for Integer(): ""#);
+                    string::format_unicode_debug_into(&mut message, arg.into())?;
+                    message.push('"');
+                    return Err(ArgumentError::from(message).into());
+                } else if '0' == first {
+                    digits.drain(..1);
+                    Some(Radix(unsafe { NonZeroU32::new_unchecked(8) }))
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        };
+        if let Sign::Negative = sign {
+            digits.insert(0, '-');
         }
+        Ok((digits, radix))
     }
 }
 
@@ -308,8 +307,8 @@ pub fn method(arg: IntegerString<'_>, radix: Option<Radix>) -> Result<Int, Excep
         }
 
         state = match current {
-            '+' => state.set_sign(Sign::Pos)?,
-            '-' => state.set_sign(Sign::Neg)?,
+            '+' => state.set_sign(Sign::Positive)?,
+            '-' => state.set_sign(Sign::Negative)?,
             digit => state.collect_digit(digit),
         };
         prev = Some(current);

--- a/artichoke-backend/src/extn/core/random/backend/default.rs
+++ b/artichoke-backend/src/extn/core/random/backend/default.rs
@@ -6,6 +6,14 @@ use crate::extn::prelude::*;
 #[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Default;
 
+impl Default {
+    /// Constructs a new, default `Default` Random backend.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
 impl RandType for Default {
     fn as_debug(&self) -> &dyn fmt::Debug {
         self

--- a/artichoke-backend/src/extn/core/random/mod.rs
+++ b/artichoke-backend/src/extn/core/random/mod.rs
@@ -15,8 +15,25 @@ pub enum Seed {
     None,
 }
 
+impl Default for Seed {
+    fn default() -> Self {
+        Self::None
+    }
+}
+
+impl From<Int> for Seed {
+    fn from(seed: Int) -> Seed {
+        Seed::New(seed)
+    }
+}
+
 impl Seed {
-    fn to_reseed(self) -> Option<u64> {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn to_reseed(self) -> Option<u64> {
         if let Self::New(seed) = self {
             #[allow(clippy::cast_possible_wrap, clippy::cast_sign_loss)]
             Some(seed as u64)

--- a/artichoke-backend/src/extn/core/random/mod.rs
+++ b/artichoke-backend/src/extn/core/random/mod.rs
@@ -33,6 +33,7 @@ impl Seed {
         Self::default()
     }
 
+    #[must_use]
     pub fn to_reseed(self) -> Option<u64> {
         if let Self::New(seed) = self {
             #[allow(clippy::cast_possible_wrap, clippy::cast_sign_loss)]

--- a/artichoke-backend/src/extn/core/regexp/enc.rs
+++ b/artichoke-backend/src/extn/core/regexp/enc.rs
@@ -11,6 +11,14 @@ use crate::extn::prelude::*;
 #[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct InvalidEncodingError;
 
+impl InvalidEncodingError {
+    /// Constructs a new, default `InvalidEncodingError`.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
 impl fmt::Display for InvalidEncodingError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Invalid Regexp encoding")

--- a/artichoke-backend/src/extn/core/regexp/enc.rs
+++ b/artichoke-backend/src/extn/core/regexp/enc.rs
@@ -91,6 +91,11 @@ impl fmt::Display for Encoding {
 }
 
 impl Encoding {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
     /// Convert an `Encoding` to its bitflag representation.
     ///
     /// Alias for the corresponding `Into<Int>` implementation.

--- a/artichoke-backend/src/extn/core/regexp/opts.rs
+++ b/artichoke-backend/src/extn/core/regexp/opts.rs
@@ -51,9 +51,15 @@ impl fmt::Display for Options {
 }
 
 impl Options {
+    /// Constructs a new, default `Options`.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
     /// An options instance that has only case insensitive mode enabled.
     #[must_use]
-    pub fn ignore_case() -> Self {
+    pub fn with_ignore_case() -> Self {
         let mut opts = Self::default();
         opts.ignore_case = true;
         opts
@@ -120,7 +126,7 @@ impl ConvertMut<Value, Options> for Artichoke {
         } else if let Ok(options) = value.try_into::<Option<bool>>(self) {
             match options {
                 Some(false) | None => Options::default(),
-                _ => Options::ignore_case(),
+                _ => Options::with_ignore_case(),
             }
         } else if let Ok(options) = value.try_into_mut::<&[u8]>(self) {
             Options {
@@ -130,7 +136,7 @@ impl ConvertMut<Value, Options> for Artichoke {
                 literal: false,
             }
         } else {
-            Options::ignore_case()
+            Options::with_ignore_case()
         }
     }
 }

--- a/artichoke-backend/src/extn/core/regexp/pattern.rs
+++ b/artichoke-backend/src/extn/core/regexp/pattern.rs
@@ -13,6 +13,11 @@ pub struct Pattern {
 }
 
 impl Pattern {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
     /// Return the pattern as a byte slice.
     #[must_use]
     pub fn pattern(&self) -> &[u8] {

--- a/artichoke-backend/src/extn/core/time/backend/chrono.rs
+++ b/artichoke-backend/src/extn/core/time/backend/chrono.rs
@@ -13,9 +13,6 @@ where
 {
 }
 
-#[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Factory;
-
 impl<T> Chrono<T>
 where
     T: TimeZone,
@@ -110,6 +107,17 @@ where
 
     fn is_sunday(&self) -> bool {
         self.0.weekday() == Weekday::Sun
+    }
+}
+
+#[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Factory;
+
+impl Factory {
+    /// Constructs a new, default `Factory` for the chrono Time backend.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
     }
 }
 

--- a/artichoke-backend/src/extn/core/time/mod.rs
+++ b/artichoke-backend/src/extn/core/time/mod.rs
@@ -27,6 +27,11 @@ impl fmt::Debug for Time {
 
 impl Time {
     #[must_use]
+    pub fn new() -> Self {
+        Self::now()
+    }
+
+    #[must_use]
     pub fn now() -> Self {
         Self(Box::new(Factory.now()))
     }

--- a/artichoke-backend/src/extn/core/time/mod.rs
+++ b/artichoke-backend/src/extn/core/time/mod.rs
@@ -25,6 +25,12 @@ impl fmt::Debug for Time {
     }
 }
 
+impl Default for Time {
+    fn default() -> Self {
+        Self::now()
+    }
+}
+
 impl Time {
     #[must_use]
     pub fn new() -> Self {

--- a/artichoke-backend/src/extn/stdlib/securerandom/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/securerandom/mod.rs
@@ -27,6 +27,14 @@ mod tests {
 #[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct SecureRandom;
 
+impl SecureRandom {
+    /// Constructs a new, default `SecureRandom`.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
 pub fn random_bytes(len: Option<Int>) -> Result<Vec<u8>, Exception> {
     let len = if let Some(len) = len {
         match usize::try_from(len) {

--- a/artichoke-backend/src/ffi.rs
+++ b/artichoke-backend/src/ffi.rs
@@ -61,6 +61,14 @@ pub unsafe fn from_user_data(
 #[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct InterpreterExtractError;
 
+impl InterpreterExtractError {
+    /// Constructs a new, default `InterpreterExtractError`.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
 impl fmt::Display for InterpreterExtractError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
@@ -143,6 +151,14 @@ pub fn os_string_to_bytes(value: OsString) -> Result<Vec<u8>, ConvertBytesError>
 
 #[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ConvertBytesError;
+
+impl ConvertBytesError {
+    /// Constructs a new, default `ConvertBytesError`.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
 
 impl fmt::Display for ConvertBytesError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/artichoke-backend/src/fs/memory.rs
+++ b/artichoke-backend/src/fs/memory.rs
@@ -97,10 +97,12 @@ impl From<Cow<'static, str>> for Code {
 }
 
 impl Code {
+    #[must_use]
     pub fn new() -> Self {
         Self::default()
     }
 
+    #[must_use]
     pub fn into_inner(self) -> Cow<'static, [u8]> {
         self.content
     }

--- a/artichoke-backend/src/fs/memory.rs
+++ b/artichoke-backend/src/fs/memory.rs
@@ -7,8 +7,15 @@ use std::path::{Path, PathBuf};
 
 use crate::fs::{absolutize_relative_to, ExtensionHook, Filesystem, RUBY_LOAD_PATH};
 
-struct Extension {
+#[derive(Clone, Copy)]
+pub struct Extension {
     hook: ExtensionHook,
+}
+
+impl From<ExtensionHook> for Extension {
+    fn from(hook: ExtensionHook) -> Self {
+        Self { hook }
+    }
 }
 
 impl Extension {
@@ -25,57 +32,157 @@ impl fmt::Debug for Extension {
     }
 }
 
-#[derive(Debug)]
-struct Code {
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Code {
     content: Cow<'static, [u8]>,
 }
 
-impl Code {
-    fn new<T>(content: T) -> Self
-    where
-        T: Into<Cow<'static, [u8]>>,
-    {
-        let content = content.into();
+impl Default for Code {
+    fn default() -> Self {
+        "# virtual source file".into()
+    }
+}
+
+impl From<Code> for Cow<'static, [u8]> {
+    fn from(code: Code) -> Self {
+        code.into_inner()
+    }
+}
+
+impl From<Vec<u8>> for Code {
+    fn from(content: Vec<u8>) -> Self {
+        Self {
+            content: content.into(),
+        }
+    }
+}
+
+impl From<&'static [u8]> for Code {
+    fn from(content: &'static [u8]) -> Self {
+        Self {
+            content: content.into(),
+        }
+    }
+}
+
+impl From<Cow<'static, [u8]>> for Code {
+    fn from(content: Cow<'static, [u8]>) -> Self {
         Self { content }
     }
 }
 
-#[derive(Debug)]
-struct Entry {
+impl From<String> for Code {
+    fn from(content: String) -> Self {
+        Self {
+            content: content.into_bytes().into(),
+        }
+    }
+}
+
+impl From<&'static str> for Code {
+    fn from(content: &'static str) -> Self {
+        Self {
+            content: content.as_bytes().into(),
+        }
+    }
+}
+
+impl From<Cow<'static, str>> for Code {
+    fn from(content: Cow<'static, str>) -> Self {
+        match content {
+            Cow::Borrowed(content) => Self::from(content.as_bytes()),
+            Cow::Owned(content) => Self::from(content.into_bytes()),
+        }
+    }
+}
+
+impl Code {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn into_inner(self) -> Cow<'static, [u8]> {
+        self.content
+    }
+}
+
+#[derive(Default, Debug)]
+pub struct Entry {
     code: Option<Code>,
     extension: Option<Extension>,
     required: bool,
 }
 
+impl From<Code> for Entry {
+    fn from(code: Code) -> Self {
+        let mut entry = Self::default();
+        entry.code = Some(code);
+        entry
+    }
+}
+
+impl From<Vec<u8>> for Entry {
+    fn from(content: Vec<u8>) -> Self {
+        let mut entry = Self::default();
+        entry.code = Some(content.into());
+        entry
+    }
+}
+
+impl From<&'static [u8]> for Entry {
+    fn from(content: &'static [u8]) -> Self {
+        let mut entry = Self::default();
+        entry.code = Some(content.into());
+        entry
+    }
+}
+
+impl From<Cow<'static, [u8]>> for Entry {
+    fn from(content: Cow<'static, [u8]>) -> Self {
+        let mut entry = Self::default();
+        entry.code = Some(content.into());
+        entry
+    }
+}
+
+impl From<String> for Entry {
+    fn from(content: String) -> Self {
+        let mut entry = Self::default();
+        entry.code = Some(content.into());
+        entry
+    }
+}
+
+impl From<&'static str> for Entry {
+    fn from(content: &'static str) -> Self {
+        let mut entry = Self::default();
+        entry.code = Some(content.into());
+        entry
+    }
+}
+
+impl From<Cow<'static, str>> for Entry {
+    fn from(content: Cow<'static, str>) -> Self {
+        let mut entry = Self::default();
+        entry.code = Some(content.into());
+        entry
+    }
+}
+
+impl From<ExtensionHook> for Entry {
+    fn from(hook: ExtensionHook) -> Self {
+        let mut entry = Self::default();
+        entry.extension = Some(hook.into());
+        entry
+    }
+}
+
 impl Entry {
-    fn default_file_contents() -> &'static [u8] {
-        &b"# virtual source file"[..]
-    }
-
-    fn from_code<T>(content: T) -> Self
-    where
-        T: Into<Cow<'static, [u8]>>,
-    {
-        Self {
-            code: Some(Code::new(content.into())),
-            extension: None,
-            required: false,
-        }
-    }
-
-    fn from_ext(hook: ExtensionHook) -> Self {
-        Self {
-            code: None,
-            extension: Some(Extension::new(hook)),
-            required: false,
-        }
-    }
-
     fn replace_content<T>(&mut self, content: T)
     where
         T: Into<Cow<'static, [u8]>>,
     {
-        self.code.replace(Code::new(content.into()));
+        self.code.replace(Code::from(content.into()));
     }
 
     fn set_extension(&mut self, hook: ExtensionHook) {
@@ -182,7 +289,7 @@ impl Filesystem for Memory {
                     Cow::Owned(ref content) => Ok(content.clone().into()),
                 }
             } else {
-                Ok(Entry::default_file_contents().into())
+                Ok(Code::default().into())
             }
         } else {
             Err(io::Error::new(
@@ -208,7 +315,7 @@ impl Filesystem for Memory {
                 entry.get_mut().replace_content(buf);
             }
             HashEntry::Vacant(entry) => {
-                entry.insert(Entry::from_code(buf));
+                entry.insert(Entry::from(buf));
             }
         }
         Ok(())
@@ -242,7 +349,7 @@ impl Filesystem for Memory {
                 entry.get_mut().set_extension(extension);
             }
             HashEntry::Vacant(entry) => {
-                entry.insert(Entry::from_ext(extension));
+                entry.insert(Entry::from(extension));
             }
         }
         Ok(())

--- a/artichoke-backend/src/interpreter.rs
+++ b/artichoke-backend/src/interpreter.rs
@@ -88,6 +88,14 @@ where
 #[allow(clippy::module_name_repetitions)]
 pub struct InterpreterAllocError;
 
+impl InterpreterAllocError {
+    /// Constructs a new, default `InterpreterAllocError`.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
 impl fmt::Display for InterpreterAllocError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Failed to allocate Artichoke interpreter")

--- a/artichoke-backend/src/method.rs
+++ b/artichoke-backend/src/method.rs
@@ -44,7 +44,7 @@ impl Spec {
                 args,
             })
         } else {
-            Err(ConstantNameError::new(name))
+            Err(name.into())
         }
     }
 

--- a/artichoke-backend/src/module.rs
+++ b/artichoke-backend/src/module.rs
@@ -132,7 +132,7 @@ impl Spec {
                 enclosing_scope: enclosing_scope.map(Box::new),
             })
         } else {
-            Err(ConstantNameError::new(name))
+            Err(name.into())
         }
     }
 

--- a/artichoke-backend/src/state/mod.rs
+++ b/artichoke-backend/src/state/mod.rs
@@ -49,7 +49,7 @@ impl State {
             regexp: regexp::State::new(),
             output: output::Strategy::new(),
             #[cfg(feature = "core-random")]
-            prng: Prng::default(),
+            prng: Prng::new(),
         };
         Some(state)
     }

--- a/artichoke-backend/src/state/output.rs
+++ b/artichoke-backend/src/state/output.rs
@@ -37,6 +37,7 @@ pub trait Output: Send + Sync {
 pub struct Process;
 
 impl Process {
+    /// Constructs a new, default `Process` output strategy.
     #[must_use]
     pub fn new() -> Self {
         Self
@@ -64,6 +65,7 @@ pub struct Captured {
 }
 
 impl Captured {
+    /// Constructs a new, default `Captured` output strategy.
     #[must_use]
     pub fn new() -> Self {
         Self::default()
@@ -121,6 +123,7 @@ impl<'a> Output for &'a mut Captured {
 pub struct Null;
 
 impl Null {
+    /// Constructs a new, default `Null` output strategy.
     #[must_use]
     pub fn new() -> Self {
         Self

--- a/artichoke-backend/src/state/output.rs
+++ b/artichoke-backend/src/state/output.rs
@@ -40,7 +40,7 @@ impl Process {
     /// Constructs a new, default `Process` output strategy.
     #[must_use]
     pub fn new() -> Self {
-        Self
+        Self::default()
     }
 }
 
@@ -126,7 +126,7 @@ impl Null {
     /// Constructs a new, default `Null` output strategy.
     #[must_use]
     pub fn new() -> Self {
-        Self
+        Self::default()
     }
 }
 

--- a/artichoke-backend/src/state/parser.rs
+++ b/artichoke-backend/src/state/parser.rs
@@ -1,7 +1,6 @@
 use std::borrow::Cow;
 use std::convert::TryFrom;
 use std::ffi::{CStr, CString};
-use std::fmt;
 use std::ptr::NonNull;
 
 use crate::core::IncrementLinenoError;
@@ -10,18 +9,10 @@ use crate::sys;
 /// Filename of the top eval context.
 pub const TOP_FILENAME: &[u8] = b"(eval)";
 
+#[derive(Debug)]
 pub struct State {
     context: NonNull<sys::mrbc_context>,
     stack: Vec<Context>,
-}
-
-impl fmt::Debug for State {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("parser::State")
-            .field("context", &"non-null mrb_context")
-            .field("stack", &self.stack)
-            .finish()
-    }
 }
 
 impl State {

--- a/artichoke-backend/src/state/prng.rs
+++ b/artichoke-backend/src/state/prng.rs
@@ -7,13 +7,36 @@ pub struct Prng {
     random: Rand<Rng>,
 }
 
-impl Prng {
-    #[must_use]
-    #[inline]
-    pub fn new(seed: Option<u64>) -> Self {
+impl From<u64> for Prng {
+    fn from(seed: u64) -> Self {
+        Self {
+            random: Rand::new(Some(seed)),
+        }
+    }
+}
+
+impl From<Option<u64>> for Prng {
+    fn from(seed: Option<u64>) -> Self {
         Self {
             random: Rand::new(seed),
         }
+    }
+}
+
+impl Default for Prng {
+    #[inline]
+    fn default() -> Self {
+        Self {
+            random: Rand::new(None),
+        }
+    }
+}
+
+impl Prng {
+    #[must_use]
+    #[inline]
+    pub fn new() -> Self {
+        Self::default()
     }
 
     #[must_use]
@@ -46,12 +69,5 @@ impl Prng {
     #[inline]
     pub fn rand_float(&mut self, max: Option<Fp>) -> Fp {
         self.random.rand_float(max)
-    }
-}
-
-impl Default for Prng {
-    #[inline]
-    fn default() -> Self {
-        Self::new(None)
     }
 }

--- a/artichoke-backend/src/state/regexp.rs
+++ b/artichoke-backend/src/state/regexp.rs
@@ -4,6 +4,7 @@ pub struct State {
 }
 
 impl State {
+    /// Constructs a new, default Regexp `State`.
     #[inline]
     #[must_use]
     pub fn new() -> Self {

--- a/artichoke-backend/src/string.rs
+++ b/artichoke-backend/src/string.rs
@@ -66,7 +66,16 @@ where
     W: fmt::Write,
     I: itoa::Integer,
 {
-    itoa::fmt(f, value).map_err(WriteError)?;
+    itoa::fmt(f, value)?;
+    Ok(())
+}
+
+pub fn write_int_into<W, I>(f: W, value: I) -> Result<(), IoWriteError>
+where
+    W: io::Write,
+    I: itoa::Integer,
+{
+    itoa::write(f, value)?;
     Ok(())
 }
 
@@ -79,7 +88,7 @@ where
     // `format_into_int` above.
     //
     // See: https://github.com/dtolnay/dtoa/issues/18
-    dtoa::write(f, value).map_err(IoWriteError)?;
+    dtoa::write(f, value)?;
     Ok(())
 }
 
@@ -88,6 +97,12 @@ where
 /// This error type wraps a [`fmt::Error`].
 #[derive(Debug, Clone)]
 pub struct WriteError(fmt::Error);
+
+impl From<fmt::Error> for WriteError {
+    fn from(err: fmt::Error) -> Self {
+        Self(err)
+    }
+}
 
 impl WriteError {
     #[inline]
@@ -166,6 +181,12 @@ impl From<Box<WriteError>> for Box<dyn RubyException> {
 /// This error type wraps an [`io::Error`].
 #[derive(Debug)]
 pub struct IoWriteError(io::Error);
+
+impl From<io::Error> for IoWriteError {
+    fn from(err: io::Error) -> Self {
+        Self(err)
+    }
+}
 
 impl IoWriteError {
     #[inline]

--- a/artichoke-backend/src/sys/protect.rs
+++ b/artichoke-backend/src/sys/protect.rs
@@ -167,7 +167,7 @@ pub struct Range {
 
 // `IsRange` must be `Copy` because the we may unwind past the frames in which
 // it is used with `longjmp` which does not allow Rust  to run destructors.
-#[derive(Clone, Copy)]
+#[derive(Default, Debug, Clone, Copy)]
 struct IsRange {
     value: sys::mrb_value,
     len: sys::mrb_int,

--- a/spec-runner/src/model.rs
+++ b/spec-runner/src/model.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use std::ffi::OsStr;
 
 /// Config file format for declaring the set of ruby/spec suites to run.
-#[derive(Default, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct Config {
     /// Specs for core language features.
     ///
@@ -41,7 +41,7 @@ impl Config {
 }
 
 /// The specs to run for a suite or API group.
-#[derive(Default, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct Suite {
     /// Suite name.
     ///

--- a/spec-runner/src/model.rs
+++ b/spec-runner/src/model.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use std::ffi::OsStr;
 
 /// Config file format for declaring the set of ruby/spec suites to run.
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct Config {
     /// Specs for core language features.
     ///
@@ -24,19 +24,24 @@ pub struct Config {
 }
 
 impl Config {
+    /// Construct a new, empty `Config`.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
     /// Lookup a suite.
     pub fn suites_for_family(&self, family: &OsStr) -> Option<&[Suite]> {
-        match family {
-            family if family == OsStr::new("lanugage") => self.language.as_deref(),
-            family if family == OsStr::new("core") => self.core.as_deref(),
-            family if family == OsStr::new("library") => self.library.as_deref(),
+        match family.to_str()? {
+            "lanugage" => self.language.as_deref(),
+            "core" => self.core.as_deref(),
+            "library" => self.library.as_deref(),
             _ => None,
         }
     }
 }
 
 /// The specs to run for a suite or API group.
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct Suite {
     /// Suite name.
     ///
@@ -51,4 +56,11 @@ pub struct Suite {
     /// Specs in this list will override an explicit include in the `specs`
     /// field.
     pub skip: Option<Vec<String>>,
+}
+
+impl Suite {
+    /// Construct a new, empty `Suite`.
+    pub fn new() -> Self {
+        Self::default()
+    }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -38,6 +38,7 @@ pub enum State {
 
 impl State {
     /// Construct a new, default `State`.
+    #[must_use]
     pub fn new() -> Self {
         Self::default()
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -37,6 +37,11 @@ pub enum State {
 }
 
 impl State {
+    /// Construct a new, default `State`.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
     /// Whether this variant indicates a code block is open.
     ///
     /// This method can be used by a REPL to check whether to buffer code or

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -31,7 +31,15 @@ mod filename_test {
 ///
 /// The parser is needed to properly enter and exit multi-line editing mode.
 #[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-struct ParserAllocError;
+pub struct ParserAllocError;
+
+impl ParserAllocError {
+    /// Constructs a new, default `ParserAllocError`.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
 
 impl fmt::Display for ParserAllocError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -43,7 +51,15 @@ impl error::Error for ParserAllocError {}
 
 /// Parser processed too many lines of input.
 #[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-struct ParserLineCountError;
+pub struct ParserLineCountError;
+
+impl ParserLineCountError {
+    /// Constructs a new, default `ParserLineCountError`.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
 
 impl fmt::Display for ParserLineCountError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -57,7 +73,15 @@ impl error::Error for ParserLineCountError {}
 ///
 /// This is usually an unknown FFI to Rust translation.
 #[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-struct ParserInternalError;
+pub struct ParserInternalError;
+
+impl ParserInternalError {
+    /// Constructs a new, default `ParserInternalError`.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
 
 impl fmt::Display for ParserInternalError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {


### PR DESCRIPTION
This PR has many quality improvements that are driven by following the advice in the [Rust API guidelines](https://rust-lang.github.io/api-guidelines/interoperability.html) to have zero argument `new` constructors.

The consequence of following this advice is many more `From` impls which I think make the code easier to reason about.