### PR TITLE
Add cfg_doc annotations to spinoso-array

### DIFF
--- a/.github/workflows/rustdoc.yaml
+++ b/.github/workflows/rustdoc.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       RUSTFLAGS: -D warnings
-      RUSTDOCFLAGS: -D warnings
+      RUSTDOCFLAGS: -D warnings --cfg docsrs
       RUST_BACKTRACE: 1
 
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,7 @@ tasks by running:
 
 ```console
 $ bundle exec rake --tasks
+rake build             # Build Rust workspace
 rake doc               # Generate Rust API documentation
 rake doc:open          # Generate Rust API documentation and open it in a web browser
 rake lint              # Lint and format

--- a/Rakefile
+++ b/Rakefile
@@ -77,17 +77,22 @@ namespace :lint do
   end
 end
 
+desc 'Build Rust workspace'
+task :build do
+  sh 'cargo build --workspace'
+end
+
 desc 'Generate Rust API documentation'
 task :doc do
   ENV['RUSTFLAGS'] = '-D warnings'
-  ENV['RUSTDOCFLAGS'] = '-D warnings'
+  ENV['RUSTDOCFLAGS'] = '-D warnings --cfg docsrs'
   sh 'rustup run --install nightly cargo doc --workspace'
 end
 
 desc 'Generate Rust API documentation and open it in a web browser'
 task :'doc:open' do
   ENV['RUSTFLAGS'] = '-D warnings'
-  ENV['RUSTDOCFLAGS'] = '-D warnings'
+  ENV['RUSTDOCFLAGS'] = '-D warnings --cfg docsrs'
   sh 'rustup run --install nightly cargo doc --workspace --open'
 end
 

--- a/spinoso-array/Cargo.toml
+++ b/spinoso-array/Cargo.toml
@@ -20,3 +20,7 @@ default = ["small-array"]
 # Add a `SmallArray` backend that implements the small vector optimization with
 # the `smallvec` crate.
 small-array = ["smallvec"]
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/spinoso-array/src/array/mod.rs
+++ b/spinoso-array/src/array/mod.rs
@@ -24,4 +24,5 @@ pub mod vec;
 ///
 /// See [`SmallArray`](smallvec::SmallArray).
 #[cfg(feature = "small-array")]
+#[cfg_attr(docsrs, doc(cfg(feature = "small-array")))]
 pub const INLINE_CAPACITY: usize = 8;

--- a/spinoso-array/src/array/smallvec/mod.rs
+++ b/spinoso-array/src/array/smallvec/mod.rs
@@ -73,6 +73,7 @@ mod impls;
 /// [`first_n`]: SmallArray::first_n
 /// [`last_n`]: SmallArray::last_n
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(docsrs, doc(cfg(feature = "small-array")))]
 pub struct SmallArray<T>(SmallVec<[T; INLINE_CAPACITY]>);
 
 impl<T> Default for SmallArray<T> {

--- a/spinoso-array/src/array/vec/mod.rs
+++ b/spinoso-array/src/array/vec/mod.rs
@@ -78,7 +78,7 @@ impl<T> Array<T> {
     /// ```
     #[inline]
     #[must_use]
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self(Vec::new())
     }
 

--- a/spinoso-array/src/lib.rs
+++ b/spinoso-array/src/lib.rs
@@ -10,6 +10,12 @@
 #![warn(trivial_casts, trivial_numeric_casts)]
 #![warn(unused_qualifications)]
 #![warn(variant_size_differences)]
+// Enable feature callouts in generated documentation:
+// https://doc.rust-lang.org/beta/unstable-book/language-features/doc-cfg.html
+//
+// This approach is borrowed from tokio.
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_alias))]
 
 //! Contiguous growable vector types that implement the [Ruby `Array`] API.
 //!


### PR DESCRIPTION
Annotate `SmallArray` and `INLINE_CAPACITY` as only available when `spinoso-array` is built with the `small-array` feature.

Add rustdoc flags to `Rakefile`, `Cargo.toml` and GitHub Actions rustdoc workflow.

Add `Rakefile` build task.

Additionally, make `Array::new` a const function.