### PR TITLE
Rubocop 1.2.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -221,7 +221,7 @@ jobs:
         run: bundle install
 
       - name: Lint and check formatting with Rubocop
-        run: bundle exec rubocop
+        run: bundle exec rubocop --format github
 
   c:
     name: Lint and format C

--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,5 @@
 source 'https://rubygems.org'
 
 gem 'rake', '>= 12.3.3', require: false
-gem 'rubocop', '~> 1.1', require: false
+gem 'rubocop', '~> 1.2', require: false
 gem 'rubocop-rake', '~> 0.5', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GEM
     rake (13.0.1)
     regexp_parser (1.8.2)
     rexml (3.2.4)
-    rubocop (1.1.0)
+    rubocop (1.2.0)
       parallel (~> 1.10)
       parser (>= 2.7.1.5)
       rainbow (>= 2.2.2, < 4.0)
@@ -18,7 +18,7 @@ GEM
       rubocop-ast (>= 1.0.1)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 2.0)
-    rubocop-ast (1.1.0)
+    rubocop-ast (1.1.1)
       parser (>= 2.7.1.5)
     rubocop-rake (0.5.1)
       rubocop
@@ -30,7 +30,7 @@ PLATFORMS
 
 DEPENDENCIES
   rake (>= 12.3.3)
-  rubocop (~> 1.1)
+  rubocop (~> 1.2)
   rubocop-rake (~> 0.5)
 
 BUNDLED WITH


### PR DESCRIPTION
Bump RuboCop to 1.2.0

Test annotations in new version. See #894.