### PR TITLE
Fix broken build due to intradoc links updates'

### DIFF
--- a/artichoke-backend/src/state/parser.rs
+++ b/artichoke-backend/src/state/parser.rs
@@ -126,8 +126,10 @@ fn reset_context_filename(mrb: &mut sys::mrb_state, context: &mut sys::mrbc_cont
 
 /// `Context` is used to manipulate the current filename on the parser.
 ///
-/// Parser [`State`] maintains a stack of `Context`s and
-/// [`eval`](crate::eval::Eval) calls XXX to set the `__FILE__` magic constant.
+/// Parser [`State`] maintains a stack of `Context`s and [`eval`] uses the
+/// `Context` stack to set the `__FILE__` magic constant.
+///
+/// [`eval`]: crate::core::Eval
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Context {
     /// Value of the `__FILE__` magic constant that also appears in stack

--- a/spinoso-securerandom/src/lib.rs
+++ b/spinoso-securerandom/src/lib.rs
@@ -424,9 +424,7 @@ pub enum Max {
     /// If `max` is less than or equal to zero, the range defaults to floats
     /// in `[0.0, 1.0]`.
     ///
-    /// If `max` is [`NaN`], an error is returned.
-    ///
-    /// [`NaN`]: https://doc.rust-lang.org/std/primitive.f64.html#associatedconstant.NAN
+    /// If `max` is [`NaN`](f64::NAN), an error is returned.
     Float(f64),
     /// Generate signed integers in the range `[0, max)`.
     ///
@@ -497,10 +495,8 @@ pub enum RandomNumber {
 ///
 /// # Errors
 ///
-/// If the float given in a [`Max::Float`] variant is [`NaN`] or infinite, a
-/// [`DomainError`] is returned.
-///
-/// [`NaN`]: https://doc.rust-lang.org/std/primitive.f64.html#associatedconstant.NAN
+/// If the float given in a [`Max::Float`] variant is [`NaN`](f64::NAN) or
+/// infinite, a [`DomainError`] is returned.
 #[inline]
 pub fn random_number(max: Max) -> Result<RandomNumber, DomainError> {
     let mut rng = rand::thread_rng();


### PR DESCRIPTION
- Primitive associated constants can now be resolved - rust-lang/rust#76093 -
  remove hard-coded links to `f64::NAN` in `spinoso-securerandom`.
- Fix unresolved link to `artichoke_backend::eval::Eval`. The trait
  definition has lived in `artichoke-core` for some time now.