### PR TITLE
doc(alias = ...) is not allowed at crate level

### DIFF
--- a/spinoso-random/src/lib.rs
+++ b/spinoso-random/src/lib.rs
@@ -87,7 +87,6 @@
 //! [`rand_core`]: rand_core_
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(docsrs, doc(alias = "random"))]
 
 use core::fmt;
 #[cfg(feature = "std")]


### PR DESCRIPTION
Fix for rust-lang/rust#76329 being merged into the latest nightly.