### PR TITLE
Update artichoke-core to be no_std + alloc compatible

### DIFF
--- a/artichoke-core/Cargo.toml
+++ b/artichoke-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "artichoke-core"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2018"
 description = "Core traits for implementing an Artichoke Ruby interpreter"
@@ -11,3 +11,10 @@ keywords = ["artichoke", "artichoke-ruby", "ruby"]
 categories = ["data-structures", "rust-patterns"]
 
 [dependencies]
+
+[features]
+default = ["std"]
+# By default, `artichoke-core` is `no_std` + `alloc`. This feature enables some
+# APIs that depend on `OsStr` and `Path`, as well as some `std::error::Error`
+# impls.
+std = []

--- a/artichoke-core/README.md
+++ b/artichoke-core/README.md
@@ -6,30 +6,94 @@
 <br>
 [![Core documentation](https://img.shields.io/badge/docs-artichoke--core-blue.svg)](https://artichoke.github.io/artichoke/artichoke_core/)
 
-`artichoke-core` crate provides a set of traits that, when implemented, provide
-a complete Ruby interpreter.
+This crate provides a set of traits that, when implemented, comprise a complete
+Ruby interpreter.
 
-[`artichoke-backend`](../artichoke-backend) is one implementation of the
-`artichoke-core` traits.
+`artichoke-core` is `no_std` + `alloc` with an optional (enabled by default)
+`std` feature.
 
-## Core APIs
+Interpreters implement the traits in Artichoke Core to indicate which
+capabilities they offer. Defining interpreters by their capabilities allows for
+interpreter agnostic implementations of Ruby Core and Standard Library.
 
-`artichoke-core` contains traits for the core set of APIs an interpreter must
-implement. The traits in `artichoke-core` define:
+## Interpreter APIs
 
-- APIs a concrete VM must implement to support the Artichoke runtime and
-  frontends.
-- How to box polymorphic core types into
-  [Ruby `Value`](https://artichoke.github.io/artichoke/artichoke_core/value/trait.Value.html).
-- [Interoperability](https://artichoke.github.io/artichoke/artichoke_core/convert/index.html)
-  between the VM backend and the Rust-implemented core.
+Artichoke Core defines traits for the following interpreter capabilities:
 
-Some of the core APIs a Ruby implementation must provide are
-[evaluating code](https://artichoke.github.io/artichoke/artichoke_core/eval/trait.Eval.html),
-[converting Rust data structures to boxed `Value`s on the interpreter heap](https://artichoke.github.io/artichoke/artichoke_core/convert/trait.ConvertMut.html),
-and
-[interning `Symbol`s](https://artichoke.github.io/artichoke/artichoke_core/intern/trait.Intern.html).
+- [`DefineConstant`]: Define global, class, and module constants to be arbitrary
+  Ruby [`Value`]s.
+- [`Eval`]: Execute Ruby source code on an interpreter from various sources.
+- [`Globals`]: Get, set, and unset interpreter-level global variables.
+- [`Intern`]: Intern bytestrings to a cheap to copy and compare symbol type.
+- [`Io`]: External I/O APIs, such as writing to the standard output of the
+  current process.
+- [`LoadSources`]: [Require][kernel#require] source code from interpreter disk
+  or [`File`] gems.
+- [`Parser`]: Manipulate the parser state, e.g. setting the current filename.
+- [`Prng`]: An interpreter-level psuedorandom number generator that is the
+  backend for [`Random::DEFAULT`].
+- [`Regexp`]: Manipulate [`Regexp`] global state.
+- [`ReleaseMetadata`]: Enable interpreters to describe themselves.
+- [`TopSelf`]: Access to the root execution context.
+- [`Warn`]: Emit warnings.
+
+Artichoke Core also describes what capabilities a Ruby [`Value`] must have and
+how to [convert] between Ruby VM and Rust types.
+
+## Examples
+
+[`artichoke-backend`](https://artichoke.github.io/artichoke/artichoke_backend/)
+is one implementation of the `artichoke-core` traits.
+
+To use all of the APIs defined in Artichoke Core, bring the traits into scope by
+importing the prelude:
+
+```
+use artichoke_core::prelude::*;
+```
+
+## Crate features
+
+All features are enabled by default:
+
+- **std**: By default, `artichoke-core` is `no_std` + `alloc`. Enabling this
+  feature adds several trait methods that depend on `OsStr` and `Path` as well
+  as several implementations of `std::error::Error`.
 
 ## License
 
 artichoke-core is licensed with the [MIT License](../LICENSE) (c) Ryan Lopopolo.
+
+[kernel#require]: https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-require
+[`random::default`]: https://ruby-doc.org/core-2.6.3/Random.html#DEFAULT
+[`regexp`]:
+  https://ruby-doc.org/core-2.6.3/Regexp.html#class-Regexp-label-Special+global+variables
+[convert]:
+  https://artichoke.github.io/artichoke/artichoke_core/convert/index.html
+[`defineconstant`]:
+  https://artichoke.github.io/artichoke/artichoke_core/constant/trait.DefineConstant.html
+[`value`]:
+  https://artichoke.github.io/artichoke/artichoke_core/value/trait.Value.html
+[`eval`]:
+  https://artichoke.github.io/artichoke/artichoke_core/eval/trait.Eval.html
+[`globals`]:
+  https://artichoke.github.io/artichoke/artichoke_core/globals/trait.Globals.html
+[`intern`]:
+  https://artichoke.github.io/artichoke/artichoke_core/intern/trait.Intern.html
+[`io`]: https://artichoke.github.io/artichoke/artichoke_core/io/trait.Io.html
+[`loadsources`]:
+  https://artichoke.github.io/artichoke/artichoke_core/load/trait.LoadSources.html
+[`file`]:
+  https://artichoke.github.io/artichoke/artichoke_core/file/trait.File.html
+[`parser`]:
+  https://artichoke.github.io/artichoke/artichoke_core/parser/trait.Parser.html
+[`prng`]:
+  https://artichoke.github.io/artichoke/artichoke_core/prng/trait.Prng.html
+[`regexp`]:
+  https://artichoke.github.io/artichoke/artichoke_core/regexp/trait.Regexp.html
+[`releasemetadata`]:
+  https://artichoke.github.io/artichoke/artichoke_core/release_metadata/trait.ReleaseMetadata.html
+[`topself`]:
+  https://artichoke.github.io/artichoke/artichoke_core/top_self/trait.TopSelf.html
+[`warn`]:
+  https://artichoke.github.io/artichoke/artichoke_core/warn/trait.Warn.html

--- a/artichoke-core/src/constant.rs
+++ b/artichoke-core/src/constant.rs
@@ -3,8 +3,6 @@
 //! Constants can be an arbitrary Ruby value. Constants can be defined globally,
 //! on a class, or on a module.
 
-use std::error;
-
 use crate::value::Value;
 
 /// Deifne constants on an interprter.
@@ -17,7 +15,7 @@ pub trait DefineConstant {
     type Value: Value;
 
     /// Concrete error type for fallible operations.
-    type Error: error::Error;
+    type Error;
 
     /// Define a global constant.
     ///

--- a/artichoke-core/src/convert.rs
+++ b/artichoke-core/src/convert.rs
@@ -1,12 +1,10 @@
 //! Convert between Rust and Ruby objects.
 
-use std::error;
-
 /// Infallible conversion between two types.
 ///
 /// Implementors may not allocate on the interpreter heap.
 ///
-/// See [`std::convert::From`].
+/// See [`core::convert::From`].
 /// See [`ConvertMut`].
 pub trait Convert<T, U> {
     /// Performs the infallible conversion.
@@ -17,12 +15,12 @@ pub trait Convert<T, U> {
 ///
 /// Implementors may not allocate on the interpreter heap.
 ///
-/// See [`std::convert::TryFrom`].
+/// See [`core::convert::TryFrom`].
 /// See [`TryConvertMut`].
 #[allow(clippy::module_name_repetitions)]
 pub trait TryConvert<T, U> {
     /// Error type for failed conversions.
-    type Error: error::Error;
+    type Error;
 
     /// Performs the fallible conversion.
     ///
@@ -37,7 +35,7 @@ pub trait TryConvert<T, U> {
 ///
 /// Implementors may allocate on the interpreter heap.
 ///
-/// See [`std::convert::From`].
+/// See [`core::convert::From`].
 /// See [`Convert`].
 #[allow(clippy::module_name_repetitions)]
 pub trait ConvertMut<T, U> {
@@ -49,11 +47,11 @@ pub trait ConvertMut<T, U> {
 ///
 /// Implementors may allocate on the interpreter heap.
 ///
-/// See [`std::convert::TryFrom`].
+/// See [`core::convert::TryFrom`].
 /// See [`TryConvert`].
 pub trait TryConvertMut<T, U> {
     /// Error type for failed conversions.
-    type Error: error::Error;
+    type Error;
 
     /// Performs the fallible conversion.
     ///

--- a/artichoke-core/src/eval.rs
+++ b/artichoke-core/src/eval.rs
@@ -1,7 +1,8 @@
 //! Run code on an Artichoke interpreter.
 
-use std::error;
+#[cfg(feature = "std")]
 use std::ffi::OsStr;
+#[cfg(feature = "std")]
 use std::path::Path;
 
 use crate::value::Value;
@@ -12,7 +13,7 @@ pub trait Eval {
     type Value: Value;
 
     /// Concrete error type for eval functions.
-    type Error: error::Error;
+    type Error;
 
     /// Eval code on the Artichoke interpreter using the current `Context`.
     ///
@@ -24,21 +25,29 @@ pub trait Eval {
     /// Eval code on the Artichoke interpreter using the current `Context` when
     /// given code as an [`OsStr`].
     ///
+    /// This trait method requires activating the `std` feature in
+    /// `artichoke-core`.
+    ///
     /// # Errors
     ///
     /// If an exception is raised on the interpreter, then an error is returned.
     ///
     /// If `code` cannot be converted to a `&[u8]` on the current platform, then
     /// an error is returned.
+    #[cfg(feature = "std")]
     fn eval_os_str(&mut self, code: &OsStr) -> Result<Self::Value, Self::Error>;
 
     /// Eval code on the Artichoke interpreter using a new file `Context` given
     /// a file path.
+    ///
+    /// This trait method requires activating the `std` feature in
+    /// `artichoke-core`.
     ///
     /// # Errors
     ///
     /// If an exception is raised on the interpreter, then an error is returned.
     ///
     /// If `path` does not exist or code cannot be read, an error is returned.
+    #[cfg(feature = "std")]
     fn eval_file(&mut self, file: &Path) -> Result<Self::Value, Self::Error>;
 }

--- a/artichoke-core/src/file.rs
+++ b/artichoke-core/src/file.rs
@@ -1,7 +1,5 @@
 //! File-backed Rust extensions for the Artichoke VM.
 
-use std::error;
-
 /// Rust extension hook that can be required.
 ///
 /// `File`s are mounted in the interpreter filesystem and can modify interpreter
@@ -11,7 +9,7 @@ pub trait File {
     type Artichoke;
 
     /// Concrete error type for eval functions.
-    type Error: error::Error;
+    type Error;
 
     /// Called when the filename mapped to this type is required by the VM.
     ///

--- a/artichoke-core/src/globals.rs
+++ b/artichoke-core/src/globals.rs
@@ -3,8 +3,7 @@
 //! Global variables can be an arbitrary Ruby value. Variable names must start
 //! with `$`.
 
-use std::borrow::Cow;
-use std::error;
+use alloc::borrow::Cow;
 
 use crate::value::Value;
 
@@ -17,7 +16,7 @@ pub trait Globals {
     type Value: Value;
 
     /// Concrete error type for failures manipulating global variables.
-    type Error: error::Error;
+    type Error;
 
     /// Set global variable pointed to by `name` to the given Ruby value.
     ///

--- a/artichoke-core/src/intern.rs
+++ b/artichoke-core/src/intern.rs
@@ -5,8 +5,7 @@
 //!
 //! [symbol]: https://ruby-doc.org/core-2.6.3/Symbol.html
 
-use std::borrow::Cow;
-use std::error;
+use alloc::borrow::Cow;
 
 /// Store and retrieve bytestrings that have the same lifetime as the
 /// interpreter.
@@ -21,7 +20,7 @@ pub trait Intern {
     type Symbol: Copy;
 
     /// Concrete type for errors returned while interning symbols.
-    type Error: error::Error;
+    type Error;
 
     /// Store an immutable bytestring for the life of the interpreter.
     ///

--- a/artichoke-core/src/io.rs
+++ b/artichoke-core/src/io.rs
@@ -1,11 +1,9 @@
 //! I/O read and write APIs.
 
-use std::error;
-
 /// Make I/O external to the interpreter.
 pub trait Io {
     /// Concrete error type for errors encountered when reading and writing.
-    type Error: error::Error;
+    type Error;
 
     /// Writes the given bytes to the interpreter stdout stream.
     ///

--- a/artichoke-core/src/lib.rs
+++ b/artichoke-core/src/lib.rs
@@ -4,30 +4,72 @@
 #![warn(missing_debug_implementations)]
 #![warn(rust_2018_idioms)]
 #![forbid(unsafe_code)]
+#![cfg_attr(not(feature = "std"), no_std)]
 
-//! # artichoke-core
+//! This crate provides a set of traits that, when implemented, comprise a
+//! complete Ruby interpreter.
 //!
-//! `artichoke-core` crate provides a set of traits that, when implemented,
-//! provide a complete Ruby interpreter.
+//! `artichoke-core` is `no_std` + `alloc` with an optional (enabled by default)
+//! `std` feature.
+//!
+//! Interpreters implement the traits in Artichoke Core to indicate which
+//! capabilities they offer. Defining interpreters by their capabilities allows
+//! for interpreter agnostic implementations of Ruby Core and Standard Library.
+//!
+//! # Interpreter APIs
+//!
+//! Artichoke Core defines traits for the following interpreter capabilities:
+//!
+//! - [`DefineConstant`](constant::DefineConstant): Define global, class, and
+//!   module constants to be arbitrary Ruby [`Value`](value::Value)s.
+//! - [`Eval`](eval::Eval): Execute Ruby source code on an interpreter from
+//!   various sources.
+//! - [`Globals`](globals::Globals): Get, set, and unset interpreter-level
+//!   global variables.
+//! - [`Intern`](intern::Intern): Intern bytestrings to a cheap to copy and
+//!   compare symbol type.
+//! - [`Io`](io::Io): External I/O APIs, such as writing to the standard output
+//!   of the current process.
+//! - [`LoadSources`](load::LoadSources): [Require][Kernel#require] source code
+//!   from interpreter disk or [`File`](file::File) gems.
+//! - [`Parser`](parser::Parser): Manipulate the parser state, e.g. setting the
+//!   current filename.
+//! - [`Prng`](prng::Prng): An interpreter-level psuedorandom number generator
+//!   that is the backend for [`Random::DEFAULT`].
+//! - [`Regexp`](regexp::Regexp): Manipulate [`Regexp`] global state.
+//! - [`ReleaseMetadata`](release_metadata::ReleaseMetadata): Enable
+//!   interpreters to describe themselves.
+//! - [`TopSelf`](top_self::TopSelf): Access to the root execution context.
+//! - [`Warn`](warn::Warn): Emit warnings.
+//!
+//! Artichoke Core also describes what capabilities a Ruby
+//! [`Value`](value::Value) must have and how to [convert] between Ruby VM and
+//! Rust types.
+//!
+//! # Examples
 //!
 //! [`artichoke-backend`](https://artichoke.github.io/artichoke/artichoke_backend/)
 //! is one implementation of the `artichoke-core` traits.
 //!
-//! ## Core APIs
+//! To use all of the APIs defined in Artichoke Core, bring the traits into
+//! scope by importing the prelude:
 //!
-//! `artichoke-core` contains traits for the core set of APIs an interpreter
-//! must implement. The traits in `artichoke-core` define:
+//! ```
+//! use artichoke_core::prelude::*;
+//! ```
 //!
-//! - APIs a concrete VM must implement to support the Artichoke runtime and
-//!   frontends.
-//! - How to box polymorphic core types into [Ruby `Value`](value::Value).
-//! - [Interoperability](convert) between the VM backend and the
-//!   Rust-implemented core.
+//! # Crate features
 //!
-//! Some of the core APIs a Ruby implementation must provide are
-//! [evaluating code](eval::Eval),
-//! [converting Rust data structures to boxed `Value`s on the interpreter heap](convert::ConvertMut),
-//! and [interning `Symbol`s](intern::Intern).
+//! All features are enabled by default:
+//!
+//! - **std**: By default, `artichoke-core` is `no_std` + `alloc`. Enabling
+//!   this feature adds several trait methods that depend on `OsStr` and `Path`
+//!   as well as several implementations of `std::error::Error`.
+//!
+//! [Kernel#require]: https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-require
+//! [`Random::DEFAULT`]: https://ruby-doc.org/core-2.6.3/Random.html#DEFAULT
+//! [`Regexp`]: https://ruby-doc.org/core-2.6.3/Regexp.html#class-Regexp-label-Special+global+variables
+//! [convert]: crate::convert
 
 #![doc(html_root_url = "https://artichoke.github.io/artichoke/artichoke_core")]
 #![doc(html_favicon_url = "https://www.artichokeruby.org/favicon.ico")]
@@ -46,6 +88,8 @@ macro_rules! readme {
 }
 #[cfg(doctest)]
 readme!();
+
+extern crate alloc;
 
 pub mod constant;
 pub mod convert;

--- a/artichoke-core/src/load.rs
+++ b/artichoke-core/src/load.rs
@@ -1,8 +1,11 @@
 //! Load Ruby and Rust sources into the VM.
 
-use std::borrow::Cow;
-use std::error;
-use std::path::Path;
+use alloc::borrow::Cow;
+
+#[cfg(feature = "std")]
+type Path = std::path::Path;
+#[cfg(not(feature = "std"))]
+type Path = str;
 
 use crate::file::File;
 
@@ -13,10 +16,10 @@ pub trait LoadSources {
     type Artichoke;
 
     /// Concrete type for errors returned from filesystem IO.
-    type Error: error::Error;
+    type Error;
 
     /// Concrete type for errors returned by `File::require`.
-    type Exception: error::Error;
+    type Exception;
 
     /// Add a Rust extension hook to the virtual filesystem. A stub Ruby file is
     /// added to the filesystem and [`File::require`] will dynamically define

--- a/artichoke-core/src/parser.rs
+++ b/artichoke-core/src/parser.rs
@@ -1,7 +1,6 @@
 //! Parse code on an Artichoke interpreter.
 
-use std::error;
-use std::fmt;
+use core::fmt;
 
 /// Manage parser state, active filename context, and line number metadata.
 ///
@@ -11,7 +10,7 @@ pub trait Parser {
     /// Concrete type for parser context.
     type Context;
     /// Error type for Parser APIs.
-    type Error: error::Error;
+    type Error;
 
     /// Reset parser state to initial values.
     ///
@@ -80,4 +79,5 @@ impl fmt::Display for IncrementLinenoError {
     }
 }
 
-impl error::Error for IncrementLinenoError {}
+#[cfg(feature = "std")]
+impl std::error::Error for IncrementLinenoError {}

--- a/artichoke-core/src/prng.rs
+++ b/artichoke-core/src/prng.rs
@@ -1,13 +1,11 @@
 //! Interpreter global psuedorandom number generator.
 
-use std::error;
-
 /// Interpreter global psuedorandom number generator.
 ///
 /// Implementors of this trait back the `Random::DEFAULT` PRNG.
 pub trait Prng {
     /// Concrete type for PRNG errors.
-    type Error: error::Error;
+    type Error;
 
     /// Cocnrete type representing the internal state of all PRNG backends.
     type InternalState;

--- a/artichoke-core/src/regexp.rs
+++ b/artichoke-core/src/regexp.rs
@@ -1,12 +1,10 @@
 //! Track `Regexp` global state.
 
-use std::error;
-
 /// Track the state of `Regexp` globals and global interpreter state.
 pub trait Regexp {
     /// Concrete error type for errors encountered when manipulating `Regexp`
     /// state.
-    type Error: error::Error;
+    type Error;
 
     /// Retrieve the current number of set `Regexp` global variables.
     ///

--- a/artichoke-core/src/types.rs
+++ b/artichoke-core/src/types.rs
@@ -1,6 +1,6 @@
 //! Ruby and Rust type mappings.
 
-use std::fmt;
+use core::fmt;
 
 /// Classes of Rust types.
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
@@ -75,8 +75,9 @@ pub enum Ruby {
     Float,
     /// Ruby `Hash` type.
     ///
-    /// Similar to a [`HashMap`](std::collections::HashMap), but with remembered
-    /// insertion order.
+    /// Similar to a [`HashMap`], but iterates by insertion order.
+    ///
+    /// [`HashMap`]: https://doc.rust-lang.org/std/collections/struct.HashMap.html
     Hash,
     /// Internal type for non-heap allocated structs.
     InlineStruct,
@@ -95,7 +96,7 @@ pub enum Ruby {
     Proc,
     /// Ruby `Range` type.
     ///
-    /// Similar to a Rust [iterator](std::iter).
+    /// Similar to a Rust [iterator](core::iter).
     Range,
     /// Internal type for the singleton class of an object.
     SingletonClass,

--- a/artichoke-core/src/value.rs
+++ b/artichoke-core/src/value.rs
@@ -1,16 +1,13 @@
 //! Types that implement `Value` can be represented in the Artichoke VM.
 
-use std::error;
+use alloc::vec::Vec;
 
 use crate::convert::{TryConvert, TryConvertMut};
 
 /// A boxed Ruby value owned by the interpreter.
 ///
 /// `Value` is equivalent to an `RValue` in MRI or `mrb_value` in mruby.
-pub trait Value
-where
-    Self: Sized,
-{
+pub trait Value {
     /// Concrete type for Artichoke interpreter.
     type Artichoke;
 
@@ -24,7 +21,7 @@ where
     type Block;
 
     /// Concrete error type for funcall errors.
-    type Error: error::Error;
+    type Error;
 
     /// Call a method on this [`Value`] with arguments and an optional block.
     ///
@@ -49,6 +46,7 @@ where
     /// If a [`TryConvert`] conversion fails, then an error is returned.
     fn try_into<T>(self, interp: &Self::Artichoke) -> Result<T, Self::Error>
     where
+        Self: Sized,
         Self::Artichoke: TryConvert<Self, T, Error = Self::Error>,
     {
         interp.try_convert(self)
@@ -62,6 +60,7 @@ where
     /// If a [`TryConvertMut`] conversion fails, then an error is returned.
     fn try_into_mut<T>(self, interp: &mut Self::Artichoke) -> Result<T, Self::Error>
     where
+        Self: Sized,
         Self::Artichoke: TryConvertMut<Self, T, Error = Self::Error>,
     {
         interp.try_convert_mut(self)

--- a/artichoke-core/src/warn.rs
+++ b/artichoke-core/src/warn.rs
@@ -1,7 +1,5 @@
 //! Emit warnings during interpreter execution.
 
-use std::error;
-
 /// Emit warnings during interpreter execution to stderr.
 ///
 /// Some functionality required to be compliant with ruby/spec is deprecated or
@@ -11,7 +9,7 @@ use std::error;
 /// [warningmod]: https://ruby-doc.org/core-2.6.3/Warning.html#method-i-warn
 pub trait Warn {
     /// Concrete error type for errors encountered when outputting warnings.
-    type Error: error::Error;
+    type Error;
 
     /// Emit a warning message using `Warning#warn`.
     ///


### PR DESCRIPTION
`artichoke-core` defines the traits that comprise an interpreter. There
is little implementation. It is feasible to make the crate `no_std`. To
make this transition, the following changes were made:

- Add `extern crate alloc` to `lib.rs`.
- Add an optional, enabled by default, `std` feature.
- `use alloc::vec::Vec` where `Vec` was used since there is no longer
  any implicit `std` prelude.
- `use alloc::borrow::Cow` instead of `use std::borrow::Cow`.
- Remove `std::error::Error` bounds on all `Error` associated types.
- Update doc comments to refer to `core` instead of `std` where
  possible, with external links otherwise.
- Gate `Eval::eval_os_str` behind the `std` feature and note the feature
  requirement in the docs.
- Gate `Eval::eval_file` behind the `std` feature and note the feature
  reqirement in the docs.
- Use `str` instead of `Path` for path arguments in `LoadSources` when
  compiling for `no_std`.

This commit moves the `where Self: Sized` bound on `Value` from the
trait definition to the `self` converter methods.

This commit significantly improves the quality of the crate-level
documentation and README.