### PR TITLE
Improve README descriptions of Italian crate prefixes

### DIFF
--- a/scolapasta-hex/README.md
+++ b/scolapasta-hex/README.md
@@ -20,8 +20,9 @@ This crate offers encoders that:
 - Encode into a [`fmt::Write`]: `format_into`.
 - Encode into a [`io::Write`]: `write_into`.
 
-_Scolapasta_ is a colander used to drain pasta. Its a tool in the kitchen,
-similar to this utility crate for building Artichoke Ruby.
+_Scolapasta_ refers to a specialized colander used to drain pasta. The utilities
+defined in the `scolapasta` family of crates are the kitchen tools for preparing
+Artichoke Ruby.
 
 ## Usage
 

--- a/scolapasta-hex/README.md
+++ b/scolapasta-hex/README.md
@@ -45,7 +45,8 @@ assert_eq!(buf, "4172746963686f6b652052756279");
 This module also exposes an iterator:
 
 ```rust
-# use scolapasta_hex::Hex;
+use scolapasta_hex::Hex;
+
 let data = "Artichoke Ruby";
 let iter = Hex::from(data);
 assert_eq!(iter.collect::<String>(), "4172746963686f6b652052756279");

--- a/scolapasta-string-escape/README.md
+++ b/scolapasta-string-escape/README.md
@@ -87,7 +87,7 @@ let literal = Literal::from(b'\x0C');
 assert_eq!(literal.collect::<String>(), r"\f");
 ```
 
-# `no_std`
+## `no_std`
 
 This crate is `no_std`. This crate does not depend on [`alloc`].
 

--- a/scolapasta-string-escape/README.md
+++ b/scolapasta-string-escape/README.md
@@ -17,8 +17,9 @@ escaped to have a valid UTF-8 representation.
 This crate exposes functions and iterators for encoding arbitrary byte slices as
 valid, printable UTF-8.
 
-_Scolapasta_ is a colander used to drain pasta. Its a tool in the kitchen,
-similar to this utility crate for building Artichoke Ruby.
+_Scolapasta_ refers to a specialized colander used to drain pasta. The utilities
+defined in the `scolapasta` family of crates are the kitchen tools for preparing
+Artichoke Ruby.
 
 ## Ruby debug escapes
 

--- a/scolapasta-string-escape/README.md
+++ b/scolapasta-string-escape/README.md
@@ -63,7 +63,6 @@ fn example() -> Result<(), core::fmt::Error> {
     );
     Ok(())
 }
-# example().unwrap();
 ```
 
 This crate exposes low level utilities for accessing escape internals. To escape
@@ -76,13 +75,13 @@ let literal = Literal::from(b'a');
 assert_eq!(literal.collect::<String>(), "a");
 
 let literal = Literal::from(b'\\');
-assert_eq!(literal.collect::<String>(), r"\\");
+assert_eq!(literal.as_str(), r"\\");
 
-let literal = Literal::from(b'\0');
-assert_eq!(literal.collect::<String>(), r"\x00");
+let literal = Literal::debug_escape(b'\0');
+assert_eq!(literal, r"\x00");
 
 let literal = Literal::from(b'\x0A');
-assert_eq!(literal.collect::<String>(), r"\n");
+assert_eq!(literal.as_str(), r"\n");
 
 let literal = Literal::from(b'\x0C');
 assert_eq!(literal.collect::<String>(), r"\f");

--- a/spinoso-array/README.md
+++ b/spinoso-array/README.md
@@ -21,8 +21,8 @@ types in this crate can be passed by pointer over FFI.
 `O(n)` at worst.
 
 _Spinoso_ refers to _Carciofo spinoso di Sardegna_, the thorny artichoke of
-Sardinia. The idea is that the data structures defined in the `spinoso` family
-of crates will form the backbone of Ruby Core in Artichoke.
+Sardinia. The data structures defined in the `spinoso` family of crates form the
+backbone of Ruby Core in Artichoke.
 
 ## Usage
 

--- a/spinoso-array/README.md
+++ b/spinoso-array/README.md
@@ -58,9 +58,11 @@ spinoso-array has two backends:
 - `SmallArray` is based on [`SmallVec`] and implements the small vector
   optimization – small arrays are stored inline without a heap allocation.
 
-## Crate features
+## `no_std`
 
-`spinoso-array` is `no_std` compatible with a required dependency on [`alloc`].
+This crate is `no_std` compatible with a required dependency on [`alloc`].
+
+## Crate features
 
 All features are enabled by default.
 

--- a/spinoso-exception/README.md
+++ b/spinoso-exception/README.md
@@ -17,8 +17,8 @@ name), an optional descriptive string, and optional traceback information.
 `Exception` subclasses may add additional information like [`NameError#name`].
 
 _Spinoso_ refers to _Carciofo spinoso di Sardegna_, the thorny artichoke of
-Sardinia. The idea is that the data structures defined in the `spinoso` family
-of crates will form the backbone of Ruby Core in Artichoke.
+Sardinia. The data structures defined in the `spinoso` family of crates form the
+backbone of Ruby Core in Artichoke.
 
 ## Usage
 

--- a/spinoso-securerandom/README.md
+++ b/spinoso-securerandom/README.md
@@ -18,8 +18,8 @@ This implementation of `SecureRandom` supports the system RNG via the
 [`getrandom`] crate. This implementation does not depend on OpenSSL.
 
 _Spinoso_ refers to _Carciofo spinoso di Sardegna_, the thorny artichoke of
-Sardinia. The idea is that the data structures defined in the `spinoso` family
-of crates will form the backbone of Ruby Core in Artichoke.
+Sardinia. The data structures defined in the `spinoso` family of crates form the
+backbone of Ruby Core in Artichoke.
 
 ## Usage
 

--- a/spinoso-symbol/README.md
+++ b/spinoso-symbol/README.md
@@ -21,8 +21,8 @@ compare. It is suitable for representing indexes into a string interner.
 > the context or meaning of that name.
 
 _Spinoso_ refers to _Carciofo spinoso di Sardegna_, the thorny artichoke of
-Sardinia. The idea is that the data structures defined in the `spinoso` family
-of crates will form the backbone of Ruby Core in Artichoke.
+Sardinia. The data structures defined in the `spinoso` family of crates form the
+backbone of Ruby Core in Artichoke.
 
 # Artichoke integration
 


### PR DESCRIPTION
## Spinoso

> _Spinoso_ refers to _Carciofo spinoso di Sardegna_, the thorny artichoke of
> Sardinia. The data structures defined in the `spinoso` family of crates form the
> backbone of Ruby Core in Artichoke.

## Scolapasta

> _Scolapasta_ refers to a specialized colander used to drain pasta. The utilities
> defined in the `scolapasta` family of crates are the kitchen tools for preparing
> Artichoke Ruby.