### PR TITLE
Modify artichoke-backend test harness to pass LeakSanitizer

### DIFF
--- a/artichoke-backend/src/convert/fixnum.rs
+++ b/artichoke-backend/src/convert/fixnum.rs
@@ -230,10 +230,10 @@ mod tests {
     #[test]
     fn fixnum_to_usize() {
         let interp = interpreter().unwrap();
-        let value = Convert::<_, Value>::convert(&interp, 100);
+        let value = Convert::<_, Value>::convert(&*interp, 100);
         let value = value.try_into::<usize>(&interp).unwrap();
         assert_eq!(100, value);
-        let value = Convert::<_, Value>::convert(&interp, -100);
+        let value = Convert::<_, Value>::convert(&*interp, -100);
         let value = value.try_into::<usize>(&interp);
         assert!(value.is_err());
     }

--- a/artichoke-backend/src/sys/mod.rs
+++ b/artichoke-backend/src/sys/mod.rs
@@ -137,6 +137,5 @@ mod tests {
                 format!("mruby 2.0 (v2.0.1) interpreter at {:p}", &*mrb)
             );
         };
-        interp.close();
     }
 }

--- a/artichoke-backend/src/value.rs
+++ b/artichoke-backend/src/value.rs
@@ -547,7 +547,7 @@ mod tests {
     fn to_s_fixnum() {
         let mut interp = interpreter().unwrap();
 
-        let value = Convert::<_, Value>::convert(&interp, 255);
+        let value = Convert::<_, Value>::convert(&*interp, 255);
         let string = value.to_s(&mut interp);
         assert_eq!(string, b"255");
     }
@@ -556,7 +556,7 @@ mod tests {
     fn inspect_fixnum() {
         let mut interp = interpreter().unwrap();
 
-        let value = Convert::<_, Value>::convert(&interp, 255);
+        let value = Convert::<_, Value>::convert(&*interp, 255);
         let debug = value.inspect(&mut interp);
         assert_eq!(debug, b"255");
     }
@@ -631,7 +631,7 @@ mod tests {
         assert!(!live.is_dead(&mut interp));
         // Fixnums are immediate even if they are created directly without an
         // interpreter.
-        let fixnum = Convert::<_, Value>::convert(&interp, 99);
+        let fixnum = Convert::<_, Value>::convert(&*interp, 99);
         assert!(!fixnum.is_dead(&mut interp));
     }
 


### PR DESCRIPTION
None of the unit tests (`#[test]` in `cfg(test)` blocks) in the
`artichoke-backend` crate call `Artichoke::close`, which means every
test that creates an interpreter via `interpreter().unwrap()` leaks
memory.

This makes running the tests with LeakSanitizer fail:

```shell
RUSTFLAGS="-Z sanitizer=leak" cargo +nightly test --target x86_64-apple-darwin -p artichoke-backend --lib
```

This commit exports a new `interpreter` function from the `test::prelude`
which wraps the `Artichoke` in a struct that derefs and deref muts to
`Artichoke` and has a custom `Drop` implementation which closes the
interpreter.

Some tests had to be modified to manually deref in cases where the
compiler could not insert auto-derefs.

Some FFI-oriented tests had to be modified to use `crate::interpreter`
directly for safety.

Fixes #930.

## LeakSanitizer run

```console
$ RUSTFLAGS="-Z sanitizer=leak" cargo +nightly test --target x86_64-apple-darwin -p artichoke-backend --lib

   Compiling artichoke-backend v0.1.0 (/Users/lopopolo/dev/artichoke/artichoke/artichoke-backend)
    Finished test [unoptimized + debuginfo] target(s) in 5.36s
     Running target/x86_64-apple-darwin/debug/deps/artichoke_backend-43f53d9969c96a66

running 199 tests
test class::tests::rclass_for_undef_nested_class ... ok
test convert::boolean::tests::fail_convert ... ok
test class::tests::super_class ... ok
test class::tests::rclass_for_undef_root_class ... ok
test class::tests::rclass_for_nested_class ... ok
test convert::array::tests::fail_convert ... ok
test class::tests::rclass_for_nested_class_under_class ... ok
test convert::boxing::tests::convert_obj_roundtrip ... ok
test convert::boxing::tests::convert_obj_not_data ... ok
test convert::bytes::tests::fail_convert ... ok
test convert::boolean::tests::nilable_bool_with_value ... ok
test convert::boolean::tests::nilable_roundtrip ... ok
test convert::boolean::tests::convert_to_nilable_bool ... ok
test convert::boolean::tests::bool_with_value ... ok
test convert::boolean::tests::convert_to_bool ... ok
test convert::boolean::tests::roundtrip_err ... ok
test convert::bytes::tests::convert_to_vec ... ok
test convert::fixnum::tests::fail_convert ... ok
test convert::array::tests::arr_int ... ok
test convert::fixnum::tests::fixnum_to_usize ... ok
test convert::array::tests::roundtrip_err ... ok
test convert::boolean::tests::roundtrip ... ok
test convert::bytes::tests::bytestring ... ok
test convert::bytes::tests::roundtrip_err ... ok
test convert::fixnum::tests::convert_to_fixnum ... ok
test convert::bytes::tests::roundtrip ... ok
test convert::float::tests::fail_convert ... ok
test convert::string::tests::fail_convert ... ok
test convert::array::tests::arr_nilable_bstr ... ok
test debug::tests::debug_array_value_as_classlike ... ok
test debug::tests::debug_false_value_as_classlike ... ok
test debug::tests::debug_fixnum_value_as_classlike ... ok
test debug::tests::debug_hash_value_as_classlike ... ok
test debug::tests::debug_nil_value_as_classlike ... ok
test def::free_test::free_prototype ... ok
test debug::tests::debug_true_value_as_classlike ... ok
test def::tests::fqname::integration_test ... ok
test def::tests::functional::define_method ... ok
test eval::tests::context_is_restored_after_eval ... ok
test eval::tests::eval_with_context ... ok
test eval::tests::file_magic_constant ... ok
test convert::array::tests::arr_utf8 ... ok
test eval::tests::file_not_persistent ... ok
test eval::tests::interpreter_is_usable_after_syntax_error ... ok
test eval::tests::nested::eval_context_is_a_stack ... ok
test eval::tests::return_syntax_error ... ok
test eval::tests::root_context_is_not_pushed_after_eval ... ok
test eval::tests::root_eval_context ... ok
test eval::tests::unparseable_code_returns_err_syntax_error ... ok
test exception_handler::tests::raise_does_not_panic_or_segfault ... ok
test exception_handler::tests::return_exception ... ok
test exception_handler::tests::return_exception_with_no_backtrace ... ok
test extn::core::exception::tests::raise ... ok
test extn::core::array::tests::functional ... ok
test convert::fixnum::tests::fixnum_with_value ... ok
test convert::fixnum::tests::roundtrip_err ... ok
test convert::fixnum::tests::roundtrip ... ok
test convert::float::tests::convert_to_float ... ok
test convert::string::tests::roundtrip ... ok
test convert::float::tests::roundtrip ... ok
test convert::string::tests::string_with_value ... ok
test convert::float::tests::roundtrip_err ... ok
test extn::core::kernel::require::test::absolute_path ... ok
test extn::core::regexp::opts::tests::parse_options ... ok
test extn::core::regexp::pattern::tests::embeds_the_pattern_after_the_options_after_parsing ... ok
test extn::core::regexp::pattern::tests::parse_a_single_group_with_options_as_the_main_regexp ... ok
test extn::core::regexp::pattern::tests::parse_abusive_options_literals ... ok
test extn::core::regexp::pattern::tests::parse_groups_with_options ... ok
test extn::core::regexp::pattern::tests::parse_literal_string_pattern ... ok
test extn::core::regexp::pattern::tests::parse_lookahead_groups ... ok
test extn::core::regexp::pattern::tests::parse_non_included_options_and_embed_expanded_modifiers_prefixed_by_a_minus_sign ... ok
test convert::float::tests::float_with_value ... ok
test extn::core::regexp::pattern::tests::parse_options_if_included_and_expand ... ok
test extn::core::regexp::pattern::tests::parse_patterns_with_no_enabled_options_and_expand_with_all_modifiers_excluded ... ok
test extn::core::regexp::pattern::tests::parse_to_fully_expanded_options_inline ... ok
test extn::core::regexp::pattern::tests::parse_uncaptured_groups ... ok
test extn::core::regexp::syntax::tests::escape_meta ... ok
test convert::string::tests::roundtrip_err ... ok
test convert::string::tests::utf8string ... ok
test extn::core::kernel::require::test::directory_err ... ok
test extn::core::kernel::require::test::path_defined_as_extension_file_then_source ... ok
test extn::core::kernel::require::test::functional ... ok
test convert::string::tests::convert_to_string ... ok
test extn::core::kernel::require::test::path_defined_as_source_then_extension_file ... ok
test extn::core::kernel::require::test::relative_with_dotted_path ... ok
This puts is displayed
#<Foo:0x62f0000cd480 @bar=1, @baz=2>
#<Foo:0x62f0000cd300 @bar=1, @baz=2>
#<Foo:0x62f0000cd2a0 @bar=3, @baz=4>
test ffi::tests::from_user_data_null_pointer ... ok
test extn::core::kernel::tests::functional ... ok
test fs::memory::hook_prototype_tests::prototype ... ok
test fs::tests::absolutize_absolute_path ... ok
test fs::tests::absolutize_absolute_path_dedot_current_dir ... ok
test fs::tests::absolutize_absolute_path_dedot_parent_dir ... ok
test fs::tests::absolutize_relative_path ... ok
test fs::tests::absolutize_relative_path_dedot_current_dir ... ok
test fs::tests::absolutize_relative_path_dedot_parent_dir_unix ... ok
test extn::core::thread::tests::functional ... ok
test extn::stdlib::forwardable::tests::functional ... ok
test extn::core::string::tests::functional ... ok
test extn::stdlib::abbrev::tests::functional ... ok
test extn::stdlib::monitor::tests::functional ... ok
test ffi::tests::from_user_data ... ok
test ffi::tests::from_user_data_null_user_data ... ok
test gc::tests::enable_disable_gc ... ok
test extn::stdlib::json::tests::functional ... ok
test gc::tests::gc_after_empty_eval ... ok
test interpreter::tests::open_close ... ok
test state::parser::context_test::top_filename_does_not_contain_nul_byte ... ok
test string::tests::ascii ... ok
test string::tests::emoji ... ok
test string::tests::escaped ... ok
test module::tests::rclass_for_nested_module ... ok
test string::tests::invalid_utf8 ... ok
test sys::ffi::bindgen_test_layout_RArray ... ok
test sys::ffi::bindgen_test_layout_RArray__bindgen_ty_1 ... ok
test sys::ffi::bindgen_test_layout_RArray__bindgen_ty_1__bindgen_ty_1 ... ok
test sys::ffi::bindgen_test_layout_RArray__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 ... ok
test sys::ffi::bindgen_test_layout_RBasic ... ok
test sys::ffi::bindgen_test_layout_RClass ... ok
test sys::ffi::bindgen_test_layout_RData ... ok
test sys::ffi::bindgen_test_layout_REnv ... ok
test sys::ffi::bindgen_test_layout_RFiber ... ok
test sys::ffi::bindgen_test_layout_RHash ... ok
test sys::ffi::bindgen_test_layout_RObject ... ok
test sys::ffi::bindgen_test_layout_RProc ... ok
test sys::ffi::bindgen_test_layout_RProc__bindgen_ty_1 ... ok
test sys::ffi::bindgen_test_layout_RProc__bindgen_ty_2 ... ok
test sys::ffi::bindgen_test_layout_RRange ... ok
test sys::ffi::bindgen_test_layout_RString ... ok
test sys::ffi::bindgen_test_layout_RString__bindgen_ty_1 ... ok
test sys::ffi::bindgen_test_layout_RString__bindgen_ty_1__bindgen_ty_1 ... ok
test sys::ffi::bindgen_test_layout_RString__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 ... ok
test sys::ffi::bindgen_test_layout___va_list_tag ... ok
test sys::ffi::bindgen_test_layout_kh_mt ... ok
test sys::ffi::bindgen_test_layout_mrb_ast_node ... ok
test sys::ffi::bindgen_test_layout_mrb_callinfo ... ok
test sys::ffi::bindgen_test_layout_mrb_context ... ok
test sys::ffi::bindgen_test_layout_mrb_data_type ... ok
test sys::ffi::bindgen_test_layout_mrb_gc ... ok
test sys::ffi::bindgen_test_layout_mrb_heap_page ... ok
test sys::ffi::bindgen_test_layout_mrb_insn_data ... ok
test sys::ffi::bindgen_test_layout_mrb_irep ... ok
test sys::ffi::bindgen_test_layout_mrb_jmpbuf ... ok
test module::tests::rclass_for_nested_module_under_class ... ok
test sys::ffi::bindgen_test_layout_mrb_kwargs ... ok
test sys::ffi::bindgen_test_layout_mrb_locals ... ok
test sys::ffi::bindgen_test_layout_mrb_parser_heredoc_info ... ok
test sys::ffi::bindgen_test_layout_mrb_parser_message ... ok
test sys::ffi::bindgen_test_layout_mrb_parser_state ... ok
test sys::ffi::bindgen_test_layout_mrb_range_edges ... ok
test sys::ffi::bindgen_test_layout_mrb_shared_array ... ok
test sys::ffi::bindgen_test_layout_mrb_state ... ok
test sys::ffi::bindgen_test_layout_mrb_value ... ok
test sys::ffi::bindgen_test_layout_mrb_value_union ... ok
test sys::ffi::bindgen_test_layout_mrbc_context ... ok
test gc::tests::arena_restore_on_drop ... ok
test gc::tests::arena_restore_on_explicit_restore ... ok
test gc::tests::gc_functional_test ... ok
test module::tests::rclass_for_undef_nested_module ... ok
test module::tests::rclass_for_root_module ... ok
test module::tests::rclass_for_undef_root_module ... ok
test sys::tests::interpreter_debug ... ok
test types::tests::parse_nil_ruby_type ... ok
test types::tests::parse_array_ruby_type ... ok
test types::tests::parse_bool_ruby_type ... ok
test types::tests::parse_class_ruby_type ... ok
test extn::stdlib::uri::tests::functional ... ok
test types::tests::parse_exception_ruby_type ... ok
test types::tests::parse_float_ruby_type ... ok
test types::tests::parse_hash_ruby_type ... ok
test types::tests::parse_fixnum_ruby_type ... ok
test types::tests::parse_module_ruby_type ... ok
test types::tests::parse_object_ruby_type ... ok
test types::tests::parse_proc_ruby_type ... ok
test types::tests::parse_range_ruby_type ... ok
test types::tests::parse_string_ruby_type ... ok
test types::tests::parse_symbol_ruby_type ... ok
test value::tests::funcall ... ok
test value::tests::funcall_different_types ... ok
test value::tests::funcall_type_error ... ok
test value::tests::funcall_method_not_exists ... ok
test value::tests::immediate_is_dead ... ok
test value::tests::inspect_empty_string ... ok
test value::tests::inspect_false ... ok
test value::tests::inspect_fixnum ... ok
test value::tests::inspect_nil ... ok
test value::tests::inspect_string ... ok
test value::tests::inspect_true ... ok
test value::tests::is_dead ... ok
test value::tests::to_s_empty_string ... ok
test value::tests::to_s_fixnum ... ok
test convert::hash::tests::roundtrip_kv ... ok
test value::tests::to_s_false ... ok
test value::tests::to_s_nil ... ok
test value::tests::to_s_string ... ok
test value::tests::to_s_true ... ok
test extn::core::integer::tests::positive_integer_division_send ... ok
test extn::core::integer::tests::negative_integer_division_send ... ok
test extn::core::integer::tests::negative_integer_division_vm_opcode ... ok
test extn::stdlib::strscan::tests::functional ... ok
test extn::core::integer::tests::positive_integer_division_vm_opcode ... ok

test result: ok. 199 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

```