### PR TITLE
Cleanups to hex impl

### DIFF
--- a/scolapasta-hex/Cargo.toml
+++ b/scolapasta-hex/Cargo.toml
@@ -16,11 +16,11 @@ categories = ["encoding", "no-std"]
 
 [features]
 default = ["std"]
-# By default, `spinoso-symbol` is `no_std`. This feature enables
-# APIs that depend on `std::io::Write`.
+# By default, `scolapasta-hex` is `no_std`. This feature enables APIs that
+# depend on `std::io::Write`.
 std = ["alloc"]
-# By default, `spinoso-symbol` is `no_std`. This feature enables
-# APIs that depend on `alloc::string::String`.
+# By default, `scolapasta-hex` is `no_std`. This feature enables APIs that
+# depend on `alloc::string::String`.
 alloc = []
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
- Remove references to spinoso-symbol in comments and feature documentation -- this
  was a leftover from copy-pasting the crate definition.
- Add EscapedByte::as_str, EscapedByte::len, and EscapedByte::is_empty.
- Simplify Iterator impl for EscapedByte.
- Use EscapedByte::len in Hex::len.
- Use EscapedByte::is_empty in Hex::is_empty.