### PR TITLE
Switch frontend binaries from ansi_term to termcolor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,13 +22,13 @@ dependencies = [
 name = "artichoke"
 version = "0.1.0-pre.0"
 dependencies = [
- "ansi_term",
  "artichoke-backend",
  "chrono",
  "doc-comment",
  "rustyline",
  "structopt",
  "target-lexicon",
+ "termcolor",
 ]
 
 [[package]]
@@ -699,6 +699,15 @@ name = "target-lexicon"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe2635952a442a01fd4cb53d98858b5e4bb461b02c0d111f22f31772e3e7a8b2"
+
+[[package]]
+name = "termcolor"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "textwrap"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,9 @@ keywords = ["artichoke", "artichoke-ruby", "mri", "cruby", "ruby"]
 categories = ["command-line-utilities"]
 
 [dependencies]
-ansi_term = "0.11" # cannot upgrade until clap 3 is released
 rustyline = { version = "6", default-features = false }
-structopt = "0.3.15"
+structopt = "0.3"
+termcolor = "1.1"
 
 [dependencies.artichoke-backend]
 path = "artichoke-backend"

--- a/src/bin/airb.rs
+++ b/src/bin/airb.rs
@@ -23,10 +23,14 @@
 use artichoke::repl;
 use std::io::{self, Write};
 use std::process;
+use termcolor::{ColorChoice, StandardStream, WriteColor};
 
 fn main() {
-    if let Err(err) = repl::run(io::stdout(), io::stderr(), None) {
-        let _ = writeln!(io::stderr(), "{}", err);
+    let mut stderr = StandardStream::stderr(ColorChoice::Auto);
+    if let Err(err) = repl::run(io::stdout(), &mut stderr, None) {
+        // reset colors
+        let _ = stderr.reset();
+        let _ = writeln!(stderr, "{}", err);
         process::exit(1);
     }
 }

--- a/src/bin/artichoke.rs
+++ b/src/bin/artichoke.rs
@@ -37,13 +37,17 @@
 use artichoke::ruby;
 use std::io::{self, Write};
 use std::process;
+use termcolor::{ColorChoice, StandardStream, WriteColor};
 
 fn main() {
-    match ruby::entrypoint(io::stdin(), io::stderr()) {
+    let mut stderr = StandardStream::stderr(ColorChoice::Auto);
+    match ruby::entrypoint(io::stdin(), &mut stderr) {
         Ok(Ok(())) => {}
         Ok(Err(())) => process::exit(1),
         Err(err) => {
-            let _ = writeln!(io::stderr(), "{}", err);
+            // reset colors
+            let _ = stderr.reset();
+            let _ = writeln!(stderr, "{}", err);
             process::exit(1);
         }
     }

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -9,6 +9,7 @@ use rustyline::Editor;
 use std::error;
 use std::fmt;
 use std::io;
+use termcolor::WriteColor;
 
 use crate::backend::state::parser::Context;
 use crate::backtrace;
@@ -166,7 +167,7 @@ pub fn run<Wout, Werr>(
 ) -> Result<(), Box<dyn error::Error>>
 where
     Wout: io::Write,
-    Werr: io::Write,
+    Werr: io::Write + WriteColor,
 {
     let config = config.unwrap_or_default();
     let mut interp = crate::interpreter()?;


### PR DESCRIPTION
Artichoke previously used ansi_term because that was bundled with clap.
clap v3 switches to using termcolor for colorizing output for better
Windows support. termcolor is also used in ripgrep.

termcolor's API is a bit more awkward, but it was fairly straightforward
to make this change.