### PR TITLE
Remove trait objects from the artichoke-backend virtual filesystem

### DIFF
--- a/artichoke-backend/src/eval.rs
+++ b/artichoke-backend/src/eval.rs
@@ -189,8 +189,6 @@ mod tests {
     }
 
     #[test]
-    // TODO(GH-528): fix failing tests on Windows.
-    #[cfg_attr(target_os = "windows", should_panic)]
     fn file_magic_constant() {
         let mut interp = interpreter().unwrap();
         interp

--- a/artichoke-backend/src/eval.rs
+++ b/artichoke-backend/src/eval.rs
@@ -198,7 +198,7 @@ mod tests {
             .unwrap();
         let result = interp.eval(b"require 'source'; file").unwrap();
         let result = result.try_into_mut::<&str>(&mut interp).unwrap();
-        assert_eq!(result, "/src/lib/source.rb");
+        assert_eq!(result, "/artichoke/virtual_root/src/lib/source.rb");
     }
 
     #[test]

--- a/artichoke-backend/src/fs.rs
+++ b/artichoke-backend/src/fs.rs
@@ -11,125 +11,50 @@
 //! Artichoke has several virtual filesystem implementations. Only some of them
 //! support reading from the system fs.
 
-use std::borrow::Cow;
-use std::fmt;
-use std::io;
+use bstr::ByteVec;
 use std::path::{Component, Path, PathBuf};
 
 use crate::error::Error;
+use crate::ffi::ConvertBytesError;
 use crate::Artichoke;
 
-pub mod hybrid;
-pub mod memory;
-pub mod native;
+mod hybrid;
+mod memory;
+mod native;
+
+pub use hybrid::Hybrid;
+pub use memory::Memory;
+pub use native::Native;
+
+/// Directory at which the [in-memory filesystem](Memory) is mounted.
+///
+/// [`Hybrid`] filesystems mount the `Memory` filesystem at this path.
+/// `RUBY_LOAD_PATH` is found within this path prefix.
+pub const MEMORY_FILESYSTEM_MOUNT_POINT: &str = "/artichoke/virtual_root";
 
 /// Directory at which Ruby sources and extensions are stored in the virtual
 /// filesystem.
 ///
 /// `RUBY_LOAD_PATH` is the default current working directory for
-/// [`Memory`](memory::Memory) filesystems.
+/// [`Memory`] filesystems.
 ///
-/// [`Hybrid`](hybrid::Hybrid) filesystems mount the `Memory` filessytem at
-/// `RUBY_LOAD_PATH`.
-pub const RUBY_LOAD_PATH: &str = "/src/lib";
+/// [`Hybrid`] filesystems locate the this path on a `Memory` filesystem below
+/// [`MEMORY_FILESYSTEM_MOUNT_POINT`].
+pub const RUBY_LOAD_PATH: &str = "/artichoke/virtual_root/src/lib";
 
 /// Function type for extension hooks stored in the virtual filesystem.
 ///
-/// This signature is equivalent to the signature for `File::require` as defined
-/// by the `artichoke-backend` implementation of
-/// [`LoadSources`](crate::core::LoadSources).
+/// This signature is equivalent to the signature for [`File::require`] as
+/// defined by the `artichoke-backend` implementation of [`LoadSources`].
+///
+/// [`File::require`]: artichoke_core::file::File::require
+/// [`LoadSources`]: crate::core::LoadSources
 pub type ExtensionHook = fn(&mut Artichoke) -> Result<(), Error>;
 
-#[must_use]
 #[cfg(all(feature = "native-filesystem-access", not(any(test, doctest))))]
-pub fn filesystem() -> Box<dyn Filesystem> {
-    let fs = hybrid::Hybrid::default();
-    Box::new(fs)
-}
-
-#[must_use]
-#[cfg(not(any(feature = "native-filesystem-access", test, doctest)))]
-pub fn filesystem() -> Box<dyn Filesystem> {
-    let fs = memory::Memory::default();
-    Box::new(fs)
-}
-
-#[must_use]
-#[cfg(any(doctest, test))]
-pub fn filesystem() -> Box<dyn Filesystem> {
-    let fs = memory::Memory::default();
-    Box::new(fs)
-}
-
-/// Filesystem APIs required by an Artichoke interpreter.
-pub trait Filesystem: fmt::Debug {
-    /// Check whether `path` points to a file in the virtual filesystem.
-    ///
-    /// This API is infallible and will return `false` for non-existent paths.
-    fn is_file(&self, path: &Path) -> bool;
-
-    /// Read file contents for the file at `path`.
-    ///
-    /// Returns a byte slice of complete file contents. If `path` is relative,
-    /// it is absolutized relative to the current working directory of the
-    /// virtual file system.
-    ///
-    /// # Errors
-    ///
-    /// If `path` does not exist, an [`io::Error`] with error kind
-    /// [`io::ErrorKind::NotFound`] is returned.
-    fn read_file(&self, path: &Path) -> io::Result<Cow<'_, [u8]>>;
-
-    /// Write file contents into the virtual file system at `path`.
-    ///
-    /// Writes the full file contents. If any file contents already exist at
-    /// `path`, they are replaced. Extension hooks are preserved.
-    ///
-    /// # Errors
-    ///
-    /// This API is currently infallible but returns [`io::Result`] to reserve
-    /// the ability to return errors in the future.
-    fn write_file(&mut self, path: &Path, buf: Cow<'static, [u8]>) -> io::Result<()>;
-
-    /// Retrieve an extension hook for the file at `path`.
-    ///
-    /// This API is infallible and will return `None` for non-existent paths.
-    fn get_extension(&self, path: &Path) -> Option<ExtensionHook>;
-
-    /// Write extension hook into the virtual file system at `path`.
-    ///
-    /// If any extension hooks already exist at `path`, they are replaced. File
-    /// contents are preserved.
-    ///
-    /// # Errors
-    ///
-    /// This API is currently infallible but returns [`io::Result`] to reserve
-    /// the ability to return errors in the future.
-    fn register_extension(&mut self, path: &Path, extension: ExtensionHook) -> io::Result<()>;
-
-    /// Check whether a file at `path` has been required already.
-    ///
-    /// This API is infallible and will return `false` for non-existent paths.
-    fn is_required(&self, path: &Path) -> bool;
-
-    /// Mark a source at `path` as required on the interpreter.
-    ///
-    /// This metadata is used by `Kernel#require` and friends to enforce that
-    /// Ruby sources are only loaded into the interpreter once to limit side
-    /// effects.
-    ///
-    /// # Errors
-    ///
-    /// If `path` does not exist, an [`io::Error`] with error kind
-    /// [`io::ErrorKind::NotFound`] is returned.
-    fn mark_required(&mut self, path: &Path) -> io::Result<()>;
-}
-
-impl Default for Box<dyn Filesystem> {
-    fn default() -> Self {
-        filesystem()
-    }
-}
+pub type Adapter = Hybrid;
+#[cfg(any(not(feature = "native-filesystem-access"), test, doctest))]
+pub type Adapter = Memory;
 
 fn absolutize_relative_to<T, U>(path: T, cwd: U) -> PathBuf
 where
@@ -163,6 +88,20 @@ where
         }
     }
     components.into_iter().collect()
+}
+
+pub fn normalize_slashes(path: PathBuf) -> Result<Vec<u8>, ConvertBytesError> {
+    let mut path = Vec::from_path_buf(path).map_err(|_| ConvertBytesError::new())?;
+    if cfg!(windows) {
+        for byte in &mut path {
+            if *byte == b'\\' {
+                *byte = b'/';
+            }
+        }
+        Ok(path)
+    } else {
+        Ok(path)
+    }
 }
 
 #[cfg(test)]

--- a/artichoke-backend/src/fs/hybrid.rs
+++ b/artichoke-backend/src/fs/hybrid.rs
@@ -2,9 +2,7 @@ use std::borrow::Cow;
 use std::io;
 use std::path::Path;
 
-use crate::fs::memory::Memory;
-use crate::fs::native::Native;
-use crate::fs::{ExtensionHook, Filesystem, RUBY_LOAD_PATH};
+use crate::fs::{ExtensionHook, Memory, Native, MEMORY_FILESYSTEM_MOUNT_POINT};
 
 #[derive(Default, Debug)]
 pub struct Hybrid {
@@ -13,43 +11,122 @@ pub struct Hybrid {
 }
 
 impl Hybrid {
+    /// Create a new hybrid virtual filesystem.
+    ///
+    /// This filesystem allows access to the host filesystem with an in-memory
+    /// filesystem mounted at [`MEMORY_FILESYSTEM_MOUNT_POINT`].
     #[must_use]
     pub fn new() -> Self {
         Self::default()
     }
-}
 
-impl Filesystem for Hybrid {
-    fn is_file(&self, path: &Path) -> bool {
-        self.memory.is_file(path) || self.native.is_file(path)
+    /// Check whether `path` points to a file in the virtual filesystem.
+    ///
+    /// This API is infallible and will return `false` for non-existent paths.
+    #[must_use]
+    pub fn is_file(&self, path: &Path) -> bool {
+        if path.strip_prefix(MEMORY_FILESYSTEM_MOUNT_POINT).is_ok() {
+            self.memory.is_file(path)
+        } else {
+            self.native.is_file(path)
+        }
     }
 
-    fn read_file(&self, path: &Path) -> io::Result<Cow<'_, [u8]>> {
-        self.memory.read_file(path).or_else(|_| self.native.read_file(path))
+    /// Read file contents for the file at `path`.
+    ///
+    /// Returns a byte slice of complete file contents. If `path` is relative,
+    /// it is absolutized relative to the current working directory of the
+    /// virtual file system.
+    ///
+    /// # Errors
+    ///
+    /// If `path` does not exist, an [`io::Error`] with error kind
+    /// [`io::ErrorKind::NotFound`] is returned.
+    pub fn read_file(&self, path: &Path) -> io::Result<Cow<'_, [u8]>> {
+        if path.strip_prefix(MEMORY_FILESYSTEM_MOUNT_POINT).is_ok() {
+            self.memory.read_file(path)
+        } else {
+            self.native.read_file(path)
+        }
     }
 
-    fn write_file(&mut self, path: &Path, buf: Cow<'static, [u8]>) -> io::Result<()> {
-        if path.starts_with(RUBY_LOAD_PATH) {
+    /// Write file contents into the virtual file system at `path`.
+    ///
+    /// Writes the full file contents. If any file contents already exist at
+    /// `path`, they are replaced. Extension hooks are preserved.
+    ///
+    /// # Errors
+    ///
+    /// If access to the [`Native`] filesystem returns an error, the error is
+    /// returned. See [`Native::write_file`].
+    pub fn write_file(&mut self, path: &Path, buf: Cow<'static, [u8]>) -> io::Result<()> {
+        if path.strip_prefix(MEMORY_FILESYSTEM_MOUNT_POINT).is_ok() {
             self.memory.write_file(path, buf)
         } else {
             self.native.write_file(path, buf)
         }
     }
 
-    fn get_extension(&self, path: &Path) -> Option<ExtensionHook> {
-        self.memory.get_extension(path)
+    /// Retrieve an extension hook for the file at `path`.
+    ///
+    /// This API is infallible and will return `None` for non-existent paths.
+    #[must_use]
+    pub fn get_extension(&self, path: &Path) -> Option<ExtensionHook> {
+        if path.strip_prefix(MEMORY_FILESYSTEM_MOUNT_POINT).is_ok() {
+            self.memory.get_extension(path)
+        } else {
+            None
+        }
     }
 
-    fn register_extension(&mut self, path: &Path, extension: ExtensionHook) -> io::Result<()> {
-        self.memory.register_extension(path, extension)
+    /// Write extension hook into the virtual file system at `path`.
+    ///
+    /// If any extension hooks already exist at `path`, they are replaced. File
+    /// contents are preserved.
+    ///
+    /// This function writes all extensions to the virtual filesystem. If the
+    /// given path does not map to the virtual filesystem, the extension is
+    /// unreachable.
+    ///
+    /// # Errors
+    ///
+    /// If the given path does not resolve to the virtual filesystem, an error
+    /// is returned.
+    pub fn register_extension(&mut self, path: &Path, extension: ExtensionHook) -> io::Result<()> {
+        if path.strip_prefix(MEMORY_FILESYSTEM_MOUNT_POINT).is_ok() {
+            self.memory.register_extension(path, extension)
+        } else {
+            Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Native filesystem does not support extensions",
+            ))
+        }
     }
 
-    fn is_required(&self, path: &Path) -> bool {
-        self.memory.is_required(path) || self.native.is_required(path)
+    /// Check whether a file at `path` has been required already.
+    ///
+    /// This API is infallible and will return `false` for non-existent paths.
+    #[must_use]
+    pub fn is_required(&self, path: &Path) -> bool {
+        if path.strip_prefix(MEMORY_FILESYSTEM_MOUNT_POINT).is_ok() {
+            self.memory.is_required(path)
+        } else {
+            self.native.is_required(path)
+        }
     }
 
-    fn mark_required(&mut self, path: &Path) -> io::Result<()> {
-        if path.starts_with(RUBY_LOAD_PATH) {
+    /// Mark a source at `path` as required on the interpreter.
+    ///
+    /// This metadata is used by `Kernel#require` and friends to enforce that
+    /// Ruby sources are only loaded into the interpreter once to limit side
+    /// effects.
+    ///
+    /// # Errors
+    ///
+    /// If `path` does not exist, an [`io::Error`] with error kind
+    /// [`io::ErrorKind::NotFound`] is returned.
+    pub fn mark_required(&mut self, path: &Path) -> io::Result<()> {
+        if path.strip_prefix(MEMORY_FILESYSTEM_MOUNT_POINT).is_ok() {
             self.memory.mark_required(path)
         } else {
             self.native.mark_required(path)

--- a/artichoke-backend/src/fs/native.rs
+++ b/artichoke-backend/src/fs/native.rs
@@ -1,26 +1,33 @@
+use bstr::{BString, ByteSlice};
 use std::borrow::Cow;
 use std::collections::HashSet;
 use std::env;
 use std::fs;
 use std::io;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
-use crate::fs::{absolutize_relative_to, ExtensionHook, Filesystem};
+use crate::fs::{absolutize_relative_to, normalize_slashes, ExtensionHook};
 
 #[derive(Default, Debug, PartialEq, Eq)]
 pub struct Native {
-    loaded_features: HashSet<PathBuf>,
+    loaded_features: HashSet<BString>,
 }
 
 impl Native {
+    /// Create a new native virtual filesystem.
+    ///
+    /// This filesystem grants access to the host filesystem.
     #[must_use]
     pub fn new() -> Self {
         Self::default()
     }
-}
 
-impl Filesystem for Native {
-    fn is_file(&self, path: &Path) -> bool {
+    /// Check whether `path` points to a file in the virtual filesystem.
+    ///
+    /// This API is infallible and will return `false` for non-existent paths.
+    #[must_use]
+    #[allow(clippy::unused_self)]
+    pub fn is_file(&self, path: &Path) -> bool {
         if let Ok(metadata) = fs::metadata(path) {
             !metadata.is_dir()
         } else {
@@ -28,38 +35,97 @@ impl Filesystem for Native {
         }
     }
 
-    fn read_file(&self, path: &Path) -> io::Result<Cow<'_, [u8]>> {
+    /// Read file contents for the file at `path`.
+    ///
+    /// Returns a byte slice of complete file contents. If `path` is relative,
+    /// it is absolutized relative to the current working directory of the
+    /// virtual file system.
+    ///
+    /// # Errors
+    ///
+    /// If `path` does not exist, an [`io::Error`] with error kind
+    /// [`io::ErrorKind::NotFound`] is returned.
+    #[allow(clippy::unused_self)]
+    pub fn read_file(&self, path: &Path) -> io::Result<Cow<'_, [u8]>> {
         Ok(fs::read(path)?.into())
     }
 
-    fn write_file(&mut self, path: &Path, buf: Cow<'static, [u8]>) -> io::Result<()> {
+    /// Write file contents into the virtual file system at `path`.
+    ///
+    /// Writes the full file contents. If any file contents already exist at
+    /// `path`, they are replaced. Extension hooks are preserved.
+    ///
+    /// # Errors
+    ///
+    /// If `path` does not exist, an [`io::Error`] with error kind
+    /// [`io::ErrorKind::NotFound`] is returned. See [`fs::write`] for further
+    /// discussion of the error modes of this API.
+    #[allow(clippy::unused_self)]
+    pub fn write_file(&mut self, path: &Path, buf: Cow<'static, [u8]>) -> io::Result<()> {
         fs::write(path, buf)
     }
 
-    fn get_extension(&self, path: &Path) -> Option<ExtensionHook> {
+    /// Retrieve an extension hook for the file at `path`.
+    ///
+    /// This API is infallible and will return `None` for non-existent paths.
+    ///
+    /// The native filesystem does not support extensions. This method always
+    /// returns [`None`].
+    #[must_use]
+    #[allow(clippy::unused_self)]
+    pub fn get_extension(&self, path: &Path) -> Option<ExtensionHook> {
         let _ = path;
         None
     }
 
-    fn register_extension(&mut self, path: &Path, extension: ExtensionHook) -> io::Result<()> {
+    /// Write extension hook into the virtual file system at `path`.
+    ///
+    /// The native filesystem does not support extensions. All given extensions
+    /// result in an error.
+    ///
+    /// # Errors
+    ///
+    /// The native filesystem does not support extensions. All given extensions
+    /// result in an error with `ErrorKind::Other`.
+    #[allow(clippy::unused_self)]
+    pub fn register_extension(&mut self, path: &Path, extension: ExtensionHook) -> io::Result<()> {
         let _ = path;
         let _ = extension;
-        Ok(())
+        Err(io::Error::new(io::ErrorKind::Other, "extensions are unsupported"))
     }
 
-    fn is_required(&self, path: &Path) -> bool {
-        if let Ok(cwd) = env::current_dir() {
-            let path = absolutize_relative_to(path, &cwd);
-            self.loaded_features.contains(&path)
+    /// Check whether a file at `path` has been required already.
+    ///
+    /// This API is infallible and will return `false` for non-existent paths.
+    #[must_use]
+    pub fn is_required(&self, path: &Path) -> bool {
+        let path = if let Ok(cwd) = env::current_dir() {
+            absolutize_relative_to(path, &cwd)
+        } else {
+            return false;
+        };
+        if let Ok(path) = normalize_slashes(path) {
+            self.loaded_features.contains(path.as_bstr())
         } else {
             false
         }
     }
 
-    fn mark_required(&mut self, path: &Path) -> io::Result<()> {
+    /// Mark a source at `path` as required on the interpreter.
+    ///
+    /// This metadata is used by `Kernel#require` and friends to enforce that
+    /// Ruby sources are only loaded into the interpreter once to limit side
+    /// effects.
+    ///
+    /// # Errors
+    ///
+    /// If `path` does not exist, an [`io::Error`] with error kind
+    /// [`io::ErrorKind::NotFound`] is returned.
+    pub fn mark_required(&mut self, path: &Path) -> io::Result<()> {
         let cwd = env::current_dir()?;
         let path = absolutize_relative_to(path, &cwd);
-        self.loaded_features.insert(path);
+        let path = normalize_slashes(path).map_err(|err| io::Error::new(io::ErrorKind::NotFound, err))?;
+        self.loaded_features.insert(path.into());
         Ok(())
     }
 }

--- a/artichoke-backend/src/state/mod.rs
+++ b/artichoke-backend/src/state/mod.rs
@@ -3,7 +3,7 @@ use intaglio::bytes::SymbolTable;
 use crate::class;
 #[cfg(feature = "core-random")]
 use crate::extn::core::random::Random;
-use crate::fs::{self, Filesystem};
+use crate::fs;
 use crate::interpreter::InterpreterAllocError;
 use crate::module;
 use crate::sys;
@@ -26,7 +26,7 @@ pub struct State {
     pub parser: Option<parser::State>,
     pub classes: class::Registry,
     pub modules: module::Registry,
-    pub vfs: Box<dyn Filesystem>,
+    pub vfs: fs::Adapter,
     pub regexp: regexp::State,
     pub symbols: SymbolTable,
     pub output: output::Strategy,
@@ -65,7 +65,7 @@ impl State {
             parser: None,
             classes: class::Registry::new(),
             modules: module::Registry::new(),
-            vfs: fs::filesystem(),
+            vfs: fs::Adapter::new(),
             regexp: regexp::State::new(),
             symbols: SymbolTable::new(),
             output: output::Strategy::new(),

--- a/spec-runner/src/mspec.rs
+++ b/spec-runner/src/mspec.rs
@@ -32,9 +32,10 @@ pub fn run<'a, T>(interp: &mut Artichoke, specs: T) -> Result<bool, Error>
 where
     T: IntoIterator<Item = &'a str>,
 {
-    interp.def_rb_source_file("/src/lib/spec_helper.rb", &b""[..])?;
-    interp.def_rb_source_file("/src/lib/test/spec_runner", &include_bytes!("spec_runner.rb")[..])?;
-    interp.eval_file(Path::new("/src/lib/test/spec_runner"))?;
+    let virtual_root = Path::new(artichoke::backend::fs::RUBY_LOAD_PATH);
+    interp.def_rb_source_file(virtual_root.join("spec_helper.rb"), &b""[..])?;
+    interp.def_rb_source_file(virtual_root.join("spec_runner"), &include_bytes!("spec_runner.rb")[..])?;
+    interp.eval_file(&virtual_root.join("spec_runner"))?;
     let specs = interp.try_convert_mut(specs.into_iter().collect::<Vec<_>>())?;
     let result = interp.top_self().funcall(interp, "run_specs", &[specs], None)?;
     interp.try_convert(result)

--- a/spec-runner/src/mspec.rs
+++ b/spec-runner/src/mspec.rs
@@ -44,8 +44,6 @@ where
 #[cfg(test)]
 mod tests {
     #[test]
-    // TODO(GH-528): fix failing tests on Windows.
-    #[cfg_attr(target_os = "windows", should_panic)]
     fn mspec_framework_loads() {
         let mut interp = artichoke::interpreter().unwrap();
         super::init(&mut interp).unwrap();


### PR DESCRIPTION
This PR removes the `Filesystem` trait from `artichoke_backend::fs`. This trait is a holdover from long ago when Artichoke depended on the `filesystem` crate (https://github.com/artichoke/ferrocarril/pull/1!).

This significant refactor of the `fs` module follows the same approach I've been using in the Spinoso crates: make multiple backends that are source compatible so they can be swapped out with Cargo feature flags.

This change introduces three `fs` backends:

- `Memory`: an in-memory backend that stores file contents in a `HashMap` and uses a `HashSet` to track `$LOADED_FEATURES`. `Memory` filesystems support storing extension hooks, which are used to initialize gems in Artichoke.
- `Native`: a host filesystem adapter that stores and reads file contents from local disk and uses a `HashSet` to track `$LOADED_FEATURES`.
- `Hybrid`: a composite `fs` backend that mounts a `Memory` instance at a prefix and forwards all operations to it that match this prefix. All other filesystem operations target the host filesystem.

This change also stores paths inside the `fs` module as `BString`. This means paths on Windows must be valid UTF-8 so they can be normalized (converting `\` to `/`). I expect this to fix a good many `should_panic` tests once this branch gets pushed to CI.

Fixes https://github.com/artichoke/artichoke/issues/528.