### PR TITLE
Improve handling of Unicode replacement character and invalid UTF-8 in Symbol#inspect

### DIFF
--- a/artichoke-backend/src/string.rs
+++ b/artichoke-backend/src/string.rs
@@ -43,6 +43,8 @@ use crate::Artichoke;
 ///
 /// This method only returns an error when the given writer returns an
 /// error.
+// TODO: deprecate this method and replace it with something like
+// `spinoso_symbol::Inspect`.
 pub fn format_unicode_debug_into<W>(mut f: W, string: &[u8]) -> Result<(), WriteError>
 where
     W: fmt::Write,

--- a/spinoso-symbol/src/lib.rs
+++ b/spinoso-symbol/src/lib.rs
@@ -123,6 +123,8 @@ mod eq;
 mod ident;
 #[cfg(feature = "inspect")]
 mod inspect;
+#[cfg(any(feature = "ident-parser", feature = "inspect"))]
+mod unicode;
 
 #[cfg(test)]
 mod fixtures;

--- a/spinoso-symbol/src/unicode.rs
+++ b/spinoso-symbol/src/unicode.rs
@@ -1,0 +1,39 @@
+pub use core::char::REPLACEMENT_CHARACTER;
+
+// ```ruby
+// [2.6.3] > "\u{FFFD}"
+// => "�"
+// [2.6.3] > "\u{FFFD}".bytes
+// => [239, 191, 189]
+// [2.6.3] > "\u{FFFD}".ord.to_s(16)
+// => "fffd"
+// [2.6.3] > '�'.ord
+// => 65533
+// [2.6.3] > '�'.ord.to_s(16)
+// => "fffd"
+// [2.6.3] > '�'.bytes
+// => [239, 191, 189]
+// ```
+pub const REPLACEMENT_CHARACTER_BYTES: [u8; 3] = [239, 191, 189];
+
+#[cfg(test)]
+mod tests {
+    use super::{REPLACEMENT_CHARACTER, REPLACEMENT_CHARACTER_BYTES};
+    use core::str;
+
+    #[test]
+    fn unicode_replacement_char_to_bytes() {
+        let mut enc = [0; 4];
+        let utf8_bytes = REPLACEMENT_CHARACTER.encode_utf8(&mut enc).as_bytes();
+        assert_eq!(utf8_bytes.len(), 3);
+        assert_eq!(utf8_bytes, REPLACEMENT_CHARACTER_BYTES);
+    }
+
+    #[test]
+    fn unicode_replacement_bytes_to_char() {
+        let enc = REPLACEMENT_CHARACTER_BYTES;
+        let string = str::from_utf8(&enc).unwrap();
+        assert_eq!(string.chars().count(), 1);
+        assert_eq!(string.chars().next().unwrap(), REPLACEMENT_CHARACTER);
+    }
+}


### PR DESCRIPTION
The `CharIndices` iterator in `bstr` overloads the meaning of � when iterating.
This requires testing the byte span to determine if the replacement character
is legitimate or a substitute char.

This uncovered a bug where otherwise valid idents with invalid UTF-8 bytes
would be considered valid identifiers.

This PR adds tests for these edge cases and fixes use of this iterator in ident
parsing and the `Inspect` iterator. The replacement character, if it legitimately
occurs in the byteslice, is no longer escaped.

Improve the quality of `Literal` escapes by including debug escapes of
ASCII control characters. These escapes include some debug escapes not
present in Rust like `\v` and `\f`. `Literal` also includes the escapes
for `"` and `\`, which eliminates some special states in the `next` and
`next_back` functions, removes the `Slash` enum and associated fields.

Add new `next_back` field to `inspect::State` to track `Literal`s
encountered when iterating backward through the byteslice.

While working on this, I reported BurntSushi/bstr#72.

Followup to #787 and #790.