### PR TITLE
Upgrade getrandom@0.1 dep to include cfg-if v1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,11 +213,11 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "libc",
  "wasi",
 ]


### PR DESCRIPTION
Enabled by https://github.com/rust-random/getrandom/pull/173.

Remaining deps pulling in cfg-if v0.1:

```console
$ cargo tree -i cfg-if:0.1.10
cfg-if v0.1.10
└── log v0.4.11
    ├── artichoke-backend v0.1.0 (/home/lopopolo/dev/artichoke/artichoke/artichoke-backend)
    │   └── artichoke v0.1.0-pre.0 (/home/lopopolo/dev/artichoke/artichoke)
    └── rustyline v7.1.0
        └── artichoke v0.1.0-pre.0 (/home/lopopolo/dev/artichoke/artichoke)
```