### PR TITLE
Add const to functions that can be in artichoke-core

### DIFF
--- a/artichoke-core/src/types.rs
+++ b/artichoke-core/src/types.rs
@@ -120,7 +120,7 @@ pub enum Ruby {
 impl Ruby {
     /// Ruby `Class` name for VM type.
     #[must_use]
-    pub fn class_name(self) -> &'static str {
+    pub const fn class_name(self) -> &'static str {
         match self {
             Self::Array => "Array",
             Self::Bool => "Boolean",


### PR DESCRIPTION
Rust 1.46.0 brings support for `match` in const fn.