### PR TITLE
Add spinoso-symbol crate

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -94,13 +94,27 @@ jobs:
       - name: Compile artichoke with all features
         run: cargo build --verbose --all-features
 
-      - name: Compile spinoso with no default features
+      - name: Compile spinoso-array with no default features
         run: cargo build --verbose --no-default-features
         working-directory: "spinoso-array"
 
-      - name: Compile spinoso with all features
+      - name: Compile spinoso-array with all features
         run: cargo build --verbose --all-features
         working-directory: "spinoso-array"
+
+      - name: Compile spinoso-symbol with no default features
+        run: cargo build --verbose --no-default-features
+        working-directory: "spinoso-symbol"
+
+      - name: Compile spinoso-symbol with all features
+        run: cargo build --verbose --all-features
+        working-directory: "spinoso-symbol"
+
+      - name: Compile spinoso-symbol with some features
+        run: |
+          cargo build --verbose --no-default-features --features inspect
+          cargo build --verbose --no-default-features --features inspect,artichoke
+        working-directory: "spinoso-symbol"
 
   rust:
     name: Lint and format Rust

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,6 +71,7 @@ rake lint              # Lint and format
 rake lint:clippy       # Run Clippy
 rake lint:deps         # Install linting dependencies
 rake lint:eslint       # Run ESlint
+rake lint:fmt          # Format sources (alias)
 rake lint:format       # Format sources
 rake lint:links        # Check markdown links
 rake lint:restriction  # Lint with Clippy restriction pass (unenforced lints)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,7 +61,7 @@ dependencies = [
 
 [[package]]
 name = "artichoke-core"
-version = "0.2.0"
+version = "0.3.0"
 
 [[package]]
 name = "atty"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,6 +186,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "134951f4028bdadb9b84baf4232681efbf277da25144b9b0ad65df75946c422b"
 
 [[package]]
+name = "focaccia"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ede9d748d34b1089e09b1120b8a95f3842b11b99efed5ba5a98381da1455bd8"
+
+[[package]]
 name = "getrandom"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -642,6 +648,15 @@ name = "spinoso-array"
 version = "0.3.0"
 dependencies = [
  "smallvec",
+]
+
+[[package]]
+name = "spinoso-symbol"
+version = "0.1.0"
+dependencies = [
+ "artichoke-core",
+ "bstr",
+ "focaccia",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,6 +55,7 @@ dependencies = [
  "rand_pcg",
  "regex",
  "spinoso-array",
+ "spinoso-symbol",
  "target-lexicon",
  "uuid",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ members = [
   "artichoke-core",
   "spec-runner",
   "spinoso-array",
+  "spinoso-symbol",
 ]
 
 [profile.release]

--- a/Rakefile
+++ b/Rakefile
@@ -29,6 +29,9 @@ namespace :lint do
     sh 'node scripts/clang-format.js'
   end
 
+  desc 'Format sources (alias)'
+  task fmt: :format
+
   desc 'Run ESlint'
   task eslint: :deps do
     sh 'npx eslint --fix .'

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -25,6 +25,7 @@ rand = { version = "0.7", optional = true }
 rand_pcg = { version = "0.2", optional = true }
 regex = "1"
 spinoso-array = { version = "0.3", path = "../spinoso-array" }
+spinoso-symbol = { version = "0.1", path = "../spinoso-symbol" }
 uuid = { version = "0.8", optional = true, features = ["v4"] }
 
 [dependencies.artichoke-core]

--- a/artichoke-backend/src/convert/nilable.rs
+++ b/artichoke-backend/src/convert/nilable.rs
@@ -66,18 +66,6 @@ impl Convert<Value, Option<Value>> for Artichoke {
     }
 }
 
-impl TryConvert<Value, Option<bool>> for Artichoke {
-    type Error = Exception;
-
-    fn try_convert(&self, value: Value) -> Result<Option<bool>, Self::Error> {
-        if value.is_nil() {
-            Ok(None)
-        } else {
-            self.try_convert(value).map(Some)
-        }
-    }
-}
-
 impl TryConvertMut<Value, Option<Vec<u8>>> for Artichoke {
     type Error = Exception;
 

--- a/artichoke-backend/src/extn/core/symbol/mod.rs
+++ b/artichoke-backend/src/extn/core/symbol/mod.rs
@@ -1,115 +1,14 @@
 use std::ffi::c_void;
 
 use crate::convert::{Immediate, UnboxedValueGuard};
-use crate::extn::core::array::Array;
 use crate::extn::prelude::*;
-use crate::intern::Symbol as SymbolId;
 
 pub mod ffi;
 pub mod mruby;
 pub mod trampoline;
 
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Symbol(SymbolId);
-
-impl Symbol {
-    pub fn all_symbols(interp: &mut Artichoke) -> Result<Array, Exception> {
-        let all_symbols = interp.all_symbols()?.map(Symbol::from).collect::<Vec<_>>();
-        let array = all_symbols
-            .into_iter()
-            .map(|symbol| Symbol::alloc_value(symbol, interp))
-            .collect::<Result<Vec<Value>, _>>()?;
-        Ok(Array::from(array))
-    }
-
-    #[inline]
-    #[must_use]
-    pub fn id(self) -> SymbolId {
-        self.0
-    }
-
-    #[must_use]
-    pub fn is_empty(self, interp: &mut Artichoke) -> bool {
-        if let Ok(Some(bytes)) = interp.lookup_symbol(self.into()) {
-            bytes.is_empty()
-        } else {
-            true
-        }
-    }
-
-    #[must_use]
-    pub fn len(self, interp: &mut Artichoke) -> usize {
-        if let Ok(Some(bytes)) = interp.lookup_symbol(self.into()) {
-            bytes.len()
-        } else {
-            0_usize
-        }
-    }
-
-    #[must_use]
-    pub fn bytes<'a>(&self, interp: &'a mut Artichoke) -> &'a [u8] {
-        if let Ok(Some(bytes)) = interp.lookup_symbol(self.into()) {
-            bytes
-        } else {
-            &[]
-        }
-    }
-
-    #[must_use]
-    pub fn inspect(self, interp: &'_ mut Artichoke) -> Vec<u8> {
-        if let Ok(Some(bytes)) = interp.lookup_symbol(self.into()) {
-            // pattern length + ':'
-            let mut inspect = Vec::with_capacity(bytes.len() + 1);
-            inspect.push(b':');
-            inspect.extend(bytes);
-            inspect
-        } else {
-            Vec::new()
-        }
-    }
-}
-
-impl From<SymbolId> for Symbol {
-    fn from(id: SymbolId) -> Self {
-        Self(id)
-    }
-}
-
-impl From<intaglio::Symbol> for Symbol {
-    fn from(id: intaglio::Symbol) -> Self {
-        Self(id.into())
-    }
-}
-
-impl From<u32> for Symbol {
-    fn from(id: u32) -> Self {
-        Self(id.into())
-    }
-}
-
-impl From<Symbol> for SymbolId {
-    fn from(sym: Symbol) -> Self {
-        sym.id()
-    }
-}
-
-impl From<&Symbol> for SymbolId {
-    fn from(sym: &Symbol) -> Self {
-        sym.id()
-    }
-}
-
-impl From<Symbol> for u32 {
-    fn from(sym: Symbol) -> Self {
-        sym.id().into()
-    }
-}
-
-impl From<Symbol> for usize {
-    fn from(sym: Symbol) -> Self {
-        sym.id().into()
-    }
-}
+#[doc(inline)]
+pub use spinoso_symbol::Symbol;
 
 impl BoxUnboxVmValue for Symbol {
     type Unboxed = Self;

--- a/artichoke-backend/src/extn/core/symbol/mruby.rs
+++ b/artichoke-backend/src/extn/core/symbol/mruby.rs
@@ -13,10 +13,20 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
             sys::mrb_args_none(),
         )?
         .add_method("==", artichoke_symbol_equal_equal, sys::mrb_args_req(1))?
+        .add_method(
+            "casecmp",
+            artichoke_symbol_ascii_casecmp,
+            sys::mrb_args_req(1),
+        )?
+        .add_method(
+            "casecmp?",
+            artichoke_symbol_unicode_casecmp,
+            sys::mrb_args_req(1),
+        )?
         .add_method("empty?", artichoke_symbol_empty, sys::mrb_args_none())?
+        .add_method("inspect", artichoke_symbol_inspect, sys::mrb_args_none())?
         .add_method("length", artichoke_symbol_length, sys::mrb_args_none())?
         .add_method("to_s", artichoke_symbol_to_s, sys::mrb_args_none())?
-        .add_method("inspect", artichoke_symbol_inspect, sys::mrb_args_none())?
         .define()?;
     interp.def_class::<symbol::Symbol>(spec)?;
     let _ = interp.eval(&include_bytes!("symbol.rb")[..])?;
@@ -57,6 +67,40 @@ unsafe extern "C" fn artichoke_symbol_equal_equal(
 }
 
 #[no_mangle]
+unsafe extern "C" fn artichoke_symbol_ascii_casecmp(
+    mrb: *mut sys::mrb_state,
+    slf: sys::mrb_value,
+) -> sys::mrb_value {
+    let other = mrb_get_args!(mrb, required = 1);
+    let mut interp = unwrap_interpreter!(mrb);
+    let mut guard = Guard::new(&mut interp);
+    let sym = Value::from(slf);
+    let other = Value::from(other);
+    let result = trampoline::ascii_casecmp(&mut guard, sym, other);
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => exception::raise(guard, exception),
+    }
+}
+
+#[no_mangle]
+unsafe extern "C" fn artichoke_symbol_unicode_casecmp(
+    mrb: *mut sys::mrb_state,
+    slf: sys::mrb_value,
+) -> sys::mrb_value {
+    let other = mrb_get_args!(mrb, required = 1);
+    let mut interp = unwrap_interpreter!(mrb);
+    let mut guard = Guard::new(&mut interp);
+    let sym = Value::from(slf);
+    let other = Value::from(other);
+    let result = trampoline::unicode_casecmp(&mut guard, sym, other);
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => exception::raise(guard, exception),
+    }
+}
+
+#[no_mangle]
 unsafe extern "C" fn artichoke_symbol_empty(
     mrb: *mut sys::mrb_state,
     slf: sys::mrb_value,
@@ -66,6 +110,22 @@ unsafe extern "C" fn artichoke_symbol_empty(
     let mut guard = Guard::new(&mut interp);
     let sym = Value::from(slf);
     let result = trampoline::is_empty(&mut guard, sym);
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => exception::raise(guard, exception),
+    }
+}
+
+#[no_mangle]
+unsafe extern "C" fn artichoke_symbol_inspect(
+    mrb: *mut sys::mrb_state,
+    slf: sys::mrb_value,
+) -> sys::mrb_value {
+    mrb_get_args!(mrb, none);
+    let mut interp = unwrap_interpreter!(mrb);
+    let mut guard = Guard::new(&mut interp);
+    let value = Value::from(slf);
+    let result = trampoline::inspect(&mut guard, value);
     match result {
         Ok(value) => value.inner(),
         Err(exception) => exception::raise(guard, exception),
@@ -98,22 +158,6 @@ unsafe extern "C" fn artichoke_symbol_to_s(
     let mut guard = Guard::new(&mut interp);
     let sym = Value::from(slf);
     let result = trampoline::bytes(&mut guard, sym);
-    match result {
-        Ok(value) => value.inner(),
-        Err(exception) => exception::raise(guard, exception),
-    }
-}
-
-#[no_mangle]
-unsafe extern "C" fn artichoke_symbol_inspect(
-    mrb: *mut sys::mrb_state,
-    slf: sys::mrb_value,
-) -> sys::mrb_value {
-    mrb_get_args!(mrb, none);
-    let mut interp = unwrap_interpreter!(mrb);
-    let mut guard = Guard::new(&mut interp);
-    let value = Value::from(slf);
-    let result = trampoline::inspect(&mut guard, value);
     match result {
         Ok(value) => value.inner(),
         Err(exception) => exception::raise(guard, exception),

--- a/artichoke-backend/src/extn/core/symbol/symbol.rb
+++ b/artichoke-backend/src/extn/core/symbol/symbol.rb
@@ -35,24 +35,11 @@ class Symbol
     to_s.capitalize(options).intern
   end
 
-  def casecmp(other)
-    return nil unless other.is_a?(Symbol)
+  # Implemented in native code.
+  # def casecmp(other); end
 
-    # Case-insensitive version of Symbol#<=>. Currently, case-insensitivity only
-    # works on characters A-Z/a-z, not all of Unicode. This is different from
-    # Symbol#casecmp?.
-    lhs = to_s.tr('a-z', 'A-Z')
-    rhs = other.to_s.tr('a-z', 'A-Z')
-    lhs <=> rhs
-  end
-
-  def casecmp?(other)
-    # Returns true if `self` and `other` are equal after Unicode case folding,
-    # false if they are not equal.
-    #
-    # Delegate to String#casecmp? which is also Unicode case folding-aware.
-    to_s.casecmp?(other.to_s)
-  end
+  # Implemented in native code.
+  # def casecmp?(other); end
 
   def downcase(options = (not_set = true))
     return to_s.downcase.intern if not_set

--- a/artichoke-backend/src/globals.rs
+++ b/artichoke-backend/src/globals.rs
@@ -19,7 +19,7 @@ impl Globals for Artichoke {
     {
         let sym = self.intern_bytes(name.into())?;
         unsafe {
-            self.with_ffi_boundary(|mrb| sys::mrb_gv_set(mrb, sym.into(), value.inner()))?;
+            self.with_ffi_boundary(|mrb| sys::mrb_gv_set(mrb, sym, value.inner()))?;
         }
         Ok(())
     }
@@ -41,7 +41,7 @@ impl Globals for Artichoke {
         let sym = self.intern_bytes(name.into())?;
         let nil = Value::nil();
         unsafe {
-            self.with_ffi_boundary(|mrb| sys::mrb_gv_set(mrb, sym.into(), nil.inner()))?;
+            self.with_ffi_boundary(|mrb| sys::mrb_gv_set(mrb, sym, nil.inner()))?;
         }
         Ok(())
     }
@@ -51,7 +51,7 @@ impl Globals for Artichoke {
         T: Into<Cow<'static, [u8]>>,
     {
         let sym = self.intern_bytes(name.into())?;
-        let value = unsafe { self.with_ffi_boundary(|mrb| sys::mrb_gv_get(mrb, sym.into()))? };
+        let value = unsafe { self.with_ffi_boundary(|mrb| sys::mrb_gv_get(mrb, sym))? };
         // NOTE: This implementation is not compliant with the spec laid out in
         // the trait documentation. This implementation always returns `Some(_)`
         // even if the global is unset.

--- a/artichoke-backend/src/intern.rs
+++ b/artichoke-backend/src/intern.rs
@@ -33,12 +33,9 @@ impl Artichoke {
         let symbol = state.symbols.intern(bytes)?;
         let symbol = u32::from(symbol);
         // mruby expexts symbols to be non-zero.
-        //
-        // Suppressing clippy lint due to rust-lang/rust-clippy#5886
-        #[allow(clippy::or_fun_call)]
         let symbol = symbol
             .checked_add(<Self as Intern>::SYMBOL_RANGE_START)
-            .ok_or(SymbolOverflowError::new())?;
+            .ok_or_else(SymbolOverflowError::new)?;
         Ok(symbol)
     }
 
@@ -51,12 +48,9 @@ impl Artichoke {
         if let Some(symbol) = symbol {
             let symbol = u32::from(symbol);
             // mruby expexts symbols to be non-zero.
-            //
-            // Suppressing clippy lint due to rust-lang/rust-clippy#5886
-            #[allow(clippy::or_fun_call)]
             let symbol = symbol
                 .checked_add(<Self as Intern>::SYMBOL_RANGE_START)
-                .ok_or(SymbolOverflowError::new())?;
+                .ok_or_else(SymbolOverflowError::new)?;
             Ok(Some(symbol))
         } else {
             Ok(None)
@@ -82,12 +76,9 @@ impl Intern for Artichoke {
         let symbol = state.symbols.intern(bytes)?;
         let symbol = u32::from(symbol);
         // mruby expexts symbols to be non-zero.
-        //
-        // Suppressing clippy lint due to rust-lang/rust-clippy#5886
-        #[allow(clippy::or_fun_call)]
         let symbol = symbol
             .checked_add(Self::SYMBOL_RANGE_START)
-            .ok_or(SymbolOverflowError::new())?;
+            .ok_or_else(SymbolOverflowError::new)?;
         Ok(symbol)
     }
 
@@ -99,12 +90,9 @@ impl Intern for Artichoke {
         if let Some(symbol) = symbol {
             let symbol = u32::from(symbol);
             // mruby expexts symbols to be non-zero.
-            //
-            // Suppressing clippy lint due to rust-lang/rust-clippy#5886
-            #[allow(clippy::or_fun_call)]
             let symbol = symbol
                 .checked_add(Self::SYMBOL_RANGE_START)
-                .ok_or(SymbolOverflowError::new())?;
+                .ok_or_else(SymbolOverflowError::new)?;
             Ok(Some(symbol))
         } else {
             Ok(None)

--- a/artichoke-backend/src/intern.rs
+++ b/artichoke-backend/src/intern.rs
@@ -1,4 +1,3 @@
-use intaglio::bytes::AllSymbols;
 use intaglio::SymbolOverflowError;
 use std::borrow::Cow;
 
@@ -11,61 +10,9 @@ use crate::ffi::InterpreterExtractError;
 use crate::sys;
 use crate::Artichoke;
 
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Symbol(intaglio::Symbol);
-
-impl From<u32> for Symbol {
-    fn from(sym: u32) -> Self {
-        Self(sym.into())
-    }
-}
-
-impl From<intaglio::Symbol> for Symbol {
-    fn from(sym: intaglio::Symbol) -> Self {
-        Self(sym)
-    }
-}
-
-impl From<Symbol> for intaglio::Symbol {
-    fn from(sym: Symbol) -> Self {
-        sym.0
-    }
-}
-
-impl From<Symbol> for u32 {
-    fn from(sym: Symbol) -> Self {
-        sym.0.into()
-    }
-}
-
-impl From<Symbol> for u64 {
-    fn from(sym: Symbol) -> Self {
-        sym.0.into()
-    }
-}
-
-impl From<Symbol> for usize {
-    fn from(sym: Symbol) -> Self {
-        sym.0.into()
-    }
-}
-
 impl Artichoke {
-    /// Return a type that yields all `Symbol`s in the interpreter.
-    pub fn all_symbols(&self) -> Result<AllSymbols<'_>, InterpreterExtractError> {
+    pub fn lookup_symbol_with_trailing_nul(&self, symbol: u32) -> Result<Option<&[u8]>, Exception> {
         let state = self.state.as_ref().ok_or(InterpreterExtractError)?;
-        // this method cannot be part of the `Intern` impl because `AllSymbols`
-        // is generic over the lifetime of the symbol table and GATs are not
-        // stable.
-        Ok(state.symbols.all_symbols())
-    }
-
-    pub fn lookup_symbol_with_trailing_nul(
-        &self,
-        symbol: Symbol,
-    ) -> Result<Option<&[u8]>, Exception> {
-        let state = self.state.as_ref().ok_or(InterpreterExtractError)?;
-        let symbol = u32::from(symbol);
         if let Some(symbol) = symbol.checked_sub(1) {
             if let Some(bytes) = state.symbols.get(symbol.into()) {
                 Ok(Some(bytes))
@@ -76,12 +23,53 @@ impl Artichoke {
             Ok(None)
         }
     }
+
+    pub fn intern_bytes_with_trailing_nul<T>(&mut self, bytes: T) -> Result<u32, Exception>
+    where
+        T: Into<Cow<'static, [u8]>>,
+    {
+        let bytes = bytes.into();
+        let state = self.state.as_mut().ok_or(InterpreterExtractError)?;
+        let symbol = state.symbols.intern(bytes)?;
+        let symbol = u32::from(symbol);
+        // mruby expexts symbols to be non-zero.
+        //
+        // Suppressing clippy lint due to rust-lang/rust-clippy#5886
+        #[allow(clippy::or_fun_call)]
+        let symbol = symbol
+            .checked_add(<Self as Intern>::SYMBOL_RANGE_START)
+            .ok_or(SymbolOverflowError::new())?;
+        Ok(symbol)
+    }
+
+    pub fn check_interned_bytes_with_trailing_nul(
+        &self,
+        bytes: &[u8],
+    ) -> Result<Option<u32>, Exception> {
+        let state = self.state.as_ref().ok_or(InterpreterExtractError)?;
+        let symbol = state.symbols.check_interned(bytes);
+        if let Some(symbol) = symbol {
+            let symbol = u32::from(symbol);
+            // mruby expexts symbols to be non-zero.
+            //
+            // Suppressing clippy lint due to rust-lang/rust-clippy#5886
+            #[allow(clippy::or_fun_call)]
+            let symbol = symbol
+                .checked_add(<Self as Intern>::SYMBOL_RANGE_START)
+                .ok_or(SymbolOverflowError::new())?;
+            Ok(Some(symbol))
+        } else {
+            Ok(None)
+        }
+    }
 }
 
 impl Intern for Artichoke {
-    type Symbol = Symbol;
+    type Symbol = u32;
 
     type Error = Exception;
+
+    const SYMBOL_RANGE_START: Self::Symbol = 1;
 
     fn intern_bytes<T>(&mut self, bytes: T) -> Result<Self::Symbol, Self::Error>
     where
@@ -89,34 +77,35 @@ impl Intern for Artichoke {
     {
         let bytes = bytes.into();
         let state = self.state.as_mut().ok_or(InterpreterExtractError)?;
-        let trailing_byte = bytes.len().checked_sub(1).and_then(|idx| bytes.get(idx));
-        let symbol = if let Some(&b'\0') = trailing_byte {
-            state.symbols.intern(bytes)?
-        } else {
-            let mut bytes = bytes.into_owned();
-            bytes.push(b'\0');
-            state.symbols.intern(bytes)?
-        };
+        let mut bytes = bytes.into_owned();
+        bytes.push(b'\0');
+        let symbol = state.symbols.intern(bytes)?;
         let symbol = u32::from(symbol);
         // mruby expexts symbols to be non-zero.
-        let symbol = symbol.checked_add(1).ok_or_else(SymbolOverflowError::new)?;
-        Ok(symbol.into())
+        //
+        // Suppressing clippy lint due to rust-lang/rust-clippy#5886
+        #[allow(clippy::or_fun_call)]
+        let symbol = symbol
+            .checked_add(Self::SYMBOL_RANGE_START)
+            .ok_or(SymbolOverflowError::new())?;
+        Ok(symbol)
     }
 
     fn check_interned_bytes(&self, bytes: &[u8]) -> Result<Option<Self::Symbol>, Self::Error> {
         let state = self.state.as_ref().ok_or(InterpreterExtractError)?;
-        let trailing_byte = bytes.len().checked_sub(1).and_then(|idx| bytes.get(idx));
-        let symbol = if let Some(&b'\0') = trailing_byte {
-            state.symbols.check_interned(bytes)
-        } else {
-            let mut bytes = bytes.to_vec();
-            bytes.push(b'\0');
-            state.symbols.check_interned(&bytes)
-        };
+        let mut bytes = bytes.to_vec();
+        bytes.push(b'\0');
+        let symbol = state.symbols.check_interned(&bytes);
         if let Some(symbol) = symbol {
             let symbol = u32::from(symbol);
-            let symbol = symbol.checked_add(1).ok_or_else(SymbolOverflowError::new)?;
-            Ok(Some(symbol.into()))
+            // mruby expexts symbols to be non-zero.
+            //
+            // Suppressing clippy lint due to rust-lang/rust-clippy#5886
+            #[allow(clippy::or_fun_call)]
+            let symbol = symbol
+                .checked_add(Self::SYMBOL_RANGE_START)
+                .ok_or(SymbolOverflowError::new())?;
+            Ok(Some(symbol))
         } else {
             Ok(None)
         }
@@ -124,8 +113,7 @@ impl Intern for Artichoke {
 
     fn lookup_symbol(&self, symbol: Self::Symbol) -> Result<Option<&[u8]>, Self::Error> {
         let state = self.state.as_ref().ok_or(InterpreterExtractError)?;
-        let symbol = u32::from(symbol);
-        if let Some(symbol) = symbol.checked_sub(1) {
+        if let Some(symbol) = symbol.checked_sub(Self::SYMBOL_RANGE_START) {
             if let Some(bytes) = state.symbols.get(symbol.into()) {
                 if bytes.is_empty() {
                     Ok(Some(bytes))
@@ -137,6 +125,14 @@ impl Intern for Artichoke {
             }
         } else {
             Ok(None)
+        }
+    }
+
+    fn symbol_count(&self) -> usize {
+        if let Some(state) = self.state.as_ref() {
+            state.symbols.len()
+        } else {
+            0
         }
     }
 }

--- a/artichoke-backend/src/module.rs
+++ b/artichoke-backend/src/module.rs
@@ -8,7 +8,6 @@ use std::ptr::NonNull;
 use crate::core::Intern;
 use crate::def::{ConstantNameError, EnclosingRubyScope, Method, NotDefinedError};
 use crate::exception::Exception;
-use crate::intern::Symbol;
 use crate::method;
 use crate::sys;
 use crate::Artichoke;
@@ -122,18 +121,14 @@ impl<'a> Builder<'a> {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Rclass {
-    sym: Symbol,
+    sym: u32,
     name: CString,
     enclosing_scope: Option<Box<EnclosingRubyScope>>,
 }
 
 impl Rclass {
     #[must_use]
-    pub fn new(
-        sym: Symbol,
-        name: CString,
-        enclosing_scope: Option<Box<EnclosingRubyScope>>,
-    ) -> Self {
+    pub fn new(sym: u32, name: CString, enclosing_scope: Option<Box<EnclosingRubyScope>>) -> Self {
         Self {
             sym,
             name,
@@ -156,7 +151,7 @@ impl Rclass {
             let is_defined_under = sys::mrb_const_defined_at(
                 mrb,
                 sys::mrb_sys_obj_value(scope.cast::<c_void>().as_mut()),
-                self.sym.into(),
+                self.sym,
             );
             if is_defined_under == 0 {
                 // Enclosing scope exists.
@@ -172,7 +167,7 @@ impl Rclass {
             let is_defined = sys::mrb_const_defined_at(
                 mrb,
                 sys::mrb_sys_obj_value((*mrb).object_class as *mut c_void),
-                self.sym.into(),
+                self.sym,
             );
             if is_defined == 0 {
                 // Class does not exist in root scope.
@@ -189,7 +184,7 @@ impl Rclass {
 #[derive(Debug, Clone)]
 pub struct Spec {
     name: Cow<'static, str>,
-    sym: Symbol,
+    sym: u32,
     cstring: CString,
     enclosing_scope: Option<Box<EnclosingRubyScope>>,
 }

--- a/artichoke-backend/src/value.rs
+++ b/artichoke-backend/src/value.rs
@@ -281,7 +281,7 @@ impl ValueCore for Value {
                 protect::funcall(
                     mrb,
                     self.inner(),
-                    func.into(),
+                    func,
                     args.as_slice(),
                     block.as_ref().map(Self::inner),
                 )

--- a/artichoke-core/Cargo.toml
+++ b/artichoke-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "artichoke-core"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2018"
 description = "Core traits for implementing an Artichoke Ruby interpreter"

--- a/artichoke-core/src/intern.rs
+++ b/artichoke-core/src/intern.rs
@@ -22,6 +22,13 @@ pub trait Intern {
     /// Concrete type for errors returned while interning symbols.
     type Error;
 
+    /// The initial `Symbol` index returned by the interner.
+    ///
+    /// Implementing `Intern` requires that symbol identifiers form an
+    /// arithmetic progression with a common difference of 1. The sequence of
+    /// symbol identifiers must be representable by a `Range<u32>`.
+    const SYMBOL_RANGE_START: Self::Symbol;
+
     /// Store an immutable bytestring for the life of the interpreter.
     ///
     /// Returns an identifier that enables retrieving the original bytes.
@@ -90,4 +97,9 @@ pub trait Intern {
     ///
     /// If the symbol store cannot be accessed, an error is returned.
     fn lookup_symbol(&self, symbol: Self::Symbol) -> Result<Option<&[u8]>, Self::Error>;
+
+    /// Retrieve the number of unique strings interned.
+    ///
+    /// This method should return the length of the underlying symbol table.
+    fn symbol_count(&self) -> usize;
 }

--- a/spec-runner/enforced-specs.yaml
+++ b/spec-runner/enforced-specs.yaml
@@ -59,6 +59,42 @@ core:
   - suite: string
     specs:
       - scan
+  - suite: symbol
+    specs:
+      - all_symbols
+      # Requires investments to Unicode support in `String`
+      # - capitalize
+      - case_compare
+      - casecmp
+      - comparison
+      # Requires investments to Unicode support in `String`
+      # - downcase
+      - dup
+      # Depends on `Regexp` indexing fixes
+      # - element_reference
+      - empty
+      - encoding
+      - equal_value
+      - id2name
+      # fails with an mruby `SyntaxError`
+      # upstream bug: https://github.com/mruby/mruby/issues/5055
+      # - inspect
+      - intern
+      - length
+      - match
+      - next
+      - size
+      # Depends on `Regexp` indexing fixes
+      # - slice
+      - succ
+      - swapcase
+      - symbol
+      # Requires working `Symbol#inspect` impl
+      # - to_proc
+      - to_s
+      - to_sym
+      # Requires investments to Unicode support in `String`
+      # - upcase
 library:
   - suite: abbrev
   - suite: delegate

--- a/spinoso-symbol/Cargo.toml
+++ b/spinoso-symbol/Cargo.toml
@@ -19,8 +19,11 @@ focaccia = { version = "1.0", optional = true, default-features = false }
 
 [features]
 default = ["artichoke", "std"]
-# Implement the Ruby `Symbol` API from Ruby Core with a generic interpreter
-# defined by the traits in `artichoke-core` with Unicode case folding support.
+# Implement the Ruby `Symbol` API from Ruby Core with a generic interner defined
+# by the traits in `artichoke-core`. Implement Ruby Core APIs with Unicode case
+# folding support.
+#
+# When this feature is enabled, several types are re-exported from `focaccia`.
 artichoke = ["artichoke-core", "bstr", "focaccia"]
 # By default, `spinoso-symbol` is `no_std`. This feature enables
 # `std::error::Error` impls. This feature activates `focaccia/std` to enable

--- a/spinoso-symbol/Cargo.toml
+++ b/spinoso-symbol/Cargo.toml
@@ -23,8 +23,14 @@ default = ["artichoke", "std"]
 # by the traits in `artichoke-core`. Implement Ruby Core APIs with Unicode case
 # folding support.
 #
+# Enabling this feature activates the `inspect` feature and additionally depends
+# on `bstr`.
+#
 # When this feature is enabled, several types are re-exported from `focaccia`.
-artichoke = ["artichoke-core", "bstr", "focaccia"]
+artichoke = ["artichoke-core", "focaccia", "inspect"]
+# Implement an iterator for printing debug output of a bytestring associated
+# with a `Symbol` that is suitable for implementing `Symbol#inspect`.
+inspect = ["bstr"]
 # By default, `spinoso-symbol` is `no_std`. This feature enables
 # `std::error::Error` impls. This feature activates `focaccia/std` to enable
 # `Error` impls on the re-exported error structs.

--- a/spinoso-symbol/Cargo.toml
+++ b/spinoso-symbol/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "spinoso-symbol"
+version = "0.1.0"
+authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
+edition = "2018"
+description = """
+Symbol implementation for Ruby Symbol core type in Artichoke Ruby
+"""
+repository = "https://github.com/artichoke/artichoke"
+readme = "README.md"
+license = "MIT"
+keywords = ["intern", "no_std", "spinoso", "symbol"]
+categories = ["data-structures", "no-std"]
+
+[dependencies]
+artichoke-core = { version = "0.3", path = "../artichoke-core", default-features = false, optional = true }
+bstr = { version = "0.2", optional = true, default-features = false }
+focaccia = { version = "1.0", optional = true, default-features = false }
+
+[features]
+default = ["artichoke", "std"]
+# Implement the Ruby `Symbol` API from Ruby Core with a generic interpreter
+# defined by the traits in `artichoke-core` with Unicode case folding support.
+artichoke = ["artichoke-core", "bstr", "focaccia"]
+# By default, `spinoso-symbol` is `no_std`. This feature enables
+# `std::error::Error` impls. This feature activates `focaccia/std` to enable
+# `Error` impls on the re-exported error structs.
+std = ["focaccia/std"]
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/spinoso-symbol/README.md
+++ b/spinoso-symbol/README.md
@@ -1,0 +1,86 @@
+# spinoso-symbol
+
+[![GitHub Actions](https://github.com/artichoke/artichoke/workflows/CI/badge.svg)](https://github.com/artichoke/artichoke/actions)
+[![Discord](https://img.shields.io/discord/607683947496734760)](https://discord.gg/QCe2tp2)
+[![Twitter](https://img.shields.io/twitter/follow/artichokeruby?label=Follow&style=social)](https://twitter.com/artichokeruby)
+<br>
+[![Crate](https://img.shields.io/crates/v/spinoso-symbol.svg)](https://crates.io/crates/spinoso-symbol)
+[![API](https://docs.rs/spinoso-symbol/badge.svg)](https://docs.rs/spinoso-symbol)
+[![API trunk](https://img.shields.io/badge/docs-trunk-blue.svg)](https://artichoke.github.io/artichoke/spinoso_symbol/)
+
+Identifier for interned bytestrings and routines for manipulating the
+underlying bytestrings.
+
+`Symbol` is a `Copy` type based on `u32`. `Symbol` is cheap to copy, store,
+and compare. It is suitable for representing indexes into a string interner.
+
+> `Symbol` objects represent names and some strings inside the Ruby interpreter.
+> They are generated using the `:name` and `:"string"` literals syntax, and by
+> the various `to_sym` methods. The same `Symbol` object will be created for a
+> given name or string for the duration of a program's execution, regardless of
+> the context or meaning of that name.
+
+_Spinoso_ refers to _Carciofo spinoso di Sardegna_, the thorny artichoke of
+Sardinia. The idea is that the data structures defined in the `spinoso` family
+of crates will form the backbone of Ruby Core in Artichoke.
+
+# Artichoke integration
+
+This crate has an `artichoke` Cargo feature. When this feature is active,
+this crate implements [the `Symbol` API from Ruby Core]. These APIs require
+resolving the underlying bytes associated with the `Symbol` via a type that
+implements `Intern` from `artichoke-core`.
+
+APIs that require this feature to be active are highlighted in the
+documentation.
+
+This crate provides an `AllSymbols` iterator for walking all symbols stored
+in an [`Intern`]er and an extension trait for constructing it which is
+suitable for implementing [`Symbol::all_symbols`] from Ruby Core.
+
+This crate provides an `Inspect` iterator for converting `Symbol` byte
+content to a debug representation suitable for implementing
+[`Symbol#inspect`] from Ruby Core.
+
+## Usage
+
+Add this to your `Cargo.toml`:
+
+```toml
+[dependencies]
+spinoso-symbol = "0.3"
+```
+
+Most of the functionality in this crate depends on a Ruby interpreter that
+implements [bytestring interning APIs] and requires activating the `artichoke`
+feature.
+
+## `no_std`
+
+This crate is `no_std` compatible when built without the `std` feature. This
+crate does not depend on [`alloc`].
+
+## Crate features
+
+All features are enabled by default.
+
+- **artichoke** - Enables additional methods, functions, and types for
+  implementing APIs from Ruby Core. Dropping this feature removes the
+  `artichoke-core`, `bstr`, and `focaccia` dependencies.
+- **std** - Enables a dependency on the Rust Standard Library. Activating
+  this feature enables [`std::error::Error`] impls on error types in this
+  crate.
+
+
+## License
+
+`spinoso-symbol` is licensed with the [MIT License](../LICENSE) (c) Ryan
+Lopopolo.
+
+[the `Symbol` API from Ruby Core]: https://ruby-doc.org/core-2.6.3/Symbol.html
+[`Intern`]: https://artichoke.github.io/artichoke/artichoke_core/intern/trait.Intern.html
+[`Symbol::all_symbols`]: https://ruby-doc.org/core-2.6.3/Symbol.html#method-c-all_symbols
+[`Symbol#inspect`]: https://ruby-doc.org/core-2.6.3/Symbol.html#method-i-inspect
+[bytestring interning APIs]: https://artichoke.github.io/artichoke/artichoke_core/intern/trait.Intern.html
+[`alloc`]: https://doc.rust-lang.org/alloc/
+[`std::error::Error`]: https://doc.rust-lang.org/std/error/trait.Error.html

--- a/spinoso-symbol/README.md
+++ b/spinoso-symbol/README.md
@@ -66,7 +66,10 @@ All features are enabled by default.
 
 - **artichoke** - Enables additional methods, functions, and types for
   implementing APIs from Ruby Core. Dropping this feature removes the
-  `artichoke-core`, `bstr`, and `focaccia` dependencies.
+  `artichoke-core` and `focaccia` dependencies. Activating this feature also
+  activates the **inspect** feature.
+- **inspect** - Enables an iterator for generating debug output of a symbol
+  bytestring. Dropping this feature removes the `bstr` dependency.
 - **std** - Enables a dependency on the Rust Standard Library. Activating this
   feature enables [`std::error::Error`] impls on error types in this crate.
 

--- a/spinoso-symbol/README.md
+++ b/spinoso-symbol/README.md
@@ -8,11 +8,11 @@
 [![API](https://docs.rs/spinoso-symbol/badge.svg)](https://docs.rs/spinoso-symbol)
 [![API trunk](https://img.shields.io/badge/docs-trunk-blue.svg)](https://artichoke.github.io/artichoke/spinoso_symbol/)
 
-Identifier for interned bytestrings and routines for manipulating the
-underlying bytestrings.
+Identifier for interned bytestrings and routines for manipulating the underlying
+bytestrings.
 
-`Symbol` is a `Copy` type based on `u32`. `Symbol` is cheap to copy, store,
-and compare. It is suitable for representing indexes into a string interner.
+`Symbol` is a `Copy` type based on `u32`. `Symbol` is cheap to copy, store, and
+compare. It is suitable for representing indexes into a string interner.
 
 > `Symbol` objects represent names and some strings inside the Ruby interpreter.
 > They are generated using the `:name` and `:"string"` literals syntax, and by
@@ -26,21 +26,21 @@ of crates will form the backbone of Ruby Core in Artichoke.
 
 # Artichoke integration
 
-This crate has an `artichoke` Cargo feature. When this feature is active,
-this crate implements [the `Symbol` API from Ruby Core]. These APIs require
-resolving the underlying bytes associated with the `Symbol` via a type that
-implements `Intern` from `artichoke-core`.
+This crate has an `artichoke` Cargo feature. When this feature is active, this
+crate implements [the `Symbol` API from Ruby Core]. These APIs require resolving
+the underlying bytes associated with the `Symbol` via a type that implements
+`Intern` from `artichoke-core`.
 
 APIs that require this feature to be active are highlighted in the
 documentation.
 
-This crate provides an `AllSymbols` iterator for walking all symbols stored
-in an [`Intern`]er and an extension trait for constructing it which is
-suitable for implementing [`Symbol::all_symbols`] from Ruby Core.
+This crate provides an `AllSymbols` iterator for walking all symbols stored in
+an [`Intern`]er and an extension trait for constructing it which is suitable for
+implementing [`Symbol::all_symbols`] from Ruby Core.
 
-This crate provides an `Inspect` iterator for converting `Symbol` byte
-content to a debug representation suitable for implementing
-[`Symbol#inspect`] from Ruby Core.
+This crate provides an `Inspect` iterator for converting `Symbol` byte content
+to a debug representation suitable for implementing [`Symbol#inspect`] from Ruby
+Core.
 
 ## Usage
 
@@ -67,20 +67,21 @@ All features are enabled by default.
 - **artichoke** - Enables additional methods, functions, and types for
   implementing APIs from Ruby Core. Dropping this feature removes the
   `artichoke-core`, `bstr`, and `focaccia` dependencies.
-- **std** - Enables a dependency on the Rust Standard Library. Activating
-  this feature enables [`std::error::Error`] impls on error types in this
-  crate.
-
+- **std** - Enables a dependency on the Rust Standard Library. Activating this
+  feature enables [`std::error::Error`] impls on error types in this crate.
 
 ## License
 
 `spinoso-symbol` is licensed with the [MIT License](../LICENSE) (c) Ryan
 Lopopolo.
 
-[the `Symbol` API from Ruby Core]: https://ruby-doc.org/core-2.6.3/Symbol.html
-[`Intern`]: https://artichoke.github.io/artichoke/artichoke_core/intern/trait.Intern.html
-[`Symbol::all_symbols`]: https://ruby-doc.org/core-2.6.3/Symbol.html#method-c-all_symbols
-[`Symbol#inspect`]: https://ruby-doc.org/core-2.6.3/Symbol.html#method-i-inspect
-[bytestring interning APIs]: https://artichoke.github.io/artichoke/artichoke_core/intern/trait.Intern.html
+[the `symbol` api from ruby core]: https://ruby-doc.org/core-2.6.3/Symbol.html
+[`intern`]:
+  https://artichoke.github.io/artichoke/artichoke_core/intern/trait.Intern.html
+[`symbol::all_symbols`]:
+  https://ruby-doc.org/core-2.6.3/Symbol.html#method-c-all_symbols
+[`symbol#inspect`]: https://ruby-doc.org/core-2.6.3/Symbol.html#method-i-inspect
+[bytestring interning apis]:
+  https://artichoke.github.io/artichoke/artichoke_core/intern/trait.Intern.html
 [`alloc`]: https://doc.rust-lang.org/alloc/
-[`std::error::Error`]: https://doc.rust-lang.org/std/error/trait.Error.html
+[`std::error::error`]: https://doc.rust-lang.org/std/error/trait.Error.html

--- a/spinoso-symbol/src/all_symbols.rs
+++ b/spinoso-symbol/src/all_symbols.rs
@@ -5,17 +5,17 @@ use core::ops::Range;
 
 use crate::Symbol;
 
-/// Expose a method for returning an iterator that returns all symbol
-/// identifiers stored in an [interner] as [`Symbol`]s.
+/// Extension trait to return an iterator that returns all symbol identifiers
+/// stored in an [interner] as [`Symbol`]s.
 ///
 /// The returned iterator yields [`Symbol`] as its item type.
 ///
-/// This function requires that the interner issues symbol identifiers as an
-/// [arithmetic progression] with a common difference of 1. The sequence of
-/// symbol identifiers must be representable by a [`Range<u32>`].
+/// Implementors of this trait must issue symbol identifiers as an [arithmetic
+/// progression] with a common difference of 1. The sequence of symbol
+/// identifiers must be representable by a [`Range<u32>`].
 ///
 /// This trait is automatically implemented for all types that implement
-/// [`Intern`].
+/// [`Intern`] from [`artichoke_core`].
 ///
 /// # Examples
 ///
@@ -86,11 +86,15 @@ pub trait InternerAllSymbols: Intern {
     /// [arithmetic progression] with a common difference of 1. The sequence of
     /// symbol identifiers must be representable by a [`Range<u32>`].
     ///
+    /// [`AllSymbols`] supports yielding up to `u32::MAX - 1` `Symbol`s.
+    ///
     /// # Examples
     ///
     /// See trait-level documentation for examples.
     ///
     /// [interner]: Intern
+    /// [arithmetic progression]: https://en.wikipedia.org/wiki/Arithmetic_progression
+    /// [`Range<u32>`]: core::ops::Range
     fn all_symbols(&self) -> AllSymbols;
 }
 
@@ -111,6 +115,7 @@ where
     T: Intern<Symbol = U>,
     U: Copy + Into<u32>,
 {
+    /// Construct a [`AllSymbols`] iterator from an interner.
     #[inline]
     fn from(interner: &T) -> Self {
         let min = T::SYMBOL_RANGE_START.into();
@@ -124,11 +129,14 @@ where
 ///
 /// This iterator yields [`Symbol`] as its item type.
 ///
+/// This iterator supports yielding up to `u32::MAX - 1` `Symbol`s.
+///
 /// This struct is created by the [`all_symbols`] method in the
-/// `InternerAllSymbols` trait.  See its documentation for more.
+/// [`InternerAllSymbols`] trait.  See its documentation for more.
 ///
 /// [interner]: Intern
 /// [`all_symbols`]: InternerAllSymbols::all_symbols
+#[must_use = "Iterator"]
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 #[cfg_attr(docsrs, doc(cfg(feature = "artichoke")))]
 pub struct AllSymbols(Range<u32>);
@@ -148,7 +156,34 @@ impl Iterator for AllSymbols {
 
     #[inline]
     fn count(self) -> usize {
-        self.0.count()
+        // Inline implementation of `Step::steps_between` since
+        // `<Range as Iterator>::count` is not specialized to use it for integer
+        // ranges.
+        if self.0.start <= self.0.end {
+            (self.0.end - self.0.start) as usize
+        } else {
+            0
+        }
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
+    }
+
+    #[inline]
+    fn last(self) -> Option<Self::Item> {
+        self.0.last().map(Symbol::from)
+    }
+
+    #[inline]
+    fn min(mut self) -> Option<Self::Item> {
+        self.0.next().map(Symbol::from)
+    }
+
+    #[inline]
+    fn max(self) -> Option<Self::Item> {
+        self.0.max().map(Symbol::from)
     }
 }
 
@@ -167,3 +202,212 @@ impl DoubleEndedIterator for AllSymbols {
 impl ExactSizeIterator for AllSymbols {}
 
 impl FusedIterator for AllSymbols {}
+
+#[cfg(test)]
+mod tests {
+    use super::InternerAllSymbols;
+    use crate::Symbol;
+    use alloc::borrow::Cow;
+    use artichoke_core::intern::Intern;
+
+    #[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+    struct Interner(u32);
+
+    impl Intern for Interner {
+        type Symbol = u32;
+        type Error = &'static str;
+        const SYMBOL_RANGE_START: Self::Symbol = 0;
+
+        fn intern_bytes<T>(&mut self, symbol: T) -> Result<Self::Symbol, Self::Error>
+        where
+            T: Into<Cow<'static, [u8]>>,
+        {
+            let _ = symbol;
+            Err("not implemented")
+        }
+
+        fn check_interned_bytes(&self, symbol: &[u8]) -> Result<Option<Self::Symbol>, Self::Error> {
+            let _ = symbol;
+            Err("not implemented")
+        }
+
+        fn lookup_symbol(&self, symbol: Self::Symbol) -> Result<Option<&[u8]>, Self::Error> {
+            let _ = symbol;
+            Err("not implemented")
+        }
+
+        fn symbol_count(&self) -> usize {
+            self.0 as usize
+        }
+    }
+
+    #[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+    struct OffByOneInterner(u32);
+
+    impl Intern for OffByOneInterner {
+        type Symbol = u32;
+        type Error = &'static str;
+        const SYMBOL_RANGE_START: Self::Symbol = 1;
+
+        fn intern_bytes<T>(&mut self, symbol: T) -> Result<Self::Symbol, Self::Error>
+        where
+            T: Into<Cow<'static, [u8]>>,
+        {
+            let _ = symbol;
+            Err("not implemented")
+        }
+
+        fn check_interned_bytes(&self, symbol: &[u8]) -> Result<Option<Self::Symbol>, Self::Error> {
+            let _ = symbol;
+            Err("not implemented")
+        }
+
+        fn lookup_symbol(&self, symbol: Self::Symbol) -> Result<Option<&[u8]>, Self::Error> {
+            let _ = symbol;
+            Err("not implemented")
+        }
+
+        fn symbol_count(&self) -> usize {
+            self.0 as usize
+        }
+    }
+
+    #[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+    struct NonZeroInterner(u32);
+
+    impl Intern for NonZeroInterner {
+        type Symbol = u32;
+        type Error = &'static str;
+        const SYMBOL_RANGE_START: Self::Symbol = u32::MAX - 16;
+
+        fn intern_bytes<T>(&mut self, symbol: T) -> Result<Self::Symbol, Self::Error>
+        where
+            T: Into<Cow<'static, [u8]>>,
+        {
+            let _ = symbol;
+            Err("not implemented")
+        }
+
+        fn check_interned_bytes(&self, symbol: &[u8]) -> Result<Option<Self::Symbol>, Self::Error> {
+            let _ = symbol;
+            Err("not implemented")
+        }
+
+        fn lookup_symbol(&self, symbol: Self::Symbol) -> Result<Option<&[u8]>, Self::Error> {
+            let _ = symbol;
+            Err("not implemented")
+        }
+
+        fn symbol_count(&self) -> usize {
+            self.0 as usize
+        }
+    }
+
+    #[test]
+    fn zero_offset_count() {
+        let interner = Interner::default();
+        let all_symbols = interner.all_symbols();
+        assert_eq!(all_symbols.count(), 0);
+
+        let interner = Interner(100);
+        let all_symbols = interner.all_symbols();
+        assert_eq!(all_symbols.count(), 100);
+
+        let interner = Interner(u32::MAX);
+        let all_symbols = interner.all_symbols();
+        assert_eq!(all_symbols.count(), u32::MAX as usize);
+    }
+
+    #[test]
+    fn zero_offset_yielded() {
+        let interner = Interner::default();
+        let mut all_symbols = interner.all_symbols();
+        assert_eq!(all_symbols.next(), None);
+
+        let interner = Interner(5);
+        let mut all_symbols = interner.all_symbols();
+        assert_eq!(all_symbols.next(), Some(Symbol::new(0)));
+        assert_eq!(all_symbols.next(), Some(Symbol::new(1)));
+        assert_eq!(all_symbols.next(), Some(Symbol::new(2)));
+        assert_eq!(all_symbols.next(), Some(Symbol::new(3)));
+        assert_eq!(all_symbols.next(), Some(Symbol::new(4)));
+        assert_eq!(all_symbols.next(), None);
+
+        let interner = Interner(u32::MAX);
+        let mut all_symbols = interner.all_symbols();
+        assert_eq!(all_symbols.next(), Some(Symbol::new(0)));
+        assert_eq!(all_symbols.next_back(), Some(Symbol::new(u32::MAX - 1)));
+    }
+
+    #[test]
+    fn one_offset_count() {
+        let interner = OffByOneInterner::default();
+        let all_symbols = interner.all_symbols();
+        assert_eq!(all_symbols.count(), 0);
+
+        let interner = OffByOneInterner(100);
+        let all_symbols = interner.all_symbols();
+        assert_eq!(all_symbols.count(), 100);
+
+        let interner = OffByOneInterner(u32::MAX);
+        let all_symbols = interner.all_symbols();
+        assert_eq!(all_symbols.count(), (u32::MAX - 1) as usize);
+    }
+
+    #[test]
+    fn one_offset_yielded() {
+        let interner = OffByOneInterner::default();
+        let mut all_symbols = interner.all_symbols();
+        assert_eq!(all_symbols.next(), None);
+
+        let interner = OffByOneInterner(5);
+        let mut all_symbols = interner.all_symbols();
+        assert_eq!(all_symbols.next(), Some(Symbol::new(1)));
+        assert_eq!(all_symbols.next(), Some(Symbol::new(2)));
+        assert_eq!(all_symbols.next(), Some(Symbol::new(3)));
+        assert_eq!(all_symbols.next(), Some(Symbol::new(4)));
+        assert_eq!(all_symbols.next(), Some(Symbol::new(5)));
+        assert_eq!(all_symbols.next(), None);
+
+        let interner = OffByOneInterner(u32::MAX);
+        let mut all_symbols = interner.all_symbols();
+        assert_eq!(all_symbols.next(), Some(Symbol::new(1)));
+        assert_eq!(all_symbols.next_back(), Some(Symbol::new(u32::MAX - 1)));
+    }
+
+    #[test]
+    fn high_offset_count() {
+        let interner = NonZeroInterner::default();
+        let all_symbols = interner.all_symbols();
+        assert_eq!(all_symbols.count(), 0);
+
+        let interner = NonZeroInterner(100);
+        let all_symbols = interner.all_symbols();
+        assert_eq!(all_symbols.count(), 16);
+
+        let interner = NonZeroInterner(u32::MAX);
+        let all_symbols = interner.all_symbols();
+        assert_eq!(all_symbols.count(), 16);
+    }
+
+    #[test]
+    fn high_offset_yielded() {
+        let interner = NonZeroInterner::default();
+        let mut all_symbols = interner.all_symbols();
+        assert_eq!(all_symbols.next(), None);
+
+        let interner = NonZeroInterner(5);
+        let mut all_symbols = interner.all_symbols();
+        assert_eq!(all_symbols.next(), Some(Symbol::new(u32::MAX - 16)));
+        assert_eq!(all_symbols.next(), Some(Symbol::new(u32::MAX - 15)));
+        assert_eq!(all_symbols.next(), Some(Symbol::new(u32::MAX - 14)));
+        assert_eq!(all_symbols.next(), Some(Symbol::new(u32::MAX - 13)));
+        assert_eq!(all_symbols.next(), Some(Symbol::new(u32::MAX - 12)));
+        assert_eq!(all_symbols.next(), None);
+
+        let interner = NonZeroInterner(u32::MAX);
+        let mut all_symbols = interner.all_symbols();
+        assert_eq!(all_symbols.next(), Some(Symbol::new(u32::MAX - 16)));
+        assert_eq!(all_symbols.next_back(), Some(Symbol::new(u32::MAX - 1)));
+    }
+}

--- a/spinoso-symbol/src/all_symbols.rs
+++ b/spinoso-symbol/src/all_symbols.rs
@@ -1,0 +1,169 @@
+use artichoke_core::intern::Intern;
+use core::convert::TryInto;
+use core::iter::FusedIterator;
+use core::ops::Range;
+
+use crate::Symbol;
+
+/// Expose a method for returning an iterator that returns all symbol
+/// identifiers stored in an [interner] as [`Symbol`]s.
+///
+/// The returned iterator yields [`Symbol`] as its item type.
+///
+/// This function requires that the interner issues symbol identifiers as an
+/// [arithmetic progression] with a common difference of 1. The sequence of
+/// symbol identifiers must be representable by a [`Range<u32>`].
+///
+/// This trait is automatically implemented for all types that implement
+/// [`Intern`].
+///
+/// # Examples
+///
+/// ```
+/// # extern crate alloc;
+/// use alloc::borrow::Cow;
+/// use alloc::boxed::Box;
+/// use artichoke_core::intern::Intern;
+/// use spinoso_symbol::{InternerAllSymbols, Symbol};
+///
+/// #[derive(Default)]
+/// struct Interner(u32);
+///
+/// impl Intern for Interner {
+///     type Symbol = u32;
+///     type Error = &'static str;
+///     const SYMBOL_RANGE_START: u32 = 1;
+///
+///     fn intern_bytes<T>(&mut self, symbol: T) -> Result<Self::Symbol, Self::Error>
+///     where
+///         T: Into<Cow<'static, [u8]>>
+///     {
+///         let boxed = Box::<[u8]>::from(symbol.into());
+///         Box::leak(boxed);
+///         self.0 += 1;
+///         let sym = self.0;
+///         Ok(sym)
+///     }
+///
+///     fn check_interned_bytes(&self, symbol: &[u8]) -> Result<Option<Self::Symbol>, Self::Error> {
+///         Err("not implemented")
+///     }
+///
+///     fn lookup_symbol(&self, symbol: Self::Symbol) -> Result<Option<&[u8]>, Self::Error> {
+///         Err("not implemented")
+///     }
+///
+///     fn symbol_count(&self) -> usize {
+///         self.0 as usize
+///     }
+/// }
+///
+/// let mut interner = Interner::default();
+/// let mut all_symbols = interner.all_symbols();
+/// assert_eq!(all_symbols.count(), 0);
+///
+/// interner.intern_bytes(&b"Spinoso"[..]);
+/// interner.intern_bytes(&b"Artichoke"[..]);
+///
+/// let mut all_symbols = interner.all_symbols();
+/// assert_eq!(all_symbols.next(), Some(Symbol::new(1)));
+/// assert_eq!(all_symbols.next(), Some(Symbol::new(2)));
+/// assert_eq!(all_symbols.next(), None);
+/// ```
+///
+/// [interner]: Intern
+/// [arithmetic progression]: https://en.wikipedia.org/wiki/Arithmetic_progression
+/// [`Range<u32>`]: core::ops::Range
+#[allow(clippy::module_name_repetitions)]
+#[cfg_attr(docsrs, doc(cfg(feature = "artichoke")))]
+pub trait InternerAllSymbols: Intern {
+    /// Returns an iterator that returns all symbol identifiers stored in an
+    /// [interner] as [`Symbol`]s.
+    ///
+    /// The returned iterator yields [`Symbol`] as its item type.
+    ///
+    /// This function requires that the interner issues symbol identifiers as an
+    /// [arithmetic progression] with a common difference of 1. The sequence of
+    /// symbol identifiers must be representable by a [`Range<u32>`].
+    ///
+    /// # Examples
+    ///
+    /// See trait-level documentation for examples.
+    ///
+    /// [interner]: Intern
+    fn all_symbols(&self) -> AllSymbols;
+}
+
+impl<T, U> InternerAllSymbols for T
+where
+    T: Intern<Symbol = U>,
+    U: Copy + Into<u32>,
+{
+    #[inline]
+    #[cfg_attr(docsrs, doc(cfg(feature = "artichoke")))]
+    fn all_symbols(&self) -> AllSymbols {
+        self.into()
+    }
+}
+
+impl<T, U> From<&T> for AllSymbols
+where
+    T: Intern<Symbol = U>,
+    U: Copy + Into<u32>,
+{
+    #[inline]
+    fn from(interner: &T) -> Self {
+        let min = T::SYMBOL_RANGE_START.into();
+        let max_idx = interner.symbol_count().try_into().unwrap_or(u32::MAX);
+        let max = min.saturating_add(max_idx);
+        AllSymbols(min..max)
+    }
+}
+
+/// An iterator that returns all of the Symbols in an [interner].
+///
+/// This iterator yields [`Symbol`] as its item type.
+///
+/// This struct is created by the [`all_symbols`] method in the
+/// `InternerAllSymbols` trait.  See its documentation for more.
+///
+/// [interner]: Intern
+/// [`all_symbols`]: InternerAllSymbols::all_symbols
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+#[cfg_attr(docsrs, doc(cfg(feature = "artichoke")))]
+pub struct AllSymbols(Range<u32>);
+
+impl Iterator for AllSymbols {
+    type Item = Symbol;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().map(Symbol::from)
+    }
+
+    #[inline]
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        self.0.nth(n).map(Symbol::from)
+    }
+
+    #[inline]
+    fn count(self) -> usize {
+        self.0.count()
+    }
+}
+
+impl DoubleEndedIterator for AllSymbols {
+    #[inline]
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.0.next_back().map(Symbol::from)
+    }
+
+    #[inline]
+    fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
+        self.0.nth_back(n).map(Symbol::from)
+    }
+}
+
+impl ExactSizeIterator for AllSymbols {}
+
+impl FusedIterator for AllSymbols {}

--- a/spinoso-symbol/src/casecmp/ascii.rs
+++ b/spinoso-symbol/src/casecmp/ascii.rs
@@ -1,9 +1,7 @@
-//! ASCII ase folding comparisons for byte content resolved from `Symbol`s.
+//! ASCII case folding comparisons for byte content resolved from `Symbol`s.
 
 use artichoke_core::intern::Intern;
 use core::cmp::Ordering;
-
-use crate::Symbol;
 
 /// Compare the byte contents of two symbols using ASCII case-insensitive
 /// comparison.
@@ -26,7 +24,7 @@ use crate::Symbol;
 pub fn casecmp<T, U>(interner: &T, left: U, right: U) -> Result<Ordering, T::Error>
 where
     T: Intern<Symbol = U>,
-    U: Copy + From<Symbol>,
+    U: Copy,
 {
     let left = interner.lookup_symbol(left)?.unwrap_or_default();
     let right = interner.lookup_symbol(right)?.unwrap_or_default();

--- a/spinoso-symbol/src/casecmp/ascii.rs
+++ b/spinoso-symbol/src/casecmp/ascii.rs
@@ -1,0 +1,34 @@
+//! ASCII ase folding comparisons for byte content resolved from `Symbol`s.
+
+use artichoke_core::intern::Intern;
+use core::cmp::Ordering;
+
+use crate::Symbol;
+
+/// Compare the byte contents of two symbols using ASCII case-insensitive
+/// comparison.
+///
+/// The byteslice associated with each symbol is resolved via the given
+/// interner. Unresolved symbols are compared as if they resolve to `&[]`.
+///
+/// This function can be used to implement [`Symbol#casecmp`] for the [`Symbol`]
+/// type defined in Ruby Core.
+///
+/// # Errors
+///
+/// If the interner returns an error while retrieving a symbol, that error is
+/// returned. See [`Intern::lookup_symbol`].
+///
+/// [`Symbol#casecmp`]: https://ruby-doc.org/core-2.6.3/Symbol.html#method-i-casecmp
+/// [`Symbol`]: https://ruby-doc.org/core-2.6.3/Symbol.html
+#[inline]
+#[cfg_attr(docsrs, doc(cfg(feature = "artichoke")))]
+pub fn casecmp<T, U>(interner: &T, left: U, right: U) -> Result<Ordering, T::Error>
+where
+    T: Intern<Symbol = U>,
+    U: Copy + From<Symbol>,
+{
+    let left = interner.lookup_symbol(left)?.unwrap_or_default();
+    let right = interner.lookup_symbol(right)?.unwrap_or_default();
+    Ok(focaccia::ascii_casecmp(left, right))
+}

--- a/spinoso-symbol/src/casecmp/mod.rs
+++ b/spinoso-symbol/src/casecmp/mod.rs
@@ -1,0 +1,7 @@
+//! Case folding comparisons for byte content resolved from `Symbol`s.
+
+mod ascii;
+mod unicode;
+
+pub use ascii::casecmp as ascii_casecmp;
+pub use unicode::case_eq as unicode_case_eq;

--- a/spinoso-symbol/src/casecmp/unicode.rs
+++ b/spinoso-symbol/src/casecmp/unicode.rs
@@ -1,0 +1,65 @@
+//! Unicode case folding comparisons for byte content resolved from `Symbol`s.
+
+use artichoke_core::intern::Intern;
+use core::str;
+
+use crate::Symbol;
+
+use focaccia::CaseFold;
+
+/// Compare the byte contents of two symbols using Unicode case-folding
+/// comparison for equality.
+///
+/// The byteslice associated with each symbol is resolved via the given
+/// interner. Unresolved symbols are compared as if they resolve to `&[]`.
+///
+/// This comparison function attempts to convert each symbol's byte content to a
+/// UTF-8 [`str`]. If both symbols resolve to UTF-8 contents, [Unicode case
+/// folding] is used when comparing the contents and this function returns
+/// `Ok(Some(bool))`. If neither symbol resolves to UTF-8 contents, this
+/// function falls back to [`ascii_casecmp`] and returns `Ok(Some(bool))`.
+/// Otherwise, the two symbols have byte contents with different encodings and
+/// `Ok(None)` is returned.
+///
+/// This function can be used to implement [`Symbol#casecmp?`] for the
+/// [`Symbol`] type defined in Ruby Core.
+///
+/// # Errors
+///
+/// If the interner returns an error while retrieving a symbol, that error is
+/// returned. See [`Intern::lookup_symbol`].
+///
+/// [Unicode case folding]: https://www.w3.org/International/wiki/Case_folding
+/// [`ascii_casecmp`]: crate::casecmp::ascii_casecmp
+/// [`Symbol#casecmp?`]: https://ruby-doc.org/core-2.6.3/Symbol.html#method-i-casecmp-3F
+/// [`Symbol`]: https://ruby-doc.org/core-2.6.3/Symbol.html
+#[inline]
+#[cfg_attr(docsrs, doc(cfg(feature = "artichoke")))]
+pub fn case_eq<T, U>(
+    interner: &T,
+    left: U,
+    right: U,
+    fold: CaseFold,
+) -> Result<Option<bool>, T::Error>
+where
+    T: Intern<Symbol = U>,
+    U: Copy + From<Symbol>,
+{
+    let left = interner.lookup_symbol(left)?.unwrap_or_default();
+    let right = interner.lookup_symbol(right)?.unwrap_or_default();
+    let cmp = match (str::from_utf8(left), str::from_utf8(right)) {
+        // Both slices are UTF-8, compare with the given Unicode case folding
+        // scheme.
+        (Ok(left), Ok(right)) => fold.case_eq(left, right),
+        // Both slices are not UTF-8, fallback to ASCII comparator.
+        (Err(_), Err(_)) => focaccia::ascii_case_eq(left, right),
+        // Encoding mismatch, the bytes are not comparable using unicode case
+        // folding.
+        //
+        // > `nil` is returned if the two symbols have incompatible encodings,
+        // > or if `other_symbol` is not a symbol.
+        // > <https://ruby-doc.org/core-2.6.3/Symbol.html#method-i-casecmp-3F>
+        (Ok(_), Err(_)) | (Err(_), Ok(_)) => return Ok(None),
+    };
+    Ok(Some(cmp))
+}

--- a/spinoso-symbol/src/casecmp/unicode.rs
+++ b/spinoso-symbol/src/casecmp/unicode.rs
@@ -3,8 +3,6 @@
 use artichoke_core::intern::Intern;
 use core::str;
 
-use crate::Symbol;
-
 use focaccia::CaseFold;
 
 /// Compare the byte contents of two symbols using Unicode case-folding
@@ -43,7 +41,7 @@ pub fn case_eq<T, U>(
 ) -> Result<Option<bool>, T::Error>
 where
     T: Intern<Symbol = U>,
-    U: Copy + From<Symbol>,
+    U: Copy,
 {
     let left = interner.lookup_symbol(left)?.unwrap_or_default();
     let right = interner.lookup_symbol(right)?.unwrap_or_default();

--- a/spinoso-symbol/src/convert.rs
+++ b/spinoso-symbol/src/convert.rs
@@ -1,0 +1,142 @@
+use core::convert::TryFrom;
+use core::num::{NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU8, NonZeroUsize};
+
+use crate::{Symbol, SymbolOverflowError};
+
+impl From<u8> for Symbol {
+    #[inline]
+    fn from(id: u8) -> Self {
+        Self(id.into())
+    }
+}
+
+impl From<NonZeroU8> for Symbol {
+    #[inline]
+    fn from(sym: NonZeroU8) -> Self {
+        Self(sym.get().into())
+    }
+}
+
+impl From<u16> for Symbol {
+    #[inline]
+    fn from(id: u16) -> Self {
+        Self(id.into())
+    }
+}
+
+impl From<NonZeroU16> for Symbol {
+    #[inline]
+    fn from(sym: NonZeroU16) -> Self {
+        Self(sym.get().into())
+    }
+}
+
+impl From<u32> for Symbol {
+    #[inline]
+    fn from(id: u32) -> Self {
+        Self(id)
+    }
+}
+
+impl From<NonZeroU32> for Symbol {
+    #[inline]
+    fn from(sym: NonZeroU32) -> Self {
+        Self(sym.get())
+    }
+}
+
+impl TryFrom<u64> for Symbol {
+    type Error = SymbolOverflowError;
+
+    #[inline]
+    fn try_from(value: u64) -> Result<Self, Self::Error> {
+        let id = u32::try_from(value)?;
+        Ok(id.into())
+    }
+}
+
+impl TryFrom<NonZeroU64> for Symbol {
+    type Error = SymbolOverflowError;
+
+    #[inline]
+    fn try_from(value: NonZeroU64) -> Result<Self, Self::Error> {
+        let id = u32::try_from(value.get())?;
+        Ok(id.into())
+    }
+}
+
+impl TryFrom<usize> for Symbol {
+    type Error = SymbolOverflowError;
+
+    #[inline]
+    fn try_from(value: usize) -> Result<Self, Self::Error> {
+        let id = u32::try_from(value)?;
+        Ok(id.into())
+    }
+}
+
+impl TryFrom<NonZeroUsize> for Symbol {
+    type Error = SymbolOverflowError;
+
+    #[inline]
+    fn try_from(value: NonZeroUsize) -> Result<Self, Self::Error> {
+        let id = u32::try_from(value.get())?;
+        Ok(id.into())
+    }
+}
+
+impl From<Symbol> for u32 {
+    #[inline]
+    fn from(sym: Symbol) -> Self {
+        sym.id()
+    }
+}
+
+impl From<Symbol> for u64 {
+    #[inline]
+    fn from(sym: Symbol) -> Self {
+        sym.id().into()
+    }
+}
+
+impl From<Symbol> for usize {
+    #[inline]
+    fn from(sym: Symbol) -> Self {
+        sym.id() as usize
+    }
+}
+
+impl From<Symbol> for i64 {
+    #[inline]
+    fn from(sym: Symbol) -> Self {
+        sym.id().into()
+    }
+}
+
+impl From<&Symbol> for u32 {
+    #[inline]
+    fn from(sym: &Symbol) -> Self {
+        sym.id()
+    }
+}
+
+impl From<&Symbol> for u64 {
+    #[inline]
+    fn from(sym: &Symbol) -> Self {
+        sym.id().into()
+    }
+}
+
+impl From<&Symbol> for usize {
+    #[inline]
+    fn from(sym: &Symbol) -> Self {
+        sym.id() as usize
+    }
+}
+
+impl From<&Symbol> for i64 {
+    #[inline]
+    fn from(sym: &Symbol) -> Self {
+        sym.id().into()
+    }
+}

--- a/spinoso-symbol/src/convert.rs
+++ b/spinoso-symbol/src/convert.rs
@@ -85,6 +85,88 @@ impl TryFrom<NonZeroUsize> for Symbol {
     }
 }
 
+impl From<&u8> for Symbol {
+    #[inline]
+    fn from(id: &u8) -> Self {
+        Self((*id).into())
+    }
+}
+
+impl From<&NonZeroU8> for Symbol {
+    #[inline]
+    fn from(sym: &NonZeroU8) -> Self {
+        Self(sym.get().into())
+    }
+}
+
+impl From<&u16> for Symbol {
+    #[inline]
+    fn from(id: &u16) -> Self {
+        Self((*id).into())
+    }
+}
+
+impl From<&NonZeroU16> for Symbol {
+    #[inline]
+    fn from(sym: &NonZeroU16) -> Self {
+        Self(sym.get().into())
+    }
+}
+
+impl From<&u32> for Symbol {
+    #[inline]
+    fn from(id: &u32) -> Self {
+        Self(*id)
+    }
+}
+
+impl From<&NonZeroU32> for Symbol {
+    #[inline]
+    fn from(sym: &NonZeroU32) -> Self {
+        Self(sym.get())
+    }
+}
+
+impl TryFrom<&u64> for Symbol {
+    type Error = SymbolOverflowError;
+
+    #[inline]
+    fn try_from(value: &u64) -> Result<Self, Self::Error> {
+        let id = u32::try_from(*value)?;
+        Ok(id.into())
+    }
+}
+
+impl TryFrom<&NonZeroU64> for Symbol {
+    type Error = SymbolOverflowError;
+
+    #[inline]
+    fn try_from(value: &NonZeroU64) -> Result<Self, Self::Error> {
+        let id = u32::try_from(value.get())?;
+        Ok(id.into())
+    }
+}
+
+impl TryFrom<&usize> for Symbol {
+    type Error = SymbolOverflowError;
+
+    #[inline]
+    fn try_from(value: &usize) -> Result<Self, Self::Error> {
+        let id = u32::try_from(*value)?;
+        Ok(id.into())
+    }
+}
+
+impl TryFrom<&NonZeroUsize> for Symbol {
+    type Error = SymbolOverflowError;
+
+    #[inline]
+    fn try_from(value: &NonZeroUsize) -> Result<Self, Self::Error> {
+        let id = u32::try_from(value.get())?;
+        Ok(id.into())
+    }
+}
+
 impl From<Symbol> for u32 {
     #[inline]
     fn from(sym: Symbol) -> Self {
@@ -102,6 +184,8 @@ impl From<Symbol> for u64 {
 impl From<Symbol> for usize {
     #[inline]
     fn from(sym: Symbol) -> Self {
+        // This conversion relies on size_of::<usize>() >= size_of::<u32>(),
+        // which is ensured with a const assertion in `lib.rs`.
         sym.id() as usize
     }
 }

--- a/spinoso-symbol/src/eq.rs
+++ b/spinoso-symbol/src/eq.rs
@@ -1,0 +1,29 @@
+use crate::Symbol;
+
+impl PartialEq<u32> for Symbol {
+    #[inline]
+    fn eq(&self, other: &u32) -> bool {
+        self.id() == *other
+    }
+}
+
+impl PartialEq<&u32> for Symbol {
+    #[inline]
+    fn eq(&self, other: &&u32) -> bool {
+        self.id() == **other
+    }
+}
+
+impl PartialEq<Symbol> for u32 {
+    #[inline]
+    fn eq(&self, other: &Symbol) -> bool {
+        *self == other.id()
+    }
+}
+
+impl PartialEq<&Symbol> for u32 {
+    #[inline]
+    fn eq(&self, other: &&Symbol) -> bool {
+        *self == other.id()
+    }
+}

--- a/spinoso-symbol/src/eq.rs
+++ b/spinoso-symbol/src/eq.rs
@@ -27,3 +27,17 @@ impl PartialEq<&Symbol> for u32 {
         *self == other.id()
     }
 }
+
+impl PartialEq<u32> for &Symbol {
+    #[inline]
+    fn eq(&self, other: &u32) -> bool {
+        self.id() == *other
+    }
+}
+
+impl PartialEq<Symbol> for &u32 {
+    #[inline]
+    fn eq(&self, other: &Symbol) -> bool {
+        **self == other.id()
+    }
+}

--- a/spinoso-symbol/src/inspect.rs
+++ b/spinoso-symbol/src/inspect.rs
@@ -52,7 +52,7 @@ use core::str::Chars;
 /// [`write_inspect_into`]: crate::Symbol::write_inspect_into
 #[must_use = "Iterator"]
 #[derive(Default, Debug, Clone)]
-#[cfg_attr(docsrs, doc(cfg(feature = "artichoke")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "inspect")))]
 pub struct Inspect<'a>(State<'a>);
 
 impl<'a> From<&'a str> for Inspect<'a> {

--- a/spinoso-symbol/src/inspect.rs
+++ b/spinoso-symbol/src/inspect.rs
@@ -1,0 +1,575 @@
+use bstr::{ByteSlice, CharIndices};
+use core::iter::FusedIterator;
+use core::str::Chars;
+
+/// An iterator that yields a debug representation of a `Symbol` and its byte
+/// contents.
+///
+/// This struct is created by the [`inspect`] method on [`Symbol`]. See its
+/// documentation for more.
+///
+/// [`inspect`]: crate::Symbol::inspect
+/// [`Symbol`]: crate::Symbol
+#[derive(Default, Debug, Clone)]
+#[cfg_attr(docsrs, doc(cfg(feature = "artichoke")))]
+pub struct Inspect<'a>(State<'a>);
+
+impl<'a> From<&'a str> for Inspect<'a> {
+    #[inline]
+    fn from(value: &'a str) -> Self {
+        Self::from(value.as_bytes())
+    }
+}
+
+impl<'a> From<&'a [u8]> for Inspect<'a> {
+    #[inline]
+    fn from(value: &'a [u8]) -> Self {
+        match value {
+            value if value.is_empty() => Self::default(),
+            value if value.is_utf8() => Self(State::unquoted(value)),
+            value => Self(State::quoted(value)),
+        }
+    }
+}
+
+impl<'a> Iterator for Inspect<'a> {
+    type Item = char;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+}
+
+impl<'a> FusedIterator for Inspect<'a> {}
+
+#[derive(Debug, Clone)]
+struct State<'a> {
+    string: &'a [u8],
+    sigil: bool,
+    open_quote: bool,
+    next: [Option<Literal>; 3],
+    iter: CharIndices<'a>,
+    close_quote: bool,
+}
+
+impl<'a> State<'a> {
+    #[inline]
+    fn unquoted(bytes: &'a [u8]) -> Self {
+        Self {
+            string: bytes,
+            sigil: true,
+            open_quote: false,
+            next: [None, None, None],
+            iter: bytes.char_indices(),
+            close_quote: false,
+        }
+    }
+
+    #[inline]
+    fn quoted(bytes: &'a [u8]) -> Self {
+        Self {
+            string: bytes,
+            sigil: true,
+            open_quote: true,
+            next: [None, None, None],
+            iter: bytes.char_indices(),
+            close_quote: true,
+        }
+    }
+}
+
+impl<'a> Default for State<'a> {
+    /// The default `State` for [`Inspect`] renders to `:""`.
+    #[inline]
+    fn default() -> Self {
+        Self {
+            string: b"",
+            sigil: true,
+            open_quote: true,
+            next: [None, None, None],
+            iter: b"".char_indices(),
+            close_quote: true,
+        }
+    }
+}
+
+impl<'a> Iterator for State<'a> {
+    type Item = char;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.sigil {
+            self.sigil = false;
+            return Some(':');
+        }
+        if self.open_quote {
+            self.open_quote = false;
+            return Some('"');
+        }
+        for cell in &mut self.next {
+            let mut done = false;
+            let mut next = None;
+            if let Some(ref mut lit) = cell {
+                next = lit.next();
+                done = next.is_none();
+            }
+            if done {
+                *cell = None;
+            }
+            if next.is_some() {
+                return next;
+            }
+        }
+        if let Some((start, end, ch)) = self.iter.next() {
+            if ch == '\u{FFFD}' {
+                let mut next = None::<char>;
+                let slice = &self.string[start..end];
+                let iter = slice.iter().zip(self.next.iter_mut()).enumerate();
+                for (idx, (&byte, cell)) in iter {
+                    let mut lit = Literal::from(byte);
+                    if idx == 0 {
+                        next = lit.0.next();
+                    }
+                    *cell = Some(lit);
+                }
+                return next;
+            } else {
+                return Some(ch);
+            }
+        }
+        if self.close_quote {
+            self.close_quote = false;
+            return Some('"');
+        }
+        None
+    }
+}
+
+impl<'a> FusedIterator for State<'a> {}
+
+#[derive(Debug, Clone)]
+struct Literal(Chars<'static>);
+
+impl From<u8> for Literal {
+    #[allow(clippy::too_many_lines)]
+    fn from(value: u8) -> Self {
+        let escape = match value {
+            0 => r"\x00",
+            1 => r"\x01",
+            2 => r"\x02",
+            3 => r"\x03",
+            4 => r"\x04",
+            5 => r"\x05",
+            6 => r"\x06",
+            7 => r"\x07",
+            8 => r"\x08",
+            9 => r"\x09",
+            10 => r"\x0A",
+            11 => r"\x0B",
+            12 => r"\x0C",
+            13 => r"\x0D",
+            14 => r"\x0E",
+            15 => r"\x0F",
+            16 => r"\x10",
+            17 => r"\x11",
+            18 => r"\x12",
+            19 => r"\x13",
+            20 => r"\x14",
+            21 => r"\x15",
+            22 => r"\x16",
+            23 => r"\x17",
+            24 => r"\x18",
+            25 => r"\x19",
+            26 => r"\x1A",
+            27 => r"\x1B",
+            28 => r"\x1C",
+            29 => r"\x1D",
+            30 => r"\x1E",
+            31 => r"\x1F",
+            32 => r"\x20",
+            33 => r"\x21",
+            34 => r"\x22",
+            35 => r"\x23",
+            36 => r"\x24",
+            37 => r"\x25",
+            38 => r"\x26",
+            39 => r"\x27",
+            40 => r"\x28",
+            41 => r"\x29",
+            42 => r"\x2A",
+            43 => r"\x2B",
+            44 => r"\x2C",
+            45 => r"\x2D",
+            46 => r"\x2E",
+            47 => r"\x2F",
+            48 => r"\x30",
+            49 => r"\x31",
+            50 => r"\x32",
+            51 => r"\x33",
+            52 => r"\x34",
+            53 => r"\x35",
+            54 => r"\x36",
+            55 => r"\x37",
+            56 => r"\x38",
+            57 => r"\x39",
+            58 => r"\x3A",
+            59 => r"\x3B",
+            60 => r"\x3C",
+            61 => r"\x3D",
+            62 => r"\x3E",
+            63 => r"\x3F",
+            64 => r"\x40",
+            65 => r"\x41",
+            66 => r"\x42",
+            67 => r"\x43",
+            68 => r"\x44",
+            69 => r"\x45",
+            70 => r"\x46",
+            71 => r"\x47",
+            72 => r"\x48",
+            73 => r"\x49",
+            74 => r"\x4A",
+            75 => r"\x4B",
+            76 => r"\x4C",
+            77 => r"\x4D",
+            78 => r"\x4E",
+            79 => r"\x4F",
+            80 => r"\x50",
+            81 => r"\x51",
+            82 => r"\x52",
+            83 => r"\x53",
+            84 => r"\x54",
+            85 => r"\x55",
+            86 => r"\x56",
+            87 => r"\x57",
+            88 => r"\x58",
+            89 => r"\x59",
+            90 => r"\x5A",
+            91 => r"\x5B",
+            92 => r"\x5C",
+            93 => r"\x5D",
+            94 => r"\x5E",
+            95 => r"\x5F",
+            96 => r"\x60",
+            97 => r"\x61",
+            98 => r"\x62",
+            99 => r"\x63",
+            100 => r"\x64",
+            101 => r"\x65",
+            102 => r"\x66",
+            103 => r"\x67",
+            104 => r"\x68",
+            105 => r"\x69",
+            106 => r"\x6A",
+            107 => r"\x6B",
+            108 => r"\x6C",
+            109 => r"\x6D",
+            110 => r"\x6E",
+            111 => r"\x6F",
+            112 => r"\x70",
+            113 => r"\x71",
+            114 => r"\x72",
+            115 => r"\x73",
+            116 => r"\x74",
+            117 => r"\x75",
+            118 => r"\x76",
+            119 => r"\x77",
+            120 => r"\x78",
+            121 => r"\x79",
+            122 => r"\x7A",
+            123 => r"\x7B",
+            124 => r"\x7C",
+            125 => r"\x7D",
+            126 => r"\x7E",
+            127 => r"\x7F",
+            128 => r"\x80",
+            129 => r"\x81",
+            130 => r"\x82",
+            131 => r"\x83",
+            132 => r"\x84",
+            133 => r"\x85",
+            134 => r"\x86",
+            135 => r"\x87",
+            136 => r"\x88",
+            137 => r"\x89",
+            138 => r"\x8A",
+            139 => r"\x8B",
+            140 => r"\x8C",
+            141 => r"\x8D",
+            142 => r"\x8E",
+            143 => r"\x8F",
+            144 => r"\x90",
+            145 => r"\x91",
+            146 => r"\x92",
+            147 => r"\x93",
+            148 => r"\x94",
+            149 => r"\x95",
+            150 => r"\x96",
+            151 => r"\x97",
+            152 => r"\x98",
+            153 => r"\x99",
+            154 => r"\x9A",
+            155 => r"\x9B",
+            156 => r"\x9C",
+            157 => r"\x9D",
+            158 => r"\x9E",
+            159 => r"\x9F",
+            160 => r"\xA0",
+            161 => r"\xA1",
+            162 => r"\xA2",
+            163 => r"\xA3",
+            164 => r"\xA4",
+            165 => r"\xA5",
+            166 => r"\xA6",
+            167 => r"\xA7",
+            168 => r"\xA8",
+            169 => r"\xA9",
+            170 => r"\xAA",
+            171 => r"\xAB",
+            172 => r"\xAC",
+            173 => r"\xAD",
+            174 => r"\xAE",
+            175 => r"\xAF",
+            176 => r"\xB0",
+            177 => r"\xB1",
+            178 => r"\xB2",
+            179 => r"\xB3",
+            180 => r"\xB4",
+            181 => r"\xB5",
+            182 => r"\xB6",
+            183 => r"\xB7",
+            184 => r"\xB8",
+            185 => r"\xB9",
+            186 => r"\xBA",
+            187 => r"\xBB",
+            188 => r"\xBC",
+            189 => r"\xBD",
+            190 => r"\xBE",
+            191 => r"\xBF",
+            192 => r"\xC0",
+            193 => r"\xC1",
+            194 => r"\xC2",
+            195 => r"\xC3",
+            196 => r"\xC4",
+            197 => r"\xC5",
+            198 => r"\xC6",
+            199 => r"\xC7",
+            200 => r"\xC8",
+            201 => r"\xC9",
+            202 => r"\xCA",
+            203 => r"\xCB",
+            204 => r"\xCC",
+            205 => r"\xCD",
+            206 => r"\xCE",
+            207 => r"\xCF",
+            208 => r"\xD0",
+            209 => r"\xD1",
+            210 => r"\xD2",
+            211 => r"\xD3",
+            212 => r"\xD4",
+            213 => r"\xD5",
+            214 => r"\xD6",
+            215 => r"\xD7",
+            216 => r"\xD8",
+            217 => r"\xD9",
+            218 => r"\xDA",
+            219 => r"\xDB",
+            220 => r"\xDC",
+            221 => r"\xDD",
+            222 => r"\xDE",
+            223 => r"\xDF",
+            224 => r"\xE0",
+            225 => r"\xE1",
+            226 => r"\xE2",
+            227 => r"\xE3",
+            228 => r"\xE4",
+            229 => r"\xE5",
+            230 => r"\xE6",
+            231 => r"\xE7",
+            232 => r"\xE8",
+            233 => r"\xE9",
+            234 => r"\xEA",
+            235 => r"\xEB",
+            236 => r"\xEC",
+            237 => r"\xED",
+            238 => r"\xEE",
+            239 => r"\xEF",
+            240 => r"\xF0",
+            241 => r"\xF1",
+            242 => r"\xF2",
+            243 => r"\xF3",
+            244 => r"\xF4",
+            245 => r"\xF5",
+            246 => r"\xF6",
+            247 => r"\xF7",
+            248 => r"\xF8",
+            249 => r"\xF9",
+            250 => r"\xFA",
+            251 => r"\xFB",
+            252 => r"\xFC",
+            253 => r"\xFD",
+            254 => r"\xFE",
+            255 => r"\xFF",
+        };
+        Self(escape.chars())
+    }
+}
+
+impl Iterator for Literal {
+    type Item = char;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+
+    #[inline]
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        self.0.nth(n)
+    }
+
+    #[inline]
+    fn count(self) -> usize {
+        self.0.count()
+    }
+}
+
+impl DoubleEndedIterator for Literal {
+    #[inline]
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.0.next_back()
+    }
+
+    #[inline]
+    fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
+        self.0.nth_back(n)
+    }
+}
+
+impl FusedIterator for Literal {}
+
+#[cfg(test)]
+mod tests {
+    use super::Inspect;
+    use alloc::string::String;
+
+    // From spec/core/symbol/inspect_spec.rb:
+    //
+    // ```ruby
+    // symbols = {
+    //   fred:         ":fred",
+    //   :fred?     => ":fred?",
+    //   :fred!     => ":fred!",
+    //   :$ruby     => ":$ruby",
+    //   :@ruby     => ":@ruby",
+    //   :@@ruby    => ":@@ruby",
+    //   :"$ruby!"  => ":\"$ruby!\"",
+    //   :"$ruby?"  => ":\"$ruby?\"",
+    //   :"@ruby!"  => ":\"@ruby!\"",
+    //   :"@ruby?"  => ":\"@ruby?\"",
+    //   :"@@ruby!" => ":\"@@ruby!\"",
+    //   :"@@ruby?" => ":\"@@ruby?\"",
+    //
+    //   :$-w       => ":$-w",
+    //   :"$-ww"    => ":\"$-ww\"",
+    //   :"$+"      => ":$+",
+    //   :"$~"      => ":$~",
+    //   :"$:"      => ":$:",
+    //   :"$?"      => ":$?",
+    //   :"$<"      => ":$<",
+    //   :"$_"      => ":$_",
+    //   :"$/"      => ":$/",
+    //   :"$'"      => ":$'",
+    //   :"$\""     => ":$\"",
+    //   :"$$"      => ":$$",
+    //   :"$."      => ":$.",
+    //   :"$,"      => ":$,",
+    //   :"$`"      => ":$`",
+    //   :"$!"      => ":$!",
+    //   :"$;"      => ":$;",
+    //   :"$\\"     => ":$\\",
+    //   :"$="      => ":$=",
+    //   :"$*"      => ":$*",
+    //   :"$>"      => ":$>",
+    //   :"$&"      => ":$&",
+    //   :"$@"      => ":$@",
+    //   :"$1234"   => ":$1234",
+    //
+    //   :-@        => ":-@",
+    //   :+@        => ":+@",
+    //   :%         => ":%",
+    //   :&         => ":&",
+    //   :*         => ":*",
+    //   :**        => ":**",
+    //   :"/"       => ":/",     # lhs quoted for emacs happiness
+    //   :<         => ":<",
+    //   :<=        => ":<=",
+    //   :<=>       => ":<=>",
+    //   :==        => ":==",
+    //   :===       => ":===",
+    //   :=~        => ":=~",
+    //   :>         => ":>",
+    //   :>=        => ":>=",
+    //   :>>        => ":>>",
+    //   :[]        => ":[]",
+    //   :[]=       => ":[]=",
+    //   :"\<\<"    => ":\<\<",
+    //   :^         => ":^",
+    //   :"`"       => ":`",     # for emacs, and justice!
+    //   :~         => ":~",
+    //   :|         => ":|",
+    //
+    //   :"!"       => [":\"!\"",  ":!" ],
+    //   :"!="      => [":\"!=\"", ":!="],
+    //   :"!~"      => [":\"!~\"", ":!~"],
+    //   :"\$"      => ":\"$\"", # for justice!
+    //   :"&&"      => ":\"&&\"",
+    //   :"'"       => ":\"\'\"",
+    //   :","       => ":\",\"",
+    //   :"."       => ":\".\"",
+    //   :".."      => ":\"..\"",
+    //   :"..."     => ":\"...\"",
+    //   :":"       => ":\":\"",
+    //   :"::"      => ":\"::\"",
+    //   :";"       => ":\";\"",
+    //   :"="       => ":\"=\"",
+    //   :"=>"      => ":\"=>\"",
+    //   :"\?"      => ":\"?\"", # rawr!
+    //   :"@"       => ":\"@\"",
+    //   :"||"      => ":\"||\"",
+    //   :"|||"     => ":\"|||\"",
+    //   :"++"      => ":\"++\"",
+    //
+    //   :"\""      => ":\"\\\"\"",
+    //   :"\"\""    => ":\"\\\"\\\"\"",
+    //
+    //   :"9"       => ":\"9\"",
+    //   :"foo bar" => ":\"foo bar\"",
+    //   :"*foo"    => ":\"*foo\"",
+    //   :"foo "    => ":\"foo \"",
+    //   :" foo"    => ":\" foo\"",
+    //   :" "       => ":\" \"",
+    // }
+    // ```
+
+    #[test]
+    fn empty() {
+        let inspect = Inspect::from("");
+        let debug = inspect.collect::<String>();
+        assert_eq!(debug, r#":"""#);
+    }
+
+    #[test]
+    fn fred() {
+        let inspect = Inspect::from("fred");
+        let debug = inspect.collect::<String>();
+        assert_eq!(debug, ":fred");
+    }
+
+    #[test]
+    fn invalid_utf8() {
+        let inspect = Inspect::from(&b"invalid-\xFF-utf8"[..]);
+        let debug = inspect.collect::<String>();
+        assert_eq!(debug, r#":"invalid-\xFF-utf8""#);
+    }
+}

--- a/spinoso-symbol/src/inspect.rs
+++ b/spinoso-symbol/src/inspect.rs
@@ -8,11 +8,48 @@ use core::str::Chars;
 /// This struct is created by the [`inspect`] method on [`Symbol`]. See its
 /// documentation for more.
 ///
-/// To format a `Symbol` directly into a writer, see [`format_inspect_into`].
+/// To format a `Symbol` directly into a writer, see [`format_inspect_into`] or
+/// [`write_inspect_into`].
+///
+/// # Examples
+///
+/// To inspect an empty bytestring:
+///
+/// ```
+/// # extern crate alloc;
+/// # use alloc::string::String;
+/// # use spinoso_symbol::Inspect;
+/// let inspect = Inspect::default();
+/// let debug = inspect.collect::<String>();
+/// assert_eq!(debug, r#":"""#);
+/// ```
+///
+/// To inspect a well-formed UTF-8 bytestring:
+///
+/// ```
+/// # extern crate alloc;
+/// # use alloc::string::String;
+/// # use spinoso_symbol::Inspect;
+/// let inspect = Inspect::from("spinoso");
+/// let debug = inspect.collect::<String>();
+/// assert_eq!(debug, ":spinoso");
+/// ```
+///
+/// To inspect a bytestring with invalid UTF-8 bytes:
+///
+/// ```
+/// # extern crate alloc;
+/// # use alloc::string::String;
+/// # use spinoso_symbol::Inspect;
+/// let inspect = Inspect::from(&b"invalid-\xFF-utf8"[..]);
+/// let debug = inspect.collect::<String>();
+/// assert_eq!(debug, r#":"invalid-\xFF-utf8""#);
+/// ```
 ///
 /// [`inspect`]: crate::Symbol::inspect
 /// [`Symbol`]: crate::Symbol
 /// [`format_inspect_into`]: crate::Symbol::format_inspect_into
+/// [`write_inspect_into`]: crate::Symbol::write_inspect_into
 #[must_use = "Iterator"]
 #[derive(Default, Debug, Clone)]
 #[cfg_attr(docsrs, doc(cfg(feature = "artichoke")))]

--- a/spinoso-symbol/src/lib.rs
+++ b/spinoso-symbol/src/lib.rs
@@ -133,7 +133,7 @@ pub struct SymbolOverflowError {
 
 impl SymbolOverflowError {
     /// The maximum identifier of a `Symbol`.
-    pub const MAX_CAPACITY: usize = u32::MAX as usize;
+    pub const MAX_IDENTIFIER: usize = u32::MAX as usize;
 
     /// Construct a new, default `SymbolOverflowError`.
     #[inline]
@@ -279,7 +279,8 @@ impl Symbol {
     /// Returns an iterator that yields a debug representation of the interned
     /// byteslice associated with the symbol in the underlying interner.
     ///
-    /// This iterator produces strings like `:spinoso` and `:invalid-\xFF-utf8`.
+    /// This iterator produces [`char`] sequences like `:spinoso` and
+    /// `:invalid-\xFF-utf8`.
     ///
     /// If there symbol does not exist in the underlying interner or there is an
     /// error looking up the symbol in the underlying interner, a default
@@ -303,9 +304,9 @@ impl Symbol {
     /// representation of the interned byteslice associated with the symbol in
     /// the underlying interner.
     ///
-    /// This formatter produces strings like `:spinoso` and
-    /// `:invalid-\xFF-utf8`. To see example output of the underlying iterator,
-    /// see the [`Inspect`] documentation.
+    /// This formatter writes content like `:spinoso` and `:invalid-\xFF-utf8`.
+    /// To see example output of the underlying iterator, see the [`Inspect`]
+    /// documentation.
     ///
     /// To write binary output, use [`write_inspect_into`], which requires the
     /// `std` feature to be activated.
@@ -340,9 +341,9 @@ impl Symbol {
     /// representation of the interned byteslice associated with the symbol in
     /// the underlying interner.
     ///
-    /// This formatter produces bytestrings like `:spinoso` and
-    /// `:invalid-\xFF-utf8`.To see example output of the underlying iterator,
-    /// see the [`Inspect`] documentation.
+    /// This formatter writes content like `:spinoso` and `:invalid-\xFF-utf8`.
+    /// To see example output of the underlying iterator, see the [`Inspect`]
+    /// documentation.
     ///
     /// To write to a `String` formatter, use [`format_inspect_into`].
     ///

--- a/spinoso-symbol/src/lib.rs
+++ b/spinoso-symbol/src/lib.rs
@@ -261,7 +261,7 @@ impl Symbol {
     #[must_use]
     #[cfg(feature = "artichoke")]
     #[cfg_attr(docsrs, doc(cfg(feature = "artichoke")))]
-    pub fn bytes<'a, T, U>(self, interner: &'a T) -> &'a [u8]
+    pub fn bytes<T, U>(self, interner: &T) -> &[u8]
     where
         T: Intern<Symbol = U>,
         U: Copy + From<Symbol>,
@@ -284,7 +284,7 @@ impl Symbol {
     #[inline]
     #[cfg(feature = "artichoke")]
     #[cfg_attr(docsrs, doc(cfg(feature = "artichoke")))]
-    pub fn inspect<'a, T, U>(self, interner: &'a T) -> Inspect<'a>
+    pub fn inspect<T, U>(self, interner: &T) -> Inspect<'_>
     where
         T: Intern<Symbol = U>,
         U: Copy + From<Symbol>,
@@ -309,11 +309,16 @@ impl Symbol {
     /// error looking up the symbol in the underlying interner, a default
     /// inspect representation is written.
     ///
+    /// # Errors
+    ///
+    /// If the given writer returns an error as it is being written to, that
+    /// error is returned.
+    ///
     /// [`write_inspect_into`]: Self::write_inspect_into
     #[inline]
     #[cfg(feature = "artichoke")]
     #[cfg_attr(docsrs, doc(cfg(feature = "artichoke")))]
-    pub fn format_inspect_into<'a, T, U, W>(self, interner: &'a T, mut dest: W) -> fmt::Result
+    pub fn format_inspect_into<T, U, W>(self, interner: &T, mut dest: W) -> fmt::Result
     where
         T: Intern<Symbol = U>,
         U: Copy + From<Symbol>,
@@ -339,15 +344,16 @@ impl Symbol {
     /// error looking up the symbol in the underlying interner, a default
     /// inspect representation is written.
     ///
+    /// # Errors
+    ///
+    /// If the given writer returns an error as it is being written to, that
+    /// error is returned.
+    ///
     /// [`format_inspect_into`]: Self::format_inspect_into
     #[inline]
     #[cfg(all(feature = "artichoke", feature = "std"))]
     #[cfg_attr(docsrs, doc(cfg((feature = "artichoke"), feature = "std")))]
-    pub fn write_inspect_into<'a, T, U, W>(
-        self,
-        interner: &'a T,
-        mut dest: W,
-    ) -> std::io::Result<()>
+    pub fn write_inspect_into<T, U, W>(self, interner: &T, mut dest: W) -> std::io::Result<()>
     where
         T: Intern<Symbol = U>,
         U: Copy + From<Symbol>,

--- a/spinoso-symbol/src/lib.rs
+++ b/spinoso-symbol/src/lib.rs
@@ -89,6 +89,7 @@ readme!();
 
 #[cfg(feature = "artichoke")]
 use artichoke_core::intern::Intern;
+use core::borrow::Borrow;
 use core::fmt;
 use core::mem::size_of;
 use core::num::TryFromIntError;
@@ -171,6 +172,12 @@ impl std::error::Error for SymbolOverflowError {}
 /// `Symbol`s are not constrained to the interner which created them.
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Symbol(u32);
+
+impl Borrow<u32> for Symbol {
+    fn borrow(&self) -> &u32 {
+        &self.0
+    }
+}
 
 impl Symbol {
     /// Construct a new `Symbol` from the given `u32`.

--- a/spinoso-symbol/src/lib.rs
+++ b/spinoso-symbol/src/lib.rs
@@ -295,4 +295,29 @@ impl Symbol {
             Inspect::default()
         }
     }
+
+    /// Write an [`Inspect`] iterator into the given destination using the debug
+    /// representation of the interned byteslice associated with the symbol in
+    /// the underlying interner.
+    ///
+    /// This formatter produces strings like `:spinoso` and `:invalid-\xFF-utf8`.
+    ///
+    /// If there symbol does not exist in the underlying interner or there is an
+    /// error looking up the symbol in the underlying interner, a default
+    /// inspect representation is written.
+    #[inline]
+    #[cfg(feature = "artichoke")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "artichoke")))]
+    pub fn format_inspect_into<'a, T, U, W>(self, interner: &'a T, mut dest: W) -> fmt::Result
+    where
+        T: Intern<Symbol = U>,
+        U: Copy + From<Symbol>,
+        W: fmt::Write,
+    {
+        let inspect = self.inspect(interner);
+        for ch in inspect {
+            dest.write_char(ch)?;
+        }
+        Ok(())
+    }
 }

--- a/spinoso-symbol/src/lib.rs
+++ b/spinoso-symbol/src/lib.rs
@@ -261,13 +261,12 @@ impl Symbol {
     #[must_use]
     #[cfg(feature = "artichoke")]
     #[cfg_attr(docsrs, doc(cfg(feature = "artichoke")))]
-    pub fn bytes<'a, T, U>(&self, interner: &'a T) -> &'a [u8]
+    pub fn bytes<'a, T, U>(self, interner: &'a T) -> &'a [u8]
     where
         T: Intern<Symbol = U>,
         U: Copy + From<Symbol>,
     {
-        let sym = *self;
-        if let Ok(Some(bytes)) = interner.lookup_symbol(sym.into()) {
+        if let Ok(Some(bytes)) = interner.lookup_symbol(self.into()) {
             bytes
         } else {
             &[]
@@ -283,16 +282,14 @@ impl Symbol {
     /// error looking up the symbol in the underlying interner, a default
     /// iterator is returned.
     #[inline]
-    #[must_use]
     #[cfg(feature = "artichoke")]
     #[cfg_attr(docsrs, doc(cfg(feature = "artichoke")))]
-    pub fn inspect<'a, T, U>(&self, interner: &'a T) -> Inspect<'a>
+    pub fn inspect<'a, T, U>(self, interner: &'a T) -> Inspect<'a>
     where
         T: Intern<Symbol = U>,
         U: Copy + From<Symbol>,
     {
-        let sym = *self;
-        if let Ok(Some(bytes)) = interner.lookup_symbol(sym.into()) {
+        if let Ok(Some(bytes)) = interner.lookup_symbol(self.into()) {
             Inspect::from(bytes)
         } else {
             Inspect::default()

--- a/spinoso-symbol/src/lib.rs
+++ b/spinoso-symbol/src/lib.rs
@@ -53,7 +53,10 @@
 //!
 //! - **artichoke** - Enables additional methods, functions, and types for
 //!   implementing APIs from Ruby Core. Dropping this feature removes the
-//!   `artichoke-core`, `bstr`, and `focaccia` dependencies.
+//!   `artichoke-core` and `focaccia` dependencies. Activating this feature also
+//!   activates the **inspect** feature.
+//! - **inspect** - Enables an iterator for generating debug output of a symbol
+//!   bytestring. Dropping this feature removes the `bstr` dependency.
 //! - **std** - Enables a dependency on the Rust Standard Library. Activating
 //!   this feature enables [`std::error::Error`] impls on error types in this
 //!   crate.
@@ -108,14 +111,14 @@ mod all_symbols;
 mod casecmp;
 mod convert;
 mod eq;
-#[cfg(feature = "artichoke")]
+#[cfg(feature = "inspect")]
 mod inspect;
 
 #[cfg(feature = "artichoke")]
 pub use all_symbols::{AllSymbols, InternerAllSymbols};
 #[cfg(feature = "artichoke")]
 pub use casecmp::{ascii_casecmp, unicode_case_eq};
-#[cfg(feature = "artichoke")]
+#[cfg(feature = "inspect")]
 pub use inspect::Inspect;
 
 /// Error returned when a symbol identifier overflows.

--- a/spinoso-symbol/src/lib.rs
+++ b/spinoso-symbol/src/lib.rs
@@ -352,7 +352,7 @@ impl Symbol {
     /// [`format_inspect_into`]: Self::format_inspect_into
     #[inline]
     #[cfg(all(feature = "artichoke", feature = "std"))]
-    #[cfg_attr(docsrs, doc(cfg((feature = "artichoke"), feature = "std")))]
+    #[cfg_attr(docsrs, doc(cfg(all(feature = "artichoke", feature = "std"))))]
     pub fn write_inspect_into<T, U, W>(self, interner: &T, mut dest: W) -> std::io::Result<()>
     where
         T: Intern<Symbol = U>,

--- a/spinoso-symbol/src/lib.rs
+++ b/spinoso-symbol/src/lib.rs
@@ -18,13 +18,71 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(docsrs, feature(doc_alias))]
 
-//! Symbol type, etc.
+//! Identifier for interned bytestrings and routines for manipulating the
+//! underlying bytestrings.
+//!
+//! `Symbol` is a `Copy` type based on `u32`. `Symbol` is cheap to copy, store,
+//! and compare. It is suitable for representing indexes into a string interner.
+//!
+//! # Artichoke integration
+//!
+//! This crate has an `artichoke` Cargo feature. When this feature is active,
+//! this crate implements [the `Symbol` API from Ruby Core]. These APIs require
+//! resolving the underlying bytes associated with the `Symbol` via a type that
+//! implements `Intern` from `artichoke-core`.
+//!
+//! APIs that require this feature to be active are highlighted in the
+//! documentation.
+//!
+//! This crate provides an `AllSymbols` iterator for walking all symbols stored
+//! in an [`Intern`]er and an extension trait for constructing it which is
+//! suitable for implementing [`Symbol::all_symbols`] from Ruby Core.
+//!
+//! This crate provides an `Inspect` iterator for converting `Symbol` byte
+//! content to a debug representation suitable for implementing
+//! [`Symbol#inspect`] from Ruby Core.
+//!
+//! # `no_std`
+//!
+//! This crate is `no_std` compatible when built without the `std` feature. This
+//! crate does not depend on [`alloc`].
+//!
+//! # Crate features
+//!
+//! All features are enabled by default.
+//!
+//! - **artichoke** - Enables additional methods, functions, and types for
+//!   implementing APIs from Ruby Core. Dropping this feature removes the
+//!   `artichoke-core`, `bstr`, and `focaccia` dependencies.
+//! - **std** - Enables a dependency on the Rust Standard Library. Activating
+//!   this feature enables [`std::error::Error`] impls on error types in this
+//!   crate.
+//!
+//! [the `Symbol` API from Ruby Core]: https://ruby-doc.org/core-2.6.3/Symbol.html
+//! [`Symbol::all_symbols`]: https://ruby-doc.org/core-2.6.3/Symbol.html#method-c-all_symbols
+//! [`Symbol#inspect`]: https://ruby-doc.org/core-2.6.3/Symbol.html#method-i-inspect
+//! [`alloc`]: https://doc.rust-lang.org/alloc/
+//! [`std::error::Error`]: https://doc.rust-lang.org/std/error/trait.Error.html
 
 // `spinoso-symbol` is a `no_std` crate unless the `std` feature is enabled.
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[cfg(test)]
 extern crate alloc;
+
+// Ensure code blocks in README.md compile
+#[cfg(doctest)]
+macro_rules! readme {
+    ($x:expr) => {
+        #[doc = $x]
+        mod readme {}
+    };
+    () => {
+        readme!(include_str!("../README.md"));
+    };
+}
+#[cfg(doctest)]
+readme!();
 
 #[cfg(feature = "artichoke")]
 use artichoke_core::intern::Intern;

--- a/spinoso-symbol/src/lib.rs
+++ b/spinoso-symbol/src/lib.rs
@@ -1,0 +1,243 @@
+#![warn(clippy::all)]
+#![warn(clippy::pedantic)]
+#![warn(clippy::cargo)]
+#![allow(unknown_lints)]
+#![warn(broken_intra_doc_links)]
+#![warn(missing_docs)]
+#![warn(missing_debug_implementations)]
+#![warn(missing_copy_implementations)]
+#![warn(rust_2018_idioms)]
+#![warn(trivial_casts, trivial_numeric_casts)]
+#![warn(unused_qualifications)]
+#![warn(variant_size_differences)]
+#![forbid(unsafe_code)]
+// Enable feature callouts in generated documentation:
+// https://doc.rust-lang.org/beta/unstable-book/language-features/doc-cfg.html
+//
+// This approach is borrowed from tokio.
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_alias))]
+
+//! Symbol type, etc.
+
+// `spinoso-symbol` is a `no_std` crate unless the `std` feature is enabled.
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(test)]
+extern crate alloc;
+
+#[cfg(feature = "artichoke")]
+use artichoke_core::intern::Intern;
+use core::fmt;
+use core::mem::size_of;
+use core::num::TryFromIntError;
+
+#[doc(inline)]
+#[cfg(feature = "artichoke")]
+#[cfg_attr(docsrs, doc(cfg(feature = "artichoke")))]
+pub use focaccia::{CaseFold, NoSuchCaseFoldingScheme};
+
+// Spinoso symbol assumes symbols are `u32` and requires `usize` to be at least
+// as big as `u32`.
+//
+// This const-evaluated expression will fail to compile if this invariant does
+// not hold.
+const _: () = [()][!(size_of::<usize>() >= size_of::<u32>()) as usize];
+
+#[cfg(feature = "artichoke")]
+mod all_symbols;
+#[cfg(feature = "artichoke")]
+mod casecmp;
+mod convert;
+mod eq;
+#[cfg(feature = "artichoke")]
+mod inspect;
+
+#[cfg(feature = "artichoke")]
+pub use all_symbols::{AllSymbols, InternerAllSymbols};
+#[cfg(feature = "artichoke")]
+pub use casecmp::{ascii_casecmp, unicode_case_eq};
+#[cfg(feature = "artichoke")]
+pub use inspect::Inspect;
+
+/// Error returned when a symbol identifier overflows.
+///
+/// Spinoso symbol uses `u32` identifiers for symbols to save space. If more
+/// than `u32::MAX` symbols are stored in the underlying table, no more
+/// identifiers can be generated.
+#[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub struct SymbolOverflowError {
+    _private: (),
+}
+
+impl SymbolOverflowError {
+    /// The maximum identifier of a `Symbol`.
+    pub const MAX_CAPACITY: usize = u32::MAX as usize;
+
+    /// Construct a new, default `SymbolOverflowError`.
+    #[inline]
+    #[must_use]
+    pub const fn new() -> Self {
+        Self { _private: () }
+    }
+}
+
+impl From<TryFromIntError> for SymbolOverflowError {
+    #[inline]
+    fn from(err: TryFromIntError) -> Self {
+        let _ = err;
+        Self::new()
+    }
+}
+
+impl fmt::Display for SymbolOverflowError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("Symbol overflow")
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for SymbolOverflowError {}
+
+/// Identifier bound to an interned bytestring.
+///
+/// A `Symbol` allows retrieving a reference to the original interned
+/// bytestring.  Equivalent `Symbol`s will resolve to an identical bytestring.
+///
+/// `Symbol`s are based on a `u32` index. They are cheap to compare and cheap to
+/// copy.
+///
+/// `Symbol`s are not constrained to the interner which created them.
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Symbol(u32);
+
+impl Symbol {
+    /// Construct a new `Symbol` from the given `u32`.
+    ///
+    /// `Symbol`s constructed manually may fail to resolve to an underlying
+    /// bytesstring.
+    ///
+    /// `Symbol`s are not constrained to the interner which created them.
+    /// No runtime checks ensure that the underlying interner is called with a
+    /// `Symbol` that the interner itself issued.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_symbol::Symbol;
+    /// let sym = Symbol::new(263);
+    /// assert_eq!(sym.id(), 263);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub const fn new(id: u32) -> Self {
+        Self(id)
+    }
+
+    /// Return the `u32` identifier from this `Symbol`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_symbol::Symbol;
+    /// let sym = Symbol::new(263);
+    /// assert_eq!(sym.id(), 263);
+    /// assert_eq!(u32::from(sym), 263);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub const fn id(self) -> u32 {
+        self.0
+    }
+
+    /// Returns whether the symbol is the empty byteslice `b""` in the
+    /// underlying interner.
+    ///
+    /// If there symbol does not exist in the underlying interner or there is an
+    /// error looking up the symbol in the underlying interner, `true` is
+    /// returned.
+    #[inline]
+    #[must_use]
+    #[cfg(feature = "artichoke")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "artichoke")))]
+    pub fn is_empty<T, U>(self, interner: &T) -> bool
+    where
+        T: Intern<Symbol = U>,
+        U: Copy + From<Symbol>,
+    {
+        if let Ok(Some(bytes)) = interner.lookup_symbol(self.into()) {
+            bytes.is_empty()
+        } else {
+            true
+        }
+    }
+
+    /// Returns the length of the byteslice associated with the symbol in the
+    /// underlying interner.
+    ///
+    /// If there symbol does not exist in the underlying interner or there is an
+    /// error looking up the symbol in the underlying interner, `0` is returned.
+    #[inline]
+    #[must_use]
+    #[cfg(feature = "artichoke")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "artichoke")))]
+    pub fn len<T, U>(self, interner: &T) -> usize
+    where
+        T: Intern<Symbol = U>,
+        U: Copy + From<Symbol>,
+    {
+        if let Ok(Some(bytes)) = interner.lookup_symbol(self.into()) {
+            bytes.len()
+        } else {
+            0_usize
+        }
+    }
+
+    /// Returns the interned byteslice associated with the symbol in the
+    /// underlying interner.
+    ///
+    /// If there symbol does not exist in the underlying interner or there is an
+    /// error looking up the symbol in the underlying interner, `&[]` is
+    /// returned.
+    #[inline]
+    #[must_use]
+    #[cfg(feature = "artichoke")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "artichoke")))]
+    pub fn bytes<'a, T, U>(&self, interner: &'a T) -> &'a [u8]
+    where
+        T: Intern<Symbol = U>,
+        U: Copy + From<Symbol>,
+    {
+        let sym = *self;
+        if let Ok(Some(bytes)) = interner.lookup_symbol(sym.into()) {
+            bytes
+        } else {
+            &[]
+        }
+    }
+
+    /// Returns an iterator that yields a debug representation of the interned
+    /// byteslice associated with the symbol in the underlying interner.
+    ///
+    /// This iterator produces strings like `:spinoso` and `:invalid-\xFF-utf8`.
+    ///
+    /// If there symbol does not exist in the underlying interner or there is an
+    /// error looking up the symbol in the underlying interner, a default
+    /// iterator is returned.
+    #[inline]
+    #[must_use]
+    #[cfg(feature = "artichoke")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "artichoke")))]
+    pub fn inspect<'a, T, U>(&self, interner: &'a T) -> Inspect<'a>
+    where
+        T: Intern<Symbol = U>,
+        U: Copy + From<Symbol>,
+    {
+        let sym = *self;
+        if let Ok(Some(bytes)) = interner.lookup_symbol(sym.into()) {
+            Inspect::from(bytes)
+        } else {
+            Inspect::default()
+        }
+    }
+}

--- a/spinoso-symbol/src/lib.rs
+++ b/spinoso-symbol/src/lib.rs
@@ -300,7 +300,9 @@ impl Symbol {
     /// representation of the interned byteslice associated with the symbol in
     /// the underlying interner.
     ///
-    /// This formatter produces strings like `:spinoso` and `:invalid-\xFF-utf8`.
+    /// This formatter produces strings like `:spinoso` and
+    /// `:invalid-\xFF-utf8`. To see example output of the underlying iterator,
+    /// see the [`Inspect`] documentation.
     ///
     /// To write binary output, use [`write_inspect_into`], which requires the
     /// `std` feature to be activated.
@@ -336,7 +338,8 @@ impl Symbol {
     /// the underlying interner.
     ///
     /// This formatter produces bytestrings like `:spinoso` and
-    /// `:invalid-\xFF-utf8`.
+    /// `:invalid-\xFF-utf8`.To see example output of the underlying iterator,
+    /// see the [`Inspect`] documentation.
     ///
     /// To write to a `String` formatter, use [`format_inspect_into`].
     ///


### PR DESCRIPTION
This continues the experiement started with `spinoso-array` (#759) to extract
data structures from `artichoke-backend` and generically implement Ruby
Core.

`spinoso-symbol` goes further than `spinoso-array` by implementing
`Symbol` APIs that depend on an Artichoke interpreter. It does this by
having an `artichoke` Cargo feature that pulls in `artichoke-core`. APIs
that require resolving the underlying `Symbol` byte content take a
generic parameter `T where T: Intern`.

`spinoso-symbol` implements an `AllSymbols` iterator that is `'static`
and implements a buggy version of `Symbol#inspect` with an iterator (#725).

`spinoso-symbol` resolves `Symbol` byte contents for ASCII and Unicode
casecmp functions using `focaccia`. `spinoso-symbol` also depends on
`bstr`.

`spinoso-symbol` re-exports some types from `focaccia`.

`spinoso-symbol` is agnostic over symbol table backend.

`spinoso-symbol` has a `std` feature that implements `std::error::Error`
on some types.

This PR adds most `Symbol` specs to `enforced-specs.yaml`.