### PR TITLE
Add raw parts APIs to spinoso_array::Array

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -565,7 +565,7 @@ checksum = "7acad6f34eb9e8a259d3283d1e8c1d34d7415943d4895f65cc73813c7396fc85"
 
 [[package]]
 name = "spinoso-array"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "smallvec",
 ]

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -19,7 +19,7 @@ log = "0.4"
 once_cell = "1"
 regex = "1"
 scolapasta-string-escape = { version = "0.1", path = "../scolapasta-string-escape" }
-spinoso-array = { version = "0.3", path = "../spinoso-array" }
+spinoso-array = { version = "0.4", path = "../spinoso-array" }
 spinoso-env = { version = "0.1", path = "../spinoso-env", optional = true }
 spinoso-exception = { version = "0.1", path = "../spinoso-exception" }
 spinoso-math = { version = "0.1", path = "../spinoso-math", optional = true }

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -566,7 +566,7 @@ checksum = "fbee7696b84bbf3d89a1c2eccff0850e3047ed46bfcd2e92c29a2d074d57e252"
 
 [[package]]
 name = "spinoso-array"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "smallvec",
 ]

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -638,7 +638,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-array"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "smallvec",
 ]

--- a/spinoso-array/Cargo.toml
+++ b/spinoso-array/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spinoso-array"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2018"
 description = """

--- a/spinoso-array/src/array/vec/mod.rs
+++ b/spinoso-array/src/array/vec/mod.rs
@@ -4,6 +4,7 @@ use alloc::boxed::Box;
 use alloc::vec;
 use alloc::vec::Vec;
 use core::cmp;
+use core::mem::ManuallyDrop;
 use core::slice::{Iter, IterMut};
 
 mod convert;
@@ -282,6 +283,58 @@ impl<T> Array<T> {
     #[inline]
     pub unsafe fn set_len(&mut self, new_len: usize) {
         self.0.set_len(new_len);
+    }
+
+    /// Creates a `Array<T>` directly from the raw components of another array.
+    ///
+    /// # Safety
+    ///
+    /// This is highly unsafe, due to the number of invariants that aren't
+    /// checked:
+    ///
+    /// - `ptr` needs to have been previously allocated via `Array<T>` (at
+    ///   least, it's highly likely to be incorrect if it wasn't).
+    /// - `T` needs to have the same size and alignment as what `ptr` was
+    ///   allocated with. (`T` having a less strict alignment is not sufficient,
+    ///   the alignment really needs to be equal to satisfy the `dealloc`
+    ///   requirement that memory must be allocated and deallocated with the
+    ///   same layout.)
+    /// - `length` needs to be less than or equal to `capacity`.
+    /// - `capacity` needs to be the `capacity` that the pointer was allocated
+    ///   with.
+    ///
+    /// Violating these may cause problems like corrupting the allocator's
+    /// internal data structures.
+    ///
+    /// The ownership of `ptr` is effectively transferred to the `Array<T>`
+    /// which may then deallocate, reallocate or change the contents of memory
+    /// pointed to by the pointer at will. Ensure that nothing else uses the
+    /// pointer after calling this function.
+    #[must_use]
+    pub unsafe fn from_raw_parts(ptr: *mut T, length: usize, capacity: usize) -> Self {
+        Self(Vec::from_raw_parts(ptr, length, capacity))
+    }
+
+    /// Decomposes an `Array<T>` into its raw components.
+    ///
+    /// Returns the raw pointer to the underlying data, the length of the array
+    /// (in elements), and the allocated capacity of the data (in elements).
+    /// These are the same arguments in the same order as the arguments to
+    /// [`from_raw_parts`].
+    ///
+    /// After calling this function, the caller is responsible for the memory
+    /// previously managed by the `Array`. The only way to do this is to convert
+    /// the raw pointer, length, and capacity back into a `Array` with the
+    /// [`from_raw_parts`] function, allowing the destructor to perform the
+    /// cleanup.
+    ///
+    /// [`from_raw_parts`]: Array::from_raw_parts
+    #[must_use]
+    pub fn into_raw_parts(self) -> (*mut T, usize, usize) {
+        // TODO: convert to `Vec::into_raw_parts` once it is stabilized.
+        // See: https://doc.rust-lang.org/1.48.0/src/alloc/vec.rs.html#399-402
+        let mut me = ManuallyDrop::new(self.0);
+        (me.as_mut_ptr(), me.len(), me.capacity())
     }
 
     /// Consume the array and return the inner [`Vec<T>`].
@@ -1643,5 +1696,43 @@ mod test {
         let drained = ary.set_slice(5, 10, &[]);
         assert_eq!(drained, 0);
         assert_eq!(ary, [0, 0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn into_raw_parts_from_raw_parts_round_trip_empty_no_alloc() {
+        let ary = Array::<i32>::new();
+        let (ptr, len, capacity) = ary.into_raw_parts();
+        let ary = unsafe { Array::from_raw_parts(ptr, len, capacity) };
+        assert_eq!(ary.len(), 0);
+        assert_eq!(ary.capacity(), 0);
+    }
+
+    #[test]
+    fn into_raw_parts_from_raw_parts_round_trip_empty_with_capacity() {
+        let ary = Array::<i32>::with_capacity(100);
+        let (ptr, len, capacity) = ary.into_raw_parts();
+        let ary = unsafe { Array::from_raw_parts(ptr, len, capacity) };
+        assert_eq!(ary.len(), 0);
+        assert_eq!(ary.capacity(), 100);
+    }
+
+    #[test]
+    fn into_raw_parts_from_raw_parts_round_trip_assoc() {
+        let ary = Array::<i32>::assoc(1, 2);
+        let (ptr, len, capacity) = ary.into_raw_parts();
+        let ary = unsafe { Array::from_raw_parts(ptr, len, capacity) };
+        assert_eq!(ary.len(), 2);
+        assert_eq!(ary.capacity(), 2);
+        assert_eq!(ary, [1, 2]);
+    }
+
+    #[test]
+    fn into_raw_parts_from_raw_parts_round_trip_from_slice() {
+        let ary = Array::<i32>::from(&[1, 2, 3, 4, 5, 6, 7, 8, 9, 0]);
+        let (ptr, len, capacity) = ary.into_raw_parts();
+        let ary = unsafe { Array::from_raw_parts(ptr, len, capacity) };
+        assert_eq!(ary.len(), 10);
+        assert!(ary.capacity() >= 10);
+        assert_eq!(ary, [1, 2, 3, 4, 5, 6, 7, 8, 9, 0]);
     }
 }


### PR DESCRIPTION
Add `Array::from_raw_parts` and `Array::into_raw_parts` APIs to the
`Vec`-based `Array` type in `spinoso-array`.

These APIs may be used to turn an `Array` into a raw pointer that can
later be reconstructed to an `Array`. These APIs are highly unsafe and
calling these APIs moves ownership of the underlying allocation.

These APIs are most useful in FFI contexts and are being introduced to
prepare for fixing GH-922.

Both `from_raw_parts` and `into_raw_parts` are marked must use to force
callers to acknowledge drop/leak intent with a wildcard binding.

The corresponding raw parts APIs cannot be added to the `SmallArray`
type because its internal `SmallVec` can only soundly be decomposed into
a raw parts triple when the storage is spilled to a `Vec`. This would
force users of `SmallArray` to forcibly spill the `SmallVec` to the
heap, which eliminates much of the usefulness of the `SmallVec`
container. Additionally, `SmallVec` does not expose an API to force a
spill to the heap.

The addition of these APIs bumps the `spinoso-array` crate version to
0.4.0.