### PR TITLE
Ban time crate from dependency tree using cargo-deny

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -24,7 +24,9 @@ multiple-versions = "deny"
 wildcards = "deny"
 highlight = "all"
 allow = []
-deny = []
+deny = [
+  { name = "time", version = ">=0.2.0" },
+]
 skip = []
 skip-tree = []
 


### PR DESCRIPTION
Followup to #857.