### PR TITLE
Do a sweep through markdown docs

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -23,8 +23,7 @@ cargo build --release --target wasm32-unknown-unknown
 
 This on its own does not produce a usable artifact. To build a WebAssembly
 bundle, depend on `artichoke` in a crate with a main. See the
-[artichoke/playground](https://github.com/artichoke/playground) repository for
-an example.
+[artichoke/playground] repository for an example.
 
 ## Prerequisites
 
@@ -39,9 +38,8 @@ compiler.
 
 #### Installation
 
-The recommended way to install the Rust toolchain is with
-[rustup](https://rustup.rs/). On macOS, you can install rustup with
-[Homebrew](https://docs.brew.sh/Installation):
+The recommended way to install the Rust toolchain is with [rustup]. On macOS,
+you can install rustup with [Homebrew]:
 
 ```sh
 brew install rustup-init
@@ -70,18 +68,17 @@ cargo build --workspace
 ### C Toolchain
 
 Some artichoke dependencies, like the mruby [`sys`](artichoke-backend/src/sys)
-FFI bindings and the [`onig`](https://crates.io/crates/onig) crate, build C
-static libraries and require a C compiler.
+FFI bindings and the [`onig`] crate, build C static libraries and require a C
+compiler.
 
 Artichoke specifically requires clang. WebAssembly targets require clang-8 or
 newer.
 
 #### `cc` Crate
 
-Artichoke and some of its dependencies use the Rust
-[`cc` crate](https://crates.io/crates/cc) to build. `cc` uses a
-[platform-dependent C compiler](https://github.com/alexcrichton/cc-rs#compile-time-requirements)
-to compile C sources. On Unix, `cc` crate uses the `cc` binary.
+Artichoke and some of its dependencies use the Rust [`cc` crate] to build. `cc`
+uses a [platform-dependent C compiler] to compile C sources. On Unix, `cc` crate
+uses the `cc` binary.
 
 ### mruby Bindings
 
@@ -89,7 +86,6 @@ To build the Artichoke mruby backend, you will need a C compiler toolchain. By
 default, mruby requires the following to compile:
 
 - clang
-- bison
 - ar
 
 You can override the requirement for clang by setting the `CC` and `LD`
@@ -97,19 +93,18 @@ environment variables.
 
 ### Ruby Toolchain
 
-Artichoke requires a recent Ruby 2.x and [bundler](https://bundler.io/) 2.x. The
+Artichoke requires a recent Ruby 2.x and [bundler] 2.x. The
 [`.ruby-version`](.ruby-version) file in this repository specifies Ruby 2.6.3.
 
-If you use [RVM](https://rvm.io/), you can install Ruby dependencies by running:
+If you use [RVM], you can install Ruby dependencies by running:
 
 ```sh
 rvm install "$(cat .ruby-version)"
 gem install bundler
 ```
 
-If you use [rbenv](https://github.com/rbenv/rbenv) and
-[ruby-build](https://github.com/rbenv/ruby-build), you can install Ruby
-dependencies by running:
+If you use [rbenv] and [ruby-build], you can install Ruby dependencies by
+running:
 
 ```sh
 rbenv install "$(cat .ruby-version)"
@@ -123,3 +118,15 @@ can install these dependencies by running:
 ```sh
 bundle install
 ```
+
+[artichoke/playground]: https://github.com/artichoke/playground
+[rustup]: https://rustup.rs/
+[homebrew]: https://docs.brew.sh/Installation
+[`onig`]: https://crates.io/crates/onig
+[`cc` crate]: https://crates.io/crates/cc
+[platform-dependent c compiler]:
+  https://github.com/alexcrichton/cc-rs#compile-time-requirements
+[bundler]: https://bundler.io/
+[rvm]: https://rvm.io/
+[rbenv]: https://github.com/rbenv/rbenv
+[ruby-build]: https://github.com/rbenv/ruby-build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,35 +1,32 @@
 # Contributing to Artichoke
 
-👋 Hi and welcome to [Artichoke](https://github.com/artichoke). Thanks for
-taking the time to contribute! 💪💎🙌
+👋 Hi and welcome to [Artichoke]. Thanks for taking the time to contribute!
+💪💎🙌
 
 Artichoke aspires to be a Ruby 2.6.3-compatible implementation of the Ruby
-programming language.
-[There is lots to do](https://github.com/artichoke/artichoke/issues).
+programming language. [There is lots to do].
 
 If Artichoke does not run Ruby source code in the same way that MRI does, it is
-a bug and we would appreciate if you
-[filed an issue so we can fix it](https://github.com/artichoke/artichoke/issues/new).
+a bug and we would appreciate if you [filed an issue so we can fix it].
 
 If you would like to contribute code 👩‍💻👨‍💻, find an issue that looks interesting
 and leave a comment that you're beginning to investigate. If there is no issue,
-please file one before beginning to work on a PR.
-[Good first issues are labeled `E-easy`](https://github.com/artichoke/artichoke/labels/E-easy).
+please file one before beginning to work on a PR. [Good first issues are labeled
+`E-easy`].
 
 ## Discussion
 
-If you'd like to engage in a discussion outside of GitHub, you can
-[join Artichoke's public Discord server](https://discord.gg/QCe2tp2).
+If you'd like to engage in a discussion outside of GitHub, you can [join
+Artichoke's public Discord server].
 
 ## Implementation Philosophy
 
 - Prefer pure Ruby implementations when initially implementing features.
 - A feature is not done until it passes [ruby/spec](RUBYSPEC.md).
-- Move implementations to Rust for performance, e.g.
-  [using Serde to implement the JSON package](https://github.com/artichoke/artichoke/issues/77).
+- Move implementations to Rust for performance, e.g. [using Serde to implement
+  the JSON package].
 - If there is a Rust crate that does what we need, prefer to use it. Forking is
-  OK, too, e.g.
-  [artichoke/rust-onig](https://github.com/artichoke/rust-onig/tree/artichoke-vendor).
+  OK, too, e.g. [artichoke/rust-onig].
 
 ## Setup
 
@@ -46,15 +43,14 @@ Toolchain requirements are documented in [`BUILD.md`](BUILD.md#rust-toolchain).
 
 ### C Toolchain
 
-Some Artichoke dependencies, like the mruby [`sys`](artichoke-backend/src/sys)
-module and the [`onig`](https://crates.io/crates/onig) crate, build C static
-libraries and require a C compiler.
+Some Artichoke dependencies, like the mruby [`sys`] module and the [`onig`]
+crate, build C static libraries and require a C compiler.
 
 Toolchain requirements are documented in [`BUILD.md`](BUILD.md#c-toolchain).
 
 ### Ruby
 
-Artichoke requires a recent Ruby 2.x and [bundler](https://bundler.io/) 2.x. The
+Artichoke requires a recent Ruby 2.x and [bundler] 2.x. The
 [`.ruby-version`](.ruby-version) file in this repository specifies Ruby 2.6.3.
 
 Toolchain requirements are documented in [`BUILD.md`](BUILD.md#ruby-toolchain).
@@ -86,8 +82,7 @@ rake spec                         # Run enforced ruby/spec suite
 rake test                         # Run Artichoke unit tests
 ```
 
-To lint Ruby sources, Artichoke uses
-[RuboCop](https://github.com/rubocop-hq/rubocop). RuboCop runs as part of the
+To lint Ruby sources, Artichoke uses [RuboCop]. RuboCop runs as part of the
 `lint` task. To run RuboCop by itself, invoke the `lint:rubocop` task.
 
 ```console
@@ -98,7 +93,7 @@ $ bundle exec rake lint:rubocop
 ### Node.js
 
 Node.js is an optional dependency that is used for formatting text sources with
-[prettier](https://prettier.io/).
+[prettier].
 
 Node.js is only required for formatting if modifying the following filetypes:
 
@@ -111,11 +106,8 @@ Node.js is only required for formatting if modifying the following filetypes:
 - `yaml`
 - `yml`
 
-You will need to install
-[Node.js](https://nodejs.org/en/download/package-manager/).
-
-On macOS, you can install Node.js with
-[Homebrew](https://docs.brew.sh/Installation):
+You will need to install [Node.js]. On macOS, you can install Node.js with
+[Homebrew]:
 
 ```sh
 brew install node
@@ -136,11 +128,10 @@ Merges will be blocked by CI if there are lint errors.
 
 ### Testing
 
-A PR must have new or existing tests for it to be merged. The
-[Rust book chapter on testing](https://doc.rust-lang.org/book/ch11-00-testing.html)
-is a good place to start. If you'd like to see some examples in Artichoke, take
-a look at the `Value` tests in
-[`artichoke-backend/src/value/mod.rs`](artichoke-backend/src/value.rs).
+A PR must have new or existing tests for it to be merged. The [Rust book chapter
+on testing] is a good place to start. If you'd like to see some examples in
+Artichoke, take a look at the `Value` tests in
+[`artichoke-backend/src/value/mod.rs`].
 
 To run tests:
 
@@ -169,25 +160,44 @@ Tests are run for every PR. All builds must pass before merging a PR.
 ### Rust Toolchain
 
 Upgrades to the Rust toolchain should happen in a dedicated PR that addresses
-any changes to ructc warnings and clippy lints. See
-[GH-482](https://github.com/artichoke/artichoke/pull/482) for an example.
+any changes to ructc warnings and clippy lints. See [artichoke/artichoke#482]
+for an example.
 
 ### Rust Crates
 
 Version specifiers in `Cargo.toml` are NPM caret-style by default. A version
 specifier of `4.1.2` means `4.1.2 <= version < 5.0.0`.
 
-To see what crates are outdated, you can use
-[cargo-outdated](https://github.com/kbknapp/cargo-outdated).
+To see what crates are outdated, you can use [cargo-outdated].
 
 If you need to pull in an updated version of a crate for a bugfix or a new
 feature, update the version number in `Cargo.toml`. See
-[GH-548](https://github.com/artichoke/artichoke/pull/548) for an example.
+[artichoke/artichoke#548] for an example.
 
-Regular dependency bumps are handled by [@dependabot](https://dependabot.com/).
+Regular dependency bumps are handled by [@dependabot].
 
-### Node.js Packages
-
-To see what packages are outdated, you can run `npm outdated`.
-
-Dependency bumps are handled by [@dependabot](https://dependabot.com/).
+[artichoke]: https://github.com/artichoke
+[there is lots to do]: https://github.com/artichoke/artichoke/issues
+[filed an issue so we can fix it]:
+  https://github.com/artichoke/artichoke/issues/new
+[good first issues are labeled `e-easy`]:
+  https://github.com/artichoke/artichoke/labels/E-easy
+[join artichoke's public discord server]: https://discord.gg/QCe2tp2
+[using serde to implement the json package]:
+  https://github.com/artichoke/artichoke/issues/77
+[artichoke/rust-onig]:
+  https://github.com/artichoke/rust-onig/tree/artichoke-vendor
+[`sys`]: artichoke-backend/src/sys
+[`onig`]: https://crates.io/crates/onig
+[bundler]: https://bundler.io/
+[rubocop]: https://github.com/rubocop-hq/rubocop
+[prettier]: https://prettier.io/
+[node.js]: https://nodejs.org/en/download/package-manager/
+[homebrew]: https://docs.brew.sh/Installation
+[rust book chapter on testing]:
+  https://doc.rust-lang.org/book/ch11-00-testing.html
+[`artichoke-backend/src/value/mod.rs`]: artichoke-backend/src/value.rs
+[artichoke/artichoke#482]: https://github.com/artichoke/artichoke/pull/482
+[cargo-outdated]: https://github.com/kbknapp/cargo-outdated
+[artichoke/artichoke#548]: https://github.com/artichoke/artichoke/pull/548
+[@dependabot]: https://dependabot.com/

--- a/VISION.md
+++ b/VISION.md
@@ -1,116 +1,131 @@
 # Design and Goals
 
 Artichoke is a platform for building Ruby implementations. You can build a
-[ruby/spec](https://github.com/ruby/spec)-compliant Ruby by combining Artichoke
-core, a VM and parser backend, and the Artichoke frontend.
+[ruby/spec]-compliant Ruby by combining Artichoke core, a VM and parser backend,
+and the Artichoke frontend.
 
 Artichoke is designed to enable experimentation. The top goals of the project
 are:
 
-- [Support WebAssembly as a build target](https://github.com/artichoke/artichoke/labels/O-wasm-unknown).
+- [Support WebAssembly as a build target][wasm-target].
 - Support embedding and executing Ruby in untrusted environments.
-- [Distribute Ruby applications as single-binary artifacts](https://github.com/artichoke/artichoke/labels/A-single-binary).
-- [Implement Ruby with state-of-the-art dependencies](https://github.com/artichoke/artichoke/labels/A-deps).
-- Experiment with VMs to support
-  [dynamic codegen](https://github.com/artichoke/artichoke/labels/A-codegen),
-  [ahead of time compilation](https://github.com/artichoke/artichoke/labels/A-compiler),
-  [parallelism and eliminating the GIL](https://github.com/artichoke/artichoke/labels/A-parallelism),
-  and novel
-  [memory management and garbage collection techniques](https://github.com/artichoke/artichoke/labels/A-memory-management).
+- [Distribute Ruby applications as single-binary artifacts][a-single-binary].
+- [Implement Ruby with state-of-the-art dependencies][a-deps].
+- Experiment with VMs to support [dynamic codegen][a-codegen], [ahead of time
+  compilation][a-compiler], [parallelism and eliminating the
+  GIL][a-parallelism], and novel [memory management and garbage collection
+  techniques][a-memory-management].
 
 ## Core
 
 `artichoke-core` contains traits for the core set of APIs an interpreter must
-implement. The traits in
-[`artichoke-core`](https://artichoke.github.io/artichoke/artichoke_core/)
-define:
+implement. The traits in [`artichoke-core`] define:
 
 - APIs a concrete VM must implement to support the Artichoke runtime and
   frontends.
-- How to box polymorphic core types into
-  [Ruby `Value`](https://artichoke.github.io/artichoke/artichoke_core/value/trait.Value.html).
-- [Interoperability](https://artichoke.github.io/artichoke/artichoke_core/convert/index.html)
-  between the VM backend and the Rust-implemented core.
+- How to box polymorphic core types into [Ruby `Value`].
+- [Interoperability] between the VM backend and the Rust-implemented core.
 
-Some of the core APIs a Ruby implementation must provide are
-[evaluating code](https://artichoke.github.io/artichoke/artichoke_core/eval/trait.Eval.html),
-[converting Rust data structures to boxed `Value`s on the interpreter heap](https://artichoke.github.io/artichoke/artichoke_core/convert/trait.ConvertMut.html),
-and
-[interning `Symbol`s](https://artichoke.github.io/artichoke/artichoke_core/intern/trait.Intern.html).
+Some of the core APIs a Ruby implementation must provide are [evaluating
+code][core-eval], [converting Rust data structures to boxed `Value`s on the
+interpreter heap][core-converter], and [interning `Symbol`s][core-intern].
 
 ### Runtime
 
 Artichoke core provides an implementation-agnostic Ruby runtime. The runtime in
-Artichoke core will pass 100% of the
-[Core](https://github.com/artichoke/artichoke/labels/A-ruby-core) and
-[Standard Library](https://github.com/artichoke/artichoke/labels/A-ruby-stdlib)
-Ruby specs. The runtime will be implemented in a hybrid of Rust and Ruby. The
-[`Regexp` implementation](artichoke-backend/src/extn/core/regexp) is a
-representative example of the approach.
+Artichoke core will pass 100% of the [Core][a-ruby-core] and [Standard
+Library][a-ruby-stdlib] Ruby specs. The runtime will be implemented in a hybrid
+of Rust and Ruby. The [`Regexp` implementation][extn-regexp] is a representative
+example of the approach.
 
 ### Embedding
 
 Artichoke core will support embedding with:
 
-- Multiple
-  [filesystem backends](https://github.com/artichoke/artichoke/labels/A-filesystem),
-  including an in-memory
-  [virtual filesystem](https://artichoke.github.io/artichoke/artichoke_backend/fs/index.html).
-- Multiple [`ENV` backends](artichoke-backend/src/extn/core/env), including an
-  in-memory `HashMap` backend.
+- Multiple [filesystem backends], including an in-memory [virtual filesystem].
+- Multiple [`ENV` backends][extn-env], including an in-memory `HashMap` backend.
 - Optional C dependencies via multiple implementations of Core classes, e.g.
-  [`Regexp`](artichoke-backend/src/extn/core/regexp).
-- [Optional standard-library](https://github.com/artichoke/artichoke/labels/A-optional-stdlib).
-- [Optional multi-threading](https://github.com/artichoke/artichoke/labels/A-parallelism).
+  [`Regexp`][extn-regexp].
+- [Optional standard-library][a-optional-stdlib].
+- [Optional multi-threading][a-parallelism].
 - Capturable IO.
 
 ### Experimentation
 
 A Rust-implemented Ruby runtime offers an opportunity to experiment with:
 
-- [Improving performance](https://github.com/artichoke/artichoke/labels/A-performance)
-  of MRI Core and Standard Library.
-- Implementing the runtime with
-  [state-of-the-art dependencies](https://github.com/artichoke/artichoke/labels/A-deps).
-- Distributing
-  [single-binary builds](https://github.com/artichoke/artichoke/labels/A-single-binary).
+- [Improving performance][a-performance] of MRI Core and Standard Library.
+- Implementing the runtime with [state-of-the-art dependencies][a-deps].
+- Distributing [single-binary builds][a-single-binary].
 
 ## VM Backend
 
 Artichoke core does not provide a parser or a VM for executing Ruby. VM backends
 provide these functions.
 
-Artichoke currently includes an
-[mruby backend](https://github.com/artichoke/artichoke/labels/B-mruby). There
-are plans to add an
-[MRI backend](https://github.com/artichoke/artichoke/labels/B-MRI) and a pure
-Rust backend.
+Artichoke currently includes an [mruby backend][b-mruby]. There are plans to add
+an [MRI backend][b-mri] and a [pure Rust backend][b-artichoke].
 
-VM backends are responsible for passing 100% of the
-[Language](https://github.com/artichoke/artichoke/labels/A-ruby-language) Ruby
-specs.
+VM backends are responsible for passing 100% of the [Language][a-ruby-language]
+Ruby specs.
 
 ### Experimentation
 
 VM backends offer an opportunity to experiment with:
 
-- [Dynamic codegen](https://github.com/artichoke/artichoke/labels/A-codegen).
-- [Compilation](https://github.com/artichoke/artichoke/labels/A-compiler).
-- [Parallelism and eliminating the GIL](https://github.com/artichoke/artichoke/labels/A-parallelism).
-- [Memory management and garbage collection techniques](https://github.com/artichoke/artichoke/labels/A-memory-management).
+- [Dynamic codegen][a-codegen].
+- [Compilation][a-compiler].
+- [Parallelism and eliminating the GIL][a-parallelism].
+- [Memory management and garbage collection techniques][a-memory-management].
 
 ## Frontend
 
-Artichoke will include `ruby` and `irb`
-[binary frontends](https://github.com/artichoke/artichoke/labels/A-frontend)
-with dynamically selectable VM backends.
+Artichoke will include `ruby` and `irb` [binary frontends][a-frontend] with
+dynamically selectable VM backends.
 
-Artichoke will produce a
-[WebAssembly frontend](https://github.com/artichoke/artichoke/labels/A-build-target).
+Artichoke will produce a [WebAssembly frontend][wasm-target].
 
-Artichoke will include implementation-agnostic
-[C APIs](https://github.com/artichoke/artichoke/labels/A-C-API) targeting:
+Artichoke will include implementation-agnostic [C APIs][a-c-api] targeting:
 
-- [MRI API](https://github.com/artichoke/artichoke/labels/CAPI-MRI) from Ruby.
-- [`MRB_API`](https://github.com/artichoke/artichoke/labels/CAPI-mruby) from
-  mruby.
+- [MRI API][capi-mri] from Ruby.
+- [`MRB_API`][capi-mruby] from mruby.
+
+[ruby/spec]: https://github.com/ruby/spec
+[wasm-target]: https://github.com/artichoke/artichoke/labels/O-wasm-unknown
+[a-single-binary]: https://github.com/artichoke/artichoke/labels/A-single-binary
+[a-deps]: https://github.com/artichoke/artichoke/labels/A-deps
+[a-codegen]: https://github.com/artichoke/artichoke/labels/A-codegen
+[a-compiler]: https://github.com/artichoke/artichoke/labels/A-compiler
+[a-parallelism]: https://github.com/artichoke/artichoke/labels/A-parallelism
+[a-memory-management]:
+  https://github.com/artichoke/artichoke/labels/A-memory-management
+[`artichoke-core`]: https://artichoke.github.io/artichoke/artichoke_core/
+[ruby `value`]:
+  https://artichoke.github.io/artichoke/artichoke_core/value/trait.Value.html
+[interoperability]:
+  https://artichoke.github.io/artichoke/artichoke_core/convert/index.html
+[core-eval]:
+  https://artichoke.github.io/artichoke/artichoke_core/eval/trait.Eval.html
+[core-converter]:
+  https://artichoke.github.io/artichoke/artichoke_core/convert/trait.ConvertMut.html
+[core-intern]:
+  https://artichoke.github.io/artichoke/artichoke_core/intern/trait.Intern.html
+[a-ruby-core]: https://github.com/artichoke/artichoke/labels/A-ruby-core
+[a-ruby-stdlib]: https://github.com/artichoke/artichoke/labels/A-ruby-stdlib
+[extn-regexp]: artichoke-backend/src/extn/core/regexp
+[filesystem backends]:
+  https://github.com/artichoke/artichoke/labels/A-filesystem
+[virtual filesystem]:
+  https://artichoke.github.io/artichoke/artichoke_backend/fs/index.html
+[extn-env]: artichoke-backend/src/extn/core/env
+[a-optional-stdlib]:
+  https://github.com/artichoke/artichoke/labels/A-optional-stdlib
+[a-performance]: https://github.com/artichoke/artichoke/labels/A-performance
+[a-frontend]: https://github.com/artichoke/artichoke/labels/A-frontend
+[b-mruby]: https://github.com/artichoke/artichoke/labels/B-mruby
+[b-mri]: https://github.com/artichoke/artichoke/labels/B-MRI
+[b-artichoke]: https://github.com/artichoke/artichoke/labels/B-Artichoke
+[a-ruby-language]: https://github.com/artichoke/artichoke/labels/A-ruby-language
+[a-c-api]: https://github.com/artichoke/artichoke/labels/A-C-API
+[capi-mri]: https://github.com/artichoke/artichoke/labels/CAPI-MRI
+[capi-mruby]: https://github.com/artichoke/artichoke/labels/CAPI-mruby

--- a/artichoke-core/README.md
+++ b/artichoke-core/README.md
@@ -42,8 +42,7 @@ how to [convert] between Ruby VM and Rust types.
 
 ## Examples
 
-[`artichoke-backend`](https://artichoke.github.io/artichoke/artichoke_backend/)
-is one implementation of the `artichoke-core` traits.
+[`artichoke-backend`] is one implementation of the `artichoke-core` traits.
 
 To use all of the APIs defined in Artichoke Core, bring the traits into scope by
 importing the prelude:
@@ -98,3 +97,4 @@ Lopopolo.
   https://artichoke.github.io/artichoke/artichoke_core/top_self/trait.TopSelf.html
 [`warn`]:
   https://artichoke.github.io/artichoke/artichoke_core/warn/trait.Warn.html
+[`artichoke-backend`]: https://artichoke.github.io/artichoke/artichoke_backend/


### PR DESCRIPTION
- Remove `bison` build dep from `BUILD.md`.
- Use named anchors in all markdown sources.
- Use org/repo#nnn syntax for refering to tickets.
- Remove section on Node.js packages from `CONTRIBUTING.md`.
- Make repeated mentions of wasm target refer to the same link in
  `VISION.md`.
- Add link to `B-Artichoke` in `VISION.md`.