### PR TITLE
Manage repository labels with a GitHub Action

### DIFF
--- a/.github/labels.json
+++ b/.github/labels.json
@@ -1,0 +1,277 @@
+[
+  {
+    "name": "A-build",
+    "color": "f7e101",
+    "description": "Area: CI build infrastructure."
+  },
+  {
+    "name": "A-build-target",
+    "color": "f7e101",
+    "description": "Area: Support for builds of specific targets."
+  },
+  {
+    "name": "A-C-API",
+    "color": "f7e101",
+    "description": "Area: C APIs for compatibility with existing interpreters."
+  },
+  {
+    "name": "A-codegen",
+    "color": "f7e101",
+    "description": "Area: Code generation while executing Ruby."
+  },
+  {
+    "name": "A-codegen",
+    "color": "f7e101",
+    "description": "Area: Ruby to Rust/machine-code compiler support."
+  },
+  {
+    "name": "A-core",
+    "color": "f7e101",
+    "description": "Area: Core traits and interpreter-agnostic Ruby Core and Ruby stdlib implementations."
+  },
+  {
+    "name": "A-crate-features",
+    "color": "f7e101",
+    "description": "Area: Compile-time features or attributes."
+  },
+  {
+    "name": "A-deps",
+    "color": "f7e101",
+    "description": "Area: Source and library dependencies."
+  },
+  {
+    "name": "A-emoji",
+    "color": "f7e101",
+    "description": "Area: Emoji support in interpreter implementations."
+  },
+  {
+    "name": "A-filesystem",
+    "color": "f7e101",
+    "description": "Area: Filesystem access and implementations."
+  },
+  {
+    "name": "A-frontend",
+    "color": "f7e101",
+    "description": "Area: Frontends for interpreters, like the `ruby` or `irb` binaries."
+  },
+  {
+    "name": "A-gems",
+    "color": "f7e101",
+    "description": "Area: Support for Rubygems."
+  },
+  {
+    "name": "A-memory-management",
+    "color": "f7e101",
+    "description": "Area: Memory management and garbage collection."
+  },
+  {
+    "name": "A-optional-stdlib",
+    "color": "f7e101",
+    "description": "Area: Optional Ruby Standard Library."
+  },
+  {
+    "name": "A-parallelism",
+    "color": "f7e101",
+    "description": "Area: Multi-threading and true parallelism at an interpreter level."
+  },
+  {
+    "name": "A-parser",
+    "color": "f7e101",
+    "description": "Area: Parser implementations."
+  },
+  {
+    "name": "A-performance",
+    "color": "f7e101",
+    "description": "Area: Performance improvements and optimizations."
+  },
+  {
+    "name": "A-project",
+    "color": "f7e101",
+    "description": "Area: Infrastructure for running an open source project."
+  },
+  {
+    "name": "A-release",
+    "color": "f7e101",
+    "description": "Area: crates.io releases and version bumps."
+  },
+  {
+    "name": "A-ruby-core",
+    "color": "f7e101",
+    "description": "Area: Ruby Core types."
+  },
+  {
+    "name": "A-ruby-language",
+    "color": "f7e101",
+    "description": "Area: Ruby language spec support."
+  },
+  {
+    "name": "A-ruby-stdlib",
+    "color": "f7e101",
+    "description": "Area: Ruby Standard Library packages."
+  },
+  {
+    "name": "A-rust-extensions",
+    "color": "f7e101",
+    "description": "Area: Rust extension support for Artichoke interpreters, support for native Rubygems."
+  },
+  {
+    "name": "A-security",
+    "color": "f7e101",
+    "description": "Area: Security vulnerabilities and unsoundness issues."
+  },
+  {
+    "name": "A-single-binary",
+    "color": "f7e101",
+    "description": "Area: Single binary distribution.."
+  },
+  {
+    "name": "A-spec",
+    "color": "f7e101",
+    "description": "Area: ruby/spec infrastructure and completeness."
+  },
+  {
+    "name": "A-vm",
+    "color": "f7e101",
+    "description": "Area: Interpreter VM implementations."
+  },
+  {
+    "name": "A-Artichoke",
+    "color": "ed95e4",
+    "description": "Backend: Implementation of artichoke-core using Rust-native backend."
+  },
+  {
+    "name": "A-MRI",
+    "color": "ed95e4",
+    "description": "Backend: Implementation of artichoke-core using MRI."
+  },
+  {
+    "name": "A-mruby",
+    "color": "ed95e4",
+    "description": "Backend: Implementation of artichoke-core using mruby."
+  },
+  {
+    "name": "C-bug",
+    "color": "c1c8ff",
+    "description": "Category: This is a bug."
+  },
+  {
+    "name": "C-docs",
+    "color": "c1c8ff",
+    "description": "Category: Improvements or additions to documentation."
+  },
+  {
+    "name": "C-enhancement",
+    "color": "c1c8ff",
+    "description": "Category: New feature or request."
+  },
+  {
+    "name": "C-quality",
+    "color": "c1c8ff",
+    "description": "Category: Refactoring, cleanup, and quality improvements."
+  },
+  {
+    "name": "C-question",
+    "color": "c1c8ff",
+    "description": "Category: Further information is requested."
+  },
+  {
+    "name": "CAPI-MRI",
+    "color": "1d76db",
+    "description": "C API: MRI-compatible C API."
+  },
+  {
+    "name": "CAPI-mruby",
+    "color": "1d76db",
+    "description": "C API: mruby MRB_API-compatible C API."
+  },
+  {
+    "name": "E-easy",
+    "color": "02e10c",
+    "description": "Call for participation: Experience needed to fix: Easy / not much."
+  },
+  {
+    "name": "E-medium",
+    "color": "02e10c",
+    "description": "Call for participation: Experience needed to fix: Medium / intermediate."
+  },
+  {
+    "name": "E-hard",
+    "color": "02e10c",
+    "description": "Call for participation: Experience needed to fix: Hard / a lot."
+  },
+  {
+    "name": "E-help-wanted",
+    "color": "02e10c",
+    "description": "Call for participation: Help is requested to fix this issue."
+  },
+  {
+    "name": "E-needs-test",
+    "color": "02e10c",
+    "description": "Call for participation: Writing correctness tests."
+  },
+  {
+    "name": "O-linux",
+    "color": "6e6ec0",
+    "description": "Target: Support for building on Linux (GNU / musl) targets."
+  },
+  {
+    "name": "O-macOS",
+    "color": "6e6ec0",
+    "description": "Target: Support for building on macOS / Darwin targets."
+  },
+  {
+    "name": "O-wasm-emscripten",
+    "color": "6e6ec0",
+    "description": "Target: Support for building the `wasm32-unknown-emscripten` target."
+  },
+  {
+    "name": "O-wasm-unknown",
+    "color": "6e6ec0",
+    "description": "Target: Support for building the `wasm32-unknown-unknown` target."
+  },
+  {
+    "name": "O-windows",
+    "color": "6e6ec0",
+    "description": "Target: Support for building on Windows targets like `x86_64-pc-windows-msvc`."
+  },
+  {
+    "name": "S-blocked",
+    "color": "d3dddd",
+    "description": "Status: Marked as blocked ❌ on something else such as other implementation work."
+  },
+  {
+    "name": "S-do-not-merge",
+    "color": "d3dddd",
+    "description": "Status: This pull request should not be merged."
+  },
+  {
+    "name": "S-duplicate",
+    "color": "d3dddd",
+    "description": "Status: This issue or pull request already exists."
+  },
+  {
+    "name": "S-invalid",
+    "color": "d3dddd",
+    "description": "Status: This issue or pull request is not well-formed."
+  },
+  {
+    "name": "S-speculative",
+    "color": "d3dddd",
+    "description": "Status: This is just an idea."
+  },
+  {
+    "name": "S-stale",
+    "color": "d3dddd",
+    "description": "Status: This PR is stale. Please open a new PR if you'd like to pick this back up."
+  },
+  {
+    "name": "S-wip",
+    "color": "d3dddd",
+    "description": "Status: This pull request is a work in progress."
+  },
+  {
+    "name": "S-wontfix",
+    "color": "d3dddd",
+    "description": "Status: This issue or pull request will not be worked on."
+  }
+]

--- a/.github/workflows/repo-labels.yaml
+++ b/.github/workflows/repo-labels.yaml
@@ -1,0 +1,17 @@
+on:
+  push:
+    branches:
+      - trunk
+    paths:
+      - .github/labels.json
+name: Create Repository Labels
+jobs:
+  labels:
+    name: Synchronize repository labels
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: lannonbr/issue-label-manager-action@2.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/repo-labels.yaml
+++ b/.github/workflows/repo-labels.yaml
@@ -1,7 +1,7 @@
 on:
   push:
     branches:
-      - trunk
+      - master
     paths:
       - .github/labels.json
 name: Create Repository Labels


### PR DESCRIPTION
Declare repository labels with a JSON file.

This PR builds on the same techniques used in many other Artichoke organization
repositories.

This PR normalizes some of the label texts for labels already present in this
repo and fleshes out some categories, for example adding O-macOS and O-linux,
or adding B-Artichoke for eventual Rust VM backend plans.

Fixes GH-532.