### PR TITLE
Remove Clone derive on class and module specs

### DIFF
--- a/artichoke-backend/src/class.rs
+++ b/artichoke-backend/src/class.rs
@@ -217,7 +217,7 @@ impl Rclass {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Spec {
     name: Cow<'static, str>,
     cstring: Box<CStr>,

--- a/artichoke-backend/src/module.rs
+++ b/artichoke-backend/src/module.rs
@@ -185,7 +185,7 @@ impl Rclass {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Spec {
     name: Cow<'static, str>,
     sym: u32,
@@ -235,6 +235,11 @@ impl Spec {
     #[must_use]
     pub fn enclosing_scope(&self) -> Option<&EnclosingRubyScope> {
         self.enclosing_scope.as_ref()
+    }
+
+    #[must_use]
+    pub fn name_symbol(&self) -> u32 {
+        self.sym
     }
 
     #[must_use]


### PR DESCRIPTION
Calling `spec.clone()` and using this cloned spec to initialize objects
with `sys::mrb_data_object_alloc` is unsafe if the cloned spec is
dropped before the interpreter is closed because a `dfree` function
pointer associated with an `mrb_data_type` may be deallocated before
the object is collected.

This commit reworks the `EnclosingRubyScope` to store the components of
the class and module specs it requires, which does not include the
`mrb_data_type`.

This refactor was made easier by #793 which moved the
`EnclosingRubyScope` `Box` to the `EnclosingRubyScope` fields that
require it instead of boxing in the specs.