### PR TITLE
Stop disabling clippy::doc_markdown lint

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -144,7 +144,7 @@ jobs:
 
       - name: Compile spinoso-random with some features
         run: |
-          cargo build --verbose --no-default-features --features rand_core
+          cargo build --verbose --no-default-features --features rand-core
           cargo build --verbose --no-default-features --features std
           cargo build --verbose --no-default-features --features rand
         working-directory: "spinoso-random"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,4 @@
+doc-valid-idents = [
+  "OpenSSL",
+  "SipHash",
+]

--- a/spinoso-random/Cargo.toml
+++ b/spinoso-random/Cargo.toml
@@ -21,7 +21,7 @@ rand_core_ = { version = "0.5", optional = true, default-features = false, packa
 [features]
 default = ["rand", "std"]
 # Enables range sampling methods for the `rand()` function.
-rand = ["rand_", "rand_core"]
+rand = ["rand_", "rand-core"]
 # Enables implementations of `RngCore` on `Random` and `Mt` types.
-rand_core = ["rand_core_"]
+rand-core = ["rand_core_"]
 std = []

--- a/spinoso-random/src/lib.rs
+++ b/spinoso-random/src/lib.rs
@@ -1,7 +1,6 @@
 #![warn(clippy::all)]
 #![warn(clippy::pedantic)]
 #![warn(clippy::cargo)]
-#![allow(clippy::doc_markdown)]
 // https://github.com/rust-lang/rust-clippy/pull/5998#issuecomment-731855891
 #![allow(clippy::map_err_ignore)]
 #![allow(clippy::option_if_let_else)]
@@ -75,9 +74,9 @@
 //! All features are enabled by default.
 //!
 //! - **rand** - Enables range sampling methods for the [`rand()`] function.
-//!   Activating this feature also activates the **rand_core** feature. Dropping
+//!   Activating this feature also activates the **rand-core** feature. Dropping
 //!   this feature removes the [`rand`] dependency.
-//! - **rand_core** - Enables implementations of [`RngCore`] on [`Random`] and
+//! - **rand-core** - Enables implementations of [`RngCore`] on [`Random`] and
 //!   [`Mt`] types. Dropping this feature removes the [`rand_core`] dependency.
 //! - **std** - Enables a dependency on the Rust Standard Library. Activating
 //!   this feature enables [`std::error::Error`] impls on error types in this

--- a/spinoso-random/src/random/mod.rs
+++ b/spinoso-random/src/random/mod.rs
@@ -3,7 +3,7 @@ use core::mem::size_of;
 
 use crate::{InitializeError, NewSeedError};
 
-#[cfg(feature = "rand_core")]
+#[cfg(feature = "rand-core")]
 mod rand;
 pub mod ruby;
 

--- a/spinoso-random/src/random/ruby/mod.rs
+++ b/spinoso-random/src/random/ruby/mod.rs
@@ -6,7 +6,7 @@ use core::fmt;
 use core::mem::size_of;
 use core::num::Wrapping;
 
-#[cfg(feature = "rand_core")]
+#[cfg(feature = "rand-core")]
 mod rand;
 
 const N: usize = 624;


### PR DESCRIPTION
Add a `clippy.toml` configuration file and add permitted idents to
`doc-valid-idents`.

This PR renames the `rand_core` feature in `spinoso-random` to `rand-core` (with hyphen). This stylizes the feature to match other multi-word crate features in this workspace and avoids adding `rand_core` to the permitted idents list (because as a crate name, `rand_core` should be surrounded by backticks).