### PR TITLE
Remove dtoa dependency from artichoke-backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,7 +38,6 @@ dependencies = [
  "bindgen",
  "bstr",
  "cc",
- "dtoa",
  "intaglio",
  "itoa",
  "libc",
@@ -189,12 +188,6 @@ dependencies = [
  "unicode-width",
  "vec_map",
 ]
-
-[[package]]
-name = "dtoa"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134951f4028bdadb9b84baf4232681efbf277da25144b9b0ad65df75946c422b"
 
 [[package]]
 name = "focaccia"

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -13,7 +13,6 @@ categories = ["api-bindings"]
 [dependencies]
 artichoke-core = { version = "0.5", path = "../artichoke-core" }
 bstr = { version = "0.2", default-features = false, features = ["std"] }
-dtoa = "0.4"
 intaglio = "1.1"
 itoa = "0.4"
 log = "0.4"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -44,7 +44,6 @@ dependencies = [
  "bindgen",
  "bstr",
  "cc",
- "dtoa",
  "intaglio",
  "itoa",
  "log",
@@ -200,12 +199,6 @@ dependencies = [
  "unicode-width",
  "vec_map",
 ]
-
-[[package]]
-name = "dtoa"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134951f4028bdadb9b84baf4232681efbf277da25144b9b0ad65df75946c422b"
 
 [[package]]
 name = "focaccia"

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -38,7 +38,6 @@ dependencies = [
  "bindgen",
  "bstr",
  "cc",
- "dtoa",
  "intaglio",
  "itoa",
  "log",


### PR DESCRIPTION
The only use of `write_float_into` was the extn `Random` implementation. The usage
was removed in GH-836.

Relates GH-561.