### PR TITLE
Compile all workspaces with --locked in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -82,6 +82,13 @@ jobs:
         with:
           ruby-version: ".ruby-version"
 
+      - name: Compile with locked Cargo.lock
+        run: cargo build --locked
+
+      - name: Compile fuzz with locked Cargo.lock
+        run: cargo build --locked
+        working-directory: "fuzz"
+
       - name: Compile artichoke with no default features
         run: cargo build --verbose --no-default-features
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,6 +65,7 @@ tasks by running:
 ```console
 $ bundle exec rake --tasks
 rake build                        # Build Rust workspace
+rake build:all                    # Build Rust workspace and sub-workspaces
 rake doc                          # Generate Rust API documentation
 rake doc:open                     # Generate Rust API documentation and open it in a web browser
 rake fmt                          # Format sources

--- a/Rakefile
+++ b/Rakefile
@@ -86,6 +86,14 @@ task :build do
   sh 'cargo build --workspace'
 end
 
+desc 'Build Rust workspace and sub-workspaces'
+task :'build:all' do
+  sh 'cargo build --workspace'
+  Dir.chdir('fuzz') do
+    sh 'cargo build --workspace'
+  end
+end
+
 desc 'Generate Rust API documentation'
 task :doc do
   ENV['RUSTFLAGS'] = '-D warnings'


### PR DESCRIPTION
Add build steps to compile the root, fuzz, and spec-runner workspaces
with the --locked argument to ensure that all workspaces maintain up-to-date
Cargo.lock files

This commit adds a `rake build:all` task that builds all Rust workspaces
in this repository.