### PR TITLE
Remove pretty name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,7 +61,7 @@ dependencies = [
 
 [[package]]
 name = "artichoke-core"
-version = "0.5.0"
+version = "0.6.0"
 
 [[package]]
 name = "atty"

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["artichoke", "artichoke-ruby", "mruby", "ruby"]
 categories = ["api-bindings"]
 
 [dependencies]
-artichoke-core = { version = "0.5", path = "../artichoke-core" }
+artichoke-core = { version = "0.6", path = "../artichoke-core" }
 bstr = { version = "0.2", default-features = false, features = ["std"] }
 intaglio = "1.1"
 itoa = "0.4"

--- a/artichoke-backend/src/coerce_to_numeric.rs
+++ b/artichoke-backend/src/coerce_to_numeric.rs
@@ -1,7 +1,8 @@
 use artichoke_core::coerce_to_numeric::CoerceToNumeric;
 use artichoke_core::convert::TryConvert;
+use artichoke_core::debug::Debug;
 use artichoke_core::eval::Eval;
-use artichoke_core::value::{pretty_name, Value as _};
+use artichoke_core::value::Value as _;
 use spinoso_exception::TypeError;
 
 use crate::types::{Fp, Ruby};
@@ -30,7 +31,7 @@ impl CoerceToNumeric for Artichoke {
         if let Ok(true) = is_a_numeric {
             if !value.respond_to(self, "to_f")? {
                 let mut message = String::from("can't convert ");
-                message.push_str(pretty_name(value, self));
+                message.push_str(self.inspect_type_name_for_value(value));
                 message.push_str(" into Float");
                 return Err(TypeError::from(message).into());
             }
@@ -39,18 +40,18 @@ impl CoerceToNumeric for Artichoke {
                 coerced.try_into::<f64>(self)
             } else {
                 let mut message = String::from("can't convert ");
-                let name = pretty_name(value, self);
+                let name = self.inspect_type_name_for_value(value);
                 message.push_str(name);
                 message.push_str(" into Float (");
                 message.push_str(name);
                 message.push_str("#to_f gives ");
-                message.push_str(pretty_name(coerced, self));
+                message.push_str(self.inspect_type_name_for_value(coerced));
                 message.push(')');
                 Err(TypeError::from(message).into())
             }
         } else {
             let mut message = String::from("can't convert ");
-            message.push_str(pretty_name(value, self));
+            message.push_str(self.inspect_type_name_for_value(value));
             message.push_str(" into Float");
             Err(TypeError::from(message).into())
         }

--- a/artichoke-backend/src/debug.rs
+++ b/artichoke-backend/src/debug.rs
@@ -1,5 +1,6 @@
-use crate::core::Debug;
-use crate::core::Value as _;
+use artichoke_core::debug::Debug;
+use artichoke_core::value::Value as _;
+
 use crate::types::Ruby;
 use crate::value::Value;
 use crate::Artichoke;

--- a/artichoke-backend/src/debug.rs
+++ b/artichoke-backend/src/debug.rs
@@ -1,0 +1,77 @@
+use crate::core::Debug;
+use crate::core::Value as _;
+use crate::types::Ruby;
+use crate::value::Value;
+use crate::Artichoke;
+
+impl Debug for Artichoke {
+    type Value = Value;
+
+    fn inspect_type_name_for_value(&mut self, value: Self::Value) -> &str {
+        match value.try_into(self) {
+            Ok(Some(true)) => "true",
+            Ok(Some(false)) => "false",
+            Ok(None) => "nil",
+            Err(_) if matches!(value.ruby_type(), Ruby::Data | Ruby::Object) => {
+                if let Ok(class) = value.funcall(self, "class", &[], None) {
+                    if let Ok(class) = class.funcall(self, "name", &[], None) {
+                        if let Ok(class) = class.try_into_mut(self) {
+                            return class;
+                        }
+                    }
+                }
+                ""
+            }
+            Err(_) => value.ruby_type().class_name(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::prelude::*;
+
+    #[test]
+    fn debug_true_value_as_classlike() {
+        let mut interp = interpreter().unwrap();
+        let value = interp.convert(true);
+        assert_eq!(interp.inspect_type_name_for_value(value), "true");
+    }
+
+    #[test]
+    fn debug_false_value_as_classlike() {
+        let mut interp = interpreter().unwrap();
+        let value = interp.convert(false);
+        assert_eq!(interp.inspect_type_name_for_value(value), "false");
+    }
+
+    #[test]
+    fn debug_nil_value_as_classlike() {
+        let mut interp = interpreter().unwrap();
+        let value = interp.convert(None::<Value>);
+        assert_eq!(interp.inspect_type_name_for_value(value), "nil");
+    }
+
+    #[test]
+    fn debug_fixnum_value_as_classlike() {
+        let mut interp = interpreter().unwrap();
+        let value = interp.convert(1_i64);
+        assert_eq!(interp.inspect_type_name_for_value(value), "Integer");
+    }
+
+    #[test]
+    fn debug_hash_value_as_classlike() {
+        let mut interp = interpreter().unwrap();
+        let value = interp
+            .try_convert_mut(vec![(b"foo".to_vec(), vec![1, 2, 3])])
+            .unwrap();
+        assert_eq!(interp.inspect_type_name_for_value(value), "Hash");
+    }
+
+    #[test]
+    fn debug_array_value_as_classlike() {
+        let mut interp = interpreter().unwrap();
+        let value = interp.try_convert_mut(vec![1_i64]).unwrap();
+        assert_eq!(interp.inspect_type_name_for_value(value), "Array");
+    }
+}

--- a/artichoke-backend/src/extn/core/array/mod.rs
+++ b/artichoke-backend/src/extn/core/array/mod.rs
@@ -1,4 +1,3 @@
-use artichoke_core::value::pretty_name;
 use spinoso_array::SmallArray as SpinosoArray;
 use std::convert::TryFrom;
 use std::iter::FromIterator;
@@ -180,12 +179,12 @@ impl Array {
                             other.0.clone()
                         } else {
                             let mut message = String::from("can't convert ");
-                            let name = pretty_name(array_or_len, interp);
+                            let name = interp.inspect_type_name_for_value(array_or_len);
                             message.push_str(name);
                             message.push_str(" to Array (");
                             message.push_str(name);
                             message.push_str("#to_ary gives ");
-                            message.push_str(pretty_name(other, interp));
+                            message.push_str(interp.inspect_type_name_for_value(other));
                             return Err(TypeError::from(message).into());
                         }
                     } else {
@@ -225,12 +224,12 @@ impl Array {
                             other.0.clone()
                         } else {
                             let mut message = String::from("can't convert ");
-                            let name = pretty_name(array_or_len, interp);
+                            let name = interp.inspect_type_name_for_value(array_or_len);
                             message.push_str(name);
                             message.push_str(" to Array (");
                             message.push_str(name);
                             message.push_str("#to_ary gives ");
-                            message.push_str(pretty_name(other, interp));
+                            message.push_str(interp.inspect_type_name_for_value(other));
                             return Err(TypeError::from(message).into());
                         }
                     } else {
@@ -318,12 +317,12 @@ impl Array {
                     self.0.set_slice(start, drain, other.0.as_slice());
                 } else {
                     let mut message = String::from("can't convert ");
-                    let name = pretty_name(elem, interp);
+                    let name = interp.inspect_type_name_for_value(elem);
                     message.push_str(name);
                     message.push_str(" to Array (");
                     message.push_str(name);
                     message.push_str("#to_ary gives ");
-                    message.push_str(pretty_name(other, interp));
+                    message.push_str(interp.inspect_type_name_for_value(other));
                     return Err(TypeError::from(message).into());
                 }
             } else {
@@ -362,17 +361,17 @@ impl Array {
                 self.0.concat(other.0.as_slice());
             } else {
                 let mut message = String::from("can't convert ");
-                let name = pretty_name(other, interp);
+                let name = interp.inspect_type_name_for_value(other);
                 message.push_str(name);
                 message.push_str(" to Array (");
                 message.push_str(name);
                 message.push_str("#to_ary gives ");
-                message.push_str(pretty_name(arr, interp));
+                message.push_str(interp.inspect_type_name_for_value(arr));
                 return Err(TypeError::from(message).into());
             }
         } else {
             let mut message = String::from("no implicit conversion of ");
-            message.push_str(pretty_name(other, interp));
+            message.push_str(interp.inspect_type_name_for_value(other));
             message.push_str(" into Array");
             return Err(TypeError::from(message).into());
         };

--- a/artichoke-backend/src/extn/core/kernel/integer.rs
+++ b/artichoke-backend/src/extn/core/kernel/integer.rs
@@ -1,4 +1,3 @@
-use artichoke_core::value::pretty_name;
 use bstr::ByteSlice;
 use std::convert::{TryFrom, TryInto};
 use std::error;
@@ -156,7 +155,7 @@ impl<'a> TryConvertMut<&'a mut Value, IntegerString<'a>> for Artichoke {
 
     fn try_convert_mut(&mut self, value: &'a mut Value) -> Result<IntegerString<'a>, Self::Error> {
         let mut message = String::from("can't convert ");
-        message.push_str(pretty_name(*value, self));
+        message.push_str(self.inspect_type_name_for_value(*value));
         message.push_str(" into Integer");
 
         if let Ok(arg) = value.implicitly_convert_to_string(self) {

--- a/artichoke-backend/src/extn/core/numeric/mod.rs
+++ b/artichoke-backend/src/extn/core/numeric/mod.rs
@@ -1,5 +1,3 @@
-use artichoke_core::value::pretty_name;
-
 use crate::extn::core::integer::Integer;
 use crate::extn::prelude::*;
 
@@ -124,12 +122,12 @@ pub fn coerce(interp: &mut Artichoke, x: Value, y: Value) -> Result<Coercion, Er
                         }
                     } else {
                         let mut message = String::from("can't convert ");
-                        message.push_str(pretty_name(y, interp));
+                        message.push_str(interp.inspect_type_name_for_value(y));
                         message.push_str(" into Float");
                         Err(TypeError::from(message).into())
                     }
                 } else {
-                    let mut message = String::from(pretty_name(y, interp));
+                    let mut message = String::from(interp.inspect_type_name_for_value(y));
                     message.push_str(" can't be coerced into Float");
                     Err(TypeError::from(message).into())
                 }

--- a/artichoke-backend/src/extn/core/string/trampoline.rs
+++ b/artichoke-backend/src/extn/core/string/trampoline.rs
@@ -1,4 +1,3 @@
-use artichoke_core::value::pretty_name;
 use bstr::ByteSlice;
 
 use crate::extn::core::matchdata::MatchData;
@@ -38,7 +37,7 @@ pub fn scan(
 ) -> Result<Value, Error> {
     if let Ruby::Symbol = pattern.ruby_type() {
         let mut message = String::from("wrong argument type ");
-        message.push_str(pretty_name(pattern, interp));
+        message.push_str(interp.inspect_type_name_for_value(pattern));
         message.push_str(" (expected Regexp)");
         Err(TypeError::from(message).into())
     } else if let Ok(regexp) = unsafe { Regexp::unbox_from_value(&mut pattern, interp) } {
@@ -106,7 +105,7 @@ pub fn scan(
         }
     } else {
         let mut message = String::from("wrong argument type ");
-        message.push_str(pretty_name(pattern, interp));
+        message.push_str(interp.inspect_type_name_for_value(pattern));
         message.push_str(" (expected Regexp)");
         Err(TypeError::from(message).into())
     }

--- a/artichoke-backend/src/extn/core/time/trampoline.rs
+++ b/artichoke-backend/src/extn/core/time/trampoline.rs
@@ -1,7 +1,5 @@
 //! Glue between mruby FFI and `Time` Rust implementation.
 
-use artichoke_core::value::pretty_name;
-
 use crate::extn::core::time::Time;
 use crate::extn::prelude::*;
 
@@ -68,7 +66,7 @@ pub fn cmp(interp: &mut Artichoke, mut time: Value, mut other: Value) -> Result<
         Ok(interp.convert(cmp as i32))
     } else {
         let mut message = String::from("comparison of Time with ");
-        message.push_str(pretty_name(other, interp));
+        message.push_str(interp.inspect_type_name_for_value(other));
         message.push_str(" failed");
         Err(ArgumentError::from(message).into())
     }

--- a/artichoke-backend/src/lib.rs
+++ b/artichoke-backend/src/lib.rs
@@ -127,6 +127,7 @@ pub mod class_registry;
 mod coerce_to_numeric;
 mod constant;
 pub mod convert;
+mod debug;
 pub mod def;
 pub mod error;
 mod eval;

--- a/artichoke-backend/src/value.rs
+++ b/artichoke-backend/src/value.rs
@@ -1,4 +1,7 @@
-use artichoke_core::value::pretty_name;
+use artichoke_core::convert::{Convert, ConvertMut, TryConvert};
+use artichoke_core::debug::Debug;
+use artichoke_core::intern::Intern;
+use artichoke_core::value::Value as ValueCore;
 use std::borrow::Cow;
 use std::convert::TryFrom;
 use std::error;
@@ -8,7 +11,6 @@ use std::ptr;
 
 use crate::class_registry::ClassRegistry;
 use crate::convert::BoxUnboxVmValue;
-use crate::core::{Convert, ConvertMut, Intern, TryConvert, Value as ValueCore};
 use crate::error::{Error, RubyException};
 use crate::exception_handler;
 use crate::extn::core::exception::{ArgumentError, Fatal, TypeError};
@@ -141,24 +143,24 @@ impl Value {
                     int
                 } else {
                     let mut message = String::from("can't convert ");
-                    let name = pretty_name(*self, interp);
+                    let name = interp.inspect_type_name_for_value(*self);
                     message.push_str(name);
                     message.push_str(" to Integer (");
                     message.push_str(name);
                     message.push_str("#to_int gives ");
-                    message.push_str(pretty_name(maybe, interp));
+                    message.push_str(interp.inspect_type_name_for_value(maybe));
                     message.push(')');
                     return Err(TypeError::from(message));
                 }
             } else {
                 let mut message = String::from("no implicit conversion of ");
-                message.push_str(pretty_name(*self, interp));
+                message.push_str(interp.inspect_type_name_for_value(*self));
                 message.push_str(" into Integer");
                 return Err(TypeError::from(message));
             }
         } else {
             let mut message = String::from("no implicit conversion of ");
-            message.push_str(pretty_name(*self, interp));
+            message.push_str(interp.inspect_type_name_for_value(*self));
             message.push_str(" into Integer");
             return Err(TypeError::from(message));
         };
@@ -187,24 +189,24 @@ impl Value {
                     string
                 } else {
                     let mut message = String::from("can't convert ");
-                    let name = pretty_name(*self, interp);
+                    let name = interp.inspect_type_name_for_value(*self);
                     message.push_str(name);
                     message.push_str(" to String (");
                     message.push_str(name);
                     message.push_str("#to_str gives ");
-                    message.push_str(pretty_name(maybe, interp));
+                    message.push_str(interp.inspect_type_name_for_value(maybe));
                     message.push(')');
                     return Err(TypeError::from(message));
                 }
             } else {
                 let mut message = String::from("no implicit conversion of ");
-                message.push_str(pretty_name(*self, interp));
+                message.push_str(interp.inspect_type_name_for_value(*self));
                 message.push_str(" into String");
                 return Err(TypeError::from(message));
             }
         } else {
             let mut message = String::from("no implicit conversion of ");
-            message.push_str(pretty_name(*self, interp));
+            message.push_str(interp.inspect_type_name_for_value(*self));
             message.push_str(" into String");
             return Err(TypeError::from(message));
         };

--- a/artichoke-core/Cargo.toml
+++ b/artichoke-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "artichoke-core"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2018"
 description = "Core traits for implementing an Artichoke Ruby interpreter"

--- a/artichoke-core/src/debug.rs
+++ b/artichoke-core/src/debug.rs
@@ -1,0 +1,18 @@
+//! Routines for debugging and printing exception messages.
+
+use crate::value::Value;
+
+/// Debugging and `Exception` message support.
+pub trait Debug {
+    /// Concrete type for return values from eval.
+    type Value: Value;
+
+    /// Return a name for thie given value's type suitable for using in an
+    /// `Exception` message.
+    ///
+    /// Some immediate types like `true`, `false`, and `nil` are shown by value
+    /// rather than by class.
+    ///
+    /// This function suppresses all errors and returns an empty string on error.
+    fn inspect_type_name_for_value(&mut self, value: Self::Value) -> &str;
+}

--- a/artichoke-core/src/lib.rs
+++ b/artichoke-core/src/lib.rs
@@ -101,6 +101,7 @@ extern crate alloc;
 pub mod coerce_to_numeric;
 pub mod constant;
 pub mod convert;
+pub mod debug;
 pub mod eval;
 pub mod file;
 pub mod globals;
@@ -131,6 +132,7 @@ pub mod prelude {
     pub use crate::coerce_to_numeric::CoerceToNumeric;
     pub use crate::constant::DefineConstant;
     pub use crate::convert::{Convert, ConvertMut, TryConvert, TryConvertMut};
+    pub use crate::debug::Debug;
     pub use crate::eval::Eval;
     pub use crate::file::File;
     pub use crate::globals::Globals;

--- a/artichoke-core/src/types.rs
+++ b/artichoke-core/src/types.rs
@@ -129,7 +129,7 @@ impl Ruby {
             Self::Data => "Rust-backed Ruby instance",
             Self::Exception => "Exception",
             Self::Fiber => "Fiber",
-            Self::Fixnum => "Fixnum",
+            Self::Fixnum => "Integer",
             Self::Float => "Float",
             Self::Hash => "Hash",
             Self::InlineStruct => "Inline Struct",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -64,7 +64,7 @@ dependencies = [
 
 [[package]]
 name = "artichoke-core"
-version = "0.5.0"
+version = "0.6.0"
 
 [[package]]
 name = "artichoke-fuzz"

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -58,7 +58,7 @@ dependencies = [
 
 [[package]]
 name = "artichoke-core"
-version = "0.5.0"
+version = "0.6.0"
 
 [[package]]
 name = "atty"

--- a/spinoso-symbol/Cargo.toml
+++ b/spinoso-symbol/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["ident", "intern", "no_std", "spinoso", "symbol"]
 categories = ["data-structures", "no-std", "parser-implementations"]
 
 [dependencies]
-artichoke-core = { version = "0.5", path = "../artichoke-core", default-features = false, optional = true }
+artichoke-core = { version = "0.6", path = "../artichoke-core", default-features = false, optional = true }
 bstr = { version = "0.2", optional = true, default-features = false }
 focaccia = { version = "1.0", optional = true, default-features = false }
 scolapasta-string-escape = { version = "0.1", path = "../scolapasta-string-escape", optional = true }


### PR DESCRIPTION
This PR removes the `pretty_name` method from `artichoke-core`, which is likely the grossest generic code in Artichoke:

```rust
pub fn pretty_name<'a, V, T>(value: V, interp: &mut T) -> &'a str
where
    V: Copy + Value<Artichoke = T>,
    T: TryConvert<V, Option<bool>, Error = V::Error>
        + TryConvertMut<V, &'a str, Error = V::Error>
        + TryConvertMut<<<V as Value>::Value as Value>::Value, &'a str, Error = V::Error>,
    V::Value: Value<Artichoke = T>,
    <V::Value as Value>::Value: Value<Artichoke = T, Error = V::Error>,
{
    // ...
}
```

This function is replaced with a new `Debug` trait and a method for retrieving the inspect name for the class of the given value: `inspect_type_name_for_value`. The name is better too.

This PR bumps `artichoke-core` to version 0.6.0.

This PR fixes a long-standing bug with the stringification of `Ruby::Fixnum` so that it returns `Integer` and adds tests for generating the pretty name.