### PR TITLE
Update formatting of ARTICHOKE_COMPILER_VERSION

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -121,9 +121,8 @@ fn compiler_version() -> Option<String> {
     let compiler_version = String::from_utf8(compiler_version.stdout).ok()?;
     let mut compiler_version = compiler_version.trim().to_owned();
     if let Ok(compiler_host) = env::var("HOST") {
-        compiler_version.push_str(" [");
+        compiler_version.push_str(" on ");
         compiler_version.push_str(&compiler_host);
-        compiler_version.push(']');
     }
     Some(compiler_version)
 }


### PR DESCRIPTION
Replace `[...]` brackets for host triple with `on ...`.

This makes the `airb` prelude more closely match the Python REPL on
which it is based.

```console
$ cargo run -q --bin airb
artichoke 0.1.0-pre.0 (2021-01-03 revision 3935) [x86_64-apple-darwin]
[rustc 1.49.0 (e1884a8e3 2020-12-29) on x86_64-apple-darwin]
>>> ARTICHOKE_COMPILER_VERSION
=> "rustc 1.49.0 (e1884a8e3 2020-12-29) on x86_64-apple-darwin"
>>>
```

Followup to #998.