### PR TITLE
Configure cargo-deny version with an organization secret

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -18,14 +18,18 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Fetch cargo-deny
+      - name: Setup cargo-deny
         run: |
-          cargo_deny_tarball="$RELEASE_BASE/$RELEASE_VERSION/cargo-deny-$RELEASE_VERSION-x86_64-unknown-linux-musl.tar.gz"
-          echo "Downloading cargo-deny $RELEASE_VERSION from $cargo_deny_tarball."
+          version=${RELEASE_VERSION#"version="}
+          cargo_deny_tarball="$RELEASE_BASE/$version/cargo-deny-$version-x86_64-unknown-linux-musl.tar.gz"
+          echo "Downloading cargo-deny $version from $cargo_deny_tarball."
           curl -sL "$cargo_deny_tarball" | sudo tar xvz -C /usr/local/bin/ --strip-components=1
         env:
           RELEASE_BASE: "https://github.com/EmbarkStudios/cargo-deny/releases/download"
-          RELEASE_VERSION: "0.7.3"
+          RELEASE_VERSION: ${{ secrets.CARGO_DENY_VERSION }}
+
+      - name: cargo-deny version
+        run: cargo-deny --version
 
       - name: Run cargo-deny
-        run: cargo-deny check
+        run: cargo-deny check --show-stats

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ structopt = "0.3"
 termcolor = "1.1"
 
 [dependencies.artichoke-backend]
+version = "0.1"
 path = "artichoke-backend"
 default-features = false
 

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -31,6 +31,7 @@ spinoso-symbol = { version = "0.1", path = "../spinoso-symbol" }
 spinoso-time = { version = "0.1", path = "../spinoso-time", optional = true }
 
 [dependencies.onig]
+version = "6.0.0"
 git = "https://github.com/artichoke/rust-onig"
 rev = "v6.0.0-artichoke.2"
 default-features = false

--- a/deny.toml
+++ b/deny.toml
@@ -21,6 +21,7 @@ confidence-threshold = 0.8
 
 [bans]
 multiple-versions = "deny"
+wildcards = "deny"
 highlight = "all"
 allow = []
 deny = []


### PR DESCRIPTION
Intend to use this same setup and execute block in all Rust
repositories, which will allow keeping the cargo-deny version in sync by
updating a single secret.

See artichoke/rand_mt#44.