### PR TITLE
Add more const fn

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -148,7 +148,7 @@ jobs:
         uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --workspace --all-features
+          args: --workspace --all-features -- -A clippy::or_fun_call'
 
   ruby:
     name: Lint and format Ruby

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -148,9 +148,7 @@ jobs:
         uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          # disable or_fun_call lint until release of:
-          # https://github.com/rust-lang/rust-clippy/pull/5889
-          args: --workspace --all-features -- -A clippy::or_fun_call
+          args: --workspace --all-features
 
   ruby:
     name: Lint and format Ruby

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -148,7 +148,9 @@ jobs:
         uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --workspace --all-features -- -A clippy::or_fun_call'
+          # disable or_fun_call lint until release of:
+          # https://github.com/rust-lang/rust-clippy/pull/5889
+          args: --workspace --all-features -- -A clippy::or_fun_call
 
   ruby:
     name: Lint and format Ruby

--- a/Rakefile
+++ b/Rakefile
@@ -14,7 +14,9 @@ namespace :lint do
     roots.each do |root|
       FileUtils.touch(root)
     end
-    sh 'cargo clippy --workspace --all-features'
+    # disable or_fun_call lint until release of:
+    # https://github.com/rust-lang/rust-clippy/pull/5889
+    sh 'cargo clippy --workspace --all-features -- -A clippy::or_fun_call'
   end
 
   desc 'Run RuboCop'

--- a/Rakefile
+++ b/Rakefile
@@ -14,9 +14,7 @@ namespace :lint do
     roots.each do |root|
       FileUtils.touch(root)
     end
-    # disable or_fun_call lint until release of:
-    # https://github.com/rust-lang/rust-clippy/pull/5889
-    sh 'cargo clippy --workspace --all-features -- -A clippy::or_fun_call'
+    sh 'cargo clippy --workspace --all-features'
   end
 
   desc 'Run RuboCop'

--- a/artichoke-backend/src/artichoke.rs
+++ b/artichoke-backend/src/artichoke.rs
@@ -89,7 +89,7 @@ impl Artichoke {
             self.state = extracted.state;
             Ok(result)
         } else {
-            Err(InterpreterExtractError)
+            Err(InterpreterExtractError::new())
         }
     }
 

--- a/artichoke-backend/src/block.rs
+++ b/artichoke-backend/src/block.rs
@@ -93,18 +93,22 @@ impl From<Ruby> for NoBlockGiven {
 
 impl Default for NoBlockGiven {
     fn default() -> Self {
-        Self(Ruby::Nil)
+        Self::new()
     }
 }
 
 impl NoBlockGiven {
+    /// Construce a new, empty no block given error.
+    ///
+    /// The inner Ruby type is `nil`.
     #[must_use]
-    pub fn new() -> Self {
-        Self::default()
+    pub const fn new() -> Self {
+        Self(Ruby::Nil)
     }
 
+    /// Return the [`Ruby`] type of the object given instead of a block.
     #[must_use]
-    pub fn ruby_type(self) -> Ruby {
+    pub const fn ruby_type(self) -> Ruby {
         self.0
     }
 }

--- a/artichoke-backend/src/class.rs
+++ b/artichoke-backend/src/class.rs
@@ -48,7 +48,11 @@ impl<'a> Builder<'a> {
         T: Any,
         U: Into<Cow<'static, str>>,
     {
-        let state = self.interp.state.as_ref().ok_or(InterpreterExtractError)?;
+        let state = self
+            .interp
+            .state
+            .as_ref()
+            .ok_or(InterpreterExtractError::new())?;
         let rclass = if let Some(spec) = state.classes.get::<T>() {
             spec.rclass()
         } else {

--- a/artichoke-backend/src/class_registry.rs
+++ b/artichoke-backend/src/class_registry.rs
@@ -48,7 +48,7 @@ impl ClassRegistry for Artichoke {
     where
         T: Any,
     {
-        let state = self.state.as_mut().ok_or(InterpreterExtractError)?;
+        let state = self.state.as_mut().ok_or(InterpreterExtractError::new())?;
         state.classes.insert::<T>(Box::new(spec));
         Ok(())
     }
@@ -61,7 +61,7 @@ impl ClassRegistry for Artichoke {
     where
         T: Any,
     {
-        let state = self.state.as_ref().ok_or(InterpreterExtractError)?;
+        let state = self.state.as_ref().ok_or(InterpreterExtractError::new())?;
         let spec = state.classes.get::<T>();
         Ok(spec)
     }
@@ -70,7 +70,7 @@ impl ClassRegistry for Artichoke {
     where
         T: Any,
     {
-        let state = self.state.as_ref().ok_or(InterpreterExtractError)?;
+        let state = self.state.as_ref().ok_or(InterpreterExtractError::new())?;
         let spec = state.classes.get::<T>();
         let rclass = if let Some(spec) = spec {
             spec.rclass()
@@ -94,7 +94,7 @@ impl ClassRegistry for Artichoke {
     where
         T: Any,
     {
-        let state = self.state.as_ref().ok_or(InterpreterExtractError)?;
+        let state = self.state.as_ref().ok_or(InterpreterExtractError::new())?;
         let spec = state.classes.get::<T>();
         let rclass = if let Some(spec) = spec {
             spec.rclass()

--- a/artichoke-backend/src/constant.rs
+++ b/artichoke-backend/src/constant.rs
@@ -44,7 +44,7 @@ impl DefineConstant for Artichoke {
         } else {
             return Err(ConstantNameError::from(String::from(constant)).into());
         };
-        let state = self.state.as_mut().ok_or(InterpreterExtractError)?;
+        let state = self.state.as_mut().ok_or(InterpreterExtractError::new())?;
         let spec = state
             .classes
             .get::<T>()
@@ -77,7 +77,7 @@ impl DefineConstant for Artichoke {
         } else {
             return Err(ConstantNameError::from(String::from(constant)).into());
         };
-        let state = self.state.as_mut().ok_or(InterpreterExtractError)?;
+        let state = self.state.as_mut().ok_or(InterpreterExtractError::new())?;
         let spec = state
             .modules
             .get::<T>()

--- a/artichoke-backend/src/convert/boxing.rs
+++ b/artichoke-backend/src/convert/boxing.rs
@@ -141,7 +141,10 @@ where
         }
 
         let mut rclass = {
-            let state = interp.state.as_ref().ok_or(InterpreterExtractError)?;
+            let state = interp
+                .state
+                .as_ref()
+                .ok_or(InterpreterExtractError::new())?;
             let spec = state
                 .classes
                 .get::<Self>()
@@ -164,7 +167,10 @@ where
 
         // Copy data pointer out of the `mrb_value` box.
         let mrb = interp.mrb.as_mut();
-        let state = interp.state.as_ref().ok_or(InterpreterExtractError)?;
+        let state = interp
+            .state
+            .as_ref()
+            .ok_or(InterpreterExtractError::new())?;
         let spec = state
             .classes
             .get::<Self>()
@@ -213,7 +219,10 @@ where
         let prior_gc_state = interp.disable_gc();
 
         let mut rclass = {
-            let state = interp.state.as_ref().ok_or(InterpreterExtractError)?;
+            let state = interp
+                .state
+                .as_ref()
+                .ok_or(InterpreterExtractError::new())?;
             let spec = state
                 .classes
                 .get::<Self>()
@@ -228,7 +237,10 @@ where
         let ptr = Box::into_raw(data);
 
         // Allocate a new `mrb_value` and inject the raw data pointer.
-        let state = interp.state.as_ref().ok_or(InterpreterExtractError)?;
+        let state = interp
+            .state
+            .as_ref()
+            .ok_or(InterpreterExtractError::new())?;
         let spec = state
             .classes
             .get::<Self>()
@@ -257,7 +269,10 @@ where
         into: Value,
         interp: &mut Artichoke,
     ) -> Result<Value, Exception> {
-        let state = interp.state.as_ref().ok_or(InterpreterExtractError)?;
+        let state = interp
+            .state
+            .as_ref()
+            .ok_or(InterpreterExtractError::new())?;
         let spec = state
             .classes
             .get::<Self>()

--- a/artichoke-backend/src/eval.rs
+++ b/artichoke-backend/src/eval.rs
@@ -21,8 +21,11 @@ impl Eval for Artichoke {
     fn eval(&mut self, code: &[u8]) -> Result<Self::Value, Self::Error> {
         trace!("Attempting eval of Ruby source");
         let result = unsafe {
-            let state = self.state.as_mut().ok_or(InterpreterExtractError)?;
-            let parser = state.parser.as_mut().ok_or(InterpreterExtractError)?;
+            let state = self.state.as_mut().ok_or(InterpreterExtractError::new())?;
+            let parser = state
+                .parser
+                .as_mut()
+                .ok_or(InterpreterExtractError::new())?;
             let context: *mut sys::mrbc_context = parser.context_mut();
             self.with_ffi_boundary(|mrb| protect::eval(mrb, context, code))?
         };

--- a/artichoke-backend/src/extn/core/array/ffi.rs
+++ b/artichoke-backend/src/extn/core/array/ffi.rs
@@ -12,7 +12,7 @@ use crate::gc::{MrbGarbageCollection, State as GcState};
 unsafe extern "C" fn artichoke_ary_new(mrb: *mut sys::mrb_state) -> sys::mrb_value {
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
-    let result = Array::default();
+    let result = Array::new();
     let result = Array::alloc_value(result, &mut guard);
     match result {
         Ok(value) => value.inner(),

--- a/artichoke-backend/src/extn/core/env/backend/system.rs
+++ b/artichoke-backend/src/extn/core/env/backend/system.rs
@@ -9,13 +9,15 @@ use crate::extn::prelude::*;
 use crate::ffi;
 
 #[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct System;
+pub struct System {
+    _private: (),
+}
 
 impl System {
     /// Constructs a new, default ENV `System` backend.
     #[must_use]
-    pub fn new() -> Self {
-        Self::default()
+    pub const fn new() -> Self {
+        Self { _private: () }
     }
 }
 

--- a/artichoke-backend/src/extn/core/float/mod.rs
+++ b/artichoke-backend/src/extn/core/float/mod.rs
@@ -191,18 +191,23 @@ impl Float {
     /// [round]: https://doc.rust-lang.org/1.42.0/std/primitive.f64.html#method.round
     pub const ROUNDS: Int = -1;
 
+    /// Construct a new, zero, float.
     #[inline]
     #[must_use]
-    pub fn new() -> Self {
-        Self::default()
+    pub const fn new() -> Self {
+        Self(0.0)
     }
 
+    /// Return the inner [`f64`].
     #[inline]
     #[must_use]
-    pub fn as_f64(self) -> f64 {
+    pub const fn as_f64(self) -> f64 {
         self.0
     }
 
+    /// Compute the remainder of self and other.
+    ///
+    /// Equivalent to `self.as_f64() % other.as_f64()`.
     #[inline]
     #[must_use]
     pub fn modulo(self, other: Self) -> Self {

--- a/artichoke-backend/src/extn/core/integer/mod.rs
+++ b/artichoke-backend/src/extn/core/integer/mod.rs
@@ -63,23 +63,23 @@ impl From<Int> for Outcome {
 }
 
 impl Integer {
-    /// Constructs a new, default `Integer`.
+    /// Constructs a new, default, zero `Integer`.
     #[inline]
     #[must_use]
-    pub fn new() -> Self {
-        Self::default()
+    pub const fn new() -> Self {
+        Self(0)
     }
 
     #[inline]
     #[must_use]
-    pub fn as_i64(self) -> i64 {
+    pub const fn as_i64(self) -> i64 {
         self.0
     }
 
     #[allow(clippy::cast_precision_loss)]
     #[inline]
     #[must_use]
-    pub fn as_f64(self) -> f64 {
+    pub const fn as_f64(self) -> f64 {
         self.0 as f64
     }
 

--- a/artichoke-backend/src/extn/core/kernel/integer.rs
+++ b/artichoke-backend/src/extn/core/kernel/integer.rs
@@ -125,11 +125,11 @@ impl From<str::Utf8Error> for Utf8Error {
 }
 
 impl<'a> IntegerString<'a> {
-    /// Constructs a new, default `IntegerString`.
+    /// Constructs a new, empty `IntegerString`.
     #[inline]
     #[must_use]
-    pub fn new() -> Self {
-        Self::default()
+    pub const fn new() -> Self {
+        Self("")
     }
 
     #[must_use]
@@ -186,10 +186,16 @@ enum Sign {
     Negative,
 }
 
+impl Sign {
+    const fn new() -> Self {
+        Self::Positive
+    }
+}
+
 impl Default for Sign {
     #[inline]
     fn default() -> Self {
-        Self::Positive
+        Self::new()
     }
 }
 
@@ -223,7 +229,7 @@ impl<'a> ParseState<'a> {
             Self::Initial(arg) => {
                 let mut digits = String::new();
                 digits.push(digit);
-                Self::Accumulate(arg, Sign::default(), digits)
+                Self::Accumulate(arg, Sign::new(), digits)
             }
             Self::Sign(arg, sign) => {
                 let mut digits = String::new();

--- a/artichoke-backend/src/extn/core/random/backend/default.rs
+++ b/artichoke-backend/src/extn/core/random/backend/default.rs
@@ -4,13 +4,15 @@ use crate::extn::core::random::backend::{InternalState, RandType};
 use crate::extn::prelude::*;
 
 #[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Default;
+pub struct Default {
+    _private: (),
+}
 
 impl Default {
     /// Constructs a new, default `Default` Random backend.
     #[must_use]
-    pub fn new() -> Self {
-        Self::default()
+    pub const fn new() -> Self {
+        Self { _private: () }
     }
 }
 

--- a/artichoke-backend/src/extn/core/random/mod.rs
+++ b/artichoke-backend/src/extn/core/random/mod.rs
@@ -17,7 +17,7 @@ pub enum Seed {
 
 impl Default for Seed {
     fn default() -> Self {
-        Self::None
+        Self::new()
     }
 }
 
@@ -28,9 +28,10 @@ impl From<Int> for Seed {
 }
 
 impl Seed {
+    /// Construct a an empty seed.
     #[must_use]
-    pub fn new() -> Self {
-        Self::default()
+    pub const fn new() -> Self {
+        Self::None
     }
 
     #[must_use]

--- a/artichoke-backend/src/extn/core/regexp/backend/lazy.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/lazy.rs
@@ -18,7 +18,7 @@ impl From<Config> for Lazy {
     fn from(config: Config) -> Self {
         Self {
             literal: config,
-            encoding: Encoding::default(),
+            encoding: Encoding::new(),
             regexp: OnceCell::new(),
         }
     }

--- a/artichoke-backend/src/extn/core/regexp/backend/onig.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/onig.rs
@@ -16,13 +16,13 @@ use super::{NameToCaptureLocations, NilableString};
 impl From<Options> for RegexOptions {
     fn from(opts: Options) -> Self {
         let mut bits = RegexOptions::REGEX_OPTION_NONE;
-        if opts.multiline {
+        if opts.multiline.is_enabled() {
             bits |= RegexOptions::REGEX_OPTION_MULTILINE;
         }
-        if opts.ignore_case {
+        if opts.ignore_case.is_enabled() {
             bits |= RegexOptions::REGEX_OPTION_IGNORECASE;
         }
-        if opts.extended {
+        if opts.extended.is_enabled() {
             bits |= RegexOptions::REGEX_OPTION_EXTEND;
         }
         bits

--- a/artichoke-backend/src/extn/core/regexp/backend/regex/utf8.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/regex/utf8.rs
@@ -26,9 +26,9 @@ impl Utf8 {
             ArgumentError::from("regex crate utf8 backend for Regexp only supports UTF-8 patterns")
         })?;
         let mut builder = RegexBuilder::new(pattern);
-        builder.case_insensitive(derived.options.ignore_case);
-        builder.multi_line(derived.options.multiline);
-        builder.ignore_whitespace(derived.options.extended);
+        builder.case_insensitive(derived.options.ignore_case.into());
+        builder.multi_line(derived.options.multiline.into());
+        builder.ignore_whitespace(derived.options.extended.into());
         let regex = match builder.build() {
             Ok(regex) => regex,
             Err(err) if literal.options.literal => {

--- a/artichoke-backend/src/extn/core/regexp/mod.rs
+++ b/artichoke-backend/src/extn/core/regexp/mod.rs
@@ -26,7 +26,7 @@ pub mod trampoline;
 
 pub use backend::{NilableString, RegexpType, Scan};
 pub use enc::Encoding;
-pub use opts::Options;
+pub use opts::{Options, RegexpOption};
 
 use backend::lazy::Lazy;
 #[cfg(feature = "core-regexp-oniguruma")]
@@ -148,7 +148,7 @@ impl Regexp {
     pub fn lazy(pattern: Vec<u8>) -> Self {
         let literal_config = Config {
             pattern: pattern.into(),
-            options: Options::default(),
+            options: Options::new(),
         };
         let backend = Box::new(Lazy::from(literal_config));
         Self(backend)
@@ -239,7 +239,7 @@ impl Regexp {
         };
 
         let derived_config = {
-            let pattern = pattern::parse(&pattern, Options::default());
+            let pattern = pattern::parse(&pattern, Options::new());
             let options = pattern.options();
             Config {
                 pattern: pattern.into_pattern().into(),
@@ -248,9 +248,9 @@ impl Regexp {
         };
         let literal_config = Config {
             pattern: pattern.into(),
-            options: Options::default(),
+            options: Options::new(),
         };
-        Self::new(literal_config, derived_config, Encoding::default())
+        Self::new(literal_config, derived_config, Encoding::new())
     }
 
     #[inline]
@@ -299,7 +299,7 @@ impl Regexp {
     #[inline]
     #[must_use]
     pub fn is_casefold(&self) -> bool {
-        self.0.literal_config().options.ignore_case
+        self.0.literal_config().options.ignore_case.is_enabled()
     }
 
     #[must_use]

--- a/artichoke-backend/src/extn/core/regexp/opts.rs
+++ b/artichoke-backend/src/extn/core/regexp/opts.rs
@@ -6,19 +6,65 @@ use std::fmt;
 use crate::extn::core::regexp;
 use crate::extn::prelude::*;
 
+/// The state of a Regexp engine flag in [`Options`].
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub enum RegexpOption {
+    /// Engine feature is disabled.
+    ///
+    /// Features are disabled by default.
+    Disabled,
+    /// Engine feature is disabled.
+    Enabled,
+}
+
+impl RegexpOption {
+    /// Construct a new, disabled `RegexpOption`.
+    pub const fn new() -> Self {
+        Self::Disabled
+    }
+
+    /// Return whether this option is enabled.
+    ///
+    /// An option is enabled if it is equal to [`RegexpOption::Enabled`].
+    pub fn is_enabled(self) -> bool {
+        self == Self::Enabled
+    }
+}
+
+impl Default for RegexpOption {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl From<bool> for RegexpOption {
+    fn from(value: bool) -> Self {
+        if value {
+            Self::Enabled
+        } else {
+            Self::Disabled
+        }
+    }
+}
+
+impl From<RegexpOption> for bool {
+    fn from(value: RegexpOption) -> Self {
+        value == RegexpOption::Enabled
+    }
+}
+
 /// Configuration options for Ruby Regexps.
 ///
 /// Options can be supplied either as an `Integer` object to `Regexp::new` or
 /// inline in Regexp literals like `/artichoke/i`.
-#[allow(clippy::struct_excessive_bools)]
 #[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Options {
     /// Multiline mode.
-    pub multiline: bool,
+    pub multiline: RegexpOption,
     /// Case-insensitive mode.
-    pub ignore_case: bool,
+    pub ignore_case: RegexpOption,
     /// Extended mode with insignificant whitespace.
-    pub extended: bool,
+    pub extended: RegexpOption,
     /// Whether the Regexp was parsed as a literal, e.g. `'/artichoke/i`.
     ///
     /// This enables Ruby parsers to inject whether a Regexp is a literal to
@@ -31,13 +77,13 @@ impl From<Options> for Int {
     /// Convert an `Options` to its bitflag representation.
     fn from(opts: Options) -> Self {
         let mut bits = 0;
-        if opts.multiline {
+        if opts.multiline.is_enabled() {
             bits |= regexp::MULTILINE;
         }
-        if opts.ignore_case {
+        if opts.ignore_case.is_enabled() {
             bits |= regexp::IGNORECASE;
         }
-        if opts.extended {
+        if opts.extended.is_enabled() {
             bits |= regexp::EXTENDED;
         }
         bits
@@ -53,15 +99,20 @@ impl fmt::Display for Options {
 impl Options {
     /// Constructs a new, default `Options`.
     #[must_use]
-    pub fn new() -> Self {
-        Self::default()
+    pub const fn new() -> Self {
+        Self {
+            multiline: RegexpOption::Disabled,
+            ignore_case: RegexpOption::Disabled,
+            extended: RegexpOption::Disabled,
+            literal: false,
+        }
     }
 
     /// An options instance that has only case insensitive mode enabled.
     #[must_use]
     pub fn with_ignore_case() -> Self {
-        let mut opts = Self::default();
-        opts.ignore_case = true;
+        let mut opts = Self::new();
+        opts.ignore_case = RegexpOption::Enabled;
         opts
     }
 
@@ -81,15 +132,17 @@ impl Options {
     /// [regexp-inspect]: https://ruby-doc.org/core-2.7.1/Regexp.html#method-i-inspect
     #[must_use]
     pub fn as_display_modifier(self) -> &'static str {
+        use RegexpOption::{Disabled, Enabled};
+
         match (self.multiline, self.ignore_case, self.extended) {
-            (true, true, true) => "mix",
-            (true, true, false) => "mi",
-            (true, false, true) => "mx",
-            (true, false, false) => "m",
-            (false, true, true) => "ix",
-            (false, true, false) => "i",
-            (false, false, true) => "x",
-            (false, false, false) => "",
+            (Enabled, Enabled, Enabled) => "mix",
+            (Enabled, Enabled, Disabled) => "mi",
+            (Enabled, Disabled, Enabled) => "mx",
+            (Enabled, Disabled, Disabled) => "m",
+            (Disabled, Enabled, Enabled) => "ix",
+            (Disabled, Enabled, Disabled) => "i",
+            (Disabled, Disabled, Enabled) => "x",
+            (Disabled, Disabled, Disabled) => "",
         }
     }
 
@@ -97,15 +150,17 @@ impl Options {
     /// pattern for configuring an underlying Regexp backend.
     #[must_use]
     pub fn as_inline_modifier(self) -> &'static str {
+        use RegexpOption::{Disabled, Enabled};
+
         match (self.multiline, self.ignore_case, self.extended) {
-            (true, true, true) => "mix",
-            (true, true, false) => "mi-x",
-            (true, false, true) => "mx-i",
-            (true, false, false) => "m-ix",
-            (false, true, true) => "ix-m",
-            (false, true, false) => "i-mx",
-            (false, false, true) => "x-mi",
-            (false, false, false) => "-mix",
+            (Enabled, Enabled, Enabled) => "mix",
+            (Enabled, Enabled, Disabled) => "mi-x",
+            (Enabled, Disabled, Enabled) => "mx-i",
+            (Enabled, Disabled, Disabled) => "m-ix",
+            (Disabled, Enabled, Enabled) => "ix-m",
+            (Disabled, Enabled, Disabled) => "i-mx",
+            (Disabled, Disabled, Enabled) => "x-mi",
+            (Disabled, Disabled, Disabled) => "-mix",
         }
     }
 }
@@ -118,21 +173,30 @@ impl ConvertMut<Value, Options> for Artichoke {
         // will be case insensitive.
         if let Ok(options) = value.implicitly_convert_to_int(self) {
             Options {
-                multiline: options & regexp::MULTILINE > 0,
-                ignore_case: options & regexp::IGNORECASE > 0,
-                extended: options & regexp::EXTENDED > 0,
-                literal: options & regexp::LITERAL > 0,
+                multiline: (options & regexp::MULTILINE > 0).into(),
+                ignore_case: (options & regexp::IGNORECASE > 0).into(),
+                extended: (options & regexp::EXTENDED > 0).into(),
+                literal: (options & regexp::LITERAL > 0).into(),
             }
         } else if let Ok(options) = value.try_into::<Option<bool>>(self) {
             match options {
-                Some(false) | None => Options::default(),
+                Some(false) | None => Options::new(),
                 _ => Options::with_ignore_case(),
             }
         } else if let Ok(options) = value.try_into_mut::<&[u8]>(self) {
             Options {
-                multiline: options.find_byte(b'm').is_some(),
-                ignore_case: options.find_byte(b'i').is_some(),
-                extended: options.find_byte(b'x').is_some(),
+                multiline: options
+                    .find_byte(b'm')
+                    .map(|_| RegexpOption::Enabled)
+                    .unwrap_or_default(),
+                ignore_case: options
+                    .find_byte(b'i')
+                    .map(|_| RegexpOption::Enabled)
+                    .unwrap_or_default(),
+                extended: options
+                    .find_byte(b'x')
+                    .map(|_| RegexpOption::Enabled)
+                    .unwrap_or_default(),
                 literal: false,
             }
         } else {

--- a/artichoke-backend/src/extn/core/regexp/opts.rs
+++ b/artichoke-backend/src/extn/core/regexp/opts.rs
@@ -152,7 +152,7 @@ impl Options {
 
     /// An options instance that has only case insensitive mode enabled.
     #[must_use]
-    pub fn with_ignore_case() -> Self {
+    pub const fn with_ignore_case() -> Self {
         let mut opts = Self::new();
         opts.ignore_case = RegexpOption::Enabled;
         opts

--- a/artichoke-backend/src/extn/core/regexp/opts.rs
+++ b/artichoke-backend/src/extn/core/regexp/opts.rs
@@ -19,6 +19,7 @@ pub enum RegexpOption {
 
 impl RegexpOption {
     /// Construct a new, disabled `RegexpOption`.
+    #[must_use]
     pub const fn new() -> Self {
         Self::Disabled
     }
@@ -26,6 +27,7 @@ impl RegexpOption {
     /// Return whether this option is enabled.
     ///
     /// An option is enabled if it is equal to [`RegexpOption::Enabled`].
+    #[must_use]
     pub fn is_enabled(self) -> bool {
         self == Self::Enabled
     }

--- a/artichoke-backend/src/extn/core/time/backend/chrono.rs
+++ b/artichoke-backend/src/extn/core/time/backend/chrono.rs
@@ -111,13 +111,15 @@ where
 }
 
 #[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Factory;
+pub struct Factory {
+    _private: (),
+}
 
 impl Factory {
     /// Constructs a new, default `Factory` for the chrono Time backend.
     #[must_use]
-    pub fn new() -> Self {
-        Self::default()
+    pub const fn new() -> Self {
+        Self { _private: () }
     }
 }
 

--- a/artichoke-backend/src/extn/core/time/mod.rs
+++ b/artichoke-backend/src/extn/core/time/mod.rs
@@ -39,7 +39,7 @@ impl Time {
 
     #[must_use]
     pub fn now() -> Self {
-        Self(Box::new(Factory.now()))
+        Self(Box::new(Factory::new().now()))
     }
 
     #[must_use]

--- a/artichoke-backend/src/extn/stdlib/securerandom/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/securerandom/mod.rs
@@ -12,11 +12,9 @@ const DEFAULT_REQUESTED_BYTES: usize = 16;
 
 #[cfg(test)]
 mod tests {
-    fn rng_must_be_cryptographically_secure<T>(_rng: T)
-    where
-        T: rand::CryptoRng,
-    {
-    }
+    use rand::CryptoRng;
+
+    fn rng_must_be_cryptographically_secure<T: CryptoRng>(_rng: T) {}
 
     #[test]
     fn rand_thread_rng_must_be_cryptographically_secure() {
@@ -25,13 +23,15 @@ mod tests {
 }
 
 #[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct SecureRandom;
+pub struct SecureRandom {
+    _private: (),
+}
 
 impl SecureRandom {
     /// Constructs a new, default `SecureRandom`.
     #[must_use]
-    pub fn new() -> Self {
-        Self::default()
+    pub const fn new() -> Self {
+        Self { _private: () }
     }
 }
 

--- a/artichoke-backend/src/fs/memory.rs
+++ b/artichoke-backend/src/fs/memory.rs
@@ -39,7 +39,7 @@ pub struct Code {
 
 impl Default for Code {
     fn default() -> Self {
-        "# virtual source file".into()
+        Self::new()
     }
 }
 
@@ -99,7 +99,9 @@ impl From<Cow<'static, str>> for Code {
 impl Code {
     #[must_use]
     pub fn new() -> Self {
-        Self::default()
+        Self {
+            content: Cow::Borrowed(&b"# virtual source file"[..]),
+        }
     }
 
     #[must_use]
@@ -117,7 +119,7 @@ pub struct Entry {
 
 impl From<Code> for Entry {
     fn from(code: Code) -> Self {
-        let mut entry = Self::default();
+        let mut entry = Self::new();
         entry.code = Some(code);
         entry
     }
@@ -125,7 +127,7 @@ impl From<Code> for Entry {
 
 impl From<Vec<u8>> for Entry {
     fn from(content: Vec<u8>) -> Self {
-        let mut entry = Self::default();
+        let mut entry = Self::new();
         entry.code = Some(content.into());
         entry
     }
@@ -133,7 +135,7 @@ impl From<Vec<u8>> for Entry {
 
 impl From<&'static [u8]> for Entry {
     fn from(content: &'static [u8]) -> Self {
-        let mut entry = Self::default();
+        let mut entry = Self::new();
         entry.code = Some(content.into());
         entry
     }
@@ -141,7 +143,7 @@ impl From<&'static [u8]> for Entry {
 
 impl From<Cow<'static, [u8]>> for Entry {
     fn from(content: Cow<'static, [u8]>) -> Self {
-        let mut entry = Self::default();
+        let mut entry = Self::new();
         entry.code = Some(content.into());
         entry
     }
@@ -149,7 +151,7 @@ impl From<Cow<'static, [u8]>> for Entry {
 
 impl From<String> for Entry {
     fn from(content: String) -> Self {
-        let mut entry = Self::default();
+        let mut entry = Self::new();
         entry.code = Some(content.into());
         entry
     }
@@ -157,7 +159,7 @@ impl From<String> for Entry {
 
 impl From<&'static str> for Entry {
     fn from(content: &'static str) -> Self {
-        let mut entry = Self::default();
+        let mut entry = Self::new();
         entry.code = Some(content.into());
         entry
     }
@@ -165,7 +167,7 @@ impl From<&'static str> for Entry {
 
 impl From<Cow<'static, str>> for Entry {
     fn from(content: Cow<'static, str>) -> Self {
-        let mut entry = Self::default();
+        let mut entry = Self::new();
         entry.code = Some(content.into());
         entry
     }
@@ -173,13 +175,21 @@ impl From<Cow<'static, str>> for Entry {
 
 impl From<ExtensionHook> for Entry {
     fn from(hook: ExtensionHook) -> Self {
-        let mut entry = Self::default();
+        let mut entry = Self::new();
         entry.extension = Some(hook.into());
         entry
     }
 }
 
 impl Entry {
+    const fn new() -> Self {
+        Self {
+            code: None,
+            extension: None,
+            required: false,
+        }
+    }
+
     fn replace_content<T>(&mut self, content: T)
     where
         T: Into<Cow<'static, [u8]>>,
@@ -291,7 +301,7 @@ impl Filesystem for Memory {
                     Cow::Owned(ref content) => Ok(content.clone().into()),
                 }
             } else {
-                Ok(Code::default().into())
+                Ok(Code::new().into())
             }
         } else {
             Err(io::Error::new(

--- a/artichoke-backend/src/gc/arena.rs
+++ b/artichoke-backend/src/gc/arena.rs
@@ -14,13 +14,15 @@ use crate::Artichoke;
 
 /// Failed to extract Artichoke interpreter at an FFI boundary.
 #[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct IndexError;
+pub struct IndexError {
+    _private: (),
+}
 
 impl IndexError {
     /// Constructs a new, default `IndexError`.
     #[must_use]
-    pub fn new() -> Self {
-        Self::default()
+    pub const fn new() -> Self {
+        Self { _private: () }
     }
 }
 
@@ -108,7 +110,7 @@ impl<'a> ArenaIndex<'a> {
             interp
                 .with_ffi_boundary(|mrb| sys::mrb_sys_gc_arena_save(mrb))
                 .map(move |index| Self { index, interp })
-                .map_err(|_| IndexError)
+                .map_err(|_| IndexError::new())
         }
     }
 

--- a/artichoke-backend/src/intern.rs
+++ b/artichoke-backend/src/intern.rs
@@ -12,7 +12,7 @@ use crate::Artichoke;
 
 impl Artichoke {
     pub fn lookup_symbol_with_trailing_nul(&self, symbol: u32) -> Result<Option<&[u8]>, Exception> {
-        let state = self.state.as_ref().ok_or(InterpreterExtractError)?;
+        let state = self.state.as_ref().ok_or(InterpreterExtractError::new())?;
         if let Some(symbol) = symbol.checked_sub(1) {
             if let Some(bytes) = state.symbols.get(symbol.into()) {
                 Ok(Some(bytes))
@@ -29,7 +29,7 @@ impl Artichoke {
         T: Into<Cow<'static, [u8]>>,
     {
         let bytes = bytes.into();
-        let state = self.state.as_mut().ok_or(InterpreterExtractError)?;
+        let state = self.state.as_mut().ok_or(InterpreterExtractError::new())?;
         let symbol = state.symbols.intern(bytes)?;
         let symbol = u32::from(symbol);
         // mruby expexts symbols to be non-zero.
@@ -43,7 +43,7 @@ impl Artichoke {
         &self,
         bytes: &[u8],
     ) -> Result<Option<u32>, Exception> {
-        let state = self.state.as_ref().ok_or(InterpreterExtractError)?;
+        let state = self.state.as_ref().ok_or(InterpreterExtractError::new())?;
         let symbol = state.symbols.check_interned(bytes);
         if let Some(symbol) = symbol {
             let symbol = u32::from(symbol);
@@ -70,7 +70,7 @@ impl Intern for Artichoke {
         T: Into<Cow<'static, [u8]>>,
     {
         let bytes = bytes.into();
-        let state = self.state.as_mut().ok_or(InterpreterExtractError)?;
+        let state = self.state.as_mut().ok_or(InterpreterExtractError::new())?;
         let mut bytes = bytes.into_owned();
         bytes.push(b'\0');
         let symbol = state.symbols.intern(bytes)?;
@@ -83,7 +83,7 @@ impl Intern for Artichoke {
     }
 
     fn check_interned_bytes(&self, bytes: &[u8]) -> Result<Option<Self::Symbol>, Self::Error> {
-        let state = self.state.as_ref().ok_or(InterpreterExtractError)?;
+        let state = self.state.as_ref().ok_or(InterpreterExtractError::new())?;
         let mut bytes = bytes.to_vec();
         bytes.push(b'\0');
         let symbol = state.symbols.check_interned(&bytes);
@@ -100,7 +100,7 @@ impl Intern for Artichoke {
     }
 
     fn lookup_symbol(&self, symbol: Self::Symbol) -> Result<Option<&[u8]>, Self::Error> {
-        let state = self.state.as_ref().ok_or(InterpreterExtractError)?;
+        let state = self.state.as_ref().ok_or(InterpreterExtractError::new())?;
         if let Some(symbol) = symbol.checked_sub(Self::SYMBOL_RANGE_START) {
             if let Some(bytes) = state.symbols.get(symbol.into()) {
                 if bytes.is_empty() {

--- a/artichoke-backend/src/interpreter.rs
+++ b/artichoke-backend/src/interpreter.rs
@@ -21,7 +21,7 @@ use crate::Artichoke;
 /// initializes an [in memory virtual filesystem](crate::fs), and loads the
 /// [`extn`] extensions to Ruby Core and Stdlib.
 pub fn interpreter() -> Result<Artichoke, Exception> {
-    interpreter_with_config(ArtichokeBackendReleaseMetadata::default())
+    interpreter_with_config(ArtichokeBackendReleaseMetadata::new())
 }
 
 /// Create and initialize an [`Artichoke`] interpreter with build metadata.
@@ -40,7 +40,7 @@ where
     let raw = unsafe { sys::mrb_open_allocf(Some(sys::mrb_default_allocf), alloc_ud) };
     debug!("Try initializing mrb interpreter");
 
-    let mut interp = unsafe { ffi::from_user_data(raw).map_err(|_| InterpreterAllocError)? };
+    let mut interp = unsafe { ffi::from_user_data(raw).map_err(|_| InterpreterAllocError::new())? };
 
     if let Some(ref mut state) = interp.state {
         if let Some(mrb) = unsafe { raw.as_mut() } {
@@ -88,13 +88,15 @@ where
 
 #[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[allow(clippy::module_name_repetitions)]
-pub struct InterpreterAllocError;
+pub struct InterpreterAllocError {
+    _private: (),
+}
 
 impl InterpreterAllocError {
     /// Constructs a new, default `InterpreterAllocError`.
     #[must_use]
-    pub fn new() -> Self {
-        Self::default()
+    pub const fn new() -> Self {
+        Self { _private: () }
     }
 }
 

--- a/artichoke-backend/src/io.rs
+++ b/artichoke-backend/src/io.rs
@@ -23,7 +23,7 @@ impl Io for Artichoke {
     ///
     /// If the output stream encounters an error, an error is returned.
     fn print<T: AsRef<[u8]>>(&mut self, message: T) -> Result<(), Self::Error> {
-        let state = self.state.as_mut().ok_or(InterpreterExtractError)?;
+        let state = self.state.as_mut().ok_or(InterpreterExtractError::new())?;
         state.output.write_stdout(message.as_ref())?;
         Ok(())
     }
@@ -37,7 +37,7 @@ impl Io for Artichoke {
     ///
     /// If the output stream encounters an error, an error is returned.
     fn puts<T: AsRef<[u8]>>(&mut self, message: T) -> Result<(), Self::Error> {
-        let state = self.state.as_mut().ok_or(InterpreterExtractError)?;
+        let state = self.state.as_mut().ok_or(InterpreterExtractError::new())?;
         state.output.write_stdout(message.as_ref())?;
         state.output.write_stdout(b"\n")?;
         Ok(())

--- a/artichoke-backend/src/lib.rs
+++ b/artichoke-backend/src/lib.rs
@@ -2,6 +2,9 @@
 #![warn(clippy::pedantic)]
 #![warn(clippy::cargo)]
 #![allow(clippy::missing_errors_doc)]
+// disable or_fun_call lint until release of:
+// https://github.com/rust-lang/rust-clippy/pull/5889
+#![allow(clippy::or_fun_call)]
 #![allow(unknown_lints)]
 #![warn(broken_intra_doc_links)]
 // #![warn(missing_docs)]

--- a/artichoke-backend/src/load.rs
+++ b/artichoke-backend/src/load.rs
@@ -17,7 +17,7 @@ impl LoadSources for Artichoke {
         P: AsRef<Path>,
         T: File<Artichoke = Self::Artichoke, Error = Self::Exception>,
     {
-        let state = self.state.as_mut().ok_or(InterpreterExtractError)?;
+        let state = self.state.as_mut().ok_or(InterpreterExtractError::new())?;
         let mut path = path.as_ref();
         let absolute_path;
         if path.is_relative() {
@@ -37,7 +37,7 @@ impl LoadSources for Artichoke {
         P: AsRef<Path>,
         T: Into<Cow<'static, [u8]>>,
     {
-        let state = self.state.as_mut().ok_or(InterpreterExtractError)?;
+        let state = self.state.as_mut().ok_or(InterpreterExtractError::new())?;
         let mut path = path.as_ref();
         let absolute_path;
         if path.is_relative() {
@@ -56,7 +56,7 @@ impl LoadSources for Artichoke {
     where
         P: AsRef<Path>,
     {
-        let state = self.state.as_ref().ok_or(InterpreterExtractError)?;
+        let state = self.state.as_ref().ok_or(InterpreterExtractError::new())?;
         let is_file = state.vfs.is_file(path.as_ref());
         Ok(is_file)
     }
@@ -66,7 +66,7 @@ impl LoadSources for Artichoke {
         P: AsRef<Path>,
     {
         {
-            let state = self.state.as_mut().ok_or(InterpreterExtractError)?;
+            let state = self.state.as_mut().ok_or(InterpreterExtractError::new())?;
             // Load Rust `File` first because an File may define classes and
             // modules with `LoadSources` and Ruby files can require arbitrary
             // other files, including some child sources that may depend on these
@@ -88,7 +88,7 @@ impl LoadSources for Artichoke {
         P: AsRef<Path>,
     {
         {
-            let state = self.state.as_mut().ok_or(InterpreterExtractError)?;
+            let state = self.state.as_mut().ok_or(InterpreterExtractError::new())?;
             // If a file is already required, short circuit.
             if state.vfs.is_required(path.as_ref()) {
                 return Ok(false);
@@ -105,7 +105,7 @@ impl LoadSources for Artichoke {
         }
         let contents = self.read_source_file_contents(path.as_ref())?.into_owned();
         self.eval(contents.as_ref())?;
-        let state = self.state.as_mut().ok_or(InterpreterExtractError)?;
+        let state = self.state.as_mut().ok_or(InterpreterExtractError::new())?;
         state.vfs.mark_required(path.as_ref())?;
         trace!(r#"Successful require of {}"#, path.as_ref().display());
         Ok(true)
@@ -115,7 +115,7 @@ impl LoadSources for Artichoke {
     where
         P: AsRef<Path>,
     {
-        let state = self.state.as_ref().ok_or(InterpreterExtractError)?;
+        let state = self.state.as_ref().ok_or(InterpreterExtractError::new())?;
         let contents = state.vfs.read_file(path.as_ref())?;
         Ok(contents.to_vec().into())
     }

--- a/artichoke-backend/src/parser.rs
+++ b/artichoke-backend/src/parser.rs
@@ -15,45 +15,63 @@ impl Parser for Artichoke {
 
     fn reset_parser(&mut self) -> Result<(), Self::Error> {
         let mrb = unsafe { self.mrb.as_mut() };
-        let state = self.state.as_mut().ok_or(InterpreterExtractError)?;
-        let parser = state.parser.as_mut().ok_or(InterpreterExtractError)?;
+        let state = self.state.as_mut().ok_or(InterpreterExtractError::new())?;
+        let parser = state
+            .parser
+            .as_mut()
+            .ok_or(InterpreterExtractError::new())?;
         parser.reset(mrb);
         Ok(())
     }
 
     fn fetch_lineno(&self) -> Result<usize, Self::Error> {
-        let state = self.state.as_ref().ok_or(InterpreterExtractError)?;
-        let parser = state.parser.as_ref().ok_or(InterpreterExtractError)?;
+        let state = self.state.as_ref().ok_or(InterpreterExtractError::new())?;
+        let parser = state
+            .parser
+            .as_ref()
+            .ok_or(InterpreterExtractError::new())?;
         let lineno = parser.fetch_lineno();
         Ok(lineno)
     }
 
     fn add_fetch_lineno(&mut self, val: usize) -> Result<usize, Self::Error> {
-        let state = self.state.as_mut().ok_or(InterpreterExtractError)?;
-        let parser = state.parser.as_mut().ok_or(InterpreterExtractError)?;
+        let state = self.state.as_mut().ok_or(InterpreterExtractError::new())?;
+        let parser = state
+            .parser
+            .as_mut()
+            .ok_or(InterpreterExtractError::new())?;
         let lineno = parser.add_fetch_lineno(val)?;
         Ok(lineno)
     }
 
     fn push_context(&mut self, context: Self::Context) -> Result<(), Self::Error> {
         let mrb = unsafe { self.mrb.as_mut() };
-        let state = self.state.as_mut().ok_or(InterpreterExtractError)?;
-        let parser = state.parser.as_mut().ok_or(InterpreterExtractError)?;
+        let state = self.state.as_mut().ok_or(InterpreterExtractError::new())?;
+        let parser = state
+            .parser
+            .as_mut()
+            .ok_or(InterpreterExtractError::new())?;
         parser.push_context(mrb, context);
         Ok(())
     }
 
     fn pop_context(&mut self) -> Result<Option<Self::Context>, Self::Error> {
         let mrb = unsafe { self.mrb.as_mut() };
-        let state = self.state.as_mut().ok_or(InterpreterExtractError)?;
-        let parser = state.parser.as_mut().ok_or(InterpreterExtractError)?;
+        let state = self.state.as_mut().ok_or(InterpreterExtractError::new())?;
+        let parser = state
+            .parser
+            .as_mut()
+            .ok_or(InterpreterExtractError::new())?;
         let context = parser.pop_context(mrb);
         Ok(context)
     }
 
     fn peek_context(&self) -> Result<Option<&Self::Context>, Self::Error> {
-        let state = self.state.as_ref().ok_or(InterpreterExtractError)?;
-        let parser = state.parser.as_ref().ok_or(InterpreterExtractError)?;
+        let state = self.state.as_ref().ok_or(InterpreterExtractError::new())?;
+        let parser = state
+            .parser
+            .as_ref()
+            .ok_or(InterpreterExtractError::new())?;
         let context = parser.peek_context();
         Ok(context)
     }

--- a/artichoke-backend/src/prng.rs
+++ b/artichoke-backend/src/prng.rs
@@ -12,60 +12,38 @@ impl Prng for Artichoke {
     type Float = Fp;
 
     fn prng_fill_bytes(&mut self, buf: &mut [u8]) -> Result<(), Self::Error> {
-        self.state
-            .as_mut()
-            .ok_or(InterpreterExtractError)?
-            .prng
-            .bytes(buf);
+        let state = self.state.as_mut().ok_or(InterpreterExtractError::new())?;
+        state.prng.bytes(buf);
         Ok(())
     }
 
     fn prng_seed(&self) -> Result<u64, Self::Error> {
-        let seed = self
-            .state
-            .as_ref()
-            .ok_or(InterpreterExtractError)?
-            .prng
-            .seed();
+        let state = self.state.as_ref().ok_or(InterpreterExtractError::new())?;
+        let seed = state.prng.seed();
         Ok(seed)
     }
 
     fn prng_reseed(&mut self, seed: Option<u64>) -> Result<(), Self::Error> {
-        self.state
-            .as_mut()
-            .ok_or(InterpreterExtractError)?
-            .prng
-            .reseed(seed);
+        let state = self.state.as_mut().ok_or(InterpreterExtractError::new())?;
+        state.prng.reseed(seed);
         Ok(())
     }
 
     fn prng_internal_state(&self) -> Result<Self::InternalState, Self::Error> {
-        let internal_state = self
-            .state
-            .as_ref()
-            .ok_or(InterpreterExtractError)?
-            .prng
-            .internal_state();
+        let state = self.state.as_ref().ok_or(InterpreterExtractError::new())?;
+        let internal_state = state.prng.internal_state();
         Ok(internal_state)
     }
 
     fn rand_int(&mut self, max: Self::Int) -> Result<Self::Int, Self::Error> {
-        let next = self
-            .state
-            .as_mut()
-            .ok_or(InterpreterExtractError)?
-            .prng
-            .rand_int(max);
+        let state = self.state.as_mut().ok_or(InterpreterExtractError::new())?;
+        let next = state.prng.rand_int(max);
         Ok(next)
     }
 
     fn rand_float(&mut self, max: Option<Self::Float>) -> Result<Self::Float, Self::Error> {
-        let next = self
-            .state
-            .as_mut()
-            .ok_or(InterpreterExtractError)?
-            .prng
-            .rand_float(max);
+        let state = self.state.as_mut().ok_or(InterpreterExtractError::new())?;
+        let next = state.prng.rand_float(max);
         Ok(next)
     }
 }

--- a/artichoke-backend/src/regexp.rs
+++ b/artichoke-backend/src/regexp.rs
@@ -6,30 +6,20 @@ impl Regexp for Artichoke {
     type Error = InterpreterExtractError;
 
     fn active_regexp_globals(&self) -> Result<usize, Self::Error> {
-        let count = self
-            .state
-            .as_ref()
-            .ok_or(InterpreterExtractError)?
-            .regexp
-            .active_regexp_globals();
+        let state = self.state.as_ref().ok_or(InterpreterExtractError::new())?;
+        let count = state.regexp.active_regexp_globals();
         Ok(count)
     }
 
     fn set_active_regexp_globals(&mut self, count: usize) -> Result<(), Self::Error> {
-        self.state
-            .as_mut()
-            .ok_or(InterpreterExtractError)?
-            .regexp
-            .set_active_regexp_globals(count);
+        let state = self.state.as_mut().ok_or(InterpreterExtractError::new())?;
+        state.regexp.set_active_regexp_globals(count);
         Ok(())
     }
 
     fn clear_regexp(&mut self) -> Result<(), Self::Error> {
-        self.state
-            .as_mut()
-            .ok_or(InterpreterExtractError)?
-            .regexp
-            .clear();
+        let state = self.state.as_mut().ok_or(InterpreterExtractError::new())?;
+        state.regexp.clear();
         Ok(())
     }
 }

--- a/artichoke-backend/src/release_metadata.rs
+++ b/artichoke-backend/src/release_metadata.rs
@@ -16,18 +16,7 @@ pub struct ReleaseMetadata<'a> {
 
 impl<'a> Default for ReleaseMetadata<'a> {
     fn default() -> Self {
-        Self {
-            copyright: "Copyright (c) 2019 Ryan Lopopolo <rjl@hyperbo.la>",
-            description: "Artichoke Ruby",
-            engine: "artichoke-mruby",
-            engine_version: env!("CARGO_PKG_VERSION"),
-            patchlevel: "0",
-            platform: "host",
-            release_date: "",
-            revision: "1",
-            ruby_version: "2.6.3",
-            compiler_version: Some("rustc"),
-        }
+        Self::new()
     }
 }
 
@@ -75,8 +64,19 @@ impl<'a> core::ReleaseMetadata for ReleaseMetadata<'a> {
 
 impl<'a> ReleaseMetadata<'a> {
     #[must_use]
-    pub fn new() -> Self {
-        Self::default()
+    pub const fn new() -> Self {
+        Self {
+            copyright: "Copyright (c) 2019 Ryan Lopopolo <rjl@hyperbo.la>",
+            description: "Artichoke Ruby",
+            engine: "artichoke-mruby",
+            engine_version: env!("CARGO_PKG_VERSION"),
+            patchlevel: "0",
+            platform: "host",
+            release_date: "",
+            revision: "1",
+            ruby_version: "2.6.3",
+            compiler_version: Some("rustc"),
+        }
     }
 
     #[must_use]

--- a/artichoke-backend/src/state/output.rs
+++ b/artichoke-backend/src/state/output.rs
@@ -34,13 +34,15 @@ pub trait Output: Send + Sync {
 }
 
 #[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Process;
+pub struct Process {
+    _private: (),
+}
 
 impl Process {
     /// Constructs a new, default `Process` output strategy.
     #[must_use]
-    pub fn new() -> Self {
-        Self::default()
+    pub const fn new() -> Self {
+        Self { _private: () }
     }
 }
 
@@ -66,6 +68,8 @@ pub struct Captured {
 
 impl Captured {
     /// Constructs a new, default `Captured` output strategy.
+    // This method cannot be const becuase of:
+    // https://github.com/BurntSushi/bstr/issues/73
     #[must_use]
     pub fn new() -> Self {
         Self::default()
@@ -120,13 +124,15 @@ impl<'a> Output for &'a mut Captured {
 }
 
 #[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Null;
+pub struct Null {
+    _private: (),
+}
 
 impl Null {
     /// Constructs a new, default `Null` output strategy.
     #[must_use]
-    pub fn new() -> Self {
-        Self::default()
+    pub const fn new() -> Self {
+        Self { _private: () }
     }
 }
 

--- a/artichoke-backend/src/state/regexp.rs
+++ b/artichoke-backend/src/state/regexp.rs
@@ -7,18 +7,20 @@ impl State {
     /// Constructs a new, default Regexp `State`.
     #[inline]
     #[must_use]
-    pub fn new() -> Self {
-        Self::default()
+    pub const fn new() -> Self {
+        Self {
+            active_regexp_globals: 0,
+        }
     }
 
     #[inline]
     pub fn clear(&mut self) {
-        *self = Self::default();
+        *self = Self::new();
     }
 
     #[inline]
     #[must_use]
-    pub fn active_regexp_globals(self) -> usize {
+    pub const fn active_regexp_globals(self) -> usize {
         self.active_regexp_globals
     }
 

--- a/artichoke-backend/src/warn.rs
+++ b/artichoke-backend/src/warn.rs
@@ -14,7 +14,7 @@ impl Warn for Artichoke {
     type Error = Exception;
 
     fn warn(&mut self, message: &[u8]) -> Result<(), Self::Error> {
-        let state = self.state.as_mut().ok_or(InterpreterExtractError)?;
+        let state = self.state.as_mut().ok_or(InterpreterExtractError::new())?;
         if let Err(err) = state.output.write_stderr(b"rb warning: ") {
             let mut message = String::from("Failed to write warning to $stderr: ");
             let _ = write!(&mut message, "{}", err);

--- a/spec-runner/src/model.rs
+++ b/spec-runner/src/model.rs
@@ -25,8 +25,12 @@ pub struct Config {
 
 impl Config {
     /// Construct a new, empty `Config`.
-    pub fn new() -> Self {
-        Self::default()
+    pub const fn new() -> Self {
+        Self {
+            language: None,
+            core: None,
+            library: None,
+        }
     }
 
     /// Lookup a suite.
@@ -60,7 +64,11 @@ pub struct Suite {
 
 impl Suite {
     /// Construct a new, empty `Suite`.
-    pub fn new() -> Self {
-        Self::default()
+    pub const fn new() -> Self {
+        Self {
+            suite: String::new(),
+            specs: None,
+            skip: None,
+        }
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -39,8 +39,8 @@ pub enum State {
 impl State {
     /// Construct a new, default `State`.
     #[must_use]
-    pub fn new() -> Self {
-        Self::default()
+    pub const fn new() -> Self {
+        Self::Valid
     }
 
     /// Whether this variant indicates a code block is open.
@@ -79,7 +79,7 @@ impl State {
 
 impl Default for State {
     fn default() -> Self {
-        Self::Valid
+        Self::new()
     }
 }
 

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -31,13 +31,15 @@ mod filename_test {
 ///
 /// The parser is needed to properly enter and exit multi-line editing mode.
 #[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct ParserAllocError;
+pub struct ParserAllocError {
+    _private: (),
+}
 
 impl ParserAllocError {
     /// Constructs a new, default `ParserAllocError`.
     #[must_use]
-    pub fn new() -> Self {
-        Self::default()
+    pub const fn new() -> Self {
+        Self { _private: () }
     }
 }
 
@@ -51,13 +53,15 @@ impl error::Error for ParserAllocError {}
 
 /// Parser processed too many lines of input.
 #[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct ParserLineCountError;
+pub struct ParserLineCountError {
+    _private: (),
+}
 
 impl ParserLineCountError {
     /// Constructs a new, default `ParserLineCountError`.
     #[must_use]
-    pub fn new() -> Self {
-        Self::default()
+    pub const fn new() -> Self {
+        Self { _private: () }
     }
 }
 
@@ -73,13 +77,15 @@ impl error::Error for ParserLineCountError {}
 ///
 /// This is usually an unknown FFI to Rust translation.
 #[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct ParserInternalError;
+pub struct ParserInternalError {
+    _private: (),
+}
 
 impl ParserInternalError {
     /// Constructs a new, default `ParserInternalError`.
     #[must_use]
-    pub fn new() -> Self {
-        Self::default()
+    pub const fn new() -> Self {
+        Self { _private: () }
     }
 }
 
@@ -180,13 +186,13 @@ where
     // - A test asserts that `REPL_FILENAME` has no NUL bytes.
     let context = unsafe { Context::new_unchecked(REPL_FILENAME.to_vec()) };
     interp.push_context(context)?;
-    let mut parser = Parser::new(&mut interp).ok_or(ParserAllocError)?;
+    let mut parser = Parser::new(&mut interp).ok_or(ParserAllocError::new())?;
 
     let mut rl = Editor::<()>::new();
     // If a code block is open, accumulate code from multiple readlines in this
     // mutable `String` buffer.
     let mut buf = String::new();
-    let mut parser_state = State::default();
+    let mut parser_state = State::new();
     loop {
         // Allow shell users to identify that they have an open code block.
         let prompt = if parser_state.is_code_block_open() {
@@ -201,7 +207,7 @@ where
                 buf.push_str(line.as_str());
                 parser_state = parser.parse(buf.as_bytes());
                 if parser_state.is_fatal() {
-                    return Err(Box::new(ParserInternalError));
+                    return Err(Box::new(ParserInternalError::new()));
                 }
                 if parser_state.is_code_block_open() {
                     buf.push('\n');
@@ -226,7 +232,7 @@ where
                     rl.add_history_entry(line);
                     interp
                         .add_fetch_lineno(1)
-                        .map_err(|_| ParserLineCountError)?;
+                        .map_err(|_| ParserLineCountError::new())?;
                 }
                 // Eval successful, so reset the REPL state for the next
                 // expression.
@@ -238,7 +244,7 @@ where
                 // Reset buffered code
                 buf.clear();
                 // clear parser state
-                parser_state = State::default();
+                parser_state = State::new();
                 writeln!(output, "^C")?;
             }
             // Gracefully exit on CTRL-D EOF

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -186,6 +186,9 @@ where
     // - A test asserts that `REPL_FILENAME` has no NUL bytes.
     let context = unsafe { Context::new_unchecked(REPL_FILENAME.to_vec()) };
     interp.push_context(context)?;
+    // disable or_fun_call lint until release of:
+    // https://github.com/rust-lang/rust-clippy/pull/5889
+    #[allow(clippy::or_fun_call)]
     let mut parser = Parser::new(&mut interp).ok_or(ParserAllocError::new())?;
 
     let mut rl = Editor::<()>::new();


### PR DESCRIPTION
This commit makes as many methods const as possible. Most involve the
modification or introduction of zero-arg `new()` methods.

This commit makes all error ZSTs only constructable via `T::new` instead
of directly instantiating the struct inline by adding a `_private: ()`
field.

This change inverts the implementation of `T::default` and `T::new` so
that `T::default` is implemented with `T::new`, allowing `T::new` to be
const. All callsites have been updated to prefer calling `T::new`.

It does not appear possible to construct byte slice literals in const
fn.

Suppress `clippy::or_fun_call` lint errors until rust-lang/rust-clippy#5889
is included in stable Rust.

This commit reworks the implementation of `regexp::Options` to store a
custom `RegexpOption` enum with `Enabled` and `Disabled` states instead
of a `bool`. This eliminates a suppressed clippy lint and makes the code
more readable. There are `From` implementations to and from `bool` as
well as `RegexpOption::is_enabled`. Much of these functions can become
const once const if match is stable.

This commit also includes some readability improvements to extracting
`RClass` pointers via `with_ffi_boundary`.