### PR TITLE
Add spinoso-math crate

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -96,6 +96,22 @@ jobs:
         run: cargo build --verbose --all-features
         working-directory: "spinoso-array"
 
+      - name: Compile spinoso-array with no default features
+        run: cargo build --verbose --no-default-features
+        working-directory: "spinoso-env"
+
+      - name: Compile spinoso-array with all features
+        run: cargo build --verbose --all-features
+        working-directory: "spinoso-env"
+
+      - name: Compile spinoso-array with no default features
+        run: cargo build --verbose --no-default-features
+        working-directory: "spinoso-math"
+
+      - name: Compile spinoso-array with all features
+        run: cargo build --verbose --all-features
+        working-directory: "spinoso-math"
+
       - name: Compile spinoso-symbol with no default features
         run: cargo build --verbose --no-default-features
         working-directory: "spinoso-symbol"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,7 +42,6 @@ dependencies = [
  "intaglio",
  "itoa",
  "libc",
- "libm",
  "log",
  "once_cell",
  "onig",
@@ -55,6 +54,7 @@ dependencies = [
  "spinoso-array",
  "spinoso-env",
  "spinoso-exception",
+ "spinoso-math",
  "spinoso-securerandom",
  "spinoso-symbol",
  "spinoso-time",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "artichoke-core"
-version = "0.3.0"
+version = "0.4.0"
 
 [[package]]
 name = "atty"
@@ -689,6 +689,13 @@ name = "spinoso-exception"
 version = "0.1.0"
 dependencies = [
  "scolapasta-string-escape",
+]
+
+[[package]]
+name = "spinoso-math"
+version = "0.1.0"
+dependencies = [
+ "libm",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ members = [
   "spinoso-array",
   "spinoso-env",
   "spinoso-exception",
+  "spinoso-math",
   "spinoso-securerandom",
   "spinoso-symbol",
   "spinoso-time",
@@ -54,7 +55,8 @@ lto = true
 default = [
   "core-env",
   "core-env-system",
-  "core-math-extra",
+  "core-math",
+  "core-math-full",
   "core-random",
   "core-regexp-oniguruma",
   "core-time",
@@ -66,9 +68,11 @@ core-env = ["artichoke-backend/core-env"]
 # Enable resolving environment variables with the `ENV` core object using native
 # OS APIs. This feature replaces the in-memory backend with `std::env`.
 core-env-system = ["core-env", "artichoke-backend/core-env-system"]
+# Enable the `Math` module in Ruby Core.
+core-math = ["artichoke-backend/core-math"]
 # Enable an extra dependency on `libm` to implement some `Math` core APIs for
 # functions not present in `std`.
-core-math-extra = ["artichoke-backend/core-math-extra"]
+core-math-full = ["core-math", "artichoke-backend/core-math-full"]
 # Implement the `Random` core class and add an interpreter-default PRNG to
 # Artichoke. This feature adds dependencies on `rand_core` and `rand_pcg`.
 core-random = ["artichoke-backend/core-random"]

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -11,12 +11,11 @@ keywords = ["artichoke", "artichoke-ruby", "mruby", "ruby"]
 categories = ["api-bindings"]
 
 [dependencies]
-artichoke-core = { version = "0.3", path = "../artichoke-core" }
+artichoke-core = { version = "0.4", path = "../artichoke-core" }
 bstr = { version = "0.2", default-features = false, features = ["std"] }
 dtoa = "0.4"
 intaglio = "1.1"
 itoa = "0.4"
-libm = { version = "0.2", optional = true }
 log = "0.4"
 once_cell = "1"
 rand = { version = "0.7", optional = true }
@@ -26,6 +25,7 @@ scolapasta-string-escape = { version = "0.1", path = "../scolapasta-string-escap
 spinoso-array = { version = "0.3", path = "../spinoso-array" }
 spinoso-env = { version = "0.1", path = "../spinoso-env", optional = true }
 spinoso-exception = { version = "0.1", path = "../spinoso-exception" }
+spinoso-math = { version = "0.1", path = "../spinoso-math", optional = true }
 spinoso-securerandom = { version = "0.1", path = "../spinoso-securerandom", optional = true }
 spinoso-symbol = { version = "0.1", path = "../spinoso-symbol" }
 spinoso-time = { version = "0.1", path = "../spinoso-time", optional = true }
@@ -51,7 +51,8 @@ target-lexicon = "0.11.0"
 default = [
   "core-env",
   "core-env-system",
-  "core-math-extra",
+  "core-math",
+  "core-math-full",
   "core-random",
   "core-regexp-oniguruma",
   "core-time",
@@ -59,7 +60,8 @@ default = [
 ]
 core-env = ["spinoso-env"]
 core-env-system = ["core-env", "spinoso-env/system-env"]
-core-math-extra = ["libm"]
+core-math = ["spinoso-math"]
+core-math-full = ["core-math", "spinoso-math/full"]
 core-random = ["rand", "rand_pcg"]
 core-regexp-oniguruma = ["onig"]
 core-time = ["spinoso-time"]

--- a/artichoke-backend/src/block.rs
+++ b/artichoke-backend/src/block.rs
@@ -4,7 +4,7 @@ use std::error;
 use std::fmt;
 
 use crate::class_registry::ClassRegistry;
-use crate::core::ConvertMut;
+use crate::core::{ConvertMut, Value as _};
 use crate::error::{Error, RubyException};
 use crate::exception_handler;
 use crate::extn::core::exception::{Fatal, TypeError};

--- a/artichoke-backend/src/coerce_to_numeric.rs
+++ b/artichoke-backend/src/coerce_to_numeric.rs
@@ -1,0 +1,58 @@
+use artichoke_core::coerce_to_numeric::CoerceToNumeric;
+use artichoke_core::convert::TryConvert;
+use artichoke_core::eval::Eval;
+use artichoke_core::value::{pretty_name, Value as _};
+use spinoso_exception::TypeError;
+
+use crate::types::{Fp, Ruby};
+use crate::value::Value;
+use crate::{Artichoke, Error};
+
+impl CoerceToNumeric for Artichoke {
+    type Value = Value;
+
+    type Float = Fp;
+
+    type Error = Error;
+
+    #[allow(clippy::cast_precision_loss)]
+    fn coerce_to_float(&mut self, value: Self::Value) -> Result<Self::Float, Self::Error> {
+        match value.ruby_type() {
+            Ruby::Float => return value.try_into(self),
+            Ruby::Fixnum => return value.try_into::<i64>(self).map(|int| int as f64),
+            Ruby::Nil => return Err(TypeError::from("can't convert nil into Float").into()),
+            _ => {}
+        }
+        // TODO: This branch should use `numeric::coerce`
+        let class_of_numeric = self.eval(b"Numeric")?;
+        let is_a_numeric = value.funcall(self, "is_a?", &[class_of_numeric], None)?;
+        let is_a_numeric = self.try_convert(is_a_numeric);
+        if let Ok(true) = is_a_numeric {
+            if !value.respond_to(self, "to_f")? {
+                let mut message = String::from("can't convert ");
+                message.push_str(pretty_name(value, self));
+                message.push_str(" into Float");
+                return Err(TypeError::from(message).into());
+            }
+            let coerced = value.funcall(self, "to_f", &[], None)?;
+            if let Ruby::Float = coerced.ruby_type() {
+                coerced.try_into::<f64>(self)
+            } else {
+                let mut message = String::from("can't convert ");
+                let name = pretty_name(value, self);
+                message.push_str(name);
+                message.push_str(" into Float (");
+                message.push_str(name);
+                message.push_str("#to_f gives ");
+                message.push_str(pretty_name(coerced, self));
+                message.push(')');
+                Err(TypeError::from(message).into())
+            }
+        } else {
+            let mut message = String::from("can't convert ");
+            message.push_str(pretty_name(value, self));
+            message.push_str(" into Float");
+            Err(TypeError::from(message).into())
+        }
+    }
+}

--- a/artichoke-backend/src/convert.rs
+++ b/artichoke-backend/src/convert.rs
@@ -3,7 +3,7 @@ use std::error;
 use std::fmt;
 
 use crate::class_registry::ClassRegistry;
-use crate::core::{Convert, ConvertMut, TryConvert, TryConvertMut};
+use crate::core::{Convert, ConvertMut, TryConvert, TryConvertMut, Value as _};
 use crate::error::{Error, RubyException};
 use crate::extn::core::exception::TypeError;
 use crate::sys;

--- a/artichoke-backend/src/convert/array.rs
+++ b/artichoke-backend/src/convert/array.rs
@@ -1,7 +1,7 @@
 use std::iter::FromIterator;
 
 use crate::convert::{BoxUnboxVmValue, UnboxRubyError};
-use crate::core::{Convert, ConvertMut, TryConvert, TryConvertMut};
+use crate::core::{Convert, ConvertMut, TryConvert, TryConvertMut, Value as _};
 use crate::error::Error;
 use crate::extn::core::array::Array;
 use crate::types::{Int, Ruby, Rust};

--- a/artichoke-backend/src/convert/boxing.rs
+++ b/artichoke-backend/src/convert/boxing.rs
@@ -5,6 +5,7 @@ use std::mem::ManuallyDrop;
 use std::ops::{Deref, DerefMut};
 use std::ptr;
 
+use crate::core::Value as _;
 use crate::def::NotDefinedError;
 use crate::error::Error;
 use crate::extn::core::exception::TypeError;

--- a/artichoke-backend/src/convert/bytes.rs
+++ b/artichoke-backend/src/convert/bytes.rs
@@ -4,7 +4,7 @@ use std::ffi::{OsStr, OsString};
 use std::slice;
 
 use crate::convert::UnboxRubyError;
-use crate::core::{ConvertMut, TryConvertMut};
+use crate::core::{ConvertMut, TryConvertMut, Value as _};
 use crate::error::Error;
 use crate::ffi;
 use crate::sys;

--- a/artichoke-backend/src/convert/fixnum.rs
+++ b/artichoke-backend/src/convert/fixnum.rs
@@ -1,7 +1,7 @@
 use std::convert::TryFrom;
 
 use crate::convert::{BoxIntoRubyError, UnboxRubyError};
-use crate::core::{Convert, TryConvert};
+use crate::core::{Convert, TryConvert, Value as _};
 use crate::error::Error;
 use crate::sys;
 use crate::types::{Int, Ruby, Rust};

--- a/artichoke-backend/src/convert/float.rs
+++ b/artichoke-backend/src/convert/float.rs
@@ -1,5 +1,5 @@
 use crate::convert::UnboxRubyError;
-use crate::core::{ConvertMut, TryConvert};
+use crate::core::{ConvertMut, TryConvert, Value as _};
 use crate::error::Error;
 use crate::sys;
 use crate::types::{Fp, Ruby, Rust};

--- a/artichoke-backend/src/convert/hash.rs
+++ b/artichoke-backend/src/convert/hash.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::convert::TryFrom;
 
 use crate::convert::{BoxUnboxVmValue, UnboxRubyError};
-use crate::core::{ConvertMut, TryConvertMut};
+use crate::core::{ConvertMut, TryConvertMut, Value as _};
 use crate::error::Error;
 use crate::extn::core::array::Array;
 use crate::sys;

--- a/artichoke-backend/src/extn/core/array/mod.rs
+++ b/artichoke-backend/src/extn/core/array/mod.rs
@@ -1,3 +1,4 @@
+use artichoke_core::value::pretty_name;
 use spinoso_array::SmallArray as SpinosoArray;
 use std::convert::TryFrom;
 use std::iter::FromIterator;
@@ -179,11 +180,12 @@ impl Array {
                             other.0.clone()
                         } else {
                             let mut message = String::from("can't convert ");
-                            message.push_str(array_or_len.pretty_name(interp));
+                            let name = pretty_name(array_or_len, interp);
+                            message.push_str(name);
                             message.push_str(" to Array (");
-                            message.push_str(array_or_len.pretty_name(interp));
+                            message.push_str(name);
                             message.push_str("#to_ary gives ");
-                            message.push_str(other.pretty_name(interp));
+                            message.push_str(pretty_name(other, interp));
                             return Err(TypeError::from(message).into());
                         }
                     } else {
@@ -223,11 +225,12 @@ impl Array {
                             other.0.clone()
                         } else {
                             let mut message = String::from("can't convert ");
-                            message.push_str(array_or_len.pretty_name(interp));
+                            let name = pretty_name(array_or_len, interp);
+                            message.push_str(name);
                             message.push_str(" to Array (");
-                            message.push_str(array_or_len.pretty_name(interp));
+                            message.push_str(name);
                             message.push_str("#to_ary gives ");
-                            message.push_str(other.pretty_name(interp));
+                            message.push_str(pretty_name(other, interp));
                             return Err(TypeError::from(message).into());
                         }
                     } else {
@@ -315,11 +318,12 @@ impl Array {
                     self.0.set_slice(start, drain, other.0.as_slice());
                 } else {
                     let mut message = String::from("can't convert ");
-                    message.push_str(elem.pretty_name(interp));
+                    let name = pretty_name(elem, interp);
+                    message.push_str(name);
                     message.push_str(" to Array (");
-                    message.push_str(elem.pretty_name(interp));
+                    message.push_str(name);
                     message.push_str("#to_ary gives ");
-                    message.push_str(other.pretty_name(interp));
+                    message.push_str(pretty_name(other, interp));
                     return Err(TypeError::from(message).into());
                 }
             } else {
@@ -358,16 +362,17 @@ impl Array {
                 self.0.concat(other.0.as_slice());
             } else {
                 let mut message = String::from("can't convert ");
-                message.push_str(other.pretty_name(interp));
+                let name = pretty_name(other, interp);
+                message.push_str(name);
                 message.push_str(" to Array (");
-                message.push_str(other.pretty_name(interp));
+                message.push_str(name);
                 message.push_str("#to_ary gives ");
-                message.push_str(other.pretty_name(interp));
+                message.push_str(pretty_name(arr, interp));
                 return Err(TypeError::from(message).into());
             }
         } else {
             let mut message = String::from("no implicit conversion of ");
-            message.push_str(other.pretty_name(interp));
+            message.push_str(pretty_name(other, interp));
             message.push_str(" into Array");
             return Err(TypeError::from(message).into());
         };

--- a/artichoke-backend/src/extn/core/kernel/integer.rs
+++ b/artichoke-backend/src/extn/core/kernel/integer.rs
@@ -1,3 +1,4 @@
+use artichoke_core::value::pretty_name;
 use bstr::ByteSlice;
 use std::convert::{TryFrom, TryInto};
 use std::error;
@@ -155,7 +156,7 @@ impl<'a> TryConvertMut<&'a mut Value, IntegerString<'a>> for Artichoke {
 
     fn try_convert_mut(&mut self, value: &'a mut Value) -> Result<IntegerString<'a>, Self::Error> {
         let mut message = String::from("can't convert ");
-        message.push_str(value.pretty_name(self));
+        message.push_str(pretty_name(*value, self));
         message.push_str(" into Integer");
 
         if let Ok(arg) = value.implicitly_convert_to_string(self) {

--- a/artichoke-backend/src/extn/core/math/mruby.rs
+++ b/artichoke-backend/src/extn/core/math/mruby.rs
@@ -1,8 +1,11 @@
-use crate::extn::core::math;
+//! FFI glue between the Rust trampolines and the mruby C interpreter.
+
+use crate::extn::core::math::trampoline;
+use crate::extn::core::math::{self, DomainError, Math};
 use crate::extn::prelude::*;
 
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
-    if interp.is_module_defined::<math::Math>() {
+    if interp.is_module_defined::<Math>() {
         return Ok(());
     }
     let spec = module::Spec::new(interp, "Math", None)?;
@@ -40,13 +43,13 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     class::Builder::for_spec(interp, &domainerror)
         .with_super_class::<StandardError, _>("StandardError")?
         .define()?;
-    interp.def_class::<math::DomainError>(domainerror)?;
+    interp.def_class::<DomainError>(domainerror)?;
 
-    interp.def_module::<math::Math>(spec)?;
+    interp.def_module::<Math>(spec)?;
     let e = interp.convert_mut(math::E);
-    interp.define_module_constant::<math::Math>("E", e)?;
+    interp.define_module_constant::<Math>("E", e)?;
     let pi = interp.convert_mut(math::PI);
-    interp.define_module_constant::<math::Math>("PI", pi)?;
+    interp.define_module_constant::<Math>("PI", pi)?;
     Ok(())
 }
 
@@ -58,7 +61,7 @@ unsafe extern "C" fn artichoke_math_acos(
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
     let value = Value::from(value);
-    let result = math::acos(&mut guard, value).map(|result| guard.convert_mut(result));
+    let result = trampoline::acos(&mut guard, value).map(|result| guard.convert_mut(result));
     match result {
         Ok(value) => value.inner(),
         Err(exception) => error::raise(guard, exception),
@@ -73,7 +76,7 @@ unsafe extern "C" fn artichoke_math_acosh(
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
     let value = Value::from(value);
-    let result = math::acosh(&mut guard, value).map(|result| guard.convert_mut(result));
+    let result = trampoline::acosh(&mut guard, value).map(|result| guard.convert_mut(result));
     match result {
         Ok(value) => value.inner(),
         Err(exception) => error::raise(guard, exception),
@@ -88,7 +91,7 @@ unsafe extern "C" fn artichoke_math_asin(
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
     let value = Value::from(value);
-    let result = math::asin(&mut guard, value).map(|result| guard.convert_mut(result));
+    let result = trampoline::asin(&mut guard, value).map(|result| guard.convert_mut(result));
     match result {
         Ok(value) => value.inner(),
         Err(exception) => error::raise(guard, exception),
@@ -103,7 +106,7 @@ unsafe extern "C" fn artichoke_math_asinh(
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
     let value = Value::from(value);
-    let result = math::asinh(&mut guard, value).map(|result| guard.convert_mut(result));
+    let result = trampoline::asinh(&mut guard, value).map(|result| guard.convert_mut(result));
     match result {
         Ok(value) => value.inner(),
         Err(exception) => error::raise(guard, exception),
@@ -118,7 +121,7 @@ unsafe extern "C" fn artichoke_math_atan(
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
     let value = Value::from(value);
-    let result = math::atan(&mut guard, value).map(|result| guard.convert_mut(result));
+    let result = trampoline::atan(&mut guard, value).map(|result| guard.convert_mut(result));
     match result {
         Ok(value) => value.inner(),
         Err(exception) => error::raise(guard, exception),
@@ -134,7 +137,8 @@ unsafe extern "C" fn artichoke_math_atan2(
     let mut guard = Guard::new(&mut interp);
     let value = Value::from(value);
     let other = Value::from(other);
-    let result = math::atan2(&mut guard, value, other).map(|result| guard.convert_mut(result));
+    let result =
+        trampoline::atan2(&mut guard, value, other).map(|result| guard.convert_mut(result));
     match result {
         Ok(value) => value.inner(),
         Err(exception) => error::raise(guard, exception),
@@ -149,7 +153,7 @@ unsafe extern "C" fn artichoke_math_atanh(
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
     let value = Value::from(value);
-    let result = math::atanh(&mut guard, value).map(|result| guard.convert_mut(result));
+    let result = trampoline::atanh(&mut guard, value).map(|result| guard.convert_mut(result));
     match result {
         Ok(value) => value.inner(),
         Err(exception) => error::raise(guard, exception),
@@ -164,7 +168,7 @@ unsafe extern "C" fn artichoke_math_cbrt(
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
     let value = Value::from(value);
-    let result = math::cbrt(&mut guard, value).map(|result| guard.convert_mut(result));
+    let result = trampoline::cbrt(&mut guard, value).map(|result| guard.convert_mut(result));
     match result {
         Ok(value) => value.inner(),
         Err(exception) => error::raise(guard, exception),
@@ -179,7 +183,7 @@ unsafe extern "C" fn artichoke_math_cos(
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
     let value = Value::from(value);
-    let result = math::cos(&mut guard, value).map(|result| guard.convert_mut(result));
+    let result = trampoline::cos(&mut guard, value).map(|result| guard.convert_mut(result));
     match result {
         Ok(value) => value.inner(),
         Err(exception) => error::raise(guard, exception),
@@ -194,7 +198,7 @@ unsafe extern "C" fn artichoke_math_cosh(
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
     let value = Value::from(value);
-    let result = math::cosh(&mut guard, value).map(|result| guard.convert_mut(result));
+    let result = trampoline::cosh(&mut guard, value).map(|result| guard.convert_mut(result));
     match result {
         Ok(value) => value.inner(),
         Err(exception) => error::raise(guard, exception),
@@ -209,7 +213,7 @@ unsafe extern "C" fn artichoke_math_erf(
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
     let value = Value::from(value);
-    let result = math::erf(&mut guard, value).map(|result| guard.convert_mut(result));
+    let result = trampoline::erf(&mut guard, value).map(|result| guard.convert_mut(result));
     match result {
         Ok(value) => value.inner(),
         Err(exception) => error::raise(guard, exception),
@@ -224,7 +228,7 @@ unsafe extern "C" fn artichoke_math_erfc(
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
     let value = Value::from(value);
-    let result = math::erfc(&mut guard, value).map(|result| guard.convert_mut(result));
+    let result = trampoline::erfc(&mut guard, value).map(|result| guard.convert_mut(result));
     match result {
         Ok(value) => value.inner(),
         Err(exception) => error::raise(guard, exception),
@@ -239,7 +243,7 @@ unsafe extern "C" fn artichoke_math_exp(
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
     let value = Value::from(value);
-    let result = math::exp(&mut guard, value).map(|result| guard.convert_mut(result));
+    let result = trampoline::exp(&mut guard, value).map(|result| guard.convert_mut(result));
     match result {
         Ok(value) => value.inner(),
         Err(exception) => error::raise(guard, exception),
@@ -254,7 +258,7 @@ unsafe extern "C" fn artichoke_math_frexp(
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
     let value = Value::from(value);
-    let result = math::frexp(&mut guard, value).and_then(|(fraction, exponent)| {
+    let result = trampoline::frexp(&mut guard, value).and_then(|(fraction, exponent)| {
         let fraction = guard.convert_mut(fraction);
         let exponent = guard.convert(exponent);
         guard.try_convert_mut(&[fraction, exponent][..])
@@ -273,7 +277,7 @@ unsafe extern "C" fn artichoke_math_gamma(
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
     let value = Value::from(value);
-    let result = math::gamma(&mut guard, value).map(|result| guard.convert_mut(result));
+    let result = trampoline::gamma(&mut guard, value).map(|result| guard.convert_mut(result));
     match result {
         Ok(value) => value.inner(),
         Err(exception) => error::raise(guard, exception),
@@ -289,7 +293,8 @@ unsafe extern "C" fn artichoke_math_hypot(
     let mut guard = Guard::new(&mut interp);
     let value = Value::from(value);
     let other = Value::from(other);
-    let result = math::hypot(&mut guard, value, other).map(|result| guard.convert_mut(result));
+    let result =
+        trampoline::hypot(&mut guard, value, other).map(|result| guard.convert_mut(result));
     match result {
         Ok(value) => value.inner(),
         Err(exception) => error::raise(guard, exception),
@@ -306,7 +311,7 @@ unsafe extern "C" fn artichoke_math_ldexp(
     let fraction = Value::from(fraction);
     let exponent = Value::from(exponent);
     let result =
-        math::ldexp(&mut guard, fraction, exponent).map(|result| guard.convert_mut(result));
+        trampoline::ldexp(&mut guard, fraction, exponent).map(|result| guard.convert_mut(result));
     match result {
         Ok(value) => value.inner(),
         Err(exception) => error::raise(guard, exception),
@@ -321,7 +326,7 @@ unsafe extern "C" fn artichoke_math_lgamma(
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
     let value = Value::from(value);
-    let result = math::lgamma(&mut guard, value).and_then(|(result, sign)| {
+    let result = trampoline::lgamma(&mut guard, value).and_then(|(result, sign)| {
         let result = guard.convert_mut(result);
         let sign = guard.convert(sign);
         guard.try_convert_mut(&[result, sign][..])
@@ -341,7 +346,7 @@ unsafe extern "C" fn artichoke_math_log(
     let mut guard = Guard::new(&mut interp);
     let value = Value::from(value);
     let base = base.map(Value::from);
-    let result = math::log(&mut guard, value, base).map(|result| guard.convert_mut(result));
+    let result = trampoline::log(&mut guard, value, base).map(|result| guard.convert_mut(result));
     match result {
         Ok(value) => value.inner(),
         Err(exception) => error::raise(guard, exception),
@@ -356,7 +361,7 @@ unsafe extern "C" fn artichoke_math_log10(
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
     let value = Value::from(value);
-    let result = math::log10(&mut guard, value).map(|result| guard.convert_mut(result));
+    let result = trampoline::log10(&mut guard, value).map(|result| guard.convert_mut(result));
     match result {
         Ok(value) => value.inner(),
         Err(exception) => error::raise(guard, exception),
@@ -371,7 +376,7 @@ unsafe extern "C" fn artichoke_math_log2(
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
     let value = Value::from(value);
-    let result = math::log2(&mut guard, value).map(|result| guard.convert_mut(result));
+    let result = trampoline::log2(&mut guard, value).map(|result| guard.convert_mut(result));
     match result {
         Ok(value) => value.inner(),
         Err(exception) => error::raise(guard, exception),
@@ -386,7 +391,7 @@ unsafe extern "C" fn artichoke_math_sin(
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
     let value = Value::from(value);
-    let result = math::sin(&mut guard, value).map(|result| guard.convert_mut(result));
+    let result = trampoline::sin(&mut guard, value).map(|result| guard.convert_mut(result));
     match result {
         Ok(value) => value.inner(),
         Err(exception) => error::raise(guard, exception),
@@ -401,7 +406,7 @@ unsafe extern "C" fn artichoke_math_sinh(
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
     let value = Value::from(value);
-    let result = math::sinh(&mut guard, value).map(|result| guard.convert_mut(result));
+    let result = trampoline::sinh(&mut guard, value).map(|result| guard.convert_mut(result));
     match result {
         Ok(value) => value.inner(),
         Err(exception) => error::raise(guard, exception),
@@ -416,7 +421,7 @@ unsafe extern "C" fn artichoke_math_sqrt(
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
     let value = Value::from(value);
-    let result = math::sqrt(&mut guard, value).map(|result| guard.convert_mut(result));
+    let result = trampoline::sqrt(&mut guard, value).map(|result| guard.convert_mut(result));
     match result {
         Ok(value) => value.inner(),
         Err(exception) => error::raise(guard, exception),
@@ -431,7 +436,7 @@ unsafe extern "C" fn artichoke_math_tan(
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
     let value = Value::from(value);
-    let result = math::tan(&mut guard, value).map(|result| guard.convert_mut(result));
+    let result = trampoline::tan(&mut guard, value).map(|result| guard.convert_mut(result));
     match result {
         Ok(value) => value.inner(),
         Err(exception) => error::raise(guard, exception),
@@ -446,7 +451,7 @@ unsafe extern "C" fn artichoke_math_tanh(
     let mut interp = unwrap_interpreter!(mrb);
     let mut guard = Guard::new(&mut interp);
     let value = Value::from(value);
-    let result = math::tanh(&mut guard, value).map(|result| guard.convert_mut(result));
+    let result = trampoline::tanh(&mut guard, value).map(|result| guard.convert_mut(result));
     match result {
         Ok(value) => value.inner(),
         Err(exception) => error::raise(guard, exception),

--- a/artichoke-backend/src/extn/core/math/trampoline.rs
+++ b/artichoke-backend/src/extn/core/math/trampoline.rs
@@ -1,0 +1,198 @@
+//! Glue between mruby FFI and `ENV` Rust implementation.
+
+use core::convert::TryFrom;
+
+use crate::extn::prelude::*;
+
+pub fn acos(interp: &mut Artichoke, value: Value) -> Result<Fp, Error> {
+    let value = interp.coerce_to_float(value)?;
+    let result = spinoso_math::acos(value)?;
+    Ok(result)
+}
+
+pub fn acosh(interp: &mut Artichoke, value: Value) -> Result<Fp, Error> {
+    let value = interp.coerce_to_float(value)?;
+    let result = spinoso_math::acosh(value)?;
+    Ok(result)
+}
+
+pub fn asin(interp: &mut Artichoke, value: Value) -> Result<Fp, Error> {
+    let value = interp.coerce_to_float(value)?;
+    let result = spinoso_math::asin(value)?;
+    Ok(result)
+}
+
+pub fn asinh(interp: &mut Artichoke, value: Value) -> Result<Fp, Error> {
+    let value = interp.coerce_to_float(value)?;
+    let result = spinoso_math::asinh(value);
+    Ok(result)
+}
+
+pub fn atan(interp: &mut Artichoke, value: Value) -> Result<Fp, Error> {
+    let value = interp.coerce_to_float(value)?;
+    let result = spinoso_math::atan(value);
+    Ok(result)
+}
+
+pub fn atan2(interp: &mut Artichoke, value: Value, other: Value) -> Result<Fp, Error> {
+    let value = interp.coerce_to_float(value)?;
+    let other = interp.coerce_to_float(other)?;
+    let result = spinoso_math::atan2(value, other);
+    Ok(result)
+}
+
+pub fn atanh(interp: &mut Artichoke, value: Value) -> Result<Fp, Error> {
+    let value = interp.coerce_to_float(value)?;
+    let result = spinoso_math::atanh(value)?;
+    Ok(result)
+}
+
+pub fn cbrt(interp: &mut Artichoke, value: Value) -> Result<Fp, Error> {
+    let value = interp.coerce_to_float(value)?;
+    let result = spinoso_math::cbrt(value);
+    Ok(result)
+}
+
+pub fn cos(interp: &mut Artichoke, value: Value) -> Result<Fp, Error> {
+    let value = interp.coerce_to_float(value)?;
+    let result = spinoso_math::cos(value);
+    Ok(result)
+}
+
+pub fn cosh(interp: &mut Artichoke, value: Value) -> Result<Fp, Error> {
+    let value = interp.coerce_to_float(value)?;
+    let result = spinoso_math::cosh(value);
+    Ok(result)
+}
+
+pub fn erf(interp: &mut Artichoke, value: Value) -> Result<Fp, Error> {
+    let value = interp.coerce_to_float(value)?;
+    let result = spinoso_math::erf(value)?;
+    Ok(result)
+}
+
+pub fn erfc(interp: &mut Artichoke, value: Value) -> Result<Fp, Error> {
+    let value = interp.coerce_to_float(value)?;
+    let result = spinoso_math::erfc(value)?;
+    Ok(result)
+}
+
+pub fn exp(interp: &mut Artichoke, value: Value) -> Result<Fp, Error> {
+    let value = interp.coerce_to_float(value)?;
+    let result = spinoso_math::exp(value);
+    Ok(result)
+}
+
+pub fn frexp(interp: &mut Artichoke, value: Value) -> Result<(Fp, Int), Error> {
+    let value = interp.coerce_to_float(value)?;
+    let (fraction, exponent) = spinoso_math::frexp(value)?;
+    Ok((fraction, exponent.into()))
+}
+
+pub fn gamma(interp: &mut Artichoke, value: Value) -> Result<Fp, Error> {
+    let value = interp.coerce_to_float(value)?;
+    let result = spinoso_math::gamma(value)?;
+    Ok(result)
+}
+
+pub fn hypot(interp: &mut Artichoke, value: Value, other: Value) -> Result<Fp, Error> {
+    let value = interp.coerce_to_float(value)?;
+    let other = interp.coerce_to_float(other)?;
+    let result = spinoso_math::hypot(value, other);
+    Ok(result)
+}
+
+pub fn ldexp(interp: &mut Artichoke, fraction: Value, exponent: Value) -> Result<Fp, Error> {
+    let fraction = interp.coerce_to_float(fraction)?;
+    let exponent = exponent.implicitly_convert_to_int(interp).or_else(|err| {
+        if let Ok(exponent) = exponent.try_into::<Fp>(interp) {
+            if exponent.is_nan() {
+                Err(RangeError::from("float NaN out of range of integer").into())
+            } else {
+                // TODO: use `approx_unchecked_to` once stabilized.
+                #[allow(clippy::cast_possible_truncation)]
+                Ok(exponent as Int)
+            }
+        } else {
+            Err(Error::from(err))
+        }
+    })?;
+    match i32::try_from(exponent) {
+        Ok(exp) => {
+            let result = spinoso_math::ldexp(fraction, exp)?;
+            Ok(result)
+        }
+        Err(_) if exponent < 0 => {
+            let mut message = String::from("integer ");
+            string::format_int_into(&mut message, exponent)?;
+            message.push_str("too small to convert to `int'");
+            Err(RangeError::from(message).into())
+        }
+        Err(_) => {
+            let mut message = String::from("integer ");
+            string::format_int_into(&mut message, exponent)?;
+            message.push_str("too big to convert to `int'");
+            Err(RangeError::from(message).into())
+        }
+    }
+}
+
+pub fn lgamma(interp: &mut Artichoke, value: Value) -> Result<(Fp, Int), Error> {
+    let value = interp.coerce_to_float(value)?;
+    let (result, sign) = spinoso_math::lgamma(value)?;
+    Ok((result, sign.into()))
+}
+
+pub fn log(interp: &mut Artichoke, value: Value, base: Option<Value>) -> Result<Fp, Error> {
+    let value = interp.coerce_to_float(value)?;
+    let base = if let Some(base) = base {
+        let base = interp.coerce_to_float(base)?;
+        Some(base)
+    } else {
+        None
+    };
+    let result = spinoso_math::log(value, base)?;
+    Ok(result)
+}
+
+pub fn log10(interp: &mut Artichoke, value: Value) -> Result<Fp, Error> {
+    let value = interp.coerce_to_float(value)?;
+    let result = spinoso_math::log10(value)?;
+    Ok(result)
+}
+
+pub fn log2(interp: &mut Artichoke, value: Value) -> Result<Fp, Error> {
+    let value = interp.coerce_to_float(value)?;
+    let result = spinoso_math::log2(value)?;
+    Ok(result)
+}
+
+pub fn sin(interp: &mut Artichoke, value: Value) -> Result<Fp, Error> {
+    let value = interp.coerce_to_float(value)?;
+    let result = value.sin();
+    Ok(result)
+}
+
+pub fn sinh(interp: &mut Artichoke, value: Value) -> Result<Fp, Error> {
+    let value = interp.coerce_to_float(value)?;
+    let result = spinoso_math::sinh(value);
+    Ok(result)
+}
+
+pub fn sqrt(interp: &mut Artichoke, value: Value) -> Result<Fp, Error> {
+    let value = interp.coerce_to_float(value)?;
+    let result = spinoso_math::sqrt(value)?;
+    Ok(result)
+}
+
+pub fn tan(interp: &mut Artichoke, value: Value) -> Result<Fp, Error> {
+    let value = interp.coerce_to_float(value)?;
+    let result = spinoso_math::tan(value);
+    Ok(result)
+}
+
+pub fn tanh(interp: &mut Artichoke, value: Value) -> Result<Fp, Error> {
+    let value = interp.coerce_to_float(value)?;
+    let result = spinoso_math::tanh(value);
+    Ok(result)
+}

--- a/artichoke-backend/src/extn/core/mod.rs
+++ b/artichoke-backend/src/extn/core/mod.rs
@@ -15,6 +15,7 @@ pub mod hash;
 pub mod integer;
 pub mod kernel;
 pub mod matchdata;
+#[cfg(feature = "core-math")]
 pub mod math;
 pub mod method;
 pub mod module;
@@ -54,6 +55,7 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     float::init(interp)?;
     kernel::mruby::init(interp)?;
     matchdata::mruby::init(interp)?;
+    #[cfg(feature = "core-math")]
     math::mruby::init(interp)?;
     method::init(interp)?;
     module::init(interp)?;

--- a/artichoke-backend/src/extn/core/numeric/mod.rs
+++ b/artichoke-backend/src/extn/core/numeric/mod.rs
@@ -1,3 +1,5 @@
+use artichoke_core::value::pretty_name;
+
 use crate::extn::core::integer::Integer;
 use crate::extn::prelude::*;
 
@@ -122,12 +124,12 @@ pub fn coerce(interp: &mut Artichoke, x: Value, y: Value) -> Result<Coercion, Er
                         }
                     } else {
                         let mut message = String::from("can't convert ");
-                        message.push_str(y.pretty_name(interp));
+                        message.push_str(pretty_name(y, interp));
                         message.push_str(" into Float");
                         Err(TypeError::from(message).into())
                     }
                 } else {
-                    let mut message = String::from(y.pretty_name(interp));
+                    let mut message = String::from(pretty_name(y, interp));
                     message.push_str(" can't be coerced into Float");
                     Err(TypeError::from(message).into())
                 }

--- a/artichoke-backend/src/extn/core/string/trampoline.rs
+++ b/artichoke-backend/src/extn/core/string/trampoline.rs
@@ -1,3 +1,4 @@
+use artichoke_core::value::pretty_name;
 use bstr::ByteSlice;
 
 use crate::extn::core::matchdata::MatchData;
@@ -37,7 +38,7 @@ pub fn scan(
 ) -> Result<Value, Error> {
     if let Ruby::Symbol = pattern.ruby_type() {
         let mut message = String::from("wrong argument type ");
-        message.push_str(pattern.pretty_name(interp));
+        message.push_str(pretty_name(pattern, interp));
         message.push_str(" (expected Regexp)");
         Err(TypeError::from(message).into())
     } else if let Ok(regexp) = unsafe { Regexp::unbox_from_value(&mut pattern, interp) } {
@@ -105,7 +106,7 @@ pub fn scan(
         }
     } else {
         let mut message = String::from("wrong argument type ");
-        message.push_str(pattern.pretty_name(interp));
+        message.push_str(pretty_name(pattern, interp));
         message.push_str(" (expected Regexp)");
         Err(TypeError::from(message).into())
     }

--- a/artichoke-backend/src/extn/core/time/trampoline.rs
+++ b/artichoke-backend/src/extn/core/time/trampoline.rs
@@ -1,5 +1,7 @@
 //! Glue between mruby FFI and `Time` Rust implementation.
 
+use artichoke_core::value::pretty_name;
+
 use crate::extn::core::time::Time;
 use crate::extn::prelude::*;
 
@@ -66,7 +68,7 @@ pub fn cmp(interp: &mut Artichoke, mut time: Value, mut other: Value) -> Result<
         Ok(interp.convert(cmp as i32))
     } else {
         let mut message = String::from("comparison of Time with ");
-        message.push_str(other.pretty_name(interp));
+        message.push_str(pretty_name(other, interp));
         message.push_str(" failed");
         Err(ArgumentError::from(message).into())
     }

--- a/artichoke-backend/src/lib.rs
+++ b/artichoke-backend/src/lib.rs
@@ -124,6 +124,7 @@ mod artichoke;
 pub mod block;
 pub mod class;
 pub mod class_registry;
+mod coerce_to_numeric;
 mod constant;
 pub mod convert;
 pub mod def;

--- a/artichoke-core/Cargo.toml
+++ b/artichoke-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "artichoke-core"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2018"
 description = "Core traits for implementing an Artichoke Ruby interpreter"

--- a/artichoke-core/src/coerce_to_numeric.rs
+++ b/artichoke-core/src/coerce_to_numeric.rs
@@ -1,0 +1,39 @@
+//! Coerce Ruby values to native numerics.
+
+use crate::value::Value;
+
+/// Coerce Ruby values to native numerics (floats and integers).
+pub trait CoerceToNumeric {
+    /// Concrete type of boxed Ruby value as inputs to coerce functions.
+    type Value: Value;
+
+    /// Concrete float type to coerce values into, e.g. [`f64`].
+    type Float;
+
+    /// Concrete error type for errors encountered when coercing values.
+    type Error;
+
+    /// Coerce the given Ruby value to a `Float`.
+    ///
+    /// This coercion mechanism is used by Ruby to handle mixed-type numeric
+    /// operations: it is intended to find a compatible common type between the two
+    /// operands of the operator.
+    ///
+    /// See [`Numeric#coerce`].
+    ///
+    /// # Errors
+    ///
+    /// If a Ruby `nil` is given, an error is returned.
+    ///
+    /// If the given value does not subclass [`Numeric`], an error is returned.
+    ///
+    /// If the [`Numeric` class] is not defined, an error is returned.
+    ///
+    /// If the underlying interpreter returns an error when calling `#to_f` or
+    /// [`Numeric#coerce`], the error is returned.
+    ///
+    /// [`Numeric`]: https://ruby-doc.org/core-2.6.3/Numeric.html
+    /// [`Numeric` class]: https://ruby-doc.org/core-2.6.3/Numeric.html
+    /// [`Numeric#coerce`]: https://ruby-doc.org/core-2.6.3/Numeric.html#method-i-coerce
+    fn coerce_to_float(&mut self, value: Self::Value) -> Result<Self::Float, Self::Error>;
+}

--- a/artichoke-core/src/lib.rs
+++ b/artichoke-core/src/lib.rs
@@ -98,6 +98,7 @@ readme!();
 
 extern crate alloc;
 
+pub mod coerce_to_numeric;
 pub mod constant;
 pub mod convert;
 pub mod eval;
@@ -127,6 +128,7 @@ pub mod warn;
 ///
 /// The prelude may grow over time as additional items see ubiquitous use.
 pub mod prelude {
+    pub use crate::coerce_to_numeric::CoerceToNumeric;
     pub use crate::constant::DefineConstant;
     pub use crate::convert::{Convert, ConvertMut, TryConvert, TryConvertMut};
     pub use crate::eval::Eval;

--- a/artichoke-core/src/value.rs
+++ b/artichoke-core/src/value.rs
@@ -3,6 +3,7 @@
 use alloc::vec::Vec;
 
 use crate::convert::{TryConvert, TryConvertMut};
+use crate::types::Ruby;
 
 /// A boxed Ruby value owned by the interpreter.
 ///
@@ -97,4 +98,42 @@ pub trait Value {
     ///
     /// This function can never fail.
     fn to_s(&self, interp: &mut Self::Artichoke) -> Vec<u8>;
+
+    /// Return this values [Rust-mapped type tag](Ruby).
+    fn ruby_type(&self) -> Ruby;
+}
+
+/// Return a name for this value's type suitable for using in an `Exception`
+/// message.
+///
+/// Some immediate types like `true`, `false`, and `nil` are shown by value
+/// rather than by class.
+///
+/// This function suppresses all errors and returns an empty string on
+/// error.
+pub fn pretty_name<'a, V, T>(value: V, interp: &mut T) -> &'a str
+where
+    V: Copy + Value<Artichoke = T>,
+    T: TryConvert<V, Option<bool>, Error = V::Error>
+        + TryConvertMut<V, &'a str, Error = V::Error>
+        + TryConvertMut<<<V as Value>::Value as Value>::Value, &'a str, Error = V::Error>,
+    V::Value: Value<Artichoke = T>,
+    <V::Value as Value>::Value: Value<Artichoke = T, Error = V::Error>,
+{
+    match value.try_into(interp) {
+        Ok(Some(true)) => "true",
+        Ok(Some(false)) => "false",
+        Ok(None) => "nil",
+        Err(_) if matches!(value.ruby_type(), Ruby::Data | Ruby::Object) => {
+            if let Ok(class) = value.funcall(interp, "class", &[], None) {
+                if let Ok(class) = class.funcall(interp, "name", &[], None) {
+                    if let Ok(class) = class.try_into_mut(interp) {
+                        return class;
+                    }
+                }
+            }
+            ""
+        }
+        Err(_) => value.ruby_type().class_name(),
+    }
 }

--- a/spinoso-exception/README.md
+++ b/spinoso-exception/README.md
@@ -64,7 +64,7 @@ pub fn array_concat(slf: Array, other: Array) -> Result<Array, Box<dyn RubyExcep
 ## `no_std`
 
 This crate is `no_std` compatible when built without the `std` feature. This
-crate unconditionally depends on [`alloc`].
+crate has a required dependency on [`alloc`].
 
 ## Crate features
 

--- a/spinoso-exception/src/lib.rs
+++ b/spinoso-exception/src/lib.rs
@@ -66,6 +66,19 @@
 //! - [`SystemStackError`]
 //! - `fatal` — impossible to rescue
 //!
+//! # `no_std`
+//!
+//! This crate is `no_std` compatible when built without the `std` feature. This
+//! crate has a required dependency on [`alloc`].
+//!
+//! # Crate features
+//!
+//! All features are enabled by default.
+//!
+//! - **std** - Enables a dependency on the Rust Standard Library. Activating
+//!   this feature enables [`std::error::Error`] impls on error types in this
+//!   crate.
+//!
 //! [`Exception`]: https://ruby-doc.org/core-2.6.3/Exception.html
 //! [`Kernel#raise`]: https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-raise
 //! [`NameError#name`]: https://ruby-doc.org/core-2.6.3/NameError.html#method-i-name

--- a/spinoso-math/Cargo.toml
+++ b/spinoso-math/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "spinoso-math"
+version = "0.1.0"
+authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
+edition = "2018"
+description = """
+Implementation of the Ruby Math module
+"""
+repository = "https://github.com/artichoke/artichoke"
+readme = "README.md"
+license = "MIT"
+keywords = ["libm", "math", "no_std", "spinoso"]
+categories = ["algorithms", "no-std"]
+
+[dependencies]
+libm = { version = "0.2", optional = true }
+
+[features]
+default = ["full", "std"]
+# Implement the full Ruby `Math` API by including external crates for missing
+# `core` APIs.
+full = ["libm"]
+# By default, `spinoso-math` is `no_std`. This feature enables
+# `std::error::Error` impls.
+std = []

--- a/spinoso-math/README.md
+++ b/spinoso-math/README.md
@@ -1,0 +1,83 @@
+# spinoso-math
+
+[![GitHub Actions](https://github.com/artichoke/artichoke/workflows/CI/badge.svg)](https://github.com/artichoke/artichoke/actions)
+[![Discord](https://img.shields.io/discord/607683947496734760)](https://discord.gg/QCe2tp2)
+[![Twitter](https://img.shields.io/twitter/follow/artichokeruby?label=Follow&style=social)](https://twitter.com/artichokeruby)
+<br>
+[![Crate](https://img.shields.io/crates/v/spinoso-math.svg)](https://crates.io/crates/spinoso-math)
+[![API](https://docs.rs/spinoso-math/badge.svg)](https://docs.rs/spinoso-math)
+[![API trunk](https://img.shields.io/badge/docs-trunk-blue.svg)](https://artichoke.github.io/artichoke/spinoso_math/)
+
+The Ruby Math module.
+
+The Math module contains module functions for basic trigonometric and
+transcendental functions. See class [`Float`] for a list of constants that
+define Ruby's floating point accuracy.
+
+This crate defines math operations as free functions. These functions differ
+from those defined in Rust [`core`] by returning a `DomainError` when an input
+is outside of the domain of the function and results in [`NaN`].
+
+`spinoso-math` assumes the Ruby VM uses double precision [`f64`] floats.
+
+_Spinoso_ refers to _Carciofo spinoso di Sardegna_, the thorny artichoke of
+Sardinia. The data structures defined in the `spinoso` family of crates form the
+backbone of Ruby Core in Artichoke.
+
+## Usage
+
+Add this to your `Cargo.toml`:
+
+```toml
+[dependencies]
+spinoso-math = "0.1"
+```
+
+Compute the hypotenuse:
+
+```rust
+use spinoso_math as math;
+assert_eq!(math::hypot(3.0, 4.0), 5.0);
+```
+
+Compute log with respect to the base 10 and handle domain errors:
+
+```rust
+use spinoso_math as math;
+assert_eq!(math::log10(1.0), Ok(0.0));
+assert_eq!(math::log10(10.0), Ok(1.0));
+assert_eq!(math::log10(1e100), Ok(100.0));
+
+assert_eq!(math::log10(0.0), Ok(f64::NEG_INFINITY));
+assert!(math::log10(-0.1).is_err());
+
+// A NaN return value is distinct from a `DomainError`.
+assert!(matches!(math::log10(f64::NAN), Ok(result) if result.is_nan()));
+```
+
+## `no_std`
+
+This crate is `no_std` compatible when built without the `std` feature. This
+crate does not depend on [`alloc`].
+
+## Crate features
+
+All features are enabled by default.
+
+- **full** - Enables implementations of math functions that do not have
+  implementations in Rust [`core`]. Dropping this feature removes the [`libm`]
+  dependency.
+- **std** - Enables a dependency on the Rust Standard Library. Activating this
+  feature enables [`std::error::Error`] impls on error types in this crate.
+
+## License
+
+`spinoso-math` is licensed with the [MIT License](../LICENSE) (c) Ryan Lopopolo.
+
+[`float`]: https://ruby-doc.org/core-2.6.3/Float.html
+[`core`]: https://doc.rust-lang.org/core/
+[`nan`]: https://doc.rust-lang.org/std/primitive.f64.html#associatedconstant.NAN
+[`f64`]: https://doc.rust-lang.org/std/primitive.f64.html
+[`alloc`]: https://doc.rust-lang.org/alloc/
+[`alloc`]: https://doc.rust-lang.org/alloc/
+[`std::error::error`]: https://doc.rust-lang.org/std/error/trait.Error.html

--- a/spinoso-math/src/lib.rs
+++ b/spinoso-math/src/lib.rs
@@ -1,0 +1,398 @@
+#![warn(clippy::all)]
+#![warn(clippy::pedantic)]
+#![warn(clippy::cargo)]
+#![allow(unknown_lints)]
+#![warn(broken_intra_doc_links)]
+#![warn(missing_docs)]
+#![warn(missing_debug_implementations)]
+#![warn(missing_copy_implementations)]
+#![warn(rust_2018_idioms)]
+#![warn(trivial_casts, trivial_numeric_casts)]
+#![warn(unused_qualifications)]
+#![warn(variant_size_differences)]
+#![forbid(unsafe_code)]
+// Enable feature callouts in generated documentation:
+// https://doc.rust-lang.org/beta/unstable-book/language-features/doc-cfg.html
+//
+// This approach is borrowed from tokio.
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_alias))]
+
+//! The Ruby Math module.
+//!
+//! The Math module contains module functions for basic trigonometric and
+//! transcendental functions. See class [`Float`] for a list of constants that
+//! define Ruby's floating point accuracy.
+//!
+//! This crate defines math operations as free functions. These functions differ
+//! from those defined in Rust [`core`] by returning a [`DomainError`] when an
+//! input is outside of the domain of the function and results in [`NaN`].
+//!
+//! `spinoso-math` assumes the Ruby VM uses double precision [`f64`] floats.
+//!
+//! # Examples
+//!
+//! Compute the hypotenuse:
+//!
+//! ```
+//! use spinoso_math as math;
+//! assert_eq!(math::hypot(3.0, 4.0), 5.0);
+//! ```
+//!
+//! Compute log with respect to the base 10 and handle domain errors:
+//!
+//! ```
+//! use spinoso_math as math;
+//! assert_eq!(math::log10(1.0), Ok(0.0));
+//! assert_eq!(math::log10(10.0), Ok(1.0));
+//! assert_eq!(math::log10(1e100), Ok(100.0));
+//!
+//! assert_eq!(math::log10(0.0), Ok(f64::NEG_INFINITY));
+//! assert!(math::log10(-0.1).is_err());
+//!
+//! // A NaN return value is distinct from a `DomainError`.
+//! assert!(matches!(math::log10(f64::NAN), Ok(result) if result.is_nan()));
+//! ```
+//!
+//! # `no_std`
+//!
+//! This crate is `no_std` compatible when built without the `std` feature. This
+//! crate does not depend on [`alloc`].
+//!
+//! # Crate features
+//!
+//! All features are enabled by default.
+//!
+//! - **full** - Enables implementations of math functions that do not have
+//!   implementations in Rust [`core`]. Dropping this feature removes the
+//!   [`libm`] dependency.
+//! - **std** - Enables a dependency on the Rust Standard Library. Activating
+//!   this feature enables [`std::error::Error`] impls on error types in this
+//!   crate.
+//!
+//! [`Float`]: https://ruby-doc.org/core-2.6.3/Float.html
+//! [`NaN`]: f64::NAN
+//! [`alloc`]: https://doc.rust-lang.org/alloc/
+
+use core::fmt;
+#[cfg(feature = "std")]
+use std::error;
+
+#[doc(inline)]
+pub use core::f64::consts::E;
+#[doc(inline)]
+pub use core::f64::consts::PI;
+
+mod math;
+
+pub use math::*;
+
+/// A handle to the `Math` module.
+///
+/// This is a copy zero-sized type with no associated methods. This type exists
+/// so a Ruby VM can attempt to unbox this type and statically dispatch to
+/// functions defined in this crate.
+///
+/// # Examples
+///
+/// ```
+/// # use spinoso_math::Math;
+/// const MATH: Math = Math::new();
+/// ```
+#[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Math {
+    _private: (),
+}
+
+impl Math {
+    /// Constructs a new, default `Math`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_math::Math;
+    /// const MATH: Math = Math::new();
+    /// ```
+    #[inline]
+    #[must_use]
+    pub const fn new() -> Self {
+        Self { _private: () }
+    }
+}
+
+/// Sum type of all errors possibly returned from `Math` functions.
+///
+/// Math functions in `spinoso-math` return errors in the following conditions:
+///
+/// - The parameters evaluate to a result that is out of range.
+/// - The function is not implemented due to missing compile-time flags.
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Error {
+    /// Error that indicates a math function returned a value that was out of
+    /// range.
+    ///
+    /// This error can be used to differentiate between [`NaN`](f64::NAN) inputs
+    /// and what would be `NaN` outputs.
+    ///
+    /// See [`DomainError`].
+    Domain(DomainError),
+    /// Error that indicates a `Math` module function is not implemented.
+    ///
+    /// See [`NotImplementedError`].
+    NotImplemented(NotImplementedError),
+}
+
+impl Error {
+    /// Retrieve the exception message associated with this error.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_math::{DomainError, Error, NotImplementedError};
+    /// let err = Error::from(DomainError::new());
+    /// assert_eq!(err.message(), "Math::DomainError");
+    ///
+    /// let err = Error::from(NotImplementedError::with_message(
+    ///     "Artichoke was not built with Math::erf support"
+    /// ));
+    /// assert_eq!(err.message(), "Artichoke was not built with Math::erf support");
+    /// ```
+    #[inline]
+    #[must_use]
+    pub const fn message(self) -> &'static str {
+        match self {
+            Self::Domain(err) => err.message(),
+            Self::NotImplemented(err) => err.message(),
+        }
+    }
+}
+
+impl From<DomainError> for Error {
+    #[inline]
+    fn from(err: DomainError) -> Self {
+        Self::Domain(err)
+    }
+}
+
+impl From<NotImplementedError> for Error {
+    #[inline]
+    fn from(err: NotImplementedError) -> Self {
+        Self::NotImplemented(err)
+    }
+}
+
+impl fmt::Display for Error {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("Math error")
+    }
+}
+
+#[cfg(feature = "std")]
+impl error::Error for Error {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        match self {
+            Self::Domain(ref err) => Some(err),
+            Self::NotImplemented(ref err) => Some(err),
+        }
+    }
+}
+
+/// Error that indicates a math function evaluated to an out of range value.
+///
+/// Domain errors have an associated message.
+///
+/// This error corresponds to the [Ruby `Math::DomainError` Exception class]. It
+/// can be used to differentiate between [`NaN`](f64::NAN) inputs and what would
+/// be `NaN` outputs.
+///
+/// # Examples
+///
+/// ```
+/// # use spinoso_math::DomainError;
+/// let err = DomainError::new();
+/// assert_eq!(err.message(), "Math::DomainError");
+///
+/// let err = DomainError::with_message(
+///     r#"Numerical argument is out of domain - "acos""#,
+/// );
+/// assert_eq!(err.message(), r#"Numerical argument is out of domain - "acos""#);
+/// ```
+///
+/// [Ruby `Math::DomainError` Exception class]: https://ruby-doc.org/core-2.6.3/Math/DomainError.html
+#[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub struct DomainError(&'static str);
+
+impl From<&'static str> for DomainError {
+    #[inline]
+    fn from(message: &'static str) -> Self {
+        Self(message)
+    }
+}
+
+impl DomainError {
+    /// Construct a new, default domain error.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_math::DomainError;
+    /// const ERR: DomainError = DomainError::new();
+    /// assert_eq!(ERR.message(), "Math::DomainError");
+    /// ```
+    #[inline]
+    #[must_use]
+    pub const fn new() -> Self {
+        // [2.6.3] > Math::DomainError.new.message
+        // => "Math::DomainError"
+        Self("Math::DomainError")
+    }
+
+    /// Construct a new, domaine error with a message.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_math::DomainError;
+    /// const ERR: DomainError = DomainError::with_message(
+    ///     r#"Numerical argument is out of domain - "acos""#,
+    /// );
+    /// assert_eq!(ERR.message(), r#"Numerical argument is out of domain - "acos""#);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub const fn with_message(message: &'static str) -> Self {
+        Self(message)
+    }
+
+    /// Retrieve the exception message associated with this error.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_math::DomainError;
+    /// let err = DomainError::new();
+    /// assert_eq!(err.message(), "Math::DomainError");
+    ///
+    /// let err = DomainError::with_message(
+    ///     r#"Numerical argument is out of domain - "acos""#,
+    /// );
+    /// assert_eq!(err.message(), r#"Numerical argument is out of domain - "acos""#);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub const fn message(self) -> &'static str {
+        self.0
+    }
+}
+
+impl fmt::Display for DomainError {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.0)
+    }
+}
+
+#[cfg(feature = "std")]
+impl error::Error for DomainError {}
+
+/// Error that indicates a `Math` module function is not implemented.
+///
+/// Some math functions are not available in the [Rust core library] and require
+/// this crate to be built with extra compile-time features to enable [additional
+/// dependencies].
+///
+/// Not implemented errors have an associated message.
+///
+/// This error corresponds to the [Ruby `NotImplementedError` Exception class].
+///
+/// # Examples
+///
+/// ```
+/// # use spinoso_math::NotImplementedError;
+/// let err = NotImplementedError::new();
+/// assert_eq!(err.message(), "NotImplementedError");
+///
+/// let err = NotImplementedError::with_message(
+///     "Artichoke was not built with Math::erf support"
+/// );
+/// assert_eq!(err.message(), "Artichoke was not built with Math::erf support");
+/// ```
+///
+/// [Rust core library]: https://doc.rust-lang.org/std/primitive.f64.html
+/// [additional dependencies]: https://crates.io/crates/libm
+/// [Ruby `NotImplementedError` Exception class]: https://ruby-doc.org/core-2.6.3/NotImplementedError.html
+#[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub struct NotImplementedError(&'static str);
+
+impl NotImplementedError {
+    /// Construct a new, default not implemented error.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_math::NotImplementedError;
+    /// const ERR: NotImplementedError = NotImplementedError::new();
+    /// assert_eq!(ERR.message(), "NotImplementedError");
+    /// ```
+    #[inline]
+    #[must_use]
+    pub const fn new() -> Self {
+        Self("NotImplementedError")
+    }
+
+    /// Construct a new, not implemented error with a message.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_math::NotImplementedError;
+    /// const ERR: NotImplementedError = NotImplementedError::with_message(
+    ///     "Artichoke was not built with Math::erf support"
+    /// );
+    /// assert_eq!(ERR.message(), "Artichoke was not built with Math::erf support");
+    /// ```
+    #[inline]
+    #[must_use]
+    pub const fn with_message(message: &'static str) -> Self {
+        Self(message)
+    }
+
+    /// Retrieve the exception message associated with this not implemented
+    /// error.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_math::NotImplementedError;
+    /// let err = NotImplementedError::new();
+    /// assert_eq!(err.message(), "NotImplementedError");
+    ///
+    /// let err = NotImplementedError::with_message(
+    ///     "Artichoke was not built with Math::erf support"
+    /// );
+    /// assert_eq!(err.message(), "Artichoke was not built with Math::erf support");
+    /// ```
+    #[inline]
+    #[must_use]
+    pub const fn message(self) -> &'static str {
+        self.0
+    }
+}
+
+impl From<&'static str> for NotImplementedError {
+    #[inline]
+    fn from(message: &'static str) -> Self {
+        Self(message)
+    }
+}
+
+impl fmt::Display for NotImplementedError {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.0)
+    }
+}
+
+#[cfg(feature = "std")]
+impl error::Error for NotImplementedError {}

--- a/spinoso-math/src/math.rs
+++ b/spinoso-math/src/math.rs
@@ -1,0 +1,903 @@
+#[cfg(feature = "full")]
+use core::convert::TryFrom;
+#[cfg(feature = "full")]
+use core::num::FpCategory;
+
+use crate::{DomainError, NotImplementedError};
+
+/// Computes the arccosine of the given value. Returns results in the range
+/// `(0..=PI)`.
+///
+/// Domain: [-1, 1]
+///
+/// Codomain: [0, PI]
+///
+/// # Examples
+///
+/// ```
+/// # use spinoso_math::PI;
+/// use spinoso_math as math;
+/// assert_eq!(math::acos(0.0), Ok(PI / 2.0));
+/// assert!(math::acos(100.0).is_err());
+///
+/// assert!(matches!(math::acos(f64::NAN), Ok(result) if result.is_nan()));
+/// ```
+///
+/// # Errors
+///
+/// If the result of computing the arccosine is [`NAN`], a domain error is
+/// returned.
+///
+/// [`NAN`]: f64::NAN
+#[inline]
+pub fn acos(value: f64) -> Result<f64, DomainError> {
+    if value.is_nan() {
+        return Ok(f64::NAN);
+    }
+    let result = value.acos();
+    if result.is_nan() {
+        Err(DomainError::with_message(
+            r#"Numerical argument is out of domain - "acos""#,
+        ))
+    } else {
+        Ok(result)
+    }
+}
+
+/// Computes the inverse hyperbolic cosine of the given value.
+///
+/// Domain: [1, INFINITY)
+///
+/// Codomain: [0, INFINITY)
+///
+/// # Examples
+///
+/// ```
+/// use spinoso_math as math;
+/// assert_eq!(math::acosh(1.0), Ok(0.0));
+/// assert!(math::acosh(0.0).is_err());
+///
+/// assert!(matches!(math::acosh(f64::NAN), Ok(result) if result.is_nan()));
+/// ```
+///
+/// # Errors
+///
+/// If the result of computing the inverse hyperbolic cosine is [`NAN`], a
+/// domain error is returned.
+///
+/// [`NAN`]: f64::NAN
+#[inline]
+pub fn acosh(value: f64) -> Result<f64, DomainError> {
+    if value.is_nan() {
+        return Ok(f64::NAN);
+    }
+    let result = value.acosh();
+    if result.is_nan() {
+        Err(DomainError::with_message(
+            r#"Numerical argument is out of domain - "acosh""#,
+        ))
+    } else {
+        Ok(result)
+    }
+}
+
+/// Computes the arcsine of the given value. Returns results in the range
+/// `(-PI/2..=PI/2)`.
+///
+/// Domain: [-1, -1]
+///
+/// Codomain: [-PI/2, PI/2]
+///
+/// # Examples
+///
+/// ```
+/// # use spinoso_math::PI;
+/// use spinoso_math as math;
+/// assert_eq!(math::asin(1.0), Ok(PI / 2.0));
+/// assert!(math::asin(100.0).is_err());
+///
+/// assert!(matches!(math::asin(f64::NAN), Ok(result) if result.is_nan()));
+/// ```
+///
+/// # Errors
+///
+/// If the result of computing the arcsine is [`NAN`], a domain error is
+/// returned.
+///
+/// [`NAN`]: f64::NAN
+#[inline]
+pub fn asin(value: f64) -> Result<f64, DomainError> {
+    if value.is_nan() {
+        return Ok(f64::NAN);
+    }
+    let result = value.asin();
+    if result.is_nan() {
+        Err(DomainError::with_message(
+            r#"Numerical argument is out of domain - "asin""#,
+        ))
+    } else {
+        Ok(result)
+    }
+}
+
+/// Computes the inverse hyperbolic sine of the given value.
+///
+/// Domain: (-INFINITY, INFINITY)
+///
+/// Codomain: (-INFINITY, INFINITY)
+///
+/// # Examples
+///
+/// ```
+/// use spinoso_math as math;
+/// assert!((math::asinh(1.0) - 0.881373587019543).abs() < f64::EPSILON);
+/// ```
+#[inline]
+#[must_use]
+pub fn asinh(value: f64) -> f64 {
+    value.asinh()
+}
+
+/// Computes the arctangent of the given value. Returns results in the range
+/// `(-PI/2..=PI/2)`.
+///
+/// Domain: (-INFINITY, INFINITY)
+///
+/// Codomain: (-PI/2, PI/2)
+///
+/// # Examples
+///
+/// ```
+/// use spinoso_math as math;
+/// assert_eq!(math::atan(0.0), 0.0);
+/// ```
+#[inline]
+#[must_use]
+pub fn atan(value: f64) -> f64 {
+    value.atan()
+}
+
+/// Computes the four quadrant arctangent of `value` (`y`) and `other` (`x`) in
+/// radians.
+///
+/// Return value is a angle in radians between the positive x-axis of cartesian
+/// plane and the point given by the coordinates (`x`, `y`) on it.
+///
+/// Domain: (-INFINITY, INFINITY)
+///
+/// Codomain: [-PI, PI]
+///
+/// # Examples
+///
+/// ```
+/// use spinoso_math as math;
+/// assert!((math::atan2(-0.0, -1.0) - (-3.141592653589793)).abs() < f64::EPSILON);
+/// assert!((math::atan2(-1.0, -1.0) - (-2.356194490192345)).abs() < f64::EPSILON);
+/// assert!((math::atan2(-1.0, 0.0) - (-1.5707963267948966)).abs() < f64::EPSILON);
+/// assert!((math::atan2(-1.0, 1.0) - (-0.7853981633974483)).abs() < f64::EPSILON);
+/// assert!(math::atan2(-0.0, 1.0) == -0.0);
+/// assert!(math::atan2(0.0, 1.0) == 0.0);
+/// assert!((math::atan2(1.0, 1.0) - 0.7853981633974483).abs() < f64::EPSILON);
+/// assert!((math::atan2(1.0, 0.0) - 1.5707963267948966).abs() < f64::EPSILON);
+/// assert!((math::atan2(1.0, -1.0) - 2.356194490192345).abs() < f64::EPSILON);
+/// assert!((math::atan2(0.0, -1.0) - 3.141592653589793).abs() < f64::EPSILON);
+/// assert!((math::atan2(f64::INFINITY, f64::INFINITY) - 0.7853981633974483).abs() < f64::EPSILON);
+/// assert!((math::atan2(f64::INFINITY, f64::NEG_INFINITY) - 2.356194490192345).abs() < f64::EPSILON);
+/// assert!((math::atan2(f64::NEG_INFINITY, f64::INFINITY) - (-0.7853981633974483)).abs() < f64::EPSILON);
+/// assert!((math::atan2(f64::NEG_INFINITY, f64::NEG_INFINITY) - (-2.356194490192345)).abs() < f64::EPSILON);
+/// ```
+#[inline]
+#[must_use]
+pub fn atan2(value: f64, other: f64) -> f64 {
+    value.atan2(other)
+}
+
+/// Computes the inverse hyperbolic tangent of the given value.
+///
+/// Domain: (-1, 1)
+///
+/// Codomain: (-INFINITY, INFINITY)
+///
+/// # Examples
+///
+/// ```
+/// use spinoso_math as math;
+/// assert_eq!(math::atanh(1.0), Ok(f64::INFINITY));
+/// assert!(math::atanh(100.0).is_err());
+///
+/// assert!(matches!(math::atanh(f64::NAN), Ok(result) if result.is_nan()));
+/// ```
+///
+/// # Errors
+///
+/// If the result of computing the inverse hyperbolic tangent is [`NAN`]
+/// a domain error is returned.
+///
+/// [`NAN`]: f64::NAN
+#[inline]
+pub fn atanh(value: f64) -> Result<f64, DomainError> {
+    if value.is_nan() {
+        return Ok(f64::NAN);
+    }
+    let result = value.atanh();
+    if result.is_nan() {
+        Err(DomainError::with_message(
+            r#"Numerical argument is out of domain - "atanh""#,
+        ))
+    } else {
+        Ok(result)
+    }
+}
+
+/// Returns the cube root of the given value.
+///
+/// Domain: (-INFINITY, INFINITY)
+///
+/// Codomain: (-INFINITY, INFINITY)
+///
+/// # Examples
+///
+/// ```
+/// use spinoso_math as math;
+/// assert!((math::cbrt(-9.0) - (-2.080083823051904)).abs() < f64::EPSILON);
+/// assert!((math::cbrt(9.0) - 2.080083823051904).abs() < f64::EPSILON);
+/// ```
+#[inline]
+#[must_use]
+pub fn cbrt(value: f64) -> f64 {
+    value.cbrt()
+}
+
+/// Computes the cosine of the given value (expressed in radians). Returns
+/// values in the range `-1.0..=1.0`.
+///
+/// Domain: (-INFINITY, INFINITY)
+///
+/// Codomain: [-1, 1]
+///
+/// # Examples
+///
+/// ```
+/// # use spinoso_math::PI;
+/// use spinoso_math as math;
+/// assert_eq!(math::cos(PI), -1.0);
+/// ```
+#[inline]
+#[must_use]
+pub fn cos(value: f64) -> f64 {
+    value.cos()
+}
+
+/// Computes the hyperbolic cosine of the given value (expressed in radians).
+///
+/// Domain: (-INFINITY, INFINITY)
+///
+/// Codomain: [1, INFINITY)
+///
+/// # Examples
+///
+/// ```
+/// use spinoso_math as math;
+/// assert_eq!(math::cosh(0.0), 1.0);
+/// ```
+#[inline]
+#[must_use]
+pub fn cosh(value: f64) -> f64 {
+    value.cosh()
+}
+
+/// Calculates the error function of the given value.
+///
+/// Domain: (-INFINITY, INFINITY)
+///
+/// Codomain: (-1, 1)
+///
+/// # Errors
+///
+/// Because `spinoso-math` was built without the `full` feature, this function
+/// will always return a not implemented error.
+#[inline]
+#[cfg(not(feature = "full"))]
+pub fn erf(value: f64) -> Result<f64, NotImplementedError> {
+    let _ = value;
+    Err(NotImplementedError::with_message(
+        "Artichoke was not built with Math::erf support",
+    ))
+}
+
+/// Calculates the error function of the given value.
+///
+/// Domain: (-INFINITY, INFINITY)
+///
+/// Codomain: (-1, 1)
+///
+/// # Examples
+///
+/// ```
+/// use spinoso_math as math;
+/// assert_eq!(math::erf(0.0), Ok(0.0));
+/// ```
+///
+/// # Errors
+///
+/// Because `spinoso-math` was built with the `full` feature, this function will
+/// always succeed and return the error function of the given value.
+#[inline]
+#[cfg(feature = "full")]
+pub fn erf(value: f64) -> Result<f64, NotImplementedError> {
+    let result = libm::erf(value);
+    Ok(result)
+}
+
+/// Calculates the complementary error function of the given value.
+///
+/// Domain: (-INFINITY, INFINITY)
+///
+/// Codomain: (0, 2)
+///
+/// # Errors
+///
+/// Because `spinoso-math` was built without the `full` feature, this function
+/// will always return a not implemented error.
+#[inline]
+#[cfg(not(feature = "full"))]
+pub fn erfc(value: f64) -> Result<f64, NotImplementedError> {
+    let _ = value;
+    Err(NotImplementedError::with_message(
+        "Artichoke was not built with Math::erfc support",
+    ))
+}
+
+/// Calculates the complementary error function of the given value.
+///
+/// Domain: (-INFINITY, INFINITY)
+///
+/// Codomain: (0, 2)
+///
+/// # Examples
+///
+/// ```
+/// use spinoso_math as math;
+/// assert_eq!(math::erfc(0.0), Ok(1.0));
+/// ```
+///
+/// # Errors
+///
+/// Because `spinoso-math` was built with the `full` feature, this function will
+/// always succeed and return the complementary error function of the given
+/// value.
+#[inline]
+#[cfg(feature = "full")]
+pub fn erfc(value: f64) -> Result<f64, NotImplementedError> {
+    let result = libm::erfc(value);
+    Ok(result)
+}
+
+/// Returns `e**x`.
+///
+/// Domain: (-INFINITY, INFINITY)
+///
+/// Codomain: (0, INFINITY)
+///
+/// # Examples
+///
+/// ```
+/// # use spinoso_math::E;
+/// use spinoso_math as math;
+/// assert_eq!(math::exp(0.0), 1.0);
+/// assert_eq!(math::exp(1.0), E);
+/// assert!((math::exp(1.5) - 4.4816890703380645).abs() < f64::EPSILON);
+/// ```
+#[inline]
+#[must_use]
+pub fn exp(value: f64) -> f64 {
+    value.exp()
+}
+
+/// Returns a tuple array containing the normalized fraction (a Float) and
+/// exponent (an Integer) of the given value.
+///
+/// # Errors
+///
+/// Because `spinoso-math` was built without the `full` feature, this function
+/// will always return a not implemented error.
+#[inline]
+#[cfg(not(feature = "full"))]
+pub const fn frexp(value: f64) -> Result<(f64, i32), NotImplementedError> {
+    let _ = value;
+    Err(NotImplementedError::with_message(
+        "Artichoke was not built with Math::frexp support",
+    ))
+}
+
+/// Returns a tuple array containing the normalized fraction (a Float) and
+/// exponent (an Integer) of the given value.
+///
+/// # Examples
+///
+/// ```
+/// use spinoso_math as math;
+/// # fn example() -> Result<(), math::NotImplementedError> {
+/// let (fraction, exponent) = math::frexp(1234.0)?;
+/// let float = math::ldexp(fraction, exponent)?;
+/// assert_eq!(float, 1234.0);
+/// # Ok(())
+/// # }
+/// # example().unwrap();
+/// ```
+///
+/// # Errors
+///
+/// Because `spinoso-math` was built with the `full` feature, this function will
+/// always succeed and return the normalized fraction and exponent of the given
+/// value.
+#[inline]
+#[cfg(feature = "full")]
+pub fn frexp(value: f64) -> Result<(f64, i32), NotImplementedError> {
+    let result = libm::frexp(value);
+    Ok(result)
+}
+
+/// Calculates the gamma function of the given value.
+///
+/// Note that `gamma(n)` is same as `fact(n-1)` for integer n > 0. However
+/// `gamma(n)` returns float and can be an approximation.
+///
+/// # Errors
+///
+/// Because `spinoso-math` was built without the `full` feature, this function
+/// will always return a not implemented error.
+#[cfg(not(feature = "full"))]
+pub const fn gamma(value: f64) -> Result<f64, NotImplementedError> {
+    let _ = value;
+    Err(NotImplementedError::with_message(
+        "Artichoke was not built with Math::gamma support",
+    ))
+}
+
+/// Calculates the gamma function of the given value.
+///
+/// Note that `gamma(n)` is same as `fact(n-1)` for integer n > 0. However
+/// `gamma(n)` returns float and can be an approximation.
+///
+/// # Examples
+///
+/// ```
+/// use spinoso_math as math;
+/// assert_eq!(math::gamma(1.0), Ok(1.0));
+/// assert_eq!(math::gamma(2.0), Ok(1.0));
+/// assert_eq!(math::gamma(3.0), Ok(2.0));
+/// assert_eq!(math::gamma(4.0), Ok(6.0));
+/// assert_eq!(math::gamma(5.0), Ok(24.0));
+/// assert_eq!(math::gamma(20.0), Ok(1.21645100408832e+17));
+///
+/// assert!(math::gamma(-15.0).is_err());
+/// assert!(matches!(math::gamma(-15.1), Ok(result) if (result - 5.9086389724319095e-12).abs() < f64::EPSILON));
+///
+/// assert!(math::gamma(f64::NEG_INFINITY).is_err());
+/// assert_eq!(math::gamma(f64::INFINITY), Ok(f64::INFINITY));
+/// ```
+///
+/// # Errors
+///
+/// If the given value is negative, a domain error is returned.
+#[inline]
+#[cfg(feature = "full")]
+pub fn gamma(value: f64) -> Result<f64, DomainError> {
+    // `gamma(n)` is the same as `n!` for integer n > 0. `gamma` returns float
+    // and might be an approximation so include a lookup table for as many `n`
+    // as can fit in the float manitssa.
+    const FACTORIAL_TABLE: [f64; 23] = [
+        1.0_f64,                         // fact(0)
+        1.0,                             // fact(1)
+        2.0,                             // fact(2)
+        6.0,                             // fact(3)
+        24.0,                            // fact(4)
+        120.0,                           // fact(5)
+        720.0,                           // fact(6)
+        5_040.0,                         // fact(7)
+        40_320.0,                        // fact(8)
+        362_880.0,                       // fact(9)
+        3_628_800.0,                     // fact(10)
+        39_916_800.0,                    // fact(11)
+        479_001_600.0,                   // fact(12)
+        6_227_020_800.0,                 // fact(13)
+        87_178_291_200.0,                // fact(14)
+        1_307_674_368_000.0,             // fact(15)
+        20_922_789_888_000.0,            // fact(16)
+        355_687_428_096_000.0,           // fact(17)
+        6_402_373_705_728_000.0,         // fact(18)
+        121_645_100_408_832_000.0,       // fact(19)
+        2_432_902_008_176_640_000.0,     // fact(20)
+        51_090_942_171_709_440_000.0,    // fact(21)
+        1_124_000_727_777_607_680_000.0, // fact(22)
+    ];
+    match value {
+        value if value.is_infinite() && value.is_sign_negative() => Err(DomainError::with_message(
+            r#"Numerical argument is out of domain - "gamma""#,
+        )),
+        value if value.is_infinite() => Ok(f64::INFINITY),
+        value if matches!(value.classify(), FpCategory::Zero) && value.is_sign_negative() => {
+            Ok(f64::NEG_INFINITY)
+        }
+        value if matches!(value.classify(), FpCategory::Zero) => Ok(f64::INFINITY),
+        value if (value - value.floor()).abs() < f64::EPSILON && value.is_sign_negative() => Err(
+            DomainError::with_message(r#"Numerical argument is out of domain - "gamma""#),
+        ),
+        value if (value - value.floor()).abs() < f64::EPSILON => {
+            #[allow(clippy::cast_possible_truncation)]
+            let idx = (value as i64).checked_sub(1).map(usize::try_from);
+            let result = match idx {
+                Some(Ok(idx)) if idx < FACTORIAL_TABLE.len() => FACTORIAL_TABLE[idx],
+                _ => libm::tgamma(value),
+            };
+            Ok(result)
+        }
+        value => {
+            let result = libm::tgamma(value);
+            Ok(result)
+        }
+    }
+}
+
+/// Returns `sqrt(x**2 + y**2)`, the hypotenuse of a right-angled triangle with
+/// sides x and y.
+///
+/// # Examples
+///
+/// ```
+/// use spinoso_math as math;
+/// assert_eq!(math::hypot(3.0, 4.0), 5.0);
+/// ```
+#[inline]
+#[must_use]
+pub fn hypot(x: f64, y: f64) -> f64 {
+    x.hypot(y)
+}
+
+/// Returns the value of `fraction * (2**exponent)`.
+///
+/// # Errors
+///
+/// Because `spinoso-math` was built without the `full` feature, this function
+/// will always return a not implemented error.
+#[cfg(not(feature = "full"))]
+pub fn ldexp(fraction: f64, exponent: i32) -> Result<f64, NotImplementedError> {
+    let _ = fraction;
+    let _ = exponent;
+    Err(NotImplementedError::with_message(
+        "Artichoke was not built with Math::ldexp support",
+    ))
+}
+
+/// Returns the value of `fraction * (2**exponent)`.
+///
+/// # Examples
+///
+/// ```
+/// use spinoso_math as math;
+/// # fn example() -> Result<(), math::NotImplementedError> {
+/// let (fraction, exponent) = math::frexp(1234.0)?;
+/// let float = math::ldexp(fraction, exponent)?;
+/// assert_eq!(float, 1234.0);
+/// # Ok(())
+/// # }
+/// # example().unwrap();
+/// ```
+///
+/// # Errors
+///
+/// Because `spinoso-math` was built with the `full` feature, this function will
+/// always succeed and return the float determined by the given fraction and
+/// exponent.
+#[inline]
+#[cfg(feature = "full")]
+pub fn ldexp(fraction: f64, exponent: i32) -> Result<f64, NotImplementedError> {
+    let result = libm::ldexp(fraction, exponent);
+    Ok(result)
+}
+
+/// Calculates the logarithmic gamma of value and the sign of gamma of value.
+///
+/// `lgamma` is same as:
+///
+/// ```ruby
+/// [Math.log(Math.gamma(x).abs), Math.gamma(x) < 0 ? -1 : 1]
+/// ```
+///
+/// but avoids overflow of `gamma` for large values.
+///
+/// # Errors
+///
+/// Because `spinoso-math` was built without the `full` feature, this function
+/// will always return a not implemented error.
+#[inline]
+#[cfg(not(feature = "full"))]
+pub fn lgamma(value: f64) -> Result<(f64, i32), NotImplementedError> {
+    let _ = value;
+    Err(NotImplementedError::with_message(
+        "Artichoke was not built with Math::lgamma support",
+    ))
+}
+
+/// Calculates the logarithmic gamma of value and the sign of gamma of value.
+///
+/// `lgamma` is same as:
+///
+/// ```ruby
+/// [Math.log(Math.gamma(x).abs), Math.gamma(x) < 0 ? -1 : 1]
+/// ```
+///
+/// but avoids overflow of `gamma` for large values.
+///
+/// # Examples
+///
+/// ```
+/// use spinoso_math as math;
+/// assert_eq!(math::lgamma(0.0), Ok((f64::INFINITY, 1)));
+///
+/// assert!(math::lgamma(f64::NEG_INFINITY).is_err());
+/// ```
+///
+/// # Errors
+///
+/// If the given value is [negative infinity], an error is returned.
+///
+/// [negative infinity]: f64::NEG_INFINITY
+#[inline]
+#[cfg(feature = "full")]
+pub fn lgamma(value: f64) -> Result<(f64, i32), DomainError> {
+    if value.is_infinite() && value.is_sign_negative() {
+        Err(DomainError::with_message(
+            r#"Numerical argument is out of domain - "lgamma""#,
+        ))
+    } else {
+        let (result, sign) = libm::lgamma_r(value);
+        Ok((result, sign))
+    }
+}
+
+/// Returns the logarithm of the number with respect to an arbitrary base.
+///
+/// Domain: (0, INFINITY)
+///
+/// Codomain: (-INFINITY, INFINITY)
+///
+/// # Examples
+///
+/// ```
+/// # use spinoso_math::E;
+/// use spinoso_math as math;
+/// assert_eq!(math::log(1.0, None), Ok(0.0));
+/// assert_eq!(math::log(E, None), Ok(1.0));
+/// assert_eq!(math::log(64.0, Some(4.0)), Ok(3.0));
+///
+/// assert_eq!(math::log(0.0, None), Ok(f64::NEG_INFINITY));
+/// assert!(math::log(-0.1, None).is_err());
+///
+/// assert!(matches!(math::log(f64::NAN, None), Ok(result) if result.is_nan()));
+/// ```
+///
+/// # Errors
+///
+/// If the given arbitrary base is [`NAN`], a domain error is returned.
+///
+/// If the result of computing the logarithm is [`NAN`], a domain error is
+/// returned.
+///
+/// [`NAN`]: f64::NAN
+#[inline]
+pub fn log(value: f64, base: Option<f64>) -> Result<f64, DomainError> {
+    if value.is_nan() {
+        return Ok(f64::NAN);
+    }
+    let result = match base {
+        Some(base) if base.is_nan() => return Ok(f64::NAN),
+        Some(base) => value.log(base),
+        None => value.ln(),
+    };
+    if result.is_nan() {
+        Err(DomainError::with_message(
+            r#"Numerical argument is out of domain - "log""#,
+        ))
+    } else {
+        Ok(result)
+    }
+}
+
+/// Returns the base 10 logarithm of the number.
+///
+/// Domain: (0, INFINITY)
+///
+/// Codomain: (-INFINITY, INFINITY)
+///
+/// # Examples
+///
+/// ```
+/// use spinoso_math as math;
+/// assert_eq!(math::log10(1.0), Ok(0.0));
+/// assert_eq!(math::log10(10.0), Ok(1.0));
+/// assert_eq!(math::log10(1e100), Ok(100.0));
+///
+/// assert_eq!(math::log10(0.0), Ok(f64::NEG_INFINITY));
+/// assert!(math::log10(-0.1).is_err());
+///
+/// assert!(matches!(math::log10(f64::NAN), Ok(result) if result.is_nan()));
+/// ```
+///
+/// # Errors
+///
+/// If the result of computing the logarithm is [`NAN`], a domain error is
+/// returned.
+///
+/// [`NAN`]: f64::NAN
+#[inline]
+pub fn log10(value: f64) -> Result<f64, DomainError> {
+    if value.is_nan() {
+        return Ok(f64::NAN);
+    }
+    let result = value.log10();
+    if result.is_nan() {
+        Err(DomainError::with_message(
+            r#"Numerical argument is out of domain - "log10""#,
+        ))
+    } else {
+        Ok(result)
+    }
+}
+
+/// Returns the base 2 logarithm of the number.
+///
+/// Domain: (0, INFINITY)
+///
+/// Codomain: (-INFINITY, INFINITY)
+///
+/// # Examples
+///
+/// ```
+/// use spinoso_math as math;
+/// assert_eq!(math::log2(1.0), Ok(0.0));
+/// assert_eq!(math::log2(2.0), Ok(1.0));
+/// assert_eq!(math::log2(32768.0), Ok(15.0));
+/// assert_eq!(math::log2(65536.0), Ok(16.0));
+///
+/// assert_eq!(math::log2(0.0), Ok(f64::NEG_INFINITY));
+/// assert!(math::log2(-0.1).is_err());
+///
+/// assert!(matches!(math::log2(f64::NAN), Ok(result) if result.is_nan()));
+/// ```
+///
+/// # Errors
+///
+/// If the result of computing the logarithm is [`NAN`], a domain error is
+/// returned.
+///
+/// [`NAN`]: f64::NAN
+#[inline]
+pub fn log2(value: f64) -> Result<f64, DomainError> {
+    if value.is_nan() {
+        return Ok(f64::NAN);
+    }
+    let result = value.log2();
+    if result.is_nan() {
+        Err(DomainError::with_message(
+            r#"Numerical argument is out of domain - "log2""#,
+        ))
+    } else {
+        Ok(result)
+    }
+}
+
+/// Computes the sine of the given value (expressed in radians). Returns a Float
+/// in the range `-1.0..=1.0`.
+///
+/// Domain: (-INFINITY, INFINITY)
+///
+/// Codomain: [-1, 1]
+///
+/// # Examples
+///
+/// ```
+/// use spinoso_math as math;
+/// assert_eq!(math::sin(math::PI / 2.0), 1.0);
+/// ```
+#[inline]
+#[must_use]
+pub fn sin(value: f64) -> f64 {
+    value.sin()
+}
+
+/// Computes the hyperbolic sine of the given value (expressed in radians).
+///
+/// Domain: (-INFINITY, INFINITY)
+///
+/// Codomain: (-INFINITY, INFINITY)
+///
+/// # Examples
+///
+/// ```
+/// use spinoso_math as math;
+/// assert_eq!(math::sinh(0.0), 0.0);
+/// ```
+#[inline]
+#[must_use]
+pub fn sinh(value: f64) -> f64 {
+    value.sinh()
+}
+
+/// Returns the non-negative square root of the given value.
+///
+/// Domain: [0, INFINITY)
+///
+/// Codomain:[0, INFINITY)
+///
+/// # Examples
+///
+/// ```
+/// # use spinoso_math::DomainError;
+/// use spinoso_math as math;
+/// assert_eq!(math::sqrt(0.0), Ok(0.0));
+/// assert_eq!(math::sqrt(1.0), Ok(1.0));
+/// assert_eq!(math::sqrt(9.0), Ok(3.0));
+///
+/// assert!(math::sqrt(-9.0).is_err());
+///
+/// assert!(matches!(math::sqrt(f64::NAN), Ok(result) if result.is_nan()));
+/// ```
+///
+/// # Errors
+///
+/// If the result of computing the square root is [`NAN`], a domain error is
+/// returned.
+///
+/// [`NAN`]: f64::NAN
+#[inline]
+pub fn sqrt(value: f64) -> Result<f64, DomainError> {
+    if value.is_nan() {
+        return Ok(f64::NAN);
+    }
+    let result = value.sqrt();
+    if result.is_nan() {
+        Err(DomainError::with_message(
+            r#"Numerical argument is out of domain - "sqrt""#,
+        ))
+    } else {
+        Ok(result)
+    }
+}
+
+/// Computes the tangent of the given value (expressed in radians).
+///
+/// Domain: (-INFINITY, INFINITY)
+///
+/// Codomain: (-INFINITY, INFINITY)
+///
+/// # Examples
+///
+/// ```
+/// use spinoso_math as math;
+/// assert_eq!(math::tan(0.0), 0.0);
+/// ```
+#[inline]
+#[must_use]
+pub fn tan(value: f64) -> f64 {
+    value.tan()
+}
+
+/// Computes the hyperbolic tangent of the given value (expressed in radians).
+///
+/// Domain: (-INFINITY, INFINITY)
+///
+/// Codomain: (-1, 1)
+///
+/// # Examples
+///
+/// ```
+/// use spinoso_math as math;
+/// assert_eq!(math::tanh(0.0), 0.0);
+/// ```
+#[inline]
+#[must_use]
+pub fn tanh(value: f64) -> f64 {
+    value.tanh()
+}

--- a/spinoso-symbol/Cargo.toml
+++ b/spinoso-symbol/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["ident", "intern", "no_std", "spinoso", "symbol"]
 categories = ["data-structures", "no-std", "parser-implementations"]
 
 [dependencies]
-artichoke-core = { version = "0.3", path = "../artichoke-core", default-features = false, optional = true }
+artichoke-core = { version = "0.4", path = "../artichoke-core", default-features = false, optional = true }
 bstr = { version = "0.2", optional = true, default-features = false }
 focaccia = { version = "1.0", optional = true, default-features = false }
 scolapasta-string-escape = { version = "0.1", path = "../scolapasta-string-escape", optional = true }


### PR DESCRIPTION
This commit extracts the `Math` implementation from artichoke-backend
`extn` into its own crate. This enables many quality improvements:

- The crate is `no_std` with an optional `std` feature for a`Error`
  impls.
- The `Math` implementation does not depend on `artichoke-backend` or
  `artichoke-core`.
- All functions in the math implementation are documented with example
  doctests.
- `DomainError` is a `Copy` type that is const constructed around a
  `&'static str`.
- Several math functions with high branching (e.g. `gamma`) were
  refactored to use `match` expressions in more places.

The `extn::core::math` module in `artichoke-backend` re-exports the core
`Math` handle, constants, and error types from `spinoso-math`. The `extn`
module wraps the underlying crate in a `trampoline` module, similar to
other spinoso extractions.

This commit introduces a new `CoerceToNumeric` trait in `artichoke-core`
for implementing the interpreter capabilities of coercing boxed Ruby
values into native numeric types. This trait is used in the `Math`
trampolines for unboxing values to `f64`. This change bumps the
`artichoke-core` version to 0.4.0.

This commit moves `Value::ruby_type` definition from
`artichoke_backend::value::Value` to `artichoke_core::value::Value`.

This extracts `Value::pretty_name` from `artichoke-backend` and
implements it generically as a free function in `artichoke-core`.