### PR TITLE
Add spinoso-securerandom crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,13 +35,11 @@ name = "artichoke-backend"
 version = "0.1.0"
 dependencies = [
  "artichoke-core",
- "base64",
  "bindgen",
  "bstr",
  "cc",
  "chrono",
  "dtoa",
- "hex",
  "intaglio",
  "itoa",
  "libc",
@@ -55,9 +53,9 @@ dependencies = [
  "rand_pcg",
  "regex",
  "spinoso-array",
+ "spinoso-securerandom",
  "spinoso-symbol",
  "target-lexicon",
- "uuid",
 ]
 
 [[package]]
@@ -226,12 +224,6 @@ checksum = "3deed196b6e7f9e44a2ae8d94225d80302d81208b1bb673fd21fe634645c85a9"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "hex"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
 
 [[package]]
 name = "intaglio"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -652,6 +652,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spinoso-securerandom"
+version = "0.1.0"
+dependencies = [
+ "base64",
+ "rand",
+ "uuid",
+]
+
+[[package]]
 name = "spinoso-symbol"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ members = [
   "artichoke-core",
   "spec-runner",
   "spinoso-array",
+  "spinoso-securerandom",
   "spinoso-symbol",
 ]
 

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -11,11 +11,9 @@ keywords = ["artichoke", "artichoke-ruby", "mruby", "ruby"]
 categories = ["api-bindings"]
 
 [dependencies]
-base64 = { version = "0.12", optional = true }
 bstr = { version = "0.2", default-features = false, features = ["std"] }
 chrono = "0.4"
 dtoa = "0.4"
-hex = { version = "0.4", optional = true }
 intaglio = "1.1"
 itoa = "0.4"
 libm = { version = "0.2", optional = true }
@@ -25,8 +23,8 @@ rand = { version = "0.7", optional = true }
 rand_pcg = { version = "0.2", optional = true }
 regex = "1"
 spinoso-array = { version = "0.3", path = "../spinoso-array" }
+spinoso-securerandom = { version = "0.1", path = "../spinoso-securerandom", optional = true }
 spinoso-symbol = { version = "0.1", path = "../spinoso-symbol" }
-uuid = { version = "0.8", optional = true, features = ["v4"] }
 
 [dependencies.artichoke-core]
 path = "../artichoke-core"
@@ -62,4 +60,4 @@ core-regexp-oniguruma = ["onig"]
 native-filesystem-access = []
 output-strategy-capture = []
 output-strategy-null = ["output-strategy-capture"]
-stdlib-securerandom = ["base64", "hex", "rand", "uuid"]
+stdlib-securerandom = ["spinoso-securerandom"]

--- a/artichoke-backend/src/extn/stdlib/securerandom/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/securerandom/mod.rs
@@ -1,3 +1,21 @@
+//! Secure random number generator interface.
+//!
+//! This module implements the [`SecureRandom`] package from the Ruby Standard
+//! Library. It is an interface to secure random number generators which are
+//! suitable for generating session keys in HTTP cookies, etc.
+//!
+//! You can use this library in your application by requiring it:
+//!
+//! ```ruby
+//! require 'securerandom'
+//! ```
+//!
+//! This implementation of `SecureRandom` supports the system RNG via the
+//! [`getrandom`] crate. This implementation does not depend on OpenSSL.
+//!
+//! [`SecureRandom`]: https://ruby-doc.org/stdlib-2.6.3/libdoc/securerandom/rdoc/SecureRandom.html
+//! [`getrandom`]: https://crates.io/crates/getrandom
+
 use crate::extn::core::exception as exc;
 use crate::extn::prelude::*;
 

--- a/artichoke-backend/src/extn/stdlib/securerandom/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/securerandom/mod.rs
@@ -24,8 +24,8 @@ pub mod trampoline;
 
 #[doc(inline)]
 pub use spinoso_securerandom::{
-    alphanumeric, base64, hex, random_bytes, random_number, uuid, ArgumentError, DomainError,
-    Error, Max, RandomBytesError, RandomNumber, SecureRandom,
+    alphanumeric, base64, hex, random_bytes, random_number, urlsafe_base64, uuid, ArgumentError,
+    DomainError, Error, Max, RandomBytesError, RandomNumber, SecureRandom,
 };
 
 impl From<Error> for Exception {

--- a/artichoke-backend/src/extn/stdlib/securerandom/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/securerandom/mod.rs
@@ -1,108 +1,79 @@
-use rand::distributions::Alphanumeric;
-use rand::{self, Rng, RngCore};
-use std::convert::TryFrom;
-use uuid::Uuid;
-
+use crate::extn::core::exception as exc;
 use crate::extn::prelude::*;
 
 pub mod mruby;
 pub mod trampoline;
 
-const DEFAULT_REQUESTED_BYTES: usize = 16;
+#[doc(inline)]
+pub use spinoso_securerandom::{
+    alphanumeric, base64, hex, random_bytes, random_number, uuid, ArgumentError, DomainError,
+    Error, Max, RandomBytesError, RandomNumber, SecureRandom,
+};
 
-#[cfg(test)]
-mod tests {
-    use rand::CryptoRng;
-
-    fn rng_must_be_cryptographically_secure<T: CryptoRng>(_rng: T) {}
-
-    #[test]
-    fn rand_thread_rng_must_be_cryptographically_secure() {
-        rng_must_be_cryptographically_secure(rand::thread_rng())
-    }
-}
-
-#[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct SecureRandom {
-    _private: (),
-}
-
-impl SecureRandom {
-    /// Constructs a new, default `SecureRandom`.
-    #[must_use]
-    pub const fn new() -> Self {
-        Self { _private: () }
-    }
-}
-
-pub fn random_bytes(len: Option<Int>) -> Result<Vec<u8>, Exception> {
-    let len = if let Some(len) = len {
-        match usize::try_from(len) {
-            Ok(0) => return Ok(Vec::new()),
-            Ok(len) => len,
-            Err(_) => {
-                return Err(ArgumentError::from("negative string size (or size too big)").into())
-            }
+impl From<Error> for Exception {
+    fn from(err: Error) -> Self {
+        match err {
+            Error::Argument(err) => err.into(),
+            Error::RandomBytes(err) => err.into(),
         }
-    } else {
-        DEFAULT_REQUESTED_BYTES
-    };
-    let mut rng = rand::thread_rng();
-    let mut bytes = vec![0; len];
-    rng.try_fill_bytes(&mut bytes)
-        .map_err(|err| RuntimeError::from(err.to_string()))?;
-    Ok(bytes)
+    }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub enum RandomNumberMax {
-    Float(Fp),
-    Integer(Int),
-    None,
+impl From<ArgumentError> for Exception {
+    fn from(err: ArgumentError) -> Self {
+        exc::ArgumentError::from(err.message()).into()
+    }
 }
 
-impl TryConvertMut<Value, RandomNumberMax> for Artichoke {
+impl From<RandomBytesError> for Exception {
+    fn from(err: RandomBytesError) -> Self {
+        RuntimeError::from(err.message()).into()
+    }
+}
+
+impl From<DomainError> for Exception {
+    fn from(err: DomainError) -> Self {
+        // TODO: MRI returns `Errno::EDOM` exception class.
+        ArgumentError::from(err.message()).into()
+    }
+}
+
+impl TryConvertMut<Value, Max> for Artichoke {
     type Error = Exception;
 
-    fn try_convert_mut(&mut self, max: Value) -> Result<RandomNumberMax, Self::Error> {
+    fn try_convert_mut(&mut self, max: Value) -> Result<Max, Self::Error> {
         let optional: Option<Value> = self.try_convert(max)?;
         self.try_convert_mut(optional)
     }
 }
 
-impl TryConvertMut<Option<Value>, RandomNumberMax> for Artichoke {
+impl TryConvertMut<Option<Value>, Max> for Artichoke {
     type Error = Exception;
 
-    fn try_convert_mut(&mut self, max: Option<Value>) -> Result<RandomNumberMax, Self::Error> {
+    fn try_convert_mut(&mut self, max: Option<Value>) -> Result<Max, Self::Error> {
         if let Some(max) = max {
             match max.ruby_type() {
                 Ruby::Fixnum => {
                     let max = max.try_into(self)?;
-                    Ok(RandomNumberMax::Integer(max))
+                    Ok(Max::Integer(max))
                 }
                 Ruby::Float => {
                     let max = max.try_into(self)?;
-                    Ok(RandomNumberMax::Float(max))
+                    Ok(Max::Float(max))
                 }
                 _ => {
                     let max = max.implicitly_convert_to_int(self).map_err(|_| {
                         let mut message = b"invalid argument - ".to_vec();
                         message.extend(max.inspect(self).as_slice());
-                        ArgumentError::from(message)
+                        exc::ArgumentError::from(message)
                     })?;
-                    Ok(RandomNumberMax::Integer(max))
+                    Ok(Max::Integer(max))
                 }
             }
         } else {
-            Ok(RandomNumberMax::None)
+            Ok(Max::None)
         }
     }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub enum RandomNumber {
-    Float(Fp),
-    Integer(Int),
 }
 
 impl ConvertMut<RandomNumber, Value> for Artichoke {
@@ -112,71 +83,4 @@ impl ConvertMut<RandomNumber, Value> for Artichoke {
             RandomNumber::Float(num) => self.convert_mut(num),
         }
     }
-}
-
-pub fn random_number(max: RandomNumberMax) -> Result<RandomNumber, ArgumentError> {
-    let mut rng = rand::thread_rng();
-    match max {
-        RandomNumberMax::Float(max) if !max.is_finite() => {
-            // NOTE: MRI returns `Errno::EDOM` exception class.
-            Err(ArgumentError::from("Numerical argument out of domain"))
-        }
-        RandomNumberMax::Float(max) if max <= 0.0 => {
-            let number = rng.gen_range(0.0, 1.0);
-            Ok(RandomNumber::Float(number))
-        }
-        RandomNumberMax::Float(max) => {
-            let number = rng.gen_range(0.0, max);
-            Ok(RandomNumber::Float(number))
-        }
-        RandomNumberMax::Integer(max) if max <= 0 => {
-            let number = rng.gen_range(0.0, 1.0);
-            Ok(RandomNumber::Float(number))
-        }
-        RandomNumberMax::Integer(max) => {
-            let number = rng.gen_range(0, max);
-            Ok(RandomNumber::Integer(number))
-        }
-        RandomNumberMax::None => {
-            let number = rng.gen_range(0.0, 1.0);
-            Ok(RandomNumber::Float(number))
-        }
-    }
-}
-
-#[inline]
-pub fn hex(len: Option<Int>) -> Result<String, Exception> {
-    let bytes = random_bytes(len)?;
-    Ok(hex::encode(bytes))
-}
-
-#[inline]
-pub fn base64(len: Option<Int>) -> Result<String, Exception> {
-    let bytes = random_bytes(len)?;
-    Ok(base64::encode(bytes))
-}
-
-pub fn alphanumeric(len: Option<Int>) -> Result<String, Exception> {
-    let len = if let Some(len) = len {
-        match usize::try_from(len) {
-            Ok(0) => return Ok(String::new()),
-            Ok(len) => len,
-            Err(_) => {
-                return Err(ArgumentError::from("negative string size (or size too big)").into())
-            }
-        }
-    } else {
-        DEFAULT_REQUESTED_BYTES
-    };
-    let rng = rand::thread_rng();
-    let string = rng.sample_iter(Alphanumeric).take(len).collect();
-    Ok(string)
-}
-
-#[must_use]
-pub fn uuid() -> String {
-    let uuid = Uuid::new_v4();
-    let mut buf = Uuid::encode_buffer();
-    let enc = uuid.to_hyphenated().encode_lower(&mut buf);
-    String::from(enc)
 }

--- a/artichoke-backend/src/extn/stdlib/securerandom/mruby.rs
+++ b/artichoke-backend/src/extn/stdlib/securerandom/mruby.rs
@@ -1,3 +1,5 @@
+//! FFI glue between the Rust trampolines and the mruby C interpreter.
+
 use crate::extn::prelude::*;
 use crate::extn::stdlib::securerandom::{self, trampoline};
 

--- a/artichoke-backend/src/extn/stdlib/securerandom/trampoline.rs
+++ b/artichoke-backend/src/extn/stdlib/securerandom/trampoline.rs
@@ -1,3 +1,5 @@
+//! Glue between mruby FFI and `securerandom` Rust implementation.
+
 use crate::extn::prelude::*;
 use crate::extn::stdlib::securerandom;
 

--- a/artichoke-backend/src/extn/stdlib/securerandom/trampoline.rs
+++ b/artichoke-backend/src/extn/stdlib/securerandom/trampoline.rs
@@ -26,6 +26,31 @@ pub fn base64(interp: &mut Artichoke, len: Option<Value>) -> Result<Value, Excep
 }
 
 #[inline]
+pub fn urlsafe_base64(
+    interp: &mut Artichoke,
+    len: Option<Value>,
+    padding: Option<Value>,
+) -> Result<Value, Exception> {
+    let padding = match padding {
+        None => false,
+        Some(val) if val.is_nil() => false,
+        Some(padding) => {
+            // All truthy values evaluate to `true` for this argument. So either
+            // `padding` is a `bool` and we can extract it, or we default to
+            // `true` since only `nil` (handled above) and `false` are falsy.
+            padding.try_into::<bool>(interp).unwrap_or(true)
+        }
+    };
+    let base64 = if let Some(len) = len {
+        let len = len.implicitly_convert_to_int(interp)?;
+        securerandom::urlsafe_base64(Some(len), padding)?
+    } else {
+        securerandom::urlsafe_base64(None, padding)?
+    };
+    Ok(interp.convert_mut(base64))
+}
+
+#[inline]
 pub fn hex(interp: &mut Artichoke, len: Option<Value>) -> Result<Value, Exception> {
     let hex = if let Some(len) = len {
         let len = len.implicitly_convert_to_int(interp)?;

--- a/artichoke-backend/src/macros.rs
+++ b/artichoke-backend/src/macros.rs
@@ -43,6 +43,7 @@ pub mod argspec {
     pub const REQ1_REQBLOCK: &[u8] = b"o&\0";
     pub const REQ1_REQBLOCK_OPT1: &[u8] = b"o&|o?\0";
     pub const REQ2: &[u8] = b"oo\0";
+    pub const OPT2: &[u8] = b"|oo\0";
     pub const OPT2_OPTBLOCK: &[u8] = b"&|o?o?\0";
     pub const REQ2_OPT1: &[u8] = b"oo|o\0";
     pub const REST: &[u8] = b"*\0";
@@ -217,6 +218,29 @@ macro_rules! mrb_get_args {
                 let req2 = req2.assume_init();
                 (req1, req2)
             }
+            _ => unreachable!("mrb_get_args should have raised"),
+        }
+    }};
+    ($mrb:expr, optional = 2) => {{
+        let mut opt1 = std::mem::MaybeUninit::<$crate::sys::mrb_value>::uninit();
+        let mut opt2 = std::mem::MaybeUninit::<$crate::sys::mrb_value>::uninit();
+        let argc = $crate::sys::mrb_get_args(
+            $mrb,
+            $crate::macros::argspec::OPT2.as_ptr() as *const i8,
+            opt1.as_mut_ptr(),
+            opt2.as_mut_ptr(),
+        );
+        match argc {
+            2 => {
+                let opt1 = opt1.assume_init();
+                let opt2 = opt2.assume_init();
+                (Some(opt1), Some(opt2))
+            }
+            1 => {
+                let opt1 = opt1.assume_init();
+                (Some(opt1), None)
+            }
+            0 => (None, None),
             _ => unreachable!("mrb_get_args should have raised"),
         }
     }};

--- a/spinoso-securerandom/Cargo.toml
+++ b/spinoso-securerandom/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "spinoso-securerandom"
+version = "0.1.0"
+authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
+edition = "2018"
+description = """
+Secure PRNG backend for Artichoke Ruby, implements 'securerandom' package
+"""
+repository = "https://github.com/artichoke/artichoke"
+readme = "README.md"
+license = "MIT"
+keywords = ["artichoke", "rand", "random", "rng", "spinoso"]
+categories = ["algorithms"]
+
+[dependencies]
+base64 = "0.12"
+rand = "0.7"
+uuid = { version = "0.8", default-features = false, features = ["v4"] }
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/spinoso-securerandom/README.md
+++ b/spinoso-securerandom/README.md
@@ -1,0 +1,89 @@
+# spinoso-securerandom
+
+[![GitHub Actions](https://github.com/artichoke/artichoke/workflows/CI/badge.svg)](https://github.com/artichoke/artichoke/actions)
+[![Discord](https://img.shields.io/discord/607683947496734760)](https://discord.gg/QCe2tp2)
+[![Twitter](https://img.shields.io/twitter/follow/artichokeruby?label=Follow&style=social)](https://twitter.com/artichokeruby)
+<br>
+[![Crate](https://img.shields.io/crates/v/spinoso-securerandom.svg)](https://crates.io/crates/spinoso-securerandom)
+[![API](https://docs.rs/spinoso-securerandom/badge.svg)](https://docs.rs/spinoso-securerandom)
+[![API trunk](https://img.shields.io/badge/docs-trunk-blue.svg)](https://artichoke.github.io/artichoke/spinoso_securerandom/)
+
+Secure random number generator interface.
+
+This module implements the [`SecureRandom`] package from the Ruby Standard
+Library. It is an interface to secure random number generators which are
+suitable for generating session keys in HTTP cookies, etc.
+
+This implementation of `SecureRandom` supports the system RNG via the
+[`getrandom`] crate. This implementation does not depend on OpenSSL.
+
+_Spinoso_ refers to _Carciofo spinoso di Sardegna_, the thorny artichoke of
+Sardinia. The idea is that the data structures defined in the `spinoso` family
+of crates will form the backbone of Ruby Core in Artichoke.
+
+## Usage
+
+Add this to your `Cargo.toml`:
+
+```toml
+[dependencies]
+spinoso-securerandom = "0.1"
+```
+
+## Examples
+
+Generate cryptographically secure random bytes:
+
+```rust
+fn example() -> Result<(), spinoso_securerandom::Error> {
+    let bytes = spinoso_securerandom::random_bytes(Some(1024))?;
+    assert_eq!(bytes.len(), 1024);
+    Ok(())
+}
+```
+
+Generate base64-encoded random data:
+
+```rust
+fn example() -> Result<(), spinoso_securerandom::Error> {
+    let bytes = spinoso_securerandom::base64(Some(1024))?;
+    assert_eq!(bytes.len(), 1368);
+    assert!(bytes.is_ascii());
+    Ok(())
+}
+```
+
+Generate random floats and integers in a range bounded from zero to a maximum:
+
+```rust
+use spinoso_securerandom::{Max, RandomNumber};
+
+fn example() -> Result<(), spinoso_securerandom::DomainError> {
+    let rand = spinoso_securerandom::random_number(Max::None)?;
+    assert!(matches!(rand, RandomNumber::Float(_)));
+
+    let rand = spinoso_securerandom::random_number(Max::Integer(57))?;
+    assert!(matches!(rand, RandomNumber::Integer(_)));
+
+    let rand = spinoso_securerandom::random_number(Max::Float(57.0))?;
+    assert!(matches!(rand, RandomNumber::Float(_)));
+    Ok(())
+}
+```
+
+Generate version 4 random UUIDs:
+
+```rust
+let bytes = spinoso_securerandom::uuid();
+assert_eq!(bytes.len(), 36);
+assert!(bytes.is_ascii());
+```
+
+## License
+
+`spinoso-securerandom` is licensed with the [MIT License](../LICENSE) (c) Ryan
+Lopopolo.
+
+[`securerandom`]:
+  https://ruby-doc.org/stdlib-2.6.3/libdoc/securerandom/rdoc/SecureRandom.html
+[`getrandom`]: https://crates.io/crates/getrandom

--- a/spinoso-securerandom/src/hex.rs
+++ b/spinoso-securerandom/src/hex.rs
@@ -1,0 +1,718 @@
+//! Functions for encoding sequences of bytes into base 16 hex encoding.
+//!
+//! [Base 16 encoding] is an encoding scheme that uses a 16 character ASCII
+//! alphabet for encoding arbitrary octets.
+//!
+//! This module offers encoders that:
+//!
+//! - Allocate and return a [`String`]: [`encode`].
+//! - Encode into an already allocated [`String`]: [`encode_into`].
+//! - Encode into a [`fmt::Write`]: [`format_into`].
+//! - Encode into a [`io::Write`]: [`write_into`].
+//!
+//! # Examples
+//!
+//! ```
+//! let data = b"Artichoke Ruby";
+//! let mut buf = String::new();
+//! spinoso_securerandom::hex::encode_into(data, &mut buf);
+//! assert_eq!(buf, "4172746963686f6b652052756279");
+//! ```
+//!
+//! This module also exposes an iterator:
+//!
+//! ```
+//! # use spinoso_securerandom::hex::Hex;
+//! let data = "Artichoke Ruby";
+//! let iter = Hex::from(data);
+//! assert_eq!(iter.collect::<String>(), "4172746963686f6b652052756279");
+//! ```
+//!
+//! [Base 16 encoding]: https://tools.ietf.org/html/rfc4648#section-8
+//! [`io::Write`]: https://doc.rust-lang.org/std/io/trait.Write.html
+
+use core::fmt;
+use core::iter::FusedIterator;
+use core::slice;
+use std::io;
+
+/// Encode arbitrary octets as base16. Returns a [`String`].
+///
+/// This function allocates a [`String`] and delegates to [`encode_into`].
+///
+/// # Examples
+///
+/// ```
+/// let data = b"Artichoke Ruby";
+/// let buf = spinoso_securerandom::hex::encode(data);
+/// assert_eq!(buf, "4172746963686f6b652052756279");
+/// ```
+#[inline]
+pub fn encode<T: AsRef<[u8]>>(data: T) -> String {
+    let mut buf = String::new();
+    encode_into(data.as_ref(), &mut buf);
+    buf
+}
+
+/// Encode arbitrary octets as base16 into the given [`String`].
+///
+/// This function writes encoded octets into the given `String`. This function
+/// will allocate at most once.
+///
+/// # Examples
+///
+/// ```
+/// # extern crate alloc;
+/// # use alloc::string::String;
+/// let data = b"Artichoke Ruby";
+/// let mut buf = String::new();
+/// spinoso_securerandom::hex::encode_into(data, &mut buf);
+/// assert_eq!(buf, "4172746963686f6b652052756279");
+/// ```
+#[inline]
+pub fn encode_into<T: AsRef<[u8]>>(data: T, buf: &mut String) {
+    let data = data.as_ref();
+    let iter = Hex::from(data);
+    buf.reserve(iter.clone().count());
+    for ch in iter {
+        buf.push(ch);
+    }
+}
+
+/// Write hex-encoded octets into the given [`fmt::Write`].
+///
+/// This function writes UTF-8 encoded octets into the given writer. This
+/// function does not allocate, but the given writer may.
+///
+/// # Examples
+///
+/// ```
+/// # extern crate alloc;
+/// # use alloc::string::String;
+/// let data = b"Artichoke Ruby";
+/// let mut buf = String::new();
+/// spinoso_securerandom::hex::format_into(data, &mut buf);
+/// assert_eq!(buf, "4172746963686f6b652052756279");
+/// ```
+#[inline]
+pub fn format_into<T, W>(data: T, mut f: W) -> fmt::Result
+where
+    T: AsRef<[u8]>,
+    W: fmt::Write,
+{
+    let data = data.as_ref();
+    let iter = Hex::from(data);
+    let mut enc = [0; 4];
+    for ch in iter {
+        let escaped = ch.encode_utf8(&mut enc);
+        f.write_str(escaped)?;
+    }
+    Ok(())
+}
+
+/// Write hex-encoded octets into the given [`io::Write`].
+///
+/// This function writes UTF-8 encoded octets into the given writer. This
+/// function does not allocate, but the given writer may.
+///
+/// # Examples
+///
+/// ```
+/// # extern crate alloc;
+/// # use alloc::vec::Vec;
+/// let data = b"Artichoke Ruby";
+/// let mut buf = Vec::new();
+/// spinoso_securerandom::hex::write_into(data, &mut buf);
+/// assert_eq!(buf, b"4172746963686f6b652052756279".to_vec());
+/// ```
+#[inline]
+pub fn write_into<T, W>(data: T, mut dest: W) -> io::Result<()>
+where
+    T: AsRef<[u8]>,
+    W: io::Write,
+{
+    let data = data.as_ref();
+    let iter = Hex::from(data);
+    let mut enc = [0; 4];
+    for ch in iter {
+        let escaped = ch.encode_utf8(&mut enc);
+        dest.write_all(escaped.as_bytes())?;
+    }
+    Ok(())
+}
+
+/// An iterator over a byte slice that returns the data as a sequence of hex
+/// encoded [`char`]s.
+///
+/// # Examples
+///
+/// ```
+/// # use spinoso_securerandom::hex::Hex;
+/// let data = "Artichoke Ruby";
+/// let iter = Hex::from(data);
+/// assert_eq!(iter.collect::<String>(), "4172746963686f6b652052756279");
+/// ```
+#[derive(Debug, Clone)]
+pub struct Hex<'a> {
+    iter: slice::Iter<'a, u8>,
+    next: Option<u8>,
+}
+
+impl<'a> From<&'a str> for Hex<'a> {
+    #[inline]
+    fn from(data: &'a str) -> Self {
+        Self::from(data.as_bytes())
+    }
+}
+
+impl<'a> From<&'a [u8]> for Hex<'a> {
+    #[inline]
+    fn from(data: &'a [u8]) -> Self {
+        Self {
+            iter: data.iter(),
+            next: None,
+        }
+    }
+}
+
+impl<'a> Iterator for Hex<'a> {
+    type Item = char;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some(byte) = self.next.take() {
+            return Some(char::from(byte));
+        }
+        let byte = self.iter.next().copied()?;
+        let mut encoded = EncodedByte::from(byte);
+        if let Some([current, next]) = encoded.next() {
+            self.next = Some(next);
+            return Some(char::from(current));
+        }
+        None
+    }
+
+    #[inline]
+    fn count(self) -> usize {
+        if self.next.is_some() {
+            self.iter.count().saturating_mul(2).saturating_add(1)
+        } else {
+            self.iter.count().saturating_mul(2)
+        }
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let size = if self.next.is_some() {
+            self.iter
+                .as_slice()
+                .len()
+                .saturating_mul(2)
+                .saturating_add(1)
+        } else {
+            self.iter.as_slice().len().saturating_mul(2)
+        };
+        (size, Some(size))
+    }
+
+    #[inline]
+    fn last(self) -> Option<Self::Item> {
+        let byte = self.iter.last().copied()?;
+        if let Some([_, last]) = EncodedByte::from(byte).last() {
+            Some(char::from(last))
+        } else {
+            None
+        }
+    }
+}
+
+impl<'a> FusedIterator for Hex<'a> {}
+
+impl<'a> ExactSizeIterator for Hex<'a> {}
+
+#[must_use = "Iterator"]
+#[derive(Debug, Clone)]
+struct EncodedByte(Option<[u8; 2]>);
+
+impl From<u8> for EncodedByte {
+    /// Map from a `u8` to a hex encoded string literal.
+    ///
+    /// For example, `00`, `20` or `ff`.
+    #[allow(clippy::too_many_lines)]
+    fn from(value: u8) -> Self {
+        let encoded = match value {
+            0 => *b"00",
+            1 => *b"01",
+            2 => *b"02",
+            3 => *b"03",
+            4 => *b"04",
+            5 => *b"05",
+            6 => *b"06",
+            7 => *b"07",
+            8 => *b"08",
+            9 => *b"09",
+            10 => *b"0a",
+            11 => *b"0b",
+            12 => *b"0c",
+            13 => *b"0d",
+            14 => *b"0e",
+            15 => *b"0f",
+            16 => *b"10",
+            17 => *b"11",
+            18 => *b"12",
+            19 => *b"13",
+            20 => *b"14",
+            21 => *b"15",
+            22 => *b"16",
+            23 => *b"17",
+            24 => *b"18",
+            25 => *b"19",
+            26 => *b"1a",
+            27 => *b"1b",
+            28 => *b"1c",
+            29 => *b"1d",
+            30 => *b"1e",
+            31 => *b"1f",
+            32 => *b"20",
+            33 => *b"21",
+            34 => *b"22",
+            35 => *b"23",
+            36 => *b"24",
+            37 => *b"25",
+            38 => *b"26",
+            39 => *b"27",
+            40 => *b"28",
+            41 => *b"29",
+            42 => *b"2a",
+            43 => *b"2b",
+            44 => *b"2c",
+            45 => *b"2d",
+            46 => *b"2e",
+            47 => *b"2f",
+            48 => *b"30",
+            49 => *b"31",
+            50 => *b"32",
+            51 => *b"33",
+            52 => *b"34",
+            53 => *b"35",
+            54 => *b"36",
+            55 => *b"37",
+            56 => *b"38",
+            57 => *b"39",
+            58 => *b"3a",
+            59 => *b"3b",
+            60 => *b"3c",
+            61 => *b"3d",
+            62 => *b"3e",
+            63 => *b"3f",
+            64 => *b"40",
+            65 => *b"41",
+            66 => *b"42",
+            67 => *b"43",
+            68 => *b"44",
+            69 => *b"45",
+            70 => *b"46",
+            71 => *b"47",
+            72 => *b"48",
+            73 => *b"49",
+            74 => *b"4a",
+            75 => *b"4b",
+            76 => *b"4c",
+            77 => *b"4d",
+            78 => *b"4e",
+            79 => *b"4f",
+            80 => *b"50",
+            81 => *b"51",
+            82 => *b"52",
+            83 => *b"53",
+            84 => *b"54",
+            85 => *b"55",
+            86 => *b"56",
+            87 => *b"57",
+            88 => *b"58",
+            89 => *b"59",
+            90 => *b"5a",
+            91 => *b"5b",
+            92 => *b"5c",
+            93 => *b"5d",
+            94 => *b"5e",
+            95 => *b"5f",
+            96 => *b"60",
+            97 => *b"61",
+            98 => *b"62",
+            99 => *b"63",
+            100 => *b"64",
+            101 => *b"65",
+            102 => *b"66",
+            103 => *b"67",
+            104 => *b"68",
+            105 => *b"69",
+            106 => *b"6a",
+            107 => *b"6b",
+            108 => *b"6c",
+            109 => *b"6d",
+            110 => *b"6e",
+            111 => *b"6f",
+            112 => *b"70",
+            113 => *b"71",
+            114 => *b"72",
+            115 => *b"73",
+            116 => *b"74",
+            117 => *b"75",
+            118 => *b"76",
+            119 => *b"77",
+            120 => *b"78",
+            121 => *b"79",
+            122 => *b"7a",
+            123 => *b"7b",
+            124 => *b"7c",
+            125 => *b"7d",
+            126 => *b"7e",
+            127 => *b"7f",
+            128 => *b"80",
+            129 => *b"81",
+            130 => *b"82",
+            131 => *b"83",
+            132 => *b"84",
+            133 => *b"85",
+            134 => *b"86",
+            135 => *b"87",
+            136 => *b"88",
+            137 => *b"89",
+            138 => *b"8a",
+            139 => *b"8b",
+            140 => *b"8c",
+            141 => *b"8d",
+            142 => *b"8e",
+            143 => *b"8f",
+            144 => *b"90",
+            145 => *b"91",
+            146 => *b"92",
+            147 => *b"93",
+            148 => *b"94",
+            149 => *b"95",
+            150 => *b"96",
+            151 => *b"97",
+            152 => *b"98",
+            153 => *b"99",
+            154 => *b"9a",
+            155 => *b"9b",
+            156 => *b"9c",
+            157 => *b"9d",
+            158 => *b"9e",
+            159 => *b"9f",
+            160 => *b"a0",
+            161 => *b"a1",
+            162 => *b"a2",
+            163 => *b"a3",
+            164 => *b"a4",
+            165 => *b"a5",
+            166 => *b"a6",
+            167 => *b"a7",
+            168 => *b"a8",
+            169 => *b"a9",
+            170 => *b"aa",
+            171 => *b"ab",
+            172 => *b"ac",
+            173 => *b"ad",
+            174 => *b"ae",
+            175 => *b"af",
+            176 => *b"b0",
+            177 => *b"b1",
+            178 => *b"b2",
+            179 => *b"b3",
+            180 => *b"b4",
+            181 => *b"b5",
+            182 => *b"b6",
+            183 => *b"b7",
+            184 => *b"b8",
+            185 => *b"b9",
+            186 => *b"ba",
+            187 => *b"bb",
+            188 => *b"bc",
+            189 => *b"bd",
+            190 => *b"be",
+            191 => *b"bf",
+            192 => *b"c0",
+            193 => *b"c1",
+            194 => *b"c2",
+            195 => *b"c3",
+            196 => *b"c4",
+            197 => *b"c5",
+            198 => *b"c6",
+            199 => *b"c7",
+            200 => *b"c8",
+            201 => *b"c9",
+            202 => *b"ca",
+            203 => *b"cb",
+            204 => *b"cc",
+            205 => *b"cd",
+            206 => *b"ce",
+            207 => *b"cf",
+            208 => *b"d0",
+            209 => *b"d1",
+            210 => *b"d2",
+            211 => *b"d3",
+            212 => *b"d4",
+            213 => *b"d5",
+            214 => *b"d6",
+            215 => *b"d7",
+            216 => *b"d8",
+            217 => *b"d9",
+            218 => *b"da",
+            219 => *b"db",
+            220 => *b"dc",
+            221 => *b"dd",
+            222 => *b"de",
+            223 => *b"df",
+            224 => *b"e0",
+            225 => *b"e1",
+            226 => *b"e2",
+            227 => *b"e3",
+            228 => *b"e4",
+            229 => *b"e5",
+            230 => *b"e6",
+            231 => *b"e7",
+            232 => *b"e8",
+            233 => *b"e9",
+            234 => *b"ea",
+            235 => *b"eb",
+            236 => *b"ec",
+            237 => *b"ed",
+            238 => *b"ee",
+            239 => *b"ef",
+            240 => *b"f0",
+            241 => *b"f1",
+            242 => *b"f2",
+            243 => *b"f3",
+            244 => *b"f4",
+            245 => *b"f5",
+            246 => *b"f6",
+            247 => *b"f7",
+            248 => *b"f8",
+            249 => *b"f9",
+            250 => *b"fa",
+            251 => *b"fb",
+            252 => *b"fc",
+            253 => *b"fd",
+            254 => *b"fe",
+            255 => *b"ff",
+        };
+        Self(Some(encoded))
+    }
+}
+
+impl Iterator for EncodedByte {
+    type Item = [u8; 2];
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.take()
+    }
+
+    #[inline]
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        if n == 0 {
+            self.0.take()
+        } else {
+            None
+        }
+    }
+
+    #[inline]
+    fn count(self) -> usize {
+        if self.0.is_some() {
+            1
+        } else {
+            0
+        }
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let size = if self.0.is_some() { 1 } else { 0 };
+        (size, Some(size))
+    }
+
+    #[inline]
+    fn last(mut self) -> Option<Self::Item> {
+        // For a size == 1 iterator, `next` and `last` are the same operation.
+        self.next()
+    }
+}
+
+impl DoubleEndedIterator for EncodedByte {
+    #[inline]
+    fn next_back(&mut self) -> Option<Self::Item> {
+        // For a size == 1 iterator, `next` and `next_back` are the same
+        // operation.
+        self.next()
+    }
+
+    #[inline]
+    fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
+        // For a size == 1 iterator, `nth` and `nth_back` are the same
+        // operation.
+        self.nth(n)
+    }
+}
+
+impl FusedIterator for EncodedByte {}
+
+impl ExactSizeIterator for EncodedByte {}
+
+#[cfg(test)]
+mod tests {
+    use super::{encode, encode_into, format_into, write_into, EncodedByte, Hex};
+
+    #[test]
+    fn literal_exhaustive() {
+        for byte in 0..=255 {
+            let mut lit = EncodedByte::from(byte);
+            let [left, right] = lit.next().unwrap();
+            let top = byte >> 4;
+            match top {
+                0x0 => assert_eq!(left, b'0'),
+                0x1 => assert_eq!(left, b'1'),
+                0x2 => assert_eq!(left, b'2'),
+                0x3 => assert_eq!(left, b'3'),
+                0x4 => assert_eq!(left, b'4'),
+                0x5 => assert_eq!(left, b'5'),
+                0x6 => assert_eq!(left, b'6'),
+                0x7 => assert_eq!(left, b'7'),
+                0x8 => assert_eq!(left, b'8'),
+                0x9 => assert_eq!(left, b'9'),
+                0xA => assert_eq!(left, b'a'),
+                0xB => assert_eq!(left, b'b'),
+                0xC => assert_eq!(left, b'c'),
+                0xD => assert_eq!(left, b'd'),
+                0xE => assert_eq!(left, b'e'),
+                0xF => assert_eq!(left, b'f'),
+                tuple => panic!("unknown top 16th: {}, from byte: {}", tuple, byte),
+            }
+            let bottom = byte & 0xF;
+            match bottom {
+                0x0 => assert_eq!(right, b'0'),
+                0x1 => assert_eq!(right, b'1'),
+                0x2 => assert_eq!(right, b'2'),
+                0x3 => assert_eq!(right, b'3'),
+                0x4 => assert_eq!(right, b'4'),
+                0x5 => assert_eq!(right, b'5'),
+                0x6 => assert_eq!(right, b'6'),
+                0x7 => assert_eq!(right, b'7'),
+                0x8 => assert_eq!(right, b'8'),
+                0x9 => assert_eq!(right, b'9'),
+                0xA => assert_eq!(right, b'a'),
+                0xB => assert_eq!(right, b'b'),
+                0xC => assert_eq!(right, b'c'),
+                0xD => assert_eq!(right, b'd'),
+                0xE => assert_eq!(right, b'e'),
+                0xF => assert_eq!(right, b'f'),
+                tuple => panic!("unknown bottom 16th: {}, from byte: {}", tuple, byte),
+            }
+            assert!(lit.next().is_none());
+        }
+    }
+
+    // https://tools.ietf.org/html/rfc4648#section-10
+    #[test]
+    fn rfc4648_test_vectors() {
+        // BASE16("") = ""
+        assert_eq!(encode(""), "");
+        assert_eq!(Hex::from("").collect::<String>(), "");
+        let mut s = String::new();
+        encode_into("", &mut s);
+        assert_eq!(s, "");
+        assert_eq!(s.capacity(), 0);
+        let mut fmt = String::new();
+        format_into("", &mut fmt).unwrap();
+        assert_eq!(fmt, "");
+        let mut write = Vec::new();
+        write_into("", &mut write).unwrap();
+        assert_eq!(write, b"".to_vec());
+
+        // BASE16("f") = "66"
+        assert_eq!(encode("f"), "66");
+        assert_eq!(Hex::from("f").collect::<String>(), "66");
+        let mut s = String::new();
+        encode_into("f", &mut s);
+        assert_eq!(s, "66");
+        assert!(s.capacity() >= 2);
+        let mut fmt = String::new();
+        format_into("f", &mut fmt).unwrap();
+        assert_eq!(fmt, "66");
+        let mut write = Vec::new();
+        write_into("f", &mut write).unwrap();
+        assert_eq!(write, b"66".to_vec());
+
+        // BASE16("fo") = "666F"
+        assert_eq!(encode("fo"), "666f");
+        assert_eq!(Hex::from("fo").collect::<String>(), "666f");
+        let mut s = String::new();
+        encode_into("fo", &mut s);
+        assert_eq!(s, "666f");
+        assert!(s.capacity() >= 4);
+        let mut fmt = String::new();
+        format_into("fo", &mut fmt).unwrap();
+        assert_eq!(fmt, "666f");
+        let mut write = Vec::new();
+        write_into("fo", &mut write).unwrap();
+        assert_eq!(write, b"666f".to_vec());
+
+        // BASE16("foo") = "666F6F"
+        assert_eq!(encode("foo"), "666f6f");
+        assert_eq!(Hex::from("foo").collect::<String>(), "666f6f");
+        let mut s = String::new();
+        encode_into("foo", &mut s);
+        assert_eq!(s, "666f6f");
+        assert!(s.capacity() >= 6);
+        let mut fmt = String::new();
+        format_into("foo", &mut fmt).unwrap();
+        assert_eq!(fmt, "666f6f");
+        let mut write = Vec::new();
+        write_into("foo", &mut write).unwrap();
+        assert_eq!(write, b"666f6f".to_vec());
+
+        // BASE16("foob") = "666F6F62"
+        assert_eq!(encode("foob"), "666f6f62");
+        assert_eq!(Hex::from("foob").collect::<String>(), "666f6f62");
+        let mut s = String::new();
+        encode_into("foob", &mut s);
+        assert_eq!(s, "666f6f62");
+        assert!(s.capacity() >= 8);
+        let mut fmt = String::new();
+        format_into("foob", &mut fmt).unwrap();
+        assert_eq!(fmt, "666f6f62");
+        let mut write = Vec::new();
+        write_into("foob", &mut write).unwrap();
+        assert_eq!(write, b"666f6f62".to_vec());
+
+        // BASE16("fooba") = "666F6F6261"
+        assert_eq!(encode("fooba"), "666f6f6261");
+        assert_eq!(Hex::from("fooba").collect::<String>(), "666f6f6261");
+        let mut s = String::new();
+        encode_into("fooba", &mut s);
+        assert_eq!(s, "666f6f6261");
+        assert!(s.capacity() >= 10);
+        let mut fmt = String::new();
+        format_into("fooba", &mut fmt).unwrap();
+        assert_eq!(fmt, "666f6f6261");
+        let mut write = Vec::new();
+        write_into("fooba", &mut write).unwrap();
+        assert_eq!(write, b"666f6f6261".to_vec());
+
+        // BASE16("foobar") = "666F6F626172"
+        assert_eq!(encode("foobar"), "666f6f626172");
+        assert_eq!(Hex::from("foobar").collect::<String>(), "666f6f626172");
+        let mut s = String::new();
+        encode_into("foobar", &mut s);
+        assert_eq!(s, "666f6f626172");
+        assert!(s.capacity() >= 12);
+        let mut fmt = String::new();
+        format_into("foobar", &mut fmt).unwrap();
+        assert_eq!(fmt, "666f6f626172");
+        let mut write = Vec::new();
+        write_into("foobar", &mut write).unwrap();
+        assert_eq!(write, b"666f6f626172".to_vec());
+    }
+}

--- a/spinoso-securerandom/src/hex.rs
+++ b/spinoso-securerandom/src/hex.rs
@@ -94,6 +94,10 @@ pub fn encode_into<T: AsRef<[u8]>>(data: T, buf: &mut String) {
 /// spinoso_securerandom::hex::format_into(data, &mut buf);
 /// assert_eq!(buf, "4172746963686f6b652052756279");
 /// ```
+///
+/// # Errors
+///
+/// If the formatter returns an error, that error is returned.
 #[inline]
 pub fn format_into<T, W>(data: T, mut f: W) -> fmt::Result
 where
@@ -125,6 +129,10 @@ where
 /// spinoso_securerandom::hex::write_into(data, &mut buf);
 /// assert_eq!(buf, b"4172746963686f6b652052756279".to_vec());
 /// ```
+///
+/// # Errors
+///
+/// If the destination returns an error, that error is returned.
 #[inline]
 pub fn write_into<T, W>(data: T, mut dest: W) -> io::Result<()>
 where
@@ -189,9 +197,8 @@ impl<'a> Hex<'a> {
         } else {
             let remaining_bytes = self.iter.as_slice().len();
             // Every byte expands to two hexadecimal ASCII `char`s.
-            let remaining_bytes_encoded_len = remaining_bytes.saturating_mul(2);
             // the only data remaining is unencoded bytes in the slice.
-            remaining_bytes_encoded_len
+            remaining_bytes.saturating_mul(2)
         }
     }
 

--- a/spinoso-securerandom/src/lib.rs
+++ b/spinoso-securerandom/src/lib.rs
@@ -449,6 +449,28 @@ pub fn base64(len: Option<i64>) -> Result<String, Error> {
     Ok(base64::encode(bytes))
 }
 
+/// Generate a URL-safe base64-encoded [`String`] of random bytes.
+///
+/// If `len` is [`Some`] and non-negative, generate a vector of `len` random
+/// bytes. If `len` is [`None`], generate 16 random bytes. Take the resulting
+/// bytes and base64 encode them.
+///
+/// # Errors
+///
+/// If the given length is negative, return an [`ArgumentError`].
+///
+/// If the underlying source of randomness returns an error, return a
+/// [`RandomBytesError`].
+#[inline]
+pub fn urlsafe_base64(len: Option<i64>, padding: bool) -> Result<String, Error> {
+    let bytes = random_bytes(len)?;
+    if padding {
+        Ok(base64::encode_config(bytes, base64::URL_SAFE))
+    } else {
+        Ok(base64::encode_config(bytes, base64::URL_SAFE_NO_PAD))
+    }
+}
+
 /// Generate a random sequence of ASCII alphanumeric bytes.
 ///
 /// If `len` is [`Some`] and non-negative, generate a [`String`] of `len`

--- a/spinoso-securerandom/src/lib.rs
+++ b/spinoso-securerandom/src/lib.rs
@@ -1,0 +1,642 @@
+#![warn(clippy::all)]
+#![warn(clippy::pedantic)]
+#![warn(clippy::cargo)]
+#![allow(unknown_lints)]
+#![warn(broken_intra_doc_links)]
+#![warn(missing_docs)]
+#![warn(missing_debug_implementations)]
+#![warn(missing_copy_implementations)]
+#![warn(rust_2018_idioms)]
+#![warn(trivial_casts, trivial_numeric_casts)]
+#![warn(unused_qualifications)]
+#![warn(variant_size_differences)]
+#![forbid(unsafe_code)]
+// Enable feature callouts in generated documentation:
+// https://doc.rust-lang.org/beta/unstable-book/language-features/doc-cfg.html
+//
+// This approach is borrowed from tokio.
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_alias))]
+
+//! etc.
+
+use core::convert::TryFrom;
+use core::fmt;
+use rand::distributions::Alphanumeric;
+use rand::{self, Rng, RngCore};
+use std::error;
+use uuid::Uuid;
+
+pub mod hex;
+
+const DEFAULT_REQUESTED_BYTES: usize = 16;
+
+/// Sum type of all errors possibly returned from [`random_bytes`].
+///
+/// `random_bytes` can return errors under several conditions:
+///
+/// - The given byte length is not a valid [`usize`].
+/// - The underlying source of randomness returns an error when generating the
+///   requested random bytes.
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Error {
+    /// Error that indicates an argument parsing or value logic error occurred.
+    ///
+    /// See [`ArgumentError`].
+    Argument(ArgumentError),
+    /// Error that indicates the underlying source of randomness failed to
+    /// generate the requested random bytes.
+    ///
+    /// See [`RandomBytesError`].
+    RandomBytes(RandomBytesError),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("SecureRandom error")
+    }
+}
+
+impl error::Error for Error {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        match self {
+            Self::Argument(ref err) => Some(err),
+            Self::RandomBytes(ref err) => Some(err),
+        }
+    }
+}
+
+/// Error that indicates an argument parsing or value logic error occurred.
+///
+/// Argument errors have an associated message.
+///
+/// This error corresponds to the [Ruby `ArgumentError` Exception class].
+///
+/// # Examples
+///
+/// ```
+/// # use spinoso_securerandom::ArgumentError;
+/// let err = ArgumentError::new();
+/// assert_eq!(err.message(), "ArgumentError");
+///
+/// let err = ArgumentError::with_message("negative string size (or size too big)");
+/// assert_eq!(err.message(), "negative string size (or size too big)");
+/// ```
+///
+/// [Ruby `ArgumentError` Exception class]: https://ruby-doc.org/core-2.6.3/ArgumentError.html
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ArgumentError(&'static str);
+
+impl From<&'static str> for ArgumentError {
+    fn from(message: &'static str) -> Self {
+        Self::with_message(message)
+    }
+}
+
+impl Default for ArgumentError {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl fmt::Display for ArgumentError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.message())
+    }
+}
+
+impl error::Error for ArgumentError {}
+
+impl ArgumentError {
+    /// Construct a new, default argument error.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_securerandom::ArgumentError;
+    /// const ERR: ArgumentError = ArgumentError::new();
+    /// assert_eq!(ERR.message(), "ArgumentError");
+    /// ```
+    #[inline]
+    #[must_use]
+    pub const fn new() -> Self {
+        Self("ArgumentError")
+    }
+
+    /// Construct a new, default argument error.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_securerandom::ArgumentError;
+    /// const ERR: ArgumentError = ArgumentError::with_message("negative string size (or size too big)");
+    /// assert_eq!(ERR.message(), "negative string size (or size too big)");
+    /// ```
+    #[inline]
+    #[must_use]
+    pub const fn with_message(message: &'static str) -> Self {
+        Self(message)
+    }
+
+    /// Retrieve the exception message associated with this argument error.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_securerandom::ArgumentError;
+    /// let err = ArgumentError::new();
+    /// assert_eq!(err.message(), "ArgumentError");
+    ///
+    /// let err = ArgumentError::with_message("negative string size (or size too big)");
+    /// assert_eq!(err.message(), "negative string size (or size too big)");
+    /// ```
+    #[inline]
+    #[must_use]
+    pub const fn message(self) -> &'static str {
+        self.0
+    }
+}
+
+/// Error that indicates the underlying source of randomness failed to generate
+/// the requested random bytes.
+///
+/// This error is typically returned by the operating system.
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub struct RandomBytesError {
+    _private: (),
+}
+
+impl fmt::Display for RandomBytesError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.message())
+    }
+}
+
+impl error::Error for RandomBytesError {}
+
+impl RandomBytesError {
+    /// Construct a new, default random bytes error.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_securerandom::RandomBytesError;
+    /// const ERR: RandomBytesError = RandomBytesError::new();
+    /// assert_eq!(ERR.message(), "OS Error: Failed to generate random bytes");
+    /// ```
+    #[inline]
+    #[must_use]
+    pub const fn new() -> Self {
+        Self { _private: () }
+    }
+
+    /// Retrieve the exception message associated with this random bytes error.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_securerandom::RandomBytesError;
+    /// let err = RandomBytesError::new();
+    /// assert_eq!(err.message(), "OS Error: Failed to generate random bytes");
+    /// ```
+    #[inline]
+    #[must_use]
+    pub const fn message(self) -> &'static str {
+        "OS Error: Failed to generate random bytes"
+    }
+}
+
+/// Error that indicates the given maximum value is not finite and cannot be
+/// used to bound a domain for generating random numbers.
+///
+/// This error is returned by [`random_number`].
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub struct DomainError {
+    _private: (),
+}
+
+impl fmt::Display for DomainError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.message())
+    }
+}
+
+impl error::Error for DomainError {}
+
+impl DomainError {
+    /// Construct a new, default random bytes error.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_securerandom::DomainError;
+    /// const ERR: DomainError = DomainError::new();
+    /// assert_eq!(ERR.message(), "Numerical argument out of domain");
+    /// ```
+    #[inline]
+    #[must_use]
+    pub const fn new() -> Self {
+        Self { _private: () }
+    }
+
+    /// Retrieve the exception message associated with this random bytes error.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_securerandom::DomainError;
+    /// let err = DomainError::new();
+    /// assert_eq!(err.message(), "Numerical argument out of domain");
+    /// ```
+    #[inline]
+    #[must_use]
+    pub const fn message(self) -> &'static str {
+        "Numerical argument out of domain"
+    }
+}
+
+/// A handle to the underlying secure random number generator.
+///
+/// This is a copy zero-sized type with no associated methods. This type exists
+/// so a Ruby VM can attempt to unbox this type and statically dispatch to
+/// functions defined in this crate.
+///
+/// # Examples
+///
+/// ```
+/// # use spinoso_securerandom::SecureRandom;
+/// const RANDOM: SecureRandom = SecureRandom::new();
+/// ```
+#[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub struct SecureRandom {
+    _private: (),
+}
+
+impl SecureRandom {
+    /// Constructs a new, default `SecureRandom`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_securerandom::SecureRandom;
+    /// const RANDOM: SecureRandom = SecureRandom::new();
+    /// ```
+    #[inline]
+    #[must_use]
+    pub const fn new() -> Self {
+        Self { _private: () }
+    }
+}
+
+/// Generate a vector of random bytes.
+///
+/// If `len` is [`Some`] and non-negative, generate a vector of `len` random
+/// bytes. If `len` is [`None`], generate 16 random bytes.
+///
+/// # Errors
+///
+/// If the given length is negative, return an [`ArgumentError`].
+///
+/// If the underlying source of randomness returns an error, return a
+/// [`RandomBytesError`].
+#[inline]
+pub fn random_bytes(len: Option<i64>) -> Result<Vec<u8>, Error> {
+    let len = if let Some(len) = len {
+        match usize::try_from(len) {
+            Ok(0) => return Ok(Vec::new()),
+            Ok(len) => len,
+            Err(_) => {
+                let err = ArgumentError::with_message("negative string size (or size too big)");
+                return Err(Error::Argument(err));
+            }
+        }
+    } else {
+        DEFAULT_REQUESTED_BYTES
+    };
+    let mut rng = rand::thread_rng();
+    let mut bytes = vec![0; len];
+    if rng.try_fill_bytes(&mut bytes).is_err() {
+        return Err(Error::RandomBytes(RandomBytesError::new()));
+    }
+    Ok(bytes)
+}
+
+/// Max value when generating a random number from a range.
+///
+/// In Ruby, the `rand` family of functions generate random numbers form within
+/// a range. This range is always anchored on the left by zero. The `Max` enum
+/// allows callers to specify the upper bound of the range. If the `None`
+/// variant is given, the default is set to generate floats in the range of
+/// `[0.0, 1.0)`.
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
+pub enum Max {
+    /// Generate floats in the range `[0, max)`.
+    ///
+    /// If `max` is less than or equal to zero, the range defaults to floats
+    /// in `[0.0, 1.0]`.
+    ///
+    /// If `max` is [`NaN`], an error is returned.
+    ///
+    /// [`NaN`]: https://doc.rust-lang.org/std/primitive.f64.html#associatedconstant.NAN
+    Float(f64),
+    /// Generate signed integers in the range `[0, max)`.
+    ///
+    /// If `max` is less than or equal to zero, the range defaults to floats
+    /// in `[0.0, 1.0]`.
+    Integer(i64),
+    /// Generate floats in the range `[0.0, 1.0]`.
+    None,
+}
+
+/// Random numeric value generated from the secure random number generator.
+///
+/// In Ruby, the `rand` family of functions generate random numbers that are
+/// either floats or signed integers.
+///
+/// The numeric contents of this enum will never be negative and will always be
+/// finite.
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
+pub enum RandomNumber {
+    /// A random float that is greater than or equal to zero.
+    Float(f64),
+    /// A random signed integer that is greater than or equal to zero.
+    Integer(i64),
+}
+
+/// Generate a single random number, either a float or an integer.
+///
+/// In Ruby, the `rand` family of functions generate random numbers that are
+/// either floats or signed integers.
+///
+/// The random numbers returned by this function will never be negative and will
+/// always be finite.
+///
+/// In Ruby, the `rand` family of functions generate random numbers form within
+/// a range. This range is always anchored on the left by zero. See the [`Max`]
+/// enum documentation for how to bound the random numbers returned by this
+/// function.
+///
+/// # Errors
+///
+/// If the float given in a [`Max::Float`] variant is [`NaN`] or infinite, a
+/// [`DomainError`] is returned.
+///
+/// [`NaN`]: https://doc.rust-lang.org/std/primitive.f64.html#associatedconstant.NAN
+#[inline]
+pub fn random_number(max: Max) -> Result<RandomNumber, DomainError> {
+    let mut rng = rand::thread_rng();
+    match max {
+        Max::Float(max) if !max.is_finite() => {
+            // NOTE: MRI returns `Errno::EDOM` exception class.
+            Err(DomainError::new())
+        }
+        Max::Float(max) if max <= 0.0 => {
+            let number = rng.gen_range(0.0, 1.0);
+            Ok(RandomNumber::Float(number))
+        }
+        Max::Float(max) => {
+            let number = rng.gen_range(0.0, max);
+            Ok(RandomNumber::Float(number))
+        }
+        Max::Integer(max) if !max.is_positive() => {
+            let number = rng.gen_range(0.0, 1.0);
+            Ok(RandomNumber::Float(number))
+        }
+        Max::Integer(max) => {
+            let number = rng.gen_range(0, max);
+            Ok(RandomNumber::Integer(number))
+        }
+        Max::None => {
+            let number = rng.gen_range(0.0, 1.0);
+            Ok(RandomNumber::Float(number))
+        }
+    }
+}
+
+/// Generate a hex-encoded [`String`] of random bytes.
+///
+/// If `len` is [`Some`] and non-negative, generate a vector of `len` random
+/// bytes. If `len` is [`None`], generate 16 random bytes. Take the resulting
+/// bytes and hexadecimal encode them.
+///
+/// # Errors
+///
+/// If the given length is negative, return an [`ArgumentError`].
+///
+/// If the underlying source of randomness returns an error, return a
+/// [`RandomBytesError`].
+#[inline]
+pub fn hex(len: Option<i64>) -> Result<String, Error> {
+    let bytes = random_bytes(len)?;
+    Ok(hex::encode(bytes))
+}
+
+/// Generate a base64-encoded [`String`] of random bytes.
+///
+/// If `len` is [`Some`] and non-negative, generate a vector of `len` random
+/// bytes. If `len` is [`None`], generate 16 random bytes. Take the resulting
+/// bytes and base64 encode them.
+///
+/// # Errors
+///
+/// If the given length is negative, return an [`ArgumentError`].
+///
+/// If the underlying source of randomness returns an error, return a
+/// [`RandomBytesError`].
+#[inline]
+pub fn base64(len: Option<i64>) -> Result<String, Error> {
+    let bytes = random_bytes(len)?;
+    Ok(base64::encode(bytes))
+}
+
+/// Generate a random sequence of ASCII alphanumeric bytes.
+///
+/// If `len` is [`Some`] and non-negative, generate a [`String`] of `len`
+/// random ASCII alphanumeric bytes. If `len` is [`None`], generate 16 random
+/// alphanumeric bytes.
+///
+/// # Errors
+///
+/// If the given length is negative, return an [`ArgumentError`].
+///
+/// If the underlying source of randomness returns an error, return a
+/// [`RandomBytesError`].
+#[inline]
+pub fn alphanumeric(len: Option<i64>) -> Result<String, Error> {
+    let len = if let Some(len) = len {
+        match usize::try_from(len) {
+            Ok(0) => return Ok(String::new()),
+            Ok(len) => len,
+            Err(_) => {
+                let err = ArgumentError::with_message("negative string size (or size too big)");
+                return Err(Error::Argument(err));
+            }
+        }
+    } else {
+        DEFAULT_REQUESTED_BYTES
+    };
+    let rng = rand::thread_rng();
+    let string = rng.sample_iter(Alphanumeric).take(len).collect();
+    Ok(string)
+}
+
+/// Generate a version 4 UUID and return a [`String`].
+///
+/// A version 4 UUID is randomly generated. See [RFC 4122] for details.
+///
+/// [RFC 4122]: https://tools.ietf.org/html/rfc4122#section-4.4
+#[inline]
+#[must_use]
+pub fn uuid() -> String {
+    let uuid = Uuid::new_v4();
+    let mut buf = Uuid::encode_buffer();
+    let enc = uuid.to_hyphenated().encode_lower(&mut buf);
+    String::from(enc)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        alphanumeric, base64, hex, random_bytes, random_number, uuid, DomainError, Error, Max,
+        RandomNumber,
+    };
+    use rand::CryptoRng;
+
+    fn rng_must_be_cryptographically_secure<T: CryptoRng>(_rng: T) {}
+
+    #[test]
+    fn rand_thread_rng_must_be_cryptographically_secure() {
+        rng_must_be_cryptographically_secure(rand::thread_rng())
+    }
+
+    #[test]
+    fn random_bytes_len_must_be_positive() {
+        assert!(matches!(random_bytes(Some(-1)), Err(Error::Argument(_))));
+        assert!(matches!(base64(Some(-1)), Err(Error::Argument(_))));
+        assert!(matches!(hex(Some(-1)), Err(Error::Argument(_))));
+        assert!(matches!(alphanumeric(Some(-1)), Err(Error::Argument(_))));
+    }
+
+    #[test]
+    fn random_bytes_zero_len_gives_empty_result() {
+        assert!(random_bytes(Some(0)).unwrap().is_empty());
+        assert!(base64(Some(0)).unwrap().is_empty());
+        assert!(hex(Some(0)).unwrap().is_empty());
+        assert!(alphanumeric(Some(0)).unwrap().is_empty());
+    }
+
+    #[test]
+    fn random_bytes_nonzero_len_gives_len_result() {
+        assert_eq!(random_bytes(Some(32)).unwrap().len(), 32);
+        assert_eq!(base64(Some(32)).unwrap().len(), 44);
+        assert_eq!(hex(Some(32)).unwrap().len(), 64);
+        assert_eq!(alphanumeric(Some(32)).unwrap().len(), 32);
+
+        // for a len that is not a power of two
+        assert_eq!(random_bytes(Some(57)).unwrap().len(), 57);
+        assert_eq!(base64(Some(57)).unwrap().len(), 76);
+        assert_eq!(hex(Some(57)).unwrap().len(), 114);
+        assert_eq!(alphanumeric(Some(57)).unwrap().len(), 57);
+    }
+
+    #[test]
+    fn random_bytes_none_len_gives_len_16_result() {
+        assert_eq!(random_bytes(None).unwrap().len(), 16);
+        assert_eq!(base64(None).unwrap().len(), 24);
+        assert_eq!(hex(None).unwrap().len(), 32);
+        assert_eq!(alphanumeric(None).unwrap().len(), 16);
+    }
+
+    #[test]
+    fn random_number_domain_error() {
+        assert_eq!(random_number(Max::Float(f64::NAN)), Err(DomainError::new()));
+        assert_eq!(
+            random_number(Max::Float(f64::INFINITY)),
+            Err(DomainError::new())
+        );
+        assert_eq!(
+            random_number(Max::Float(f64::NEG_INFINITY)),
+            Err(DomainError::new())
+        );
+    }
+
+    #[test]
+    fn random_number_in_float_out_float() {
+        assert!(matches!(
+            random_number(Max::None),
+            Ok(RandomNumber::Float(_))
+        ));
+        assert!(matches!(
+            random_number(Max::Float(0.5)),
+            Ok(RandomNumber::Float(_))
+        ));
+        assert!(matches!(
+            random_number(Max::Float(1.0)),
+            Ok(RandomNumber::Float(_))
+        ));
+        assert!(matches!(
+            random_number(Max::Float(9000.63)),
+            Ok(RandomNumber::Float(_))
+        ));
+        assert!(matches!(
+            random_number(Max::Float(0.0)),
+            Ok(RandomNumber::Float(_))
+        ));
+        assert!(matches!(
+            random_number(Max::Float(-0.0)),
+            Ok(RandomNumber::Float(_))
+        ));
+        assert!(matches!(
+            random_number(Max::Float(-1.0)),
+            Ok(RandomNumber::Float(_))
+        ));
+    }
+
+    #[test]
+    fn random_number_in_neg_integer_out_float() {
+        assert!(matches!(
+            random_number(Max::Integer(-1)),
+            Ok(RandomNumber::Float(_))
+        ));
+    }
+
+    #[test]
+    fn random_number_in_zero_integer_out_float() {
+        assert!(matches!(
+            random_number(Max::Integer(0)),
+            Ok(RandomNumber::Float(_))
+        ));
+    }
+
+    #[test]
+    fn random_number_in_pos_integer_out_integer() {
+        assert!(matches!(
+            random_number(Max::Integer(1)),
+            Ok(RandomNumber::Integer(_))
+        ));
+        assert!(matches!(
+            random_number(Max::Integer(9000)),
+            Ok(RandomNumber::Integer(_))
+        ));
+        assert!(matches!(
+            random_number(Max::Integer(i64::MAX)),
+            Ok(RandomNumber::Integer(_))
+        ));
+    }
+
+    #[test]
+    fn uuid_format() {
+        let id = uuid();
+        assert_eq!(id.len(), 36);
+        assert!(id.find(char::is_uppercase).is_none());
+        assert_eq!(&id[14..15], "4");
+    }
+
+    #[test]
+    fn alphanumeric_format() {
+        let random = alphanumeric(Some(1024)).unwrap();
+        assert!(random
+            .find(|ch: char| !ch.is_ascii_alphanumeric())
+            .is_none());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,19 +63,19 @@
 //!
 //! ## Crate Features
 //!
-//! - `core-env-system` - **Enabled** by default. This activates the `std::env`
-//!   backend for the [`ENV` object][core-obj-env]. When this feature is
-//!   disabled, access to the environ is emulated with an in-memory store.
-//! - `core-math-extra` - **Enabled** by default. This enables additional
-//!   dependencies to implement some functions in the
-//!   [`Math` module][core-mod-math].  When this feature is disabled, these
-//!   functions raise `NotImplementedError`.
-//! - `core-random` - **Enabled** by default. This includes an implementation of
-//!   the [`Random` class][core-class-random]. This feature includes additional
+//! All features are enabled by default.
+//!
+//! - **core-env-system** - Activates the [`std::env`](module@std::env) backend
+//!   for the [`ENV` object][core-obj-env]. When this feature is disabled,
+//!   access to the environ is emulated with an in-memory store.
+//! - **core-math-extra** - Activates additional dependencies to implement some
+//!   functions in the [`Math` module][core-mod-math].  When this feature is
+//!   disabled, these functions raise `NotImplementedError`.
+//! - **core-random** - This includes an implementation of the
+//!   [`Random` class][core-class-random]. This feature includes additional
 //!   dependencies. When this feature is disabled, Artichoke does not have
 //!   support for generating psuedorandom numbers.
-//! - `stdlib-securerandom` - **Enabled** by default. This feature includes an
-//!   implementation of a CSPRNG for the
+//! - **stdlib-securerandom** - An implementation of a CSPRNG for the
 //!   [`SecureRandom` module][stdlib-mod-securerandom]. This feature includes
 //!   additional dependencies.  When this feature is disabled, the
 //!   `SecureRandom` module is not present.


### PR DESCRIPTION
This PR extracts the implementation of `SecureRandom` from `artichoke-backend` into a separate crate.

This is desirable because:

- Code quality has improved significantly: the new crate has tests, documentation, examples, and doctests.
- There is a proper space to include utilities: this PR removes the dependency on `hex` in favor of a hand rolled hexadecimal encoder using techniques similar to the ones in `spinoso-symbol`.
- Disabling the swath of dependencies related with a CSPRNG in `artichoke-backend` is much simpler: there is now a single optional dependency linked up to a single Cargo feature.
- The new crate is a drop-in replacement: other than deleting the now duplicate code, there was zero code change in the `extn::stdlib::securerandom` module.
- Errors in the secure random APIs now return proper errors (ZST where possible) instead of `artichoke-backend` `RubyException` derivatives. These error types are converted into `RubyException` at the trampoline edge.

This PR also adds some additional features:

- Implement `SecureRandom::urlsafe_base64`.
- Simplified crate features documentation for `artichoke` crate.