### PR TITLE
Group imports using rustfmt

### DIFF
--- a/artichoke-backend/build.rs
+++ b/artichoke-backend/build.rs
@@ -7,6 +7,7 @@ use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
+
 use target_lexicon::Triple;
 
 fn enumerate_sources<T>(path: T, paths: &mut Vec<PathBuf>) -> io::Result<()>
@@ -97,6 +98,7 @@ mod libmruby {
     use std::path::PathBuf;
     use std::process::Command;
     use std::str;
+
     use target_lexicon::{Architecture, OperatingSystem, Triple};
 
     use super::buildpath;

--- a/artichoke-backend/src/convert/hash.rs
+++ b/artichoke-backend/src/convert/hash.rs
@@ -106,8 +106,9 @@ impl TryConvertMut<Value, Vec<(Value, Value)>> for Artichoke {
 
 #[cfg(test)]
 mod tests {
-    use quickcheck::quickcheck;
     use std::collections::HashMap;
+
+    use quickcheck::quickcheck;
 
     use crate::test::prelude::*;
 

--- a/artichoke-backend/src/convert/string.rs
+++ b/artichoke-backend/src/convert/string.rs
@@ -55,9 +55,10 @@ impl<'a> TryConvertMut<Value, &'a str> for Artichoke {
 
 #[cfg(test)]
 mod tests {
-    use quickcheck::quickcheck;
     use std::convert::TryFrom;
     use std::slice;
+
+    use quickcheck::quickcheck;
 
     use crate::test::prelude::*;
 

--- a/artichoke-backend/src/eval.rs
+++ b/artichoke-backend/src/eval.rs
@@ -1,6 +1,7 @@
-use bstr::ByteSlice;
 use std::ffi::OsStr;
 use std::path::Path;
+
+use bstr::ByteSlice;
 
 use crate::core::{Eval, LoadSources, Parser, Value as _};
 use crate::error::Error;

--- a/artichoke-backend/src/exception_handler.rs
+++ b/artichoke-backend/src/exception_handler.rs
@@ -1,7 +1,8 @@
-use bstr::BString;
 use std::borrow::Cow;
 use std::error;
 use std::fmt;
+
+use bstr::BString;
 
 use crate::core::{TryConvertMut, Value as _};
 use crate::error::{Error, RubyException};

--- a/artichoke-backend/src/extn/core/array/mod.rs
+++ b/artichoke-backend/src/extn/core/array/mod.rs
@@ -1,9 +1,10 @@
-use spinoso_array::Array as SpinosoArray;
 use std::convert::TryFrom;
 use std::ffi::c_void;
 use std::iter::FromIterator;
 use std::ops::{Deref, DerefMut};
 use std::slice;
+
+use spinoso_array::Array as SpinosoArray;
 
 use crate::convert::UnboxedValueGuard;
 use crate::extn::prelude::*;
@@ -590,8 +591,9 @@ impl<'a> DerefMut for UnboxedValueGuard<'a, Array> {
 
 #[cfg(test)]
 mod tests {
-    use crate::test::prelude::*;
     use bstr::ByteSlice;
+
+    use crate::test::prelude::*;
 
     const SUBJECT: &str = "Array";
     const FUNCTIONAL_TEST: &[u8] = include_bytes!("array_functional_test.rb");

--- a/artichoke-backend/src/extn/core/env/mod.rs
+++ b/artichoke-backend/src/extn/core/env/mod.rs
@@ -18,9 +18,10 @@
 //!
 //! [`ENV`]: https://ruby-doc.org/core-2.6.3/ENV.html
 
-use spinoso_env::{ArgumentError as EnvArgumentError, Error as EnvError, InvalidError};
 use std::borrow::Cow;
 use std::collections::HashMap;
+
+use spinoso_env::{ArgumentError as EnvArgumentError, Error as EnvError, InvalidError};
 
 use crate::extn::prelude::*;
 

--- a/artichoke-backend/src/extn/core/kernel/integer.rs
+++ b/artichoke-backend/src/extn/core/kernel/integer.rs
@@ -1,10 +1,11 @@
-use bstr::ByteSlice;
 use std::convert::{TryFrom, TryInto};
 use std::error;
 use std::fmt;
 use std::iter::Iterator;
 use std::num::NonZeroU32;
 use std::str::{self, FromStr};
+
+use bstr::ByteSlice;
 
 use crate::extn::prelude::*;
 

--- a/artichoke-backend/src/extn/core/kernel/mod.rs
+++ b/artichoke-backend/src/extn/core/kernel/mod.rs
@@ -8,8 +8,9 @@ pub struct Kernel;
 
 #[cfg(test)]
 mod tests {
-    use crate::test::prelude::*;
     use bstr::ByteSlice;
+
+    use crate::test::prelude::*;
 
     const SUBJECT: &str = "Kernel";
     const FUNCTIONAL_TEST: &[u8] = include_bytes!("kernel_test.rb");

--- a/artichoke-backend/src/extn/core/kernel/require.rs
+++ b/artichoke-backend/src/extn/core/kernel/require.rs
@@ -1,8 +1,9 @@
 //! [`Kernel#require`](https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-require)
 
-use bstr::ByteSlice;
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
+
+use bstr::ByteSlice;
 
 use crate::extn::prelude::*;
 use crate::ffi;

--- a/artichoke-backend/src/extn/core/matchdata/mod.rs
+++ b/artichoke-backend/src/extn/core/matchdata/mod.rs
@@ -9,11 +9,12 @@
 //! [matchdata]: https://ruby-doc.org/core-2.6.3/MatchData.html
 //! [rubyspec]: https://github.com/ruby/spec
 
-use bstr::BString;
 use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::ops::{Bound, RangeBounds};
 use std::str;
+
+use bstr::BString;
 
 use crate::extn::core::regexp::backend::NilableString;
 use crate::extn::core::regexp::Regexp;

--- a/artichoke-backend/src/extn/core/math/mod.rs
+++ b/artichoke-backend/src/extn/core/math/mod.rs
@@ -26,7 +26,6 @@ pub mod trampoline;
 
 #[doc(inline)]
 pub use spinoso_math::{DomainError, Math, E, PI};
-
 use spinoso_math::{Error as MathError, NotImplementedError as MathNotImplementedError};
 
 impl RubyException for DomainError {

--- a/artichoke-backend/src/extn/core/random/mod.rs
+++ b/artichoke-backend/src/extn/core/random/mod.rs
@@ -21,15 +21,15 @@
 
 use core::convert::TryFrom;
 use core::ops::{Deref, DerefMut};
+
 use spinoso_random::{
     ArgumentError as RandomArgumentError, InitializeError, NewSeedError, Random as SpinosoRandom, UrandomError,
 };
+#[doc(inline)]
+pub use spinoso_random::{Max, Rand};
 
 use crate::convert::HeapAllocatedData;
 use crate::extn::prelude::*;
-
-#[doc(inline)]
-pub use spinoso_random::{Max, Rand};
 
 pub mod mruby;
 pub mod trampoline;

--- a/artichoke-backend/src/extn/core/regexp/backend/lazy.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/lazy.rs
@@ -1,11 +1,11 @@
-use once_cell::sync::OnceCell;
 use std::collections::HashMap;
 use std::fmt;
 
-use crate::extn::core::regexp::{Config, Encoding, Regexp, RegexpType, Scan, Source};
-use crate::extn::prelude::*;
+use once_cell::sync::OnceCell;
 
 use super::{NameToCaptureLocations, NilableString};
+use crate::extn::core::regexp::{Config, Encoding, Regexp, RegexpType, Scan, Source};
+use crate::extn::prelude::*;
 
 #[derive(Default, Debug)]
 pub struct Lazy {

--- a/artichoke-backend/src/extn/core/regexp/backend/onig.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/onig.rs
@@ -1,5 +1,4 @@
 use core::mem::size_of;
-use onig::{Regex, Syntax};
 use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::fmt;
@@ -7,11 +6,12 @@ use std::num::NonZeroUsize;
 use std::rc::Rc;
 use std::str;
 
+use onig::{Regex, Syntax};
+
+use super::{NameToCaptureLocations, NilableString};
 use crate::extn::core::matchdata::MatchData;
 use crate::extn::core::regexp::{self, Config, Encoding, Regexp, RegexpType, Scan, Source};
 use crate::extn::prelude::*;
-
-use super::{NameToCaptureLocations, NilableString};
 
 // The oniguruma `Regexp` backend requries that `u32` can be widened to `usize`
 // losslessly.

--- a/artichoke-backend/src/extn/core/regexp/backend/regex/utf8.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/regex/utf8.rs
@@ -1,15 +1,15 @@
-use regex::{Match, Regex, RegexBuilder};
 use std::collections::HashMap;
 use std::convert::{self, TryFrom};
 use std::fmt;
 use std::num::NonZeroUsize;
 use std::str;
 
+use regex::{Match, Regex, RegexBuilder};
+
+use super::super::{NameToCaptureLocations, NilableString};
 use crate::extn::core::matchdata::MatchData;
 use crate::extn::core::regexp::{self, Config, Encoding, Regexp, RegexpType, Scan, Source};
 use crate::extn::prelude::*;
-
-use super::super::{NameToCaptureLocations, NilableString};
 
 #[derive(Debug, Clone)]
 pub struct Utf8 {

--- a/artichoke-backend/src/extn/core/regexp/mod.rs
+++ b/artichoke-backend/src/extn/core/regexp/mod.rs
@@ -10,14 +10,14 @@ use std::hash::{Hash, Hasher};
 use std::num::NonZeroUsize;
 use std::str;
 
-use crate::extn::core::array::Array;
-use crate::extn::prelude::*;
-
 #[doc(inline)]
 pub use spinoso_regexp::{
     nth_match_group, Config, Encoding, Flags, InvalidEncodingError, Options, RegexpError, RegexpOption, Source,
     HIGHEST_MATCH_GROUP, LAST_MATCH, LAST_MATCHED_STRING, STRING_LEFT_OF_MATCH, STRING_RIGHT_OF_MATCH,
 };
+
+use crate::extn::core::array::Array;
+use crate::extn::prelude::*;
 
 pub mod backend;
 mod boxing;
@@ -28,12 +28,11 @@ pub mod pattern;
 pub mod syntax;
 pub mod trampoline;
 
-pub use backend::{NilableString, RegexpType, Scan};
-
 use backend::lazy::Lazy;
 #[cfg(feature = "core-regexp-oniguruma")]
 use backend::onig::Onig;
 use backend::regex::utf8::Utf8;
+pub use backend::{NilableString, RegexpType, Scan};
 
 pub type NameToCaptureLocations = Vec<(Vec<u8>, Vec<Int>)>;
 

--- a/artichoke-backend/src/extn/core/regexp/pattern.rs
+++ b/artichoke-backend/src/extn/core/regexp/pattern.rs
@@ -1,7 +1,8 @@
 //! Regexp pattern parsers.
 
-use bstr::ByteSlice;
 use core::iter;
+
+use bstr::ByteSlice;
 
 use super::{Flags, Options, RegexpOption};
 

--- a/artichoke-backend/src/extn/core/string/mod.rs
+++ b/artichoke-backend/src/extn/core/string/mod.rs
@@ -6,8 +6,9 @@ pub struct String;
 
 #[cfg(test)]
 mod tests {
-    use crate::test::prelude::*;
     use bstr::ByteSlice;
+
+    use crate::test::prelude::*;
 
     const SUBJECT: &str = "String";
     const FUNCTIONAL_TEST: &[u8] = include_bytes!("string_test.rb");

--- a/artichoke-backend/src/extn/core/thread/mod.rs
+++ b/artichoke-backend/src/extn/core/thread/mod.rs
@@ -28,8 +28,9 @@ pub struct Mutex;
 
 #[cfg(test)]
 mod tests {
-    use crate::test::prelude::*;
     use bstr::ByteSlice;
+
+    use crate::test::prelude::*;
 
     const SUBJECT: &str = "Thread";
     const FUNCTIONAL_TEST: &[u8] = include_bytes!("thread_test.rb");

--- a/artichoke-backend/src/extn/stdlib/abbrev/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/abbrev/mod.rs
@@ -12,8 +12,9 @@ pub struct Abbrev;
 
 #[cfg(test)]
 mod tests {
-    use crate::test::prelude::*;
     use bstr::ByteSlice;
+
+    use crate::test::prelude::*;
 
     const SUBJECT: &str = "Abbrev";
     const FUNCTIONAL_TEST: &[u8] = include_bytes!("abbrev_test.rb");

--- a/artichoke-backend/src/extn/stdlib/forwardable/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/forwardable/mod.rs
@@ -13,8 +13,9 @@ pub struct Forwardable;
 
 #[cfg(test)]
 mod tests {
-    use crate::test::prelude::*;
     use bstr::ByteSlice;
+
+    use crate::test::prelude::*;
 
     const SUBJECT: &str = "Forwardable";
     const FUNCTIONAL_TEST: &[u8] = include_bytes!("forwardable_test.rb");

--- a/artichoke-backend/src/extn/stdlib/json/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/json/mod.rs
@@ -27,8 +27,9 @@ pub struct Json;
 
 #[cfg(test)]
 mod tests {
-    use crate::test::prelude::*;
     use bstr::ByteSlice;
+
+    use crate::test::prelude::*;
 
     const SUBJECT: &str = "JSON";
     const FUNCTIONAL_TEST: &[u8] = include_bytes!("json_test.rb");

--- a/artichoke-backend/src/extn/stdlib/monitor/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/monitor/mod.rs
@@ -12,8 +12,9 @@ pub struct Monitor;
 
 #[cfg(test)]
 mod tests {
-    use crate::test::prelude::*;
     use bstr::ByteSlice;
+
+    use crate::test::prelude::*;
 
     const SUBJECT: &str = "Monitor";
     const FUNCTIONAL_TEST: &[u8] = include_bytes!("monitor_test.rb");

--- a/artichoke-backend/src/extn/stdlib/strscan/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/strscan/mod.rs
@@ -12,8 +12,9 @@ pub struct StringScanner;
 
 #[cfg(test)]
 mod tests {
-    use crate::test::prelude::*;
     use bstr::ByteSlice;
+
+    use crate::test::prelude::*;
 
     const SUBJECT: &str = "StringScanner";
     const FUNCTIONAL_TEST: &[u8] = include_bytes!("strscan_test.rb");

--- a/artichoke-backend/src/extn/stdlib/uri/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/uri/mod.rs
@@ -43,8 +43,9 @@ pub struct Uri;
 
 #[cfg(test)]
 mod tests {
-    use crate::test::prelude::*;
     use bstr::ByteSlice;
+
+    use crate::test::prelude::*;
 
     const SUBJECT: &str = "URI";
     const FUNCTIONAL_TEST: &[u8] = include_bytes!("uri_test.rb");

--- a/artichoke-backend/src/ffi.rs
+++ b/artichoke-backend/src/ffi.rs
@@ -2,13 +2,14 @@
 //!
 //! These functions are unsafe. Use them carefully.
 
-use bstr::{ByteSlice, ByteVec};
 use std::borrow::Cow;
 use std::error;
 use std::ffi::{OsStr, OsString};
 use std::fmt;
 use std::mem;
 use std::ptr::{self, NonNull};
+
+use bstr::{ByteSlice, ByteVec};
 
 use crate::class_registry::ClassRegistry;
 use crate::core::ConvertMut;

--- a/artichoke-backend/src/fs/memory.rs
+++ b/artichoke-backend/src/fs/memory.rs
@@ -405,9 +405,8 @@ impl Filesystem for Memory {
 
 #[cfg(test)]
 mod hook_prototype_tests {
-    use crate::test::prelude::*;
-
     use super::Extension;
+    use crate::test::prelude::*;
 
     struct TestFile;
 

--- a/artichoke-backend/src/intern.rs
+++ b/artichoke-backend/src/intern.rs
@@ -1,5 +1,6 @@
-use intaglio::SymbolOverflowError;
 use std::borrow::Cow;
+
+use intaglio::SymbolOverflowError;
 
 use crate::class_registry::ClassRegistry;
 use crate::core::ConvertMut;

--- a/artichoke-backend/src/lib.rs
+++ b/artichoke-backend/src/lib.rs
@@ -162,10 +162,11 @@ mod warn;
 #[cfg(test)]
 mod test;
 
+pub use artichoke_core::prelude as core;
+
 pub use crate::artichoke::{Artichoke, Guard};
 pub use crate::error::{Error, RubyException};
 pub use crate::interpreter::{interpreter, interpreter_with_config};
-pub use artichoke_core::prelude as core;
 
 /// A "prelude" for users of the `artichoke-backend` crate.
 ///

--- a/artichoke-backend/src/state/output.rs
+++ b/artichoke-backend/src/state/output.rs
@@ -1,6 +1,7 @@
-use bstr::BString;
 use std::fmt;
 use std::io::{self, Write};
+
+use bstr::BString;
 
 #[cfg(all(not(feature = "output-strategy-capture"), not(feature = "output-strategy-null")))]
 pub type Strategy = Process;

--- a/artichoke-backend/src/string.rs
+++ b/artichoke-backend/src/string.rs
@@ -6,10 +6,11 @@
 //!
 //! Artichoke aims to support ASCII, UTF-8, maybe UTF-8, and binary encodings.
 
-use scolapasta_string_escape::format_debug_escape_into;
 use std::borrow::{Borrow, BorrowMut, Cow};
 use std::error;
 use std::fmt;
+
+use scolapasta_string_escape::format_debug_escape_into;
 
 use crate::class_registry::ClassRegistry;
 use crate::core::ConvertMut;

--- a/artichoke-backend/src/value.rs
+++ b/artichoke-backend/src/value.rs
@@ -1,13 +1,14 @@
-use artichoke_core::convert::{Convert, ConvertMut, TryConvert};
-use artichoke_core::debug::Debug;
-use artichoke_core::intern::Intern;
-use artichoke_core::value::Value as ValueCore;
 use std::borrow::Cow;
 use std::convert::TryFrom;
 use std::error;
 use std::fmt;
 use std::mem;
 use std::ptr;
+
+use artichoke_core::convert::{Convert, ConvertMut, TryConvert};
+use artichoke_core::debug::Debug;
+use artichoke_core::intern::Intern;
+use artichoke_core::value::Value as ValueCore;
 
 use crate::class_registry::ClassRegistry;
 use crate::convert::BoxUnboxVmValue;

--- a/build.rs
+++ b/build.rs
@@ -2,12 +2,13 @@
 #![deny(clippy::pedantic)]
 #![allow(clippy::restriction)]
 
-use chrono::prelude::*;
 use std::env;
 use std::ffi::OsString;
 use std::fmt;
 use std::process::Command;
 use std::str::{self, FromStr};
+
+use chrono::prelude::*;
 use target_lexicon::Triple;
 
 #[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -10,3 +10,5 @@ use_small_heuristics = "Default"
 
 use_field_init_shorthand = true
 use_try_shorthand = true
+
+group_imports = 'StdExternalCrate'

--- a/scolapasta-string-escape/src/literal.rs
+++ b/scolapasta-string-escape/src/literal.rs
@@ -584,8 +584,9 @@ impl FusedIterator for Literal {}
 /// ```
 #[cfg(test)]
 mod tests {
-    use super::Literal;
     use alloc::string::String;
+
+    use super::Literal;
 
     #[test]
     #[allow(clippy::too_many_lines)]

--- a/scolapasta-string-escape/src/string.rs
+++ b/scolapasta-string-escape/src/string.rs
@@ -62,8 +62,9 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::format_debug_escape_into;
     use alloc::string::String;
+
+    use super::format_debug_escape_into;
 
     #[test]
     fn format_ascii_message() {

--- a/spinoso-array/src/array/smallvec/eq.rs
+++ b/spinoso-array/src/array/smallvec/eq.rs
@@ -1,5 +1,6 @@
 use alloc::boxed::Box;
 use alloc::vec::Vec;
+
 use smallvec::SmallVec;
 
 use crate::array::smallvec::SmallArray;

--- a/spinoso-array/src/array/smallvec/impls.rs
+++ b/spinoso-array/src/array/smallvec/impls.rs
@@ -1,6 +1,7 @@
 use core::borrow::{Borrow, BorrowMut};
 use core::ops::{Deref, DerefMut, Index, IndexMut};
 use core::slice::{Iter, IterMut, SliceIndex};
+
 use smallvec::SmallVec;
 
 use crate::array::smallvec::SmallArray;

--- a/spinoso-array/src/array/smallvec/mod.rs
+++ b/spinoso-array/src/array/smallvec/mod.rs
@@ -4,6 +4,7 @@ use alloc::boxed::Box;
 use alloc::vec::Vec;
 use core::cmp;
 use core::slice::{Iter, IterMut};
+
 use smallvec::SmallVec;
 
 use crate::array::INLINE_CAPACITY;

--- a/spinoso-array/src/array/vec/convert.rs
+++ b/spinoso-array/src/array/vec/convert.rs
@@ -8,10 +8,9 @@ use core::iter::FromIterator;
 #[cfg(feature = "small-array")]
 use smallvec::SmallVec;
 
-use crate::array::vec::Array;
-
 #[cfg(feature = "small-array")]
 use crate::array::smallvec::SmallArray;
+use crate::array::vec::Array;
 #[cfg(feature = "small-array")]
 use crate::array::INLINE_CAPACITY;
 

--- a/spinoso-array/src/lib.rs
+++ b/spinoso-array/src/lib.rs
@@ -155,7 +155,6 @@ mod array;
 
 #[cfg(feature = "small-array")]
 pub use array::smallvec::SmallArray;
+pub use array::vec::Array;
 #[cfg(feature = "small-array")]
 pub use array::INLINE_CAPACITY;
-
-pub use array::vec::Array;

--- a/spinoso-env/src/env/memory.rs
+++ b/spinoso-env/src/env/memory.rs
@@ -1,6 +1,7 @@
-use bstr::ByteSlice;
 use std::borrow::Cow;
 use std::collections::HashMap;
+
+use bstr::ByteSlice;
 
 use crate::{ArgumentError, Error, InvalidError};
 

--- a/spinoso-env/src/env/system.rs
+++ b/spinoso-env/src/env/system.rs
@@ -1,7 +1,8 @@
-use bstr::{ByteSlice, ByteVec};
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::env;
+
+use bstr::{ByteSlice, ByteVec};
 
 use crate::{ArgumentError, Error, InvalidError};
 

--- a/spinoso-env/src/lib.rs
+++ b/spinoso-env/src/lib.rs
@@ -108,9 +108,10 @@ macro_rules! readme {
 readme!();
 
 use core::fmt;
-use scolapasta_string_escape::format_debug_escape_into;
 use std::borrow::Cow;
 use std::error;
+
+use scolapasta_string_escape::format_debug_escape_into;
 
 mod env;
 

--- a/spinoso-math/src/lib.rs
+++ b/spinoso-math/src/lib.rs
@@ -78,14 +78,13 @@
 //! [`NaN`]: f64::NAN
 //! [`alloc`]: https://doc.rust-lang.org/alloc/
 
-use core::fmt;
-#[cfg(feature = "std")]
-use std::error;
-
 #[doc(inline)]
 pub use core::f64::consts::E;
 #[doc(inline)]
 pub use core::f64::consts::PI;
+use core::fmt;
+#[cfg(feature = "std")]
+use std::error;
 
 mod math;
 

--- a/spinoso-random/src/lib.rs
+++ b/spinoso-random/src/lib.rs
@@ -105,11 +105,12 @@ mod rand;
 mod random;
 mod urandom;
 
-#[cfg(feature = "random-rand")]
-pub use self::rand::{rand, Max, Rand};
 pub use random::ruby::Mt;
 pub use random::{new_seed, seed_to_key, Random};
 pub use urandom::urandom;
+
+#[cfg(feature = "random-rand")]
+pub use self::rand::{rand, Max, Rand};
 
 // Ensure code blocks in README.md compile
 #[cfg(doctest)]

--- a/spinoso-random/src/rand.rs
+++ b/spinoso-random/src/rand.rs
@@ -1,4 +1,5 @@
 use core::fmt;
+
 use rand::Rng;
 
 use crate::{ArgumentError, Random};

--- a/spinoso-regexp/src/debug.rs
+++ b/spinoso-regexp/src/debug.rs
@@ -1,5 +1,6 @@
 use core::fmt;
 use core::iter::FusedIterator;
+
 use scolapasta_string_escape::Literal;
 
 #[derive(Debug, Clone, Copy)]

--- a/spinoso-regexp/src/encoding.rs
+++ b/spinoso-regexp/src/encoding.rs
@@ -1,11 +1,12 @@
 //! Parse encoding parameter to `Regexp#initialize` and `Regexp::compile`.
 
-use bstr::ByteSlice;
 use core::convert::TryFrom;
 use core::fmt;
 use core::hash::{Hash, Hasher};
 use core::mem;
 use std::error;
+
+use bstr::ByteSlice;
 
 use crate::Flags;
 

--- a/spinoso-regexp/src/lib.rs
+++ b/spinoso-regexp/src/lib.rs
@@ -1,10 +1,11 @@
 #[macro_use]
 extern crate bitflags;
 
-use bstr::ByteSlice;
 use core::fmt;
 use core::num::NonZeroUsize;
 use std::borrow::Cow;
+
+use bstr::ByteSlice;
 
 pub mod debug;
 mod encoding;

--- a/spinoso-regexp/src/options.rs
+++ b/spinoso-regexp/src/options.rs
@@ -1,8 +1,9 @@
 //! Parse options parameter to `Regexp#initialize` and `Regexp::compile`.
 
-use bstr::ByteSlice;
 use core::convert::TryFrom;
 use core::fmt;
+
+use bstr::ByteSlice;
 
 use crate::Flags;
 

--- a/spinoso-securerandom/src/lib.rs
+++ b/spinoso-securerandom/src/lib.rs
@@ -106,10 +106,10 @@ readme!();
 
 use core::convert::TryFrom;
 use core::fmt;
-use rand::distributions::Alphanumeric;
-use rand::{self, Rng, RngCore};
 use std::error;
 
+use rand::distributions::Alphanumeric;
+use rand::{self, Rng, RngCore};
 use scolapasta_hex as hex;
 
 mod uuid;
@@ -724,6 +724,7 @@ pub fn uuid() -> Result<String, RandomBytesError> {
 #[cfg(test)]
 mod tests {
     use core::ops::Not;
+
     use rand::CryptoRng;
 
     use super::{alphanumeric, base64, hex, random_bytes, random_number, uuid, DomainError, Error, Max, Rand};

--- a/spinoso-symbol/src/all_symbols.rs
+++ b/spinoso-symbol/src/all_symbols.rs
@@ -1,7 +1,8 @@
-use artichoke_core::intern::Intern;
 use core::convert::TryInto;
 use core::iter::FusedIterator;
 use core::ops::Range;
+
+use artichoke_core::intern::Intern;
 
 use crate::Symbol;
 
@@ -205,8 +206,9 @@ impl FusedIterator for AllSymbols {}
 
 #[cfg(test)]
 mod tests {
-    use artichoke_core::intern::Intern;
     use std::borrow::Cow;
+
+    use artichoke_core::intern::Intern;
 
     use super::InternerAllSymbols;
     use crate::Symbol;

--- a/spinoso-symbol/src/casecmp/ascii.rs
+++ b/spinoso-symbol/src/casecmp/ascii.rs
@@ -1,7 +1,8 @@
 //! ASCII case folding comparisons for byte content resolved from `Symbol`s.
 
-use artichoke_core::intern::Intern;
 use core::cmp::Ordering;
+
+use artichoke_core::intern::Intern;
 
 /// Compare the byte contents of two symbols using ASCII case-insensitive
 /// comparison.

--- a/spinoso-symbol/src/casecmp/unicode.rs
+++ b/spinoso-symbol/src/casecmp/unicode.rs
@@ -1,8 +1,8 @@
 //! Unicode case folding comparisons for byte content resolved from `Symbol`s.
 
-use artichoke_core::intern::Intern;
 use core::str;
 
+use artichoke_core::intern::Intern;
 use focaccia::CaseFold;
 
 /// Compare the byte contents of two symbols using Unicode case-folding

--- a/spinoso-symbol/src/ident.rs
+++ b/spinoso-symbol/src/ident.rs
@@ -48,10 +48,11 @@
 //! assert_eq!("spinoso_symbol=".parse::<IdentifierType>(), Ok(IdentifierType::AttrSet));
 //! ```
 
-use bstr::ByteSlice;
 use core::convert::TryFrom;
 use core::fmt;
 use core::str::FromStr;
+
+use bstr::ByteSlice;
 
 /// Valid types for Ruby identifiers.
 ///
@@ -630,10 +631,11 @@ fn is_special_global_punct(ch: u8) -> bool {
 #[cfg(test)]
 #[allow(clippy::shadow_unrelated)]
 mod tests {
+    use core::convert::TryFrom;
+
     use super::{
         is_ident_until, is_next_ident_exhausting, is_special_global_name, IdentifierType, ParseIdentifierError,
     };
-    use core::convert::TryFrom;
 
     #[test]
     fn special_global_name() {

--- a/spinoso-symbol/src/inspect.rs
+++ b/spinoso-symbol/src/inspect.rs
@@ -1,6 +1,7 @@
 use core::convert::TryFrom;
 use core::fmt;
 use core::iter::FusedIterator;
+
 use scolapasta_string_escape::{is_ascii_char_with_escape, Literal};
 
 use crate::ident::IdentifierType;

--- a/spinoso-symbol/src/lib.rs
+++ b/spinoso-symbol/src/lib.rs
@@ -95,13 +95,13 @@ macro_rules! readme {
 #[cfg(all(feature = "inspect", doctest))]
 readme!();
 
-#[cfg(feature = "artichoke")]
-use artichoke_core::intern::Intern;
 use core::borrow::Borrow;
 use core::fmt;
 use core::mem::size_of;
 use core::num::TryFromIntError;
 
+#[cfg(feature = "artichoke")]
+use artichoke_core::intern::Intern;
 #[doc(inline)]
 #[cfg(feature = "artichoke")]
 #[cfg_attr(docsrs, doc(cfg(feature = "artichoke")))]

--- a/spinoso-time/src/time/chrono/mod.rs
+++ b/spinoso-time/src/time/chrono/mod.rs
@@ -1,7 +1,8 @@
-use chrono::prelude::*;
 use core::cmp::Ordering;
 use core::convert::TryFrom;
 use core::hash::{Hash, Hasher};
+
+use chrono::prelude::*;
 
 use crate::{ComponentOutOfRangeError, NANOS_IN_SECOND};
 
@@ -282,8 +283,9 @@ impl TryFrom<ToA> for Time {
 
 #[cfg(test)]
 mod leap_second {
-    use super::{Time, ToA, NANOS_IN_SECOND};
     use chrono::prelude::*;
+
+    use super::{Time, ToA, NANOS_IN_SECOND};
 
     #[test]
     fn from_datetime() {
@@ -317,12 +319,14 @@ mod leap_second {
 
 #[cfg(test)]
 mod tests {
-    use super::Time;
-    use chrono::prelude::*;
-    use chrono_tz::Tz;
     use core::cmp::Ordering;
     use core::hash::{Hash, Hasher};
     use std::collections::hash_map::DefaultHasher;
+
+    use chrono::prelude::*;
+    use chrono_tz::Tz;
+
+    use super::Time;
 
     fn date() -> NaiveDateTime {
         // Artichoke's birthday, 2019-04-07T01:30Z

--- a/spinoso-time/src/time/chrono/ops.rs
+++ b/spinoso-time/src/time/chrono/ops.rs
@@ -1,9 +1,10 @@
-use chrono::prelude::*;
-use chrono::Duration;
-use chrono_tz::Tz;
 use core::convert::TryFrom;
 use core::ops::{Add, Sub};
 use std::time;
+
+use chrono::prelude::*;
+use chrono::Duration;
+use chrono_tz::Tz;
 
 use crate::time::chrono::{Offset, Time};
 
@@ -322,8 +323,9 @@ impl Sub<f64> for Time {
 
 #[cfg(test)]
 mod tests {
-    use super::Time;
     use chrono::prelude::*;
+
+    use super::Time;
 
     fn datetime() -> DateTime<Utc> {
         // halfway through a second

--- a/src/backtrace.rs
+++ b/src/backtrace.rs
@@ -2,6 +2,7 @@
 
 use std::error;
 use std::io;
+
 use termcolor::{ColorSpec, WriteColor};
 
 use crate::prelude::*;

--- a/src/bin/airb.rs
+++ b/src/bin/airb.rs
@@ -27,9 +27,10 @@
 #![doc(html_favicon_url = "https://www.artichokeruby.org/favicon.ico")]
 #![doc(html_logo_url = "https://www.artichokeruby.org/artichoke-logo.svg")]
 
-use artichoke::repl;
 use std::io::{self, Write};
 use std::process;
+
+use artichoke::repl;
 use termcolor::{ColorChoice, StandardStream, WriteColor};
 
 fn main() {

--- a/src/bin/artichoke.rs
+++ b/src/bin/artichoke.rs
@@ -41,12 +41,13 @@
 //!     <programfile>
 //! ```
 
-use artichoke::ruby::{self, Args};
-use clap::{App, Arg};
 use std::ffi::OsString;
 use std::io::{self, Write};
 use std::path::PathBuf;
 use std::process;
+
+use artichoke::ruby::{self, Args};
+use clap::{App, Arg};
 use termcolor::{ColorChoice, StandardStream, WriteColor};
 
 fn main() {

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -4,11 +4,12 @@
 //! multi-line Ruby expressions, CTRL-C to break out of an expression, and can
 //! inspect return values and exception backtraces.
 
-use rustyline::error::ReadlineError;
-use rustyline::Editor;
 use std::error;
 use std::fmt;
 use std::io;
+
+use rustyline::error::ReadlineError;
+use rustyline::Editor;
 use termcolor::WriteColor;
 
 use crate::backend::state::parser::Context;

--- a/src/ruby.rs
+++ b/src/ruby.rs
@@ -7,6 +7,7 @@ use std::error;
 use std::ffi::{OsStr, OsString};
 use std::io;
 use std::path::{Path, PathBuf};
+
 use termcolor::WriteColor;
 
 use crate::backend::ffi;


### PR DESCRIPTION
Add `group_imports = 'StdExternalCrate'` rustfmt config and format
with rustfmt 1.4.29-nightly (70ce1825 2020-12-04) from
rustc 1.50.0-nightly (f0f68778f 2020-12-09).

This PR should not be deployed until Rust 1.50.0 is released.