### PR TITLE
Switch to Onig Stable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -341,8 +341,9 @@ checksum = "260e51e7efe62b592207e9e13a68e43692a7a279171d6ba57abd208bf23645ad"
 
 [[package]]
 name = "onig"
-version = "6.0.0"
-source = "git+https://github.com/artichoke/rust-onig?rev=v6.0.0-artichoke.2#6588100a1f29afb0412f778de14db611ee0d0a10"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a155d13862da85473665694f4c05d77fb96598bdceeaf696433c84ea9567e20"
 dependencies = [
  "bitflags",
  "lazy_static",
@@ -352,8 +353,9 @@ dependencies = [
 
 [[package]]
 name = "onig_sys"
-version = "69.5.0"
-source = "git+https://github.com/artichoke/rust-onig?rev=v6.0.0-artichoke.2#6588100a1f29afb0412f778de14db611ee0d0a10"
+version = "69.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bff06597a6b17855040955cae613af000fc0bfc8ad49ea68b9479a74e59292d"
 dependencies = [
  "cc",
  "pkg-config",

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -29,9 +29,7 @@ spinoso-symbol = { version = "0.1", path = "../spinoso-symbol" }
 spinoso-time = { version = "0.1", path = "../spinoso-time", optional = true }
 
 [dependencies.onig]
-version = "6.0.0"
-git = "https://github.com/artichoke/rust-onig"
-rev = "v6.0.0-artichoke.2"
+version = "6.1.0"
 default-features = false
 optional = true
 

--- a/deny.toml
+++ b/deny.toml
@@ -33,4 +33,4 @@ skip-tree = []
 [sources]
 unknown-registry = "deny"
 unknown-git = "deny"
-allow-git = ["https://github.com/artichoke/rust-onig"]
+# allow-git = ["https://github.com/artichoke/rust-onig"]

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -363,8 +363,9 @@ checksum = "0b631f7e854af39a1739f401cf34a8a013dfe09eac4fa4dba91e9768bd28168d"
 
 [[package]]
 name = "onig"
-version = "6.0.0"
-source = "git+https://github.com/artichoke/rust-onig?rev=v6.0.0-artichoke.2#6588100a1f29afb0412f778de14db611ee0d0a10"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a155d13862da85473665694f4c05d77fb96598bdceeaf696433c84ea9567e20"
 dependencies = [
  "bitflags",
  "lazy_static",
@@ -374,8 +375,9 @@ dependencies = [
 
 [[package]]
 name = "onig_sys"
-version = "69.5.0"
-source = "git+https://github.com/artichoke/rust-onig?rev=v6.0.0-artichoke.2#6588100a1f29afb0412f778de14db611ee0d0a10"
+version = "69.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bff06597a6b17855040955cae613af000fc0bfc8ad49ea68b9479a74e59292d"
 dependencies = [
  "cc",
  "pkg-config",

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -350,8 +350,9 @@ checksum = "260e51e7efe62b592207e9e13a68e43692a7a279171d6ba57abd208bf23645ad"
 
 [[package]]
 name = "onig"
-version = "6.0.0"
-source = "git+https://github.com/artichoke/rust-onig?rev=v6.0.0-artichoke.2#6588100a1f29afb0412f778de14db611ee0d0a10"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a155d13862da85473665694f4c05d77fb96598bdceeaf696433c84ea9567e20"
 dependencies = [
  "bitflags",
  "lazy_static",
@@ -361,8 +362,9 @@ dependencies = [
 
 [[package]]
 name = "onig_sys"
-version = "69.5.0"
-source = "git+https://github.com/artichoke/rust-onig?rev=v6.0.0-artichoke.2#6588100a1f29afb0412f778de14db611ee0d0a10"
+version = "69.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bff06597a6b17855040955cae613af000fc0bfc8ad49ea68b9479a74e59292d"
 dependencies = [
  "cc",
  "pkg-config",


### PR DESCRIPTION
Switch bak to the stable build of `onig`. This now contains the
bindgen + WASM work done by the Artichoke team. Nice work peeps!