### PR TITLE
Split Array GC routines out of data structure

### DIFF
--- a/artichoke-backend/src/extn/core/array/ffi.rs
+++ b/artichoke-backend/src/extn/core/array/ffi.rs
@@ -2,6 +2,7 @@ use std::convert::TryFrom;
 use std::ptr;
 use std::slice;
 
+use crate::extn::core::array::gc;
 use crate::extn::core::array::Array;
 use crate::extn::prelude::*;
 use crate::gc::{MrbGarbageCollection, State as GcState};
@@ -333,7 +334,7 @@ unsafe extern "C" fn artichoke_gc_mark_ary(mrb: *mut sys::mrb_state, ary: sys::m
     let mut guard = Guard::new(&mut interp);
     let mut array = Value::from(ary);
     if let Ok(array) = Array::unbox_from_value(&mut array, &mut guard) {
-        array.gc_mark(&mut guard);
+        gc::mark(&array, &mut guard);
     }
 }
 
@@ -346,7 +347,7 @@ unsafe extern "C" fn artichoke_gc_mark_ary_size(
     let mut guard = Guard::new(&mut interp);
     let mut array = Value::from(ary);
     if let Ok(array) = Array::unbox_from_value(&mut array, &mut guard) {
-        array.real_children()
+        gc::children(&array)
     } else {
         0
     }

--- a/artichoke-backend/src/extn/core/array/gc.rs
+++ b/artichoke-backend/src/extn/core/array/gc.rs
@@ -1,0 +1,26 @@
+//! Garbage collection routines for `Array` types.
+
+use super::Array;
+use crate::gc::MrbGarbageCollection;
+use crate::Artichoke;
+
+/// Mark all elements in the `Array` as reachable to the garbage collector.
+///
+/// This method ensures that the contents of the conained
+/// [`sys::mrb_value`]s do not get deallocated while the given `Array` is alive
+/// in the mruby VM.
+pub fn mark(ary: &Array, interp: &mut Artichoke) {
+    for elem in ary {
+        interp.mark_value(&elem);
+    }
+}
+
+/// The count of [`sys::mrb_value`]s in the given `Array`.
+///
+/// This method allows for `Array`s with holes or other virtualized
+/// elements. `Array` does not store virtual elements so this method always
+/// returns the array's length.
+#[must_use]
+pub fn children(ary: &Array) -> usize {
+    ary.len()
+}

--- a/artichoke-backend/src/extn/core/array/mod.rs
+++ b/artichoke-backend/src/extn/core/array/mod.rs
@@ -8,6 +8,7 @@ use crate::extn::prelude::*;
 pub mod args;
 mod boxing;
 mod ffi;
+mod gc;
 pub mod mruby;
 pub mod trampoline;
 
@@ -152,27 +153,6 @@ impl Array {
 
     pub fn clear(&mut self) {
         self.0.clear();
-    }
-
-    /// Mark all elements in the `Array` as reachable to the garbage collector.
-    ///
-    /// This method ensures that the contents of the conained
-    /// [`sys::mrb_value`]s do not get deallocated while this `Array` is alive
-    /// in the mruby VM.
-    pub fn gc_mark(&self, interp: &mut Artichoke) {
-        for elem in self {
-            interp.mark_value(&elem);
-        }
-    }
-
-    /// The count of [`sys::mrb_value`]s in this `Array`.
-    ///
-    /// This method allows for `Array`s with holes or other virtualized
-    /// elements. `Array` does not store virtual elements so this method always
-    /// returns the array's length.
-    #[must_use]
-    fn real_children(&self) -> usize {
-        self.0.len()
     }
 
     pub fn initialize(


### PR DESCRIPTION
These functions are specific to mruby. If `Array` APIs are moved to
`spinoso-array`, these functions cannot go with them.