### PR TITLE
Enable clippy::needless_borrow lint

### DIFF
--- a/artichoke-backend/src/eval.rs
+++ b/artichoke-backend/src/eval.rs
@@ -56,7 +56,7 @@ impl Eval for Artichoke {
 
     fn eval_os_str(&mut self, code: &OsStr) -> Result<Self::Value, Self::Error> {
         let code = ffi::os_str_to_bytes(code)?;
-        self.eval(&code)
+        self.eval(code)
     }
 
     fn eval_file(&mut self, file: &Path) -> Result<Self::Value, Self::Error> {

--- a/artichoke-backend/src/fs/memory.rs
+++ b/artichoke-backend/src/fs/memory.rs
@@ -294,7 +294,7 @@ impl Filesystem for Memory {
     /// [`io::ErrorKind::NotFound`] is returned.
     fn read_file(&self, path: &Path) -> io::Result<Cow<'_, [u8]>> {
         let path = absolutize_relative_to(path, &self.cwd);
-        if let Some(ref entry) = self.fs.get(&path) {
+        if let Some(entry) = self.fs.get(&path) {
             if let Some(ref code) = entry.code {
                 match code.content {
                     Cow::Borrowed(content) => Ok(content.into()),

--- a/artichoke-backend/src/lib.rs
+++ b/artichoke-backend/src/lib.rs
@@ -1,6 +1,7 @@
 #![warn(clippy::all)]
 #![warn(clippy::pedantic)]
 #![warn(clippy::cargo)]
+#![warn(clippy::needless_borrow)]
 // https://github.com/rust-lang/rust-clippy/pull/5998#issuecomment-731855891
 #![allow(clippy::map_err_ignore)]
 #![allow(clippy::missing_errors_doc)]

--- a/artichoke-backend/src/load.rs
+++ b/artichoke-backend/src/load.rs
@@ -24,7 +24,7 @@ impl LoadSources for Artichoke {
             absolute_path = Path::new(RUBY_LOAD_PATH).join(path);
             path = &absolute_path;
         }
-        state.vfs.register_extension(&path, T::require)?;
+        state.vfs.register_extension(path, T::require)?;
         trace!(
             "Added Rust extension to interpreter filesystem -- {}",
             path.display()

--- a/artichoke-core/src/lib.rs
+++ b/artichoke-core/src/lib.rs
@@ -1,6 +1,7 @@
 #![warn(clippy::all)]
 #![warn(clippy::pedantic)]
 #![warn(clippy::cargo)]
+#![warn(clippy::needless_borrow)]
 // https://github.com/rust-lang/rust-clippy/pull/5998#issuecomment-731855891
 #![allow(clippy::map_err_ignore)]
 #![allow(clippy::option_if_let_else)]

--- a/scolapasta-hex/src/lib.rs
+++ b/scolapasta-hex/src/lib.rs
@@ -1,6 +1,7 @@
 #![warn(clippy::all)]
 #![warn(clippy::pedantic)]
 #![warn(clippy::cargo)]
+#![warn(clippy::needless_borrow)]
 // https://github.com/rust-lang/rust-clippy/pull/5998#issuecomment-731855891
 #![allow(clippy::map_err_ignore)]
 #![allow(clippy::option_if_let_else)]

--- a/scolapasta-string-escape/src/lib.rs
+++ b/scolapasta-string-escape/src/lib.rs
@@ -1,6 +1,7 @@
 #![warn(clippy::all)]
 #![warn(clippy::pedantic)]
 #![warn(clippy::cargo)]
+#![warn(clippy::needless_borrow)]
 // https://github.com/rust-lang/rust-clippy/pull/5998#issuecomment-731855891
 #![allow(clippy::map_err_ignore)]
 #![allow(clippy::option_if_let_else)]

--- a/spec-runner/src/main.rs
+++ b/spec-runner/src/main.rs
@@ -1,6 +1,7 @@
 #![warn(clippy::all)]
 #![warn(clippy::pedantic)]
 #![warn(clippy::cargo)]
+#![warn(clippy::clippy::needless_borrow)]
 #![allow(unknown_lints)]
 #![warn(broken_intra_doc_links)]
 #![warn(missing_docs)]

--- a/spinoso-array/src/lib.rs
+++ b/spinoso-array/src/lib.rs
@@ -1,6 +1,7 @@
 #![warn(clippy::all)]
 #![warn(clippy::pedantic)]
 #![warn(clippy::cargo)]
+#![warn(clippy::needless_borrow)]
 // https://github.com/rust-lang/rust-clippy/pull/5998#issuecomment-731855891
 #![allow(clippy::map_err_ignore)]
 #![allow(clippy::option_if_let_else)]

--- a/spinoso-env/src/lib.rs
+++ b/spinoso-env/src/lib.rs
@@ -1,6 +1,7 @@
 #![warn(clippy::all)]
 #![warn(clippy::pedantic)]
 #![warn(clippy::cargo)]
+#![warn(clippy::needless_borrow)]
 // https://github.com/rust-lang/rust-clippy/pull/5998#issuecomment-731855891
 #![allow(clippy::map_err_ignore)]
 #![allow(clippy::option_if_let_else)]

--- a/spinoso-exception/src/lib.rs
+++ b/spinoso-exception/src/lib.rs
@@ -1,6 +1,7 @@
 #![warn(clippy::all)]
 #![warn(clippy::pedantic)]
 #![warn(clippy::cargo)]
+#![warn(clippy::needless_borrow)]
 // https://github.com/rust-lang/rust-clippy/pull/5998#issuecomment-731855891
 #![allow(clippy::map_err_ignore)]
 #![allow(clippy::option_if_let_else)]

--- a/spinoso-math/src/lib.rs
+++ b/spinoso-math/src/lib.rs
@@ -1,6 +1,7 @@
 #![warn(clippy::all)]
 #![warn(clippy::pedantic)]
 #![warn(clippy::cargo)]
+#![warn(clippy::needless_borrow)]
 // https://github.com/rust-lang/rust-clippy/pull/5998#issuecomment-731855891
 #![allow(clippy::map_err_ignore)]
 #![allow(clippy::option_if_let_else)]

--- a/spinoso-random/src/lib.rs
+++ b/spinoso-random/src/lib.rs
@@ -1,6 +1,7 @@
 #![warn(clippy::all)]
 #![warn(clippy::pedantic)]
 #![warn(clippy::cargo)]
+#![warn(clippy::needless_borrow)]
 // https://github.com/rust-lang/rust-clippy/pull/5998#issuecomment-731855891
 #![allow(clippy::map_err_ignore)]
 #![allow(clippy::option_if_let_else)]

--- a/spinoso-securerandom/src/lib.rs
+++ b/spinoso-securerandom/src/lib.rs
@@ -1,6 +1,7 @@
 #![warn(clippy::all)]
 #![warn(clippy::pedantic)]
 #![warn(clippy::cargo)]
+#![warn(clippy::needless_borrow)]
 // https://github.com/rust-lang/rust-clippy/pull/5998#issuecomment-731855891
 #![allow(clippy::map_err_ignore)]
 #![allow(clippy::option_if_let_else)]

--- a/spinoso-symbol/src/lib.rs
+++ b/spinoso-symbol/src/lib.rs
@@ -1,6 +1,7 @@
 #![warn(clippy::all)]
 #![warn(clippy::pedantic)]
 #![warn(clippy::cargo)]
+#![warn(clippy::needless_borrow)]
 // https://github.com/rust-lang/rust-clippy/pull/5998#issuecomment-731855891
 #![allow(clippy::map_err_ignore)]
 #![allow(clippy::option_if_let_else)]

--- a/spinoso-time/src/lib.rs
+++ b/spinoso-time/src/lib.rs
@@ -1,6 +1,7 @@
 #![warn(clippy::all)]
 #![warn(clippy::pedantic)]
 #![warn(clippy::cargo)]
+#![warn(clippy::needless_borrow)]
 // https://github.com/rust-lang/rust-clippy/pull/5998#issuecomment-731855891
 #![allow(clippy::map_err_ignore)]
 #![allow(clippy::option_if_let_else)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![warn(clippy::all)]
 #![warn(clippy::pedantic)]
 #![warn(clippy::cargo)]
+#![warn(clippy::needless_borrow)]
 // https://github.com/rust-lang/rust-clippy/pull/5998#issuecomment-731855891
 #![allow(clippy::map_err_ignore)]
 #![allow(unknown_lints)]

--- a/src/ruby.rs
+++ b/src/ruby.rs
@@ -103,7 +103,7 @@ where
     // - A test asserts that `INLINE_EVAL_SWITCH_FILENAME` has no NUL bytes.
     let context = unsafe { Context::new_unchecked(INLINE_EVAL_SWITCH_FILENAME) };
     interp.push_context(context)?;
-    if let Some(ref fixture) = fixture {
+    if let Some(fixture) = fixture {
         setup_fixture_hack(&mut interp, fixture)?;
     }
     for command in commands {
@@ -126,7 +126,7 @@ where
     W: io::Write + WriteColor,
 {
     let mut interp = crate::interpreter()?;
-    if let Some(ref fixture) = fixture {
+    if let Some(fixture) = fixture {
         setup_fixture_hack(&mut interp, fixture)?;
     }
     if let Err(ref exc) = interp.eval_file(programfile) {
@@ -140,7 +140,7 @@ fn load_error<P: AsRef<OsStr>>(file: P, message: &str) -> Result<String, Error> 
     let mut buf = String::from(message);
     buf.push_str(" -- ");
     let path = ffi::os_str_to_bytes(file.as_ref())?;
-    string::format_unicode_debug_into(&mut buf, &path)?;
+    string::format_unicode_debug_into(&mut buf, path)?;
     Ok(buf)
 }
 


### PR DESCRIPTION
Enable `clippy:needless_borrow` lint to check for unnecessary references
that are immediately dereferenced by the compiler.

I first asked about this in rust-lang/rust-clippy#4271 but never got
around to enabling it.

This lint is in the nursery lint group, so explicitly activate it in all
`lib.rs` sources for all workspace crates.

This lint caught a few needless borrows in `artichoke-backend`'s
interpreter infrastructure and `artichoke`'s Ruby CLI.