### PR TITLE
Improve setup and assertions in extn functional tests

### DIFF
--- a/artichoke-backend/src/extn/core/array/mod.rs
+++ b/artichoke-backend/src/extn/core/array/mod.rs
@@ -417,14 +417,14 @@ impl Array {
 
 #[cfg(test)]
 mod tests {
+    use crate::test::prelude::*;
     use bstr::ByteSlice;
 
-    use crate::test::prelude::*;
-
+    const SUBJECT: &str = "Array";
     const FUNCTIONAL_TEST: &[u8] = include_bytes!("array_functional_test.rb");
 
     #[test]
-    fn functional_test() {
+    fn functional() {
         let mut interp = crate::interpreter().unwrap();
         let _ = interp.eval(FUNCTIONAL_TEST).unwrap();
         let result = interp.eval(b"spec");
@@ -432,7 +432,9 @@ mod tests {
             let backtrace = exc.vm_backtrace(&mut interp);
             let backtrace = bstr::join("\n", backtrace.unwrap_or_default());
             panic!(
-                "Array tests failed with backtrace:\n{:?}",
+                "{} tests failed with message: {:?} and backtrace:\n{:?}",
+                SUBJECT,
+                exc.message().as_bstr(),
                 backtrace.as_bstr()
             );
         }

--- a/artichoke-backend/src/extn/core/kernel/mod.rs
+++ b/artichoke-backend/src/extn/core/kernel/mod.rs
@@ -9,157 +9,24 @@ pub struct Kernel;
 #[cfg(test)]
 mod tests {
     use crate::test::prelude::*;
+    use bstr::ByteSlice;
+
+    const SUBJECT: &str = "Kernel";
+    const FUNCTIONAL_TEST: &[u8] = include_bytes!("kernel_test.rb");
 
     #[test]
-    fn integration_test() {
+    fn functional() {
         let mut interp = crate::interpreter().unwrap();
-        let _ = interp.eval(&include_bytes!("kernel_test.rb")[..]).unwrap();
+        let _ = interp.eval(FUNCTIONAL_TEST).unwrap();
         let result = interp.eval(b"spec");
-        let result = result.unwrap().try_into::<bool>(&interp).unwrap();
-        assert!(result);
-    }
-
-    mod require {
-        use crate::test::prelude::*;
-
-        #[derive(Debug)]
-        struct IntegrationTest;
-
-        impl File for IntegrationTest {
-            type Artichoke = Artichoke;
-
-            type Error = Exception;
-
-            fn require(interp: &mut Artichoke) -> Result<(), Self::Error> {
-                let _ = interp.eval(b"@i = 255").unwrap();
-                Ok(())
-            }
-        }
-
-        #[derive(Debug)]
-        struct HybridRustAndRuby;
-
-        impl File for HybridRustAndRuby {
-            type Artichoke = Artichoke;
-
-            type Error = Exception;
-
-            fn require(interp: &mut Artichoke) -> Result<(), Self::Error> {
-                let _ = interp.eval(b"module Foo; RUST = 7; end").unwrap();
-                Ok(())
-            }
-        }
-
-        // Integration test for `Kernel::require`:
-        //
-        // - require side effects (e.g. ivar set or class def) effect the interpreter
-        // - Successful first require returns `true`.
-        // - Second require returns `false`.
-        // - Second require does not cause require side effects.
-        // - Require non-existing file raises and returns `nil`.
-        #[test]
-        fn integration_test() {
-            let mut interp = crate::interpreter().unwrap();
-            interp
-                .def_file_for_type::<_, IntegrationTest>("file.rb")
-                .unwrap();
-            let result = interp.eval(b"require 'file'").unwrap();
-            let require_result = result.try_into::<bool>(&interp).unwrap();
-            assert!(require_result);
-            let result = interp.eval(b"@i").unwrap();
-            let i_result = result.try_into::<i64>(&interp).unwrap();
-            assert_eq!(i_result, 255);
-            let result = interp.eval(b"@i = 1000; require 'file'").unwrap();
-            let second_require_result = result.try_into::<bool>(&interp).unwrap();
-            assert!(!second_require_result);
-            let result = interp.eval(b"@i").unwrap();
-            let second_i_result = result.try_into::<i64>(&interp).unwrap();
-            assert_eq!(second_i_result, 1000);
-            let err = interp.eval(b"require 'non-existent-source'").unwrap_err();
-            assert_eq!(
-                &b"cannot load such file -- non-existent-source"[..],
-                err.message().as_ref()
-            );
-            let expected = vec![Vec::from(&b"(eval):1"[..])];
-            assert_eq!(Some(expected), err.vm_backtrace(&mut interp),);
-        }
-
-        #[test]
-        fn absolute_path() {
-            let mut interp = crate::interpreter().unwrap();
-            interp
-                .def_rb_source_file("/foo/bar/source.rb", &b"# a source file"[..])
-                .unwrap();
-            let result = interp.eval(b"require '/foo/bar/source.rb'").unwrap();
-            assert!(result.try_into::<bool>(&interp).unwrap());
-            let result = interp.eval(b"require '/foo/bar/source.rb'").unwrap();
-            assert!(!result.try_into::<bool>(&interp).unwrap());
-        }
-
-        #[test]
-        fn relative_with_dotted_path() {
-            let mut interp = crate::interpreter().unwrap();
-            interp
-                .def_rb_source_file("/foo/bar/source.rb", &b"require_relative '../bar.rb'"[..])
-                .unwrap();
-            interp
-                .def_rb_source_file("/foo/bar.rb", &b"# a source file"[..])
-                .unwrap();
-            let result = interp.eval(b"require '/foo/bar/source.rb'").unwrap();
-            assert!(result.try_into::<bool>(&interp).unwrap());
-            let result = interp.eval(b"require '/foo/bar.rb'").unwrap();
-            assert!(!result.try_into::<bool>(&interp).unwrap());
-        }
-
-        #[test]
-        fn directory_err() {
-            let mut interp = crate::interpreter().unwrap();
-            let err = interp.eval(b"require '/src'").unwrap_err();
-            assert_eq!(
-                &b"cannot load such file -- /src"[..],
-                err.message().as_ref()
-            );
-            let expected = vec![Vec::from(&b"(eval):1"[..])];
-            assert_eq!(Some(expected), err.vm_backtrace(&mut interp));
-        }
-
-        #[test]
-        fn path_defined_as_source_then_extension_file() {
-            let mut interp = crate::interpreter().unwrap();
-            interp
-                .def_rb_source_file("foo.rb", &b"module Foo; RUBY = 3; end"[..])
-                .unwrap();
-            interp
-                .def_file_for_type::<_, HybridRustAndRuby>("foo.rb")
-                .unwrap();
-            let result = interp.eval(b"require 'foo'").unwrap();
-            let result = result.try_into::<bool>(&interp).unwrap();
-            assert!(result, "successfully required foo.rb");
-            let result = interp.eval(b"Foo::RUBY + Foo::RUST").unwrap();
-            let result = result.try_into::<i64>(&interp).unwrap();
-            assert_eq!(
-                result, 10,
-                "defined Ruby and Rust sources from single require"
-            );
-        }
-
-        #[test]
-        fn path_defined_as_extension_file_then_source() {
-            let mut interp = crate::interpreter().unwrap();
-            interp
-                .def_file_for_type::<_, HybridRustAndRuby>("foo.rb")
-                .unwrap();
-            interp
-                .def_rb_source_file("foo.rb", &b"module Foo; RUBY = 3; end"[..])
-                .unwrap();
-            let result = interp.eval(b"require 'foo'").unwrap();
-            let result = result.try_into::<bool>(&interp).unwrap();
-            assert!(result, "successfully required foo.rb");
-            let result = interp.eval(b"Foo::RUBY + Foo::RUST").unwrap();
-            let result = result.try_into::<i64>(&interp).unwrap();
-            assert_eq!(
-                result, 10,
-                "defined Ruby and Rust sources from single require"
+        if let Err(exc) = result {
+            let backtrace = exc.vm_backtrace(&mut interp);
+            let backtrace = bstr::join("\n", backtrace.unwrap_or_default());
+            panic!(
+                "{} tests failed with message: {:?} and backtrace:\n{:?}",
+                SUBJECT,
+                exc.message().as_bstr(),
+                backtrace.as_bstr()
             );
         }
     }

--- a/artichoke-backend/src/extn/core/kernel/require.rs
+++ b/artichoke-backend/src/extn/core/kernel/require.rs
@@ -140,3 +140,149 @@ impl RelativePath {
         }
     }
 }
+
+#[cfg(test)]
+mod test {
+    use crate::test::prelude::*;
+
+    #[derive(Debug)]
+    struct MockSourceFile;
+
+    impl File for MockSourceFile {
+        type Artichoke = Artichoke;
+
+        type Error = Exception;
+
+        fn require(interp: &mut Artichoke) -> Result<(), Self::Error> {
+            let _ = interp.eval(b"@i = 255").unwrap();
+            Ok(())
+        }
+    }
+
+    #[derive(Debug)]
+    struct MockExtensionAndSourceFile;
+
+    impl File for MockExtensionAndSourceFile {
+        type Artichoke = Artichoke;
+
+        type Error = Exception;
+
+        fn require(interp: &mut Artichoke) -> Result<(), Self::Error> {
+            let _ = interp.eval(b"module Foo; RUST = 7; end").unwrap();
+            Ok(())
+        }
+    }
+
+    // Functional test for `Kernel::require`:
+    //
+    // - require side effects (e.g. ivar set or class def) effect the interpreter
+    // - Successful first require returns `true`.
+    // - Second require returns `false`.
+    // - Second require does not cause require side effects.
+    // - Require non-existing file raises and returns `nil`.
+    #[test]
+    fn functional() {
+        let mut interp = crate::interpreter().unwrap();
+        interp
+            .def_file_for_type::<_, MockSourceFile>("file.rb")
+            .unwrap();
+        let result = interp.eval(b"require 'file'").unwrap();
+        let require_result = result.try_into::<bool>(&interp).unwrap();
+        assert!(require_result);
+        let result = interp.eval(b"@i").unwrap();
+        let i_result = result.try_into::<i64>(&interp).unwrap();
+        assert_eq!(i_result, 255);
+        let result = interp.eval(b"@i = 1000; require 'file'").unwrap();
+        let second_require_result = result.try_into::<bool>(&interp).unwrap();
+        assert!(!second_require_result);
+        let result = interp.eval(b"@i").unwrap();
+        let second_i_result = result.try_into::<i64>(&interp).unwrap();
+        assert_eq!(second_i_result, 1000);
+        let err = interp.eval(b"require 'non-existent-source'").unwrap_err();
+        assert_eq!(
+            &b"cannot load such file -- non-existent-source"[..],
+            err.message().as_ref()
+        );
+        let expected = vec![Vec::from(&b"(eval):1"[..])];
+        assert_eq!(Some(expected), err.vm_backtrace(&mut interp),);
+    }
+
+    #[test]
+    fn absolute_path() {
+        let mut interp = crate::interpreter().unwrap();
+        interp
+            .def_rb_source_file("/foo/bar/source.rb", &b"# a source file"[..])
+            .unwrap();
+        let result = interp.eval(b"require '/foo/bar/source.rb'").unwrap();
+        assert!(result.try_into::<bool>(&interp).unwrap());
+        let result = interp.eval(b"require '/foo/bar/source.rb'").unwrap();
+        assert!(!result.try_into::<bool>(&interp).unwrap());
+    }
+
+    #[test]
+    fn relative_with_dotted_path() {
+        let mut interp = crate::interpreter().unwrap();
+        interp
+            .def_rb_source_file("/foo/bar/source.rb", &b"require_relative '../bar.rb'"[..])
+            .unwrap();
+        interp
+            .def_rb_source_file("/foo/bar.rb", &b"# a source file"[..])
+            .unwrap();
+        let result = interp.eval(b"require '/foo/bar/source.rb'").unwrap();
+        assert!(result.try_into::<bool>(&interp).unwrap());
+        let result = interp.eval(b"require '/foo/bar.rb'").unwrap();
+        assert!(!result.try_into::<bool>(&interp).unwrap());
+    }
+
+    #[test]
+    fn directory_err() {
+        let mut interp = crate::interpreter().unwrap();
+        let err = interp.eval(b"require '/src'").unwrap_err();
+        assert_eq!(
+            &b"cannot load such file -- /src"[..],
+            err.message().as_ref()
+        );
+        let expected = vec![Vec::from(&b"(eval):1"[..])];
+        assert_eq!(Some(expected), err.vm_backtrace(&mut interp));
+    }
+
+    #[test]
+    fn path_defined_as_source_then_extension_file() {
+        let mut interp = crate::interpreter().unwrap();
+        interp
+            .def_rb_source_file("foo.rb", &b"module Foo; RUBY = 3; end"[..])
+            .unwrap();
+        interp
+            .def_file_for_type::<_, MockExtensionAndSourceFile>("foo.rb")
+            .unwrap();
+        let result = interp.eval(b"require 'foo'").unwrap();
+        let result = result.try_into::<bool>(&interp).unwrap();
+        assert!(result, "successfully required foo.rb");
+        let result = interp.eval(b"Foo::RUBY + Foo::RUST").unwrap();
+        let result = result.try_into::<i64>(&interp).unwrap();
+        assert_eq!(
+            result, 10,
+            "defined Ruby and Rust sources from single require"
+        );
+    }
+
+    #[test]
+    fn path_defined_as_extension_file_then_source() {
+        let mut interp = crate::interpreter().unwrap();
+        interp
+            .def_file_for_type::<_, MockExtensionAndSourceFile>("foo.rb")
+            .unwrap();
+        interp
+            .def_rb_source_file("foo.rb", &b"module Foo; RUBY = 3; end"[..])
+            .unwrap();
+        let result = interp.eval(b"require 'foo'").unwrap();
+        let result = result.try_into::<bool>(&interp).unwrap();
+        assert!(result, "successfully required foo.rb");
+        let result = interp.eval(b"Foo::RUBY + Foo::RUST").unwrap();
+        let result = result.try_into::<i64>(&interp).unwrap();
+        assert_eq!(
+            result, 10,
+            "defined Ruby and Rust sources from single require"
+        );
+    }
+}

--- a/artichoke-backend/src/extn/core/string/mod.rs
+++ b/artichoke-backend/src/extn/core/string/mod.rs
@@ -7,13 +7,25 @@ pub struct String;
 #[cfg(test)]
 mod tests {
     use crate::test::prelude::*;
+    use bstr::ByteSlice;
+
+    const SUBJECT: &str = "String";
+    const FUNCTIONAL_TEST: &[u8] = include_bytes!("string_test.rb");
 
     #[test]
-    fn integration_test() {
+    fn functional() {
         let mut interp = crate::interpreter().unwrap();
-        let _ = interp.eval(&include_bytes!("string_test.rb")[..]).unwrap();
+        let _ = interp.eval(FUNCTIONAL_TEST).unwrap();
         let result = interp.eval(b"spec");
-        let result = result.unwrap().try_into::<bool>(&interp).unwrap();
-        assert!(result);
+        if let Err(exc) = result {
+            let backtrace = exc.vm_backtrace(&mut interp);
+            let backtrace = bstr::join("\n", backtrace.unwrap_or_default());
+            panic!(
+                "{} tests failed with message: {:?} and backtrace:\n{:?}",
+                SUBJECT,
+                exc.message().as_bstr(),
+                backtrace.as_bstr()
+            );
+        }
     }
 }

--- a/artichoke-backend/src/extn/core/thread/mod.rs
+++ b/artichoke-backend/src/extn/core/thread/mod.rs
@@ -31,16 +31,20 @@ mod tests {
     use crate::test::prelude::*;
     use bstr::ByteSlice;
 
+    const SUBJECT: &str = "Thread";
+    const FUNCTIONAL_TEST: &[u8] = include_bytes!("thread_test.rb");
+
     #[test]
-    fn integration_test() {
+    fn functional() {
         let mut interp = crate::interpreter().unwrap();
-        let _ = interp.eval(&include_bytes!("thread_test.rb")[..]).unwrap();
+        let _ = interp.eval(FUNCTIONAL_TEST).unwrap();
         let result = interp.eval(b"spec");
         if let Err(exc) = result {
             let backtrace = exc.vm_backtrace(&mut interp);
             let backtrace = bstr::join("\n", backtrace.unwrap_or_default());
             panic!(
-                "Thread tests failed with message: '{:?}' and backtrace:\n{:?}",
+                "{} tests failed with message: {:?} and backtrace:\n{:?}",
+                SUBJECT,
                 exc.message().as_bstr(),
                 backtrace.as_bstr()
             );

--- a/artichoke-backend/src/extn/stdlib/abbrev/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/abbrev/mod.rs
@@ -13,13 +13,25 @@ pub struct Abbrev;
 #[cfg(test)]
 mod tests {
     use crate::test::prelude::*;
+    use bstr::ByteSlice;
+
+    const SUBJECT: &str = "Abbrev";
+    const FUNCTIONAL_TEST: &[u8] = include_bytes!("abbrev_test.rb");
 
     #[test]
-    fn integration_test() {
+    fn functional() {
         let mut interp = crate::interpreter().unwrap();
-        let _ = interp.eval(&include_bytes!("abbrev_test.rb")[..]).unwrap();
+        let _ = interp.eval(FUNCTIONAL_TEST).unwrap();
         let result = interp.eval(b"spec");
-        let result = result.unwrap().try_into::<bool>(&interp).unwrap();
-        assert!(result);
+        if let Err(exc) = result {
+            let backtrace = exc.vm_backtrace(&mut interp);
+            let backtrace = bstr::join("\n", backtrace.unwrap_or_default());
+            panic!(
+                "{} tests failed with message: {:?} and backtrace:\n{:?}",
+                SUBJECT,
+                exc.message().as_bstr(),
+                backtrace.as_bstr()
+            );
+        }
     }
 }

--- a/artichoke-backend/src/extn/stdlib/forwardable/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/forwardable/mod.rs
@@ -20,17 +20,27 @@ pub struct Forwardable;
 #[cfg(test)]
 mod tests {
     use crate::test::prelude::*;
+    use bstr::ByteSlice;
+
+    const SUBJECT: &str = "Forwardable";
+    const FUNCTIONAL_TEST: &[u8] = include_bytes!("forwardable_test.rb");
 
     #[test]
     // TODO(GH-528): fix failing tests on Windows.
     #[cfg_attr(target_os = "windows", should_panic)]
-    fn integration_test() {
+    fn functional() {
         let mut interp = crate::interpreter().unwrap();
-        let _ = interp
-            .eval(&include_bytes!("forwardable_test.rb")[..])
-            .unwrap();
+        let _ = interp.eval(FUNCTIONAL_TEST).unwrap();
         let result = interp.eval(b"spec");
-        let result = result.unwrap().try_into::<bool>(&interp).unwrap();
-        assert!(result);
+        if let Err(exc) = result {
+            let backtrace = exc.vm_backtrace(&mut interp);
+            let backtrace = bstr::join("\n", backtrace.unwrap_or_default());
+            panic!(
+                "{} tests failed with message: {:?} and backtrace:\n{:?}",
+                SUBJECT,
+                exc.message().as_bstr(),
+                backtrace.as_bstr()
+            );
+        }
     }
 }

--- a/artichoke-backend/src/extn/stdlib/json/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/json/mod.rs
@@ -37,15 +37,27 @@ pub struct Json;
 #[cfg(test)]
 mod tests {
     use crate::test::prelude::*;
+    use bstr::ByteSlice;
+
+    const SUBJECT: &str = "JSON";
+    const FUNCTIONAL_TEST: &[u8] = include_bytes!("json_test.rb");
 
     #[test]
     // TODO(GH-528): fix failing tests on Windows.
     #[cfg_attr(target_os = "windows", should_panic)]
-    fn integration_test() {
+    fn functional() {
         let mut interp = crate::interpreter().unwrap();
-        let _ = interp.eval(&include_bytes!("json_test.rb")[..]).unwrap();
+        let _ = interp.eval(FUNCTIONAL_TEST).unwrap();
         let result = interp.eval(b"spec");
-        let result = result.unwrap().try_into::<bool>(&interp).unwrap();
-        assert!(result);
+        if let Err(exc) = result {
+            let backtrace = exc.vm_backtrace(&mut interp);
+            let backtrace = bstr::join("\n", backtrace.unwrap_or_default());
+            panic!(
+                "{} tests failed with message: {:?} and backtrace:\n{:?}",
+                SUBJECT,
+                exc.message().as_bstr(),
+                backtrace.as_bstr()
+            );
+        }
     }
 }

--- a/artichoke-backend/src/extn/stdlib/monitor/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/monitor/mod.rs
@@ -13,13 +13,25 @@ pub struct Monitor;
 #[cfg(test)]
 mod tests {
     use crate::test::prelude::*;
+    use bstr::ByteSlice;
+
+    const SUBJECT: &str = "Monitor";
+    const FUNCTIONAL_TEST: &[u8] = include_bytes!("monitor_test.rb");
 
     #[test]
-    fn integration_test() {
+    fn functional() {
         let mut interp = crate::interpreter().unwrap();
-        let _ = interp.eval(&include_bytes!("monitor_test.rb")[..]).unwrap();
+        let _ = interp.eval(FUNCTIONAL_TEST).unwrap();
         let result = interp.eval(b"spec");
-        let result = result.unwrap().try_into::<bool>(&interp).unwrap();
-        assert!(result);
+        if let Err(exc) = result {
+            let backtrace = exc.vm_backtrace(&mut interp);
+            let backtrace = bstr::join("\n", backtrace.unwrap_or_default());
+            panic!(
+                "{} tests failed with message: {:?} and backtrace:\n{:?}",
+                SUBJECT,
+                exc.message().as_bstr(),
+                backtrace.as_bstr()
+            );
+        }
     }
 }

--- a/artichoke-backend/src/extn/stdlib/uri/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/uri/mod.rs
@@ -47,13 +47,25 @@ pub struct Uri;
 #[cfg(test)]
 mod tests {
     use crate::test::prelude::*;
+    use bstr::ByteSlice;
+
+    const SUBJECT: &str = "URI";
+    const FUNCTIONAL_TEST: &[u8] = include_bytes!("uri_test.rb");
 
     #[test]
-    fn integration_test() {
+    fn functional() {
         let mut interp = crate::interpreter().unwrap();
-        let _ = interp.eval(&include_bytes!("uri_test.rb")[..]).unwrap();
+        let _ = interp.eval(FUNCTIONAL_TEST).unwrap();
         let result = interp.eval(b"spec");
-        let result = result.unwrap().try_into::<bool>(&interp).unwrap();
-        assert!(result);
+        if let Err(exc) = result {
+            let backtrace = exc.vm_backtrace(&mut interp);
+            let backtrace = bstr::join("\n", backtrace.unwrap_or_default());
+            panic!(
+                "{} tests failed with message: {:?} and backtrace:\n{:?}",
+                SUBJECT,
+                exc.message().as_bstr(),
+                backtrace.as_bstr()
+            );
+        }
     }
 }


### PR DESCRIPTION
Ensure all exceptions are output with the full message and backtrace.

Parameterize harness to make it easier to copy and paste.

Relocate the `Kernel#require` functionals to the
`extn::core::kernel::require` module.