### PR TITLE
Add Symbol#to_proc to enforced ruby/specs

### DIFF
--- a/artichoke-backend/src/extn/core/symbol/symbol.rb
+++ b/artichoke-backend/src/extn/core/symbol/symbol.rb
@@ -74,7 +74,18 @@ class Symbol
   end
 
   def to_proc
-    ->(obj, *args, &block) { obj.__send__(self, *args, &block) }
+    pr = lambda do |*args, &block|
+      raise ArgumentError, 'no receiver given' if args.empty?
+
+      obj, *rest = *args
+      obj.__send__(self, *rest, &block)
+    end
+
+    def pr.parameters
+      [[:rest]]
+    end
+
+    pr
   end
 
   # Implemented in native code.

--- a/spec-runner/enforced-specs.yaml
+++ b/spec-runner/enforced-specs.yaml
@@ -89,8 +89,7 @@ core:
       - succ
       - swapcase
       - symbol
-      # Requires working `Symbol#inspect` impl
-      # - to_proc
+      - to_proc
       - to_s
       - to_sym
       # Requires investments to Unicode support in `String`


### PR DESCRIPTION
This required moving from a stabby lambda definition to a more relaxed
lambda expression, checking for no receiver, and overriding Proc#parameters.

Enabled by #787.