### PR TITLE
Improve spinoso-env docs

### DIFF
--- a/spinoso-env/src/env/memory.rs
+++ b/spinoso-env/src/env/memory.rs
@@ -6,7 +6,7 @@ use crate::{ArgumentError, Error, InvalidError};
 
 type Bytes = Vec<u8>;
 
-/// An in-memory fake store of environment variables.
+/// A hash-like accessor for environment variables using a fake in-memory store.
 ///
 /// `Memory` offers the same API as other environment variable backends in this
 /// crate, but does not access or mutate the underlying system.

--- a/spinoso-env/src/env/system.rs
+++ b/spinoso-env/src/env/system.rs
@@ -7,8 +7,7 @@ use crate::{ArgumentError, Error, InvalidError};
 
 type Bytes = Vec<u8>;
 
-/// ENV is a hash-like accessor for environment variables using the platform
-/// APIs for accessing the environment.
+/// A hash-like accessor for environment variables using platform APIs.
 ///
 /// `System` is an accessor to the host system's environment variables using the
 /// functions provided by the [Rust Standard Library] in the
@@ -42,6 +41,7 @@ type Bytes = Vec<u8>;
 /// ```
 ///
 /// [Rust Standard Library]: std
+#[cfg_attr(docsrs, doc(cfg(feature = "system-env")))]
 #[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct System {
     _private: (),

--- a/spinoso-env/src/lib.rs
+++ b/spinoso-env/src/lib.rs
@@ -127,17 +127,23 @@ pub use env::system::System;
 /// [`Hash`]: https://ruby-doc.org/core-2.6.3/Hash.html
 pub const RUBY_API_POLYFILLS: &str = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/env.rb"));
 
-/// Sum type of all errors possibly returned from [`put`].
+/// Sum type of all errors possibly returned from [`get`], [`put`], and
+/// [`to_map`].
 ///
-/// `put` can return errors under several conditions:
+/// These APIs can return errors under several conditions:
 ///
-/// - The name contains a NUL byte.
-/// - The name contains an `=` byte.
-/// - The value contains a NUL byte.
+/// - An environment variable name is not convertable to a [platform string].
+/// - An environment variable value is not convertable to a [platform string].
+/// - An environment variable name contains a NUL byte.
+/// - An environment variable name contains an `=` byte.
+/// - An environment variable value contains a NUL byte.
 ///
 /// Ruby represents these error conditions with different exception types.
 ///
+/// [`get`]: Memory::get
 /// [`put`]: Memory::put
+/// [`to_map`]: Memory::to_map
+/// [platform string]: std::ffi::OsString
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Error {
     /// Error that indicates an argument parsing or value logic error occurred.

--- a/spinoso-symbol/src/lib.rs
+++ b/spinoso-symbol/src/lib.rs
@@ -301,7 +301,7 @@ impl Symbol {
     /// byteslice associated with the symbol in the underlying interner.
     ///
     /// This iterator produces [`char`] sequences like `:spinoso` and
-    /// `:invalid-\xFF-utf8`.
+    /// `:"invalid-\xFF-utf8"`.
     ///
     /// If there symbol does not exist in the underlying interner or there is an
     /// error looking up the symbol in the underlying interner, a default
@@ -325,7 +325,7 @@ impl Symbol {
     /// representation of the interned byteslice associated with the symbol in
     /// the underlying interner.
     ///
-    /// This formatter writes content like `:spinoso` and `:invalid-\xFF-utf8`.
+    /// This formatter writes content like `:spinoso` and `:"invalid-\xFF-utf8"`.
     /// To see example output of the underlying iterator, see the [`Inspect`]
     /// documentation.
     ///
@@ -362,7 +362,7 @@ impl Symbol {
     /// representation of the interned byteslice associated with the symbol in
     /// the underlying interner.
     ///
-    /// This formatter writes content like `:spinoso` and `:invalid-\xFF-utf8`.
+    /// This formatter writes content like `:spinoso` and `:"invalid-\xFF-utf8"`.
     /// To see example output of the underlying iterator, see the [`Inspect`]
     /// documentation.
     ///


### PR DESCRIPTION
- Quote symbol examples with invalid UTF-8.
- Add more fallible APIs and examples to Error docs.
- Add doc(cfg(feature = ...)) to System backend.
- Make first doc line consistent between Memory and System type.