### PR TITLE
Replace string::format_int_into with direct usage of itoa::fmt

### DIFF
--- a/artichoke-backend/src/extn/core/array/args.rs
+++ b/artichoke-backend/src/extn/core/array/args.rs
@@ -1,6 +1,7 @@
 use std::convert::TryFrom;
 
 use crate::extn::prelude::*;
+use crate::string::WriteError;
 use crate::sys::protect;
 
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
@@ -61,9 +62,9 @@ pub fn element_assignment(
                 start
             } else {
                 let mut message = String::from("index ");
-                string::format_int_into(&mut message, start)?;
+                itoa::fmt(&mut message, start).map_err(WriteError::from)?;
                 message.push_str(" too small for array; minimum: -");
-                string::format_int_into(&mut message, len)?;
+                itoa::fmt(&mut message, len).map_err(WriteError::from)?;
                 return Err(IndexError::from(message).into());
             }
         };
@@ -72,7 +73,7 @@ pub fn element_assignment(
             Ok((start, Some(slice_len), elem))
         } else {
             let mut message = String::from("negative length (");
-            string::format_int_into(&mut message, slice_len)?;
+            itoa::fmt(&mut message, slice_len).map_err(WriteError::from)?;
             message.push(')');
             Err(IndexError::from(message).into())
         }
@@ -88,9 +89,9 @@ pub fn element_assignment(
                 Ok((idx, None, second))
             } else {
                 let mut message = String::from("index ");
-                string::format_int_into(&mut message, index)?;
+                itoa::fmt(&mut message, index).map_err(WriteError::from)?;
                 message.push_str(" too small for array; minimum: -");
-                string::format_int_into(&mut message, len)?;
+                itoa::fmt(&mut message, len).map_err(WriteError::from)?;
                 Err(IndexError::from(message).into())
             }
         }
@@ -112,9 +113,9 @@ pub fn element_assignment(
             // TODO: This conditional is probably not doing the right thing
             if start + (end - start) < 0 {
                 let mut message = String::new();
-                string::format_int_into(&mut message, start)?;
+                itoa::fmt(&mut message, start).map_err(WriteError::from)?;
                 message.push_str("..");
-                string::format_int_into(&mut message, end)?;
+                itoa::fmt(&mut message, end).map_err(WriteError::from)?;
                 message.push_str(" out of range");
                 return Err(RangeError::from(message).into());
             }
@@ -129,18 +130,18 @@ pub fn element_assignment(
                         Ok((start, end.checked_sub(start), second))
                     } else {
                         let mut message = String::from("index ");
-                        string::format_int_into(&mut message, start)?;
+                        itoa::fmt(&mut message, start).map_err(WriteError::from)?;
                         message.push_str(" too small for array; minimum: -");
-                        string::format_int_into(&mut message, len)?;
+                        itoa::fmt(&mut message, len).map_err(WriteError::from)?;
                         Err(IndexError::from(message).into())
                     }
                 }
                 (Ok(start), Err(_)) => Ok((start, None, second)),
                 (Err(_), Err(_)) => {
                     let mut message = String::from("index ");
-                    string::format_int_into(&mut message, start)?;
+                    itoa::fmt(&mut message, start).map_err(WriteError::from)?;
                     message.push_str(" too small for array; minimum: -");
-                    string::format_int_into(&mut message, len)?;
+                    itoa::fmt(&mut message, len).map_err(WriteError::from)?;
                     Err(IndexError::from(message).into())
                 }
             }

--- a/artichoke-backend/src/extn/core/integer/mod.rs
+++ b/artichoke-backend/src/extn/core/integer/mod.rs
@@ -3,6 +3,7 @@ use std::mem;
 
 use crate::extn::core::numeric::{self, Coercion, Outcome};
 use crate::extn::prelude::*;
+use crate::string::WriteError;
 
 pub mod mruby;
 pub mod trampoline;
@@ -127,7 +128,7 @@ impl Integer {
                 }
                 _ => {
                     let mut message = String::new();
-                    string::format_int_into(&mut message, self.as_i64())?;
+                    itoa::fmt(&mut message, self.as_i64()).map_err(WriteError::from)?;
                     message.push_str(" out of char range");
                     Err(RangeError::from(message).into())
                 }

--- a/artichoke-backend/src/extn/core/kernel/integer.rs
+++ b/artichoke-backend/src/extn/core/kernel/integer.rs
@@ -7,6 +7,7 @@ use std::num::NonZeroU32;
 use std::str::{self, FromStr};
 
 use crate::extn::prelude::*;
+use crate::string::WriteError;
 
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Radix(NonZeroU32);
@@ -63,7 +64,7 @@ impl TryConvertMut<Option<Value>, Option<Radix>> for Artichoke {
                 Ok(Radix::new(radix))
             } else {
                 let mut message = String::from("invalid radix ");
-                string::format_int_into(&mut message, radix)?;
+                itoa::fmt(&mut message, radix).map_err(WriteError::from)?;
                 Err(ArgumentError::from(message).into())
             }
         } else {

--- a/artichoke-backend/src/extn/core/matchdata/mod.rs
+++ b/artichoke-backend/src/extn/core/matchdata/mod.rs
@@ -19,6 +19,7 @@ use crate::extn::core::regexp::backend::NilableString;
 use crate::extn::core::regexp::Regexp;
 use crate::extn::core::symbol::Symbol;
 use crate::extn::prelude::*;
+use crate::string::WriteError;
 
 mod boxing;
 pub mod mruby;
@@ -314,7 +315,7 @@ impl MatchData {
                     Ok(idx) if idx < captures_len => idx,
                     _ => {
                         let mut message = String::from("index ");
-                        string::format_int_into(&mut message, index)?;
+                        itoa::fmt(&mut message, index).map_err(WriteError::from)?;
                         message.push_str(" out of matches");
                         return Err(IndexError::from(message).into());
                     }

--- a/artichoke-backend/src/extn/core/math/trampoline.rs
+++ b/artichoke-backend/src/extn/core/math/trampoline.rs
@@ -3,6 +3,7 @@
 use core::convert::TryFrom;
 
 use crate::extn::prelude::*;
+use crate::string::WriteError;
 
 pub fn acos(interp: &mut Artichoke, value: Value) -> Result<Fp, Error> {
     let value = interp.coerce_to_float(value)?;
@@ -127,13 +128,13 @@ pub fn ldexp(interp: &mut Artichoke, fraction: Value, exponent: Value) -> Result
         }
         Err(_) if exponent < 0 => {
             let mut message = String::from("integer ");
-            string::format_int_into(&mut message, exponent)?;
+            itoa::fmt(&mut message, exponent).map_err(WriteError::from)?;
             message.push_str("too small to convert to `int'");
             Err(RangeError::from(message).into())
         }
         Err(_) => {
             let mut message = String::from("integer ");
-            string::format_int_into(&mut message, exponent)?;
+            itoa::fmt(&mut message, exponent).map_err(WriteError::from)?;
             message.push_str("too big to convert to `int'");
             Err(RangeError::from(message).into())
         }

--- a/artichoke-backend/src/extn/core/regexp/mod.rs
+++ b/artichoke-backend/src/extn/core/regexp/mod.rs
@@ -84,11 +84,11 @@ pub fn nth_match_group(group: NonZeroUsize) -> Cow<'static, [u8]> {
         20 => b"$20".as_ref().into(),
         num => {
             let mut buf = String::from("$");
-            // Suppress io errors because this function is infallible.
+            // Suppress fmt errors because this function is infallible.
             //
-            // In practice string::format_int_into will never error because the
-            // fmt::Write impl for String never panics.
-            let _ = string::format_int_into(&mut buf, num);
+            // In practice `itoa::fmt` will never error because the `fmt::Write`
+            // impl for `String` never panics.
+            let _ = itoa::fmt(&mut buf, num);
             buf.into_bytes().into()
         }
     }

--- a/artichoke-backend/src/string.rs
+++ b/artichoke-backend/src/string.rs
@@ -7,7 +7,7 @@
 //! Artichoke aims to support ASCII, UTF-8, maybe UTF-8, and binary encodings.
 
 use scolapasta_string_escape::format_debug_escape_into;
-use std::borrow::Cow;
+use std::borrow::{Borrow, BorrowMut, Cow};
 use std::error;
 use std::fmt;
 
@@ -72,6 +72,30 @@ impl WriteError {
     #[must_use]
     pub fn into_inner(self) -> fmt::Error {
         self.0
+    }
+}
+
+impl AsRef<fmt::Error> for WriteError {
+    fn as_ref(&self) -> &fmt::Error {
+        &self.0
+    }
+}
+
+impl AsMut<fmt::Error> for WriteError {
+    fn as_mut(&mut self) -> &mut fmt::Error {
+        &mut self.0
+    }
+}
+
+impl Borrow<fmt::Error> for WriteError {
+    fn borrow(&self) -> &fmt::Error {
+        &self.0
+    }
+}
+
+impl BorrowMut<fmt::Error> for WriteError {
+    fn borrow_mut(&mut self) -> &mut fmt::Error {
+        &mut self.0
     }
 }
 

--- a/artichoke-backend/src/string.rs
+++ b/artichoke-backend/src/string.rs
@@ -50,9 +50,14 @@ where
     format_debug_escape_into(dest, string).map_err(WriteError)
 }
 
-/// Error type for [`format_unicode_debug_into`] and [`format_int_into`].
+/// Error type for [`format_unicode_debug_into`].
+///
+/// This error type can also be used to convert generic [`fmt::Error`] into an
+/// [`Error`], such as when formatting integers with [`itoa::fmt`].
 ///
 /// This  error type wraps a [`fmt::Error`].
+///
+/// [`Error`]: crate::error::Error
 #[derive(Debug, Clone, Copy)]
 pub struct WriteError(fmt::Error);
 

--- a/artichoke-backend/src/string.rs
+++ b/artichoke-backend/src/string.rs
@@ -67,6 +67,12 @@ impl From<fmt::Error> for WriteError {
     }
 }
 
+impl From<WriteError> for fmt::Error {
+    fn from(err: WriteError) -> Self {
+        err.into_inner()
+    }
+}
+
 impl WriteError {
     #[inline]
     #[must_use]

--- a/artichoke-backend/src/string.rs
+++ b/artichoke-backend/src/string.rs
@@ -42,20 +42,12 @@ use crate::Artichoke;
 ///
 /// This method only returns an error when the given writer returns an
 /// error.
+#[inline]
 pub fn format_unicode_debug_into<W>(dest: W, string: &[u8]) -> Result<(), WriteError>
 where
     W: fmt::Write,
 {
     format_debug_escape_into(dest, string).map_err(WriteError)
-}
-
-pub fn format_int_into<W, I>(dest: W, value: I) -> Result<(), WriteError>
-where
-    W: fmt::Write,
-    I: itoa::Integer,
-{
-    itoa::fmt(dest, value)?;
-    Ok(())
 }
 
 /// Error type for [`format_unicode_debug_into`] and [`format_int_into`].

--- a/artichoke-backend/src/sys/mod.rs
+++ b/artichoke-backend/src/sys/mod.rs
@@ -11,7 +11,6 @@
 use std::ffi::CStr;
 use std::fmt::{self, Write};
 
-use crate::string;
 use crate::types::{self, Ruby};
 
 mod args;
@@ -47,11 +46,10 @@ impl fmt::Debug for mrb_value {
             Ruby::Bool => f.write_str("false"),
             Ruby::Fixnum => {
                 let fixnum = unsafe { mrb_sys_fixnum_to_cint(*self) };
-                string::format_int_into(f, fixnum).map_err(string::WriteError::into_inner)
+                itoa::fmt(f, fixnum)
             }
             Ruby::Float => {
                 let float = unsafe { mrb_sys_float_to_cdouble(*self) };
-                // dtoa can't write to `fmt::Write` streams.
                 write!(f, "{}", float)
             }
             type_tag => write!(f, "<{}>", type_tag),


### PR DESCRIPTION
Remove `string::format_int_into` and replace call sites with direct
calls to `itoa::fmt`.

`string::format_int_into` was a minimal wrapper around `itoa::fmt` that
only mapped the error type. It introduced a function call overhead for
minimal abstraction. There are only a handful of calls to this function,
so replace them with the one-liner implementation.

Some calls immediately unwrapped the inner `fmt::Error`. These calls
have been simplified to only `itoa::fmt(f, num)`.