### PR TITLE
Re-organize Rakefile

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,6 +12,8 @@ Layout/LineLength:
   Exclude:
     - "**/Rakefile"
     - "**/extn/**/*"
+Layout/MultilineMethodCallIndentation:
+  EnforcedStyle: indented
 Metrics:
   Enabled: false
 Style/Documentation:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,20 +64,25 @@ tasks by running:
 
 ```console
 $ bundle exec rake --tasks
-rake build             # Build Rust workspace
-rake doc               # Generate Rust API documentation
-rake doc:open          # Generate Rust API documentation and open it in a web browser
-rake lint              # Lint and format
-rake lint:clippy       # Run Clippy
-rake lint:deps         # Install linting dependencies
-rake lint:eslint       # Run ESlint
-rake lint:fmt          # Format sources (alias)
-rake lint:format       # Format sources
-rake lint:links        # Check markdown links
-rake lint:restriction  # Lint with Clippy restriction pass (unenforced lints)
-rake lint:rubocop      # Run RuboCop
-rake spec              # Run enforced ruby/spec suite
-rake test              # Run Artichoke unit tests
+rake build                      # Build Rust workspace
+rake doc                        # Generate Rust API documentation
+rake doc:open                   # Generate Rust API documentation and open it in a web browser
+rake fmt                        # Format sources
+rake fmt:c                      # Format .c and .h sources with clang-format
+rake fmt:rust                   # Format Rust sources with rustfmt
+rake fmt:text                   # Format text, YAML, and Markdown sources with prettier
+rake format                     # Format sources
+rake format:c                   # Format .c and .h sources with clang-format
+rake format:rust                # Format Rust sources with rustfmt
+rake format:text                # Format text, YAML, and Markdown sources with prettier
+rake lint                       # Lint sources
+rake lint:clippy                # Lint Rust sources with Clippy
+rake lint:clippy:restriction    # Lint Rust sources with Clippy restriction pass (unenforced lints)
+rake lint:links                 # Check for broken markdown links
+rake lint:rubocop               # Run RuboCop
+rake lint:rubocop:auto_correct  # Auto-correct RuboCop offenses
+rake spec                       # Run enforced ruby/spec suite
+rake test                       # Run Artichoke unit tests
 ```
 
 To lint Ruby sources, Artichoke uses
@@ -120,10 +125,10 @@ brew install node
 ### Linting
 
 Once you [configure a development environment](#setup), run the following to
-lint sources:
+lint and format sources:
 
 ```sh
-rake lint
+rake
 ```
 
 Merges will be blocked by CI if there are lint errors.

--- a/artichoke-backend/scripts/auto_import/get_package_files.rb
+++ b/artichoke-backend/scripts/auto_import/get_package_files.rb
@@ -12,8 +12,8 @@ require PACKAGE
 lib_sources = $LOADED_FEATURES.select { |f| f.include?(BASE) }
 lib_sources +=
   $LOADED_FEATURES
-  .map { |f| f.gsub('/', '\\') }
-  .select { |f| f.include?(BASE) }
+    .map { |f| f.gsub('/', '\\') }
+    .select { |f| f.include?(BASE) }
 package_sources = lib_sources.select { |f| f =~ /#{PACKAGE}/ }
 
 puts package_sources.sort.uniq


### PR DESCRIPTION
- Use `RuboCop::RakeTask` to define RuboCop tasks.
- Split formatting tasks into their own namespace.
- Default task runs `format` and `lint`.
- Add separate tasks for formatting Rust, C, and text sources.
- Make formatting tasks available as `format` or `fmt` and e.g.
  `format:rust` or `fmt:rust`.
- Update Clippy restriction lint names.
- Refactor clippy restriction lint to use an array of lints and
  shelljoin to construct a command.
- Move `lint:restriction` to `lint:clippy:restriction`.
- Adopt code to touch Rust source roots for `lint:clippy:restriction`.
- Dynamically discover markdown sources in `lint:links` task.
- Add a sleep to `lint:links` to avoid 429 rate limiting errors.
- Improve task descriptions.