### PR TITLE
Use Artichoke::with_ffi_boundary in more places

### DIFF
--- a/artichoke-backend/src/class_registry.rs
+++ b/artichoke-backend/src/class_registry.rs
@@ -4,7 +4,6 @@ use std::convert::TryFrom;
 use crate::class;
 use crate::exception::Exception;
 use crate::ffi::InterpreterExtractError;
-use crate::gc::{MrbGarbageCollection, State as GcState};
 use crate::sys;
 use crate::types::Int;
 use crate::value::Value;
@@ -73,56 +72,32 @@ impl ClassRegistry for Artichoke {
     {
         let state = self.state.as_ref().ok_or(InterpreterExtractError)?;
         let spec = state.classes.get::<T>();
-        let spec = if let Some(spec) = spec {
-            spec
+        let rclass = if let Some(spec) = spec {
+            spec.rclass()
         } else {
             return Ok(None);
         };
-        unsafe {
-            let mrb = self.mrb.as_mut();
-            if let Some(mut rclass) = spec.rclass(mrb) {
-                let class = sys::mrb_sys_class_value(rclass.as_mut());
-                Ok(Some(Value::from(class)))
-            } else {
-                Ok(None)
-            }
-        }
+        let class = unsafe {
+            self.with_ffi_boundary(|mrb| {
+                if let Some(mut rclass) = rclass.resolve(mrb) {
+                    let class = sys::mrb_sys_class_value(rclass.as_mut());
+                    Some(Value::from(class))
+                } else {
+                    None
+                }
+            })?
+        };
+        Ok(class)
     }
 
     fn new_instance<T>(&mut self, args: &[Value]) -> Result<Option<Value>, Exception>
     where
         T: Any,
     {
-        // Disable the GC to prevent a collection cycle from re-entering into
-        // Rust code while the `State` is moved out of the `mrb`.
-        //
-        // It is not safe to run with the GC enabled in this method because:
-        //
-        // 1. This method must hold a borrow on the `State` to grab a handle to
-        //    the class spec -> `sys::mrb_data_type`.
-        // 2. Because of (1), the `State` must be moved into the `Artichoke`
-        //    struct.
-        // 3. Because of (2), subsequent mruby FFI calls will have a `NULL` ud
-        //    pointer.
-        // 4. Because of (3), it is not safe to re-enter into any Artichoke
-        //    implemented FFI trampolines that expect to extract an interpreter.
-        // 5. Garbage collection mark functions are one such trampoline that are
-        //    not safe to re-enter.
-        // 6. `Array` is implemented in Rust and implements its GC mark routine
-        //    expecting to extract an intialized `Artichoke`.
-        // 7. Failing to extract an initialized `Artichoke`, `Array` GC mark is
-        //    a no-op.
-        // 6. Values in these `Array`s are deallocated as unreachable, creating
-        //    dangling references that when accessed result in a use-after-free.
-        //
-        // The most expedient way to avoid this is turn off the GC when
-        // allocating with `mrb_data_object_alloc` below.
-        let prior_gc_state = self.disable_gc();
-
         let state = self.state.as_ref().ok_or(InterpreterExtractError)?;
         let spec = state.classes.get::<T>();
-        let spec = if let Some(spec) = spec {
-            spec
+        let rclass = if let Some(spec) = spec {
+            spec.rclass()
         } else {
             return Ok(None);
         };
@@ -133,18 +108,16 @@ impl ClassRegistry for Artichoke {
             return Ok(None);
         };
         let instance = unsafe {
-            let mrb = self.mrb.as_mut();
-            if let Some(mut rclass) = spec.rclass(mrb) {
-                let value = sys::mrb_obj_new(mrb, rclass.as_mut(), arglen, args.as_ptr());
-                Ok(Some(Value::from(value)))
-            } else {
-                Ok(None)
-            }
+            self.with_ffi_boundary(|mrb| {
+                if let Some(mut rclass) = rclass.resolve(mrb) {
+                    let value = sys::mrb_obj_new(mrb, rclass.as_mut(), arglen, args.as_ptr());
+                    Some(Value::from(value))
+                } else {
+                    None
+                }
+            })?
         };
-        if let GcState::Enabled = prior_gc_state {
-            self.enable_gc();
-        }
 
-        instance
+        Ok(instance)
     }
 }

--- a/artichoke-backend/src/convert/string.rs
+++ b/artichoke-backend/src/convert/string.rs
@@ -76,11 +76,14 @@ mod tests {
         let mut interp = crate::interpreter().unwrap();
         let value = interp.convert_mut(s.clone());
         let string = unsafe {
-            let mrb = interp.mrb.as_mut();
-            let ptr = sys::mrb_string_value_ptr(mrb, value.inner());
-            let len = sys::mrb_string_value_len(mrb, value.inner());
-            let len = usize::try_from(len).unwrap();
-            slice::from_raw_parts(ptr as *const u8, len)
+            interp
+                .with_ffi_boundary(|mrb| {
+                    let ptr = sys::mrb_string_value_ptr(mrb, value.inner());
+                    let len = sys::mrb_string_value_len(mrb, value.inner());
+                    let len = usize::try_from(len).unwrap();
+                    slice::from_raw_parts(ptr as *const u8, len)
+                })
+                .unwrap()
         };
         s.as_bytes() == string
     }

--- a/artichoke-backend/src/gc/arena.rs
+++ b/artichoke-backend/src/gc/arena.rs
@@ -87,9 +87,10 @@ impl<'a> DerefMut for ArenaIndex<'a> {
 
 impl<'a> Drop for ArenaIndex<'a> {
     fn drop(&mut self) {
-        unsafe {
-            let mrb = self.interp.mrb.as_mut();
-            sys::mrb_sys_gc_arena_restore(mrb, self.index);
-        }
+        let idx = self.index;
+        let _ = unsafe {
+            self.interp
+                .with_ffi_boundary(|mrb| sys::mrb_sys_gc_arena_restore(mrb, idx))
+        };
     }
 }

--- a/artichoke-backend/src/globals.rs
+++ b/artichoke-backend/src/globals.rs
@@ -17,10 +17,9 @@ impl Globals for Artichoke {
     where
         T: Into<Cow<'static, [u8]>>,
     {
-        let sym = self.intern_symbol(name.into());
+        let sym = self.intern_symbol(name.into())?;
         unsafe {
-            let mrb = self.mrb.as_mut();
-            sys::mrb_gv_set(mrb, sym, value.inner());
+            self.with_ffi_boundary(|mrb| sys::mrb_gv_set(mrb, sym, value.inner()))?;
         }
         Ok(())
     }
@@ -39,11 +38,10 @@ impl Globals for Artichoke {
     where
         T: Into<Cow<'static, [u8]>>,
     {
-        let sym = self.intern_symbol(name.into());
+        let sym = self.intern_symbol(name.into())?;
         let nil = Value::nil();
         unsafe {
-            let mrb = self.mrb.as_mut();
-            sys::mrb_gv_set(mrb, sym, nil.inner());
+            self.with_ffi_boundary(|mrb| sys::mrb_gv_set(mrb, sym, nil.inner()))?;
         }
         Ok(())
     }
@@ -52,11 +50,8 @@ impl Globals for Artichoke {
     where
         T: Into<Cow<'static, [u8]>>,
     {
-        let sym = self.intern_symbol(name.into());
-        let value = unsafe {
-            let mrb = self.mrb.as_mut();
-            sys::mrb_gv_get(mrb, sym)
-        };
+        let sym = self.intern_symbol(name.into())?;
+        let value = unsafe { self.with_ffi_boundary(|mrb| sys::mrb_gv_get(mrb, sym))? };
         // NOTE: This implementation is not compliant with the spec laid out in
         // the trait documentation. This implementation always returns `Some(_)`
         // even if the global is unset.

--- a/artichoke-backend/src/intern.rs
+++ b/artichoke-backend/src/intern.rs
@@ -1,26 +1,26 @@
 use std::borrow::Cow;
 
 use crate::core::Intern;
+use crate::exception::Exception;
 use crate::sys;
 use crate::Artichoke;
 
 impl Intern for Artichoke {
     type Symbol = sys::mrb_sym;
+    type Error = Exception;
 
-    fn intern_symbol<T>(&mut self, symbol: T) -> Self::Symbol
+    fn intern_symbol<T>(&mut self, symbol: T) -> Result<Self::Symbol, Self::Error>
     where
         T: Into<Cow<'static, [u8]>>,
     {
-        match symbol.into() {
-            Cow::Borrowed(bytes) => unsafe {
-                let mrb = self.mrb.as_mut();
+        let symbol = symbol.into();
+        let bytes = symbol.as_ref();
+        let sym = unsafe {
+            self.with_ffi_boundary(|mrb| {
                 sys::mrb_intern(mrb, bytes.as_ptr() as *const i8, bytes.len())
-            },
-            Cow::Owned(bytes) => unsafe {
-                let mrb = self.mrb.as_mut();
-                sys::mrb_intern(mrb, bytes.as_ptr() as *const i8, bytes.len())
-            },
-        }
+            })?
+        };
+        Ok(sym)
     }
 
     fn lookup_symbol(&self, symbol: Self::Symbol) -> Option<&[u8]> {

--- a/artichoke-backend/src/module.rs
+++ b/artichoke-backend/src/module.rs
@@ -76,33 +76,112 @@ impl<'a> Builder<'a> {
     }
 
     pub fn define(self) -> Result<(), NotDefinedError> {
-        let mrb = unsafe { self.interp.mrb.as_mut() };
-        let mut rclass = if let Some(rclass) = self.spec.rclass(mrb) {
+        let name = self.spec.name_c_str().as_ptr();
+
+        let rclass = self.spec.rclass();
+        let rclass = unsafe { self.interp.with_ffi_boundary(|mrb| rclass.resolve(mrb)) };
+
+        let mut rclass = if let Ok(Some(rclass)) = rclass {
             rclass
-        } else if let Some(scope) = self.spec.enclosing_scope() {
-            let mut scope_rclass = scope
-                .rclass(mrb)
-                .ok_or_else(|| NotDefinedError::enclosing_scope(scope.fqname().into_owned()))?;
-            let rclass = unsafe {
-                sys::mrb_define_module_under(
-                    mrb,
-                    scope_rclass.as_mut(),
-                    self.spec.name_c_str().as_ptr(),
-                )
+        } else if let Some(enclosing_scope) = self.spec.enclosing_scope() {
+            let scope = unsafe {
+                self.interp
+                    .with_ffi_boundary(|mrb| enclosing_scope.rclass(mrb))
             };
-            NonNull::new(rclass)
-                .ok_or_else(|| NotDefinedError::module(self.spec.name.as_ref().to_owned()))?
+            if let Ok(Some(mut scope)) = scope {
+                let rclass = unsafe {
+                    self.interp.with_ffi_boundary(|mrb| {
+                        sys::mrb_define_module_under(mrb, scope.as_mut(), name)
+                    })
+                };
+                let rclass = rclass.map_err(|_| NotDefinedError::module(self.spec.name()))?;
+                NonNull::new(rclass).ok_or_else(|| NotDefinedError::module(self.spec.name()))?
+            } else {
+                return Err(NotDefinedError::enclosing_scope(
+                    enclosing_scope.fqname().into_owned(),
+                ));
+            }
         } else {
-            let rclass = unsafe { sys::mrb_define_module(mrb, self.spec.name_c_str().as_ptr()) };
-            NonNull::new(rclass)
-                .ok_or_else(|| NotDefinedError::module(self.spec.name.as_ref().to_owned()))?
+            let rclass = unsafe {
+                self.interp
+                    .with_ffi_boundary(|mrb| sys::mrb_define_module(mrb, name))
+            };
+            let rclass = rclass.map_err(|_| NotDefinedError::module(self.spec.name()))?;
+            NonNull::new(rclass).ok_or_else(|| NotDefinedError::module(self.spec.name()))?
         };
+
         for method in self.methods {
             unsafe {
-                method.define(self.interp, rclass.as_mut());
+                method.define(self.interp, rclass.as_mut())?;
             }
         }
         Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Rclass {
+    sym: sys::mrb_sym,
+    name: CString,
+    enclosing_scope: Option<Box<EnclosingRubyScope>>,
+}
+
+impl Rclass {
+    #[must_use]
+    pub fn new(
+        sym: sys::mrb_sym,
+        name: CString,
+        enclosing_scope: Option<Box<EnclosingRubyScope>>,
+    ) -> Self {
+        Self {
+            sym,
+            name,
+            enclosing_scope,
+        }
+    }
+
+    /// Resolve a type's [`sys::RClass`] using its enclosing scope and name.
+    ///
+    /// # Safety
+    ///
+    /// This function must be called within an [`Artichoke::with_ffi_boundary`]
+    /// closure because the FFI APIs called in this function may require access
+    /// to the Artichoke [`State](crate::state::State).
+    pub unsafe fn resolve(&self, mrb: *mut sys::mrb_state) -> Option<NonNull<sys::RClass>> {
+        let module_name = self.name.as_ptr();
+        if let Some(ref scope) = self.enclosing_scope {
+            // Short circuit if enclosing scope does not exist.
+            let mut scope = scope.rclass(mrb)?;
+            let is_defined_under = sys::mrb_const_defined_at(
+                mrb,
+                sys::mrb_sys_obj_value(scope.cast::<c_void>().as_mut()),
+                self.sym,
+            );
+            if is_defined_under == 0 {
+                // Enclosing scope exists.
+                // Module is not defined under the enclosing scope.
+                None
+            } else {
+                // Enclosing scope exists.
+                // Module is defined under the enclosing scope.
+                let module = sys::mrb_module_get_under(mrb, scope.as_mut(), module_name);
+                NonNull::new(module)
+            }
+        } else {
+            let is_defined = sys::mrb_const_defined_at(
+                mrb,
+                sys::mrb_sys_obj_value((*mrb).object_class as *mut c_void),
+                self.sym,
+            );
+            if is_defined == 0 {
+                // Class does not exist in root scope.
+                None
+            } else {
+                // Module exists in root scope.
+                let module = sys::mrb_module_get(mrb, module_name);
+                NonNull::new(module)
+            }
+        }
     }
 }
 
@@ -129,20 +208,27 @@ impl Spec {
                 Cow::Borrowed(name) => interp.intern_symbol(name.as_bytes()),
                 Cow::Owned(ref name) => interp.intern_symbol(name.clone().into_bytes()),
             };
-            Ok(Self {
-                name,
-                cstring,
-                sym,
-                enclosing_scope: enclosing_scope.map(Box::new),
-            })
+            if let Ok(sym) = sym {
+                Ok(Self {
+                    name,
+                    cstring,
+                    sym,
+                    enclosing_scope: enclosing_scope.map(Box::new),
+                })
+            } else {
+                Err(name.into())
+            }
         } else {
             Err(name.into())
         }
     }
 
     #[must_use]
-    pub fn name(&self) -> &str {
-        self.name.as_ref()
+    pub fn name(&self) -> Cow<'static, str> {
+        match &self.name {
+            Cow::Borrowed(name) => Cow::Borrowed(name),
+            Cow::Owned(name) => name.clone().into(),
+        }
     }
 
     #[must_use]
@@ -167,48 +253,9 @@ impl Spec {
         }
     }
 
-    #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub fn rclass(&self, mrb: *mut sys::mrb_state) -> Option<NonNull<sys::RClass>> {
-        if let Some(ref scope) = self.enclosing_scope {
-            if let Some(mut scope) = scope.rclass(mrb) {
-                let defined = unsafe {
-                    sys::mrb_const_defined_at(
-                        mrb,
-                        sys::mrb_sys_obj_value(scope.cast::<c_void>().as_mut()),
-                        self.sym,
-                    )
-                };
-                if defined == 0 {
-                    // Enclosing scope exists and module is NOT defined under
-                    // the enclosing scope.
-                    None
-                } else {
-                    // Enclosing scope exists module IS defined under the
-                    // enclosing scope.
-                    NonNull::new(unsafe {
-                        sys::mrb_module_get_under(mrb, scope.as_mut(), self.name_c_str().as_ptr())
-                    })
-                }
-            } else {
-                // Enclosing scope does not exist.
-                None
-            }
-        } else {
-            let defined = unsafe {
-                sys::mrb_const_defined_at(
-                    mrb,
-                    sys::mrb_sys_obj_value((*mrb).object_class as *mut c_void),
-                    self.sym,
-                )
-            };
-            if defined == 0 {
-                // Module does NOT exist in root scop.
-                None
-            } else {
-                // Module exists in root scope.
-                NonNull::new(unsafe { sys::mrb_module_get(mrb, self.name_c_str().as_ptr()) })
-            }
-        }
+    #[must_use]
+    pub fn rclass(&self) -> Rclass {
+        Rclass::new(self.sym, self.cstring.clone(), self.enclosing_scope.clone())
     }
 }
 
@@ -242,7 +289,7 @@ mod tests {
     fn rclass_for_undef_root_module() {
         let mut interp = crate::interpreter().unwrap();
         let spec = Spec::new(&mut interp, "Foo", None).unwrap();
-        let rclass = spec.rclass(unsafe { interp.mrb.as_mut() });
+        let rclass = unsafe { interp.with_ffi_boundary(|mrb| spec.rclass().resolve(mrb)) }.unwrap();
         assert!(rclass.is_none());
     }
 
@@ -252,7 +299,7 @@ mod tests {
         let scope = Spec::new(&mut interp, "Kernel", None).unwrap();
         let scope = EnclosingRubyScope::module(&scope);
         let spec = Spec::new(&mut interp, "Foo", Some(scope)).unwrap();
-        let rclass = spec.rclass(unsafe { interp.mrb.as_mut() });
+        let rclass = unsafe { interp.with_ffi_boundary(|mrb| spec.rclass().resolve(mrb)) }.unwrap();
         assert!(rclass.is_none());
     }
 
@@ -260,7 +307,7 @@ mod tests {
     fn rclass_for_root_module() {
         let mut interp = crate::interpreter().unwrap();
         let spec = Spec::new(&mut interp, "Kernel", None).unwrap();
-        let rclass = spec.rclass(unsafe { interp.mrb.as_mut() });
+        let rclass = unsafe { interp.with_ffi_boundary(|mrb| spec.rclass().resolve(mrb)) }.unwrap();
         assert!(rclass.is_some());
     }
 
@@ -271,7 +318,7 @@ mod tests {
         let scope = Spec::new(&mut interp, "Foo", None).unwrap();
         let scope = EnclosingRubyScope::module(&scope);
         let spec = Spec::new(&mut interp, "Bar", Some(scope)).unwrap();
-        let rclass = spec.rclass(unsafe { interp.mrb.as_mut() });
+        let rclass = unsafe { interp.with_ffi_boundary(|mrb| spec.rclass().resolve(mrb)) }.unwrap();
         assert!(rclass.is_some());
     }
 
@@ -282,7 +329,7 @@ mod tests {
         let scope = class::Spec::new("Foo", None, None).unwrap();
         let scope = EnclosingRubyScope::class(&scope);
         let spec = Spec::new(&mut interp, "Bar", Some(scope)).unwrap();
-        let rclass = spec.rclass(unsafe { interp.mrb.as_mut() });
+        let rclass = unsafe { interp.with_ffi_boundary(|mrb| spec.rclass().resolve(mrb)) }.unwrap();
         assert!(rclass.is_some());
     }
 }

--- a/artichoke-backend/src/module_registry.rs
+++ b/artichoke-backend/src/module_registry.rs
@@ -71,14 +71,17 @@ impl ModuleRegistry for Artichoke {
         } else {
             return Ok(None);
         };
-        unsafe {
-            let mrb = self.mrb.as_mut();
-            if let Some(mut rclass) = spec.rclass(mrb) {
-                let module = sys::mrb_sys_module_value(rclass.as_mut());
-                Ok(Some(Value::from(module)))
-            } else {
-                Ok(None)
-            }
-        }
+        let rclass = spec.rclass();
+        let module = unsafe {
+            self.with_ffi_boundary(|mrb| {
+                if let Some(mut rclass) = rclass.resolve(mrb) {
+                    let module = sys::mrb_sys_module_value(rclass.as_mut());
+                    Some(Value::from(module))
+                } else {
+                    None
+                }
+            })?
+        };
+        Ok(module)
     }
 }

--- a/artichoke-backend/src/parser.rs
+++ b/artichoke-backend/src/parser.rs
@@ -15,62 +15,46 @@ impl Parser for Artichoke {
 
     fn reset_parser(&mut self) -> Result<(), Self::Error> {
         let mrb = unsafe { self.mrb.as_mut() };
-        self.state
-            .as_mut()
-            .ok_or(InterpreterExtractError)?
-            .parser
-            .reset(mrb);
+        let state = self.state.as_mut().ok_or(InterpreterExtractError)?;
+        let parser = &mut state.parser;
+        parser.reset(mrb);
         Ok(())
     }
 
     fn fetch_lineno(&self) -> Result<usize, Self::Error> {
-        let lineno = self
-            .state
-            .as_ref()
-            .ok_or(InterpreterExtractError)?
-            .parser
-            .fetch_lineno();
+        let state = self.state.as_ref().ok_or(InterpreterExtractError)?;
+        let parser = &state.parser;
+        let lineno = parser.fetch_lineno();
         Ok(lineno)
     }
 
     fn add_fetch_lineno(&mut self, val: usize) -> Result<usize, Self::Error> {
-        let lineno = self
-            .state
-            .as_mut()
-            .ok_or(InterpreterExtractError)?
-            .parser
-            .add_fetch_lineno(val)?;
+        let state = self.state.as_mut().ok_or(InterpreterExtractError)?;
+        let parser = &mut state.parser;
+        let lineno = parser.add_fetch_lineno(val)?;
         Ok(lineno)
     }
 
     fn push_context(&mut self, context: Self::Context) -> Result<(), Self::Error> {
         let mrb = unsafe { self.mrb.as_mut() };
-        self.state
-            .as_mut()
-            .ok_or(InterpreterExtractError)?
-            .parser
-            .push_context(mrb, context);
+        let state = self.state.as_mut().ok_or(InterpreterExtractError)?;
+        let parser = &mut state.parser;
+        parser.push_context(mrb, context);
         Ok(())
     }
 
     fn pop_context(&mut self) -> Result<Option<Self::Context>, Self::Error> {
         let mrb = unsafe { self.mrb.as_mut() };
-        let context = self
-            .state
-            .as_mut()
-            .ok_or(InterpreterExtractError)?
-            .parser
-            .pop_context(mrb);
+        let state = self.state.as_mut().ok_or(InterpreterExtractError)?;
+        let parser = &mut state.parser;
+        let context = parser.pop_context(mrb);
         Ok(context)
     }
 
     fn peek_context(&self) -> Result<Option<&Self::Context>, Self::Error> {
-        let context = self
-            .state
-            .as_ref()
-            .ok_or(InterpreterExtractError)?
-            .parser
-            .peek_context();
+        let state = self.state.as_ref().ok_or(InterpreterExtractError)?;
+        let parser = &state.parser;
+        let context = parser.peek_context();
         Ok(context)
     }
 }

--- a/artichoke-backend/src/top_self.rs
+++ b/artichoke-backend/src/top_self.rs
@@ -7,10 +7,7 @@ impl TopSelf for Artichoke {
     type Value = Value;
 
     fn top_self(&mut self) -> Value {
-        let top_self = unsafe {
-            let mrb = self.mrb.as_mut();
-            sys::mrb_top_self(mrb)
-        };
-        Value::from(top_self)
+        let top_self = unsafe { self.with_ffi_boundary(|mrb| sys::mrb_top_self(mrb)) };
+        top_self.map(Value::from).unwrap_or_default()
     }
 }

--- a/artichoke-backend/src/value.rs
+++ b/artichoke-backend/src/value.rs
@@ -122,10 +122,10 @@ impl Value {
     /// Return whether this object is unreachable by any GC roots.
     #[must_use]
     pub fn is_dead(&self, interp: &mut Artichoke) -> bool {
-        unsafe {
-            let mrb = interp.mrb.as_mut();
-            sys::mrb_sys_value_is_dead(mrb, self.inner())
-        }
+        let value = self.inner();
+        let is_dead =
+            unsafe { interp.with_ffi_boundary(|mrb| sys::mrb_sys_value_is_dead(mrb, value)) };
+        is_dead.unwrap_or_default()
     }
 
     pub fn is_range(
@@ -258,7 +258,7 @@ impl ValueCore for Value {
             args.len(),
             if block.is_some() { " and block" } else { "" }
         );
-        let func = arena.intern_symbol(func.as_bytes().to_vec());
+        let func = arena.intern_symbol(func.as_bytes().to_vec())?;
         let result = unsafe {
             arena.with_ffi_boundary(|mrb| {
                 protect::funcall(
@@ -297,10 +297,10 @@ impl ValueCore for Value {
     }
 
     fn is_frozen(&self, interp: &mut Self::Artichoke) -> bool {
-        unsafe {
-            let mrb = interp.mrb.as_mut();
-            sys::mrb_sys_obj_frozen(mrb, self.inner())
-        }
+        let value = self.inner();
+        let is_frozen =
+            unsafe { interp.with_ffi_boundary(|mrb| sys::mrb_sys_obj_frozen(mrb, value)) };
+        is_frozen.unwrap_or_default()
     }
 
     fn inspect(&self, interp: &mut Self::Artichoke) -> Vec<u8> {

--- a/artichoke-core/src/intern.rs
+++ b/artichoke-core/src/intern.rs
@@ -6,6 +6,7 @@
 //! [symbol]: https://ruby-doc.org/core-2.6.3/Symbol.html
 
 use std::borrow::Cow;
+use std::error;
 
 /// Store and retrieve byte vectors that have the same lifetime as the
 /// interpreter.
@@ -19,10 +20,18 @@ pub trait Intern {
     /// The symbol identifier enables lookups in the underlying storage.
     type Symbol: Copy;
 
+    /// Concrete type for falible operations.
+    type Error: error::Error;
+
     /// Store an immutable byte vector for the life of the interpreter.
     ///
     /// Returns an identifier that enables retrieving the original bytes.
-    fn intern_symbol<T>(&mut self, symbol: T) -> Self::Symbol
+    ///
+    /// # Errors
+    ///
+    /// If the underlying interpreter state is not accessible, an error is
+    /// returned.
+    fn intern_symbol<T>(&mut self, symbol: T) -> Result<Self::Symbol, Self::Error>
     where
         T: Into<Cow<'static, [u8]>>;
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -97,7 +97,11 @@ impl Parser {
         let state = interp.state.as_mut()?;
         let context = state.parser.context_mut();
         let context = NonNull::new(context)?;
-        let parser = unsafe { sys::mrb_parser_new(interp.mrb.as_mut()) };
+        let parser = unsafe {
+            interp
+                .with_ffi_boundary(|mrb| sys::mrb_parser_new(mrb))
+                .ok()?
+        };
         let parser = NonNull::new(parser)?;
         Some(Self { parser, context })
     }


### PR DESCRIPTION
`Artichoke::with_ffi_boundary` was introduced in https://github.com/artichoke/artichoke/pull/670.

I'm currently working on implementing `Symbol` and the backing symbol
table in Rust. _Lots_ of operations in the mruby VM depend on access to
the symbol table. This PR ensures that the `State` is moved into the
`mrb_state` whenever an mruby FFI function is called.

This commit also unnnests some long functional chains to make them
friendlier to the debugger.

The primary mechanism for rolling this change out is to move
`sys::RClass` resolution out of the `class::Spec` and `module::Spec`
into a companion struct. Resolving an `RClass` does not require the
`mrb_data_type`, so it is not necessary to maintain a borrow on the
`State` when resolving one. This change enables using
`with_ffi_boundary` when getting a type's `RClass`.

Before:

```rust
let state = self.interp.state.as_ref().ok_or(InterpreterExtractError)?;
let spec = state.classes.get::<T>()?;
let rclass = unsafe {
    let mrb = interp.mrb.as_mut();
    spec.rclass(mrb)
};
```

After:

```rust
let state = self.interp.state.as_ref().ok_or(InterpreterExtractError)?;
let spec = state.classes.get::<T>()?;
let rclass = spec.rclass();
let rclass = unsafe { self.interp.with_ffi_boundary(|mrb| rclass.resolve(mrb))? };
```

`Method::define` is now fallible.
Symbol interning is now fallible.
`ClassRegistry::new_instance` no longer requires disabling the GC.