### PR TITLE
Remove generic bound in artichoke_backend::interpreter_with_config

### DIFF
--- a/artichoke-backend/src/extn/mod.rs
+++ b/artichoke-backend/src/extn/mod.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::needless_pass_by_value)]
 
-use crate::core::ReleaseMetadata;
+use crate::release_metadata::ReleaseMetadata;
 
 pub mod core;
 pub mod prelude;
@@ -10,10 +10,7 @@ use prelude::*;
 
 pub const INPUT_RECORD_SEPARATOR: &str = "\n";
 
-pub fn init<T>(interp: &mut Artichoke, config: T) -> InitializeResult<()>
-where
-    T: ReleaseMetadata,
-{
+pub fn init(interp: &mut Artichoke, config: ReleaseMetadata<'_>) -> InitializeResult<()> {
     let copyright = interp.convert_mut(config.ruby_copyright());
     interp.define_global_constant("RUBY_COPYRIGHT", copyright)?;
 

--- a/artichoke-backend/src/interpreter.rs
+++ b/artichoke-backend/src/interpreter.rs
@@ -4,13 +4,13 @@ use std::ffi::c_void;
 use std::fmt;
 
 use crate::class_registry::ClassRegistry;
-use crate::core::{ConvertMut, Eval, ReleaseMetadata};
+use crate::core::{ConvertMut, Eval};
 use crate::error::{Error, RubyException};
 use crate::extn;
 use crate::extn::core::exception::Fatal;
 use crate::ffi;
 use crate::gc::{MrbGarbageCollection, State as GcState};
-use crate::release_metadata::ReleaseMetadata as ArtichokeBackendReleaseMetadata;
+use crate::release_metadata::ReleaseMetadata;
 use crate::state::State;
 use crate::sys;
 use crate::Artichoke;
@@ -21,7 +21,7 @@ use crate::Artichoke;
 /// initializes an [in memory virtual filesystem](crate::fs), and loads the
 /// [`extn`] extensions to Ruby Core and Stdlib.
 pub fn interpreter() -> Result<Artichoke, Error> {
-    let release_meta = ArtichokeBackendReleaseMetadata::new();
+    let release_meta = ReleaseMetadata::new();
     interpreter_with_config(release_meta)
 }
 
@@ -31,10 +31,7 @@ pub fn interpreter() -> Result<Artichoke, Error> {
 /// about how Artichoke was built. Otherwise, it behaves identically to the
 /// [`interpreter`] function.
 #[allow(clippy::module_name_repetitions)]
-pub fn interpreter_with_config<T>(config: T) -> Result<Artichoke, Error>
-where
-    T: ReleaseMetadata,
-{
+pub fn interpreter_with_config(config: ReleaseMetadata<'_>) -> Result<Artichoke, Error> {
     let state = State::new()?;
     let state = Box::new(state);
     let alloc_ud = Box::into_raw(state) as *mut c_void;

--- a/artichoke-backend/src/release_metadata.rs
+++ b/artichoke-backend/src/release_metadata.rs
@@ -138,4 +138,54 @@ impl<'a> ReleaseMetadata<'a> {
         self.compiler_version = compiler_version;
         self
     }
+
+    #[must_use]
+    pub const fn ruby_copyright(&self) -> &str {
+        self.copyright
+    }
+
+    #[must_use]
+    pub const fn ruby_description(&self) -> &str {
+        self.description
+    }
+
+    #[must_use]
+    pub const fn ruby_engine(&self) -> &str {
+        self.engine
+    }
+
+    #[must_use]
+    pub const fn ruby_engine_version(&self) -> &str {
+        self.engine_version
+    }
+
+    #[must_use]
+    pub const fn ruby_patchlevel(&self) -> &str {
+        self.patchlevel
+    }
+
+    #[must_use]
+    pub const fn ruby_platform(&self) -> &str {
+        self.platform
+    }
+
+    #[must_use]
+    pub const fn ruby_release_date(&self) -> &str {
+        self.release_date
+    }
+
+    #[must_use]
+    pub const fn ruby_revision(&self) -> &str {
+        self.revision
+    }
+
+    #[must_use]
+    pub const fn ruby_version(&self) -> &str {
+        self.ruby_version
+    }
+
+    #[must_use]
+    pub const fn artichoke_compiler_version(&self) -> Option<&str> {
+        self.compiler_version
+    }
 }


### PR DESCRIPTION
Remove the generic bound on `ReleaseMetadata` in
`artichoke_backend::interpreter_with_config` and
`artichoke_backend::extn::init`. Replace it with taking the
concrete `ReleaseMetadata` type defined in `artichoke-backend`.

Implement all of the `core::ReleaseMetadata` trait methods as `const fn`
associated methods on `ReleaseMetadata`. Combined with taking the
concrete type, this should allow const propagation to fill in the Ruby
constants.

Followup to #703.