### PR TITLE
Improve implementation of Random::fill_bytes

### DIFF
--- a/spinoso-random/src/random/mod.rs
+++ b/spinoso-random/src/random/mod.rs
@@ -352,9 +352,11 @@ mod tests {
         let random = Random::with_seed(874);
         let debug = format!("{:?}", random);
         assert!(!debug.contains("894"));
+        assert_eq!(debug, "Random {}");
 
         let random = Random::with_seed(123_456);
         let debug = format!("{:?}", random);
         assert!(!debug.contains("123456"));
+        assert_eq!(debug, "Random {}");
     }
 }


### PR DESCRIPTION
- Use a constant for the chunk size magic number.
- Sync the implementation from `rand_mt` which uses a while loop and
  `[_]::split_at_mut`.
- Add more assertions to debug seed leak tests for public-facing
  `Random` struct.