### PR TITLE
Remove dependency on uuid crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -607,7 +607,6 @@ dependencies = [
  "base64",
  "rand",
  "scolapasta-hex",
- "uuid",
 ]
 
 [[package]]
@@ -725,15 +724,6 @@ name = "utf8parse"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "936e4b492acfd135421d8dca4b1aa80a7bfc26e702ef3af710e0752684df5372"
-
-[[package]]
-name = "uuid"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fde2f6a4bea1d6e007c4ad38c6839fa71cbb63b6dbf5b595aa38dc9b1093c11"
-dependencies = [
- "rand",
-]
 
 [[package]]
 name = "vec_map"

--- a/artichoke-backend/src/extn/stdlib/securerandom/trampoline.rs
+++ b/artichoke-backend/src/extn/stdlib/securerandom/trampoline.rs
@@ -81,6 +81,6 @@ pub fn random_number(interp: &mut Artichoke, max: Option<Value>) -> Result<Value
 
 #[inline]
 pub fn uuid(interp: &mut Artichoke) -> Result<Value, Error> {
-    let uuid = securerandom::uuid();
+    let uuid = securerandom::uuid()?;
     Ok(interp.convert_mut(uuid))
 }

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -608,7 +608,6 @@ dependencies = [
  "base64",
  "rand",
  "scolapasta-hex",
- "uuid",
 ]
 
 [[package]]
@@ -726,15 +725,6 @@ name = "utf8parse"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "936e4b492acfd135421d8dca4b1aa80a7bfc26e702ef3af710e0752684df5372"
-
-[[package]]
-name = "uuid"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fde2f6a4bea1d6e007c4ad38c6839fa71cbb63b6dbf5b595aa38dc9b1093c11"
-dependencies = [
- "rand",
-]
 
 [[package]]
 name = "vec_map"

--- a/scolapasta-hex/src/lib.rs
+++ b/scolapasta-hex/src/lib.rs
@@ -357,6 +357,21 @@ impl<'a> FusedIterator for Hex<'a> {}
 
 impl<'a> ExactSizeIterator for Hex<'a> {}
 
+/// Map from a `u8` to a hex encoded string literal.
+///
+/// # Examples
+///
+/// ```
+/// assert_eq!(scolapasta_hex::escape_byte(0), "00");
+/// assert_eq!(scolapasta_hex::escape_byte(0x20), "20");
+/// assert_eq!(scolapasta_hex::escape_byte(255), "ff");
+/// ```
+#[inline]
+#[must_use]
+pub const fn escape_byte(byte: u8) -> &'static str {
+    EscapedByte::hex_escape(byte)
+}
+
 #[derive(Debug, Clone)]
 #[must_use = "this `EscapedByte` is an `Iterator`, which should be consumed if constructed"]
 struct EscapedByte(Chars<'static>);

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -680,7 +680,6 @@ dependencies = [
  "base64",
  "rand",
  "scolapasta-hex",
- "uuid",
 ]
 
 [[package]]
@@ -798,15 +797,6 @@ name = "utf8parse"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "936e4b492acfd135421d8dca4b1aa80a7bfc26e702ef3af710e0752684df5372"
-
-[[package]]
-name = "uuid"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fde2f6a4bea1d6e007c4ad38c6839fa71cbb63b6dbf5b595aa38dc9b1093c11"
-dependencies = [
- "rand",
-]
 
 [[package]]
 name = "vec_map"

--- a/spinoso-securerandom/Cargo.toml
+++ b/spinoso-securerandom/Cargo.toml
@@ -15,7 +15,6 @@ categories = ["algorithms"]
 [dependencies]
 base64 = "0.13"
 rand = "0.7"
-uuid = { version = "0.8", default-features = false, features = ["v4"] }
 
 [dependencies.scolapasta-hex]
 version = "0.1"

--- a/spinoso-securerandom/README.md
+++ b/spinoso-securerandom/README.md
@@ -74,9 +74,12 @@ fn example() -> Result<(), DomainError> {
 Generate version 4 random UUIDs:
 
 ```rust
-let bytes = spinoso_securerandom::uuid();
-assert_eq!(bytes.len(), 36);
-assert!(bytes.is_ascii());
+fn example() -> Result<(), spinoso_securerandom::Error> {
+    let uuid = spinoso_securerandom::uuid()?;
+    assert_eq!(uuid.len(), 36);
+    assert!(uuid.chars().all(|ch| ch == '-' || ch.is_ascii_hexdigit()));
+    Ok(())
+}
 ```
 
 ## License

--- a/spinoso-securerandom/src/uuid.rs
+++ b/spinoso-securerandom/src/uuid.rs
@@ -1,0 +1,103 @@
+//! Generator for Version 4 UUIDs.
+//!
+//! See [RFC 4122], Section 4.4.
+//!
+//! [RFC 4122]: https://tools.ietf.org/html/rfc4122#section-4.4
+
+use rand::RngCore;
+use scolapasta_hex as hex;
+
+use crate::RandomBytesError;
+
+/// The UUID format is 16 octets.
+///
+/// See [RFC 4122, Section 4.1].
+///
+/// [RFC 4122, Section 4.1]: https://tools.ietf.org/html/rfc4122#section-4.1
+const OCTETS: usize = 16;
+
+// See the BNF from JDK 8 that confirms stringified UUIDs are 36 characters
+// long:
+//
+// https://docs.oracle.com/javase/8/docs/api/java/util/UUID.html#toString--
+const ENCODED_LENGTH: usize = 36;
+
+#[inline]
+pub fn v4() -> Result<String, RandomBytesError> {
+    let mut bytes = [0; OCTETS];
+    if rand::thread_rng().try_fill_bytes(&mut bytes).is_err() {
+        return Err(RandomBytesError::new());
+    }
+    // Per RFC 4122, Section 4.4, set bits for version and `clock_seq_hi_and_reserved`.
+    bytes[6] = (bytes[6] & 0x0f) | 0x40;
+    bytes[8] = (bytes[8] & 0x3f) | 0x80;
+
+    let mut buf = String::with_capacity(ENCODED_LENGTH);
+    let mut iter = bytes.iter().copied();
+    for byte in iter.by_ref().take(4) {
+        let escaped = hex::escape_byte(byte);
+        buf.push_str(escaped);
+    }
+    buf.push('-');
+    for byte in iter.by_ref().take(2) {
+        let escaped = hex::escape_byte(byte);
+        buf.push_str(escaped);
+    }
+    buf.push('-');
+    for byte in iter.by_ref().take(2) {
+        let escaped = hex::escape_byte(byte);
+        buf.push_str(escaped);
+    }
+    buf.push('-');
+    for byte in iter.by_ref().take(2) {
+        let escaped = hex::escape_byte(byte);
+        buf.push_str(escaped);
+    }
+    buf.push('-');
+    for byte in iter {
+        let escaped = hex::escape_byte(byte);
+        buf.push_str(escaped);
+    }
+    debug_assert!(buf.len() == ENCODED_LENGTH);
+    Ok(buf)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::v4 as uuid;
+
+    const ITERATIONS: usize = 1 << 12;
+    const PATTERN: &str = "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx";
+
+    #[test]
+    fn harness() {
+        validate(PATTERN);
+    }
+
+    #[test]
+    fn check() {
+        for _ in 0..ITERATIONS {
+            let gen = uuid().unwrap();
+            validate(gen.as_str());
+            let uuid_only_contains_chars_in_alphabet = gen
+                .chars()
+                .all(|ch| matches!(ch, 'a'..='f' | '0'..='9' | '-'));
+            assert!(
+                uuid_only_contains_chars_in_alphabet,
+                "Expected alphabet 'a'..='f', '0'..='9', '-', found '{}'",
+                gen
+            );
+        }
+    }
+
+    fn validate(pattern: &str) {
+        assert_eq!(pattern.len(), 36);
+        assert!(pattern.is_ascii());
+        assert_eq!(&pattern[8..9], "-");
+        assert_eq!(&pattern[13..14], "-");
+        assert_eq!(&pattern[14..15], "4");
+        assert_eq!(&pattern[18..19], "-");
+        assert!(matches!(&pattern[19..20], "8" | "9" | "a" | "b" | "y"));
+        assert_eq!(&pattern[23..24], "-");
+    }
+}


### PR DESCRIPTION
Remove the dependency on the `uuid` crate and implement the UUID V4
generation algorithm directly with `rand`.

The UUID V4 generation algorithm is ~25 lines and is not worth the cost
of an extra dependency.

Pulling this code into `spinoso-securerandom` drops another dependeny
that indirectly depends on `rand` and `getrandom`. Both of these crates
have pending semver incompatible updates. Removing transitive deps on
these crates will make orchestrating the upgrade easier.

The code change in `artichoke-backend` to consume this new change, which
properly exposes the fallibility of random bytes generation, is trivial
(the addition of a single `?` operator to propagate the error).

This change adds property tests to ensure the generated UUIDs serialize
to the correct format with the correct version and generation tags.

This change adds a new `escape_byte` free function to `scolapasta-hex`
to expose the inner hex escaping APIs for single bytes.