### PR TITLE
Split Regexp source from derived config

### DIFF
--- a/artichoke-backend/src/extn/core/regexp/backend/mod.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/mod.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::fmt;
 use std::hash::{Hash, Hasher};
 
-use crate::extn::core::regexp::{Config, Encoding};
+use crate::extn::core::regexp::{Config, Encoding, Source};
 use crate::extn::prelude::*;
 
 pub mod lazy;
@@ -43,9 +43,9 @@ pub trait RegexpType {
 
     fn debug(&self) -> String;
 
-    fn literal_config(&self) -> &Config;
+    fn source(&self) -> &Source;
 
-    fn derived_config(&self) -> &Config;
+    fn config(&self) -> &Config;
 
     fn encoding(&self) -> &Encoding;
 
@@ -124,13 +124,13 @@ impl fmt::Debug for &dyn RegexpType {
 
 impl Hash for &dyn RegexpType {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.literal_config().hash(state);
+        self.source().hash(state);
     }
 }
 
 impl PartialEq for &dyn RegexpType {
     fn eq(&self, other: &Self) -> bool {
-        self.derived_config().pattern == other.derived_config().pattern && self.encoding() == other.encoding()
+        self.config().pattern() == other.config().pattern() && self.encoding() == other.encoding()
     }
 }
 

--- a/artichoke-backend/src/extn/core/regexp/backend/regex/utf8.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/regex/utf8.rs
@@ -6,39 +6,39 @@ use std::num::NonZeroUsize;
 use std::str;
 
 use crate::extn::core::matchdata::MatchData;
-use crate::extn::core::regexp::{self, Config, Encoding, Regexp, RegexpType, Scan};
+use crate::extn::core::regexp::{self, Config, Encoding, Regexp, RegexpType, Scan, Source};
 use crate::extn::prelude::*;
 
 use super::super::{NameToCaptureLocations, NilableString};
 
 #[derive(Debug, Clone)]
 pub struct Utf8 {
-    literal: Config,
-    derived: Config,
+    source: Source,
+    config: Config,
     encoding: Encoding,
     regex: Regex,
 }
 
 impl Utf8 {
-    pub fn new(literal: Config, derived: Config, encoding: Encoding) -> Result<Self, Error> {
-        let pattern = str::from_utf8(derived.pattern.as_slice())
+    pub fn new(source: Source, config: Config, encoding: Encoding) -> Result<Self, Error> {
+        let pattern = str::from_utf8(config.pattern())
             .map_err(|_| ArgumentError::from("regex crate utf8 backend for Regexp only supports UTF-8 patterns"))?;
 
         let mut builder = RegexBuilder::new(pattern);
-        builder.case_insensitive(derived.options.ignore_case().into());
-        builder.multi_line(derived.options.multiline().into());
-        builder.ignore_whitespace(derived.options.extended().into());
+        builder.case_insensitive(config.options().ignore_case().into());
+        builder.multi_line(config.options().multiline().into());
+        builder.ignore_whitespace(config.options().extended().into());
 
         let regex = match builder.build() {
             Ok(regex) => regex,
-            Err(err) if literal.options.is_literal() => {
+            Err(err) if source.is_literal() => {
                 return Err(SyntaxError::from(err.to_string()).into());
             }
             Err(err) => return Err(RegexpError::from(err.to_string()).into()),
         };
         let regexp = Self {
-            literal,
-            derived,
+            source,
+            config,
             encoding,
             regex,
         };
@@ -48,7 +48,7 @@ impl Utf8 {
 
 impl fmt::Display for Utf8 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let pattern = self.derived.pattern.as_slice();
+        let pattern = self.config.pattern();
         format_unicode_debug_into(f, pattern).map_err(WriteError::into_inner)
     }
 }
@@ -127,20 +127,20 @@ impl RegexpType for Utf8 {
         // In practice this error will never be triggered since the only
         // fallible call in `format_unicode_debug_into` is to `write!` which
         // never `panic!`s for a `String` formatter, which we are using here.
-        let _ = format_unicode_debug_into(&mut pattern, self.literal.pattern.as_slice());
+        let _ = format_unicode_debug_into(&mut pattern, self.source.pattern());
         debug.push_str(pattern.replace("/", r"\/").as_str());
         debug.push('/');
-        debug.push_str(self.literal.options.as_display_modifier());
+        debug.push_str(self.source.options().as_display_modifier());
         debug.push_str(self.encoding.modifier_string());
         debug
     }
 
-    fn literal_config(&self) -> &Config {
-        &self.literal
+    fn source(&self) -> &Source {
+        &self.source
     }
 
-    fn derived_config(&self) -> &Config {
-        &self.derived
+    fn config(&self) -> &Config {
+        &self.config
     }
 
     fn encoding(&self) -> &Encoding {
@@ -149,21 +149,21 @@ impl RegexpType for Utf8 {
 
     fn inspect(&self) -> Vec<u8> {
         // pattern length + 2x '/' + mix + encoding
-        let mut inspect = Vec::with_capacity(self.literal.pattern.len() + 2 + 4);
+        let mut inspect = Vec::with_capacity(self.source.pattern().len() + 2 + 4);
         inspect.push(b'/');
-        if let Ok(pat) = str::from_utf8(self.literal.pattern.as_slice()) {
-            inspect.extend(pat.replace("/", r"\/").as_bytes());
+        if let Ok(pat) = str::from_utf8(self.source.pattern()) {
+            inspect.extend_from_slice(pat.replace("/", r"\/").as_bytes());
         } else {
-            inspect.extend(self.literal.pattern.iter());
+            inspect.extend_from_slice(self.source.pattern());
         }
         inspect.push(b'/');
-        inspect.extend(self.literal.options.as_display_modifier().as_bytes());
-        inspect.extend(self.encoding.modifier_string().as_bytes());
+        inspect.extend_from_slice(self.source.options().as_display_modifier().as_bytes());
+        inspect.extend_from_slice(self.encoding.modifier_string().as_bytes());
         inspect
     }
 
     fn string(&self) -> &[u8] {
-        self.derived.pattern.as_slice()
+        self.config.pattern()
     }
 
     fn case_match(&self, interp: &mut Artichoke, haystack: &[u8]) -> Result<bool, Error> {

--- a/spinoso-regexp/src/options.rs
+++ b/spinoso-regexp/src/options.rs
@@ -28,7 +28,7 @@ impl RegexpOption {
     ///
     /// An option is enabled if it is equal to [`RegexpOption::Enabled`].
     #[must_use]
-    pub fn is_enabled(self) -> bool {
+    pub const fn is_enabled(self) -> bool {
         matches!(self, Self::Enabled)
     }
 }


### PR DESCRIPTION
Introduce a new `spinso_regexp::Source` type that represents the
`Regexp` source as distinct from its derived configuration. This commit
threads the `Source` through to `extn::core::regexp`.

This commit also deletes the `extn`-defined `Config` struct and instead
uses the `Config` struct from `spinoso-regexp`.

This commit adds constructors and several accessor methods to `Config`
and `Source`.

Followup to #987.