### PR TITLE
Update fork of regex-syntax escape functions

### DIFF
--- a/artichoke-backend/src/extn/core/regexp/mod.rs
+++ b/artichoke-backend/src/extn/core/regexp/mod.rs
@@ -203,16 +203,16 @@ impl Regexp {
             value: &mut Value,
         ) -> Result<Vec<u8>, Exception> {
             if let Ok(regexp) = unsafe { Regexp::unbox_from_value(value, interp) } {
-                Ok(regexp.inner().derived_config().pattern.clone().into())
+                let config = regexp.inner().derived_config();
+                let pattern = config.pattern.clone();
+                Ok(pattern.into())
             } else {
                 let bytes = value.implicitly_convert_to_string(interp)?;
-                let pattern = if let Ok(pattern) = str::from_utf8(bytes) {
-                    pattern
+                if let Ok(pattern) = str::from_utf8(bytes) {
+                    Ok(syntax::escape(pattern).into_bytes())
                 } else {
-                    // drop(bytes);
-                    return Err(ArgumentError::from("invalid encoding (non UTF-8)").into());
-                };
-                Ok(syntax::escape(pattern).into_bytes())
+                    Err(ArgumentError::from("invalid encoding (non UTF-8)").into())
+                }
             }
         }
         let mut iter = patterns.into_iter();


### PR DESCRIPTION
artichoke-backend maintains a small fork of several functions from regex-syntax.
There have been some upstream changes I noticed. This commit pulls them in and
rebases the fork.

This commit restructures the 'escape_into' function, changes how form feed char
is handled, adds comments, and adds tests.

The only use of the 'syntax' module is Regexp::escape. The call sites were
refactored to be more debugger friendly.