### PR TITLE
README tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ If you'd like to engage in a discussion outside of GitHub, you can
 
 ## License
 
-artichoke is licensed with the [MIT License](LICENSE) (c) Ryan Lopopolo.
+`artichoke` is licensed with the [MIT License](LICENSE) (c) Ryan Lopopolo.
 
 Some portions of Artichoke are derived from third party sources. The READMEs in
 each crate discuss which third party licenses are applicable to the sources and

--- a/artichoke-backend/README.md
+++ b/artichoke-backend/README.md
@@ -84,7 +84,7 @@ between boxed Ruby values and native Rust types like `i64` and
 
 ## License
 
-artichoke-backend is licensed with the [MIT License](../LICENSE) (c) Ryan
+`artichoke-backend` is licensed with the [MIT License](../LICENSE) (c) Ryan
 Lopopolo.
 
 Some portions of artichoke-backend are derived from

--- a/artichoke-core/README.md
+++ b/artichoke-core/README.md
@@ -48,7 +48,7 @@ is one implementation of the `artichoke-core` traits.
 To use all of the APIs defined in Artichoke Core, bring the traits into scope by
 importing the prelude:
 
-```
+```rust
 use artichoke_core::prelude::*;
 ```
 
@@ -62,7 +62,8 @@ All features are enabled by default:
 
 ## License
 
-artichoke-core is licensed with the [MIT License](../LICENSE) (c) Ryan Lopopolo.
+`artichoke-core` is licensed with the [MIT License](../LICENSE) (c) Ryan
+Lopopolo.
 
 [kernel#require]: https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-require
 [`random::default`]: https://ruby-doc.org/core-2.6.3/Random.html#DEFAULT

--- a/spinoso-array/README.md
+++ b/spinoso-array/README.md
@@ -70,7 +70,7 @@ All features are enabled by default.
 
 ## License
 
-`spinoso-array` is licensed under the [MIT License](../LICENSE) (c) Ryan
+`spinoso-array` is licensed with the [MIT License](../LICENSE) (c) Ryan
 Lopopolo.
 
 [ruby-array]: https://ruby-doc.org/core-2.6.3/Array.html


### PR DESCRIPTION
- Make the code block in artichoke-core a Rust code block.
- Make wording and code annotations consistent in License section of
  crate READMEs.