### PR TITLE
Add a CI job to compile Artichoke with its minimum dependency versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -224,6 +224,41 @@ jobs:
         run: cargo clippy --workspace --all-features --all-targets
         working-directory: "spec-runner"
 
+  rust-minimal-versions:
+    name: Compile with minimum dependency versions
+    runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: -D warnings
+      RUST_BACKTRACE: 1
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          components: rustfmt, clippy
+
+      - name: Install Rust nightly toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          profile: minimal
+
+      - name: Test compile with minimal versions
+        run: |
+          cargo +nightly generate-lockfile -Z minimal-versions
+          cargo build --workspace --verbose
+          cargo test --workspace --no-run
+
+      - name: Test compile with minimal versions (spec-runner)
+        run: |
+          cargo +nightly generate-lockfile -Z minimal-versions
+          cargo build --workspace --verbose
+          cargo test --workspace --no-run
+        working-directory: "spec-runner"
+
   ruby:
     name: Lint and format Ruby
     runs-on: ubuntu-latest

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -12,10 +12,10 @@ categories = ["api-bindings"]
 
 [dependencies]
 artichoke-core = { version = "0.6", path = "../artichoke-core" }
-bstr = { version = "0.2", default-features = false, features = ["std"] }
-intaglio = "1.1"
+bstr = { version = "0.2, >= 0.2.2", default-features = false, features = ["std"] }
+intaglio = "1, >= 1.1.1"
 itoa = "0.4"
-log = "0.4"
+log = "0.4, >= 0.4.5"
 once_cell = "1"
 regex = "1"
 scolapasta-string-escape = { version = "0.1", path = "../scolapasta-string-escape" }

--- a/spec-runner/Cargo.toml
+++ b/spec-runner/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["development-tools::testing"]
 [dependencies]
 artichoke = { path = "..", default-features = false, features = ["backtrace", "kitchen-sink"] }
 rust-embed = "5.7.0"
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0, >= 1.0.7", features = ["derive"] }
 structopt = "0.3"
 termcolor = "1.1"
 toml = { version = "0.5", default-features = false }


### PR DESCRIPTION
Ensure that Artichoke and the spec-runner compile with the lowest valid
dependency versions based on the constraints in `Cargo.toml`.

Dependency constraints are a contract that declares any satisfying
version is valid for building the crate. If this is not true, the
dependency specifiers are buggy.

This PR updates the minimum dependency constraints for several crates:

- `bstr` in `artichoke-backend` moved from `0.2` to `0.2, >= 0.2.2` to
  ensure `impl Default for &'a Bstr` and `impl Default for BString`.
- `intaglio` in `artichoke-backend` moved from `1` to `1, >= 1.1.1` to
  remove the dependency on `bstr`, which improperly specified its
  minimum version as `0.2` when it relied on `impl Default for &'a BStr`
  which was introduced in `0.2.2`.
- `log` in `artichoke-backend` moved from `0.4` to `0.4, >= 0.4.5` to
  pull in a fix for an inner macro resolution compile error.
- `serde` in `spec-runner` moved from `1.0` to `1.0, >= 1.0.7` to work
  around a bug in minimal vesions of `toml` which improperly declare the
  minimum version of `serde`.

This commit adds a non-blocking CI job which tests both `artichoke` and
`spec-runner` compile and test compile with their minimal versions by
forcibly generating a minimal-versions lockfile using nightly `cargo`.

This PR was enabled by https://github.com/artichoke/artichoke/pull/972#issuecomment-749857478.