### PR TITLE
Raise the correct exception message when negative len given to Range#first

### DIFF
--- a/artichoke-backend/src/extn/core/range/range.rb
+++ b/artichoke-backend/src/extn/core/range/range.rb
@@ -104,6 +104,7 @@ class Range
     unless n.is_a?(Integer)
       raise TypeError, "can't convert #{arg.class} to Integer (#{arg.class}#to_int gives #{n.class})"
     end
+    raise ArgumentError, 'negative array size (or size too big)' if n.negative?
 
     each.take(n).to_a
   end


### PR DESCRIPTION
Match the message MRI raises.