### PR TITLE
Updates to GitHub Actions package installers

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -19,9 +19,12 @@ jobs:
 
       - name: Fetch cargo-deny
         run: |
-          curl -sL "$RELEASE" | sudo tar xvz -C /usr/local/bin/ --strip-components=1
+          cargo_deny_tarball="$RELEASE_BASE/$RELEASE_VERSION/cargo-deny-$RELEASE_VERSION-x86_64-unknown-linux-musl.tar.gz"
+          echo "Downloading cargo-deny $RELEASE_VERSION from $cargo_deny_tarball."
+          curl -sL "$cargo_deny_tarball" | sudo tar xvz -C /usr/local/bin/ --strip-components=1
         env:
-          RELEASE: "https://github.com/EmbarkStudios/cargo-deny/releases/download/0.6.8/cargo-deny-0.6.8-x86_64-unknown-linux-musl.tar.gz"
+          RELEASE_BASE: "https://github.com/EmbarkStudios/cargo-deny/releases/download"
+          RELEASE_VERSION: "0.7.3"
 
       - name: Run cargo-deny
         run: cargo-deny check

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,10 +33,6 @@ jobs:
         with:
           ruby-version: ".ruby-version"
 
-      - name: Install Bison
-        run: sudo apt install bison
-        if: matrix.os == 'ubuntu-latest'
-
       # avoid choco because it takes forever to initialize on first use
       # instead, install directly from GitHub releases
       - name: Install Bison
@@ -84,9 +80,6 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ".ruby-version"
-
-      - name: Install Bison
-        run: sudo apt install bison
 
       - name: Compile artichoke with no default features
         run: cargo build --verbose --no-default-features
@@ -159,9 +152,6 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ".ruby-version"
-
-      - name: Install Bison
-        run: sudo apt install bison
 
       - name: Check formatting
         run: cargo fmt -- --check --color=auto

--- a/.github/workflows/fuzz.yaml
+++ b/.github/workflows/fuzz.yaml
@@ -28,9 +28,6 @@ jobs:
         with:
           ruby-version: ".ruby-version"
 
-      - name: Install Bison
-        run: sudo apt install bison
-
       - name: Install cargo-fuzz
         run: cargo install cargo-fuzz
 

--- a/.github/workflows/rustdoc.yaml
+++ b/.github/workflows/rustdoc.yaml
@@ -33,9 +33,6 @@ jobs:
         with:
           ruby-version: ".ruby-version"
 
-      - name: Install Bison
-        run: sudo apt install bison
-
       - name: Build Documentation
         run: cargo doc --workspace
 


### PR DESCRIPTION
- Do not explicitly install `bison` on Ubuntu runners -- it is installed by default.
- Update `cargo-deny` to latest release.
- Refactor `cargo-deny` installer workflow step to be easier to update.