### PR TITLE
Fix: Do not leak Random seed in fmt::Debug implementation in spinoso-random

### DIFF
--- a/spinoso-random/src/random/mod.rs
+++ b/spinoso-random/src/random/mod.rs
@@ -1,3 +1,4 @@
+use core::fmt;
 use core::mem::size_of;
 
 use crate::{InitializeError, NewSeedError};
@@ -55,7 +56,7 @@ const DEFAULT_SEED: u32 = 5489_u32;
 /// let mut random = Random::with_array_seed(seed);
 /// let rand = random.next_int32();
 /// ```
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Hash, PartialEq, Eq)]
 pub struct Random {
     mt: Mt,
     seed: [u32; 4],
@@ -69,6 +70,12 @@ impl Default for Random {
         } else {
             Random::with_seed(DEFAULT_SEED)
         }
+    }
+}
+
+impl fmt::Debug for Random {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("Random {}")
     }
 }
 
@@ -320,6 +327,10 @@ mod tests {
 
     #[test]
     fn fmt_debug_does_not_leak_seed() {
+        let random = Random::with_seed(874);
+        let debug = format!("{:?}", random);
+        assert!(!debug.contains("894"));
+
         let random = Random::with_seed(123_456);
         let debug = format!("{:?}", random);
         assert!(!debug.contains("123456"));

--- a/spinoso-random/src/random/mod.rs
+++ b/spinoso-random/src/random/mod.rs
@@ -313,3 +313,15 @@ pub fn new_seed() -> Result<[u32; DEFAULT_SEED_CNT], NewSeedError> {
     let seed = seed_to_key(seed);
     Ok(seed)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::Random;
+
+    #[test]
+    fn fmt_debug_does_not_leak_seed() {
+        let random = Random::with_seed(123_456);
+        let debug = format!("{:?}", random);
+        assert!(!debug.contains("123456"));
+    }
+}

--- a/spinoso-random/src/random/ruby/mod.rs
+++ b/spinoso-random/src/random/ruby/mod.rs
@@ -339,6 +339,17 @@ mod tests {
     use super::Mt;
 
     #[test]
+    fn fmt_debug_does_not_leak_seed() {
+        let mt = Mt::with_seed(874);
+        let debug = format!("{:?}", mt);
+        assert!(!debug.contains("894"));
+
+        let mt = Mt::with_seed(123_456);
+        let debug = format!("{:?}", mt);
+        assert!(!debug.contains("123456"));
+    }
+
+    #[test]
     fn seed_with_empty_iter_returns() {
         let _ = Mt::new_with_key(core::iter::empty());
     }


### PR DESCRIPTION
Previously, printing a `spinoso_random::Random` with the debug format specifier would output something like:

```
---- random::tests::fmt_debug_does_not_leak_seed stdout ----
thread 'random::tests::fmt_debug_does_not_leak_seed' panicked at 'Random { mt: Mt {}, seed: [123456, 0, 0, 0] }', spinoso-random/src/random/mod.rs:325:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    random::tests::fmt_debug_does_not_leak_seed
```

which leaks the internal seed.

It is typical for PRNGs to hide internal state in `fmt::Debug` implementations.

This commit alters the debug repr of `Random` to print `Random {}` and enforces this behavior with a test.