### PR TITLE
Sync package.metadata.docs.rs section to all workspace Cargo.toml files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,3 +95,7 @@ output-strategy-null = ["artichoke-backend/output-strategy-null"]
 # Implement the `SecureRandom` Standard Library package. This feature adds
 # dependencies on `base64`, `hex`, `rand`, `rand_core`, and `uuid`.
 stdlib-securerandom = ["artichoke-backend/stdlib-securerandom"]
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -65,3 +65,7 @@ native-filesystem-access = []
 output-strategy-capture = []
 output-strategy-null = ["output-strategy-capture"]
 stdlib-securerandom = ["spinoso-securerandom"]
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/artichoke-core/Cargo.toml
+++ b/artichoke-core/Cargo.toml
@@ -18,3 +18,7 @@ default = ["std"]
 # APIs that depend on `OsStr` and `Path`, as well as some `std::error::Error`
 # impls.
 std = []
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/spec-runner/Cargo.toml
+++ b/spec-runner/Cargo.toml
@@ -24,3 +24,7 @@ path = ".."
 # Remove it from the main artichoke workspace.
 [workspace]
 members = ["."]
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/spinoso-math/Cargo.toml
+++ b/spinoso-math/Cargo.toml
@@ -23,3 +23,7 @@ full = ["libm"]
 # By default, `spinoso-math` is `no_std`. This feature enables
 # `std::error::Error` impls.
 std = []
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/spinoso-random/Cargo.toml
+++ b/spinoso-random/Cargo.toml
@@ -25,3 +25,7 @@ rand = ["rand_", "rand_core"]
 # Enables implementations of `RngCore` on `Random` and `Mt` types.
 rand_core = ["rand_core_"]
 std = []
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]


### PR DESCRIPTION
Enable docsrs cfg for access to nightly rustdoc features.