### PR TITLE
Amortize double pointer deref on Artichoke State

### DIFF
--- a/artichoke-backend/src/class.rs
+++ b/artichoke-backend/src/class.rs
@@ -48,7 +48,7 @@ impl<'a> Builder<'a> {
         T: Any,
         U: Into<Cow<'static, str>>,
     {
-        let state = self.interp.state.as_ref().ok_or_else(InterpreterExtractError::new)?;
+        let state = self.interp.state.as_deref().ok_or_else(InterpreterExtractError::new)?;
         let rclass = if let Some(spec) = state.classes.get::<T>() {
             spec.rclass()
         } else {

--- a/artichoke-backend/src/class_registry.rs
+++ b/artichoke-backend/src/class_registry.rs
@@ -44,7 +44,7 @@ impl ClassRegistry for Artichoke {
     where
         T: Any,
     {
-        let state = self.state.as_mut().ok_or_else(InterpreterExtractError::new)?;
+        let state = self.state.as_deref_mut().ok_or_else(InterpreterExtractError::new)?;
         state.classes.insert::<T>(Box::new(spec));
         Ok(())
     }
@@ -57,7 +57,7 @@ impl ClassRegistry for Artichoke {
     where
         T: Any,
     {
-        let state = self.state.as_ref().ok_or_else(InterpreterExtractError::new)?;
+        let state = self.state.as_deref().ok_or_else(InterpreterExtractError::new)?;
         let spec = state.classes.get::<T>();
         Ok(spec)
     }
@@ -66,7 +66,7 @@ impl ClassRegistry for Artichoke {
     where
         T: Any,
     {
-        let state = self.state.as_ref().ok_or_else(InterpreterExtractError::new)?;
+        let state = self.state.as_deref().ok_or_else(InterpreterExtractError::new)?;
         let spec = state.classes.get::<T>();
         let rclass = if let Some(spec) = spec {
             spec.rclass()
@@ -90,7 +90,7 @@ impl ClassRegistry for Artichoke {
     where
         T: Any,
     {
-        let state = self.state.as_ref().ok_or_else(InterpreterExtractError::new)?;
+        let state = self.state.as_deref().ok_or_else(InterpreterExtractError::new)?;
         let spec = state.classes.get::<T>();
         let rclass = if let Some(spec) = spec {
             spec.rclass()

--- a/artichoke-backend/src/constant.rs
+++ b/artichoke-backend/src/constant.rs
@@ -34,7 +34,7 @@ impl DefineConstant for Artichoke {
         } else {
             return Err(ConstantNameError::from(String::from(constant)).into());
         };
-        let state = self.state.as_mut().ok_or_else(InterpreterExtractError::new)?;
+        let state = self.state.as_deref_mut().ok_or_else(InterpreterExtractError::new)?;
         let spec = state
             .classes
             .get::<T>()
@@ -63,7 +63,7 @@ impl DefineConstant for Artichoke {
         } else {
             return Err(ConstantNameError::from(String::from(constant)).into());
         };
-        let state = self.state.as_mut().ok_or_else(InterpreterExtractError::new)?;
+        let state = self.state.as_deref_mut().ok_or_else(InterpreterExtractError::new)?;
         let spec = state
             .modules
             .get::<T>()

--- a/artichoke-backend/src/eval.rs
+++ b/artichoke-backend/src/eval.rs
@@ -21,7 +21,7 @@ impl Eval for Artichoke {
     fn eval(&mut self, code: &[u8]) -> Result<Self::Value, Self::Error> {
         trace!("Attempting eval of Ruby source");
         let result = unsafe {
-            let state = self.state.as_mut().ok_or_else(InterpreterExtractError::new)?;
+            let state = self.state.as_deref_mut().ok_or_else(InterpreterExtractError::new)?;
             let parser = state.parser.as_mut().ok_or_else(InterpreterExtractError::new)?;
             let context: *mut sys::mrbc_context = parser.context_mut();
             self.with_ffi_boundary(|mrb| protect::eval(mrb, context, code))?

--- a/artichoke-backend/src/intern.rs
+++ b/artichoke-backend/src/intern.rs
@@ -12,7 +12,7 @@ use crate::Artichoke;
 
 impl Artichoke {
     pub fn lookup_symbol_with_trailing_nul(&self, symbol: u32) -> Result<Option<&[u8]>, Error> {
-        let state = self.state.as_ref().ok_or_else(InterpreterExtractError::new)?;
+        let state = self.state.as_deref().ok_or_else(InterpreterExtractError::new)?;
         if let Some(symbol) = symbol.checked_sub(1) {
             if let Some(bytes) = state.symbols.get(symbol.into()) {
                 Ok(Some(bytes))
@@ -29,7 +29,7 @@ impl Artichoke {
         T: Into<Cow<'static, [u8]>>,
     {
         let bytes = bytes.into();
-        let state = self.state.as_mut().ok_or_else(InterpreterExtractError::new)?;
+        let state = self.state.as_deref_mut().ok_or_else(InterpreterExtractError::new)?;
         let symbol = state.symbols.intern(bytes)?;
         let symbol = u32::from(symbol);
         // mruby expexts symbols to be non-zero.
@@ -40,7 +40,7 @@ impl Artichoke {
     }
 
     pub fn check_interned_bytes_with_trailing_nul(&self, bytes: &[u8]) -> Result<Option<u32>, Error> {
-        let state = self.state.as_ref().ok_or_else(InterpreterExtractError::new)?;
+        let state = self.state.as_deref().ok_or_else(InterpreterExtractError::new)?;
         let symbol = state.symbols.check_interned(bytes);
         if let Some(symbol) = symbol {
             let symbol = u32::from(symbol);
@@ -67,7 +67,7 @@ impl Intern for Artichoke {
         T: Into<Cow<'static, [u8]>>,
     {
         let bytes = bytes.into();
-        let state = self.state.as_mut().ok_or_else(InterpreterExtractError::new)?;
+        let state = self.state.as_deref_mut().ok_or_else(InterpreterExtractError::new)?;
         let mut bytes = bytes.into_owned();
         bytes.push(b'\0');
         let symbol = state.symbols.intern(bytes)?;
@@ -80,7 +80,7 @@ impl Intern for Artichoke {
     }
 
     fn check_interned_bytes(&self, bytes: &[u8]) -> Result<Option<Self::Symbol>, Self::Error> {
-        let state = self.state.as_ref().ok_or_else(InterpreterExtractError::new)?;
+        let state = self.state.as_deref().ok_or_else(InterpreterExtractError::new)?;
         let mut bytes = bytes.to_vec();
         bytes.push(b'\0');
         let symbol = state.symbols.check_interned(&bytes);
@@ -97,7 +97,7 @@ impl Intern for Artichoke {
     }
 
     fn lookup_symbol(&self, symbol: Self::Symbol) -> Result<Option<&[u8]>, Self::Error> {
-        let state = self.state.as_ref().ok_or_else(InterpreterExtractError::new)?;
+        let state = self.state.as_deref().ok_or_else(InterpreterExtractError::new)?;
         if let Some(symbol) = symbol.checked_sub(Self::SYMBOL_RANGE_START) {
             if let Some(bytes) = state.symbols.get(symbol.into()) {
                 if bytes.is_empty() {
@@ -114,7 +114,7 @@ impl Intern for Artichoke {
     }
 
     fn symbol_count(&self) -> usize {
-        if let Some(state) = self.state.as_ref() {
+        if let Some(state) = self.state.as_deref() {
             state.symbols.len()
         } else {
             0

--- a/artichoke-backend/src/io.rs
+++ b/artichoke-backend/src/io.rs
@@ -23,7 +23,7 @@ impl Io for Artichoke {
     ///
     /// If the output stream encounters an error, an error is returned.
     fn print<T: AsRef<[u8]>>(&mut self, message: T) -> Result<(), Self::Error> {
-        let state = self.state.as_mut().ok_or_else(InterpreterExtractError::new)?;
+        let state = self.state.as_deref_mut().ok_or_else(InterpreterExtractError::new)?;
         state.output.write_stdout(message.as_ref())?;
         Ok(())
     }
@@ -37,7 +37,7 @@ impl Io for Artichoke {
     ///
     /// If the output stream encounters an error, an error is returned.
     fn puts<T: AsRef<[u8]>>(&mut self, message: T) -> Result<(), Self::Error> {
-        let state = self.state.as_mut().ok_or_else(InterpreterExtractError::new)?;
+        let state = self.state.as_deref_mut().ok_or_else(InterpreterExtractError::new)?;
         state.output.write_stdout(message.as_ref())?;
         state.output.write_stdout(b"\n")?;
         Ok(())

--- a/artichoke-backend/src/load.rs
+++ b/artichoke-backend/src/load.rs
@@ -17,7 +17,7 @@ impl LoadSources for Artichoke {
         P: AsRef<Path>,
         T: File<Artichoke = Self::Artichoke, Error = Self::Exception>,
     {
-        let state = self.state.as_mut().ok_or_else(InterpreterExtractError::new)?;
+        let state = self.state.as_deref_mut().ok_or_else(InterpreterExtractError::new)?;
         let mut path = path.as_ref();
         let absolute_path;
         if path.is_relative() {
@@ -34,7 +34,7 @@ impl LoadSources for Artichoke {
         P: AsRef<Path>,
         T: Into<Cow<'static, [u8]>>,
     {
-        let state = self.state.as_mut().ok_or_else(InterpreterExtractError::new)?;
+        let state = self.state.as_deref_mut().ok_or_else(InterpreterExtractError::new)?;
         let mut path = path.as_ref();
         let absolute_path;
         if path.is_relative() {
@@ -50,7 +50,7 @@ impl LoadSources for Artichoke {
     where
         P: AsRef<Path>,
     {
-        let state = self.state.as_ref().ok_or_else(InterpreterExtractError::new)?;
+        let state = self.state.as_deref().ok_or_else(InterpreterExtractError::new)?;
         let is_file = state.vfs.is_file(path.as_ref());
         Ok(is_file)
     }
@@ -60,7 +60,7 @@ impl LoadSources for Artichoke {
         P: AsRef<Path>,
     {
         {
-            let state = self.state.as_mut().ok_or_else(InterpreterExtractError::new)?;
+            let state = self.state.as_deref_mut().ok_or_else(InterpreterExtractError::new)?;
             // Load Rust `File` first because an File may define classes and
             // modules with `LoadSources` and Ruby files can require arbitrary
             // other files, including some child sources that may depend on these
@@ -82,7 +82,7 @@ impl LoadSources for Artichoke {
         P: AsRef<Path>,
     {
         {
-            let state = self.state.as_mut().ok_or_else(InterpreterExtractError::new)?;
+            let state = self.state.as_deref_mut().ok_or_else(InterpreterExtractError::new)?;
             // If a file is already required, short circuit.
             if state.vfs.is_required(path.as_ref()) {
                 return Ok(false);
@@ -99,7 +99,7 @@ impl LoadSources for Artichoke {
         }
         let contents = self.read_source_file_contents(path.as_ref())?.into_owned();
         self.eval(contents.as_ref())?;
-        let state = self.state.as_mut().ok_or_else(InterpreterExtractError::new)?;
+        let state = self.state.as_deref_mut().ok_or_else(InterpreterExtractError::new)?;
         state.vfs.mark_required(path.as_ref())?;
         trace!(r#"Successful require of {}"#, path.as_ref().display());
         Ok(true)
@@ -109,7 +109,7 @@ impl LoadSources for Artichoke {
     where
         P: AsRef<Path>,
     {
-        let state = self.state.as_ref().ok_or_else(InterpreterExtractError::new)?;
+        let state = self.state.as_deref().ok_or_else(InterpreterExtractError::new)?;
         let contents = state.vfs.read_file(path.as_ref())?;
         Ok(contents.to_vec().into())
     }

--- a/artichoke-backend/src/module_registry.rs
+++ b/artichoke-backend/src/module_registry.rs
@@ -38,7 +38,7 @@ impl ModuleRegistry for Artichoke {
     where
         T: Any,
     {
-        let state = self.state.as_mut().ok_or_else(InterpreterExtractError::new)?;
+        let state = self.state.as_deref_mut().ok_or_else(InterpreterExtractError::new)?;
         state.modules.insert::<T>(Box::new(spec));
         Ok(())
     }
@@ -51,7 +51,7 @@ impl ModuleRegistry for Artichoke {
     where
         T: Any,
     {
-        let state = self.state.as_ref().ok_or_else(InterpreterExtractError::new)?;
+        let state = self.state.as_deref().ok_or_else(InterpreterExtractError::new)?;
         let spec = state.modules.get::<T>();
         Ok(spec)
     }
@@ -60,7 +60,7 @@ impl ModuleRegistry for Artichoke {
     where
         T: Any,
     {
-        let state = self.state.as_ref().ok_or_else(InterpreterExtractError::new)?;
+        let state = self.state.as_deref().ok_or_else(InterpreterExtractError::new)?;
         let spec = state.modules.get::<T>();
         let spec = if let Some(spec) = spec {
             spec

--- a/artichoke-backend/src/parser.rs
+++ b/artichoke-backend/src/parser.rs
@@ -18,21 +18,21 @@ impl Parser for Artichoke {
 
     fn reset_parser(&mut self) -> Result<(), Self::Error> {
         let mrb = unsafe { self.mrb.as_mut() };
-        let state = self.state.as_mut().ok_or_else(InterpreterExtractError::new)?;
+        let state = self.state.as_deref_mut().ok_or_else(InterpreterExtractError::new)?;
         let parser = state.parser.as_mut().ok_or_else(InterpreterExtractError::new)?;
         parser.reset(mrb);
         Ok(())
     }
 
     fn fetch_lineno(&self) -> Result<usize, Self::Error> {
-        let state = self.state.as_ref().ok_or_else(InterpreterExtractError::new)?;
+        let state = self.state.as_deref().ok_or_else(InterpreterExtractError::new)?;
         let parser = state.parser.as_ref().ok_or_else(InterpreterExtractError::new)?;
         let lineno = parser.fetch_lineno();
         Ok(lineno)
     }
 
     fn add_fetch_lineno(&mut self, val: usize) -> Result<usize, Self::Error> {
-        let state = self.state.as_mut().ok_or_else(InterpreterExtractError::new)?;
+        let state = self.state.as_deref_mut().ok_or_else(InterpreterExtractError::new)?;
         let parser = state.parser.as_mut().ok_or_else(InterpreterExtractError::new)?;
         let lineno = parser.add_fetch_lineno(val)?;
         Ok(lineno)
@@ -40,7 +40,7 @@ impl Parser for Artichoke {
 
     fn push_context(&mut self, context: Self::Context) -> Result<(), Self::Error> {
         let mrb = unsafe { self.mrb.as_mut() };
-        let state = self.state.as_mut().ok_or_else(InterpreterExtractError::new)?;
+        let state = self.state.as_deref_mut().ok_or_else(InterpreterExtractError::new)?;
         let parser = state.parser.as_mut().ok_or_else(InterpreterExtractError::new)?;
         parser.push_context(mrb, context);
         Ok(())
@@ -48,14 +48,14 @@ impl Parser for Artichoke {
 
     fn pop_context(&mut self) -> Result<Option<Self::Context>, Self::Error> {
         let mrb = unsafe { self.mrb.as_mut() };
-        let state = self.state.as_mut().ok_or_else(InterpreterExtractError::new)?;
+        let state = self.state.as_deref_mut().ok_or_else(InterpreterExtractError::new)?;
         let parser = state.parser.as_mut().ok_or_else(InterpreterExtractError::new)?;
         let context = parser.pop_context(mrb);
         Ok(context)
     }
 
     fn peek_context(&self) -> Result<Option<&Self::Context>, Self::Error> {
-        let state = self.state.as_ref().ok_or_else(InterpreterExtractError::new)?;
+        let state = self.state.as_deref().ok_or_else(InterpreterExtractError::new)?;
         let parser = state.parser.as_ref().ok_or_else(InterpreterExtractError::new)?;
         let context = parser.peek_context();
         Ok(context)

--- a/artichoke-backend/src/prng.rs
+++ b/artichoke-backend/src/prng.rs
@@ -8,12 +8,12 @@ impl Prng for Artichoke {
     type Prng = Random;
 
     fn prng(&self) -> Result<&Self::Prng, Self::Error> {
-        let state = self.state.as_ref().ok_or_else(InterpreterExtractError::new)?;
+        let state = self.state.as_deref().ok_or_else(InterpreterExtractError::new)?;
         Ok(&state.prng)
     }
 
     fn prng_mut(&mut self) -> Result<&mut Self::Prng, Self::Error> {
-        let state = self.state.as_mut().ok_or_else(InterpreterExtractError::new)?;
+        let state = self.state.as_deref_mut().ok_or_else(InterpreterExtractError::new)?;
         Ok(&mut state.prng)
     }
 }

--- a/artichoke-backend/src/regexp.rs
+++ b/artichoke-backend/src/regexp.rs
@@ -6,19 +6,19 @@ impl Regexp for Artichoke {
     type Error = InterpreterExtractError;
 
     fn active_regexp_globals(&self) -> Result<usize, Self::Error> {
-        let state = self.state.as_ref().ok_or_else(InterpreterExtractError::new)?;
+        let state = self.state.as_deref().ok_or_else(InterpreterExtractError::new)?;
         let count = state.regexp.active_regexp_globals();
         Ok(count)
     }
 
     fn set_active_regexp_globals(&mut self, count: usize) -> Result<(), Self::Error> {
-        let state = self.state.as_mut().ok_or_else(InterpreterExtractError::new)?;
+        let state = self.state.as_deref_mut().ok_or_else(InterpreterExtractError::new)?;
         state.regexp.set_active_regexp_globals(count);
         Ok(())
     }
 
     fn clear_regexp(&mut self) -> Result<(), Self::Error> {
-        let state = self.state.as_mut().ok_or_else(InterpreterExtractError::new)?;
+        let state = self.state.as_deref_mut().ok_or_else(InterpreterExtractError::new)?;
         state.regexp.clear();
         Ok(())
     }

--- a/artichoke-backend/src/warn.rs
+++ b/artichoke-backend/src/warn.rs
@@ -14,7 +14,7 @@ impl Warn for Artichoke {
     type Error = Error;
 
     fn warn(&mut self, message: &[u8]) -> Result<(), Self::Error> {
-        let state = self.state.as_mut().ok_or_else(InterpreterExtractError::new)?;
+        let state = self.state.as_deref_mut().ok_or_else(InterpreterExtractError::new)?;
         if let Err(err) = state.output.write_stderr(b"rb warning: ") {
             let mut message = String::from("Failed to write warning to $stderr: ");
             let _ = write!(&mut message, "{}", err);

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -92,7 +92,7 @@ impl Parser {
     /// Create a new parser from an interpreter instance.
     #[must_use]
     pub fn new(interp: &mut Artichoke) -> Option<Self> {
-        let state = interp.state.as_mut()?;
+        let state = interp.state.as_deref_mut()?;
         let context = state.parser.as_mut()?.context_mut();
         let context = NonNull::new(context)?;
         let parser = unsafe { interp.with_ffi_boundary(|mrb| sys::mrb_parser_new(mrb)).ok()? };


### PR DESCRIPTION
The inner Rust `State` is stored as a `Option<Box<State>>` property on the
`Artichoke` interpreter. When `artichoke-backend` implements interpreter
traits from `artichoke-core`, it is common to access the inner `State`
using `Option::as_ref` and `Option::as_mut` at the beginning of a method
to unwrap the `State` or error out. These APIs return `&Box<State>` and
`&mut Box<State>` (aka pointers to a pointer), which results in a double
indirection.

Replace all calls to unwrap the `State` with `Option::as_deref` and
`Option::as_deref_mut` to retrieve a `&State` and `&mut State`.
Implementations of `artichoke-core` traits often unwrap the `State` once
before performing several operations on it. This change results in
following the double pointer once via `Deref` to amortize its cost over
the entire function call.

This PR inspired filing https://github.com/rust-lang/rust-clippy/issues/6393.