### PR TITLE
Reduce size of spinoso_symbol::Inspect iterator

### DIFF
--- a/scolapasta-string-escape/src/literal.rs
+++ b/scolapasta-string-escape/src/literal.rs
@@ -1,5 +1,6 @@
 use core::iter::FusedIterator;
-use core::str::Chars;
+use core::slice;
+use core::str;
 
 /// Returns whether a [`char`] is ASCII and has a literal escape code.
 ///
@@ -99,7 +100,13 @@ pub const fn is_ascii_char_with_escape(ch: char) -> bool {
 /// [`format_debug_escape_into`]: crate::format_debug_escape_into
 #[derive(Debug, Clone)]
 #[must_use = "this `Literal` is an `Iterator`, which should be consumed if constructed"]
-pub struct Literal(Chars<'static>);
+pub struct Literal(slice::Iter<'static, u8>);
+
+impl Default for Literal {
+    fn default() -> Self {
+        Literal(b"".iter())
+    }
+}
 
 impl Literal {
     /// Views the underlying data as a subslice of the original data.
@@ -125,7 +132,7 @@ impl Literal {
     #[inline]
     #[must_use]
     pub fn as_str(&self) -> &'static str {
-        self.0.as_str()
+        str::from_utf8(self.0.as_slice()).unwrap_or_default()
     }
 
     /// Return the debug escape code for the given byte.
@@ -503,7 +510,7 @@ impl From<u8> for Literal {
     #[inline]
     fn from(byte: u8) -> Self {
         let escape = Self::debug_escape(byte);
-        Self(escape.chars())
+        Self(escape.as_bytes().iter())
     }
 }
 
@@ -512,12 +519,12 @@ impl Iterator for Literal {
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
-        self.0.next()
+        self.0.next().map(|&byte| byte as char)
     }
 
     #[inline]
     fn nth(&mut self, n: usize) -> Option<Self::Item> {
-        self.0.nth(n)
+        self.0.nth(n).map(|&byte| byte as char)
     }
 
     #[inline]
@@ -532,19 +539,19 @@ impl Iterator for Literal {
 
     #[inline]
     fn last(self) -> Option<Self::Item> {
-        self.0.last()
+        self.0.last().map(|&byte| byte as char)
     }
 }
 
 impl DoubleEndedIterator for Literal {
     #[inline]
     fn next_back(&mut self) -> Option<Self::Item> {
-        self.0.next_back()
+        self.0.next_back().map(|&byte| byte as char)
     }
 
     #[inline]
     fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
-        self.0.nth_back(n)
+        self.0.nth_back(n).map(|&byte| byte as char)
     }
 }
 


### PR DESCRIPTION
Reduce the size of `spinoso_symbol::Inspect` from 152 bytes to 136
bytes. This commit contains optimizations and code quality and
readability improvements:

- Change `scolapasta_string_escape::Literal` to wrap a byte slice
  iterator instead of a `Chars` iterator. `Literal` only ever yields
  ASCII characters, so this change removes the overhead of decoding
  codepoints from the underlying slice.
- Implement `Default` for `scolapasta_string_escape::Literal` such that
  it yields the empty string.
- Remove the `string` field of the source byte slice from `Inspect`'s
  inner `State` struct. `bstr::CharIndices` has a
  `CharIndices::as_bytes` method that gives access to the remaining
  slice. This change required reworking the subslice indexing slightly.
- Collapse `is_ident`, `leading_colon_sigil`, `open_quote`, and
  `close_quote` into a `Flags` newtype around a `u8`. All states are
  implemented using bitflags. The `Flags` struct has mutable methods
  that consume bitflags and yield `Option<char>`. This makes the
  `Iterator::next` and `DoubleEndedIterator::next_back` methods on
  `State` easier to read.
- Rename `next` and `next_back` fields on `State` to
  `forward_byte_literal` and `reverse_byte_literal`.
- Replace `[Option<Literal>; 3]` fields with a struct that implements
  `Iterator` and `DoubleEndedIterator`. This pulls construction of the
  byte literal iterator out of the `next` and `next_back` methods on
  `State`, which makes the code easier to read.