### PR TITLE
Sync SecureRandom implementation with spinoso-random

### DIFF
--- a/artichoke-backend/src/extn/stdlib/securerandom/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/securerandom/mod.rs
@@ -25,7 +25,7 @@ pub mod trampoline;
 #[doc(inline)]
 pub use spinoso_securerandom::{
     alphanumeric, base64, hex, random_bytes, random_number, urlsafe_base64, uuid, ArgumentError,
-    DomainError, Error as SecureRandomError, Max, RandomBytesError, RandomNumber, SecureRandom,
+    DomainError, Error as SecureRandomError, Max, Rand, RandomBytesError, SecureRandom,
 };
 
 impl From<SecureRandomError> for Error {
@@ -94,11 +94,11 @@ impl TryConvertMut<Option<Value>, Max> for Artichoke {
     }
 }
 
-impl ConvertMut<RandomNumber, Value> for Artichoke {
-    fn convert_mut(&mut self, from: RandomNumber) -> Value {
+impl ConvertMut<Rand, Value> for Artichoke {
+    fn convert_mut(&mut self, from: Rand) -> Value {
         match from {
-            RandomNumber::Integer(num) => self.convert(num),
-            RandomNumber::Float(num) => self.convert_mut(num),
+            Rand::Integer(num) => self.convert(num),
+            Rand::Float(num) => self.convert_mut(num),
         }
     }
 }

--- a/spinoso-securerandom/README.md
+++ b/spinoso-securerandom/README.md
@@ -56,17 +56,17 @@ fn example() -> Result<(), spinoso_securerandom::Error> {
 Generate random floats and integers in a range bounded from zero to a maximum:
 
 ```rust
-use spinoso_securerandom::{Max, RandomNumber};
+use spinoso_securerandom::{DomainError, Max, Rand};
 
-fn example() -> Result<(), spinoso_securerandom::DomainError> {
+fn example() -> Result<(), DomainError> {
     let rand = spinoso_securerandom::random_number(Max::None)?;
-    assert!(matches!(rand, RandomNumber::Float(_)));
+    assert!(matches!(rand, Rand::Float(_)));
 
     let rand = spinoso_securerandom::random_number(Max::Integer(57))?;
-    assert!(matches!(rand, RandomNumber::Integer(_)));
+    assert!(matches!(rand, Rand::Integer(_)));
 
     let rand = spinoso_securerandom::random_number(Max::Float(57.0))?;
-    assert!(matches!(rand, RandomNumber::Float(_)));
+    assert!(matches!(rand, Rand::Float(_)));
     Ok(())
 }
 ```


### PR DESCRIPTION
- Rename `RandomNumber` to `Rand`.
- Simplify `len` checking in `random_bytes` and `alphanumeric` by matching over `Option<Result<usize>>` from calling `len.map(usize::try_from)`.
- Add `From<E> for Error` impls for sum type sub-errors.
- Add `#[inline]` annotations to all trait methods.
- Return more specific error from `alphanumeric`.

Followup to #836.