### PR TITLE
Lint and format spec-runner with clippy and rustfmt

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -216,6 +216,14 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --workspace --all-features
 
+      - name: Check formatting (spec-runner)
+        run: cargo fmt -- --check --color=auto
+        working-directory: "spec-runner"
+
+      - name: Lint with Clippy (spec-runner)
+        run: cargo clippy --workspace --all-features --all-targets
+        working-directory: "spec-runner"
+
   ruby:
     name: Lint and format Ruby
     runs-on: ubuntu-latest

--- a/Rakefile
+++ b/Rakefile
@@ -17,6 +17,9 @@ namespace :lint do
       FileUtils.touch(root)
     end
     sh 'cargo clippy --workspace --all-features'
+    Dir.chdir('spec-runner') do
+      sh 'cargo clippy --workspace --all-features --all-targets'
+    end
   end
 
   desc 'Lint Rust sources with Clippy restriction pass (unenforced lints)'
@@ -48,6 +51,9 @@ namespace :format do
   desc 'Format Rust sources with rustfmt'
   task :rust do
     sh 'cargo fmt -- --color=auto'
+    Dir.chdir('spec-runner') do
+      sh 'cargo fmt -- --color=auto'
+    end
   end
 
   desc 'Format text, YAML, and Markdown sources with prettier'
@@ -68,6 +74,9 @@ namespace :fmt do
   desc 'Format Rust sources with rustfmt'
   task :rust do
     sh 'cargo fmt -- --color=auto'
+    Dir.chdir('spec-runner') do
+      sh 'cargo fmt -- --color=auto'
+    end
   end
 
   desc 'Format text, YAML, and Markdown sources with prettier'

--- a/spec-runner/src/main.rs
+++ b/spec-runner/src/main.rs
@@ -2,6 +2,7 @@
 #![warn(clippy::pedantic)]
 #![warn(clippy::cargo)]
 #![warn(clippy::clippy::needless_borrow)]
+#![allow(clippy::option_if_let_else)]
 #![allow(unknown_lints)]
 #![warn(broken_intra_doc_links)]
 #![warn(missing_docs)]
@@ -183,10 +184,7 @@ pub fn is_require_path(config: &model::Config, name: &str) -> Option<()> {
         }
     }
     if let Some(ref specs) = suite.specs {
-        specs
-            .iter()
-            .position(|name| spec_name.starts_with(name))
-            .map(|_| ())
+        specs.iter().position(|name| spec_name.starts_with(name)).map(|_| ())
     } else {
         Some(())
     }

--- a/spec-runner/src/mspec.rs
+++ b/spec-runner/src/mspec.rs
@@ -33,15 +33,10 @@ where
     T: IntoIterator<Item = &'a str>,
 {
     interp.def_rb_source_file("/src/lib/spec_helper.rb", &b""[..])?;
-    interp.def_rb_source_file(
-        "/src/lib/test/spec_runner",
-        &include_bytes!("spec_runner.rb")[..],
-    )?;
+    interp.def_rb_source_file("/src/lib/test/spec_runner", &include_bytes!("spec_runner.rb")[..])?;
     interp.eval_file(Path::new("/src/lib/test/spec_runner"))?;
     let specs = interp.try_convert_mut(specs.into_iter().collect::<Vec<_>>())?;
-    let result = interp
-        .top_self()
-        .funcall(interp, "run_specs", &[specs], None)?;
+    let result = interp.top_self().funcall(interp, "run_specs", &[specs], None)?;
     interp.try_convert(result)
 }
 


### PR DESCRIPTION
Since moving the spec-runner to its own workspace, rake tooling and CI have not
enforced formatting and linting.

This commit adds steps to lint:clippy, fmt:rust, and format:rust to account for
the separate spec-runner workspace. These steps are also added to CI of the 'rust'
job.

Fixes a regression introduced in https://github.com/artichoke/artichoke/pull/849.