### PR TITLE
Remove uses of bstr::CharIndices from spinoso-symbol ident parser

### DIFF
--- a/spinoso-symbol/Cargo.toml
+++ b/spinoso-symbol/Cargo.toml
@@ -31,9 +31,9 @@ default = ["artichoke", "std"]
 artichoke = ["artichoke-core", "focaccia", "inspect"]
 # Implement an iterator for printing debug output of a bytestring associated
 # with a `Symbol` that is suitable for implementing `Symbol#inspect`.
-inspect = ["ident-parser"]
+inspect = ["ident-parser", "scolapasta-string-escape"]
 # Add a parser for valid Ruby identifiers.
-ident-parser = ["bstr", "scolapasta-string-escape"]
+ident-parser = ["bstr"]
 # By default, `spinoso-symbol` is `no_std`. This feature enables
 # `std::error::Error` impls. This feature activates `focaccia/std` to enable
 # `Error` impls on the re-exported error structs.

--- a/spinoso-symbol/src/ident.rs
+++ b/spinoso-symbol/src/ident.rs
@@ -528,7 +528,7 @@ fn is_ident_until(mut name: &[u8]) -> Option<usize> {
         match ch {
             Some(ch) if !is_ident_char(ch) => return Some(start),
             None => return Some(start),
-            _ => {
+            Some(_) => {
                 name = &name[size..];
                 start += size;
             }


### PR DESCRIPTION
- Use `ByteSlice::chars` when only checking for case properties of valid
  UTF-8 characters.
- Use `bstr::decode_utf8` in local/constant ident parsing routines.
- Add tests for `is_special_global_name`.
- Add tests for `is_ident_until`.
- Add tests for `is_next_ident_exhausting`.

Similar to #953.