### PR TITLE
Folds and max value

### DIFF
--- a/artichoke-backend/src/convert/fixnum.rs
+++ b/artichoke-backend/src/convert/fixnum.rs
@@ -107,8 +107,8 @@ impl TryConvert<isize, Value> for Artichoke {
 /// # use std::mem;
 /// # use artichoke_backend::types::Int;
 /// assert_eq!(mem::size_of::<i64>(), mem::size_of::<Int>());
-/// assert_eq!(i64::min_value(), Int::min_value());
-/// assert_eq!(i64::max_value(), Int::max_value());
+/// assert_eq!(i64::MIN, Int::MIN);
+/// assert_eq!(i64::MAX, Int::MAX);
 /// assert_eq!(TypeId::of::<i64>(), TypeId::of::<Int>());
 /// ```
 impl Convert<Int, Value> for Artichoke {

--- a/artichoke-backend/src/extn/core/regexp/backend/onig.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/onig.rs
@@ -1,6 +1,5 @@
 use core::mem::size_of;
 use onig::{Regex, RegexOptions, Syntax};
-use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::fmt;
@@ -410,9 +409,9 @@ impl RegexpType for Onig {
             true
         });
         capture_names.sort_by(|left, right| {
-            let left = left.1.iter().copied().fold(u32::max_value(), u32::min);
-            let right = right.1.iter().copied().fold(u32::max_value(), u32::min);
-            left.partial_cmp(&right).unwrap_or(Ordering::Equal)
+            let left = left.1.iter().min().copied().unwrap_or(u32::MAX);
+            let right = right.1.iter().min().copied().unwrap_or(u32::MAX);
+            left.cmp(&right)
         });
         for (name, _) in capture_names {
             if !names.contains(&name) {

--- a/artichoke-backend/src/extn/core/regexp/backend/regex/utf8.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/regex/utf8.rs
@@ -1,5 +1,4 @@
 use regex::{Regex, RegexBuilder};
-use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::convert::{self, TryFrom};
 use std::fmt;
@@ -432,9 +431,9 @@ impl RegexpType for Utf8 {
         let mut names = vec![];
         let mut capture_names = self.named_captures().unwrap_or_default();
         capture_names.sort_by(|left, right| {
-            let left = left.1.iter().copied().fold(usize::max_value(), usize::min);
-            let right = right.1.iter().copied().fold(usize::max_value(), usize::min);
-            left.partial_cmp(&right).unwrap_or(Ordering::Equal)
+            let left = left.1.iter().min().copied().unwrap_or(usize::MAX);
+            let right = right.1.iter().min().copied().unwrap_or(usize::MAX);
+            left.cmp(&right)
         });
         for (name, _) in capture_names {
             if !names.contains(&name) {

--- a/artichoke-backend/src/state/parser.rs
+++ b/artichoke-backend/src/state/parser.rs
@@ -64,9 +64,9 @@ impl State {
         let old = usize::from(unsafe { self.context.as_ref() }.lineno);
         let new = old
             .checked_add(val)
-            .ok_or_else(|| IncrementLinenoError::Overflow(usize::from(u16::max_value())))?;
+            .ok_or_else(|| IncrementLinenoError::Overflow(usize::from(u16::MAX)))?;
         let store = u16::try_from(new)
-            .map_err(|_| IncrementLinenoError::Overflow(usize::from(u16::max_value())))?;
+            .map_err(|_| IncrementLinenoError::Overflow(usize::from(u16::MAX)))?;
         unsafe {
             self.context.as_mut().lineno = store;
         }

--- a/artichoke-backend/src/types.rs
+++ b/artichoke-backend/src/types.rs
@@ -27,8 +27,8 @@ pub type Fp = f64;
 /// # use std::mem;
 /// # use artichoke_backend::types::Int;
 /// assert_eq!(mem::size_of::<i64>(), mem::size_of::<Int>());
-/// assert_eq!(i64::min_value(), Int::min_value());
-/// assert_eq!(i64::max_value(), Int::max_value());
+/// assert_eq!(i64::MIN, Int::MIN);
+/// assert_eq!(i64::MAX, Int::MAX);
 /// assert_eq!(TypeId::of::<i64>(), TypeId::of::<Int>());
 /// ```
 pub type Int = i64;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -18,7 +18,7 @@ use crate::backend::Artichoke;
 pub enum State {
     /// Internal parser error. This is a fatal error.
     ParseError,
-    /// Code must be fewer than `isize::max_value` bytes.
+    /// Code must be fewer than [`isize::MAX`] bytes.
     CodeTooLong,
     /// The code has too many end statements.
     UnexpectedEnd,


### PR DESCRIPTION
Replace explicit calls to Iterator::fold with Iterator::min

use `::MAX` associated constants instead of `::max_value` associated
function.

Use `cmp` instead of `partial_cmp` since we're comparing unsigned
integers which are total.

---
Use `::MAX` and `::MIN` instead of `::max_value()` and `::min_value()` for integer primitives