### PR TITLE
Print exception backtraces for top-level errors in spec-runner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -640,6 +640,7 @@ dependencies = [
  "serde",
  "serde_yaml",
  "structopt",
+ "termcolor",
 ]
 
 [[package]]

--- a/spec-runner/Cargo.toml
+++ b/spec-runner/Cargo.toml
@@ -15,6 +15,7 @@ rust-embed = "5.5.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.8"
 structopt = "0.3"
+termcolor = "1.1"
 
 [dependencies.artichoke]
 path = ".."


### PR DESCRIPTION
If an exception in the spec-runner happens outside of `MSpec`, it is
currently swallowed. This makes debugging difficult as we modify the
core VM.

This change catches errors returned from the interpreter and formats
them to stderr with the backtrace formatting routines in Artichoke
crate.

This change brings in a dependency in spec-runner on `termcolor`.