### PR TITLE
Enable crates that depend on artichoke to easily opt out of CLI feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,15 @@ lto = true
 [features]
 default = [
   "cli",
+  "kitchen-sink",
+]
+# Enable a CLI frontend for Artichoke, including a `ruby`-equivalent CLI and
+# REPL.
+cli = ["backtrace", "rustyline", "structopt"]
+# Enable a module for formtting backtraces from Ruby exceptions.
+backtrace = ["termcolor"]
+# Enable all features of Ruby Core, Standard Library, and the underlying VM.
+kitchen-sink = [
   "core-env",
   "core-env-system",
   "core-math",
@@ -72,9 +81,8 @@ default = [
   "core-regexp-oniguruma",
   "core-time",
   "native-filesystem-access",
-  "stdlib-securerandom"
+  "stdlib-securerandom",
 ]
-cli = ["rustyline", "structopt", "termcolor"]
 # Enable resolving environment variables with the `ENV` core object.
 core-env = ["artichoke-backend/core-env"]
 # Enable resolving environment variables with the `ENV` core object using native

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -10,15 +10,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "arbitrary"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -30,10 +21,7 @@ version = "0.1.0-pre.0"
 dependencies = [
  "artichoke-backend",
  "chrono",
- "rustyline",
- "structopt",
  "target-lexicon",
- "termcolor",
 ]
 
 [[package]]
@@ -72,17 +60,6 @@ version = "0.0.0"
 dependencies = [
  "artichoke",
  "libfuzzer-sys",
-]
-
-[[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -186,21 +163,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "clap"
-version = "2.33.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10040cdf04294b565d9e0319955430099ec3813a64c952b86a41200ad714ae48"
-dependencies = [
- "ansi_term",
- "atty",
- "bitflags",
- "strsim",
- "textwrap",
- "unicode-width",
- "vec_map",
-]
-
-[[package]]
 name = "focaccia"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -222,24 +184,6 @@ name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
-
-[[package]]
-name = "heck"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3deed196b6e7f9e44a2ae8d94225d80302d81208b1bb673fd21fe634645c85a9"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "intaglio"
@@ -311,19 +255,6 @@ name = "memchr"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
-
-[[package]]
-name = "nix"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50e4785f2c3b7589a0d0c1dd60285e1188adac4006e8abd6dd578e1567027363"
-dependencies = [
- "bitflags",
- "cc",
- "cfg-if",
- "libc",
- "void",
-]
 
 [[package]]
 name = "nom"
@@ -410,30 +341,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "237a5ed80e274dbc66f86bd59c1e25edc039660be53194b5fe0a482e0f2612ea"
 
 [[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -517,24 +424,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
-name = "rustyline"
-version = "6.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3358c21cbbc1a751892528db4e1de4b7a2b6a73f001e215aaba97d712cfa9777"
-dependencies = [
- "cfg-if",
- "libc",
- "log",
- "memchr",
- "nix",
- "scopeguard",
- "unicode-segmentation",
- "unicode-width",
- "utf8parse",
- "winapi",
-]
-
-[[package]]
 name = "scolapasta-hex"
 version = "0.1.0"
 
@@ -544,12 +433,6 @@ version = "0.1.0"
 dependencies = [
  "bstr",
 ]
-
-[[package]]
-name = "scopeguard"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "shlex"
@@ -621,69 +504,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "structopt"
-version = "0.3.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de5472fb24d7e80ae84a7801b7978f95a19ec32cb1876faea59ab711eb901976"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0eb37335aeeebe51be42e2dc07f031163fbabfa6ac67d7ea68b5c2f68d5f99"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "syn"
-version = "1.0.38"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e69abc24912995b3038597a7a593be5053eb0fb44f3cc5beec0deb421790c1f4"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-xid",
-]
-
-[[package]]
 name = "target-lexicon"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee5a98e506fb7231a304c3a1bd7c132a55016cf65001e0282480665870dfcb9"
-
-[[package]]
-name = "termcolor"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
 
 [[package]]
 name = "thread_local"
@@ -695,46 +519,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
-
-[[package]]
 name = "unicode-xid"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
-name = "utf8parse"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "936e4b492acfd135421d8dca4b1aa80a7bfc26e702ef3af710e0752684df5372"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
-
-[[package]]
 name = "version_check"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
-
-[[package]]
-name = "void"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "wasi"
@@ -757,15 +551,6 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -10,10 +10,8 @@ edition = "2018"
 cargo-fuzz = true
 
 [dependencies]
+artichoke = { path = "..", default-features = false, features = ["kitchen-sink"] }
 libfuzzer-sys = "0.3"
-
-[dependencies.artichoke]
-path = ".."
 
 # Prevent this from interfering with workspaces
 [workspace]

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -24,8 +24,6 @@ version = "0.1.0-pre.0"
 dependencies = [
  "artichoke-backend",
  "chrono",
- "rustyline",
- "structopt",
  "target-lexicon",
  "termcolor",
 ]
@@ -301,18 +299,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 
 [[package]]
-name = "nix"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83450fe6a6142ddd95fb064b746083fc4ef1705fe81f64a64e1d4b39f54a1055"
-dependencies = [
- "bitflags",
- "cc",
- "cfg-if",
- "libc",
-]
-
-[[package]]
 name = "nom"
 version = "5.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -536,24 +522,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
-name = "rustyline"
-version = "6.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f0d5e7b0219a3eadd5439498525d4765c59b7c993ef0c12244865cd2d988413"
-dependencies = [
- "cfg-if",
- "libc",
- "log",
- "memchr",
- "nix",
- "scopeguard",
- "unicode-segmentation",
- "unicode-width",
- "utf8parse",
- "winapi",
-]
-
-[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -572,12 +540,6 @@ version = "0.1.0"
 dependencies = [
  "bstr",
 ]
-
-[[package]]
-name = "scopeguard"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
@@ -783,12 +745,6 @@ name = "unicode-xid"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
-
-[[package]]
-name = "utf8parse"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "936e4b492acfd135421d8dca4b1aa80a7bfc26e702ef3af710e0752684df5372"
 
 [[package]]
 name = "vec_map"

--- a/spec-runner/Cargo.toml
+++ b/spec-runner/Cargo.toml
@@ -11,14 +11,12 @@ keywords = ["artichoke", "artichoke-ruby", "ruby", "ruby-spec", "testing"]
 categories = ["development-tools::testing"]
 
 [dependencies]
+artichoke = { path = "..", default-features = false, features = ["backtrace", "kitchen-sink"] }
 rust-embed = "5.7.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.8"
 structopt = "0.3"
 termcolor = "1.1"
-
-[dependencies.artichoke]
-path = ".."
 
 # `spec-runner` is a regression testing tool
 # Remove it from the main artichoke workspace.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,32 +68,12 @@
 //!
 //! All features are enabled by default.
 //!
-//! - **core-env-system** - Activates the [`std::env`](module@std::env) backend
-//!   for the [`ENV` object][core-obj-env]. When this feature is disabled,
-//!   access to the environ is emulated with an in-memory store.
-//! - **core-math-extra** - Activates additional dependencies to implement some
-//!   functions in the [`Math` module][core-mod-math].  When this feature is
-//!   disabled, these functions raise `NotImplementedError`.
-//! - **core-random** - Include an implementation of the
-//!   [`Random` class][core-class-random]. This feature includes additional
-//!   dependencies. When this feature is disabled, Artichoke does not have
-//!   support for generating psuedorandom numbers.
-//! - **core-time** - Include an implementation of the
-//!   [`Time` class][core-class-time]. This feature includes additional
-//!   dependencies. When this feature is disabled, Artichoke does not have
-//!   datetime support.
-//! - **stdlib-securerandom** - An implementation of a CSPRNG for the
-//!   [`SecureRandom` module][stdlib-mod-securerandom]. This feature includes
-//!   additional dependencies.  When this feature is disabled, the
-//!   `SecureRandom` module is not present.
+//! The features exposed by this crate are unstable. Please refer to the
+//! documentation in the [source `Cargo.toml`].
 //!
 //! [rubylang]: https://www.ruby-lang.org/
 //! [rubyspec]: https://github.com/ruby/spec
-//! [core-obj-env]: https://ruby-doc.org/core-2.6.3/ENV.html
-//! [core-mod-math]: https://ruby-doc.org/core-2.6.3/Math.html
-//! [core-class-random]: https://ruby-doc.org/core-2.6.3/Random.html
-//! [core-class-time]: https://ruby-doc.org/core-2.6.3/Time.html
-//! [stdlib-mod-securerandom]: https://ruby-doc.org/stdlib-2.6.3/libdoc/securerandom/rdoc/SecureRandom.html
+//! [source `Cargo.toml`]: https://github.com/artichoke/artichoke/blob/trunk/Cargo.toml
 
 #![doc(html_root_url = "https://docs.rs/artichoke/0.1.0-pre.0")]
 #![doc(html_favicon_url = "https://www.artichokeruby.org/favicon.ico")]
@@ -115,7 +95,7 @@ readme!();
 
 pub use artichoke_backend as backend;
 
-#[cfg(feature = "cli")]
+#[cfg(feature = "backtrace")]
 pub mod backtrace;
 pub mod parser;
 #[cfg(feature = "cli")]


### PR DESCRIPTION
- Add a new meta-feature called `kitchen-sink` that collects all non-CLI
  interpreter features such as Ruby Core API and Standard Library flags.
- Add `backtrace` feature for `Exception` backtrace formatting and make
  this feature independent of the `cli` feature.
- Remove `cli` feature from `fuzz` crate.
- Remove `cli` feature from `spec-runner` crate. Add `backtrace` feature
  to `spec-runner` crate.

Followup to https://github.com/artichoke/artichoke/pull/925.