### PR TITLE
Fix Time locals in airb REPL

### DIFF
--- a/artichoke-backend/src/extn/core/time/trampoline.rs
+++ b/artichoke-backend/src/extn/core/time/trampoline.rs
@@ -155,9 +155,22 @@ pub fn asctime(interp: &mut Artichoke, time: Value) -> Result<Value, Error> {
 }
 
 pub fn to_string(interp: &mut Artichoke, time: Value) -> Result<Value, Error> {
-    let _ = interp;
     let _ = time;
-    Err(NotImplementedError::new().into())
+    // XXX: This function is used to implement `Time#inspect`. Raising in an
+    // `#inspect` implementation interacts poorly with the locals table when
+    // running Artichoke in a REPL.
+    //
+    // Rather than fix this, which will involve deep diving into mruby, work
+    // around this by returning a `String` that says `Time#inspect` is not
+    // implemented. This allows us to uphold the API contract without
+    // implementing `strftime`.
+    //
+    // This hack replaces this code:
+    //
+    // ```rust
+    // Err(NotImplementedError::new().into())
+    // ```
+    Ok(interp.convert_mut("Time<Time#inspect is not implemented>"))
 }
 
 pub fn to_array(interp: &mut Artichoke, time: Value) -> Result<Value, Error> {


### PR DESCRIPTION
The `airb` REPL calls `#inspect` on each value returned by
`Artichoke::eval`. `Time` raises `NotImplementedError` in its `#inspect`
implementation. There is a nasty interaction here between the
`Time#inspect` implementation and the mruby locals tables that cause a
local bound to a `Time` to get reassigned to the `NotImplementedError`.

```console
artichoke 0.1.0-pre.0 (2020-10-01 revision 3626) [x86_64-apple-darwin]
[rustc 1.46.0 (04488afe3 2020-08-24)]
>>> t = Time.now
=>
>>> t.month
Traceback (most recent call last):
	1: from (airb):2
NoMethodError (undefined method 'month')
>>> t.class
=> NilClass
>>>
```

With this patch, the REPL behaves like this:

```console
artichoke 0.1.0-pre.0 (2020-10-01 revision 3627) [x86_64-apple-darwin]
[rustc 1.46.0 (04488afe3 2020-08-24)]
>>> t = Time.now
=> Time<Time#inspect is not implemented>
>>> t.month
=> 9
```