### PR TITLE
Add tests and documentation for default bytes returned by SecureRandom

### DIFF
--- a/artichoke-backend/src/extn/stdlib/securerandom/trampoline.rs
+++ b/artichoke-backend/src/extn/stdlib/securerandom/trampoline.rs
@@ -64,6 +64,10 @@ pub fn hex(interp: &mut Artichoke, len: Option<Value>) -> Result<Value, Error> {
 #[inline]
 pub fn random_bytes(interp: &mut Artichoke, len: Option<Value>) -> Result<Value, Error> {
     let bytes = if let Some(len) = len {
+        // Upstream uses `n.to_int`, which means we must implicitly convert to
+        // int.
+        //
+        // https://github.com/ruby/ruby/blob/v2_6_3/lib/securerandom.rb#L135
         let len = len.implicitly_convert_to_int(interp)?;
         securerandom::random_bytes(Some(len))?
     } else {

--- a/spinoso-securerandom/src/lib.rs
+++ b/spinoso-securerandom/src/lib.rs
@@ -732,6 +732,14 @@ mod tests {
     }
 
     #[test]
+    fn random_bytes_default_bytes() {
+        // https://github.com/ruby/ruby/blob/v2_6_3/lib/securerandom.rb#L135
+        assert_eq!(super::DEFAULT_REQUESTED_BYTES, 16);
+        let default_requested_bytes = random_bytes(None).unwrap();
+        assert_eq!(default_requested_bytes.len(), 16);
+    }
+
+    #[test]
     fn random_bytes_len_must_be_positive() {
         assert!(matches!(random_bytes(Some(-1)), Err(Error::Argument(_))));
         assert!(matches!(base64(Some(-1)), Err(Error::Argument(_))));


### PR DESCRIPTION
`SecureRandom::random_bytes` returns 16 bytes by default if given a
`nil` length. Add a test that asserts the constant used in
`spinoso-secursecurerandom` is set correctly.

`SecureRandom::random_bytes` converts its argument using
`Object#to_int`. Add a comment documenting this to the `SecureRandom`
trampoline in `artichoke-backend`.

https://github.com/ruby/ruby/blob/v2_6_3/lib/securerandom.rb#L135