### PR TITLE
Add spinoso-array crate

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -94,6 +94,14 @@ jobs:
       - name: Compile artichoke with all features
         run: cargo build --verbose --all-features
 
+      - name: Compile spinoso with no default features
+        run: cargo build --verbose --no-default-features
+        working-directory: "spinoso-array"
+
+      - name: Compile spinoso with all features
+        run: cargo build --verbose --all-features
+        working-directory: "spinoso-array"
+
   rust:
     name: Lint and format Rust
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -643,6 +643,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "spinoso-array"
+version = "0.1.0"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,8 @@ target-lexicon = "0.11.0"
 members = [
   "artichoke-backend",
   "artichoke-core",
-  "spec-runner"
+  "spec-runner",
+  "spinoso-array",
 ]
 
 [profile.release]

--- a/Rakefile
+++ b/Rakefile
@@ -80,13 +80,13 @@ end
 desc 'Generate Rust API documentation'
 task :doc do
   ENV['RUSTDOCFLAGS'] = '-D warnings'
-  sh 'rustup run --install nightly cargo doc --workspace --no-deps'
+  sh 'rustup run --install nightly cargo doc --workspace'
 end
 
 desc 'Generate Rust API documentation and open it in a web browser'
 task :'doc:open' do
   ENV['RUSTDOCFLAGS'] = '-D warnings'
-  sh 'rustup run --install nightly cargo doc --workspace --no-deps --open'
+  sh 'rustup run --install nightly cargo doc --workspace --open'
 end
 
 desc 'Run enforced ruby/spec suite'

--- a/artichoke-core/Cargo.toml
+++ b/artichoke-core/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/artichoke/artichoke"
 readme = "README.md"
 license = "MIT"
 keywords = ["artichoke", "artichoke-ruby", "ruby"]
-categories = ["data-structures", "rust-patterns"]
+categories = ["data-structures", "no-std", "rust-patterns"]
 
 [dependencies]
 

--- a/spinoso-array/Cargo.toml
+++ b/spinoso-array/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "spinoso-array"
+version = "0.1.0"
+authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
+edition = "2018"
+description = """
+Growable vector backends for the Ruby Array core type in Artichoke Ruby
+"""
+repository = "https://github.com/artichoke/artichoke"
+readme = "README.md"
+license = "MIT"
+keywords = ["array", "no_std", "spinoso", "vec", "vector"]
+categories = ["data-structures", "no-std"]
+
+[dependencies]
+smallvec = { version = "1.4.1", optional = true }
+
+[features]
+default = ["small-array"]
+# Add a `SmallArray` backend that implements the small vector optimization with
+# the `smallvec` crate.
+small-array = ["smallvec"]

--- a/spinoso-array/README.md
+++ b/spinoso-array/README.md
@@ -1,0 +1,77 @@
+# intaglio
+
+[![GitHub Actions](https://github.com/artichoke/artichoke/workflows/CI/badge.svg)](https://github.com/artichoke/artichoke/actions)
+[![Discord](https://img.shields.io/discord/607683947496734760)](https://discord.gg/QCe2tp2)
+[![Twitter](https://img.shields.io/twitter/follow/artichokeruby?label=Follow&style=social)](https://twitter.com/artichokeruby)
+<br>
+[![Crate](https://img.shields.io/crates/v/spinoso-array.svg)](https://crates.io/crates/spinoso-array)
+[![API](https://docs.rs/spinoso-array/badge.svg)](https://docs.rs/spinoso-array)
+[![API trunk](https://img.shields.io/badge/docs-trunk-blue.svg)](https://artichoke.github.io/artichoke/spinoso_array/)
+
+Contiguous growable vector types. Used to implement the backend for the [Ruby
+`Array`][ruby-array] type in [Artichoke Ruby][artichoke].
+
+> Arrays are ordered, integer-indexed collections of any object. (Ruby Array
+> documentation)
+
+`Array` types are growable vectors with potentially heap-allocated contents. The
+types in this crate can be passed by pointer over FFI.
+
+`Array`s have `O(1)` access to individual elements and slices. Mutation APIs are
+`O(n)` at worst.
+
+_Spinoso_ refers to _Carciofo spinoso di Sardegna_, the thorny artichoke of
+Sardinia. The idea is that the data structures defined in the `spinoso` family
+of crates will form the backbone of Ruby Core in Artichoke.
+
+## Usage
+
+Add this to your `Cargo.toml`:
+
+```toml
+[dependencies]
+spinoso-array = "0.1"
+```
+
+Then construct and manipulate an `Array` like this:
+
+```rust
+use spinoso_array::Array;
+let mut ary: Array<i32> = Array::from(&[1, 2, 3, 4]);
+assert_eq!(ary.pop(), Some(4));
+ary.unshift(0);
+assert_eq!(ary, [0, 1, 2, 3]);
+let other = ary.shift_n(10);
+assert_eq!(ary, []);
+assert_eq!(other, [0, 1, 2, 3]);
+```
+
+## Implementation
+
+spinoso-array has two backends:
+
+- `Array` is based on [`Vec`] from the Rust `alloc` crate and standard library.
+  This Spinoso array type is enabled by default.
+- `SmallArray` is based on [`SmallVec`] and implements the small vector
+  optimization – small arrays are stored inline without a heap allocation.
+
+## Crate features
+
+`spinoso-array` is `no_std` compatible with a required dependency on [`alloc`].
+
+All features are enabled by default.
+
+- **small-array** - Enables an additional `SmallArray` array backend based on
+  `SmallVec` that implements the small vector optimization. Disabling this
+  feature drops the `smallvec` dependency.
+
+## License
+
+`spinoso-array` is licensed under the [MIT License](../LICENSE) (c) Ryan
+Lopopolo.
+
+[ruby-array]: https://ruby-doc.org/core-2.6.3/Array.html
+[artichoke]: https://github.com/artichoke/artichoke
+[`vec`]: https://doc.rust-lang.org/alloc/vec/struct.Vec.html
+[`smallvec`]: https://docs.rs/smallvec/latest/smallvec/struct.SmallVec.html
+[`alloc`]: https://doc.rust-lang.org/alloc/

--- a/spinoso-array/src/array/mod.rs
+++ b/spinoso-array/src/array/mod.rs
@@ -1,0 +1,27 @@
+//! Implementations of Ruby [`Array`], a growable vector.
+//!
+//! This module contains multiple implementations of a backing store for the
+//! Ruby `Array` core class. [`Array`](vec::Array) is based on the [`Vec`] type
+//! in `std`. [`SmallArray`](smallvec::SmallArray) is based on [`SmallVec`].
+//!
+//! The smallvec backend uses small vector optimization to store
+//! [some elements][inline-capacity] inline without spilling to the heap.
+//!
+//! The `SmallArray` backend requires the `small-array` Cargo feature to be
+//! enabled.
+//!
+//! [`Array`]: https://ruby-doc.org/core-2.6.3/Array.html
+//! [`Vec`]: alloc::vec::Vec
+//! [`SmallVec`]: ::smallvec::SmallVec
+//! [inline-capacity]: INLINE_CAPACITY
+
+#[cfg(feature = "small-array")]
+pub mod smallvec;
+pub mod vec;
+
+/// Vectors that implement the small vector optimization can store 8 elements
+/// inline without a heap allocation.
+///
+/// See [`SmallArray`](smallvec::SmallArray).
+#[cfg(feature = "small-array")]
+pub const INLINE_CAPACITY: usize = 8;

--- a/spinoso-array/src/array/smallvec/convert.rs
+++ b/spinoso-array/src/array/smallvec/convert.rs
@@ -1,0 +1,432 @@
+use alloc::borrow::Cow;
+use alloc::boxed::Box;
+use alloc::rc::Rc;
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+use core::iter::FromIterator;
+
+use smallvec::SmallVec;
+
+use crate::array::smallvec::SmallArray;
+use crate::array::vec::Array;
+use crate::array::INLINE_CAPACITY;
+
+impl<T> From<Vec<T>> for SmallArray<T> {
+    #[inline]
+    fn from(values: Vec<T>) -> Self {
+        Self(values.into())
+    }
+}
+
+impl<T> From<SmallArray<T>> for Vec<T> {
+    #[inline]
+    fn from(values: SmallArray<T>) -> Self {
+        values.into_vec()
+    }
+}
+
+impl<'a, T> From<&'a [T]> for SmallArray<T>
+where
+    T: Copy,
+{
+    #[inline]
+    fn from(values: &'a [T]) -> Self {
+        Self(SmallVec::from_slice(values))
+    }
+}
+
+impl<'a, T> From<&'a mut [T]> for SmallArray<T>
+where
+    T: Copy,
+{
+    #[inline]
+    fn from(values: &'a mut [T]) -> Self {
+        Self(SmallVec::from_slice(values))
+    }
+}
+
+impl<T> From<Box<[T]>> for SmallArray<T> {
+    #[inline]
+    fn from(values: Box<[T]>) -> Self {
+        Self(Vec::from(values).into())
+    }
+}
+
+impl<T> From<SmallArray<T>> for Box<[T]> {
+    #[inline]
+    fn from(values: SmallArray<T>) -> Self {
+        values.into_boxed_slice()
+    }
+}
+
+impl<'a, T> From<Cow<'a, [T]>> for SmallArray<T>
+where
+    T: Copy,
+{
+    #[inline]
+    fn from(values: Cow<'a, [T]>) -> Self {
+        match values {
+            Cow::Borrowed(slice) => slice.into(),
+            Cow::Owned(vec) => vec.into(),
+        }
+    }
+}
+
+impl<'a, T> From<SmallArray<T>> for Cow<'a, [T]>
+where
+    T: Clone,
+{
+    #[inline]
+    fn from(values: SmallArray<T>) -> Self {
+        values.into_vec().into()
+    }
+}
+
+impl<T> From<SmallArray<T>> for Rc<[T]> {
+    #[inline]
+    fn from(values: SmallArray<T>) -> Self {
+        values.into_vec().into()
+    }
+}
+
+impl<T> From<SmallArray<T>> for Arc<[T]> {
+    #[inline]
+    fn from(values: SmallArray<T>) -> Self {
+        values.into_vec().into()
+    }
+}
+
+// The below hand-crafted `From` implementations for fixed-sized arrays length 8
+// or shorter relies on the parameterized fixed array of `SmallArray`s
+// underlying `SmallVec` being `[T; 8]` to avoid allocating (and making the
+// hand rolled implementations worthwhile instead of delegating to
+// `<[_]>::to_vec`.
+const _: () = [()][!(INLINE_CAPACITY == 8) as usize];
+
+impl<T> From<[T; 0]> for SmallArray<T> {
+    #[inline]
+    fn from(values: [T; 0]) -> Self {
+        // Values is empty, so it can be ignored.
+        let _ = values;
+        Self::new()
+    }
+}
+
+impl<T> From<&[T; 0]> for SmallArray<T> {
+    #[inline]
+    fn from(values: &[T; 0]) -> Self {
+        // Values is empty, so it can be ignored.
+        let _ = values;
+        Self::new()
+    }
+}
+
+impl<T> From<[T; 1]> for SmallArray<T> {
+    #[inline]
+    fn from(values: [T; 1]) -> Self {
+        let [a] = values;
+        let mut vec = SmallVec::new();
+        vec.push(a);
+        Self(vec)
+    }
+}
+
+impl<T> From<&[T; 1]> for SmallArray<T>
+where
+    T: Copy,
+{
+    #[inline]
+    fn from(values: &[T; 1]) -> Self {
+        let mut vec = SmallVec::new();
+        for value in values.iter().copied() {
+            vec.push(value);
+        }
+        Self(vec)
+    }
+}
+
+impl<T> From<[T; 2]> for SmallArray<T> {
+    #[inline]
+    fn from(values: [T; 2]) -> Self {
+        let [a, b] = values;
+        let mut vec = SmallVec::new();
+        vec.push(a);
+        vec.push(b);
+        Self(vec)
+    }
+}
+
+impl<T> From<&[T; 2]> for SmallArray<T>
+where
+    T: Copy,
+{
+    #[inline]
+    fn from(values: &[T; 2]) -> Self {
+        let mut vec = SmallVec::new();
+        for value in values.iter().copied() {
+            vec.push(value);
+        }
+        Self(vec)
+    }
+}
+
+impl<T> From<[T; 3]> for SmallArray<T> {
+    #[inline]
+    fn from(values: [T; 3]) -> Self {
+        let [a, b, c] = values;
+        let mut vec = SmallVec::new();
+        vec.push(a);
+        vec.push(b);
+        vec.push(c);
+        Self(vec)
+    }
+}
+
+impl<T> From<&[T; 3]> for SmallArray<T>
+where
+    T: Copy,
+{
+    #[inline]
+    fn from(values: &[T; 3]) -> Self {
+        let mut vec = SmallVec::new();
+        for value in values.iter().copied() {
+            vec.push(value);
+        }
+        Self(vec)
+    }
+}
+
+impl<T> From<[T; 4]> for SmallArray<T> {
+    #[inline]
+    fn from(values: [T; 4]) -> Self {
+        let [a, b, c, d] = values;
+        let mut vec = SmallVec::new();
+        vec.push(a);
+        vec.push(b);
+        vec.push(c);
+        vec.push(d);
+        Self(vec)
+    }
+}
+
+impl<T> From<&[T; 4]> for SmallArray<T>
+where
+    T: Copy,
+{
+    #[inline]
+    fn from(values: &[T; 4]) -> Self {
+        let mut vec = SmallVec::new();
+        for value in values.iter().copied() {
+            vec.push(value);
+        }
+        Self(vec)
+    }
+}
+
+impl<T> From<[T; 5]> for SmallArray<T> {
+    #[inline]
+    #[allow(clippy::many_single_char_names)]
+    fn from(values: [T; 5]) -> Self {
+        let [a, b, c, d, e] = values;
+        let mut vec = SmallVec::new();
+        vec.push(a);
+        vec.push(b);
+        vec.push(c);
+        vec.push(d);
+        vec.push(e);
+        Self(vec)
+    }
+}
+
+impl<T> From<&[T; 5]> for SmallArray<T>
+where
+    T: Copy,
+{
+    #[inline]
+    fn from(values: &[T; 5]) -> Self {
+        let mut vec = SmallVec::new();
+        for value in values.iter().copied() {
+            vec.push(value);
+        }
+        Self(vec)
+    }
+}
+
+impl<T> From<[T; 6]> for SmallArray<T> {
+    #[inline]
+    #[allow(clippy::many_single_char_names)]
+    fn from(values: [T; 6]) -> Self {
+        let [a, b, c, d, e, f] = values;
+        let mut vec = SmallVec::new();
+        vec.push(a);
+        vec.push(b);
+        vec.push(c);
+        vec.push(d);
+        vec.push(e);
+        vec.push(f);
+        Self(vec)
+    }
+}
+
+impl<T> From<&[T; 6]> for SmallArray<T>
+where
+    T: Copy,
+{
+    #[inline]
+    fn from(values: &[T; 6]) -> Self {
+        let mut vec = SmallVec::new();
+        for value in values.iter().copied() {
+            vec.push(value);
+        }
+        Self(vec)
+    }
+}
+
+impl<T> From<[T; 7]> for SmallArray<T> {
+    #[inline]
+    #[allow(clippy::many_single_char_names)]
+    fn from(values: [T; 7]) -> Self {
+        let [a, b, c, d, e, f, g] = values;
+        let mut vec = SmallVec::new();
+        vec.push(a);
+        vec.push(b);
+        vec.push(c);
+        vec.push(d);
+        vec.push(e);
+        vec.push(f);
+        vec.push(g);
+        Self(vec)
+    }
+}
+
+impl<T> From<&[T; 7]> for SmallArray<T>
+where
+    T: Copy,
+{
+    #[inline]
+    fn from(values: &[T; 7]) -> Self {
+        let mut vec = SmallVec::new();
+        for value in values.iter().copied() {
+            vec.push(value);
+        }
+        Self(vec)
+    }
+}
+
+impl<T> From<[T; INLINE_CAPACITY]> for SmallArray<T> {
+    #[inline]
+    fn from(values: [T; INLINE_CAPACITY]) -> Self {
+        Self(SmallVec::from(values))
+    }
+}
+
+impl<T> From<&[T; INLINE_CAPACITY]> for SmallArray<T>
+where
+    T: Copy,
+{
+    #[inline]
+    fn from(values: &[T; INLINE_CAPACITY]) -> Self {
+        Self(SmallVec::from(*values))
+    }
+}
+
+macro_rules! __smallarray_T_from_primitive_array {
+    ($len:expr) => {
+        impl<T> From<[T; $len]> for SmallArray<T> {
+            #[inline]
+            fn from(values: [T; $len]) -> Self {
+                Self(SmallVec::from_vec(Vec::from(values)))
+            }
+        }
+
+        impl<T> From<&[T; $len]> for SmallArray<T>
+        where
+            T: Copy,
+        {
+            #[inline]
+            fn from(values: &[T; $len]) -> Self {
+                Self(SmallVec::from_slice(values))
+            }
+        }
+    };
+}
+
+// Skip to avoid a vec allocation because the lengths are less than
+// `INLINE_CAPACITY`.
+// __smallarray_T_from_primitive_array!(1);
+// __smallarray_T_from_primitive_array!(2);
+// __smallarray_T_from_primitive_array!(3);
+// __smallarray_T_from_primitive_array!(4);
+// __smallarray_T_from_primitive_array!(5);
+// __smallarray_T_from_primitive_array!(6);
+// __smallarray_T_from_primitive_array!(7);
+// Skip because we have manually implemented for `INLINE_CAPACITY` arrays.
+// __smallarray_T_from_primitive_array!(8);
+__smallarray_T_from_primitive_array!(9);
+__smallarray_T_from_primitive_array!(10);
+__smallarray_T_from_primitive_array!(11);
+__smallarray_T_from_primitive_array!(12);
+__smallarray_T_from_primitive_array!(13);
+__smallarray_T_from_primitive_array!(14);
+__smallarray_T_from_primitive_array!(15);
+__smallarray_T_from_primitive_array!(16);
+__smallarray_T_from_primitive_array!(17);
+__smallarray_T_from_primitive_array!(18);
+__smallarray_T_from_primitive_array!(19);
+__smallarray_T_from_primitive_array!(20);
+__smallarray_T_from_primitive_array!(21);
+__smallarray_T_from_primitive_array!(22);
+__smallarray_T_from_primitive_array!(23);
+__smallarray_T_from_primitive_array!(24);
+__smallarray_T_from_primitive_array!(25);
+__smallarray_T_from_primitive_array!(26);
+__smallarray_T_from_primitive_array!(27);
+__smallarray_T_from_primitive_array!(28);
+__smallarray_T_from_primitive_array!(29);
+__smallarray_T_from_primitive_array!(30);
+__smallarray_T_from_primitive_array!(31);
+__smallarray_T_from_primitive_array!(32);
+
+impl<T> From<SmallVec<[T; INLINE_CAPACITY]>> for SmallArray<T> {
+    #[inline]
+    fn from(values: SmallVec<[T; INLINE_CAPACITY]>) -> Self {
+        Self(values)
+    }
+}
+
+impl<T> From<SmallArray<T>> for SmallVec<[T; INLINE_CAPACITY]> {
+    #[inline]
+    fn from(values: SmallArray<T>) -> Self {
+        values.into_inner()
+    }
+}
+
+impl<T> From<Array<T>> for SmallArray<T> {
+    #[inline]
+    fn from(values: Array<T>) -> Self {
+        Self::from(values.into_vec())
+    }
+}
+
+impl<T> FromIterator<T> for SmallArray<T> {
+    #[inline]
+    fn from_iter<I>(iter: I) -> Self
+    where
+        I: IntoIterator<Item = T>,
+    {
+        Self(iter.into_iter().collect())
+    }
+}
+
+impl<'a, T> FromIterator<&'a T> for SmallArray<T>
+where
+    T: 'a + Copy,
+{
+    #[inline]
+    fn from_iter<I>(iter: I) -> Self
+    where
+        I: IntoIterator<Item = &'a T>,
+    {
+        Self(iter.into_iter().copied().collect())
+    }
+}

--- a/spinoso-array/src/array/smallvec/eq.rs
+++ b/spinoso-array/src/array/smallvec/eq.rs
@@ -1,0 +1,185 @@
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+use smallvec::SmallVec;
+
+use crate::array::smallvec::SmallArray;
+use crate::array::vec::Array;
+use crate::array::INLINE_CAPACITY;
+
+impl<T, U> PartialEq<SmallVec<[U; INLINE_CAPACITY]>> for SmallArray<T>
+where
+    T: PartialEq<U>,
+{
+    #[inline]
+    fn eq(&self, other: &SmallVec<[U; INLINE_CAPACITY]>) -> bool {
+        self[..] == other[..]
+    }
+}
+
+impl<T, U> PartialEq<SmallArray<U>> for SmallVec<[T; INLINE_CAPACITY]>
+where
+    T: PartialEq<U>,
+{
+    #[inline]
+    fn eq(&self, other: &SmallArray<U>) -> bool {
+        self[..] == other[..]
+    }
+}
+
+impl<T, U> PartialEq<Vec<U>> for SmallArray<T>
+where
+    T: PartialEq<U>,
+{
+    #[inline]
+    fn eq(&self, other: &Vec<U>) -> bool {
+        self[..] == other[..]
+    }
+}
+
+impl<T, U> PartialEq<SmallArray<U>> for Vec<T>
+where
+    T: PartialEq<U>,
+{
+    #[inline]
+    fn eq(&self, other: &SmallArray<U>) -> bool {
+        self[..] == other[..]
+    }
+}
+
+impl<T, U> PartialEq<[U]> for SmallArray<T>
+where
+    T: PartialEq<U>,
+{
+    #[inline]
+    fn eq(&self, other: &[U]) -> bool {
+        self[..] == other[..]
+    }
+}
+
+impl<T, U> PartialEq<SmallArray<U>> for [T]
+where
+    T: PartialEq<U>,
+{
+    #[inline]
+    fn eq(&self, other: &SmallArray<U>) -> bool {
+        self[..] == other[..]
+    }
+}
+
+impl<T, U> PartialEq<Box<[U]>> for SmallArray<T>
+where
+    T: PartialEq<U>,
+{
+    #[inline]
+    fn eq(&self, other: &Box<[U]>) -> bool {
+        self[..] == other[..]
+    }
+}
+
+impl<T, U> PartialEq<SmallArray<U>> for Box<[T]>
+where
+    T: PartialEq<U>,
+{
+    #[inline]
+    fn eq(&self, other: &SmallArray<U>) -> bool {
+        self[..] == other[..]
+    }
+}
+
+impl<T, U> PartialEq<SmallArray<U>> for Array<T>
+where
+    T: PartialEq<U>,
+{
+    #[inline]
+    fn eq(&self, other: &SmallArray<U>) -> bool {
+        self[..] == other[..]
+    }
+}
+
+impl<T, U> PartialEq<Array<U>> for SmallArray<T>
+where
+    T: PartialEq<U>,
+{
+    #[inline]
+    fn eq(&self, other: &Array<U>) -> bool {
+        self[..] == other[..]
+    }
+}
+
+macro_rules! __smallarray_T_eq_primitive_array {
+    ($len:expr) => {
+        impl<T, U> PartialEq<[U; $len]> for SmallArray<T>
+        where
+            T: PartialEq<U>,
+        {
+            #[inline]
+            fn eq(&self, other: &[U; $len]) -> bool {
+                self[..] == other[..]
+            }
+        }
+
+        impl<T, U> PartialEq<SmallArray<U>> for [T; $len]
+        where
+            T: PartialEq<U>,
+        {
+            #[inline]
+            fn eq(&self, other: &SmallArray<U>) -> bool {
+                self[..] == other[..]
+            }
+        }
+
+        impl<T, U> PartialEq<&[U; $len]> for SmallArray<T>
+        where
+            T: PartialEq<U>,
+        {
+            #[inline]
+            fn eq(&self, other: &&[U; $len]) -> bool {
+                self[..] == other[..]
+            }
+        }
+
+        impl<T, U> PartialEq<SmallArray<U>> for &[T; $len]
+        where
+            T: PartialEq<U>,
+        {
+            #[inline]
+            fn eq(&self, other: &SmallArray<U>) -> bool {
+                self[..] == other[..]
+            }
+        }
+    };
+}
+
+__smallarray_T_eq_primitive_array!(0);
+__smallarray_T_eq_primitive_array!(1);
+__smallarray_T_eq_primitive_array!(2);
+__smallarray_T_eq_primitive_array!(3);
+__smallarray_T_eq_primitive_array!(4);
+__smallarray_T_eq_primitive_array!(5);
+__smallarray_T_eq_primitive_array!(6);
+__smallarray_T_eq_primitive_array!(7);
+__smallarray_T_eq_primitive_array!(8);
+__smallarray_T_eq_primitive_array!(9);
+__smallarray_T_eq_primitive_array!(10);
+__smallarray_T_eq_primitive_array!(11);
+__smallarray_T_eq_primitive_array!(12);
+__smallarray_T_eq_primitive_array!(13);
+__smallarray_T_eq_primitive_array!(14);
+__smallarray_T_eq_primitive_array!(15);
+__smallarray_T_eq_primitive_array!(16);
+__smallarray_T_eq_primitive_array!(17);
+__smallarray_T_eq_primitive_array!(18);
+__smallarray_T_eq_primitive_array!(19);
+__smallarray_T_eq_primitive_array!(20);
+__smallarray_T_eq_primitive_array!(21);
+__smallarray_T_eq_primitive_array!(22);
+__smallarray_T_eq_primitive_array!(23);
+__smallarray_T_eq_primitive_array!(24);
+__smallarray_T_eq_primitive_array!(25);
+__smallarray_T_eq_primitive_array!(26);
+__smallarray_T_eq_primitive_array!(27);
+__smallarray_T_eq_primitive_array!(28);
+__smallarray_T_eq_primitive_array!(29);
+__smallarray_T_eq_primitive_array!(30);
+__smallarray_T_eq_primitive_array!(31);
+__smallarray_T_eq_primitive_array!(32);

--- a/spinoso-array/src/array/smallvec/impls.rs
+++ b/spinoso-array/src/array/smallvec/impls.rs
@@ -1,0 +1,124 @@
+use core::borrow::{Borrow, BorrowMut};
+use core::ops::{Deref, DerefMut, Index, IndexMut};
+use core::slice::{Iter, IterMut, SliceIndex};
+use smallvec::SmallVec;
+
+use crate::array::smallvec::SmallArray;
+use crate::array::INLINE_CAPACITY;
+
+impl<T> AsRef<SmallVec<[T; INLINE_CAPACITY]>> for SmallArray<T> {
+    #[inline]
+    fn as_ref(&self) -> &SmallVec<[T; INLINE_CAPACITY]> {
+        &self.0
+    }
+}
+
+impl<T> AsRef<[T]> for SmallArray<T> {
+    #[inline]
+    fn as_ref(&self) -> &[T] {
+        self.0.as_ref()
+    }
+}
+
+impl<T> AsMut<SmallVec<[T; INLINE_CAPACITY]>> for SmallArray<T> {
+    #[inline]
+    fn as_mut(&mut self) -> &mut SmallVec<[T; INLINE_CAPACITY]> {
+        &mut self.0
+    }
+}
+
+impl<T> AsMut<[T]> for SmallArray<T> {
+    #[inline]
+    fn as_mut(&mut self) -> &mut [T] {
+        self.0.as_mut()
+    }
+}
+
+impl<T> Borrow<[T]> for SmallArray<T> {
+    #[inline]
+    fn borrow(&self) -> &[T] {
+        self.0.borrow()
+    }
+}
+
+impl<T> BorrowMut<[T]> for SmallArray<T> {
+    #[inline]
+    fn borrow_mut(&mut self) -> &mut [T] {
+        self.0.borrow_mut()
+    }
+}
+
+impl<T> Deref for SmallArray<T> {
+    type Target = [T];
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        self.0.as_slice()
+    }
+}
+
+impl<T> DerefMut for SmallArray<T> {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.0.as_mut_slice()
+    }
+}
+
+impl<T> Extend<T> for SmallArray<T> {
+    #[inline]
+    fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
+        self.0.extend(iter.into_iter())
+    }
+}
+
+impl<'a, T> Extend<&'a T> for SmallArray<T>
+where
+    T: 'a + Copy,
+{
+    #[inline]
+    fn extend<I: IntoIterator<Item = &'a T>>(&mut self, iter: I) {
+        self.0.extend(iter.into_iter().copied())
+    }
+}
+
+impl<T, I> Index<I> for SmallArray<T>
+where
+    I: SliceIndex<[T]>,
+{
+    type Output = I::Output;
+
+    #[inline]
+    fn index(&self, index: I) -> &I::Output {
+        &self.0[index]
+    }
+}
+
+impl<T, I> IndexMut<I> for SmallArray<T>
+where
+    I: SliceIndex<[T]>,
+{
+    #[inline]
+    fn index_mut(&mut self, index: I) -> &mut I::Output {
+        &mut self.0[index]
+    }
+}
+
+impl<'a, T> IntoIterator for &'a SmallArray<T> {
+    type Item = &'a T;
+    type IntoIter = Iter<'a, T>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter()
+    }
+}
+
+impl<'a, T> IntoIterator for &'a mut SmallArray<T> {
+    type Item = &'a mut T;
+    type IntoIter = IterMut<'a, T>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter_mut()
+    }
+}

--- a/spinoso-array/src/array/smallvec/mod.rs
+++ b/spinoso-array/src/array/smallvec/mod.rs
@@ -1,0 +1,1806 @@
+//! Ruby `Array` based on [`SmallVec`].
+
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+use core::cmp;
+use core::ptr;
+use core::slice::{Iter, IterMut};
+use smallvec::SmallVec;
+
+use crate::array::INLINE_CAPACITY;
+
+mod convert;
+mod eq;
+mod impls;
+
+/// A contiguous growable array type based on
+/// [`SmallVec<[T; INLINE_CAPACITY]>`](SmallVec) that implements the small vector
+/// optimization.
+///
+/// `SmallArray` is an alternate implementation of [`Array`] that implements the
+/// small vector optimization. For `SmallArray`s less then [`INLINE_CAPACITY`]
+/// elements long, there is no heap allocation.
+///
+/// `SmallArray` provides a nearly identical API to the one in [`Array`]. There
+/// are two important differences:
+///
+/// 1. `SmallVec<[T; INLINE_CAPACITY]>` is used in some places where
+///    [`Vec<T>`](Vec) would have been used.
+/// 2. Trait bounds on some methods are more restrictive and require elements to
+///    be [`Copy`].
+///
+/// Similar to `Array`, `SmallArray` implements indexing and mutating APIs that
+/// make an ideal backend for the [Ruby `Array` core class][ruby-array]. In
+/// practice, this results in less generic, more single-use APIs. For example,
+/// instead of [`Vec::drain`], `SmallArray` implements [`shift`], [`shift_n`],
+/// [`pop`], and [`pop_n`].
+///
+/// Similarly, slicing APIs are more specialized, such as [`first_n`] and
+/// [`last_n`]. Slicing APIs do not return [`Option`], instead preferring to
+/// return an empty slice.
+///
+/// # Examples
+///
+/// ```
+/// # use spinoso_array::SmallArray;
+/// let mut ary = SmallArray::new();
+/// ary.push(1);
+/// ary.push(2);
+///
+/// assert_eq!(ary.len(), 2);
+/// assert_eq!(ary[0], 1);
+///
+/// assert_eq!(ary.pop(), Some(2));
+/// assert_eq!(ary.len(), 1);
+///
+/// ary[0] = 7;
+/// assert_eq!(ary[0], 7);
+///
+/// ary.extend([1, 2, 3].iter().copied());
+///
+/// for x in &ary {
+///     println!("{}", x);
+/// }
+/// assert_eq!(ary, &[7, 1, 2, 3]);
+/// ```
+///
+/// [`Array`]: crate::Array
+/// [ruby-array]: https://ruby-doc.org/core-2.6.3/Array.html
+/// [`shift`]: SmallArray::shift
+/// [`shift_n`]: SmallArray::shift_n
+/// [`drop_n`]: SmallArray::drop_n
+/// [`pop`]: SmallArray::pop
+/// [`pop_n`]: SmallArray::pop_n
+/// [`first_n`]: SmallArray::first_n
+/// [`last_n`]: SmallArray::last_n
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub struct SmallArray<T>(SmallVec<[T; INLINE_CAPACITY]>);
+
+impl<T> Default for SmallArray<T> {
+    #[inline]
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T> SmallArray<T> {
+    /// Construct a new, empty `SmallArray<T>`.
+    ///
+    /// The vector will not allocate until more than [`INLINE_CAPACITY`]
+    /// elements are pushed into it.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use spinoso_array::{INLINE_CAPACITY, SmallArray};
+    /// let ary: SmallArray<i32> = SmallArray::new();
+    /// assert!(ary.is_empty());
+    /// assert_eq!(ary.capacity(), INLINE_CAPACITY);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn new() -> Self {
+        Self(SmallVec::new())
+    }
+
+    /// Construct a new, empty `SmallArray<T>` with the specified capacity.
+    ///
+    /// The vector will be able to hold `max(capacity, INLINE_CAPACITY)`
+    /// elements without reallocating. If `capacity` is less than or equal to
+    /// [`INLINE_CAPACITY`], the vector will not allocate.
+    ///
+    /// It is important to note that although the returned vector has the
+    /// _capacity_ specified, the vector will have a zero _length_.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::SmallArray;
+    /// let mut ary: SmallArray<i32> = SmallArray::with_capacity(10);
+    /// assert_eq!(ary.len(), 0);
+    /// assert_eq!(ary.capacity(), 10);
+    ///
+    /// // These are pushes all done without reallocating...
+    /// for i in 0..10 {
+    ///     ary.push(i);
+    /// }
+    ///
+    /// // ...but this may make the vector reallocate
+    /// ary.push(11);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self(SmallVec::with_capacity(capacity))
+    }
+
+    /// Constuct a new two-element `SmallArray` from the given arguments.
+    ///
+    /// The vector is constructed without a heap allocation.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use spinoso_array::{INLINE_CAPACITY, SmallArray};
+    /// let ary = SmallArray::assoc(0, 100);
+    /// assert_eq!(ary.capacity(), INLINE_CAPACITY);
+    /// assert_eq!(ary.len(), 2);
+    /// assert_eq!(ary[0], 0);
+    /// assert_eq!(ary[1], 100);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn assoc(first: T, second: T) -> Self {
+        let pair: [T; 2] = [first, second];
+        Self::from(pair)
+    }
+
+    /// Returns an iterator over the slice.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::SmallArray;
+    /// let ary = SmallArray::from(&[1, 2, 4]);
+    /// let mut iterator = ary.iter();
+    ///
+    /// assert_eq!(iterator.next(), Some(&1));
+    /// assert_eq!(iterator.next(), Some(&2));
+    /// assert_eq!(iterator.next(), Some(&4));
+    /// assert_eq!(iterator.next(), None);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn iter(&self) -> Iter<'_, T> {
+        self.into_iter()
+    }
+
+    /// Returns an iterator that allows modifying each value.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::SmallArray;
+    /// let mut ary = SmallArray::from(&[1, 2, 4]);
+    /// for elem in ary.iter_mut() {
+    ///     *elem += 2;
+    /// }
+    ///
+    /// assert_eq!(ary, &[3, 4, 6]);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn iter_mut(&mut self) -> IterMut<'_, T> {
+        self.into_iter()
+    }
+
+    /// Extracts a slice containing the entire vector.
+    ///
+    /// Equivalent to `&ary[..]`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::SmallArray;
+    /// let ary = SmallArray::from(&[1, 2, 4]);
+    /// let four_index = ary.as_slice().binary_search(&4);
+    /// assert_eq!(four_index, Ok(2));
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn as_slice(&self) -> &[T] {
+        self.0.as_slice()
+    }
+
+    /// Extracts a mutable slice containing the entire vector.
+    ///
+    /// Equivalent to `&mut ary[..]`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::SmallArray;
+    /// let mut ary = SmallArray::from(&[2, 1, 4]);
+    /// ary.as_mut_slice().sort();
+    /// assert_eq!(ary, &[1, 2, 4]);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn as_mut_slice(&mut self) -> &mut [T] {
+        self.0.as_mut_slice()
+    }
+
+    /// Returns a raw pointer to the vector's buffer.
+    ///
+    /// The caller must ensure that the vector outlives the pointer this
+    /// function returns, or else it will end up pointing to garbage. Modifying
+    /// the vector may cause its buffer to be reallocated, which would also make
+    /// any pointers to it invalid.
+    ///
+    /// The caller must also ensure that the memory the pointer
+    /// (non-transitively) points to is never written to (except inside an
+    /// `UnsafeCell`) using this pointer or any pointer derived from it. If you
+    /// need to mutate the contents of the slice, use
+    /// [`as_mut_ptr`](Self::as_mut_ptr).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::SmallArray;
+    /// let ary = SmallArray::from(&[1, 2, 4]);
+    /// let ary_ptr = ary.as_ptr();
+    ///
+    /// unsafe {
+    ///     for i in 0..ary.len() {
+    ///         assert_eq!(*ary_ptr.add(i), 1 << i);
+    ///     }
+    /// }
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn as_ptr(&self) -> *const T {
+        self.0.as_ptr()
+    }
+
+    /// Returns an unsafe mutable pointer to the vector's buffer.
+    ///
+    /// The caller must ensure that the vector outlives the pointer this
+    /// function returns, or else it will end up pointing to garbage.
+    /// Modifying the vector may cause its buffer to be reallocated, which would
+    /// also make any pointers to it invalid.
+    ///
+    /// # Examples
+    ///
+    /// This method is primarily used when mutating a `Array` via a raw pointer
+    /// passed over FFI.
+    ///
+    /// See the [`ARY_PTR`] macro in mruby.
+    ///
+    /// [`ARY_PTR`]: https://github.com/artichoke/mruby/blob/d66440864d08f1c3ac5820d45f11df031b7d43c6/include/mruby/array.h#L52
+    #[inline]
+    #[must_use]
+    pub fn as_mut_ptr(&mut self) -> *mut T {
+        self.0.as_mut_ptr()
+    }
+
+    /// Set the vector's length without dropping or moving out elements
+    ///
+    /// This method is unsafe because it changes the notion of the number of
+    /// "valid" elements in the vector. Use with care.
+    ///
+    /// # Safety
+    ///
+    /// - `new_len` must be less than or equal to capacity().
+    /// - The elements at `old_len..new_len` must be initialized.
+    ///
+    /// # Examples
+    ///
+    /// This method is primarily used when mutating a `Array` via a raw pointer
+    /// passed over FFI.
+    ///
+    /// See the [`ARY_PTR`] macro in mruby.
+    ///
+    /// [`ARY_PTR`]: https://github.com/artichoke/mruby/blob/d66440864d08f1c3ac5820d45f11df031b7d43c6/include/mruby/array.h#L52
+    #[inline]
+    pub unsafe fn set_len(&mut self, new_len: usize) {
+        self.0.set_len(new_len);
+    }
+
+    /// Consume the array and return the inner
+    /// [`SmallVec<[T; INLINE_CAPACITY]>`](SmallVec).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use smallvec::SmallVec;
+    /// use spinoso_array::{INLINE_CAPACITY, SmallArray};
+    /// let ary = SmallArray::from(&[1, 2, 4]);
+    /// let vec: SmallVec<[i32; INLINE_CAPACITY]> = ary.into_inner();
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn into_inner(self) -> SmallVec<[T; INLINE_CAPACITY]> {
+        self.0
+    }
+
+    /// Consume the array and return its elements as a [`Vec<T>`].
+    ///
+    /// For `SmallArray`s with `len() > INLINE_CAPACITY`, this is a cheap
+    /// operation that unwraps the spilled `Vec` from the `SmallVec`. For
+    /// shorter arrays, this method will allocate.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::SmallArray;
+    /// let ary = SmallArray::from(&[1, 2, 4]);
+    /// let vec: Vec<i32> = ary.into_vec();
+    /// ```
+    ///
+    /// [`Vec<T>`]: alloc::vec::Vec
+    #[inline]
+    #[must_use]
+    pub fn into_vec(self) -> Vec<T> {
+        self.0.into_vec()
+    }
+
+    /// Converts the vector into [`Box<[T]>`](Box).
+    ///
+    /// This will drop any excess capacity.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::SmallArray;
+    /// let ary = SmallArray::from(&[1, 2, 4]);
+    /// let slice: Box<[i32]> = ary.into_boxed_slice();
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn into_boxed_slice(self) -> Box<[T]> {
+        self.0.into_boxed_slice()
+    }
+
+    /// Returns the number of elements the vector can hold without reallocating.
+    ///
+    /// The minimum capacity of a `SmallArray` is [`INLINE_CAPACITY`].
+    /// `SmallArray`s with capacity less than or equal to `INLINE_CAPACITY` are
+    /// not allocated on the heap.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use spinoso_array::{INLINE_CAPACITY, SmallArray};
+    /// let ary: SmallArray<i32> = SmallArray::with_capacity(1);
+    /// assert_eq!(ary.capacity(), INLINE_CAPACITY);
+    ///
+    /// let ary: SmallArray<i32> = SmallArray::with_capacity(10);
+    /// assert_eq!(ary.capacity(), 10);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn capacity(&self) -> usize {
+        self.0.capacity()
+    }
+
+    /// Reserves capacity for at least `additional` more elements to be inserted
+    /// in the given `SmallArray<T>`. The collection may reserve more space to
+    /// avoid frequent reallocations. After calling reserve, capacity will be
+    /// greater than or equal to `self.len() + additional`. Does nothing if
+    /// capacity is already sufficient.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the new capacity overflows `usize`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::SmallArray;
+    /// let mut ary = SmallArray::from(&[1]);
+    /// ary.reserve(10);
+    /// assert!(ary.capacity() >= 11);
+    /// ```
+    #[inline]
+    pub fn reserve(&mut self, additional: usize) {
+        self.0.reserve(additional);
+    }
+
+    /// Shrinks the capacity of the vector as much as possible.
+    ///
+    /// It will drop down as close as possible to the length but the allocator
+    /// may still inform the vector that there is space for a few more elements.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::SmallArray;
+    /// let mut ary = SmallArray::with_capacity(10);
+    /// ary.extend([1, 2, 3].iter().copied());
+    /// assert_eq!(ary.capacity(), 10);
+    /// ary.shrink_to_fit();
+    /// assert!(ary.capacity() >= 3);
+    /// ```
+    #[inline]
+    pub fn shrink_to_fit(&mut self) {
+        self.0.shrink_to_fit();
+    }
+
+    /// Clears the vector, removing all values.
+    ///
+    /// Note that this method has no effect on the allocated capacity of the
+    /// vector.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::SmallArray;
+    /// let mut ary = SmallArray::from(&[1, 2, 4]);
+    /// let capacity = ary.capacity();
+    /// ary.clear();
+    /// assert!(ary.is_empty());
+    /// assert_eq!(ary.capacity(), capacity);
+    /// ```
+    #[inline]
+    pub fn clear(&mut self) {
+        self.0.clear();
+    }
+
+    /// Returns the number of elements in the vector, also referred to as its
+    /// 'length'.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::SmallArray;
+    /// let ary = SmallArray::from(&[1, 2, 4]);
+    /// assert_eq!(ary.len(), 3);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Returns `true` if the vector contains no elements.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use spinoso_array::SmallArray;
+    /// let mut ary = SmallArray::new();
+    /// assert!(ary.is_empty());
+    /// ary.push(1);
+    /// assert!(!ary.is_empty());
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Returns a reference to an element at the index.
+    ///
+    /// Unlike [`Vec`], this method does not support indexing with a range.  See
+    /// the [`slice`](Self::slice) method for retrieving a sub-slice from the
+    /// array.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::SmallArray;
+    /// let ary = SmallArray::from(&[1, 2, 4]);
+    /// assert_eq!(ary.get(1), Some(&2));
+    /// assert_eq!(ary.get(3), None);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn get(&self, index: usize) -> Option<&T> {
+        self.0.get(index)
+    }
+
+    /// Appends the elements of `other` to self.
+    ///
+    /// Alias for `extend`. This operation is analogous to "push n".
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::SmallArray;
+    /// let mut ary = SmallArray::from(&[1, 2, 4]);
+    /// ary.concat(vec![7, 8, 9]);
+    /// assert_eq!(ary.len(), 6);
+    /// ```
+    #[inline]
+    pub fn concat<I>(&mut self, other: I)
+    where
+        I: IntoIterator<Item = T>,
+    {
+        self.0.extend(other.into_iter());
+    }
+
+    /// Deletes the element at the specified `index`, returning that element, or
+    /// [`None`] if the `index` is out of range.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::SmallArray;
+    /// let mut ary = SmallArray::from(&[1, 2, 4]);
+    /// assert_eq!(ary.delete_at(1), Some(2));
+    /// assert_eq!(ary.delete_at(10), None);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn delete_at(&mut self, index: usize) -> Option<T> {
+        if index < self.0.len() {
+            Some(self.0.remove(index))
+        } else {
+            None
+        }
+    }
+
+    /// Returns the first element from the vector, or [`None`] if the vector is
+    /// empty.
+    ///
+    /// To retrieve a slice of the first elements in the vector, use
+    /// [`first_n`](Self::first_n).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::SmallArray;
+    /// let mut ary = SmallArray::new();
+    /// assert_eq!(ary.first(), None);
+    /// ary.push(1);
+    /// assert_eq!(ary.first(), Some(&1));
+    /// ary.push(2);
+    /// assert_eq!(ary.first(), Some(&1));
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn first(&self) -> Option<&T> {
+        self.0.first()
+    }
+
+    /// Returns up to `n` of the first elements from the vector, or `&[]` if the
+    /// vector is empty.
+    ///
+    /// To retrieve only the first element in the vector, use
+    /// [`first`](Self::first).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::SmallArray;
+    /// let mut ary = SmallArray::new();
+    /// assert_eq!(ary.first_n(0), &[]);
+    /// assert_eq!(ary.first_n(4), &[]);
+    ///
+    /// ary.push(1);
+    /// ary.push(2);
+    /// assert_eq!(ary.first_n(0), &[]);
+    /// assert_eq!(ary.first_n(4), &[1, 2]);
+    ///
+    /// ary.concat(vec![3, 4, 5, 6, 7, 8, 9, 10]);
+    /// assert_eq!(ary.first_n(0), &[]);
+    /// assert_eq!(ary.first_n(4), &[1, 2, 3, 4]);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn first_n(&self, n: usize) -> &[T] {
+        self.0.get(..n).unwrap_or_else(|| &self.0[..])
+    }
+
+    /// Returns the last element from the vector, or [`None`] if the vector is
+    /// empty.
+    ///
+    /// To retrieve a slice of the last elements in the vector, use
+    /// [`last_n`](Self::last_n).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::SmallArray;
+    /// let mut ary = SmallArray::new();
+    /// assert_eq!(ary.last(), None);
+    /// ary.push(1);
+    /// assert_eq!(ary.last(), Some(&1));
+    /// ary.push(2);
+    /// assert_eq!(ary.last(), Some(&2));
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn last(&self) -> Option<&T> {
+        self.0.last()
+    }
+
+    /// Returns up to `n` of the last elements from the vector, or `&[]` if the
+    /// vector is empty.
+    ///
+    /// To retrieve only the last element in the vector, use
+    /// [`last`](Self::last).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::SmallArray;
+    /// let mut ary = SmallArray::new();
+    /// assert_eq!(ary.last_n(0), &[]);
+    /// assert_eq!(ary.last_n(4), &[]);
+    ///
+    /// ary.push(1);
+    /// ary.push(2);
+    /// assert_eq!(ary.last_n(0), &[]);
+    /// assert_eq!(ary.last_n(4), &[1, 2]);
+    ///
+    /// ary.concat(vec![3, 4, 5, 6, 7, 8, 9, 10]);
+    /// assert_eq!(ary.last_n(0), &[]);
+    /// assert_eq!(ary.last_n(4), &[7, 8, 9, 10]);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn last_n(&self, n: usize) -> &[T] {
+        let begin = self.len().checked_sub(n).unwrap_or_default();
+        &self.0[begin..]
+    }
+
+    /// Returns a slice of the underlying vector that includes only the first
+    /// `n` elements.
+    ///
+    /// If `n` is greater than or equal to the length of the vector, `&self[..]`
+    /// is returned.
+    ///
+    /// The inverse of this operation is [`drop_n`](Self::drop_n).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::SmallArray;
+    /// let ary = SmallArray::from(&[1, 2, 4, 7, 8, 9]);
+    /// assert_eq!(ary.take_n(0), &[]);
+    /// assert_eq!(ary.take_n(2), &[1, 2]);
+    /// assert_eq!(ary.take_n(10), &[1, 2, 4, 7, 8, 9]);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn take_n(&self, n: usize) -> &[T] {
+        self.0.get(..n).unwrap_or_else(|| &self.0[..])
+    }
+
+    /// Returns a slice of the underlying vector that excludes the first `n`
+    /// elements.
+    ///
+    /// If `n` is greater than or equal to the length of the vector, `&[]` is
+    /// returned.
+    ///
+    /// The inverse of this operation is [`take_n`](Self::take_n).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::SmallArray;
+    /// let ary = SmallArray::from(&[1, 2, 4, 7, 8, 9]);
+    /// assert_eq!(ary.drop_n(0), &[1, 2, 4, 7, 8, 9]);
+    /// assert_eq!(ary.drop_n(4), &[8, 9]);
+    /// assert_eq!(ary.drop_n(10), &[]);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn drop_n(&self, n: usize) -> &[T] {
+        self.0.get(n..).unwrap_or_else(|| &[])
+    }
+
+    /// Removes the last element from the vector and returns it, or [`None`] if
+    /// the vector is empty.
+    ///
+    /// To pop more than one element from the end of the vector, use
+    /// [`pop_n`](Self::pop_n).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::SmallArray;
+    /// let mut ary = SmallArray::from(&[1, 2, 4]);
+    /// assert_eq!(ary.pop(), Some(4));
+    /// assert_eq!(ary, &[1, 2]);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn pop(&mut self) -> Option<T> {
+        self.0.pop()
+    }
+
+    /// Removes the last `n` elements from the vector.
+    ///
+    /// To pop a single element from the end of the vector, use
+    /// [`pop`](Self::pop).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::SmallArray;
+    /// let mut ary = SmallArray::from(&[1, 2, 4, 7, 8, 9]);
+    /// assert_eq!(ary.pop_n(0), &[]);
+    /// assert_eq!(ary, &[1, 2, 4, 7, 8, 9]);
+    ///
+    /// assert_eq!(ary.pop_n(3), &[7, 8, 9]);
+    /// assert_eq!(ary, &[1, 2, 4]);
+    ///
+    /// assert_eq!(ary.pop_n(100), &[1, 2, 4]);
+    /// assert!(ary.is_empty());
+    ///
+    /// assert_eq!(ary.pop_n(1), &[]);
+    /// assert!(ary.is_empty());
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn pop_n(&mut self, n: usize) -> Self {
+        if n == 0 {
+            return Self::new();
+        }
+        let begin = self.len().checked_sub(n).unwrap_or_default();
+        self.0.drain(begin..).collect()
+    }
+
+    /// Appends an element to the back of the vector.
+    ///
+    /// To push more than one element to the end of the vector, use
+    /// [`concat`](Self::concat) or `extend`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the number of elements in the vector overflows a `usize`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::SmallArray;
+    /// let mut ary = SmallArray::from(&[1, 2]);
+    /// ary.push(3);
+    /// assert_eq!(ary, &[1, 2, 3]);
+    /// ```
+    #[inline]
+    pub fn push(&mut self, elem: T) {
+        self.0.push(elem);
+    }
+
+    /// Reverses the order of elements of the vector, in place.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::SmallArray;
+    /// let mut ary = SmallArray::from(&[1, 2, 4]);
+    /// ary.reverse();
+    /// assert_eq!(ary, &[4, 2, 1]);
+    /// ```
+    #[inline]
+    pub fn reverse(&mut self) {
+        self.0.reverse();
+    }
+
+    /// Removes the first element of the vector and returns it (shifting all
+    /// other elements down by one). Returns [`None`] if the vector is empty.
+    ///
+    /// This operation is also known as "pop front".
+    ///
+    /// To remove more than one element from the front of the vector, use
+    /// [`shift_n`](Self::shift_n).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::SmallArray;
+    /// let mut ary = SmallArray::from(&[1, 2]);
+    /// assert_eq!(ary.shift(), Some(1));
+    /// assert_eq!(ary.shift(), Some(2));
+    /// assert_eq!(ary.shift(), None);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn shift(&mut self) -> Option<T> {
+        if self.is_empty() {
+            None
+        } else {
+            Some(self.0.remove(0))
+        }
+    }
+
+    /// Removes the first `n` elements from the vector.
+    ///
+    /// To shift a single element from the front of the vector, use
+    /// [`shift`](Self::shift).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::SmallArray;
+    /// let mut ary = SmallArray::from(&[1, 2, 4, 7, 8, 9]);
+    /// assert_eq!(ary.shift_n(0), &[]);
+    /// assert_eq!(ary, &[1, 2, 4, 7, 8, 9]);
+    ///
+    /// assert_eq!(ary.shift_n(3), &[1, 2, 4]);
+    /// assert_eq!(ary, &[7, 8, 9]);
+    ///
+    /// assert_eq!(ary.shift_n(100), &[7, 8, 9]);
+    /// assert!(ary.is_empty());
+    ///
+    /// assert_eq!(ary.shift_n(1), &[]);
+    /// assert!(ary.is_empty());
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn shift_n(&mut self, n: usize) -> Self {
+        match n {
+            0 => Self::new(),
+            n if n < self.0.len() => self.0.drain(..n).collect(),
+            _ => self.0.drain(..).collect(),
+        }
+    }
+
+    /// Inserts an element to the front of the vector.
+    ///
+    /// To insert more than one element to the front of the vector, use
+    /// [`unshift_n`](Self::unshift_n).
+    ///
+    /// This operation is also known as "prepend".
+    ///
+    /// # Panics
+    ///
+    /// Panics if the number of elements in the vector overflows a `usize`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::SmallArray;
+    /// let mut ary = SmallArray::from(&[1, 2]);
+    /// ary.unshift(3);
+    /// assert_eq!(ary, &[3, 1, 2]);
+    /// ```
+    #[inline]
+    pub fn unshift(&mut self, elem: T) {
+        self.0.insert(0, elem);
+    }
+
+    /// Return a reference to a subslice of the vector.
+    ///
+    /// This function always returns a slice. If the range specified by `start`
+    /// and `end` overlaps the vector (even if only partially), the overlapping
+    /// slice is returned. If the range does not overlap the vector, an empty
+    /// slice is returned.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::SmallArray;
+    /// let empty: SmallArray<i32> = SmallArray::new();
+    /// assert_eq!(empty.slice(0, 0), &[]);
+    /// assert_eq!(empty.slice(0, 4), &[]);
+    /// assert_eq!(empty.slice(2, 4), &[]);
+    ///
+    /// let ary = SmallArray::from(&[1, 2, 3]);
+    /// assert_eq!(ary.slice(0, 0), &[]);
+    /// assert_eq!(ary.slice(0, 4), &[1, 2, 3]);
+    /// assert_eq!(ary.slice(2, 0), &[]);
+    /// assert_eq!(ary.slice(2, 4), &[3]);
+    /// assert_eq!(ary.slice(10, 100), &[]);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn slice(&self, start: usize, len: usize) -> &[T] {
+        if self.0.is_empty() || len == 0 {
+            return &[];
+        }
+        self.0
+            .get(start..start + len)
+            .or_else(|| self.0.get(start..))
+            .unwrap_or_default()
+    }
+}
+
+impl<T> SmallArray<T>
+where
+    T: Clone,
+{
+    /// Construct a new `SmallArray<T>` with length `len` and all elements set
+    /// to `default`. The `SmallArray` will have capacity at least `len`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::SmallArray;
+    /// let ary: SmallArray<&str> = SmallArray::with_len_and_default(3, "spinoso");
+    /// assert_eq!(ary.len(), 3);
+    /// assert!(ary.capacity() >= 3);
+    /// assert_eq!(ary, &["spinoso", "spinoso", "spinoso"]);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn with_len_and_default(len: usize, default: T) -> Self {
+        let mut vec = SmallVec::with_capacity(len);
+        for _ in 0..len {
+            vec.push(default.clone());
+        }
+        Self(vec)
+    }
+}
+
+impl<T> SmallArray<T>
+where
+    T: Copy,
+{
+    /// Prepends the elements of `other` to self.
+    ///
+    /// To insert one element to the front of the vector, use
+    /// [`unshift`](Self::unshift).
+    ///
+    /// This operation is also known as "prepend".
+    ///
+    /// # Panics
+    ///
+    /// Panics if the number of elements in the vector overflows a `usize`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::SmallArray;
+    /// let mut ary = SmallArray::from(&[1, 2]);
+    /// ary.unshift_n(&[0, 5, 9]);
+    /// assert_eq!(ary, &[0, 5, 9, 1, 2]);
+    /// ```
+    #[inline]
+    pub fn unshift_n(&mut self, other: &[T]) {
+        self.0.reserve(other.len());
+        self.0.insert_from_slice(0, other);
+    }
+}
+
+impl<T> SmallArray<T>
+where
+    T: Default,
+{
+    /// Set element at position `index` within the vector, extending the vector
+    /// with `T::default()` if `index` is out of bounds.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::SmallArray;
+    /// let mut ary = SmallArray::from(&[1, 2 ,4]);
+    /// ary.set(1, 11);
+    /// assert_eq!(ary, &[1, 11, 4]);
+    /// ary.set(5, 263);
+    /// assert_eq!(ary, &[1, 11, 4, 0, 0, 263]);
+    /// ```
+    #[inline]
+    pub fn set(&mut self, index: usize, elem: T) {
+        if let Some(cell) = self.0.get_mut(index) {
+            *cell = elem;
+        } else {
+            let buflen = self.len();
+            // index is *at least* buflen, so this calculation never underflows
+            // and ensures we allocate an additional slot.
+            self.0.reserve(index + 1 - buflen);
+            for _ in buflen..index {
+                self.0.push(T::default());
+            }
+            self.0.push(elem);
+        }
+    }
+
+    /// Insert element at position `start` within the vector and remove the
+    /// following `drain` elements. If `start` is out of bounds, the vector will
+    /// be extended with `T::default()`.
+    ///
+    /// This method sets a slice of the `SmallArray` to a single element,
+    /// including the zero-length slice. It is similar in intent to calling
+    /// [`Vec::splice`] with a one-element iterator.
+    ///
+    /// `set_with_drain` will only drain up to the end of the vector.
+    ///
+    /// To set a single element without draining, use [`set`](Self::set).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::SmallArray;
+    /// let mut ary = SmallArray::from(&[1, 2, 4]);
+    /// ary.set_with_drain(1, 0, 10);
+    /// assert_eq!(ary, &[1, 10, 2, 4]);
+    /// ary.set_with_drain(2, 5, 20);
+    /// assert_eq!(ary, &[1, 10, 20]);
+    /// ary.set_with_drain(5, 5, 30);
+    /// assert_eq!(ary, &[1, 10, 20, 0, 0, 30]);
+    /// ```
+    #[inline]
+    pub fn set_with_drain(&mut self, start: usize, drain: usize, elem: T) -> usize {
+        let buflen = self.0.len();
+        let drained = cmp::min(buflen.checked_sub(start).unwrap_or_default(), drain);
+
+        if let Some(cell) = self.0.get_mut(start) {
+            match drain {
+                0 => self.0.insert(start, elem),
+                1 => *cell = elem,
+                _ => {
+                    *cell = elem;
+                    let drain_end_idx = cmp::min(start + drain, buflen);
+                    self.0.drain(start + 1..drain_end_idx);
+                }
+            }
+        } else {
+            // start is *at least* buflen, so this calculation never underflows
+            // and ensures we allocate an additional slot.
+            self.0.reserve(start + 1 - buflen);
+            for _ in buflen..start {
+                self.0.push(T::default());
+            }
+            self.0.push(elem);
+        }
+
+        drained
+    }
+}
+
+impl<T> SmallArray<T>
+where
+    T: Default + Copy,
+{
+    /// Insert the elements from a slice at a position `index` in the vector,
+    /// extending the vector with `T::default()` if `index` is out of bounds.
+    ///
+    /// This method is similar to [`Vec::splice`] when called with a zero-length
+    /// range.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::SmallArray;
+    /// let mut ary = SmallArray::from(&[1, 2, 4]);
+    /// ary.insert_slice(1, &[7, 8, 9]);
+    /// assert_eq!(ary, &[1, 7, 8, 9, 2, 4]);
+    /// ary.insert_slice(8, &[100, 200]);
+    /// assert_eq!(ary, &[1, 7, 8, 9, 2, 4, 0, 0, 100, 200]);
+    /// ```
+    #[inline]
+    pub fn insert_slice(&mut self, index: usize, values: &[T]) {
+        let additional = index.checked_sub(self.0.len()).unwrap_or_default() + values.len();
+        self.0.reserve(additional);
+
+        for _ in self.0.len()..index {
+            self.0.push(T::default());
+        }
+        self.0.insert_from_slice(index, values);
+    }
+
+    /// Insert the elements from a slice at a position `index` in the vector and
+    /// remove the following `drain` elements. The vector is extended with
+    /// `T::default()` if `index` is out of bounds.
+    ///
+    /// This method is similar to [`Vec::splice`] when called with a
+    /// nonzero-length range.
+    ///
+    /// When called with `drain == 0`, this method is equivalent to
+    /// [`insert_slice`](Self::insert_slice).
+    ///
+    /// If `drain >= src.len()` or the tail of the vector is replaced, this
+    /// method is efficient. Otherwise, a temporary buffer is used to move the
+    /// elements.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::SmallArray;
+    /// let mut ary = SmallArray::from(&[1, 2, 4]);
+    /// ary.set_slice(1, 5, &[7, 8, 9]);
+    /// assert_eq!(ary, &[1, 7, 8, 9]);
+    /// ary.set_slice(6, 1, &[100, 200]);
+    /// assert_eq!(ary, &[1, 7, 8, 9, 0, 0, 100, 200]);
+    /// ary.set_slice(4, 2, &[88, 99]);
+    /// assert_eq!(ary, &[1, 7, 8, 9, 88, 99, 100, 200]);
+    /// ary.set_slice(6, 2, &[1000, 2000, 3000, 4000]);
+    /// assert_eq!(ary, &[1, 7, 8, 9, 88, 99, 1000, 2000, 3000, 4000]);
+    /// ```
+    #[inline]
+    pub fn set_slice(&mut self, index: usize, drain: usize, values: &[T]) -> usize {
+        let additional = index.checked_sub(self.0.len()).unwrap_or_default() + values.len();
+        self.0.reserve(additional);
+
+        // Extend the vector to account for out of bounds `index`.
+        for _ in self.0.len()..index {
+            self.0.push(T::default());
+        }
+        // `self.len()` is at least `index` so the below sub can never overflow.
+        let tail = self.len() - index;
+        // This is a direct append to the end of the vector, either because the
+        // given `index` was the vector's length or because we have extended the
+        // vector from an out of bounds index.
+        if tail == 0 {
+            self.0.extend_from_slice(values);
+            return 0;
+        }
+        // If the tail of the vector is shorter than or as long as the number of
+        // elements to drain, we can truncate and extend the underlying vector.
+        // `truncate` does not affect the existing capacity of the vector.
+        if tail <= drain {
+            self.0.truncate(index);
+            self.0.extend_from_slice(values);
+            return tail;
+        }
+
+        // Short circuit to a direct insert if `drain == 0`.
+        if drain == 0 {
+            self.0.insert_from_slice(index, values);
+            return 0;
+        }
+
+        // At this point, `index + drain` is guaranteed to be a valid index
+        // within the vector. There are two cases:
+        //
+        // - If `values.len() == drain`, we can drain elements by overwriting
+        //   them in the vector.
+        // - If `values.len() >= drain`, we can drain elements by overwriting
+        //   them in the vector and inserting the remainder.
+        // - Otherwise, overwrite `values` into the vector and remove the
+        //   remaining elements we must drain.
+        match values.len() {
+            len if len == drain => {
+                let slice = &mut self.0[index..index + drain];
+                slice.copy_from_slice(values);
+            }
+            len if len > drain => {
+                let slice = &mut self.0[index..index + drain];
+                let (overwrite, insert) = values.split_at(drain);
+                slice.copy_from_slice(overwrite);
+                self.0.insert_from_slice(index + drain, insert);
+            }
+            0 => {
+                // This unsafe block is necessary to ensure that partial drains
+                // have `O(n)` complexity where `n` is `drain`. `SmallVec` only
+                // exposes [`SmallVec::remove`] to remove a single element.
+                // Calling this API multiple times would make the drain
+                // `O(n^2)`.
+                //
+                // This unsafe code was copied from `SmallVec::remove` and
+                // modified to remove multiple elements.
+                //
+                // Safety:
+                //
+                // We are copying elements from `index + remaining..end`
+                // to `start + index`.
+                //
+                // - Drained elements are read out of the `SmallVec` storage and
+                //   properly dropped.
+                // - `index` is asserted to be within the bounds of the vector.
+                // - `index + remaining` is asserted to be within the bounds of
+                //   the vector.
+                // - The length of the vector is shrunk to `len - remaining`.
+                // - We copy from one element beyond the drain to `index`.
+                // - We copy only the elements beyond the index and the drain.
+                unsafe {
+                    let mut ptr = self.0.as_mut_ptr();
+                    let len = self.0.len();
+                    assert!(index < len);
+                    // `< len` because draining the entire tail is handled above.
+                    assert!(index + drain < len);
+                    // It is not necessary to call `ptr::read` to drop all of
+                    // the to-be-overwritten elements since `SmallArray` imposes
+                    // a `Copy` bound on this method and `Copy` types are not
+                    // allowed to have destructors.
+                    self.0.set_len(len - drain);
+                    ptr = ptr.add(index);
+                    // Shift elements in the vector down by `drain` items we
+                    // have to drain.
+                    let remaining = len - index - drain;
+                    ptr::copy(ptr.add(drain), ptr, remaining);
+                }
+            }
+            len => {
+                let slice = &mut self.0[index..index + len];
+                slice.copy_from_slice(values);
+                // Update index and drain to account for the shorter slice we
+                // just inserted.
+                let still_to_drain = drain - values.len();
+                let index = index + len;
+                // This unsafe block is necessary to ensure that partial drains
+                // have `O(n)` complexity where `n` is `drain`. `SmallVec` only
+                // exposes [`SmallVec::remove`] to remove a single element.
+                // Calling this API multiple times would make the drain
+                // `O(n^2)`.
+                //
+                // This unsafe code was copied from `SmallVec::remove` and
+                // modified to remove multiple elements.
+                //
+                // Safety:
+                //
+                // We are copying elements from `index + remaining..end`
+                // to `start + index`.
+                //
+                // - Drained elements are read out of the `SmallVec` storage and
+                //   properly dropped.
+                // - `index` is asserted to be within the bounds of the vector.
+                // - `index + remaining` is asserted to be within the bounds of
+                //   the vector.
+                // - The length of the vector is shrunk to `len - remaining`.
+                // - We copy from one element beyond the drain to `index`.
+                // - We copy only the elements beyond the index and the drain.
+                unsafe {
+                    let mut ptr = self.0.as_mut_ptr();
+                    let len = self.0.len();
+                    assert!(index < len);
+                    // `< len` because draining the entire tail is handled above.
+                    assert!(index + still_to_drain < len);
+                    // It is not necessary to call `ptr::read` to drop all of
+                    // the to-be-overwritten elements since `SmallArray` imposes
+                    // a `Copy` bound on this method and `Copy` types are not
+                    // allowed to have destructors.
+                    self.0.set_len(len - still_to_drain);
+                    ptr = ptr.add(index);
+                    // Shift elements in the vector down by `drain` items we
+                    // have to drain.
+                    let remaining = len - index - still_to_drain;
+                    ptr::copy(ptr.add(still_to_drain), ptr, remaining);
+                }
+            }
+        }
+
+        drain
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::array::smallvec::SmallArray;
+
+    // `insert_slice`
+
+    #[test]
+    fn non_empty_array_insert_slice_end_empty() {
+        let mut ary = SmallArray::from([1, 2, 3, 4, 5]);
+        ary.insert_slice(5, &[]);
+        assert_eq!(ary, [1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn non_empty_array_insert_slice_out_of_bounds_empty() {
+        let mut ary = SmallArray::from([1, 2, 3, 4, 5]);
+        ary.insert_slice(10, &[]);
+        assert_eq!(ary, [1, 2, 3, 4, 5, 0, 0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn non_empty_array_insert_slice_interior_empty() {
+        let mut ary = SmallArray::from([1, 2, 3, 4, 5]);
+        ary.insert_slice(2, &[]);
+        assert_eq!(ary, [1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn non_empty_array_insert_slice_begin_empty() {
+        let mut ary = SmallArray::from([1, 2, 3, 4, 5]);
+        ary.insert_slice(0, &[]);
+        assert_eq!(ary, [1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn empty_array_insert_slice_end_empty() {
+        let mut ary = SmallArray::<i32>::new();
+        ary.insert_slice(0, &[]);
+        assert_eq!(ary, []);
+    }
+
+    #[test]
+    fn empty_array_insert_slice_out_of_bounds_empty() {
+        let mut ary = SmallArray::<i32>::new();
+        ary.insert_slice(10, &[]);
+        assert_eq!(ary, [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn empty_array_insert_slice_begin_empty() {
+        let mut ary = SmallArray::<i32>::new();
+        ary.insert_slice(0, &[]);
+        assert_eq!(ary, []);
+    }
+
+    #[test]
+    fn non_empty_array_insert_slice_end() {
+        let mut ary = SmallArray::from([1, 2, 3, 4, 5]);
+        ary.insert_slice(5, &[8, 9, 10]);
+        assert_eq!(ary, [1, 2, 3, 4, 5, 8, 9, 10]);
+    }
+
+    #[test]
+    fn non_empty_array_insert_slice_out_of_bounds() {
+        let mut ary = SmallArray::from([1, 2, 3, 4, 5]);
+        ary.insert_slice(10, &[8, 9, 10]);
+        assert_eq!(ary, [1, 2, 3, 4, 5, 0, 0, 0, 0, 0, 8, 9, 10]);
+    }
+
+    #[test]
+    fn non_empty_array_insert_slice_interior() {
+        let mut ary = SmallArray::from([1, 2, 3, 4, 5]);
+        ary.insert_slice(2, &[8, 9, 10]);
+        assert_eq!(ary, [1, 2, 8, 9, 10, 3, 4, 5]);
+    }
+
+    #[test]
+    fn non_empty_array_insert_slice_begin() {
+        let mut ary = SmallArray::from([1, 2, 3, 4, 5]);
+        ary.insert_slice(0, &[8, 9, 10]);
+        assert_eq!(ary, [8, 9, 10, 1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn empty_array_insert_slice_end() {
+        let mut ary = SmallArray::<i32>::new();
+        ary.insert_slice(0, &[8, 9, 10]);
+        assert_eq!(ary, [8, 9, 10]);
+    }
+
+    #[test]
+    fn empty_array_insert_slice_out_of_bounds() {
+        let mut ary = SmallArray::<i32>::new();
+        ary.insert_slice(10, &[8, 9, 10]);
+        assert_eq!(ary, [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 8, 9, 10]);
+    }
+
+    #[test]
+    fn empty_array_insert_slice_begin() {
+        let mut ary = SmallArray::<i32>::new();
+        ary.insert_slice(0, &[8, 9, 10]);
+        assert_eq!(ary, [8, 9, 10]);
+    }
+
+    // `set_slice`
+
+    #[test]
+    fn non_empty_array_set_slice_end_empty_drain_0() {
+        let mut ary = SmallArray::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(5, 0, &[]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_end_empty_drain_less_than_insert_length() {
+        let mut ary = SmallArray::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(5, 0, &[]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_end_empty_drain_equal_to_insert_length() {
+        let mut ary = SmallArray::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(5, 0, &[]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_end_empty_drain_greater_than_insert_length() {
+        let mut ary = SmallArray::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(5, 5, &[]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_out_of_bounds_empty_drain_0() {
+        let mut ary = SmallArray::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(10, 0, &[]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [1, 2, 3, 4, 5, 0, 0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_out_of_bounds_empty_drain_less_than_insert_length() {
+        let mut ary = SmallArray::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(10, 0, &[]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [1, 2, 3, 4, 5, 0, 0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_out_of_bounds_empty_drain_equal_to_insert_length() {
+        let mut ary = SmallArray::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(10, 0, &[]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [1, 2, 3, 4, 5, 0, 0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_out_of_bounds_empty_drain_greater_than_insert_length() {
+        let mut ary = SmallArray::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(10, 0, &[]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [1, 2, 3, 4, 5, 0, 0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_interior_empty_drain_0() {
+        let mut ary = SmallArray::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(1, 0, &[]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_interior_empty_drain_less_than_insert_length() {
+        let mut ary = SmallArray::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(1, 0, &[]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_interior_empty_drain_equal_to_insert_length() {
+        let mut ary = SmallArray::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(1, 0, &[]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_interior_empty_drain_greater_than_insert_length() {
+        let mut ary = SmallArray::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(1, 2, &[]);
+        assert_eq!(drained, 2);
+        assert_eq!(ary, [1, 4, 5]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_interior_empty_drain_greater_than_insert_length_to_end() {
+        let mut ary = SmallArray::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(1, 4, &[]);
+        assert_eq!(drained, 4);
+        assert_eq!(ary, [1]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_interior_empty_drain_greater_than_insert_length_overrun_end() {
+        let mut ary = SmallArray::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(1, 10, &[]);
+        assert_eq!(drained, 4);
+        assert_eq!(ary, [1]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_end_non_empty_drain_0() {
+        let mut ary = SmallArray::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(5, 0, &[7, 8, 9]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [1, 2, 3, 4, 5, 7, 8, 9]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_end_non_empty_drain_less_than_insert_length() {
+        let mut ary = SmallArray::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(5, 2, &[7, 8, 9]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [1, 2, 3, 4, 5, 7, 8, 9]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_end_non_empty_drain_equal_to_insert_length() {
+        let mut ary = SmallArray::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(5, 3, &[7, 8, 9]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [1, 2, 3, 4, 5, 7, 8, 9]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_end_non_empty_drain_greater_than_insert_length() {
+        let mut ary = SmallArray::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(5, 5, &[7, 8, 9]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [1, 2, 3, 4, 5, 7, 8, 9]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_out_of_bounds_non_empty_drain_0() {
+        let mut ary = SmallArray::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(10, 0, &[7, 8, 9]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [1, 2, 3, 4, 5, 0, 0, 0, 0, 0, 7, 8, 9]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_out_of_bounds_non_empty_drain_less_than_insert_length() {
+        let mut ary = SmallArray::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(10, 2, &[7, 8, 9]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [1, 2, 3, 4, 5, 0, 0, 0, 0, 0, 7, 8, 9]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_out_of_bounds_non_empty_drain_equal_to_insert_length() {
+        let mut ary = SmallArray::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(10, 3, &[7, 8, 9]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [1, 2, 3, 4, 5, 0, 0, 0, 0, 0, 7, 8, 9]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_out_of_bounds_non_empty_drain_greater_than_insert_length() {
+        let mut ary = SmallArray::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(10, 5, &[7, 8, 9]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [1, 2, 3, 4, 5, 0, 0, 0, 0, 0, 7, 8, 9]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_interior_non_empty_drain_0() {
+        let mut ary = SmallArray::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(1, 0, &[7, 8, 9]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [1, 7, 8, 9, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_interior_non_empty_drain_less_than_insert_length() {
+        let mut ary = SmallArray::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(1, 2, &[7, 8, 9]);
+        assert_eq!(drained, 2);
+        assert_eq!(ary, [1, 7, 8, 9, 4, 5]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_interior_non_empty_drain_equal_to_insert_length() {
+        let mut ary = SmallArray::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(1, 3, &[7, 8, 9]);
+        assert_eq!(drained, 3);
+        assert_eq!(ary, [1, 7, 8, 9, 5]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_interior_non_empty_drain_greater_than_insert_length() {
+        let mut ary = SmallArray::from([1, 2, 3, 4, 5, 6]);
+        let drained = ary.set_slice(1, 4, &[7, 8, 9]);
+        assert_eq!(drained, 4);
+        assert_eq!(ary, [1, 7, 8, 9, 6]);
+        assert_eq!(ary.len(), 5);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_interior_non_empty_drain_equal_to_insert_length_to_tail() {
+        let mut ary = SmallArray::from([1, 2, 3, 4]);
+        let drained = ary.set_slice(1, 3, &[7, 8, 9]);
+        assert_eq!(drained, 3);
+        assert_eq!(ary, [1, 7, 8, 9]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_interior_non_empty_drain_greater_than_insert_length_to_tail() {
+        let mut ary = SmallArray::from([1, 2, 3, 4]);
+        let drained = ary.set_slice(1, 10, &[7, 8, 9]);
+        assert_eq!(drained, 3);
+        assert_eq!(ary, [1, 7, 8, 9]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_interior_non_empty_drain_less_than_insert_length_overrun_tail() {
+        let mut ary = SmallArray::from([1, 2, 3, 4]);
+        let drained = ary.set_slice(3, 2, &[7, 8, 9]);
+        assert_eq!(drained, 1);
+        assert_eq!(ary, [1, 2, 3, 7, 8, 9]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_interior_non_empty_drain_equal_to_insert_length_overrun_tail() {
+        let mut ary = SmallArray::from([1, 2, 3, 4]);
+        let drained = ary.set_slice(3, 3, &[7, 8, 9]);
+        assert_eq!(drained, 1);
+        assert_eq!(ary, [1, 2, 3, 7, 8, 9]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_interior_non_empty_drain_greater_than_insert_length_overrun_tail()
+    {
+        let mut ary = SmallArray::from([1, 2, 3, 4]);
+        let drained = ary.set_slice(3, 10, &[7, 8, 9]);
+        assert_eq!(drained, 1);
+        assert_eq!(ary, [1, 2, 3, 7, 8, 9]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_begin_non_empty_drain_0() {
+        let mut ary = SmallArray::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(0, 0, &[7, 8, 9]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [7, 8, 9, 1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_begin_non_empty_drain_less_than_insert_length() {
+        let mut ary = SmallArray::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(0, 2, &[7, 8, 9]);
+        assert_eq!(drained, 2);
+        assert_eq!(ary, [7, 8, 9, 3, 4, 5]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_begin_non_empty_drain_equal_to_insert_length() {
+        let mut ary = SmallArray::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(0, 3, &[7, 8, 9]);
+        assert_eq!(drained, 3);
+        assert_eq!(ary, [7, 8, 9, 4, 5]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_begin_non_empty_drain_greater_than_insert_length() {
+        let mut ary = SmallArray::from([1, 2, 3, 4, 5, 6]);
+        let drained = ary.set_slice(0, 4, &[7, 8, 9]);
+        assert_eq!(drained, 4);
+        assert_eq!(ary, [7, 8, 9, 5, 6]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_begin_non_empty_drain_equal_to_insert_length_to_tail() {
+        let mut ary = SmallArray::from([1, 2, 3, 4]);
+        let drained = ary.set_slice(0, 4, &[7, 8, 9, 10]);
+        assert_eq!(drained, 4);
+        assert_eq!(ary, [7, 8, 9, 10]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_begin_non_empty_drain_greater_than_insert_length_to_tail() {
+        let mut ary = SmallArray::from([1, 2, 3, 4]);
+        let drained = ary.set_slice(0, 10, &[7, 8, 9, 10]);
+        assert_eq!(drained, 4);
+        assert_eq!(ary, [7, 8, 9, 10]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_begin_non_empty_drain_less_than_insert_length_overrun_tail() {
+        let mut ary = SmallArray::from([1, 2, 3, 4]);
+        let drained = ary.set_slice(0, 4, &[7, 8, 9, 10, 11]);
+        assert_eq!(drained, 4);
+        assert_eq!(ary, [7, 8, 9, 10, 11]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_begin_non_empty_drain_equal_to_insert_length_overrun_tail() {
+        let mut ary = SmallArray::from([1, 2, 3, 4]);
+        let drained = ary.set_slice(0, 5, &[7, 8, 9, 10, 11]);
+        assert_eq!(drained, 4);
+        assert_eq!(ary, [7, 8, 9, 10, 11]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_begin_non_empty_drain_greater_than_insert_length_overrun_tail() {
+        let mut ary = SmallArray::from([1, 2, 3, 4]);
+        let drained = ary.set_slice(0, 10, &[7, 8, 9, 10, 11]);
+        assert_eq!(drained, 4);
+        assert_eq!(ary, [7, 8, 9, 10, 11]);
+    }
+
+    #[test]
+    fn empty_array_set_slice_non_empty_drain_0() {
+        let mut ary = SmallArray::<i32>::new();
+        let drained = ary.set_slice(0, 0, &[7, 8, 9]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [7, 8, 9]);
+    }
+
+    #[test]
+    fn empty_array_set_slice_non_empty_drain_less_than_insert_length() {
+        let mut ary = SmallArray::<i32>::new();
+        let drained = ary.set_slice(0, 1, &[7, 8, 9]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [7, 8, 9]);
+    }
+
+    #[test]
+    fn empty_array_set_slice_non_empty_drain_equal_to_insert_length() {
+        let mut ary = SmallArray::<i32>::new();
+        let drained = ary.set_slice(0, 3, &[7, 8, 9]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [7, 8, 9]);
+    }
+
+    #[test]
+    fn empty_array_set_slice_begin_non_empty_drain_greater_than_insert_length() {
+        let mut ary = SmallArray::<i32>::new();
+        let drained = ary.set_slice(0, 10, &[7, 8, 9]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [7, 8, 9]);
+    }
+
+    #[test]
+    fn empty_array_set_slice_out_of_bounds_non_empty_drain_0() {
+        let mut ary = SmallArray::<i32>::new();
+        let drained = ary.set_slice(5, 0, &[7, 8, 9]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [0, 0, 0, 0, 0, 7, 8, 9]);
+    }
+
+    #[test]
+    fn empty_array_set_slice_out_of_bounds_non_empty_drain_less_than_insert_length() {
+        let mut ary = SmallArray::<i32>::new();
+        let drained = ary.set_slice(5, 1, &[7, 8, 9]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [0, 0, 0, 0, 0, 7, 8, 9]);
+    }
+
+    #[test]
+    fn empty_array_set_slice_out_of_bounds_non_empty_drain_equal_to_insert_length() {
+        let mut ary = SmallArray::<i32>::new();
+        let drained = ary.set_slice(5, 3, &[7, 8, 9]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [0, 0, 0, 0, 0, 7, 8, 9]);
+    }
+
+    #[test]
+    fn empty_array_set_slice_out_of_bounds_non_empty_drain_greater_than_insert_length() {
+        let mut ary = SmallArray::<i32>::new();
+        let drained = ary.set_slice(5, 10, &[7, 8, 9]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [0, 0, 0, 0, 0, 7, 8, 9]);
+    }
+
+    #[test]
+    fn empty_array_set_slice_empty_drain_0() {
+        let mut ary = SmallArray::<i32>::new();
+        let drained = ary.set_slice(0, 0, &[]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, []);
+    }
+
+    #[test]
+    fn empty_array_set_slice_empty_drain_less_than_insert_length() {
+        let mut ary = SmallArray::<i32>::new();
+        let drained = ary.set_slice(0, 0, &[]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, []);
+    }
+
+    #[test]
+    fn empty_array_set_slice_empty_drain_equal_to_insert_length() {
+        let mut ary = SmallArray::<i32>::new();
+        let drained = ary.set_slice(0, 0, &[]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, []);
+    }
+
+    #[test]
+    fn empty_array_set_slice_begin_empty_drain_greater_than_insert_length() {
+        let mut ary = SmallArray::<i32>::new();
+        let drained = ary.set_slice(0, 10, &[]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, []);
+    }
+
+    #[test]
+    fn empty_array_set_slice_out_of_bounds_empty_drain_0() {
+        let mut ary = SmallArray::<i32>::new();
+        let drained = ary.set_slice(5, 0, &[]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [0, 0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn empty_array_set_slice_out_of_bounds_empty_drain_less_than_insert_length() {
+        let mut ary = SmallArray::<i32>::new();
+        let drained = ary.set_slice(5, 1, &[]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [0, 0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn empty_array_set_slice_out_of_bounds_empty_drain_equal_to_insert_length() {
+        let mut ary = SmallArray::<i32>::new();
+        let drained = ary.set_slice(5, 3, &[]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [0, 0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn empty_array_set_slice_out_of_bounds_empty_drain_greater_than_insert_length() {
+        let mut ary = SmallArray::<i32>::new();
+        let drained = ary.set_slice(5, 10, &[]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [0, 0, 0, 0, 0]);
+    }
+}

--- a/spinoso-array/src/array/vec/convert.rs
+++ b/spinoso-array/src/array/vec/convert.rs
@@ -1,0 +1,220 @@
+use alloc::borrow::Cow;
+use alloc::boxed::Box;
+use alloc::rc::Rc;
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+use core::iter::FromIterator;
+
+#[cfg(feature = "small-array")]
+use smallvec::SmallVec;
+
+use crate::array::vec::Array;
+
+#[cfg(feature = "small-array")]
+use crate::array::smallvec::SmallArray;
+#[cfg(feature = "small-array")]
+use crate::array::INLINE_CAPACITY;
+
+impl<T> From<Vec<T>> for Array<T> {
+    #[inline]
+    fn from(values: Vec<T>) -> Self {
+        Self(values)
+    }
+}
+
+impl<T> From<Array<T>> for Vec<T> {
+    #[inline]
+    fn from(values: Array<T>) -> Self {
+        values.into_vec()
+    }
+}
+
+impl<'a, T> From<&'a [T]> for Array<T>
+where
+    T: Clone,
+{
+    #[inline]
+    fn from(values: &'a [T]) -> Self {
+        Self(values.to_vec())
+    }
+}
+
+impl<'a, T> From<&'a mut [T]> for Array<T>
+where
+    T: Clone,
+{
+    #[inline]
+    fn from(values: &'a mut [T]) -> Self {
+        Self(values.to_vec())
+    }
+}
+
+impl<T> From<Box<[T]>> for Array<T> {
+    #[inline]
+    fn from(values: Box<[T]>) -> Self {
+        Self(Vec::from(values))
+    }
+}
+
+impl<T> From<Array<T>> for Box<[T]> {
+    #[inline]
+    fn from(values: Array<T>) -> Self {
+        values.into_boxed_slice()
+    }
+}
+
+impl<'a, T> From<Cow<'a, [T]>> for Array<T>
+where
+    T: Clone,
+{
+    #[inline]
+    fn from(values: Cow<'a, [T]>) -> Self {
+        match values {
+            Cow::Borrowed(slice) => slice.into(),
+            Cow::Owned(vec) => vec.into(),
+        }
+    }
+}
+
+impl<'a, T> From<Array<T>> for Cow<'a, [T]>
+where
+    T: Clone,
+{
+    #[inline]
+    fn from(values: Array<T>) -> Self {
+        values.into_vec().into()
+    }
+}
+
+impl<T> From<Array<T>> for Rc<[T]> {
+    #[inline]
+    fn from(values: Array<T>) -> Self {
+        values.into_vec().into()
+    }
+}
+
+impl<T> From<Array<T>> for Arc<[T]> {
+    #[inline]
+    fn from(values: Array<T>) -> Self {
+        values.into_vec().into()
+    }
+}
+
+impl<T> From<[T; 0]> for Array<T> {
+    #[inline]
+    fn from(values: [T; 0]) -> Self {
+        // Values is empty, so it can be ignored.
+        let _ = values;
+        Self::new()
+    }
+}
+
+impl<T> From<&[T; 0]> for Array<T> {
+    #[inline]
+    fn from(values: &[T; 0]) -> Self {
+        // Values is empty, so it can be ignored.
+        let _ = values;
+        Self::new()
+    }
+}
+
+macro_rules! __array_T_from_primitive_array {
+    ($len:expr) => {
+        impl<T> From<[T; $len]> for Array<T> {
+            #[inline]
+            fn from(values: [T; $len]) -> Self {
+                Self(Vec::from(values))
+            }
+        }
+
+        impl<T> From<&[T; $len]> for Array<T>
+        where
+            T: Clone,
+        {
+            #[inline]
+            fn from(values: &[T; $len]) -> Self {
+                Self(values.to_vec())
+            }
+        }
+    };
+}
+
+__array_T_from_primitive_array!(1);
+__array_T_from_primitive_array!(2);
+__array_T_from_primitive_array!(3);
+__array_T_from_primitive_array!(4);
+__array_T_from_primitive_array!(5);
+__array_T_from_primitive_array!(6);
+__array_T_from_primitive_array!(7);
+__array_T_from_primitive_array!(8);
+__array_T_from_primitive_array!(9);
+__array_T_from_primitive_array!(10);
+__array_T_from_primitive_array!(11);
+__array_T_from_primitive_array!(12);
+__array_T_from_primitive_array!(13);
+__array_T_from_primitive_array!(14);
+__array_T_from_primitive_array!(15);
+__array_T_from_primitive_array!(16);
+__array_T_from_primitive_array!(17);
+__array_T_from_primitive_array!(18);
+__array_T_from_primitive_array!(19);
+__array_T_from_primitive_array!(20);
+__array_T_from_primitive_array!(21);
+__array_T_from_primitive_array!(22);
+__array_T_from_primitive_array!(23);
+__array_T_from_primitive_array!(24);
+__array_T_from_primitive_array!(25);
+__array_T_from_primitive_array!(26);
+__array_T_from_primitive_array!(27);
+__array_T_from_primitive_array!(28);
+__array_T_from_primitive_array!(29);
+__array_T_from_primitive_array!(30);
+__array_T_from_primitive_array!(31);
+__array_T_from_primitive_array!(32);
+
+#[cfg(feature = "small-array")]
+impl<T> From<SmallVec<[T; INLINE_CAPACITY]>> for Array<T> {
+    #[inline]
+    fn from(values: SmallVec<[T; INLINE_CAPACITY]>) -> Self {
+        Self(values.into_vec())
+    }
+}
+
+#[cfg(feature = "small-array")]
+impl<T> From<Array<T>> for SmallVec<[T; INLINE_CAPACITY]> {
+    #[inline]
+    fn from(values: Array<T>) -> Self {
+        SmallVec::from_vec(values.into_vec())
+    }
+}
+
+#[cfg(feature = "small-array")]
+impl<T> From<SmallArray<T>> for Array<T> {
+    #[inline]
+    fn from(values: SmallArray<T>) -> Self {
+        Self::from(values.into_vec())
+    }
+}
+
+impl<T> FromIterator<T> for Array<T> {
+    #[inline]
+    fn from_iter<I>(iter: I) -> Self
+    where
+        I: IntoIterator<Item = T>,
+    {
+        Self(iter.into_iter().collect())
+    }
+}
+
+impl<'a, T> FromIterator<&'a T> for Array<T>
+where
+    T: 'a + Clone,
+{
+    #[inline]
+    fn from_iter<I>(iter: I) -> Self
+    where
+        I: IntoIterator<Item = &'a T>,
+    {
+        Self(iter.into_iter().cloned().collect())
+    }
+}

--- a/spinoso-array/src/array/vec/eq.rs
+++ b/spinoso-array/src/array/vec/eq.rs
@@ -1,0 +1,142 @@
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+
+use crate::array::vec::Array;
+
+impl<T, U> PartialEq<Vec<U>> for Array<T>
+where
+    T: PartialEq<U>,
+{
+    #[inline]
+    fn eq(&self, other: &Vec<U>) -> bool {
+        self[..] == other[..]
+    }
+}
+
+impl<T, U> PartialEq<Array<U>> for Vec<T>
+where
+    T: PartialEq<U>,
+{
+    #[inline]
+    fn eq(&self, other: &Array<U>) -> bool {
+        self[..] == other[..]
+    }
+}
+
+impl<T, U> PartialEq<[U]> for Array<T>
+where
+    T: PartialEq<U>,
+{
+    #[inline]
+    fn eq(&self, other: &[U]) -> bool {
+        self[..] == other[..]
+    }
+}
+
+impl<T, U> PartialEq<Array<U>> for [T]
+where
+    T: PartialEq<U>,
+{
+    #[inline]
+    fn eq(&self, other: &Array<U>) -> bool {
+        self[..] == other[..]
+    }
+}
+
+impl<T, U> PartialEq<Box<[U]>> for Array<T>
+where
+    T: PartialEq<U>,
+{
+    #[inline]
+    fn eq(&self, other: &Box<[U]>) -> bool {
+        self[..] == other[..]
+    }
+}
+
+impl<T, U> PartialEq<Array<U>> for Box<[T]>
+where
+    T: PartialEq<U>,
+{
+    #[inline]
+    fn eq(&self, other: &Array<U>) -> bool {
+        self[..] == other[..]
+    }
+}
+
+macro_rules! __array_T_eq_primitive_array {
+    ($len:expr) => {
+        impl<T, U> PartialEq<[U; $len]> for Array<T>
+        where
+            T: PartialEq<U>,
+        {
+            #[inline]
+            fn eq(&self, other: &[U; $len]) -> bool {
+                self[..] == other[..]
+            }
+        }
+
+        impl<T, U> PartialEq<Array<U>> for [T; $len]
+        where
+            T: PartialEq<U>,
+        {
+            #[inline]
+            fn eq(&self, other: &Array<U>) -> bool {
+                self[..] == other[..]
+            }
+        }
+
+        impl<T, U> PartialEq<&[U; $len]> for Array<T>
+        where
+            T: PartialEq<U>,
+        {
+            #[inline]
+            fn eq(&self, other: &&[U; $len]) -> bool {
+                self[..] == other[..]
+            }
+        }
+
+        impl<T, U> PartialEq<Array<U>> for &[T; $len]
+        where
+            T: PartialEq<U>,
+        {
+            #[inline]
+            fn eq(&self, other: &Array<U>) -> bool {
+                self[..] == other[..]
+            }
+        }
+    };
+}
+
+__array_T_eq_primitive_array!(0);
+__array_T_eq_primitive_array!(1);
+__array_T_eq_primitive_array!(2);
+__array_T_eq_primitive_array!(3);
+__array_T_eq_primitive_array!(4);
+__array_T_eq_primitive_array!(5);
+__array_T_eq_primitive_array!(6);
+__array_T_eq_primitive_array!(7);
+__array_T_eq_primitive_array!(8);
+__array_T_eq_primitive_array!(9);
+__array_T_eq_primitive_array!(10);
+__array_T_eq_primitive_array!(11);
+__array_T_eq_primitive_array!(12);
+__array_T_eq_primitive_array!(13);
+__array_T_eq_primitive_array!(14);
+__array_T_eq_primitive_array!(15);
+__array_T_eq_primitive_array!(16);
+__array_T_eq_primitive_array!(17);
+__array_T_eq_primitive_array!(18);
+__array_T_eq_primitive_array!(19);
+__array_T_eq_primitive_array!(20);
+__array_T_eq_primitive_array!(21);
+__array_T_eq_primitive_array!(22);
+__array_T_eq_primitive_array!(23);
+__array_T_eq_primitive_array!(24);
+__array_T_eq_primitive_array!(25);
+__array_T_eq_primitive_array!(26);
+__array_T_eq_primitive_array!(27);
+__array_T_eq_primitive_array!(28);
+__array_T_eq_primitive_array!(29);
+__array_T_eq_primitive_array!(30);
+__array_T_eq_primitive_array!(31);
+__array_T_eq_primitive_array!(32);

--- a/spinoso-array/src/array/vec/impls.rs
+++ b/spinoso-array/src/array/vec/impls.rs
@@ -1,0 +1,123 @@
+use alloc::vec::Vec;
+use core::borrow::{Borrow, BorrowMut};
+use core::ops::{Deref, DerefMut, Index, IndexMut};
+use core::slice::{Iter, IterMut, SliceIndex};
+
+use crate::array::vec::Array;
+
+impl<T> AsRef<Vec<T>> for Array<T> {
+    #[inline]
+    fn as_ref(&self) -> &Vec<T> {
+        &self.0
+    }
+}
+
+impl<T> AsRef<[T]> for Array<T> {
+    #[inline]
+    fn as_ref(&self) -> &[T] {
+        self.0.as_ref()
+    }
+}
+
+impl<T> AsMut<Vec<T>> for Array<T> {
+    #[inline]
+    fn as_mut(&mut self) -> &mut Vec<T> {
+        &mut self.0
+    }
+}
+
+impl<T> AsMut<[T]> for Array<T> {
+    #[inline]
+    fn as_mut(&mut self) -> &mut [T] {
+        self.0.as_mut()
+    }
+}
+
+impl<T> Borrow<[T]> for Array<T> {
+    #[inline]
+    fn borrow(&self) -> &[T] {
+        self.0.borrow()
+    }
+}
+
+impl<T> BorrowMut<[T]> for Array<T> {
+    #[inline]
+    fn borrow_mut(&mut self) -> &mut [T] {
+        self.0.borrow_mut()
+    }
+}
+
+impl<T> Deref for Array<T> {
+    type Target = [T];
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        self.0.as_slice()
+    }
+}
+
+impl<T> DerefMut for Array<T> {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.0.as_mut_slice()
+    }
+}
+
+impl<T> Extend<T> for Array<T> {
+    #[inline]
+    fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
+        self.0.extend(iter.into_iter())
+    }
+}
+
+impl<'a, T> Extend<&'a T> for Array<T>
+where
+    T: 'a + Copy,
+{
+    #[inline]
+    fn extend<I: IntoIterator<Item = &'a T>>(&mut self, iter: I) {
+        self.0.extend(iter.into_iter())
+    }
+}
+
+impl<T, I> Index<I> for Array<T>
+where
+    I: SliceIndex<[T]>,
+{
+    type Output = I::Output;
+
+    #[inline]
+    fn index(&self, index: I) -> &I::Output {
+        &self.0[index]
+    }
+}
+
+impl<T, I> IndexMut<I> for Array<T>
+where
+    I: SliceIndex<[T]>,
+{
+    #[inline]
+    fn index_mut(&mut self, index: I) -> &mut I::Output {
+        &mut self.0[index]
+    }
+}
+
+impl<'a, T> IntoIterator for &'a Array<T> {
+    type Item = &'a T;
+    type IntoIter = Iter<'a, T>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter()
+    }
+}
+
+impl<'a, T> IntoIterator for &'a mut Array<T> {
+    type Item = &'a mut T;
+    type IntoIter = IterMut<'a, T>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter_mut()
+    }
+}

--- a/spinoso-array/src/array/vec/mod.rs
+++ b/spinoso-array/src/array/vec/mod.rs
@@ -1,0 +1,1654 @@
+//! Ruby `Array` based on [`Vec`].
+
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+use core::cmp;
+use core::slice::{Iter, IterMut};
+
+mod convert;
+mod eq;
+mod impls;
+
+/// A contiguous growable array type based on [`Vec<T>`](Vec).
+///
+/// `Array` implements indexing and mutating APIs that make an ideal backend for
+/// the [Ruby `Array` core class][ruby-array]. In practice, this results in less
+/// generic, more single-use APIs. For example, instead of [`Vec::drain`],
+/// `Array` implements [`shift`], [`shift_n`], [`pop`], and [`pop_n`].
+///
+/// Similarly, slicing APIs are more specialized, such as [`first_n`] and
+/// [`last_n`]. Slicing APIs do not return [`Option`], instead preferring to
+/// return an empty slice.
+///
+/// # Examples
+///
+/// ```
+/// # use spinoso_array::Array;
+/// let mut ary = Array::new();
+/// ary.push(1);
+/// ary.push(2);
+///
+/// assert_eq!(ary.len(), 2);
+/// assert_eq!(ary[0], 1);
+///
+/// assert_eq!(ary.pop(), Some(2));
+/// assert_eq!(ary.len(), 1);
+///
+/// ary[0] = 7;
+/// assert_eq!(ary[0], 7);
+///
+/// ary.extend([1, 2, 3].iter().copied());
+///
+/// for x in &ary {
+///     println!("{}", x);
+/// }
+/// assert_eq!(ary, &[7, 1, 2, 3]);
+/// ```
+///
+/// [ruby-array]: https://ruby-doc.org/core-2.6.3/Array.html
+/// [`shift`]: Array::shift
+/// [`shift_n`]: Array::shift_n
+/// [`drop_n`]: Array::drop_n
+/// [`pop`]: Array::pop
+/// [`pop_n`]: Array::pop_n
+/// [`first_n`]: Array::first_n
+/// [`last_n`]: Array::last_n
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Array<T>(Vec<T>);
+
+impl<T> Default for Array<T> {
+    #[inline]
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T> Array<T> {
+    /// Construct a new, empty `Array<T>`.
+    ///
+    /// The vector will not allocate until elements are pushed into it.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::Array;
+    /// let ary: Array<i32> = Array::new();
+    /// assert!(ary.is_empty());
+    /// assert_eq!(ary.capacity(), 0);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn new() -> Self {
+        Self(Vec::new())
+    }
+
+    /// Construct a new, empty `Array<T>` with the specified capacity.
+    ///
+    /// The vector will be able to hold exactly `capacity` elements without
+    /// reallocating. If `capacity` is 0, the vector will not allocate.
+    ///
+    /// It is important to note that although the returned vector has the
+    /// _capacity_ specified, the vector will have a zero _length_.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::Array;
+    /// let mut ary: Array<i32> = Array::with_capacity(10);
+    /// assert_eq!(ary.len(), 0);
+    /// assert_eq!(ary.capacity(), 10);
+    ///
+    /// // These are pushes all done without reallocating...
+    /// for i in 0..10 {
+    ///     ary.push(i);
+    /// }
+    ///
+    /// // ...but this may make the vector reallocate
+    /// ary.push(11);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self(Vec::with_capacity(capacity))
+    }
+
+    /// Constuct a new two-element `Array` from the given arguments.
+    ///
+    /// The vector is constructed with `capacity` of 2.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::Array;
+    /// let ary = Array::assoc(0, 100);
+    /// assert_eq!(ary.capacity(), 2);
+    /// assert_eq!(ary.len(), 2);
+    /// assert_eq!(ary[0], 0);
+    /// assert_eq!(ary[1], 100);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn assoc(first: T, second: T) -> Self {
+        let pair: [T; 2] = [first, second];
+        Self::from(pair)
+    }
+
+    /// Returns an iterator over the slice.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::Array;
+    /// let ary = Array::from(&[1, 2, 4]);
+    /// let mut iterator = ary.iter();
+    ///
+    /// assert_eq!(iterator.next(), Some(&1));
+    /// assert_eq!(iterator.next(), Some(&2));
+    /// assert_eq!(iterator.next(), Some(&4));
+    /// assert_eq!(iterator.next(), None);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn iter(&self) -> Iter<'_, T> {
+        self.into_iter()
+    }
+
+    /// Returns an iterator that allows modifying each value.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::Array;
+    /// let mut ary = Array::from(&[1, 2, 4]);
+    /// for elem in ary.iter_mut() {
+    ///     *elem += 2;
+    /// }
+    ///
+    /// assert_eq!(ary, &[3, 4, 6]);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn iter_mut(&mut self) -> IterMut<'_, T> {
+        self.into_iter()
+    }
+
+    /// Extracts a slice containing the entire vector.
+    ///
+    /// Equivalent to `&ary[..]`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::Array;
+    /// let ary = Array::from(&[1, 2, 4]);
+    /// let four_index = ary.as_slice().binary_search(&4);
+    /// assert_eq!(four_index, Ok(2));
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn as_slice(&self) -> &[T] {
+        self.0.as_slice()
+    }
+
+    /// Extracts a mutable slice containing the entire vector.
+    ///
+    /// Equivalent to `&mut ary[..]`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::Array;
+    /// let mut ary = Array::from(&[2, 1, 4]);
+    /// ary.as_mut_slice().sort();
+    /// assert_eq!(ary, &[1, 2, 4]);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn as_mut_slice(&mut self) -> &mut [T] {
+        self.0.as_mut_slice()
+    }
+
+    /// Returns a raw pointer to the vector's buffer.
+    ///
+    /// The caller must ensure that the vector outlives the pointer this
+    /// function returns, or else it will end up pointing to garbage. Modifying
+    /// the vector may cause its buffer to be reallocated, which would also make
+    /// any pointers to it invalid.
+    ///
+    /// The caller must also ensure that the memory the pointer
+    /// (non-transitively) points to is never written to (except inside an
+    /// `UnsafeCell`) using this pointer or any pointer derived from it. If you
+    /// need to mutate the contents of the slice, use
+    /// [`as_mut_ptr`](Self::as_mut_ptr).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::Array;
+    /// let ary = Array::from(&[1, 2, 4]);
+    /// let ary_ptr = ary.as_ptr();
+    ///
+    /// unsafe {
+    ///     for i in 0..ary.len() {
+    ///         assert_eq!(*ary_ptr.add(i), 1 << i);
+    ///     }
+    /// }
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn as_ptr(&self) -> *const T {
+        self.0.as_ptr()
+    }
+
+    /// Returns an unsafe mutable pointer to the vector's buffer.
+    ///
+    /// The caller must ensure that the vector outlives the pointer this
+    /// function returns, or else it will end up pointing to garbage.
+    /// Modifying the vector may cause its buffer to be reallocated, which would
+    /// also make any pointers to it invalid.
+    ///
+    /// # Examples
+    ///
+    /// This method is primarily used when mutating a `Array` via a raw pointer
+    /// passed over FFI.
+    ///
+    /// See the [`ARY_PTR`] macro in mruby.
+    ///
+    /// [`ARY_PTR`]: https://github.com/artichoke/mruby/blob/d66440864d08f1c3ac5820d45f11df031b7d43c6/include/mruby/array.h#L52
+    #[inline]
+    #[must_use]
+    pub fn as_mut_ptr(&mut self) -> *mut T {
+        self.0.as_mut_ptr()
+    }
+
+    /// Set the vector's length without dropping or moving out elements
+    ///
+    /// This method is unsafe because it changes the notion of the number of
+    /// "valid" elements in the vector. Use with care.
+    ///
+    /// # Safety
+    ///
+    /// - `new_len` must be less than or equal to capacity().
+    /// - The elements at `old_len..new_len` must be initialized.
+    ///
+    /// # Examples
+    ///
+    /// This method is primarily used when mutating a `Array` via a raw pointer
+    /// passed over FFI.
+    ///
+    /// See the [`ARY_PTR`] macro in mruby.
+    ///
+    /// [`ARY_PTR`]: https://github.com/artichoke/mruby/blob/d66440864d08f1c3ac5820d45f11df031b7d43c6/include/mruby/array.h#L52
+    #[inline]
+    pub unsafe fn set_len(&mut self, new_len: usize) {
+        self.0.set_len(new_len);
+    }
+
+    /// Consume the array and return the inner [`Vec<T>`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::Array;
+    /// let ary = Array::from(&[1, 2, 4]);
+    /// let vec: Vec<i32> = ary.into_inner();
+    /// ```
+    ///
+    /// [`Vec<T>`]: alloc::vec::Vec
+    #[inline]
+    #[must_use]
+    pub fn into_inner(self) -> Vec<T> {
+        self.0
+    }
+
+    /// Consume the array and return its elements as a [`Vec<T>`].
+    ///
+    /// For `Array`, this is a cheap operation that unwraps the inner `Vec` and
+    /// is an alias for [`into_inner`](Self::into_inner).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::Array;
+    /// let ary = Array::from(&[1, 2, 4]);
+    /// let vec: Vec<i32> = ary.into_vec();
+    /// ```
+    ///
+    /// [`Vec<T>`]: alloc::vec::Vec
+    #[inline]
+    #[must_use]
+    pub fn into_vec(self) -> Vec<T> {
+        self.0
+    }
+
+    /// Converts the vector into [`Box<[T]>`](Box).
+    ///
+    /// This will drop any excess capacity.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::Array;
+    /// let ary = Array::from(&[1, 2, 4]);
+    /// let slice: Box<[i32]> = ary.into_boxed_slice();
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn into_boxed_slice(self) -> Box<[T]> {
+        self.0.into_boxed_slice()
+    }
+
+    /// Returns the number of elements the vector can hold without reallocating.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::Array;
+    /// let ary: Array<i32> = Array::with_capacity(10);
+    /// assert_eq!(ary.capacity(), 10);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn capacity(&self) -> usize {
+        self.0.capacity()
+    }
+
+    /// Reserves capacity for at least `additional` more elements to be inserted
+    /// in the given `Array<T>`. The collection may reserve more space to avoid
+    /// frequent reallocations. After calling reserve, capacity will be greater
+    /// than or equal to `self.len() + additional`. Does nothing if capacity is
+    /// already sufficient.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the new capacity overflows `usize`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::Array;
+    /// let mut ary = Array::from(&[1]);
+    /// ary.reserve(10);
+    /// assert!(ary.capacity() >= 11);
+    /// ```
+    #[inline]
+    pub fn reserve(&mut self, additional: usize) {
+        self.0.reserve(additional);
+    }
+
+    /// Shrinks the capacity of the vector as much as possible.
+    ///
+    /// It will drop down as close as possible to the length but the allocator
+    /// may still inform the vector that there is space for a few more elements.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::Array;
+    /// let mut ary = Array::with_capacity(10);
+    /// ary.extend([1, 2, 3].iter().copied());
+    /// assert_eq!(ary.capacity(), 10);
+    /// ary.shrink_to_fit();
+    /// assert!(ary.capacity() >= 3);
+    /// ```
+    #[inline]
+    pub fn shrink_to_fit(&mut self) {
+        self.0.shrink_to_fit();
+    }
+
+    /// Clears the vector, removing all values.
+    ///
+    /// Note that this method has no effect on the allocated capacity of the
+    /// vector.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::Array;
+    /// let mut ary = Array::from(&[1, 2, 4]);
+    /// let capacity = ary.capacity();
+    /// ary.clear();
+    /// assert!(ary.is_empty());
+    /// assert_eq!(ary.capacity(), capacity);
+    /// ```
+    #[inline]
+    pub fn clear(&mut self) {
+        self.0.clear();
+    }
+
+    /// Returns the number of elements in the vector, also referred to as its
+    /// 'length'.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::Array;
+    /// let ary = Array::from(&[1, 2, 4]);
+    /// assert_eq!(ary.len(), 3);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Returns `true` if the vector contains no elements.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::Array;
+    /// let mut ary = Array::new();
+    /// assert!(ary.is_empty());
+    /// ary.push(1);
+    /// assert!(!ary.is_empty());
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Returns a reference to an element at the index.
+    ///
+    /// Unlike [`Vec`], this method does not support indexing with a range.  See
+    /// the [`slice`](Self::slice) method for retrieving a sub-slice from the
+    /// array.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::Array;
+    /// let ary = Array::from(&[1, 2, 4]);
+    /// assert_eq!(ary.get(1), Some(&2));
+    /// assert_eq!(ary.get(3), None);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn get(&self, index: usize) -> Option<&T> {
+        self.0.get(index)
+    }
+
+    /// Appends the elements of `other` to self.
+    ///
+    /// Alias for `extend`. This operation is analogous to "push n".
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::Array;
+    /// let mut ary = Array::from(&[1, 2, 4]);
+    /// ary.concat(vec![7, 8, 9]);
+    /// assert_eq!(ary.len(), 6);
+    /// ```
+    #[inline]
+    pub fn concat<I>(&mut self, other: I)
+    where
+        I: IntoIterator<Item = T>,
+    {
+        self.0.extend(other.into_iter());
+    }
+
+    /// Deletes the element at the specified `index`, returning that element, or
+    /// [`None`] if the `index` is out of range.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::Array;
+    /// let mut ary = Array::from(&[1, 2, 4]);
+    /// assert_eq!(ary.delete_at(1), Some(2));
+    /// assert_eq!(ary.delete_at(10), None);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn delete_at(&mut self, index: usize) -> Option<T> {
+        if index < self.0.len() {
+            Some(self.0.remove(index))
+        } else {
+            None
+        }
+    }
+
+    /// Returns the first element from the vector, or [`None`] if the vector is
+    /// empty.
+    ///
+    /// To retrieve a slice of the first elements in the vector, use
+    /// [`first_n`](Self::first_n).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::Array;
+    /// let mut ary = Array::new();
+    /// assert_eq!(ary.first(), None);
+    /// ary.push(1);
+    /// assert_eq!(ary.first(), Some(&1));
+    /// ary.push(2);
+    /// assert_eq!(ary.first(), Some(&1));
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn first(&self) -> Option<&T> {
+        self.0.first()
+    }
+
+    /// Returns up to `n` of the first elements from the vector, or `&[]` if the
+    /// vector is empty.
+    ///
+    /// To retrieve only the first element in the vector, use
+    /// [`first`](Self::first).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::Array;
+    /// let mut ary = Array::new();
+    /// assert_eq!(ary.first_n(0), &[]);
+    /// assert_eq!(ary.first_n(4), &[]);
+    ///
+    /// ary.push(1);
+    /// ary.push(2);
+    /// assert_eq!(ary.first_n(0), &[]);
+    /// assert_eq!(ary.first_n(4), &[1, 2]);
+    ///
+    /// ary.concat(vec![3, 4, 5, 6, 7, 8, 9, 10]);
+    /// assert_eq!(ary.first_n(0), &[]);
+    /// assert_eq!(ary.first_n(4), &[1, 2, 3, 4]);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn first_n(&self, n: usize) -> &[T] {
+        self.0.get(..n).unwrap_or_else(|| &self.0[..])
+    }
+
+    /// Returns the last element from the vector, or [`None`] if the vector is
+    /// empty.
+    ///
+    /// To retrieve a slice of the last elements in the vector, use
+    /// [`last_n`](Self::last_n).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::Array;
+    /// let mut ary = Array::new();
+    /// assert_eq!(ary.last(), None);
+    /// ary.push(1);
+    /// assert_eq!(ary.last(), Some(&1));
+    /// ary.push(2);
+    /// assert_eq!(ary.last(), Some(&2));
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn last(&self) -> Option<&T> {
+        self.0.last()
+    }
+
+    /// Returns up to `n` of the last elements from the vector, or `&[]` if the
+    /// vector is empty.
+    ///
+    /// To retrieve only the last element in the vector, use
+    /// [`last`](Self::last).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::Array;
+    /// let mut ary = Array::new();
+    /// assert_eq!(ary.last_n(0), &[]);
+    /// assert_eq!(ary.last_n(4), &[]);
+    ///
+    /// ary.push(1);
+    /// ary.push(2);
+    /// assert_eq!(ary.last_n(0), &[]);
+    /// assert_eq!(ary.last_n(4), &[1, 2]);
+    ///
+    /// ary.concat(vec![3, 4, 5, 6, 7, 8, 9, 10]);
+    /// assert_eq!(ary.last_n(0), &[]);
+    /// assert_eq!(ary.last_n(4), &[7, 8, 9, 10]);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn last_n(&self, n: usize) -> &[T] {
+        let begin = self.len().checked_sub(n).unwrap_or_default();
+        &self.0[begin..]
+    }
+
+    /// Returns a slice of the underlying vector that includes only the first
+    /// `n` elements.
+    ///
+    /// If `n` is greater than or equal to the length of the vector, `&self[..]`
+    /// is returned.
+    ///
+    /// The inverse of this operation is [`drop_n`](Self::drop_n).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::Array;
+    /// let ary = Array::from(&[1, 2, 4, 7, 8, 9]);
+    /// assert_eq!(ary.take_n(0), &[]);
+    /// assert_eq!(ary.take_n(2), &[1, 2]);
+    /// assert_eq!(ary.take_n(10), &[1, 2, 4, 7, 8, 9]);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn take_n(&self, n: usize) -> &[T] {
+        self.0.get(..n).unwrap_or_else(|| &self.0[..])
+    }
+
+    /// Returns a slice of the underlying vector that excludes the first `n`
+    /// elements.
+    ///
+    /// If `n` is greater than or equal to the length of the vector, `&[]` is
+    /// returned.
+    ///
+    /// The inverse of this operation is [`take_n`](Self::take_n).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::Array;
+    /// let ary = Array::from(&[1, 2, 4, 7, 8, 9]);
+    /// assert_eq!(ary.drop_n(0), &[1, 2, 4, 7, 8, 9]);
+    /// assert_eq!(ary.drop_n(4), &[8, 9]);
+    /// assert_eq!(ary.drop_n(10), &[]);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn drop_n(&self, n: usize) -> &[T] {
+        self.0.get(n..).unwrap_or_else(|| &[])
+    }
+
+    /// Removes the last element from the vector and returns it, or [`None`] if
+    /// the vector is empty.
+    ///
+    /// To pop more than one element from the end of the vector, use
+    /// [`pop_n`](Self::pop_n).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::Array;
+    /// let mut ary = Array::from(&[1, 2, 4]);
+    /// assert_eq!(ary.pop(), Some(4));
+    /// assert_eq!(ary, &[1, 2]);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn pop(&mut self) -> Option<T> {
+        self.0.pop()
+    }
+
+    /// Removes the last `n` elements from the vector.
+    ///
+    /// To pop a single element from the end of the vector, use
+    /// [`pop`](Self::pop).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::Array;
+    /// let mut ary = Array::from(&[1, 2, 4, 7, 8, 9]);
+    /// assert_eq!(ary.pop_n(0), &[]);
+    /// assert_eq!(ary, &[1, 2, 4, 7, 8, 9]);
+    ///
+    /// assert_eq!(ary.pop_n(3), &[7, 8, 9]);
+    /// assert_eq!(ary, &[1, 2, 4]);
+    ///
+    /// assert_eq!(ary.pop_n(100), &[1, 2, 4]);
+    /// assert!(ary.is_empty());
+    ///
+    /// assert_eq!(ary.pop_n(1), &[]);
+    /// assert!(ary.is_empty());
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn pop_n(&mut self, n: usize) -> Self {
+        if n == 0 {
+            return Self::new();
+        }
+        let split_at = self.len().checked_sub(n).unwrap_or_default();
+        let popped = self.0.split_off(split_at);
+        Self(popped)
+    }
+
+    /// Appends an element to the back of the vector.
+    ///
+    /// To push more than one element to the end of the vector, use
+    /// [`concat`](Self::concat) or `extend`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the number of elements in the vector overflows a `usize`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::Array;
+    /// let mut ary = Array::from(&[1, 2]);
+    /// ary.push(3);
+    /// assert_eq!(ary, &[1, 2, 3]);
+    /// ```
+    #[inline]
+    pub fn push(&mut self, elem: T) {
+        self.0.push(elem);
+    }
+
+    /// Reverses the order of elements of the vector, in place.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::Array;
+    /// let mut ary = Array::from(&[1, 2, 4]);
+    /// ary.reverse();
+    /// assert_eq!(ary, &[4, 2, 1]);
+    /// ```
+    #[inline]
+    pub fn reverse(&mut self) {
+        self.0.reverse();
+    }
+
+    /// Removes the first element of the vector and returns it (shifting all
+    /// other elements down by one). Returns [`None`] if the vector is empty.
+    ///
+    /// This operation is also known as "pop front".
+    ///
+    /// To remove more than one element from the front of the vector, use
+    /// [`shift_n`](Self::shift_n).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::Array;
+    /// let mut ary = Array::from(&[1, 2]);
+    /// assert_eq!(ary.shift(), Some(1));
+    /// assert_eq!(ary.shift(), Some(2));
+    /// assert_eq!(ary.shift(), None);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn shift(&mut self) -> Option<T> {
+        if self.is_empty() {
+            None
+        } else {
+            Some(self.0.remove(0))
+        }
+    }
+
+    /// Removes the first `n` elements from the vector.
+    ///
+    /// To shift a single element from the front of the vector, use
+    /// [`shift`](Self::shift).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::Array;
+    /// let mut ary = Array::from(&[1, 2, 4, 7, 8, 9]);
+    /// assert_eq!(ary.shift_n(0), &[]);
+    /// assert_eq!(ary, &[1, 2, 4, 7, 8, 9]);
+    ///
+    /// assert_eq!(ary.shift_n(3), &[1, 2, 4]);
+    /// assert_eq!(ary, &[7, 8, 9]);
+    ///
+    /// assert_eq!(ary.shift_n(100), &[7, 8, 9]);
+    /// assert!(ary.is_empty());
+    ///
+    /// assert_eq!(ary.shift_n(1), &[]);
+    /// assert!(ary.is_empty());
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn shift_n(&mut self, n: usize) -> Self {
+        match n {
+            0 => Self::new(),
+            n if n < self.0.len() => self.0.drain(..n).collect(),
+            _ => {
+                let shifted = self.0.split_off(0);
+                Self(shifted)
+            }
+        }
+    }
+
+    /// Inserts an element to the front of the vector.
+    ///
+    /// To insert more than one element to the front of the vector, use
+    /// [`unshift_n`](Self::unshift_n).
+    ///
+    /// This operation is also known as "prepend".
+    ///
+    /// # Panics
+    ///
+    /// Panics if the number of elements in the vector overflows a `usize`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::Array;
+    /// let mut ary = Array::from(&[1, 2]);
+    /// ary.unshift(3);
+    /// assert_eq!(ary, &[3, 1, 2]);
+    /// ```
+    #[inline]
+    pub fn unshift(&mut self, elem: T) {
+        self.0.insert(0, elem);
+    }
+
+    /// Return a reference to a subslice of the vector.
+    ///
+    /// This function always returns a slice. If the range specified by `start`
+    /// and `end` overlaps the vector (even if only partially), the overlapping
+    /// slice is returned. If the range does not overlap the vector, an empty
+    /// slice is returned.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::Array;
+    /// let empty: Array<i32> = Array::new();
+    /// assert_eq!(empty.slice(0, 0), &[]);
+    /// assert_eq!(empty.slice(0, 4), &[]);
+    /// assert_eq!(empty.slice(2, 4), &[]);
+    ///
+    /// let ary = Array::from(&[1, 2, 3]);
+    /// assert_eq!(ary.slice(0, 0), &[]);
+    /// assert_eq!(ary.slice(0, 4), &[1, 2, 3]);
+    /// assert_eq!(ary.slice(2, 0), &[]);
+    /// assert_eq!(ary.slice(2, 4), &[3]);
+    /// assert_eq!(ary.slice(10, 100), &[]);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn slice(&self, start: usize, len: usize) -> &[T] {
+        if self.0.is_empty() || len == 0 {
+            return &[];
+        }
+        self.0
+            .get(start..start + len)
+            .or_else(|| self.0.get(start..))
+            .unwrap_or_default()
+    }
+}
+
+impl<T> Array<T>
+where
+    T: Clone,
+{
+    /// Construct a new `Array<T>` with length `len` and all elements set to
+    /// `default`. The `Array` will have capacity `len`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::Array;
+    /// let ary: Array<&str> = Array::with_len_and_default(3, "spinoso");
+    /// assert_eq!(ary.len(), 3);
+    /// assert_eq!(ary.capacity(), 3);
+    /// assert_eq!(ary, &["spinoso", "spinoso", "spinoso"]);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn with_len_and_default(len: usize, default: T) -> Self {
+        let mut vec = Vec::with_capacity(len);
+        for _ in 0..len {
+            vec.push(default.clone());
+        }
+        Self(vec)
+    }
+
+    /// Prepends the elements of `other` to self.
+    ///
+    /// To insert one element to the front of the vector, use
+    /// [`unshift`](Self::unshift).
+    ///
+    /// This operation is also known as "prepend".
+    ///
+    /// # Panics
+    ///
+    /// Panics if the number of elements in the vector overflows a `usize`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::Array;
+    /// let mut ary = Array::from(&[1, 2]);
+    /// ary.unshift_n(&[0, 5, 9]);
+    /// assert_eq!(ary, &[0, 5, 9, 1, 2]);
+    /// ```
+    #[inline]
+    pub fn unshift_n(&mut self, other: &[T]) {
+        self.0.reserve(other.len());
+        let mut tail = self.0.split_off(0);
+        self.0.extend_from_slice(other);
+        self.0.append(&mut tail);
+    }
+}
+
+impl<T> Array<T>
+where
+    T: Default,
+{
+    /// Set element at position `index` within the vector, extending the vector
+    /// with `T::default()` if `index` is out of bounds.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::Array;
+    /// let mut ary = Array::from(&[1, 2 ,4]);
+    /// ary.set(1, 11);
+    /// assert_eq!(ary, &[1, 11, 4]);
+    /// ary.set(5, 263);
+    /// assert_eq!(ary, &[1, 11, 4, 0, 0, 263]);
+    /// ```
+    #[inline]
+    pub fn set(&mut self, index: usize, elem: T) {
+        if let Some(cell) = self.0.get_mut(index) {
+            *cell = elem;
+        } else {
+            let buflen = self.len();
+            // index is *at least* buflen, so this calculation never underflows
+            // and ensures we allocate an additional slot.
+            self.0.reserve(index + 1 - buflen);
+            for _ in buflen..index {
+                self.0.push(T::default());
+            }
+            self.0.push(elem);
+        }
+    }
+
+    /// Insert element at position `start` within the vector and remove the
+    /// following `drain` elements. If `start` is out of bounds, the vector will
+    /// be extended with `T::default()`.
+    ///
+    /// This method sets a slice of the `Array` to a single element, including
+    /// the zero-length slice. It is similar in intent to calling
+    /// [`Vec::splice`] with a one-element iterator.
+    ///
+    /// `set_with_drain` will only drain up to the end of the vector.
+    ///
+    /// To set a single element without draining, use [`set`](Self::set).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::Array;
+    /// let mut ary = Array::from(&[1, 2, 4]);
+    /// ary.set_with_drain(1, 0, 10);
+    /// assert_eq!(ary, &[1, 10, 2, 4]);
+    /// ary.set_with_drain(2, 5, 20);
+    /// assert_eq!(ary, &[1, 10, 20]);
+    /// ary.set_with_drain(5, 5, 30);
+    /// assert_eq!(ary, &[1, 10, 20, 0, 0, 30]);
+    /// ```
+    #[inline]
+    pub fn set_with_drain(&mut self, start: usize, drain: usize, elem: T) -> usize {
+        let buflen = self.0.len();
+        let drained = cmp::min(buflen.checked_sub(start).unwrap_or_default(), drain);
+
+        if let Some(cell) = self.0.get_mut(start) {
+            match drain {
+                0 => self.0.insert(start, elem),
+                1 => *cell = elem,
+                _ => {
+                    *cell = elem;
+                    let drain_end_idx = cmp::min(start + drain, buflen);
+                    self.0.drain(start + 1..drain_end_idx);
+                }
+            }
+        } else {
+            // start is *at least* buflen, so this calculation never underflows
+            // and ensures we allocate an additional slot.
+            self.0.reserve(start + 1 - buflen);
+            for _ in buflen..start {
+                self.0.push(T::default());
+            }
+            self.0.push(elem);
+        }
+
+        drained
+    }
+}
+
+impl<T> Array<T>
+where
+    T: Default + Clone,
+{
+    /// Insert the elements from a slice at a position `index` in the vector,
+    /// extending the vector with `T::default()` if `index` is out of bounds.
+    ///
+    /// This method is similar to [`Vec::splice`] when called with a zero-length
+    /// range.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::Array;
+    /// let mut ary = Array::from(&[1, 2, 4]);
+    /// ary.insert_slice(1, &[7, 8, 9]);
+    /// assert_eq!(ary, &[1, 7, 8, 9, 2, 4]);
+    /// ary.insert_slice(8, &[100, 200]);
+    /// assert_eq!(ary, &[1, 7, 8, 9, 2, 4, 0, 0, 100, 200]);
+    /// ```
+    #[inline]
+    pub fn insert_slice(&mut self, index: usize, values: &[T]) {
+        let additional = index.checked_sub(self.0.len()).unwrap_or_default() + values.len();
+        self.0.reserve(additional);
+
+        for _ in self.0.len()..index {
+            self.0.push(T::default());
+        }
+        if index == self.0.len() {
+            self.0.extend_from_slice(values);
+        } else {
+            let mut tail = self.0.split_off(index);
+            self.0.extend_from_slice(values);
+            self.0.append(&mut tail);
+        }
+    }
+
+    /// Insert the elements from a slice at a position `index` in the vector and
+    /// remove the following `drain` elements. The vector is extended with
+    /// `T::default()` if `index` is out of bounds.
+    ///
+    /// This method is similar to [`Vec::splice`] when called with a
+    /// nonzero-length range.
+    ///
+    /// When called with `drain == 0`, this method is equivalent to
+    /// [`insert_slice`](Self::insert_slice).
+    ///
+    /// If `drain >= src.len()` or the tail of the vector is replaced, this
+    /// method is efficient. Otherwise, a temporary buffer is used to move the
+    /// elements.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::Array;
+    /// let mut ary = Array::from(&[1, 2, 4]);
+    /// ary.set_slice(1, 5, &[7, 8, 9]);
+    /// assert_eq!(ary, &[1, 7, 8, 9]);
+    /// ary.set_slice(6, 1, &[100, 200]);
+    /// assert_eq!(ary, &[1, 7, 8, 9, 0, 0, 100, 200]);
+    /// ```
+    #[inline]
+    pub fn set_slice(&mut self, index: usize, drain: usize, values: &[T]) -> usize {
+        let buflen = self.0.len();
+        let drained = cmp::min(buflen.checked_sub(index).unwrap_or_default(), drain);
+
+        let additional = index.checked_sub(self.0.len()).unwrap_or_default() + values.len();
+        self.0.reserve(additional);
+
+        for _ in self.0.len()..index {
+            self.0.push(T::default());
+        }
+        if index == self.0.len() {
+            self.0.extend_from_slice(values);
+        } else {
+            self.0
+                .splice(index..index + drained, values.iter().cloned());
+        }
+
+        drained
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::array::vec::Array;
+
+    // `insert_slice`
+
+    #[test]
+    fn non_empty_array_insert_slice_end_empty() {
+        let mut ary = Array::from([1, 2, 3, 4, 5]);
+        ary.insert_slice(5, &[]);
+        assert_eq!(ary, [1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn non_empty_array_insert_slice_out_of_bounds_empty() {
+        let mut ary = Array::from([1, 2, 3, 4, 5]);
+        ary.insert_slice(10, &[]);
+        assert_eq!(ary, [1, 2, 3, 4, 5, 0, 0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn non_empty_array_insert_slice_interior_empty() {
+        let mut ary = Array::from([1, 2, 3, 4, 5]);
+        ary.insert_slice(2, &[]);
+        assert_eq!(ary, [1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn non_empty_array_insert_slice_begin_empty() {
+        let mut ary = Array::from([1, 2, 3, 4, 5]);
+        ary.insert_slice(0, &[]);
+        assert_eq!(ary, [1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn empty_array_insert_slice_end_empty() {
+        let mut ary = Array::<i32>::new();
+        ary.insert_slice(0, &[]);
+        assert_eq!(ary, []);
+    }
+
+    #[test]
+    fn empty_array_insert_slice_out_of_bounds_empty() {
+        let mut ary = Array::<i32>::new();
+        ary.insert_slice(10, &[]);
+        assert_eq!(ary, [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn empty_array_insert_slice_begin_empty() {
+        let mut ary = Array::<i32>::new();
+        ary.insert_slice(0, &[]);
+        assert_eq!(ary, []);
+    }
+
+    #[test]
+    fn non_empty_array_insert_slice_end() {
+        let mut ary = Array::from([1, 2, 3, 4, 5]);
+        ary.insert_slice(5, &[8, 9, 10]);
+        assert_eq!(ary, [1, 2, 3, 4, 5, 8, 9, 10]);
+    }
+
+    #[test]
+    fn non_empty_array_insert_slice_out_of_bounds() {
+        let mut ary = Array::from([1, 2, 3, 4, 5]);
+        ary.insert_slice(10, &[8, 9, 10]);
+        assert_eq!(ary, [1, 2, 3, 4, 5, 0, 0, 0, 0, 0, 8, 9, 10]);
+    }
+
+    #[test]
+    fn non_empty_array_insert_slice_interior() {
+        let mut ary = Array::from([1, 2, 3, 4, 5]);
+        ary.insert_slice(2, &[8, 9, 10]);
+        assert_eq!(ary, [1, 2, 8, 9, 10, 3, 4, 5]);
+    }
+
+    #[test]
+    fn non_empty_array_insert_slice_begin() {
+        let mut ary = Array::from([1, 2, 3, 4, 5]);
+        ary.insert_slice(0, &[8, 9, 10]);
+        assert_eq!(ary, [8, 9, 10, 1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn empty_array_insert_slice_end() {
+        let mut ary = Array::<i32>::new();
+        ary.insert_slice(0, &[8, 9, 10]);
+        assert_eq!(ary, [8, 9, 10]);
+    }
+
+    #[test]
+    fn empty_array_insert_slice_out_of_bounds() {
+        let mut ary = Array::<i32>::new();
+        ary.insert_slice(10, &[8, 9, 10]);
+        assert_eq!(ary, [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 8, 9, 10]);
+    }
+
+    #[test]
+    fn empty_array_insert_slice_begin() {
+        let mut ary = Array::<i32>::new();
+        ary.insert_slice(0, &[8, 9, 10]);
+        assert_eq!(ary, [8, 9, 10]);
+    }
+
+    // `set_slice`
+
+    #[test]
+    fn non_empty_array_set_slice_end_empty_drain_0() {
+        let mut ary = Array::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(5, 0, &[]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_end_empty_drain_less_than_insert_length() {
+        let mut ary = Array::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(5, 0, &[]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_end_empty_drain_equal_to_insert_length() {
+        let mut ary = Array::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(5, 0, &[]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_end_empty_drain_greater_than_insert_length() {
+        let mut ary = Array::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(5, 5, &[]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_out_of_bounds_empty_drain_0() {
+        let mut ary = Array::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(10, 0, &[]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [1, 2, 3, 4, 5, 0, 0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_out_of_bounds_empty_drain_less_than_insert_length() {
+        let mut ary = Array::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(10, 0, &[]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [1, 2, 3, 4, 5, 0, 0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_out_of_bounds_empty_drain_equal_to_insert_length() {
+        let mut ary = Array::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(10, 0, &[]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [1, 2, 3, 4, 5, 0, 0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_out_of_bounds_empty_drain_greater_than_insert_length() {
+        let mut ary = Array::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(10, 0, &[]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [1, 2, 3, 4, 5, 0, 0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_interior_empty_drain_0() {
+        let mut ary = Array::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(1, 0, &[]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_interior_empty_drain_less_than_insert_length() {
+        let mut ary = Array::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(1, 0, &[]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_interior_empty_drain_equal_to_insert_length() {
+        let mut ary = Array::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(1, 0, &[]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_interior_empty_drain_greater_than_insert_length() {
+        let mut ary = Array::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(1, 2, &[]);
+        assert_eq!(drained, 2);
+        assert_eq!(ary, [1, 4, 5]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_interior_empty_drain_greater_than_insert_length_to_end() {
+        let mut ary = Array::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(1, 4, &[]);
+        assert_eq!(drained, 4);
+        assert_eq!(ary, [1]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_interior_empty_drain_greater_than_insert_length_overrun_end() {
+        let mut ary = Array::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(1, 10, &[]);
+        assert_eq!(drained, 4);
+        assert_eq!(ary, [1]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_end_non_empty_drain_0() {
+        let mut ary = Array::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(5, 0, &[7, 8, 9]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [1, 2, 3, 4, 5, 7, 8, 9]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_end_non_empty_drain_less_than_insert_length() {
+        let mut ary = Array::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(5, 2, &[7, 8, 9]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [1, 2, 3, 4, 5, 7, 8, 9]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_end_non_empty_drain_equal_to_insert_length() {
+        let mut ary = Array::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(5, 3, &[7, 8, 9]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [1, 2, 3, 4, 5, 7, 8, 9]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_end_non_empty_drain_greater_than_insert_length() {
+        let mut ary = Array::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(5, 5, &[7, 8, 9]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [1, 2, 3, 4, 5, 7, 8, 9]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_out_of_bounds_non_empty_drain_0() {
+        let mut ary = Array::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(10, 0, &[7, 8, 9]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [1, 2, 3, 4, 5, 0, 0, 0, 0, 0, 7, 8, 9]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_out_of_bounds_non_empty_drain_less_than_insert_length() {
+        let mut ary = Array::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(10, 2, &[7, 8, 9]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [1, 2, 3, 4, 5, 0, 0, 0, 0, 0, 7, 8, 9]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_out_of_bounds_non_empty_drain_equal_to_insert_length() {
+        let mut ary = Array::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(10, 3, &[7, 8, 9]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [1, 2, 3, 4, 5, 0, 0, 0, 0, 0, 7, 8, 9]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_out_of_bounds_non_empty_drain_greater_than_insert_length() {
+        let mut ary = Array::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(10, 5, &[7, 8, 9]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [1, 2, 3, 4, 5, 0, 0, 0, 0, 0, 7, 8, 9]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_interior_non_empty_drain_0() {
+        let mut ary = Array::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(1, 0, &[7, 8, 9]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [1, 7, 8, 9, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_interior_non_empty_drain_less_than_insert_length() {
+        let mut ary = Array::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(1, 2, &[7, 8, 9]);
+        assert_eq!(drained, 2);
+        assert_eq!(ary, [1, 7, 8, 9, 4, 5]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_interior_non_empty_drain_equal_to_insert_length() {
+        let mut ary = Array::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(1, 3, &[7, 8, 9]);
+        assert_eq!(drained, 3);
+        assert_eq!(ary, [1, 7, 8, 9, 5]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_interior_non_empty_drain_greater_than_insert_length() {
+        let mut ary = Array::from([1, 2, 3, 4, 5, 6]);
+        let drained = ary.set_slice(1, 4, &[7, 8, 9]);
+        assert_eq!(drained, 4);
+        assert_eq!(ary, [1, 7, 8, 9, 6]);
+        assert_eq!(ary.len(), 5);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_interior_non_empty_drain_equal_to_insert_length_to_tail() {
+        let mut ary = Array::from([1, 2, 3, 4]);
+        let drained = ary.set_slice(1, 3, &[7, 8, 9]);
+        assert_eq!(drained, 3);
+        assert_eq!(ary, [1, 7, 8, 9]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_interior_non_empty_drain_greater_than_insert_length_to_tail() {
+        let mut ary = Array::from([1, 2, 3, 4]);
+        let drained = ary.set_slice(1, 10, &[7, 8, 9]);
+        assert_eq!(drained, 3);
+        assert_eq!(ary, [1, 7, 8, 9]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_interior_non_empty_drain_less_than_insert_length_overrun_tail() {
+        let mut ary = Array::from([1, 2, 3, 4]);
+        let drained = ary.set_slice(3, 2, &[7, 8, 9]);
+        assert_eq!(drained, 1);
+        assert_eq!(ary, [1, 2, 3, 7, 8, 9]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_interior_non_empty_drain_equal_to_insert_length_overrun_tail() {
+        let mut ary = Array::from([1, 2, 3, 4]);
+        let drained = ary.set_slice(3, 3, &[7, 8, 9]);
+        assert_eq!(drained, 1);
+        assert_eq!(ary, [1, 2, 3, 7, 8, 9]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_interior_non_empty_drain_greater_than_insert_length_overrun_tail()
+    {
+        let mut ary = Array::from([1, 2, 3, 4]);
+        let drained = ary.set_slice(3, 10, &[7, 8, 9]);
+        assert_eq!(drained, 1);
+        assert_eq!(ary, [1, 2, 3, 7, 8, 9]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_begin_non_empty_drain_0() {
+        let mut ary = Array::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(0, 0, &[7, 8, 9]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [7, 8, 9, 1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_begin_non_empty_drain_less_than_insert_length() {
+        let mut ary = Array::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(0, 2, &[7, 8, 9]);
+        assert_eq!(drained, 2);
+        assert_eq!(ary, [7, 8, 9, 3, 4, 5]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_begin_non_empty_drain_equal_to_insert_length() {
+        let mut ary = Array::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(0, 3, &[7, 8, 9]);
+        assert_eq!(drained, 3);
+        assert_eq!(ary, [7, 8, 9, 4, 5]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_begin_non_empty_drain_greater_than_insert_length() {
+        let mut ary = Array::from([1, 2, 3, 4, 5, 6]);
+        let drained = ary.set_slice(0, 4, &[7, 8, 9]);
+        assert_eq!(drained, 4);
+        assert_eq!(ary, [7, 8, 9, 5, 6]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_begin_non_empty_drain_equal_to_insert_length_to_tail() {
+        let mut ary = Array::from([1, 2, 3, 4]);
+        let drained = ary.set_slice(0, 4, &[7, 8, 9, 10]);
+        assert_eq!(drained, 4);
+        assert_eq!(ary, [7, 8, 9, 10]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_begin_non_empty_drain_greater_than_insert_length_to_tail() {
+        let mut ary = Array::from([1, 2, 3, 4]);
+        let drained = ary.set_slice(0, 10, &[7, 8, 9, 10]);
+        assert_eq!(drained, 4);
+        assert_eq!(ary, [7, 8, 9, 10]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_begin_non_empty_drain_less_than_insert_length_overrun_tail() {
+        let mut ary = Array::from([1, 2, 3, 4]);
+        let drained = ary.set_slice(0, 4, &[7, 8, 9, 10, 11]);
+        assert_eq!(drained, 4);
+        assert_eq!(ary, [7, 8, 9, 10, 11]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_begin_non_empty_drain_equal_to_insert_length_overrun_tail() {
+        let mut ary = Array::from([1, 2, 3, 4]);
+        let drained = ary.set_slice(0, 5, &[7, 8, 9, 10, 11]);
+        assert_eq!(drained, 4);
+        assert_eq!(ary, [7, 8, 9, 10, 11]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_begin_non_empty_drain_greater_than_insert_length_overrun_tail() {
+        let mut ary = Array::from([1, 2, 3, 4]);
+        let drained = ary.set_slice(0, 10, &[7, 8, 9, 10, 11]);
+        assert_eq!(drained, 4);
+        assert_eq!(ary, [7, 8, 9, 10, 11]);
+    }
+
+    #[test]
+    fn empty_array_set_slice_non_empty_drain_0() {
+        let mut ary = Array::<i32>::new();
+        let drained = ary.set_slice(0, 0, &[7, 8, 9]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [7, 8, 9]);
+    }
+
+    #[test]
+    fn empty_array_set_slice_non_empty_drain_less_than_insert_length() {
+        let mut ary = Array::<i32>::new();
+        let drained = ary.set_slice(0, 1, &[7, 8, 9]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [7, 8, 9]);
+    }
+
+    #[test]
+    fn empty_array_set_slice_non_empty_drain_equal_to_insert_length() {
+        let mut ary = Array::<i32>::new();
+        let drained = ary.set_slice(0, 3, &[7, 8, 9]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [7, 8, 9]);
+    }
+
+    #[test]
+    fn empty_array_set_slice_begin_non_empty_drain_greater_than_insert_length() {
+        let mut ary = Array::<i32>::new();
+        let drained = ary.set_slice(0, 10, &[7, 8, 9]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [7, 8, 9]);
+    }
+
+    #[test]
+    fn empty_array_set_slice_out_of_bounds_non_empty_drain_0() {
+        let mut ary = Array::<i32>::new();
+        let drained = ary.set_slice(5, 0, &[7, 8, 9]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [0, 0, 0, 0, 0, 7, 8, 9]);
+    }
+
+    #[test]
+    fn empty_array_set_slice_out_of_bounds_non_empty_drain_less_than_insert_length() {
+        let mut ary = Array::<i32>::new();
+        let drained = ary.set_slice(5, 1, &[7, 8, 9]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [0, 0, 0, 0, 0, 7, 8, 9]);
+    }
+
+    #[test]
+    fn empty_array_set_slice_out_of_bounds_non_empty_drain_equal_to_insert_length() {
+        let mut ary = Array::<i32>::new();
+        let drained = ary.set_slice(5, 3, &[7, 8, 9]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [0, 0, 0, 0, 0, 7, 8, 9]);
+    }
+
+    #[test]
+    fn empty_array_set_slice_out_of_bounds_non_empty_drain_greater_than_insert_length() {
+        let mut ary = Array::<i32>::new();
+        let drained = ary.set_slice(5, 10, &[7, 8, 9]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [0, 0, 0, 0, 0, 7, 8, 9]);
+    }
+
+    #[test]
+    fn empty_array_set_slice_empty_drain_0() {
+        let mut ary = Array::<i32>::new();
+        let drained = ary.set_slice(0, 0, &[]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, []);
+    }
+
+    #[test]
+    fn empty_array_set_slice_empty_drain_less_than_insert_length() {
+        let mut ary = Array::<i32>::new();
+        let drained = ary.set_slice(0, 0, &[]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, []);
+    }
+
+    #[test]
+    fn empty_array_set_slice_empty_drain_equal_to_insert_length() {
+        let mut ary = Array::<i32>::new();
+        let drained = ary.set_slice(0, 0, &[]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, []);
+    }
+
+    #[test]
+    fn empty_array_set_slice_begin_empty_drain_greater_than_insert_length() {
+        let mut ary = Array::<i32>::new();
+        let drained = ary.set_slice(0, 10, &[]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, []);
+    }
+
+    #[test]
+    fn empty_array_set_slice_out_of_bounds_empty_drain_0() {
+        let mut ary = Array::<i32>::new();
+        let drained = ary.set_slice(5, 0, &[]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [0, 0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn empty_array_set_slice_out_of_bounds_empty_drain_less_than_insert_length() {
+        let mut ary = Array::<i32>::new();
+        let drained = ary.set_slice(5, 1, &[]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [0, 0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn empty_array_set_slice_out_of_bounds_empty_drain_equal_to_insert_length() {
+        let mut ary = Array::<i32>::new();
+        let drained = ary.set_slice(5, 3, &[]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [0, 0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn empty_array_set_slice_out_of_bounds_empty_drain_greater_than_insert_length() {
+        let mut ary = Array::<i32>::new();
+        let drained = ary.set_slice(5, 10, &[]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [0, 0, 0, 0, 0]);
+    }
+}

--- a/spinoso-array/src/lib.rs
+++ b/spinoso-array/src/lib.rs
@@ -1,0 +1,149 @@
+#![warn(clippy::all)]
+#![warn(clippy::pedantic)]
+#![warn(clippy::cargo)]
+#![warn(missing_docs, intra_doc_link_resolution_failure)]
+#![warn(missing_debug_implementations)]
+#![warn(missing_copy_implementations)]
+#![warn(rust_2018_idioms)]
+#![warn(trivial_casts, trivial_numeric_casts)]
+#![warn(unused_qualifications)]
+#![warn(variant_size_differences)]
+
+//! Contiguous growable vector types that implement the [Ruby `Array`] API.
+//!
+//! `Array` types are growable vectors with potentially heap-allocated contents.
+//! The types in this crate can be passed by pointer over FFI.
+//!
+//! `Array` types implement the mutating APIs in the Ruby `Array` core class as
+//! well as indexing and slicing APIs.
+//!
+//! `spinoso-array` is part of a [collection of crates] that implement the data
+//! structures that comprise the Ruby Core and Standard Library implementation
+//! for [Artichoke Ruby].
+//!
+//! # Array types
+//!
+//! - [`Array`] is based on [`Vec`] from the Rust `alloc` crate and standard
+//!   library. This Spinoso array type is enabled by default.
+//! - [`SmallArray`] is based on [`SmallVec`] and implements the small vector
+//!   optimization – small arrays are stored inline without a heap allocation.
+//!   This Spinoso array type requires the `small-array` Cargo feature.
+//!
+//! # `no_std`
+//!
+//! This crate is `no_std` with a required dependency on the [`alloc`] crate.
+//!
+//! # Examples
+//!
+//! You can create an [`Array<T>`](Array) with [`new`](Array::new):
+//!
+//! ```
+//! # use spinoso_array::Array;
+//! let ary: Array<i32> = Array::new();
+//! ```
+//!
+//! Or with one of the many [`From`] and [`FromIterator`] implementations:
+//!
+//! ```
+//! # use core::iter;
+//! # use spinoso_array::Array;
+//! let ary: Array<i32> = Array::from(vec![1, 2, 3, 4]);
+//! let ary2: Array<i32> = iter::repeat(1).take(10).collect();
+//! ```
+//!
+//! You can [`push`](Array::push) values onto the end of an array (which will
+//! grow the array as needed):
+//!
+//! ```
+//! # use spinoso_array::Array;
+//! let mut ary = Array::from(&[1, 2]);
+//! ary.push(3);
+//! ```
+//!
+//! Popping values behaves similarly:
+//!
+//! ```
+//! # use spinoso_array::Array;
+//! let mut ary = Array::from(&[1, 2]);
+//! assert_eq!(ary.pop(), Some(2));
+//! ```
+//!
+//! Arrays also support indexing (through the [`Index`] and [`IndexMut`]
+//! traits):
+//!
+//! ```
+//! # use spinoso_array::Array;
+//! let mut a = Array::from(&[1, 2, 3]);
+//! let three = a[2];
+//! a[1] = a[1] + 5;
+//! ```
+//!
+//! The `Array` vector types in this crate differ from [`Vec`] in the Rust `std`
+//! by offering many specialized slicing and mutation APIs. For example, rather
+//! than offering APIs like [`Vec::drain`] and [`Vec::splice`], array types in
+//! this crate offer specialized methods like [`shift`], [`shift_n`],
+//! [`unshift`], and [`unshift_n`] and `splice`-like methods with
+//! [`insert_slice`], and [`set_slice`].
+//!
+//! ```
+//! # use spinoso_array::Array;
+//! let mut a = Array::from(&[1, 2, 3]);
+//! a.unshift(0);
+//! assert_eq!(a, [0, 1, 2, 3]);
+//! let b = a.shift_n(10);
+//! assert_eq!(a, []);
+//! assert_eq!(b, [0, 1, 2, 3]);
+//! ```
+//!
+//! # Panics
+//!
+//! `Array`s in this crate do not expose panicking slicing operations (with the
+//! exception of [`Index`] and [`IndexMut`] implementations). Instead of
+//! panicking, slicing APIs operate until the end of the vector or return `&[]`.
+//! Mutating APIs extend `Array`s on out of bounds access.
+//!
+//! [Ruby `Array`]: https://ruby-doc.org/core-2.6.3/Array.html
+//! [collection of crates]: https://crates.io/keywords/spinoso
+//! [Artichoke Ruby]: https://www.artichokeruby.org/
+//! [`Vec`]: alloc::vec::Vec
+//! [`SmallVec`]: smallvec::SmallVec
+//! [`From`]: core::convert::From
+//! [`FromIterator`]: core::iter::FromIterator
+//! [`Index`]: core::ops::Index
+//! [`IndexMut`]: core::ops::IndexMut
+//! [`Vec::drain`]: alloc::vec::Vec::drain
+//! [`Vec::splice`]: alloc::vec::Vec::splice
+//! [`shift`]: Array::shift
+//! [`shift_n`]: Array::shift_n
+//! [`unshift`]: Array::unshift
+//! [`unshift_n`]: Array::unshift_n
+//! [`insert_slice`]: Array::insert_slice
+//! [`set_slice`]: Array::set_slice
+
+// This crate is `no_std` + `alloc`
+#![no_std]
+
+extern crate alloc;
+
+// Ensure code blocks in README.md compile
+#[cfg(doctest)]
+macro_rules! readme {
+    ($x:expr) => {
+        #[doc = $x]
+        mod readme {}
+    };
+    () => {
+        readme!(include_str!("../README.md"));
+    };
+}
+#[cfg(doctest)]
+readme!();
+
+mod array;
+
+#[cfg(feature = "small-array")]
+pub use array::smallvec::SmallArray;
+#[cfg(feature = "small-array")]
+pub use array::INLINE_CAPACITY;
+
+pub use array::vec::Array;


### PR DESCRIPTION
This is an experiment to move core data structures used to implement
Ruby Core and Standard Library out of `artichoke-backend`. The goal is
to have `artichoke-backend` be the VM and Ruby <-> Rust type
orchestrator via the `BoxUnboxVmValue` trait.

This idea has already been trialed with `intaglio` extracting the
`Symbol` backend.

The `spinoso` crate prefix comes from _Carciofo spinoso di Sardegna_,
the thorny artichoke of Sardinia. The idea is that the data structures
defined in the `spinoso` family of crates will form the backbone of Ruby
Core in Artichoke.

`spinoso-array` is a generalization of the `Array` and `InlineBuffer`
found in `artichoke_backend::extn::core::array`. It includes many more
slice and mutation methods which will allow defining more of Ruby
`Array` in native code at minimal maintenance cost.

`spinoso-array` includes two `Array` implementations:

- `Array`, based on `Vec` from Rust `alloc` and `std`. This backend
  contains no unsafe code.
- `SmallArray`, based on `SmallVec` from the Servo `smallvec` crate.
  This backend contains some unsafe code to implement a performant
  `set_slice` API for the case where a slice inserted into the interior
  of the array is less than the number of elements to drain.

`SmallArray` is gated behind the `small-array` feature. When the
`small-array` feature is not activated, the `smallvec` dependency is
dropped.

This crate has two `unsafe fn set_len` for manipulating Array length in
combination with raw pointers to support FFI usecases. The `SmallArray`
backend has two `unsafe` blocks to support a performant `O(n)` `set_slice`
API for an interior inserted slice that must drain `n` additional elements.
There are extensive _Safety_ comments.

`spinoso-array` has complete API documentation. Every method has an
_Examples_ section with doctests. `insert_slice` and `set_slice`, which
both have a large number of internal branches, have exhaustive
integration tests with full coverage.

Compared to the `InlineBuffer` implementation in `artichoke-backend`
that `spinoso-array` intends to replace, the API is more complete, there
are more tests, the tests do not depend on the Ruby VM, the code is
simpler, more well commented, and easier to follow, and more performant,
and there are docs.

A separate PR will replace `InlineBuffer` with one of the backends from
`spinoso-array`.