### PR TITLE
Return `Result` from ArenaIndex::new

### DIFF
--- a/artichoke-backend/src/block.rs
+++ b/artichoke-backend/src/block.rs
@@ -162,7 +162,7 @@ impl Block {
     }
 
     pub fn yield_arg(&self, interp: &mut Artichoke, arg: &Value) -> Result<Value, Exception> {
-        let mut arena = interp.create_arena_savepoint();
+        let mut arena = interp.create_arena_savepoint()?;
 
         let result = unsafe {
             arena

--- a/artichoke-backend/src/exception_handler.rs
+++ b/artichoke-backend/src/exception_handler.rs
@@ -10,7 +10,8 @@ use crate::Artichoke;
 ///
 /// This function makes funcalls on the interpreter which are fallible.
 pub fn last_error(interp: &mut Artichoke, exception: Value) -> Result<Exception, Exception> {
-    let mut arena = interp.create_arena_savepoint();
+    let mut arena = interp.create_arena_savepoint()?;
+
     // Clear the current exception from the mruby interpreter so subsequent
     // calls to the mruby VM are not tainted by an error they did not
     // generate.

--- a/artichoke-backend/src/gc/arena.rs
+++ b/artichoke-backend/src/gc/arena.rs
@@ -37,7 +37,7 @@ impl error::Error for IndexError {}
 
 impl RubyException for IndexError {
     fn message(&self) -> Cow<'_, [u8]> {
-        Cow::Borrowed(b"Failed to extract Artichoke Ruby interpreter from mrb_state")
+        Cow::Borrowed(b"Failed to create internal garbage collection savepoint")
     }
 
     fn name(&self) -> Cow<'_, str> {

--- a/artichoke-backend/src/gc/arena.rs
+++ b/artichoke-backend/src/gc/arena.rs
@@ -26,10 +26,7 @@ impl IndexError {
 
 impl fmt::Display for IndexError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "Failed to create internal garbage collection savepoint"
-        )
+        write!(f, "Failed to create internal garbage collection savepoint")
     }
 }
 

--- a/artichoke-backend/src/gc/arena.rs
+++ b/artichoke-backend/src/gc/arena.rs
@@ -1,9 +1,84 @@
 //! Garbage collection arenas for native code.
 
+use std::borrow::Cow;
+use std::error;
+use std::fmt;
 use std::ops::{Deref, DerefMut};
 
+use crate::class_registry::ClassRegistry;
+use crate::core::ConvertMut;
+use crate::exception::{Exception, RubyException};
+use crate::extn::core::exception::Fatal;
 use crate::sys;
 use crate::Artichoke;
+
+/// Failed to extract Artichoke interpreter at an FFI boundary.
+#[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub struct IndexError;
+
+impl IndexError {
+    /// Constructs a new, default `IndexError`.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl fmt::Display for IndexError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Failed to extract Artichoke Ruby interpreter from mrb_state userdata"
+        )
+    }
+}
+
+impl error::Error for IndexError {}
+
+impl RubyException for IndexError {
+    fn message(&self) -> Cow<'_, [u8]> {
+        Cow::Borrowed(b"Failed to extract Artichoke Ruby interpreter from mrb_state")
+    }
+
+    fn name(&self) -> Cow<'_, str> {
+        "fatal".into()
+    }
+
+    fn vm_backtrace(&self, interp: &mut Artichoke) -> Option<Vec<Vec<u8>>> {
+        let _ = interp;
+        None
+    }
+
+    fn as_mrb_value(&self, interp: &mut Artichoke) -> Option<sys::mrb_value> {
+        let message = interp.convert_mut(self.message());
+        let value = interp.new_instance::<Fatal>(&[message]).ok().flatten()?;
+        Some(value.inner())
+    }
+}
+
+impl From<IndexError> for Exception {
+    fn from(exception: IndexError) -> Self {
+        Self::from(Box::<dyn RubyException>::from(exception))
+    }
+}
+
+impl From<Box<IndexError>> for Exception {
+    fn from(exception: Box<IndexError>) -> Self {
+        Self::from(Box::<dyn RubyException>::from(exception))
+    }
+}
+
+impl From<IndexError> for Box<dyn RubyException> {
+    fn from(exception: IndexError) -> Box<dyn RubyException> {
+        Box::new(exception)
+    }
+}
+
+impl From<Box<IndexError>> for Box<dyn RubyException> {
+    fn from(exception: Box<IndexError>) -> Box<dyn RubyException> {
+        exception
+    }
+}
 
 /// Interpreter guard that acts as a GC arena savepoint.
 ///
@@ -31,13 +106,13 @@ pub struct ArenaIndex<'a> {
 
 impl<'a> ArenaIndex<'a> {
     /// Create a new arena savepoint.
-    pub fn new(interp: &'a mut Artichoke) -> Self {
-        let index = unsafe {
+    pub fn new(interp: &'a mut Artichoke) -> Result<Self, IndexError> {
+        unsafe {
             interp
                 .with_ffi_boundary(|mrb| sys::mrb_sys_gc_arena_save(mrb))
-                .unwrap_or_default()
-        };
-        Self { index, interp }
+                .and_then(move |index| Ok(Self { index, interp }))
+                .map_err(|_| IndexError)
+        }
     }
 
     /// Restore the arena stack pointer to its prior index.

--- a/artichoke-backend/src/gc/arena.rs
+++ b/artichoke-backend/src/gc/arena.rs
@@ -110,7 +110,7 @@ impl<'a> ArenaIndex<'a> {
         unsafe {
             interp
                 .with_ffi_boundary(|mrb| sys::mrb_sys_gc_arena_save(mrb))
-                .and_then(move |index| Ok(Self { index, interp }))
+                .map(move |index| Self { index, interp })
                 .map_err(|_| IndexError)
         }
     }

--- a/artichoke-backend/src/gc/arena.rs
+++ b/artichoke-backend/src/gc/arena.rs
@@ -28,7 +28,7 @@ impl fmt::Display for IndexError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "Failed to extract Artichoke Ruby interpreter from mrb_state userdata"
+            "Failed to create internal garbage collection savepoint"
         )
     }
 }

--- a/artichoke-backend/src/interpreter.rs
+++ b/artichoke-backend/src/interpreter.rs
@@ -59,7 +59,8 @@ where
     debug!("Succeeded initializing Artichoke Core and Standard Library");
 
     // Load mrbgems
-    let mut arena = interp.create_arena_savepoint();
+    let mut arena = interp.create_arena_savepoint()?;
+
     unsafe {
         arena
             .interp()
@@ -75,7 +76,7 @@ where
     // mruby lazily initializes some core objects like top_self and generates a
     // lot of garbage on startup. Eagerly initialize the interpreter to provide
     // predictable initialization behavior.
-    interp.create_arena_savepoint().interp().eval(&[])?;
+    interp.create_arena_savepoint()?.interp().eval(&[])?;
 
     if let GcState::Enabled = prior_gc_state {
         interp.enable_gc();

--- a/artichoke-backend/src/value.rs
+++ b/artichoke-backend/src/value.rs
@@ -136,7 +136,7 @@ impl Value {
         interp: &mut Artichoke,
         len: Int,
     ) -> Result<Option<protect::Range>, Exception> {
-        let mut arena = interp.create_arena_savepoint();
+        let mut arena = interp.create_arena_savepoint()?;
         let result = unsafe {
             arena
                 .interp()
@@ -261,7 +261,7 @@ impl ValueCore for Value {
         args: &[Self::Arg],
         block: Option<Self::Block>,
     ) -> Result<Self::Value, Self::Error> {
-        let mut arena = interp.create_arena_savepoint();
+        let mut arena = interp.create_arena_savepoint()?;
         if let Ok(arg_count_error) = ArgCountError::try_from(args) {
             warn!("{}", arg_count_error);
             return Err(arg_count_error.into());
@@ -615,7 +615,7 @@ mod tests {
     #[test]
     fn is_dead() {
         let mut interp = crate::interpreter().unwrap();
-        let mut arena = interp.create_arena_savepoint();
+        let mut arena = interp.create_arena_savepoint().unwrap();
         let live = arena.eval(b"'dead'").unwrap();
         assert!(!live.is_dead(&mut arena));
         let dead = live;
@@ -632,7 +632,7 @@ mod tests {
     #[test]
     fn immediate_is_dead() {
         let mut interp = crate::interpreter().unwrap();
-        let mut arena = interp.create_arena_savepoint();
+        let mut arena = interp.create_arena_savepoint().unwrap();
         let live = arena.eval(b"27").unwrap();
         assert!(!live.is_dead(&mut arena));
         let immediate = live;

--- a/artichoke-backend/tests/leak_unbounded_arena_growth.rs
+++ b/artichoke-backend/tests/leak_unbounded_arena_growth.rs
@@ -46,7 +46,7 @@ end
         .with_tolerance(LEAK_TOLERANCE)
         .check_leaks(|interp| {
             let code = b"bad_code";
-            let mut arena = interp.create_arena_savepoint();
+            let mut arena = interp.create_arena_savepoint().unwrap();
             let result = arena.eval(code).unwrap_err();
             let backtrace = result.vm_backtrace(&mut arena);
             assert_eq!(expected, backtrace);
@@ -64,7 +64,7 @@ end
         .with_tolerance(LEAK_TOLERANCE)
         .check_leaks_with_finalizer(
             |interp| {
-                let mut arena = interp.create_arena_savepoint();
+                let mut arena = interp.create_arena_savepoint().unwrap();
                 let result = arena.eval(b"'a' * 1024 * 1024").unwrap();
                 let display = result.to_s(&mut arena);
                 assert_eq!(display, expected.as_bytes());
@@ -84,7 +84,7 @@ end
         .with_tolerance(LEAK_TOLERANCE)
         .check_leaks_with_finalizer(
             |interp| {
-                let mut arena = interp.create_arena_savepoint();
+                let mut arena = interp.create_arena_savepoint().unwrap();
                 let result = arena.eval(b"'a' * 1024 * 1024").unwrap();
                 let debug = result.inspect(&mut arena);
                 assert_eq!(debug, expected);


### PR DESCRIPTION
This commit try to solve issue #669. Now, if somehow fails to retrieve
the ArenaIndex in the GC, the default behavior is to return an error.
Down the path those exception are dealt with an `.expect(msg)`, as it
isn't clear at the time of writing, what should be the approach to a
failed retrieval.

Fixes GH-669.