### PR TITLE
Lint entire workspace with clippy

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -125,7 +125,7 @@ jobs:
         uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features
+          args: --workspace --all-features
 
   ruby:
     name: Lint and format Ruby

--- a/Rakefile
+++ b/Rakefile
@@ -14,7 +14,7 @@ namespace :lint do
     roots.each do |root|
       FileUtils.touch(root)
     end
-    sh 'cargo clippy'
+    sh 'cargo clippy --workspace --all-features'
   end
 
   desc 'Run RuboCop'

--- a/artichoke-backend/README.md
+++ b/artichoke-backend/README.md
@@ -21,7 +21,6 @@ The `artichoke-backend` interpreter implements
 [`Eval` from `artichoke-core`](https://artichoke.github.io/artichoke/artichoke_core/eval/trait.Eval.html).
 
 ```rust
-use artichoke_backend::prelude::core::*;
 use artichoke_backend::prelude::*;
 
 fn example() -> Result<(), Exception> {
@@ -40,7 +39,6 @@ fn example() -> Result<(), Exception> {
 which enables calling Ruby functions from Rust.
 
 ```rust
-use artichoke_backend::prelude::core::*;
 use artichoke_backend::prelude::*;
 
 fn example() -> Result<(), Exception> {

--- a/artichoke-backend/src/extn/core/numeric/mod.rs
+++ b/artichoke-backend/src/extn/core/numeric/mod.rs
@@ -57,9 +57,9 @@ pub enum Coercion {
 /// # Examples
 ///
 /// ```
-/// # use artichoke_backend::prelude::core::*;
+/// # use artichoke_backend::prelude::*;
 /// # use artichoke_backend::extn::core::numeric::{self, Coercion};
-/// # fn main() -> Result<(), Box<std::error::Error>> {
+/// # fn example() -> Result<(), Box<std::error::Error>> {
 /// # let mut interp = artichoke_backend::interpreter()?;
 /// let x = interp.convert(1_i64);
 /// let y = interp.convert_mut(2.5_f64);
@@ -72,6 +72,7 @@ pub enum Coercion {
 /// assert_eq!(Coercion::Integer(1, 2), numeric::coerce(&mut interp, x, y)?);
 /// # Ok(())
 /// # }
+/// # example().unwrap();
 /// ```
 ///
 /// [numeric]: https://ruby-doc.org/core-2.6.3/Numeric.html#method-i-coerce

--- a/artichoke-backend/src/lib.rs
+++ b/artichoke-backend/src/lib.rs
@@ -19,19 +19,19 @@
 //! ### Evaling Source Code
 //!
 //! The `artichoke-backend` interpreter implements
-//! [`Eval` from `artichoke-core`](crate::prelude::core::Eval).
+//! [`Eval` from `artichoke-core`](crate::core::Eval).
 //!
 //! ```rust
-//! use artichoke_backend::prelude::core::*;
 //! use artichoke_backend::prelude::*;
 //!
-//! # fn main() -> Result<(), Exception> {
+//! # fn example() -> Result<(), Exception> {
 //! let mut interp = artichoke_backend::interpreter()?;
 //! let result = interp.eval(b"10 * 10")?;
 //! let result = result.try_into::<i64>(&interp)?;
 //! assert_eq!(result, 100);
 //! # Ok(())
 //! # }
+//! # example().unwrap();
 //! ```
 //!
 //! ### Calling Functions on Ruby Objects
@@ -41,10 +41,9 @@
 //! calling Ruby functions from Rust.
 //!
 //! ```rust
-//! use artichoke_backend::prelude::core::*;
 //! use artichoke_backend::prelude::*;
 //!
-//! # fn main() -> Result<(), Exception> {
+//! # fn example() -> Result<(), Exception> {
 //! let mut interp = artichoke_backend::interpreter()?;
 //! let result = interp.eval(b"'ruby funcall'")?;
 //! let result = result.funcall(&mut interp, "length", &[], None)?;
@@ -52,6 +51,7 @@
 //! assert_eq!(result, 12);
 //! # Ok(())
 //! # }
+//! # example().unwrap();
 //! ```
 //!
 //! ## Virtual Filesystem and `Kernel#require`
@@ -165,7 +165,7 @@ pub use artichoke_core::prelude as core;
 ///
 /// The prelude may grow over time as additional items see ubiquitous use.
 pub mod prelude {
-    pub use crate::core;
+    pub use artichoke_core::prelude::*;
 
     pub use crate::exception::{raise, Exception, RubyException};
     pub use crate::extn::core::exception::{Exception as _, *};

--- a/artichoke-backend/tests/leak_funcall.rs
+++ b/artichoke-backend/tests/leak_funcall.rs
@@ -13,7 +13,6 @@
 //! If resident memory increases more than 10MB during the test, we likely are
 //! leaking memory.
 
-use artichoke_backend::prelude::core::*;
 use artichoke_backend::prelude::*;
 
 mod leak;

--- a/artichoke-backend/tests/leak_unbounded_arena_growth.rs
+++ b/artichoke-backend/tests/leak_unbounded_arena_growth.rs
@@ -19,7 +19,6 @@
 //! This test fails before commit
 //! `a450ca7c458d0a4db6fdc60375d8c2c8482c85a7` with a fairly massive leak.
 
-use artichoke_backend::prelude::core::*;
 use artichoke_backend::prelude::*;
 
 mod leak;

--- a/fuzz/fuzz_targets/eval.rs
+++ b/fuzz/fuzz_targets/eval.rs
@@ -1,7 +1,7 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
 
-use artichoke::prelude::core::*;
+use artichoke::prelude::*;
 
 fuzz_target!(|data: &[u8]| {
     let mut interp = artichoke::interpreter().unwrap();

--- a/spec-runner/src/main.rs
+++ b/spec-runner/src/main.rs
@@ -157,6 +157,7 @@ where
 ///
 /// This function evaluates a ruby/spec source file against the parsed spec
 /// manifest config to determine if the source should be tested.
+#[must_use]
 pub fn is_require_path(config: &model::Config, name: &str) -> Option<()> {
     let path = Path::new(name);
     let mut components = path.components();

--- a/spec-runner/src/main.rs
+++ b/spec-runner/src/main.rs
@@ -59,7 +59,7 @@
 #[macro_use]
 extern crate rust_embed;
 
-use artichoke::prelude::core::*;
+use artichoke::prelude::*;
 use std::error::Error;
 use std::ffi::OsStr;
 use std::fs;

--- a/spec-runner/src/mspec.rs
+++ b/spec-runner/src/mspec.rs
@@ -2,7 +2,6 @@
 
 use std::path::Path;
 
-use artichoke::prelude::core::*;
 use artichoke::prelude::*;
 
 /// Load `MSpec` sources into the Artichoke virtual filesystem.

--- a/spec-runner/src/rubyspec.rs
+++ b/spec-runner/src/rubyspec.rs
@@ -1,6 +1,5 @@
 //! Embedded copy of ruby/spec suites.
 
-use artichoke::prelude::core::*;
 use artichoke::prelude::*;
 
 /// Load ruby/spec sources into the Artichoke virtual filesystem.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@
 //! - A Rust and Ruby implementation of Ruby Core and Standard Library using
 //!   high-quality Rust dependencies and modern Ruby.
 //! - Support for injecting Rust code and types into the interpreter with a
-//!   rubygems-style [`File`](backend::prelude::core::File) API.
+//!   rubygems-style [`File`](prelude::File) API.
 //! - The ability to disable parts of the interpreter VM or library functions at
 //!   compile time. For example, deny access to the system environ by disabling
 //!   the `core-env-system` feature.
@@ -27,22 +27,23 @@
 //! You can create an interpreter and begin executing code on it:
 //!
 //! ```
-//! # use artichoke::prelude::core::*;
-//! # use artichoke::prelude::*;
-//! # fn main() -> Result<(), Exception> {
+//! use artichoke::prelude::*;
+//!
+//! # fn example() -> Result<(), Exception> {
 //! let mut interp = artichoke::interpreter()?;
 //! let result = interp.eval(b"2 + 5")?;
 //! # Ok(())
 //! # }
+//! # example().unwrap();
 //! ```
 //!
 //! Artichoke supports calling Ruby functions from Rust and converting between
 //! Ruby boxed values and Rust native types:
 //!
 //! ```
-//! # use artichoke::prelude::core::*;
-//! # use artichoke::prelude::*;
-//! # fn main() -> Result<(), Exception> {
+//! use artichoke::prelude::*;
+//!
+//! # fn example() -> Result<(), Exception> {
 //! let mut interp = artichoke::interpreter()?;
 //! let s = interp.convert_mut("💎");
 //! let codepoint = s.funcall(&mut interp, "ord", &[] /* args */, None /* block */)?;
@@ -50,6 +51,7 @@
 //! assert_eq!(128142, codepoint);
 //! # Ok(())
 //! # }
+//! # example().unwrap();
 //! ```
 //!
 //! ## Crate Features

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -14,8 +14,7 @@ use termcolor::WriteColor;
 use crate::backend::state::parser::Context;
 use crate::backtrace;
 use crate::parser::{Parser, State};
-use crate::prelude::core::{Eval, Parser as _, Value};
-use crate::prelude::*;
+use crate::prelude::{Parser as _, *};
 
 const REPL_FILENAME: &[u8] = b"(airb)";
 

--- a/src/ruby.rs
+++ b/src/ruby.rs
@@ -14,7 +14,6 @@ use crate::backend::ffi;
 use crate::backend::state::parser::Context;
 use crate::backend::string;
 use crate::backtrace;
-use crate::prelude::core::{ConvertMut, Eval, Globals, Parser};
 use crate::prelude::*;
 
 const INLINE_EVAL_SWITCH_FILENAME: &[u8] = b"-e";


### PR DESCRIPTION
Pass `--workspace` flag to clippy in `Rakefile` and CI.

This PR syncs the `Rakefile` to include the `--all-features` flag present in CI.

All doctests that wrap the example in a function renamed that function from `main` to `example` and add an additional hidden line `example().unwrap()` to ensure the example code is executed.

The biggest code change in this PR is reworking the way traits in `artichoke-core` are included in the `prelude` modules in `artichoke-backend` and `artichoke` to avoid clippy complaining about glob imports.