### PR TITLE
Fixup some deviations from preferred style

### DIFF
--- a/artichoke-backend/src/convert/boxing.rs
+++ b/artichoke-backend/src/convert/boxing.rs
@@ -295,6 +295,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    use bstr::ByteSlice;
+
     use crate::test::prelude::*;
 
     // this struct is heap allocated.
@@ -345,7 +347,7 @@ mod tests {
         let mut value = Container::alloc_value(obj, &mut interp).unwrap();
         let class = value.funcall(&mut interp, "class", &[], None).unwrap();
         let class_display = class.to_s(&mut interp);
-        assert_eq!(class_display, b"Container");
+        assert_eq!(class_display.as_bstr(), b"Container".as_bstr());
 
         let data = unsafe { Container::unbox_from_value(&mut value, &mut interp) }.unwrap();
 
@@ -382,7 +384,7 @@ mod tests {
         let mut value = interp.convert_mut("string");
         let class = value.funcall(&mut interp, "class", &[], None).unwrap();
         let class_display = class.to_s(&mut interp);
-        assert_eq!(class_display, b"String");
+        assert_eq!(class_display.as_bstr(), b"String".as_bstr());
 
         let data = unsafe { Container::unbox_from_value(&mut value, &mut interp) };
         assert!(data.is_err());
@@ -391,7 +393,7 @@ mod tests {
         let mut value = Box::<Flag>::alloc_value(flag, &mut interp).unwrap();
         let class = value.funcall(&mut interp, "class", &[], None).unwrap();
         let class_display = class.to_s(&mut interp);
-        assert_eq!(class_display, b"Flag");
+        assert_eq!(class_display.as_bstr(), b"Flag".as_bstr());
 
         let data = unsafe { Container::unbox_from_value(&mut value, &mut interp) };
         assert!(data.is_err());

--- a/artichoke-backend/src/convert/fixnum.rs
+++ b/artichoke-backend/src/convert/fixnum.rs
@@ -41,10 +41,7 @@ impl TryConvert<u64, Value> for Artichoke {
             let fixnum = unsafe { sys::mrb_sys_fixnum_value(value) };
             Ok(Value::from(fixnum))
         } else {
-            Err(Error::from(BoxIntoRubyError::new(
-                Rust::UnsignedInt,
-                Ruby::Fixnum,
-            )))
+            Err(BoxIntoRubyError::new(Rust::UnsignedInt, Ruby::Fixnum).into())
         }
     }
 }
@@ -61,10 +58,7 @@ impl TryConvert<usize, Value> for Artichoke {
             let fixnum = unsafe { sys::mrb_sys_fixnum_value(value) };
             Ok(Value::from(fixnum))
         } else {
-            Err(Error::from(BoxIntoRubyError::new(
-                Rust::UnsignedInt,
-                Ruby::Fixnum,
-            )))
+            Err(BoxIntoRubyError::new(Rust::UnsignedInt, Ruby::Fixnum).into())
         }
     }
 }
@@ -102,10 +96,7 @@ impl TryConvert<isize, Value> for Artichoke {
             let fixnum = unsafe { sys::mrb_sys_fixnum_value(value) };
             Ok(Value::from(fixnum))
         } else {
-            Err(Error::from(BoxIntoRubyError::new(
-                Rust::SignedInt,
-                Ruby::Fixnum,
-            )))
+            Err(BoxIntoRubyError::new(Rust::SignedInt, Ruby::Fixnum).into())
         }
     }
 }

--- a/artichoke-backend/src/eval.rs
+++ b/artichoke-backend/src/eval.rs
@@ -72,6 +72,8 @@ impl Eval for Artichoke {
 
 #[cfg(test)]
 mod tests {
+    use bstr::ByteSlice;
+
     use crate::test::prelude::*;
 
     #[test]
@@ -90,7 +92,7 @@ mod tests {
         let _ = interp.eval(b"15").unwrap();
         let context = interp.peek_context().unwrap();
         let filename = context.unwrap().filename();
-        assert_eq!(filename, &b"context.rb"[..]);
+        assert_eq!(filename.as_bstr(), b"context.rb".as_bstr());
     }
 
     #[test]

--- a/artichoke-backend/src/extn/core/array/args.rs
+++ b/artichoke-backend/src/extn/core/array/args.rs
@@ -1,7 +1,6 @@
 use std::convert::TryFrom;
 
 use crate::extn::prelude::*;
-use crate::string::WriteError;
 use crate::sys::protect;
 
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]

--- a/artichoke-backend/src/extn/core/exception/mod.rs
+++ b/artichoke-backend/src/extn/core/exception/mod.rs
@@ -128,6 +128,8 @@ ruby_exception_impl!(Fatal);
 
 #[cfg(test)]
 mod tests {
+    use bstr::ByteSlice;
+
     use crate::test::prelude::*;
 
     struct Run;
@@ -159,8 +161,12 @@ mod tests {
         Run::require(&mut interp).unwrap();
         let err = interp.eval(b"Run.run").unwrap_err();
         assert_eq!("RuntimeError", err.name().as_ref());
-        assert_eq!(&b"something went wrong"[..], err.message().as_ref());
-        let frame = b"(eval):1".to_vec();
-        assert_eq!(Some(vec![frame]), err.vm_backtrace(&mut interp));
+        assert_eq!(
+            b"something went wrong".as_bstr(),
+            err.message().as_ref().as_bstr()
+        );
+        let expected_backtrace = b"(eval):1".to_vec();
+        let actual_backtrace = bstr::join("\n", err.vm_backtrace(&mut interp).unwrap());
+        assert_eq!(expected_backtrace, actual_backtrace);
     }
 }

--- a/artichoke-backend/src/extn/core/integer/mod.rs
+++ b/artichoke-backend/src/extn/core/integer/mod.rs
@@ -3,7 +3,6 @@ use std::mem;
 
 use crate::extn::core::numeric::{self, Coercion, Outcome};
 use crate::extn::prelude::*;
-use crate::string::WriteError;
 
 pub mod mruby;
 pub mod trampoline;

--- a/artichoke-backend/src/extn/core/kernel/integer.rs
+++ b/artichoke-backend/src/extn/core/kernel/integer.rs
@@ -7,7 +7,6 @@ use std::num::NonZeroU32;
 use std::str::{self, FromStr};
 
 use crate::extn::prelude::*;
-use crate::string::WriteError;
 
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Radix(NonZeroU32);
@@ -164,7 +163,7 @@ impl<'a> TryConvertMut<&'a mut Value, IntegerString<'a>> for Artichoke {
                 Ok(converted)
             } else {
                 let mut message = String::from(r#"invalid value for Integer(): ""#);
-                string::format_unicode_debug_into(&mut message, arg)?;
+                format_unicode_debug_into(&mut message, arg)?;
                 message.push('"');
                 Err(ArgumentError::from(message).into())
             }
@@ -217,7 +216,7 @@ impl<'a> ParseState<'a> {
         match self {
             Self::Sign(arg, _) | Self::Accumulate(arg, _, _) => {
                 let mut message = String::from(r#"invalid value for Integer(): ""#);
-                string::format_unicode_debug_into(&mut message, arg.into())?;
+                format_unicode_debug_into(&mut message, arg.into())?;
                 message.push('"');
                 Err(ArgumentError::from(message).into())
             }
@@ -249,7 +248,7 @@ impl<'a> ParseState<'a> {
             Self::Accumulate(arg, sign, digits) => (arg, sign, digits),
             Self::Initial(arg) | Self::Sign(arg, _) => {
                 let mut message = String::from(r#"invalid value for Integer(): ""#);
-                string::format_unicode_debug_into(&mut message, arg.into())?;
+                format_unicode_debug_into(&mut message, arg.into())?;
                 message.push('"');
                 return Err(ArgumentError::from(message).into());
             }
@@ -276,7 +275,7 @@ impl<'a> ParseState<'a> {
                 let next = char::from(*y);
                 if !next.is_numeric() && !next.is_alphabetic() {
                     let mut message = String::from(r#"invalid value for Integer(): ""#);
-                    string::format_unicode_debug_into(&mut message, arg.into())?;
+                    format_unicode_debug_into(&mut message, arg.into())?;
                     message.push('"');
                     return Err(ArgumentError::from(message).into());
                 } else if '0' == first {
@@ -317,7 +316,7 @@ pub fn method(arg: IntegerString<'_>, radix: Option<Radix>) -> Result<Int, Error
         if current.is_whitespace() {
             if let Some('+') | Some('-') = prev {
                 let mut message = String::from(r#"invalid value for Integer(): ""#);
-                string::format_unicode_debug_into(&mut message, arg.into())?;
+                format_unicode_debug_into(&mut message, arg.into())?;
                 message.push('"');
                 return Err(ArgumentError::from(message).into());
             } else {
@@ -348,7 +347,7 @@ pub fn method(arg: IntegerString<'_>, radix: Option<Radix>) -> Result<Int, Error
         Ok(parsed_int)
     } else {
         let mut message = String::from(r#"invalid value for Integer(): ""#);
-        string::format_unicode_debug_into(&mut message, arg.into())?;
+        format_unicode_debug_into(&mut message, arg.into())?;
         message.push('"');
         Err(ArgumentError::from(message).into())
     }

--- a/artichoke-backend/src/extn/core/matchdata/mod.rs
+++ b/artichoke-backend/src/extn/core/matchdata/mod.rs
@@ -19,7 +19,6 @@ use crate::extn::core::regexp::backend::NilableString;
 use crate::extn::core::regexp::Regexp;
 use crate::extn::core::symbol::Symbol;
 use crate::extn::prelude::*;
-use crate::string::WriteError;
 
 mod boxing;
 pub mod mruby;
@@ -227,7 +226,7 @@ impl MatchData {
                     Ok(CaptureMatch::Single(capture.map(<[_]>::to_vec)))
                 } else {
                     let mut message = String::from("undefined group name reference: \"");
-                    string::format_unicode_debug_into(&mut message, name)?;
+                    format_unicode_debug_into(&mut message, name)?;
                     message.push('"');
                     Err(IndexError::from(message).into())
                 }

--- a/artichoke-backend/src/extn/core/math/trampoline.rs
+++ b/artichoke-backend/src/extn/core/math/trampoline.rs
@@ -3,7 +3,6 @@
 use core::convert::TryFrom;
 
 use crate::extn::prelude::*;
-use crate::string::WriteError;
 
 pub fn acos(interp: &mut Artichoke, value: Value) -> Result<Fp, Error> {
     let value = interp.coerce_to_float(value)?;

--- a/artichoke-backend/src/extn/core/regexp/backend/lazy.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/lazy.rs
@@ -39,8 +39,8 @@ impl Lazy {
 
 impl fmt::Display for Lazy {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        string::format_unicode_debug_into(f, self.literal.pattern.as_slice())
-            .map_err(string::WriteError::into_inner)
+        let pattern = self.literal.pattern.as_slice();
+        format_unicode_debug_into(f, pattern).map_err(WriteError::into_inner)
     }
 }
 
@@ -78,9 +78,9 @@ impl RegexpType for Lazy {
         // cannot panic.
         //
         // In practice this error will never be triggered since the only
-        // fallible call in `string::format_unicode_debug_into` is to `write!` which never
-        // `panic!`s for a `String` formatter, which we are using here.
-        let _ = string::format_unicode_debug_into(&mut pattern, self.literal.pattern.as_slice());
+        // fallible call in `format_unicode_debug_into` is to `write!` which
+        // never `panic!`s for a `String` formatter, which we are using here.
+        let _ = format_unicode_debug_into(&mut pattern, self.literal.pattern.as_slice());
         debug.push_str(pattern.replace("/", r"\/").as_str());
         debug.push('/');
         debug.push_str(self.literal.options.as_display_modifier());

--- a/artichoke-backend/src/extn/core/regexp/backend/onig.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/onig.rs
@@ -68,8 +68,8 @@ impl Onig {
 
 impl fmt::Display for Onig {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        string::format_unicode_debug_into(f, self.derived.pattern.as_slice())
-            .map_err(string::WriteError::into_inner)
+        let pattern = self.derived.pattern.as_slice();
+        format_unicode_debug_into(f, pattern).map_err(WriteError::into_inner)
     }
 }
 
@@ -148,9 +148,9 @@ impl RegexpType for Onig {
         // cannot panic.
         //
         // In practice this error will never be triggered since the only
-        // fallible call in `string::format_unicode_debug_into` is to `write!` which never
-        // `panic!`s for a `String` formatter, which we are using here.
-        let _ = string::format_unicode_debug_into(&mut pattern, self.literal.pattern.as_slice());
+        // fallible call in `format_unicode_debug_into` is to `write!` which
+        // never `panic!`s for a `String` formatter, which we are using here.
+        let _ = format_unicode_debug_into(&mut pattern, self.literal.pattern.as_slice());
         debug.push_str(pattern.replace("/", r"\/").as_str());
         debug.push('/');
         debug.push_str(self.literal.options.as_display_modifier());

--- a/artichoke-backend/src/extn/core/regexp/backend/regex/utf8.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/regex/utf8.rs
@@ -1,4 +1,4 @@
-use regex::{Regex, RegexBuilder};
+use regex::{Match, Regex, RegexBuilder};
 use std::collections::HashMap;
 use std::convert::{self, TryFrom};
 use std::fmt;
@@ -47,8 +47,8 @@ impl Utf8 {
 
 impl fmt::Display for Utf8 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        string::format_unicode_debug_into(f, self.derived.pattern.as_slice())
-            .map_err(string::WriteError::into_inner)
+        let pattern = self.derived.pattern.as_slice();
+        format_unicode_debug_into(f, pattern).map_err(WriteError::into_inner)
     }
 }
 
@@ -116,7 +116,7 @@ impl RegexpType for Utf8 {
             .captures(haystack)
             .and_then(|captures| captures.get(0))
             .as_ref()
-            .map(regex::Match::as_str)
+            .map(Match::as_str)
             .map(str::as_bytes);
         Ok(result)
     }
@@ -128,9 +128,9 @@ impl RegexpType for Utf8 {
         // cannot panic.
         //
         // In practice this error will never be triggered since the only
-        // fallible call in `string::format_unicode_debug_into` is to `write!` which never
-        // `panic!`s for a `String` formatter, which we are using here.
-        let _ = string::format_unicode_debug_into(&mut pattern, self.literal.pattern.as_slice());
+        // fallible call in `format_unicode_debug_into` is to `write!` which
+        // never `panic!`s for a `String` formatter, which we are using here.
+        let _ = format_unicode_debug_into(&mut pattern, self.literal.pattern.as_slice());
         debug.push_str(pattern.replace("/", r"\/").as_str());
         debug.push('/');
         debug.push_str(self.literal.options.as_display_modifier());
@@ -186,7 +186,7 @@ impl RegexpType for Utf8 {
             let fullmatch = captures
                 .get(0)
                 .as_ref()
-                .map(regex::Match::as_str)
+                .map(Match::as_str)
                 .map(str::as_bytes);
             let value = interp.convert_mut(fullmatch);
             interp.set_global_variable(regexp::LAST_MATCHED_STRING, &value)?;
@@ -194,7 +194,7 @@ impl RegexpType for Utf8 {
                 let capture = captures
                     .get(group)
                     .as_ref()
-                    .map(regex::Match::as_str)
+                    .map(Match::as_str)
                     .map(str::as_bytes);
                 let value = interp.convert_mut(capture);
                 let group = unsafe { NonZeroUsize::new_unchecked(group) };
@@ -292,7 +292,7 @@ impl RegexpType for Utf8 {
             let fullmatch = captures
                 .get(0)
                 .as_ref()
-                .map(regex::Match::as_str)
+                .map(Match::as_str)
                 .map(str::as_bytes);
             let value = interp.convert_mut(fullmatch);
             interp.set_global_variable(regexp::LAST_MATCHED_STRING, &value)?;
@@ -300,7 +300,7 @@ impl RegexpType for Utf8 {
                 let capture = captures
                     .get(group)
                     .as_ref()
-                    .map(regex::Match::as_str)
+                    .map(Match::as_str)
                     .map(str::as_bytes);
                 let value = interp.convert_mut(capture);
                 let group = unsafe { NonZeroUsize::new_unchecked(group) };
@@ -352,7 +352,7 @@ impl RegexpType for Utf8 {
             let fullmatch = captures
                 .get(0)
                 .as_ref()
-                .map(regex::Match::as_str)
+                .map(Match::as_str)
                 .map(str::as_bytes);
             let value = interp.convert_mut(fullmatch);
             interp.set_global_variable(regexp::LAST_MATCHED_STRING, &value)?;
@@ -360,7 +360,7 @@ impl RegexpType for Utf8 {
                 let capture = captures
                     .get(group)
                     .as_ref()
-                    .map(regex::Match::as_str)
+                    .map(Match::as_str)
                     .map(str::as_bytes);
                 let value = interp.convert_mut(capture);
                 let group = unsafe { NonZeroUsize::new_unchecked(group) };
@@ -482,7 +482,7 @@ impl RegexpType for Utf8 {
                     let matched = captures
                         .get(0)
                         .as_ref()
-                        .map(regex::Match::as_str)
+                        .map(Match::as_str)
                         .map(str::as_bytes);
                     let capture = interp.convert_mut(matched);
                     interp.set_global_variable(regexp::LAST_MATCHED_STRING, &capture)?;
@@ -492,7 +492,7 @@ impl RegexpType for Utf8 {
                         let matched = captures
                             .get(group)
                             .as_ref()
-                            .map(regex::Match::as_str)
+                            .map(Match::as_str)
                             .map(str::as_bytes);
                         let capture = interp.convert_mut(matched);
                         let group = unsafe { NonZeroUsize::new_unchecked(group) };
@@ -541,7 +541,7 @@ impl RegexpType for Utf8 {
                         let matched = captures
                             .get(group)
                             .as_ref()
-                            .map(regex::Match::as_str)
+                            .map(Match::as_str)
                             .map(str::as_bytes)
                             .map(Vec::from);
                         groups.push(matched);

--- a/artichoke-backend/src/extn/prelude.rs
+++ b/artichoke-backend/src/extn/prelude.rs
@@ -24,7 +24,7 @@ pub use crate::ffi::InterpreterExtractError;
 pub use crate::module;
 pub use crate::module_registry::ModuleRegistry;
 pub use crate::prelude::*;
-pub use crate::string;
+pub use crate::string::{format_unicode_debug_into, WriteError};
 pub use crate::sys;
 pub use crate::types::{Fp, Int};
 pub use crate::value::Value;

--- a/artichoke-backend/src/test/prelude.rs
+++ b/artichoke-backend/src/test/prelude.rs
@@ -22,7 +22,7 @@ pub use crate::module;
 pub use crate::module_registry::ModuleRegistry;
 pub use crate::prelude::*;
 pub use crate::state::parser::Context;
-pub use crate::string;
+pub use crate::string::{format_unicode_debug_into, WriteError};
 pub use crate::sys;
 pub use crate::types::{Fp, Int};
 pub use crate::value::Value;

--- a/artichoke-backend/src/value.rs
+++ b/artichoke-backend/src/value.rs
@@ -486,6 +486,8 @@ impl From<Box<ArgCountError>> for Box<dyn RubyException> {
 
 #[cfg(test)]
 mod tests {
+    use bstr::ByteSlice;
+
     use crate::gc::MrbGarbageCollection;
     use crate::test::prelude::*;
 
@@ -495,7 +497,7 @@ mod tests {
 
         let value = interp.convert(true);
         let string = value.to_s(&mut interp);
-        assert_eq!(string, b"true");
+        assert_eq!(string.as_bstr(), b"true".as_bstr());
     }
 
     #[test]
@@ -504,7 +506,7 @@ mod tests {
 
         let value = interp.convert(true);
         let debug = value.inspect(&mut interp);
-        assert_eq!(debug, b"true");
+        assert_eq!(debug.as_bstr(), b"true".as_bstr());
     }
 
     #[test]
@@ -513,7 +515,7 @@ mod tests {
 
         let value = interp.convert(false);
         let string = value.to_s(&mut interp);
-        assert_eq!(string, b"false");
+        assert_eq!(string.as_bstr(), b"false".as_bstr());
     }
 
     #[test]
@@ -522,7 +524,7 @@ mod tests {
 
         let value = interp.convert(false);
         let debug = value.inspect(&mut interp);
-        assert_eq!(debug, b"false");
+        assert_eq!(debug.as_bstr(), b"false".as_bstr());
     }
 
     #[test]
@@ -531,7 +533,7 @@ mod tests {
 
         let value = Value::nil();
         let string = value.to_s(&mut interp);
-        assert_eq!(string, b"");
+        assert_eq!(string.as_bstr(), b"".as_bstr());
     }
 
     #[test]
@@ -540,7 +542,7 @@ mod tests {
 
         let value = Value::nil();
         let debug = value.inspect(&mut interp);
-        assert_eq!(debug, b"nil");
+        assert_eq!(debug.as_bstr(), b"nil".as_bstr());
     }
 
     #[test]
@@ -549,7 +551,7 @@ mod tests {
 
         let value = Convert::<_, Value>::convert(&*interp, 255);
         let string = value.to_s(&mut interp);
-        assert_eq!(string, b"255");
+        assert_eq!(string.as_bstr(), b"255".as_bstr());
     }
 
     #[test]
@@ -558,7 +560,7 @@ mod tests {
 
         let value = Convert::<_, Value>::convert(&*interp, 255);
         let debug = value.inspect(&mut interp);
-        assert_eq!(debug, b"255");
+        assert_eq!(debug.as_bstr(), b"255".as_bstr());
     }
 
     #[test]
@@ -567,7 +569,7 @@ mod tests {
 
         let value = interp.convert_mut("interstate");
         let string = value.to_s(&mut interp);
-        assert_eq!(string, b"interstate");
+        assert_eq!(string.as_bstr(), b"interstate".as_bstr());
     }
 
     #[test]
@@ -576,7 +578,7 @@ mod tests {
 
         let value = interp.convert_mut("interstate");
         let debug = value.inspect(&mut interp);
-        assert_eq!(debug, br#""interstate""#);
+        assert_eq!(debug.as_bstr(), br#""interstate""#.as_bstr());
     }
 
     #[test]
@@ -585,7 +587,7 @@ mod tests {
 
         let value = interp.convert_mut("");
         let string = value.to_s(&mut interp);
-        assert_eq!(string, b"");
+        assert_eq!(string.as_bstr(), b"".as_bstr());
     }
 
     #[test]
@@ -594,7 +596,7 @@ mod tests {
 
         let value = interp.convert_mut("");
         let debug = value.inspect(&mut interp);
-        assert_eq!(debug, br#""""#);
+        assert_eq!(debug.as_bstr(), br#""""#.as_bstr());
     }
 
     #[test]
@@ -679,8 +681,8 @@ mod tests {
             .unwrap_err();
         assert_eq!("TypeError", err.name().as_ref());
         assert_eq!(
-            &b"nil cannot be converted to String"[..],
-            err.message().as_ref()
+            b"nil cannot be converted to String".as_bstr(),
+            err.message().as_ref().as_bstr()
         );
     }
 
@@ -694,8 +696,8 @@ mod tests {
             .unwrap_err();
         assert_eq!("NoMethodError", err.name().as_ref());
         assert_eq!(
-            &b"undefined method 'garbage_method_name'"[..],
-            err.message().as_ref()
+            b"undefined method 'garbage_method_name'".as_bstr(),
+            err.message().as_ref().as_bstr()
         );
     }
 }

--- a/spinoso-exception/src/core/argumenterror.rs
+++ b/spinoso-exception/src/core/argumenterror.rs
@@ -1,10 +1,13 @@
+// @generated
+
 use alloc::borrow::Cow;
 use alloc::string::String;
 use alloc::vec::Vec;
 use core::fmt;
-use scolapasta_string_escape::format_debug_escape_into;
 #[cfg(feature = "std")]
 use std::error;
+
+use scolapasta_string_escape::format_debug_escape_into;
 
 use crate::RubyException;
 
@@ -46,6 +49,23 @@ impl ArgumentError {
         // `raise RuntimeError` or `RuntimeError.new` have `message`
         // equal to the exception's class name.
         let message = Cow::Borrowed(DEFAULT_MESSAGE);
+        Self { message }
+    }
+
+    /// Construct a new, `ArgumentError` Ruby exception with the given
+    /// message.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_exception::*;
+    /// let exception = ArgumentError::with_message("an error occurred");
+    /// assert_eq!(exception.message(), b"an error occurred");
+    /// ```
+    #[inline]
+    #[must_use]
+    pub const fn with_message(message: &'static str) -> Self {
+        let message = Cow::Borrowed(message.as_bytes());
         Self { message }
     }
 

--- a/spinoso-exception/src/core/encodingerror.rs
+++ b/spinoso-exception/src/core/encodingerror.rs
@@ -1,10 +1,13 @@
+// @generated
+
 use alloc::borrow::Cow;
 use alloc::string::String;
 use alloc::vec::Vec;
 use core::fmt;
-use scolapasta_string_escape::format_debug_escape_into;
 #[cfg(feature = "std")]
 use std::error;
+
+use scolapasta_string_escape::format_debug_escape_into;
 
 use crate::RubyException;
 
@@ -46,6 +49,23 @@ impl EncodingError {
         // `raise RuntimeError` or `RuntimeError.new` have `message`
         // equal to the exception's class name.
         let message = Cow::Borrowed(DEFAULT_MESSAGE);
+        Self { message }
+    }
+
+    /// Construct a new, `EncodingError` Ruby exception with the given
+    /// message.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_exception::*;
+    /// let exception = EncodingError::with_message("an error occurred");
+    /// assert_eq!(exception.message(), b"an error occurred");
+    /// ```
+    #[inline]
+    #[must_use]
+    pub const fn with_message(message: &'static str) -> Self {
+        let message = Cow::Borrowed(message.as_bytes());
         Self { message }
     }
 

--- a/spinoso-exception/src/core/eoferror.rs
+++ b/spinoso-exception/src/core/eoferror.rs
@@ -1,10 +1,13 @@
+// @generated
+
 use alloc::borrow::Cow;
 use alloc::string::String;
 use alloc::vec::Vec;
 use core::fmt;
-use scolapasta_string_escape::format_debug_escape_into;
 #[cfg(feature = "std")]
 use std::error;
+
+use scolapasta_string_escape::format_debug_escape_into;
 
 use crate::RubyException;
 
@@ -46,6 +49,23 @@ impl EOFError {
         // `raise RuntimeError` or `RuntimeError.new` have `message`
         // equal to the exception's class name.
         let message = Cow::Borrowed(DEFAULT_MESSAGE);
+        Self { message }
+    }
+
+    /// Construct a new, `EOFError` Ruby exception with the given
+    /// message.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_exception::*;
+    /// let exception = EOFError::with_message("an error occurred");
+    /// assert_eq!(exception.message(), b"an error occurred");
+    /// ```
+    #[inline]
+    #[must_use]
+    pub const fn with_message(message: &'static str) -> Self {
+        let message = Cow::Borrowed(message.as_bytes());
         Self { message }
     }
 

--- a/spinoso-exception/src/core/exception.rs
+++ b/spinoso-exception/src/core/exception.rs
@@ -1,10 +1,13 @@
+// @generated
+
 use alloc::borrow::Cow;
 use alloc::string::String;
 use alloc::vec::Vec;
 use core::fmt;
-use scolapasta_string_escape::format_debug_escape_into;
 #[cfg(feature = "std")]
 use std::error;
+
+use scolapasta_string_escape::format_debug_escape_into;
 
 use crate::RubyException;
 
@@ -46,6 +49,23 @@ impl Exception {
         // `raise RuntimeError` or `RuntimeError.new` have `message`
         // equal to the exception's class name.
         let message = Cow::Borrowed(DEFAULT_MESSAGE);
+        Self { message }
+    }
+
+    /// Construct a new, `Exception` Ruby exception with the given
+    /// message.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_exception::*;
+    /// let exception = Exception::with_message("an error occurred");
+    /// assert_eq!(exception.message(), b"an error occurred");
+    /// ```
+    #[inline]
+    #[must_use]
+    pub const fn with_message(message: &'static str) -> Self {
+        let message = Cow::Borrowed(message.as_bytes());
         Self { message }
     }
 

--- a/spinoso-exception/src/core/fatal.rs
+++ b/spinoso-exception/src/core/fatal.rs
@@ -1,10 +1,13 @@
+// @generated
+
 use alloc::borrow::Cow;
 use alloc::string::String;
 use alloc::vec::Vec;
 use core::fmt;
-use scolapasta_string_escape::format_debug_escape_into;
 #[cfg(feature = "std")]
 use std::error;
+
+use scolapasta_string_escape::format_debug_escape_into;
 
 use crate::RubyException;
 
@@ -46,6 +49,23 @@ impl Fatal {
         // `raise RuntimeError` or `RuntimeError.new` have `message`
         // equal to the exception's class name.
         let message = Cow::Borrowed(DEFAULT_MESSAGE);
+        Self { message }
+    }
+
+    /// Construct a new, `fatal` Ruby exception with the given
+    /// message.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_exception::*;
+    /// let exception = Fatal::with_message("an error occurred");
+    /// assert_eq!(exception.message(), b"an error occurred");
+    /// ```
+    #[inline]
+    #[must_use]
+    pub const fn with_message(message: &'static str) -> Self {
+        let message = Cow::Borrowed(message.as_bytes());
         Self { message }
     }
 

--- a/spinoso-exception/src/core/fibererror.rs
+++ b/spinoso-exception/src/core/fibererror.rs
@@ -1,10 +1,13 @@
+// @generated
+
 use alloc::borrow::Cow;
 use alloc::string::String;
 use alloc::vec::Vec;
 use core::fmt;
-use scolapasta_string_escape::format_debug_escape_into;
 #[cfg(feature = "std")]
 use std::error;
+
+use scolapasta_string_escape::format_debug_escape_into;
 
 use crate::RubyException;
 
@@ -46,6 +49,23 @@ impl FiberError {
         // `raise RuntimeError` or `RuntimeError.new` have `message`
         // equal to the exception's class name.
         let message = Cow::Borrowed(DEFAULT_MESSAGE);
+        Self { message }
+    }
+
+    /// Construct a new, `FiberError` Ruby exception with the given
+    /// message.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_exception::*;
+    /// let exception = FiberError::with_message("an error occurred");
+    /// assert_eq!(exception.message(), b"an error occurred");
+    /// ```
+    #[inline]
+    #[must_use]
+    pub const fn with_message(message: &'static str) -> Self {
+        let message = Cow::Borrowed(message.as_bytes());
         Self { message }
     }
 

--- a/spinoso-exception/src/core/floatdomainerror.rs
+++ b/spinoso-exception/src/core/floatdomainerror.rs
@@ -1,10 +1,13 @@
+// @generated
+
 use alloc::borrow::Cow;
 use alloc::string::String;
 use alloc::vec::Vec;
 use core::fmt;
-use scolapasta_string_escape::format_debug_escape_into;
 #[cfg(feature = "std")]
 use std::error;
+
+use scolapasta_string_escape::format_debug_escape_into;
 
 use crate::RubyException;
 
@@ -46,6 +49,23 @@ impl FloatDomainError {
         // `raise RuntimeError` or `RuntimeError.new` have `message`
         // equal to the exception's class name.
         let message = Cow::Borrowed(DEFAULT_MESSAGE);
+        Self { message }
+    }
+
+    /// Construct a new, `FloatDomainError` Ruby exception with the given
+    /// message.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_exception::*;
+    /// let exception = FloatDomainError::with_message("an error occurred");
+    /// assert_eq!(exception.message(), b"an error occurred");
+    /// ```
+    #[inline]
+    #[must_use]
+    pub const fn with_message(message: &'static str) -> Self {
+        let message = Cow::Borrowed(message.as_bytes());
         Self { message }
     }
 

--- a/spinoso-exception/src/core/frozenerror.rs
+++ b/spinoso-exception/src/core/frozenerror.rs
@@ -1,10 +1,13 @@
+// @generated
+
 use alloc::borrow::Cow;
 use alloc::string::String;
 use alloc::vec::Vec;
 use core::fmt;
-use scolapasta_string_escape::format_debug_escape_into;
 #[cfg(feature = "std")]
 use std::error;
+
+use scolapasta_string_escape::format_debug_escape_into;
 
 use crate::RubyException;
 
@@ -46,6 +49,23 @@ impl FrozenError {
         // `raise RuntimeError` or `RuntimeError.new` have `message`
         // equal to the exception's class name.
         let message = Cow::Borrowed(DEFAULT_MESSAGE);
+        Self { message }
+    }
+
+    /// Construct a new, `FrozenError` Ruby exception with the given
+    /// message.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_exception::*;
+    /// let exception = FrozenError::with_message("an error occurred");
+    /// assert_eq!(exception.message(), b"an error occurred");
+    /// ```
+    #[inline]
+    #[must_use]
+    pub const fn with_message(message: &'static str) -> Self {
+        let message = Cow::Borrowed(message.as_bytes());
         Self { message }
     }
 

--- a/spinoso-exception/src/core/indexerror.rs
+++ b/spinoso-exception/src/core/indexerror.rs
@@ -1,10 +1,13 @@
+// @generated
+
 use alloc::borrow::Cow;
 use alloc::string::String;
 use alloc::vec::Vec;
 use core::fmt;
-use scolapasta_string_escape::format_debug_escape_into;
 #[cfg(feature = "std")]
 use std::error;
+
+use scolapasta_string_escape::format_debug_escape_into;
 
 use crate::RubyException;
 
@@ -46,6 +49,23 @@ impl IndexError {
         // `raise RuntimeError` or `RuntimeError.new` have `message`
         // equal to the exception's class name.
         let message = Cow::Borrowed(DEFAULT_MESSAGE);
+        Self { message }
+    }
+
+    /// Construct a new, `IndexError` Ruby exception with the given
+    /// message.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_exception::*;
+    /// let exception = IndexError::with_message("an error occurred");
+    /// assert_eq!(exception.message(), b"an error occurred");
+    /// ```
+    #[inline]
+    #[must_use]
+    pub const fn with_message(message: &'static str) -> Self {
+        let message = Cow::Borrowed(message.as_bytes());
         Self { message }
     }
 

--- a/spinoso-exception/src/core/interrupt.rs
+++ b/spinoso-exception/src/core/interrupt.rs
@@ -1,10 +1,13 @@
+// @generated
+
 use alloc::borrow::Cow;
 use alloc::string::String;
 use alloc::vec::Vec;
 use core::fmt;
-use scolapasta_string_escape::format_debug_escape_into;
 #[cfg(feature = "std")]
 use std::error;
+
+use scolapasta_string_escape::format_debug_escape_into;
 
 use crate::RubyException;
 
@@ -46,6 +49,23 @@ impl Interrupt {
         // `raise RuntimeError` or `RuntimeError.new` have `message`
         // equal to the exception's class name.
         let message = Cow::Borrowed(DEFAULT_MESSAGE);
+        Self { message }
+    }
+
+    /// Construct a new, `Interrupt` Ruby exception with the given
+    /// message.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_exception::*;
+    /// let exception = Interrupt::with_message("an error occurred");
+    /// assert_eq!(exception.message(), b"an error occurred");
+    /// ```
+    #[inline]
+    #[must_use]
+    pub const fn with_message(message: &'static str) -> Self {
+        let message = Cow::Borrowed(message.as_bytes());
         Self { message }
     }
 

--- a/spinoso-exception/src/core/ioerror.rs
+++ b/spinoso-exception/src/core/ioerror.rs
@@ -1,10 +1,13 @@
+// @generated
+
 use alloc::borrow::Cow;
 use alloc::string::String;
 use alloc::vec::Vec;
 use core::fmt;
-use scolapasta_string_escape::format_debug_escape_into;
 #[cfg(feature = "std")]
 use std::error;
+
+use scolapasta_string_escape::format_debug_escape_into;
 
 use crate::RubyException;
 
@@ -46,6 +49,23 @@ impl IOError {
         // `raise RuntimeError` or `RuntimeError.new` have `message`
         // equal to the exception's class name.
         let message = Cow::Borrowed(DEFAULT_MESSAGE);
+        Self { message }
+    }
+
+    /// Construct a new, `IOError` Ruby exception with the given
+    /// message.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_exception::*;
+    /// let exception = IOError::with_message("an error occurred");
+    /// assert_eq!(exception.message(), b"an error occurred");
+    /// ```
+    #[inline]
+    #[must_use]
+    pub const fn with_message(message: &'static str) -> Self {
+        let message = Cow::Borrowed(message.as_bytes());
         Self { message }
     }
 

--- a/spinoso-exception/src/core/keyerror.rs
+++ b/spinoso-exception/src/core/keyerror.rs
@@ -1,10 +1,13 @@
+// @generated
+
 use alloc::borrow::Cow;
 use alloc::string::String;
 use alloc::vec::Vec;
 use core::fmt;
-use scolapasta_string_escape::format_debug_escape_into;
 #[cfg(feature = "std")]
 use std::error;
+
+use scolapasta_string_escape::format_debug_escape_into;
 
 use crate::RubyException;
 
@@ -46,6 +49,23 @@ impl KeyError {
         // `raise RuntimeError` or `RuntimeError.new` have `message`
         // equal to the exception's class name.
         let message = Cow::Borrowed(DEFAULT_MESSAGE);
+        Self { message }
+    }
+
+    /// Construct a new, `KeyError` Ruby exception with the given
+    /// message.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_exception::*;
+    /// let exception = KeyError::with_message("an error occurred");
+    /// assert_eq!(exception.message(), b"an error occurred");
+    /// ```
+    #[inline]
+    #[must_use]
+    pub const fn with_message(message: &'static str) -> Self {
+        let message = Cow::Borrowed(message.as_bytes());
         Self { message }
     }
 

--- a/spinoso-exception/src/core/loaderror.rs
+++ b/spinoso-exception/src/core/loaderror.rs
@@ -1,10 +1,13 @@
+// @generated
+
 use alloc::borrow::Cow;
 use alloc::string::String;
 use alloc::vec::Vec;
 use core::fmt;
-use scolapasta_string_escape::format_debug_escape_into;
 #[cfg(feature = "std")]
 use std::error;
+
+use scolapasta_string_escape::format_debug_escape_into;
 
 use crate::RubyException;
 
@@ -46,6 +49,23 @@ impl LoadError {
         // `raise RuntimeError` or `RuntimeError.new` have `message`
         // equal to the exception's class name.
         let message = Cow::Borrowed(DEFAULT_MESSAGE);
+        Self { message }
+    }
+
+    /// Construct a new, `LoadError` Ruby exception with the given
+    /// message.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_exception::*;
+    /// let exception = LoadError::with_message("an error occurred");
+    /// assert_eq!(exception.message(), b"an error occurred");
+    /// ```
+    #[inline]
+    #[must_use]
+    pub const fn with_message(message: &'static str) -> Self {
+        let message = Cow::Borrowed(message.as_bytes());
         Self { message }
     }
 

--- a/spinoso-exception/src/core/localjumperror.rs
+++ b/spinoso-exception/src/core/localjumperror.rs
@@ -1,10 +1,13 @@
+// @generated
+
 use alloc::borrow::Cow;
 use alloc::string::String;
 use alloc::vec::Vec;
 use core::fmt;
-use scolapasta_string_escape::format_debug_escape_into;
 #[cfg(feature = "std")]
 use std::error;
+
+use scolapasta_string_escape::format_debug_escape_into;
 
 use crate::RubyException;
 
@@ -46,6 +49,23 @@ impl LocalJumpError {
         // `raise RuntimeError` or `RuntimeError.new` have `message`
         // equal to the exception's class name.
         let message = Cow::Borrowed(DEFAULT_MESSAGE);
+        Self { message }
+    }
+
+    /// Construct a new, `LocalJumpError` Ruby exception with the given
+    /// message.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_exception::*;
+    /// let exception = LocalJumpError::with_message("an error occurred");
+    /// assert_eq!(exception.message(), b"an error occurred");
+    /// ```
+    #[inline]
+    #[must_use]
+    pub const fn with_message(message: &'static str) -> Self {
+        let message = Cow::Borrowed(message.as_bytes());
         Self { message }
     }
 

--- a/spinoso-exception/src/core/mod.rs
+++ b/spinoso-exception/src/core/mod.rs
@@ -1,3 +1,5 @@
+// @generated
+
 //! Ruby exception class implementations.
 //!
 //! See crate-level documentation for more about the types exposed in this

--- a/spinoso-exception/src/core/nameerror.rs
+++ b/spinoso-exception/src/core/nameerror.rs
@@ -1,10 +1,13 @@
+// @generated
+
 use alloc::borrow::Cow;
 use alloc::string::String;
 use alloc::vec::Vec;
 use core::fmt;
-use scolapasta_string_escape::format_debug_escape_into;
 #[cfg(feature = "std")]
 use std::error;
+
+use scolapasta_string_escape::format_debug_escape_into;
 
 use crate::RubyException;
 
@@ -46,6 +49,23 @@ impl NameError {
         // `raise RuntimeError` or `RuntimeError.new` have `message`
         // equal to the exception's class name.
         let message = Cow::Borrowed(DEFAULT_MESSAGE);
+        Self { message }
+    }
+
+    /// Construct a new, `NameError` Ruby exception with the given
+    /// message.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_exception::*;
+    /// let exception = NameError::with_message("an error occurred");
+    /// assert_eq!(exception.message(), b"an error occurred");
+    /// ```
+    #[inline]
+    #[must_use]
+    pub const fn with_message(message: &'static str) -> Self {
+        let message = Cow::Borrowed(message.as_bytes());
         Self { message }
     }
 

--- a/spinoso-exception/src/core/nomemoryerror.rs
+++ b/spinoso-exception/src/core/nomemoryerror.rs
@@ -1,10 +1,13 @@
+// @generated
+
 use alloc::borrow::Cow;
 use alloc::string::String;
 use alloc::vec::Vec;
 use core::fmt;
-use scolapasta_string_escape::format_debug_escape_into;
 #[cfg(feature = "std")]
 use std::error;
+
+use scolapasta_string_escape::format_debug_escape_into;
 
 use crate::RubyException;
 
@@ -46,6 +49,23 @@ impl NoMemoryError {
         // `raise RuntimeError` or `RuntimeError.new` have `message`
         // equal to the exception's class name.
         let message = Cow::Borrowed(DEFAULT_MESSAGE);
+        Self { message }
+    }
+
+    /// Construct a new, `NoMemoryError` Ruby exception with the given
+    /// message.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_exception::*;
+    /// let exception = NoMemoryError::with_message("an error occurred");
+    /// assert_eq!(exception.message(), b"an error occurred");
+    /// ```
+    #[inline]
+    #[must_use]
+    pub const fn with_message(message: &'static str) -> Self {
+        let message = Cow::Borrowed(message.as_bytes());
         Self { message }
     }
 

--- a/spinoso-exception/src/core/nomethoderror.rs
+++ b/spinoso-exception/src/core/nomethoderror.rs
@@ -1,10 +1,13 @@
+// @generated
+
 use alloc::borrow::Cow;
 use alloc::string::String;
 use alloc::vec::Vec;
 use core::fmt;
-use scolapasta_string_escape::format_debug_escape_into;
 #[cfg(feature = "std")]
 use std::error;
+
+use scolapasta_string_escape::format_debug_escape_into;
 
 use crate::RubyException;
 
@@ -46,6 +49,23 @@ impl NoMethodError {
         // `raise RuntimeError` or `RuntimeError.new` have `message`
         // equal to the exception's class name.
         let message = Cow::Borrowed(DEFAULT_MESSAGE);
+        Self { message }
+    }
+
+    /// Construct a new, `NoMethodError` Ruby exception with the given
+    /// message.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_exception::*;
+    /// let exception = NoMethodError::with_message("an error occurred");
+    /// assert_eq!(exception.message(), b"an error occurred");
+    /// ```
+    #[inline]
+    #[must_use]
+    pub const fn with_message(message: &'static str) -> Self {
+        let message = Cow::Borrowed(message.as_bytes());
         Self { message }
     }
 

--- a/spinoso-exception/src/core/notimplementederror.rs
+++ b/spinoso-exception/src/core/notimplementederror.rs
@@ -1,10 +1,13 @@
+// @generated
+
 use alloc::borrow::Cow;
 use alloc::string::String;
 use alloc::vec::Vec;
 use core::fmt;
-use scolapasta_string_escape::format_debug_escape_into;
 #[cfg(feature = "std")]
 use std::error;
+
+use scolapasta_string_escape::format_debug_escape_into;
 
 use crate::RubyException;
 
@@ -46,6 +49,23 @@ impl NotImplementedError {
         // `raise RuntimeError` or `RuntimeError.new` have `message`
         // equal to the exception's class name.
         let message = Cow::Borrowed(DEFAULT_MESSAGE);
+        Self { message }
+    }
+
+    /// Construct a new, `NotImplementedError` Ruby exception with the given
+    /// message.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_exception::*;
+    /// let exception = NotImplementedError::with_message("an error occurred");
+    /// assert_eq!(exception.message(), b"an error occurred");
+    /// ```
+    #[inline]
+    #[must_use]
+    pub const fn with_message(message: &'static str) -> Self {
+        let message = Cow::Borrowed(message.as_bytes());
         Self { message }
     }
 

--- a/spinoso-exception/src/core/rangeerror.rs
+++ b/spinoso-exception/src/core/rangeerror.rs
@@ -1,10 +1,13 @@
+// @generated
+
 use alloc::borrow::Cow;
 use alloc::string::String;
 use alloc::vec::Vec;
 use core::fmt;
-use scolapasta_string_escape::format_debug_escape_into;
 #[cfg(feature = "std")]
 use std::error;
+
+use scolapasta_string_escape::format_debug_escape_into;
 
 use crate::RubyException;
 
@@ -46,6 +49,23 @@ impl RangeError {
         // `raise RuntimeError` or `RuntimeError.new` have `message`
         // equal to the exception's class name.
         let message = Cow::Borrowed(DEFAULT_MESSAGE);
+        Self { message }
+    }
+
+    /// Construct a new, `RangeError` Ruby exception with the given
+    /// message.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_exception::*;
+    /// let exception = RangeError::with_message("an error occurred");
+    /// assert_eq!(exception.message(), b"an error occurred");
+    /// ```
+    #[inline]
+    #[must_use]
+    pub const fn with_message(message: &'static str) -> Self {
+        let message = Cow::Borrowed(message.as_bytes());
         Self { message }
     }
 

--- a/spinoso-exception/src/core/regexperror.rs
+++ b/spinoso-exception/src/core/regexperror.rs
@@ -1,10 +1,13 @@
+// @generated
+
 use alloc::borrow::Cow;
 use alloc::string::String;
 use alloc::vec::Vec;
 use core::fmt;
-use scolapasta_string_escape::format_debug_escape_into;
 #[cfg(feature = "std")]
 use std::error;
+
+use scolapasta_string_escape::format_debug_escape_into;
 
 use crate::RubyException;
 
@@ -46,6 +49,23 @@ impl RegexpError {
         // `raise RuntimeError` or `RuntimeError.new` have `message`
         // equal to the exception's class name.
         let message = Cow::Borrowed(DEFAULT_MESSAGE);
+        Self { message }
+    }
+
+    /// Construct a new, `RegexpError` Ruby exception with the given
+    /// message.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_exception::*;
+    /// let exception = RegexpError::with_message("an error occurred");
+    /// assert_eq!(exception.message(), b"an error occurred");
+    /// ```
+    #[inline]
+    #[must_use]
+    pub const fn with_message(message: &'static str) -> Self {
+        let message = Cow::Borrowed(message.as_bytes());
         Self { message }
     }
 

--- a/spinoso-exception/src/core/runtimeerror.rs
+++ b/spinoso-exception/src/core/runtimeerror.rs
@@ -1,10 +1,13 @@
+// @generated
+
 use alloc::borrow::Cow;
 use alloc::string::String;
 use alloc::vec::Vec;
 use core::fmt;
-use scolapasta_string_escape::format_debug_escape_into;
 #[cfg(feature = "std")]
 use std::error;
+
+use scolapasta_string_escape::format_debug_escape_into;
 
 use crate::RubyException;
 
@@ -46,6 +49,23 @@ impl RuntimeError {
         // `raise RuntimeError` or `RuntimeError.new` have `message`
         // equal to the exception's class name.
         let message = Cow::Borrowed(DEFAULT_MESSAGE);
+        Self { message }
+    }
+
+    /// Construct a new, `RuntimeError` Ruby exception with the given
+    /// message.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_exception::*;
+    /// let exception = RuntimeError::with_message("an error occurred");
+    /// assert_eq!(exception.message(), b"an error occurred");
+    /// ```
+    #[inline]
+    #[must_use]
+    pub const fn with_message(message: &'static str) -> Self {
+        let message = Cow::Borrowed(message.as_bytes());
         Self { message }
     }
 

--- a/spinoso-exception/src/core/scripterror.rs
+++ b/spinoso-exception/src/core/scripterror.rs
@@ -1,10 +1,13 @@
+// @generated
+
 use alloc::borrow::Cow;
 use alloc::string::String;
 use alloc::vec::Vec;
 use core::fmt;
-use scolapasta_string_escape::format_debug_escape_into;
 #[cfg(feature = "std")]
 use std::error;
+
+use scolapasta_string_escape::format_debug_escape_into;
 
 use crate::RubyException;
 
@@ -46,6 +49,23 @@ impl ScriptError {
         // `raise RuntimeError` or `RuntimeError.new` have `message`
         // equal to the exception's class name.
         let message = Cow::Borrowed(DEFAULT_MESSAGE);
+        Self { message }
+    }
+
+    /// Construct a new, `ScriptError` Ruby exception with the given
+    /// message.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_exception::*;
+    /// let exception = ScriptError::with_message("an error occurred");
+    /// assert_eq!(exception.message(), b"an error occurred");
+    /// ```
+    #[inline]
+    #[must_use]
+    pub const fn with_message(message: &'static str) -> Self {
+        let message = Cow::Borrowed(message.as_bytes());
         Self { message }
     }
 

--- a/spinoso-exception/src/core/securityerror.rs
+++ b/spinoso-exception/src/core/securityerror.rs
@@ -1,10 +1,13 @@
+// @generated
+
 use alloc::borrow::Cow;
 use alloc::string::String;
 use alloc::vec::Vec;
 use core::fmt;
-use scolapasta_string_escape::format_debug_escape_into;
 #[cfg(feature = "std")]
 use std::error;
+
+use scolapasta_string_escape::format_debug_escape_into;
 
 use crate::RubyException;
 
@@ -46,6 +49,23 @@ impl SecurityError {
         // `raise RuntimeError` or `RuntimeError.new` have `message`
         // equal to the exception's class name.
         let message = Cow::Borrowed(DEFAULT_MESSAGE);
+        Self { message }
+    }
+
+    /// Construct a new, `SecurityError` Ruby exception with the given
+    /// message.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_exception::*;
+    /// let exception = SecurityError::with_message("an error occurred");
+    /// assert_eq!(exception.message(), b"an error occurred");
+    /// ```
+    #[inline]
+    #[must_use]
+    pub const fn with_message(message: &'static str) -> Self {
+        let message = Cow::Borrowed(message.as_bytes());
         Self { message }
     }
 

--- a/spinoso-exception/src/core/signalexception.rs
+++ b/spinoso-exception/src/core/signalexception.rs
@@ -1,10 +1,13 @@
+// @generated
+
 use alloc::borrow::Cow;
 use alloc::string::String;
 use alloc::vec::Vec;
 use core::fmt;
-use scolapasta_string_escape::format_debug_escape_into;
 #[cfg(feature = "std")]
 use std::error;
+
+use scolapasta_string_escape::format_debug_escape_into;
 
 use crate::RubyException;
 
@@ -46,6 +49,23 @@ impl SignalException {
         // `raise RuntimeError` or `RuntimeError.new` have `message`
         // equal to the exception's class name.
         let message = Cow::Borrowed(DEFAULT_MESSAGE);
+        Self { message }
+    }
+
+    /// Construct a new, `SignalException` Ruby exception with the given
+    /// message.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_exception::*;
+    /// let exception = SignalException::with_message("an error occurred");
+    /// assert_eq!(exception.message(), b"an error occurred");
+    /// ```
+    #[inline]
+    #[must_use]
+    pub const fn with_message(message: &'static str) -> Self {
+        let message = Cow::Borrowed(message.as_bytes());
         Self { message }
     }
 

--- a/spinoso-exception/src/core/standarderror.rs
+++ b/spinoso-exception/src/core/standarderror.rs
@@ -1,10 +1,13 @@
+// @generated
+
 use alloc::borrow::Cow;
 use alloc::string::String;
 use alloc::vec::Vec;
 use core::fmt;
-use scolapasta_string_escape::format_debug_escape_into;
 #[cfg(feature = "std")]
 use std::error;
+
+use scolapasta_string_escape::format_debug_escape_into;
 
 use crate::RubyException;
 
@@ -46,6 +49,23 @@ impl StandardError {
         // `raise RuntimeError` or `RuntimeError.new` have `message`
         // equal to the exception's class name.
         let message = Cow::Borrowed(DEFAULT_MESSAGE);
+        Self { message }
+    }
+
+    /// Construct a new, `StandardError` Ruby exception with the given
+    /// message.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_exception::*;
+    /// let exception = StandardError::with_message("an error occurred");
+    /// assert_eq!(exception.message(), b"an error occurred");
+    /// ```
+    #[inline]
+    #[must_use]
+    pub const fn with_message(message: &'static str) -> Self {
+        let message = Cow::Borrowed(message.as_bytes());
         Self { message }
     }
 

--- a/spinoso-exception/src/core/stopiteration.rs
+++ b/spinoso-exception/src/core/stopiteration.rs
@@ -1,10 +1,13 @@
+// @generated
+
 use alloc::borrow::Cow;
 use alloc::string::String;
 use alloc::vec::Vec;
 use core::fmt;
-use scolapasta_string_escape::format_debug_escape_into;
 #[cfg(feature = "std")]
 use std::error;
+
+use scolapasta_string_escape::format_debug_escape_into;
 
 use crate::RubyException;
 
@@ -46,6 +49,23 @@ impl StopIteration {
         // `raise RuntimeError` or `RuntimeError.new` have `message`
         // equal to the exception's class name.
         let message = Cow::Borrowed(DEFAULT_MESSAGE);
+        Self { message }
+    }
+
+    /// Construct a new, `StopIteration` Ruby exception with the given
+    /// message.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_exception::*;
+    /// let exception = StopIteration::with_message("an error occurred");
+    /// assert_eq!(exception.message(), b"an error occurred");
+    /// ```
+    #[inline]
+    #[must_use]
+    pub const fn with_message(message: &'static str) -> Self {
+        let message = Cow::Borrowed(message.as_bytes());
         Self { message }
     }
 

--- a/spinoso-exception/src/core/syntaxerror.rs
+++ b/spinoso-exception/src/core/syntaxerror.rs
@@ -1,10 +1,13 @@
+// @generated
+
 use alloc::borrow::Cow;
 use alloc::string::String;
 use alloc::vec::Vec;
 use core::fmt;
-use scolapasta_string_escape::format_debug_escape_into;
 #[cfg(feature = "std")]
 use std::error;
+
+use scolapasta_string_escape::format_debug_escape_into;
 
 use crate::RubyException;
 
@@ -46,6 +49,23 @@ impl SyntaxError {
         // `raise RuntimeError` or `RuntimeError.new` have `message`
         // equal to the exception's class name.
         let message = Cow::Borrowed(DEFAULT_MESSAGE);
+        Self { message }
+    }
+
+    /// Construct a new, `SyntaxError` Ruby exception with the given
+    /// message.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_exception::*;
+    /// let exception = SyntaxError::with_message("an error occurred");
+    /// assert_eq!(exception.message(), b"an error occurred");
+    /// ```
+    #[inline]
+    #[must_use]
+    pub const fn with_message(message: &'static str) -> Self {
+        let message = Cow::Borrowed(message.as_bytes());
         Self { message }
     }
 

--- a/spinoso-exception/src/core/systemcallerror.rs
+++ b/spinoso-exception/src/core/systemcallerror.rs
@@ -1,10 +1,13 @@
+// @generated
+
 use alloc::borrow::Cow;
 use alloc::string::String;
 use alloc::vec::Vec;
 use core::fmt;
-use scolapasta_string_escape::format_debug_escape_into;
 #[cfg(feature = "std")]
 use std::error;
+
+use scolapasta_string_escape::format_debug_escape_into;
 
 use crate::RubyException;
 
@@ -46,6 +49,23 @@ impl SystemCallError {
         // `raise RuntimeError` or `RuntimeError.new` have `message`
         // equal to the exception's class name.
         let message = Cow::Borrowed(DEFAULT_MESSAGE);
+        Self { message }
+    }
+
+    /// Construct a new, `SystemCallError` Ruby exception with the given
+    /// message.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_exception::*;
+    /// let exception = SystemCallError::with_message("an error occurred");
+    /// assert_eq!(exception.message(), b"an error occurred");
+    /// ```
+    #[inline]
+    #[must_use]
+    pub const fn with_message(message: &'static str) -> Self {
+        let message = Cow::Borrowed(message.as_bytes());
         Self { message }
     }
 

--- a/spinoso-exception/src/core/systemexit.rs
+++ b/spinoso-exception/src/core/systemexit.rs
@@ -1,10 +1,13 @@
+// @generated
+
 use alloc::borrow::Cow;
 use alloc::string::String;
 use alloc::vec::Vec;
 use core::fmt;
-use scolapasta_string_escape::format_debug_escape_into;
 #[cfg(feature = "std")]
 use std::error;
+
+use scolapasta_string_escape::format_debug_escape_into;
 
 use crate::RubyException;
 
@@ -46,6 +49,23 @@ impl SystemExit {
         // `raise RuntimeError` or `RuntimeError.new` have `message`
         // equal to the exception's class name.
         let message = Cow::Borrowed(DEFAULT_MESSAGE);
+        Self { message }
+    }
+
+    /// Construct a new, `SystemExit` Ruby exception with the given
+    /// message.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_exception::*;
+    /// let exception = SystemExit::with_message("an error occurred");
+    /// assert_eq!(exception.message(), b"an error occurred");
+    /// ```
+    #[inline]
+    #[must_use]
+    pub const fn with_message(message: &'static str) -> Self {
+        let message = Cow::Borrowed(message.as_bytes());
         Self { message }
     }
 

--- a/spinoso-exception/src/core/systemstackerror.rs
+++ b/spinoso-exception/src/core/systemstackerror.rs
@@ -1,10 +1,13 @@
+// @generated
+
 use alloc::borrow::Cow;
 use alloc::string::String;
 use alloc::vec::Vec;
 use core::fmt;
-use scolapasta_string_escape::format_debug_escape_into;
 #[cfg(feature = "std")]
 use std::error;
+
+use scolapasta_string_escape::format_debug_escape_into;
 
 use crate::RubyException;
 
@@ -46,6 +49,23 @@ impl SystemStackError {
         // `raise RuntimeError` or `RuntimeError.new` have `message`
         // equal to the exception's class name.
         let message = Cow::Borrowed(DEFAULT_MESSAGE);
+        Self { message }
+    }
+
+    /// Construct a new, `SystemStackError` Ruby exception with the given
+    /// message.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_exception::*;
+    /// let exception = SystemStackError::with_message("an error occurred");
+    /// assert_eq!(exception.message(), b"an error occurred");
+    /// ```
+    #[inline]
+    #[must_use]
+    pub const fn with_message(message: &'static str) -> Self {
+        let message = Cow::Borrowed(message.as_bytes());
         Self { message }
     }
 

--- a/spinoso-exception/src/core/threaderror.rs
+++ b/spinoso-exception/src/core/threaderror.rs
@@ -1,10 +1,13 @@
+// @generated
+
 use alloc::borrow::Cow;
 use alloc::string::String;
 use alloc::vec::Vec;
 use core::fmt;
-use scolapasta_string_escape::format_debug_escape_into;
 #[cfg(feature = "std")]
 use std::error;
+
+use scolapasta_string_escape::format_debug_escape_into;
 
 use crate::RubyException;
 
@@ -46,6 +49,23 @@ impl ThreadError {
         // `raise RuntimeError` or `RuntimeError.new` have `message`
         // equal to the exception's class name.
         let message = Cow::Borrowed(DEFAULT_MESSAGE);
+        Self { message }
+    }
+
+    /// Construct a new, `ThreadError` Ruby exception with the given
+    /// message.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_exception::*;
+    /// let exception = ThreadError::with_message("an error occurred");
+    /// assert_eq!(exception.message(), b"an error occurred");
+    /// ```
+    #[inline]
+    #[must_use]
+    pub const fn with_message(message: &'static str) -> Self {
+        let message = Cow::Borrowed(message.as_bytes());
         Self { message }
     }
 

--- a/spinoso-exception/src/core/typeerror.rs
+++ b/spinoso-exception/src/core/typeerror.rs
@@ -1,10 +1,13 @@
+// @generated
+
 use alloc::borrow::Cow;
 use alloc::string::String;
 use alloc::vec::Vec;
 use core::fmt;
-use scolapasta_string_escape::format_debug_escape_into;
 #[cfg(feature = "std")]
 use std::error;
+
+use scolapasta_string_escape::format_debug_escape_into;
 
 use crate::RubyException;
 
@@ -46,6 +49,23 @@ impl TypeError {
         // `raise RuntimeError` or `RuntimeError.new` have `message`
         // equal to the exception's class name.
         let message = Cow::Borrowed(DEFAULT_MESSAGE);
+        Self { message }
+    }
+
+    /// Construct a new, `TypeError` Ruby exception with the given
+    /// message.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_exception::*;
+    /// let exception = TypeError::with_message("an error occurred");
+    /// assert_eq!(exception.message(), b"an error occurred");
+    /// ```
+    #[inline]
+    #[must_use]
+    pub const fn with_message(message: &'static str) -> Self {
+        let message = Cow::Borrowed(message.as_bytes());
         Self { message }
     }
 

--- a/spinoso-exception/src/core/uncaughtthrowerror.rs
+++ b/spinoso-exception/src/core/uncaughtthrowerror.rs
@@ -1,10 +1,13 @@
+// @generated
+
 use alloc::borrow::Cow;
 use alloc::string::String;
 use alloc::vec::Vec;
 use core::fmt;
-use scolapasta_string_escape::format_debug_escape_into;
 #[cfg(feature = "std")]
 use std::error;
+
+use scolapasta_string_escape::format_debug_escape_into;
 
 use crate::RubyException;
 
@@ -46,6 +49,23 @@ impl UncaughtThrowError {
         // `raise RuntimeError` or `RuntimeError.new` have `message`
         // equal to the exception's class name.
         let message = Cow::Borrowed(DEFAULT_MESSAGE);
+        Self { message }
+    }
+
+    /// Construct a new, `UncaughtThrowError` Ruby exception with the given
+    /// message.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_exception::*;
+    /// let exception = UncaughtThrowError::with_message("an error occurred");
+    /// assert_eq!(exception.message(), b"an error occurred");
+    /// ```
+    #[inline]
+    #[must_use]
+    pub const fn with_message(message: &'static str) -> Self {
+        let message = Cow::Borrowed(message.as_bytes());
         Self { message }
     }
 

--- a/spinoso-exception/src/core/zerodivisionerror.rs
+++ b/spinoso-exception/src/core/zerodivisionerror.rs
@@ -1,10 +1,13 @@
+// @generated
+
 use alloc::borrow::Cow;
 use alloc::string::String;
 use alloc::vec::Vec;
 use core::fmt;
-use scolapasta_string_escape::format_debug_escape_into;
 #[cfg(feature = "std")]
 use std::error;
+
+use scolapasta_string_escape::format_debug_escape_into;
 
 use crate::RubyException;
 
@@ -46,6 +49,23 @@ impl ZeroDivisionError {
         // `raise RuntimeError` or `RuntimeError.new` have `message`
         // equal to the exception's class name.
         let message = Cow::Borrowed(DEFAULT_MESSAGE);
+        Self { message }
+    }
+
+    /// Construct a new, `ZeroDivisionError` Ruby exception with the given
+    /// message.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_exception::*;
+    /// let exception = ZeroDivisionError::with_message("an error occurred");
+    /// assert_eq!(exception.message(), b"an error occurred");
+    /// ```
+    #[inline]
+    #[must_use]
+    pub const fn with_message(message: &'static str) -> Self {
+        let message = Cow::Borrowed(message.as_bytes());
         Self { message }
     }
 

--- a/spinoso-securerandom/src/lib.rs
+++ b/spinoso-securerandom/src/lib.rs
@@ -81,7 +81,7 @@
 //! # fn example() -> Result<(), spinoso_securerandom::Error> {
 //! let uuid = spinoso_securerandom::uuid()?;
 //! assert_eq!(uuid.len(), 36);
-//! assert!(uuid.is_ascii());
+//! assert!(uuid.chars().all(|ch| ch == '-' || ch.is_ascii_hexdigit()));
 //! # Ok(())
 //! # }
 //! # example().unwrap()
@@ -719,10 +719,12 @@ pub fn uuid() -> Result<String, RandomBytesError> {
 
 #[cfg(test)]
 mod tests {
+    use core::ops::Not;
+    use rand::CryptoRng;
+
     use super::{
         alphanumeric, base64, hex, random_bytes, random_number, uuid, DomainError, Error, Max, Rand,
     };
-    use rand::CryptoRng;
 
     fn rng_must_be_cryptographically_secure<T: CryptoRng>(_rng: T) {}
 
@@ -844,15 +846,13 @@ mod tests {
         let id = uuid().unwrap();
         assert_eq!(id.len(), 36);
         assert!(id.chars().all(|ch| ch == '-' || ch.is_ascii_hexdigit()));
-        assert!(id.find(char::is_uppercase).is_none());
+        assert!(id.chars().any(char::is_uppercase).not());
         assert_eq!(&id[14..15], "4");
     }
 
     #[test]
     fn alphanumeric_format() {
         let random = alphanumeric(Some(1024)).unwrap();
-        assert!(random
-            .find(|ch: char| !ch.is_ascii_alphanumeric())
-            .is_none());
+        assert!(random.chars().all(|ch| ch.is_ascii_alphanumeric()));
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -50,12 +50,10 @@ impl State {
     /// an interpreter.
     #[must_use]
     pub fn is_code_block_open(self) -> bool {
-        match self {
-            Self::Valid | Self::UnexpectedEnd | Self::UnexpectedRegexpBegin | Self::CodeTooLong => {
-                false
-            }
-            _ => true,
-        }
+        !matches!(
+            self,
+            Self::Valid | Self::UnexpectedEnd | Self::UnexpectedRegexpBegin | Self::CodeTooLong
+        )
     }
 
     /// Whether this variant is a recoverable error.
@@ -64,7 +62,7 @@ impl State {
     /// buffer.
     #[must_use]
     pub fn is_recoverable_error(self) -> bool {
-        self == Self::CodeTooLong
+        matches!(self, Self::CodeTooLong)
     }
 
     /// Whether this variant is a fatal parse error.
@@ -73,7 +71,7 @@ impl State {
     /// again.
     #[must_use]
     pub fn is_fatal(self) -> bool {
-        self == Self::ParseError
+        matches!(self, Self::ParseError)
     }
 }
 

--- a/src/ruby.rs
+++ b/src/ruby.rs
@@ -12,7 +12,7 @@ use termcolor::WriteColor;
 
 use crate::backend::ffi;
 use crate::backend::state::parser::Context;
-use crate::backend::string;
+use crate::backend::string::format_unicode_debug_into;
 use crate::backtrace;
 use crate::prelude::*;
 
@@ -140,7 +140,7 @@ fn load_error<P: AsRef<OsStr>>(file: P, message: &str) -> Result<String, Error> 
     let mut buf = String::from(message);
     buf.push_str(" -- ");
     let path = ffi::os_str_to_bytes(file.as_ref())?;
-    string::format_unicode_debug_into(&mut buf, path)?;
+    format_unicode_debug_into(&mut buf, path)?;
     Ok(buf)
 }
 


### PR DESCRIPTION
- Import `regex::Match` in `artichoke_backend::extn::core::regexp::utf8`.
- Use `matches!` in more places.
- Import `format_unicode_debug_into` and `string::WriteError`.
- Add `format_unicode_debug_into` and `string::WriteError` to
  `extn::prelude` and `test::prelude`.
- Use `into` instead of `Error::from`.
- Use `ByteSlice::as_bstr` on byte slices that appear in test assertions
  for better assertion failure output in tests.
- Add `// @generated` comments to the top of generated sources. This
  magic comment is recognized by rustfmt.
  https://github.com/rust-lang/rustfmt/blob/81ad114d12c2d7dd2253afd64f0d2019697aa6de/Configurations.md#format_generated_files
- Add `const fn with_message(message: &'static str) -> Self` to all
  `spinoso-exception` `Exception` structs.
- Fixup `spinoso-exception` autogen script to output pre-formatted code.
- Improve format assertions for `alphanumeric` and `uuid` in `spinoso-securerandom`.