### PR TITLE
Tweaks to rustdoc generation

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -21,7 +21,7 @@ jobs:
         run: |
           curl -sL "$RELEASE" | sudo tar xvz -C /usr/local/bin/ --strip-components=1
         env:
-          RELEASE: "https://github.com/EmbarkStudios/cargo-deny/releases/download/0.6.6/cargo-deny-0.6.6-x86_64-unknown-linux-musl.tar.gz"
+          RELEASE: "https://github.com/EmbarkStudios/cargo-deny/releases/download/0.6.8/cargo-deny-0.6.8-x86_64-unknown-linux-musl.tar.gz"
 
       - name: Run cargo-deny
         run: cargo-deny check

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,6 +47,10 @@ jobs:
         if: matrix.os == 'windows-latest'
 
       - name: Check Bison
+        run: bison --version
+        if: matrix.os != 'windows-latest'
+
+      - name: Check Bison
         run: |
           win_bison.exe --version
           win_bison --version

--- a/.github/workflows/rustdoc.yaml
+++ b/.github/workflows/rustdoc.yaml
@@ -38,7 +38,7 @@ jobs:
         run: sudo apt install bison
 
       - name: Build Documentation
-        run: cargo doc --workspace --no-deps
+        run: cargo doc
 
       - name: Copy static content
         run: cp --verbose .github/rustdoc/* target/doc/

--- a/artichoke-backend/src/interpreter.rs
+++ b/artichoke-backend/src/interpreter.rs
@@ -23,7 +23,7 @@ pub fn interpreter() -> Result<Artichoke, Exception> {
     interpreter_with_config(ArtichokeBackendReleaseMetadata::default())
 }
 
-/// Create and initialize an [`Artichoke`] interpreter.
+/// Create and initialize an [`Artichoke`] interpreter with build metadata.
 ///
 /// This function takes a customizable configuration for embedding metadata
 /// about how Artichoke was built. Otherwise, it behaves identically to the


### PR DESCRIPTION
Don't pass --workspace or --no-deps to `cargo doc` to enable better inter crate linking and linking to `std`.

Pull in latest cargo-deny release