### PR TITLE
Add host compiler triple to ARTICHOKE_COMPILER_VERSION global constant

### DIFF
--- a/artichoke-backend/src/extn/mod.rs
+++ b/artichoke-backend/src/extn/mod.rs
@@ -11,16 +11,20 @@ use prelude::*;
 pub const INPUT_RECORD_SEPARATOR: &str = "\n";
 
 pub fn init(interp: &mut Artichoke, config: ReleaseMetadata<'_>) -> InitializeResult<()> {
-    let copyright = interp.convert_mut(config.ruby_copyright());
+    let mut copyright = interp.convert_mut(config.ruby_copyright());
+    copyright.freeze(interp)?;
     interp.define_global_constant("RUBY_COPYRIGHT", copyright)?;
 
-    let description = interp.convert_mut(config.ruby_description());
+    let mut description = interp.convert_mut(config.ruby_description());
+    description.freeze(interp)?;
     interp.define_global_constant("RUBY_DESCRIPTION", description)?;
 
-    let engine = interp.convert_mut(config.ruby_engine());
+    let mut engine = interp.convert_mut(config.ruby_engine());
+    engine.freeze(interp)?;
     interp.define_global_constant("RUBY_ENGINE", engine)?;
 
-    let engine_version = interp.convert_mut(config.ruby_engine_version());
+    let mut engine_version = interp.convert_mut(config.ruby_engine_version());
+    engine_version.freeze(interp)?;
     interp.define_global_constant("RUBY_ENGINE_VERSION", engine_version)?;
 
     let patchlevel = config
@@ -30,10 +34,12 @@ pub fn init(interp: &mut Artichoke, config: ReleaseMetadata<'_>) -> InitializeRe
     let patchlevel = interp.convert(patchlevel);
     interp.define_global_constant("RUBY_PATCHLEVEL", patchlevel)?;
 
-    let platform = interp.convert_mut(config.ruby_platform());
+    let mut platform = interp.convert_mut(config.ruby_platform());
+    platform.freeze(interp)?;
     interp.define_global_constant("RUBY_PLATFORM", platform)?;
 
-    let release_date = interp.convert_mut(config.ruby_release_date());
+    let mut release_date = interp.convert_mut(config.ruby_release_date());
+    release_date.freeze(interp)?;
     interp.define_global_constant("RUBY_RELEASE_DATE", release_date)?;
 
     let revision = config
@@ -43,10 +49,12 @@ pub fn init(interp: &mut Artichoke, config: ReleaseMetadata<'_>) -> InitializeRe
     let revision = interp.convert(revision);
     interp.define_global_constant("RUBY_REVISION", revision)?;
 
-    let version = interp.convert_mut(config.ruby_version());
+    let mut version = interp.convert_mut(config.ruby_version());
+    version.freeze(interp)?;
     interp.define_global_constant("RUBY_VERSION", version)?;
 
-    let compiler_version = interp.convert_mut(config.artichoke_compiler_version());
+    let mut compiler_version = interp.convert_mut(config.artichoke_compiler_version());
+    compiler_version.freeze(interp)?;
     interp.define_global_constant("ARTICHOKE_COMPILER_VERSION", compiler_version)?;
 
     core::init(interp)?;

--- a/build.rs
+++ b/build.rs
@@ -118,7 +118,14 @@ fn description(version: &str, release_date: Date, revision_count: Option<usize>,
 fn compiler_version() -> Option<String> {
     let cmd = env::var_os("RUSTC").unwrap_or_else(|| OsString::from("rustc"));
     let compiler_version = Command::new(cmd).arg("-V").output().ok()?;
-    String::from_utf8(compiler_version.stdout).ok()
+    let compiler_version = String::from_utf8(compiler_version.stdout).ok()?;
+    let mut compiler_version = compiler_version.trim().to_owned();
+    if let Ok(compiler_host) = env::var("HOST") {
+        compiler_version.push_str(" [");
+        compiler_version.push_str(&compiler_host);
+        compiler_version.push(']');
+    }
+    Some(compiler_version)
 }
 
 fn main() {


### PR DESCRIPTION
https://github.com/artichoke/nightly/pull/17 adds a nightly cross-compiled target for Apple Silicon. We have also been shipping a cross-compiled artifact for `x86_64-unknown-linux-musl`. This PR modifies the `String` value of the `ARTICHOKE_COMPILER_VERSION` global constant to include the host compiler triple:

```console
$ cargo run -q --bin airb
artichoke 0.1.0-pre.0 (2021-01-03 revision 3931) [x86_64-apple-darwin]
[rustc 1.49.0 (e1884a8e3 2020-12-29) [x86_64-apple-darwin]]
>>> ARTICHOKE_COMPILER_VERSION
=> "rustc 1.49.0 (e1884a8e3 2020-12-29) [x86_64-apple-darwin]"
>>>
```

This PR also freezes all of the global metadata constants injected into the interpreter in `extn::init`.