### PR TITLE
Enhance API of spinoso_random::Random

### DIFF
--- a/spinoso-random/src/rand.rs
+++ b/spinoso-random/src/rand.rs
@@ -25,6 +25,12 @@ pub enum Max {
     None,
 }
 
+impl Default for Max {
+    fn default() -> Self {
+        Self::None
+    }
+}
+
 impl fmt::Display for Max {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {

--- a/spinoso-random/src/random/mod.rs
+++ b/spinoso-random/src/random/mod.rs
@@ -79,6 +79,27 @@ impl fmt::Debug for Random {
     }
 }
 
+impl From<u32> for Random {
+    #[inline]
+    fn from(seed: u32) -> Self {
+        Self::with_seed(seed)
+    }
+}
+
+impl From<[u32; DEFAULT_SEED_CNT]> for Random {
+    #[inline]
+    fn from(seed: [u32; DEFAULT_SEED_CNT]) -> Self {
+        Self::with_array_seed(seed)
+    }
+}
+
+impl From<[u8; DEFAULT_SEED_BYTES]> for Random {
+    #[inline]
+    fn from(seed: [u8; DEFAULT_SEED_BYTES]) -> Self {
+        Self::with_byte_array_seed(seed)
+    }
+}
+
 impl Random {
     /// Create a new Mersenne Twister random number generator with a randomly
     /// generated seed.
@@ -283,8 +304,9 @@ fn int_pair_to_real_inclusive(a: u32, b: u32) -> f64 {
 pub fn seed_to_key(seed: [u8; DEFAULT_SEED_BYTES]) -> [u32; DEFAULT_SEED_CNT] {
     let mut key = [0_u32; DEFAULT_SEED_CNT];
     let iter = key.iter_mut().zip(seed.chunks_exact(size_of::<u32>()));
+
+    let mut bytes = [0; size_of::<u32>()];
     for (cell, chunk) in iter {
-        let mut bytes = [0; size_of::<u32>()];
         bytes.copy_from_slice(chunk);
         *cell = u32::from_le_bytes(bytes);
     }

--- a/spinoso-random/src/random/ruby/mod.rs
+++ b/spinoso-random/src/random/ruby/mod.rs
@@ -37,8 +37,11 @@ const LOWER_MASK: Wrapping<u32> = Wrapping(0x7fff_ffff);
 /// [`Box`]: https://doc.rust-lang.org/std/boxed/struct.Box.html
 #[derive(Clone)]
 #[cfg_attr(docsrs, doc(alias = "Mersenne"))]
+#[cfg_attr(docsrs, doc(alias = "Twister"))]
+#[cfg_attr(docsrs, doc(alias = "Mersenne Twister"))]
 #[cfg_attr(docsrs, doc(alias = "mersenne"))]
 #[cfg_attr(docsrs, doc(alias = "twister"))]
+#[cfg_attr(docsrs, doc(alias = "mersenne twister"))]
 #[cfg_attr(docsrs, doc(alias = "MT"))]
 #[cfg_attr(docsrs, doc(alias = "MT19937"))]
 #[allow(missing_copy_implementations)] // RNGs should not implement `Copy`
@@ -295,6 +298,8 @@ const fn temper(mut x: u32) -> u32 {
 
 #[cfg(test)]
 mod tests {
+    use core::iter;
+
     use super::Mt;
 
     #[test]
@@ -306,10 +311,11 @@ mod tests {
         let mt = Mt::with_seed(123_456);
         let debug = format!("{:?}", mt);
         assert!(!debug.contains("123456"));
+        assert_eq!(debug, "Mt {}");
     }
 
     #[test]
     fn seed_with_empty_iter_returns() {
-        let _ = Mt::new_with_key(core::iter::empty());
+        let _ = Mt::new_with_key(iter::empty());
     }
 }

--- a/spinoso-random/src/random/ruby/rand.rs
+++ b/spinoso-random/src/random/ruby/rand.rs
@@ -127,7 +127,7 @@ impl RngCore for Mt {
     /// [`fill_bytes`]: Mt::fill_bytes
     #[inline]
     fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Error> {
-        self.fill_bytes(dest);
+        Self::fill_bytes(self, dest);
         Ok(())
     }
 }

--- a/spinoso-random/src/urandom.rs
+++ b/spinoso-random/src/urandom.rs
@@ -47,6 +47,6 @@ mod tests {
         let mut buf_b = [0; 256];
         urandom(&mut buf_a).unwrap();
         urandom(&mut buf_b).unwrap();
-        assert_ne!(buf_a[..], buf_b[..]);
+        assert_ne!(buf_a, buf_b);
     }
 }


### PR DESCRIPTION
- Add `Default` impl for `Max` -> `Max::None`.
- Add `From<u32>` impl for `Random` that wraps `Random::with_seed`.
- Add `From<[u32; DEFAULT_SEED_CNT]>` impl for `Random` that wraps
  `Random::with_array_seed`.
- Add `From<[u8; DEFAULT_SEED_BYTES]>` impl for `Random` that wraps
  `Random::with_byte_array_seed`.
- Small performance optimization to avoid zeroing a temporary buffer in
  a loop in `seed_to_key`.
- Add more doc aliases to `Mt`.
- Small improvements to tests.
- Use fully qualified syntax for delegating to inherent impls in
  `RngCore` impl for `Mt`.