### PR TITLE
Fix Array#inspect implementation

### DIFF
--- a/artichoke-backend/src/extn/core/array/array.rb
+++ b/artichoke-backend/src/extn/core/array/array.rb
@@ -2,19 +2,19 @@
 
 module Artichoke
   class Array
+    # rubocop:disable Lint/HashCompareByIdentity
     def self.reachable?(src, dest, reachable_objects = nil)
       raise ArgumentError, 'reachable requires an Array src' unless src.is_a?(::Array)
 
       reachable_objects ||= ::Hash.new { |h, k| h[k] = [] }
-      reachable_objects.compare_by_identity
-      reachable_objects[src] << src.class unless reachable_objects.key?(src)
-      return true if reachable_objects[dest].include?(dest.class)
+      reachable_objects[src.object_id] << src.class unless reachable_objects.key?(src.object_id)
+      return true if reachable_objects[dest.object_id].include?(dest.class)
 
       if dest.equal?(nil) || dest.equal?(true) || dest.equal?(false) || dest.is_a?(::Integer) || dest.is_a?(::Float)
         return false
       end
 
-      reachable_objects[dest] << dest.class
+      reachable_objects[dest.object_id] << dest.class
       case dest
       when ::Array
         dest.each do |item|
@@ -31,6 +31,7 @@ module Artichoke
       end
       false
     end
+    # rubocop:enable Lint/HashCompareByIdentity
   end
 end
 


### PR DESCRIPTION
Revert Hash#compare_by_identity RuboCop fix from Artichoke::Array::reachable?
introduced in 13a1fb945abe08119348b78addc6796914830d8b. Hash#compare_by_identity
is not implemented, which made Array#inspect raise an exception.

## Before

```
$ cargo run -q --bin airb
artichoke 0.1.0-pre.0 (2020-11-08 revision 3708) [x86_64-apple-darwin]
[rustc 1.47.0 (18bf6b4f0 2020-10-07)]
>>> [1,2,3]
=>
>>> a = [1,2,3]
=>
>>> a.inspect
Traceback (most recent call last):
	3: from (airb):3
	2: from (eval):927:in inspect
	1: from (eval):9:in reachable?
NoMethodError (undefined method 'compare_by_identity')
>>>
```

## After

```
$ cargo run -q --bin airb
artichoke 0.1.0-pre.0 (2020-11-08 revision 3708) [x86_64-apple-darwin]
[rustc 1.47.0 (18bf6b4f0 2020-10-07)]
>>> [1,2,3]
=> [1, 2, 3]
>>> a = [1,2,3]
=> [1, 2, 3]
>>> a.inspect
=> "[1, 2, 3]"
```