### PR TITLE
Ensure a newline is written after the calling inspect on the last value

### DIFF
--- a/src/repl.rs
+++ b/src/repl.rs
@@ -224,6 +224,7 @@ where
                         let result = value.inspect(&mut interp);
                         output.write_all(config.result_prefix.as_bytes())?;
                         output.write_all(result.as_slice())?;
+                        output.write_all(b"\n")?;
                     }
                     Err(ref exc) => backtrace::format_repl_trace_into(&mut error, &mut interp, exc)?,
                 }


### PR DESCRIPTION
In v7.0.0 and later, `rustyline` overwrites lines in the terminal that
are not newline-terminated (not flushed?). This results in an `airb`
REPL that doesn't display the `#inspect` value of the last expression.

This commit fixes this bug by writing a `"\n"` to the output stream
after writing the `#inspect` value of the last expression.

Prior to this commit:

```console
$ cargo run -q --bin airb
artichoke 0.1.0-pre.0 (2020-12-24 revision 3889) [x86_64-apple-darwin]
[rustc 1.48.0 (7eac88abb 2020-11-16)]
>>> "a"
>>>
```

After this commit:

```console
$ cargo run -q --bin airb
artichoke 0.1.0-pre.0 (2020-12-24 revision 3890) [x86_64-apple-darwin]
[rustc 1.48.0 (7eac88abb 2020-11-16)]
>>> "a"
=> "a"
>>>
```

This regression was introduced in 2a94a10df8aacb27d8b182999f38880777776be2 and #970.

See also https://github.com/artichoke/artichoke/issues/595 which proposes some UI snapshotting tests, which would have prevented this regression.