### PR TITLE
Clean up artichoke-backend Cargo.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -344,7 +344,7 @@ checksum = "260e51e7efe62b592207e9e13a68e43692a7a279171d6ba57abd208bf23645ad"
 [[package]]
 name = "onig"
 version = "6.0.0"
-source = "git+https://github.com/artichoke/rust-onig?rev=ec266cae185ef4119008ea0b4799b9abd7161436#ec266cae185ef4119008ea0b4799b9abd7161436"
+source = "git+https://github.com/artichoke/rust-onig?rev=v6.0.0-artichoke.2#6588100a1f29afb0412f778de14db611ee0d0a10"
 dependencies = [
  "bitflags",
  "lazy_static",
@@ -355,7 +355,7 @@ dependencies = [
 [[package]]
 name = "onig_sys"
 version = "69.5.0"
-source = "git+https://github.com/artichoke/rust-onig?rev=ec266cae185ef4119008ea0b4799b9abd7161436#ec266cae185ef4119008ea0b4799b9abd7161436"
+source = "git+https://github.com/artichoke/rust-onig?rev=v6.0.0-artichoke.2#6588100a1f29afb0412f778de14db611ee0d0a10"
 dependencies = [
  "cc",
  "pkg-config",

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["artichoke", "artichoke-ruby", "mruby", "ruby"]
 categories = ["api-bindings"]
 
 [dependencies]
+artichoke-core = { version = "0.3", path = "../artichoke-core" }
 bstr = { version = "0.2", default-features = false, features = ["std"] }
 chrono = "0.4"
 dtoa = "0.4"
@@ -27,12 +28,9 @@ spinoso-exception = { version = "0.1", path = "../spinoso-exception" }
 spinoso-securerandom = { version = "0.1", path = "../spinoso-securerandom", optional = true }
 spinoso-symbol = { version = "0.1", path = "../spinoso-symbol" }
 
-[dependencies.artichoke-core]
-path = "../artichoke-core"
-
 [dependencies.onig]
 git = "https://github.com/artichoke/rust-onig"
-rev = "ec266cae185ef4119008ea0b4799b9abd7161436"
+rev = "v6.0.0-artichoke.2"
 default-features = false
 optional = true
 


### PR DESCRIPTION
I started publishing git tags for each vendored SHA of our rust-onig
fork. Store the git tag name in the `rev` field instead of a raw SHA.

Move `artichoke-core` to inline syntax like the spinoso crates. Add
crate version to `artichoke-core` dependency declaration.