### PR TITLE
Allow building artichoke crate without CLI for lib targets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,9 @@ keywords = ["artichoke", "artichoke-ruby", "mri", "cruby", "ruby"]
 categories = ["command-line-utilities"]
 
 [dependencies]
-rustyline = { version = "6", default-features = false }
-structopt = "0.3"
-termcolor = "1.1"
+rustyline = { version = "6", default-features = false, optional = true }
+structopt = { version = "0.3", optional = true }
+termcolor = { version = "1.1", optional = true }
 
 [dependencies.artichoke-backend]
 version = "0.1"
@@ -30,6 +30,16 @@ default-features = false
 [build-dependencies]
 chrono = { version = "0.4.19", default-features = false, features = ["clock"] }
 target-lexicon = "0.11.1"
+
+[[bin]]
+name = "airb"
+path = "src/bin/airb.rs"
+required-features = ["cli"]
+
+[[bin]]
+name = "artichoke"
+path = "src/bin/artichoke.rs"
+required-features = ["cli"]
 
 [workspace]
 members = [
@@ -53,6 +63,7 @@ lto = true
 
 [features]
 default = [
+  "cli",
   "core-env",
   "core-env-system",
   "core-math",
@@ -63,6 +74,7 @@ default = [
   "native-filesystem-access",
   "stdlib-securerandom"
 ]
+cli = ["rustyline", "structopt", "termcolor"]
 # Enable resolving environment variables with the `ENV` core object.
 core-env = ["artichoke-backend/core-env"]
 # Enable resolving environment variables with the `ENV` core object using native

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,9 +115,12 @@ readme!();
 
 pub use artichoke_backend as backend;
 
+#[cfg(feature = "cli")]
 pub mod backtrace;
 pub mod parser;
+#[cfg(feature = "cli")]
 pub mod repl;
+#[cfg(feature = "cli")]
 pub mod ruby;
 
 /// A "prelude" for users of the `artichoke-backend` crate.


### PR DESCRIPTION
The `artichoke` crate is the public frontend to the Artichoke
interpreter. It exposes a top-level `artichoke::interpreter` function
that constructs an interpreter with all of the correct metadata that is
generated from its `build.rs` script. For these reasons, `artichoke` is
useful as a library crate.

The `artichoke` crate also exposes two executables: `artichoke` and
`airb`. These exceutables depend on platform-specific libraries like
`termcolor` and `rustyline` as well as unneeded dependencies in a lib
setting like `clap` and `structopt`.

The inclusion of `nix` via `rustyline` prevents the `artichoke` crate
from compiling on the `wasm32-unknown-emscripten` target even though the
readline binary frontend is not used. `wasm32-unknown-emscripten` is not
a supported platform in any tier for `nix`.

This PR makes `rustyline`, `structopt` and `termcolor` optional
dependencies that can be activated by an on by default `cli` feature.
`Cargo.toml` is modified to include stanzas for the `artichoke` and
`airb` binary targets that declare `required-features = ["cli"]`. I
learned this trick from bindgen:

https://github.com/rust-lang/rust-bindgen/blob/01cbe446/Cargo.toml#L36-L52

See also rust-lang/cargo#1982.

After these changes, `cargo install` and `cargo build --workspace`
continue to generate the `artichoke` and `airb` binaries as before.
Including `artichoke` as a lib dependency no longer includes
`rustyline`, `structopt`, and `termcolor` as dependencies.