### PR TITLE
Avoid leaking sys::mrb_data_type on class::Spec construction

### DIFF
--- a/artichoke-backend/src/class.rs
+++ b/artichoke-backend/src/class.rs
@@ -221,7 +221,7 @@ impl Rclass {
 pub struct Spec {
     name: Cow<'static, str>,
     cstring: Box<CStr>,
-    data_type: *mut sys::mrb_data_type,
+    data_type: Box<sys::mrb_data_type>,
     enclosing_scope: Option<EnclosingRubyScope>,
 }
 
@@ -253,7 +253,6 @@ impl Spec {
                 dfree: free,
             };
             let data_type = Box::new(data_type);
-            let data_type: &'static mut sys::mrb_data_type = Box::leak(data_type);
             Ok(Self {
                 name,
                 cstring,
@@ -266,8 +265,8 @@ impl Spec {
     }
 
     #[must_use]
-    pub fn data_type(&self) -> *mut sys::mrb_data_type {
-        self.data_type
+    pub fn data_type(&self) -> *const sys::mrb_data_type {
+        self.data_type.as_ref()
     }
 
     #[must_use]


### PR DESCRIPTION
The fuzz GitHub Actions workflow found a small memory leak:
https://github.com/artichoke/artichoke/runs/1469791093?check_suite_focus=true

This leak was intentionally introduced in #927 to allow the
`BoxUnboxVmValue` implementation for `HeapAllocatedData` to pass the
data type to `mrb_data_object_alloc` without holding a borrow on the
interpreter so the mruby API call could be wrapped in
`Artichoke::with_ffi_boundary`.

This leak to raw `*mut sys::mrb_data_type` is not necessary:

- `mrb_data_type`s can be safely cloned.
- It is safe to reference a cloned `free` function or `&CStr` name.
- `mrb_data_object_alloc` only takes `*const sys::mrb_data_type`.

These three factors allow implementing `class::Spec::data_type` in safe
code without ever leaking the `mrb_data_type`.