### PR TITLE
Unsafe internals code quality improvements

### DIFF
--- a/artichoke-backend/src/method.rs
+++ b/artichoke-backend/src/method.rs
@@ -17,7 +17,7 @@ pub enum Type {
 #[derive(Debug, Clone)]
 pub struct Spec {
     name: Cow<'static, str>,
-    cstring: CString,
+    cstring: Box<CStr>,
     method_type: Type,
     method: Method,
     args: sys::mrb_aspec,
@@ -34,10 +34,10 @@ impl Spec {
         T: Into<Cow<'static, str>>,
     {
         let name = method_name.into();
-        if let Ok(method_cstr) = CString::new(name.as_ref()) {
+        if let Ok(cstring) = CString::new(name.as_ref()) {
             Ok(Self {
                 name,
-                cstring: method_cstr,
+                cstring: cstring.into_boxed_c_str(),
                 method_type,
                 method,
                 args,
@@ -67,7 +67,7 @@ impl Spec {
 
     #[must_use]
     pub fn name_c_str(&self) -> &CStr {
-        self.cstring.as_c_str()
+        self.cstring.as_ref()
     }
 
     /// Define this method on the class-like pointed to by `into`.

--- a/artichoke-backend/src/module.rs
+++ b/artichoke-backend/src/module.rs
@@ -122,13 +122,13 @@ impl<'a> Builder<'a> {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Rclass {
     sym: u32,
-    name: CString,
-    enclosing_scope: Option<Box<EnclosingRubyScope>>,
+    name: Box<CStr>,
+    enclosing_scope: Option<EnclosingRubyScope>,
 }
 
 impl Rclass {
     #[must_use]
-    pub fn new(sym: u32, name: CString, enclosing_scope: Option<Box<EnclosingRubyScope>>) -> Self {
+    pub fn new(sym: u32, name: Box<CStr>, enclosing_scope: Option<EnclosingRubyScope>) -> Self {
         Self {
             sym,
             name,
@@ -185,8 +185,8 @@ impl Rclass {
 pub struct Spec {
     name: Cow<'static, str>,
     sym: u32,
-    cstring: CString,
-    enclosing_scope: Option<Box<EnclosingRubyScope>>,
+    cstring: Box<CStr>,
+    enclosing_scope: Option<EnclosingRubyScope>,
 }
 
 impl Spec {
@@ -206,9 +206,9 @@ impl Spec {
             };
             Ok(Self {
                 name,
-                cstring,
+                cstring: cstring.into_boxed_c_str(),
                 sym,
-                enclosing_scope: enclosing_scope.map(Box::new),
+                enclosing_scope,
             })
         } else {
             Err(ConstantNameError::from(name).into())
@@ -225,12 +225,12 @@ impl Spec {
 
     #[must_use]
     pub fn name_c_str(&self) -> &CStr {
-        self.cstring.as_c_str()
+        self.cstring.as_ref()
     }
 
     #[must_use]
     pub fn enclosing_scope(&self) -> Option<&EnclosingRubyScope> {
-        self.enclosing_scope.as_deref()
+        self.enclosing_scope.as_ref()
     }
 
     #[must_use]


### PR DESCRIPTION
Remove unnecessary `CStr` unsafe from `mrb_state` debug functions

Replace unsafe calls to `CStr::from_bytes_with_nul_unchecked` with safe calls to
`CStr::from_bytes_with_nul` and additional error handling/squashing.

Update the tests module to pull in the test prelude.

---
Improve readability of `DefineConstant` impl in artichoke-backend

Short circuit return with `CString` errors to unnest the indent level.

Split calls to resolve `RClass` into separate `with_ffi_boundary` invocations.

---
Improve safety and code quality of artichoke-backend VM internals

- Add safety comments for `CString` pointer lifetime invariants being
  upheld by `class::Spec`.
- Store `Box<CStr>` instead of `CString` because these C strings do not
  need to be mutable.
- Refactor `EnclosingScope` enum to use tuple variants.
- Refactor `EnclosingScope` to store `Box`ed class and module specs.
  This fixes a long-standing inversion where the specs depended on
  `EnclosingScope`, but the implementation of `EnclosingScope` leaked
  into the method signature and field types of the specs.
- Refactor `EnclosingScope` to derive `Hash`, `PartialEq`, and `Eq`.
- Fixup outdated doc comments in `EnclosingScope` methods that
  referenced `Rc`. `Rc` has not been part of the `EnclosingScope`
  variants or API since #398.
- Make `ConstantNameError::new` a const function.