### PR TITLE
Use with_message constructor from spinoso-exception for &'static str msg

### DIFF
--- a/artichoke-backend/src/coerce_to_numeric.rs
+++ b/artichoke-backend/src/coerce_to_numeric.rs
@@ -21,7 +21,7 @@ impl CoerceToNumeric for Artichoke {
         match value.ruby_type() {
             Ruby::Float => return value.try_into(self),
             Ruby::Fixnum => return value.try_into::<i64>(self).map(|int| int as f64),
-            Ruby::Nil => return Err(TypeError::from("can't convert nil into Float").into()),
+            Ruby::Nil => return Err(TypeError::with_message("can't convert nil into Float").into()),
             _ => {}
         }
         // TODO: This branch should use `numeric::coerce`

--- a/artichoke-backend/src/eval.rs
+++ b/artichoke-backend/src/eval.rs
@@ -58,7 +58,7 @@ impl Eval for Artichoke {
 
     fn eval_file(&mut self, file: &Path) -> Result<Self::Value, Self::Error> {
         let context = Context::new(ffi::os_str_to_bytes(file.as_os_str())?.to_vec())
-            .ok_or_else(|| ArgumentError::from("path name contains null byte"))?;
+            .ok_or_else(|| ArgumentError::with_message("path name contains null byte"))?;
         self.push_context(context)?;
         let code = self.read_source_file_contents(file)?.into_owned();
         let result = self.eval(code.as_slice());

--- a/artichoke-backend/src/extn/core/array/mod.rs
+++ b/artichoke-backend/src/extn/core/array/mod.rs
@@ -193,7 +193,7 @@ impl Array {
         let vector = match (first, second, block) {
             (Some(mut array_or_len), default, None) => {
                 if let Ok(len) = array_or_len.try_into::<Int>(interp) {
-                    let len = usize::try_from(len).map_err(|_| ArgumentError::from("negative array size"))?;
+                    let len = usize::try_from(len).map_err(|_| ArgumentError::with_message("negative array size"))?;
                     let default = default.unwrap_or_else(Value::nil);
                     SpinosoArray::with_len_and_default(len, default.inner())
                 } else {
@@ -217,7 +217,8 @@ impl Array {
                         }
                     } else {
                         let len = array_or_len.implicitly_convert_to_int(interp)?;
-                        let len = usize::try_from(len).map_err(|_| ArgumentError::from("negative array size"))?;
+                        let len =
+                            usize::try_from(len).map_err(|_| ArgumentError::with_message("negative array size"))?;
                         let default = default.unwrap_or_else(Value::nil);
                         SpinosoArray::with_len_and_default(len, default.inner())
                     }
@@ -225,14 +226,14 @@ impl Array {
             }
             (Some(mut array_or_len), default, Some(block)) => {
                 if let Ok(len) = array_or_len.try_into::<Int>(interp) {
-                    let len = usize::try_from(len).map_err(|_| ArgumentError::from("negative array size"))?;
+                    let len = usize::try_from(len).map_err(|_| ArgumentError::with_message("negative array size"))?;
                     if default.is_some() {
                         interp.warn(b"warning: block supersedes default value argument")?;
                     }
                     let mut buffer = SpinosoArray::with_capacity(len);
                     for idx in 0..len {
                         let idx = Int::try_from(idx)
-                            .map_err(|_| RangeError::from("bignum too big to convert into `long'"))?;
+                            .map_err(|_| RangeError::with_message("bignum too big to convert into `long'"))?;
                         let idx = interp.convert(idx);
                         let elem = block.yield_arg(interp, &idx)?;
                         buffer.push(elem.inner());
@@ -259,14 +260,15 @@ impl Array {
                         }
                     } else {
                         let len = array_or_len.implicitly_convert_to_int(interp)?;
-                        let len = usize::try_from(len).map_err(|_| ArgumentError::from("negative array size"))?;
+                        let len =
+                            usize::try_from(len).map_err(|_| ArgumentError::with_message("negative array size"))?;
                         if default.is_some() {
                             interp.warn(b"warning: block supersedes default value argument")?;
                         }
                         let mut buffer = SpinosoArray::with_capacity(len);
                         for idx in 0..len {
                             let idx = Int::try_from(idx)
-                                .map_err(|_| RangeError::from("bignum too big to convert into `long'"))?;
+                                .map_err(|_| RangeError::with_message("bignum too big to convert into `long'"))?;
                             let idx = interp.convert(idx);
                             let elem = block.yield_arg(interp, &idx)?;
                             buffer.push(elem.inner());

--- a/artichoke-backend/src/extn/core/array/trampoline.rs
+++ b/artichoke-backend/src/extn/core/array/trampoline.rs
@@ -6,7 +6,7 @@ use crate::gc::{MrbGarbageCollection, State as GcState};
 
 pub fn clear(interp: &mut Artichoke, mut ary: Value) -> Result<Value, Error> {
     if ary.is_frozen(interp) {
-        return Err(FrozenError::from("can't modify frozen Array").into());
+        return Err(FrozenError::with_message("can't modify frozen Array").into());
     }
     let mut array = unsafe { Array::unbox_from_value(&mut ary, interp)? };
     array.clear();
@@ -39,7 +39,7 @@ pub fn element_assignment(
     third: Option<Value>,
 ) -> Result<Value, Error> {
     if ary.is_frozen(interp) {
-        return Err(FrozenError::from("can't modify frozen Array").into());
+        return Err(FrozenError::with_message("can't modify frozen Array").into());
     }
     // TODO: properly handle self-referential sets.
     if ary == first || ary == second || Some(ary) == third {
@@ -65,7 +65,7 @@ pub fn element_assignment(
 
 pub fn pop(interp: &mut Artichoke, mut ary: Value) -> Result<Value, Error> {
     if ary.is_frozen(interp) {
-        return Err(FrozenError::from("can't modify frozen Array").into());
+        return Err(FrozenError::with_message("can't modify frozen Array").into());
     }
     let mut array = unsafe { Array::unbox_from_value(&mut ary, interp)? };
     let result = array.pop();
@@ -81,7 +81,7 @@ pub fn pop(interp: &mut Artichoke, mut ary: Value) -> Result<Value, Error> {
 
 pub fn concat(interp: &mut Artichoke, mut ary: Value, other: Option<Value>) -> Result<Value, Error> {
     if ary.is_frozen(interp) {
-        return Err(FrozenError::from("can't modify frozen Array").into());
+        return Err(FrozenError::with_message("can't modify frozen Array").into());
     }
     if let Some(other) = other {
         let mut array = unsafe { Array::unbox_from_value(&mut ary, interp)? };
@@ -98,7 +98,7 @@ pub fn concat(interp: &mut Artichoke, mut ary: Value, other: Option<Value>) -> R
 
 pub fn push(interp: &mut Artichoke, mut ary: Value, value: Value) -> Result<Value, Error> {
     if ary.is_frozen(interp) {
-        return Err(FrozenError::from("can't modify frozen Array").into());
+        return Err(FrozenError::with_message("can't modify frozen Array").into());
     }
     let mut array = unsafe { Array::unbox_from_value(&mut ary, interp)? };
     array.push(value);
@@ -114,7 +114,7 @@ pub fn push(interp: &mut Artichoke, mut ary: Value, value: Value) -> Result<Valu
 
 pub fn reverse_bang(interp: &mut Artichoke, mut ary: Value) -> Result<Value, Error> {
     if ary.is_frozen(interp) {
-        return Err(FrozenError::from("can't modify frozen Array").into());
+        return Err(FrozenError::with_message("can't modify frozen Array").into());
     }
     let mut array = unsafe { Array::unbox_from_value(&mut ary, interp)? };
     array.reverse();
@@ -145,12 +145,12 @@ pub fn initialize_copy(interp: &mut Artichoke, ary: Value, mut from: Value) -> R
 
 pub fn shift(interp: &mut Artichoke, mut ary: Value, count: Option<Value>) -> Result<Value, Error> {
     if ary.is_frozen(interp) {
-        return Err(FrozenError::from("can't modify frozen Array").into());
+        return Err(FrozenError::with_message("can't modify frozen Array").into());
     }
     let mut array = unsafe { Array::unbox_from_value(&mut ary, interp)? };
     let result = if let Some(count) = count {
         let count = count.implicitly_convert_to_int(interp)?;
-        let count = usize::try_from(count).map_err(|_| ArgumentError::from("negative array size"))?;
+        let count = usize::try_from(count).map_err(|_| ArgumentError::with_message("negative array size"))?;
         let shifted = array.shift_n(count);
 
         Array::alloc_value(shifted, interp)

--- a/artichoke-backend/src/extn/core/exception/mod.rs
+++ b/artichoke-backend/src/extn/core/exception/mod.rs
@@ -136,7 +136,7 @@ mod tests {
 
     unsafe extern "C" fn run_run(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {
         unwrap_interpreter!(mrb, to => guard);
-        let exc = RuntimeError::from("something went wrong");
+        let exc = RuntimeError::with_message("something went wrong");
         error::raise(guard, exc)
     }
 

--- a/artichoke-backend/src/extn/core/integer/mod.rs
+++ b/artichoke-backend/src/extn/core/integer/mod.rs
@@ -150,7 +150,7 @@ impl Integer {
                 let denom = denominator.try_into::<Int>(interp)?;
                 let value = self.as_i64();
                 if denom == 0 {
-                    Err(ZeroDivisionError::from("divided by 0").into())
+                    Err(ZeroDivisionError::with_message("divided by 0").into())
                 } else if value < 0 && (value % denom) != 0 {
                     Ok(((value / denom) - 1).into())
                 } else {
@@ -165,8 +165,10 @@ impl Integer {
                 let x = interp.convert(self);
                 let coerced = numeric::coerce(interp, x, denominator)?;
                 match coerced {
-                    Coercion::Float(_, denom) if denom == 0.0 => Err(ZeroDivisionError::from("divided by 0").into()),
-                    Coercion::Integer(_, 0) => Err(ZeroDivisionError::from("divided by 0").into()),
+                    Coercion::Float(_, denom) if denom == 0.0 => {
+                        Err(ZeroDivisionError::with_message("divided by 0").into())
+                    }
+                    Coercion::Integer(_, 0) => Err(ZeroDivisionError::with_message("divided by 0").into()),
                     Coercion::Float(numer, denom) => Ok((numer / denom).into()),
                     Coercion::Integer(numer, denom) if numer < 0 && (numer % denom) != 0 => {
                         Ok(((numer / denom) - 1).into())

--- a/artichoke-backend/src/extn/core/kernel/integer.rs
+++ b/artichoke-backend/src/extn/core/kernel/integer.rs
@@ -58,7 +58,7 @@ impl TryConvertMut<Option<Value>, Option<Radix>> for Artichoke {
     fn try_convert_mut(&mut self, value: Option<Value>) -> Result<Option<Radix>, Self::Error> {
         if let Some(value) = value {
             let num = value.implicitly_convert_to_int(self)?;
-            let radix = u32::try_from(num).map_err(|_| ArgumentError::from("invalid radix"))?;
+            let radix = u32::try_from(num).map_err(|_| ArgumentError::with_message("invalid radix"))?;
             if (2..=36).contains(&radix) {
                 Ok(Radix::new(radix))
             } else {

--- a/artichoke-backend/src/extn/core/kernel/require.rs
+++ b/artichoke-backend/src/extn/core/kernel/require.rs
@@ -14,7 +14,7 @@ const RUBY_EXTENSION: &str = "rb";
 pub fn load(interp: &mut Artichoke, mut filename: Value) -> Result<bool, Error> {
     let filename = filename.implicitly_convert_to_string(interp)?;
     if filename.find_byte(b'\0').is_some() {
-        return Err(ArgumentError::from("path name contains null byte").into());
+        return Err(ArgumentError::with_message("path name contains null byte").into());
     }
     let file = ffi::bytes_to_os_str(filename)?;
     let pathbuf;
@@ -29,7 +29,7 @@ pub fn load(interp: &mut Artichoke, mut filename: Value) -> Result<bool, Error> 
         return Err(LoadError::from(message).into());
     }
     let context = Context::new(ffi::os_str_to_bytes(path.as_os_str())?.to_vec())
-        .ok_or_else(|| ArgumentError::from("path name contains null byte"))?;
+        .ok_or_else(|| ArgumentError::with_message("path name contains null byte"))?;
     interp.push_context(context)?;
     let result = interp.load_source(path);
     let _ = interp.pop_context()?;
@@ -39,7 +39,7 @@ pub fn load(interp: &mut Artichoke, mut filename: Value) -> Result<bool, Error> 
 pub fn require(interp: &mut Artichoke, mut filename: Value, base: Option<RelativePath>) -> Result<bool, Error> {
     let filename = filename.implicitly_convert_to_string(interp)?;
     if filename.find_byte(b'\0').is_some() {
-        return Err(ArgumentError::from("path name contains null byte").into());
+        return Err(ArgumentError::with_message("path name contains null byte").into());
     }
     let file = ffi::bytes_to_os_str(filename)?;
     let path = Path::new(file);
@@ -66,7 +66,7 @@ pub fn require(interp: &mut Artichoke, mut filename: Value, base: Option<Relativ
     };
     if interp.source_is_file(&path)? {
         let context = Context::new(ffi::os_str_to_bytes(path.as_os_str())?.to_vec())
-            .ok_or_else(|| ArgumentError::from("path name contains null byte"))?;
+            .ok_or_else(|| ArgumentError::with_message("path name contains null byte"))?;
         interp.push_context(context)?;
         let result = interp.require_source(&path);
         let _ = interp.pop_context()?;
@@ -75,7 +75,7 @@ pub fn require(interp: &mut Artichoke, mut filename: Value, base: Option<Relativ
     if let Some(path) = alternate {
         if interp.source_is_file(&path)? {
             let context = Context::new(ffi::os_str_to_bytes(path.as_os_str())?.to_vec())
-                .ok_or_else(|| ArgumentError::from("path name contains null byte"))?;
+                .ok_or_else(|| ArgumentError::with_message("path name contains null byte"))?;
             interp.push_context(context)?;
             let result = interp.require_source(&path);
             let _ = interp.pop_context()?;

--- a/artichoke-backend/src/extn/core/matchdata/trampoline.rs
+++ b/artichoke-backend/src/extn/core/matchdata/trampoline.rs
@@ -17,7 +17,7 @@ pub fn begin(interp: &mut Artichoke, mut value: Value, mut at: Value) -> Result<
     let begin = data.begin(capture)?;
     match begin.map(Int::try_from) {
         Some(Ok(begin)) => Ok(interp.convert(begin)),
-        Some(Err(_)) => Err(ArgumentError::from("input string too long").into()),
+        Some(Err(_)) => Err(ArgumentError::with_message("input string too long").into()),
         None => Ok(Value::nil()),
     }
 }
@@ -52,7 +52,8 @@ pub fn element_reference(
         // NOTE(lopopolo): Encapsulation is broken here by reaching into the
         // inner regexp.
         let captures_len = data.regexp.inner().captures_len(None)?;
-        let rangelen = Int::try_from(captures_len).map_err(|_| ArgumentError::from("input string too long"))?;
+        let rangelen =
+            Int::try_from(captures_len).map_err(|_| ArgumentError::with_message("input string too long"))?;
         if let Some(protect::Range { start, len }) = elem.is_range(interp, rangelen)? {
             CaptureAt::StartLen(start, len)
         } else {
@@ -73,7 +74,7 @@ pub fn end(interp: &mut Artichoke, mut value: Value, mut at: Value) -> Result<Va
     let end = data.end(capture)?;
     match end.map(Int::try_from) {
         Some(Ok(end)) => Ok(interp.convert(end)),
-        Some(Err(_)) => Err(ArgumentError::from("input string too long").into()),
+        Some(Err(_)) => Err(ArgumentError::with_message("input string too long").into()),
         None => Ok(Value::nil()),
     }
 }
@@ -84,7 +85,7 @@ pub fn length(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> 
     if let Ok(len) = Int::try_from(len) {
         Ok(interp.convert(len))
     } else {
-        Err(ArgumentError::from("input string too long").into())
+        Err(ArgumentError::with_message("input string too long").into())
     }
 }
 
@@ -112,7 +113,7 @@ pub fn offset(interp: &mut Artichoke, mut value: Value, mut at: Value) -> Result
             let ary = Array::assoc(interp.convert(begin), interp.convert(end));
             Array::alloc_value(ary, interp)
         } else {
-            Err(ArgumentError::from("input string too long").into())
+            Err(ArgumentError::with_message("input string too long").into())
         }
     } else {
         let ary = Array::assoc(Value::nil(), Value::nil());

--- a/artichoke-backend/src/extn/core/math/trampoline.rs
+++ b/artichoke-backend/src/extn/core/math/trampoline.rs
@@ -111,7 +111,7 @@ pub fn ldexp(interp: &mut Artichoke, fraction: Value, exponent: Value) -> Result
     let exponent = match exponent {
         Ok(exp) => exp,
         Err(Ok(exp)) if exp.is_nan() => {
-            return Err(RangeError::from("float NaN out of range of integer").into());
+            return Err(RangeError::with_message("float NaN out of range of integer").into());
         }
         Err(Ok(exp)) => {
             // This saturating cast will be rejected by the `i32::try_from`

--- a/artichoke-backend/src/extn/core/numeric/mod.rs
+++ b/artichoke-backend/src/extn/core/numeric/mod.rs
@@ -79,7 +79,7 @@ pub enum Coercion {
 pub fn coerce(interp: &mut Artichoke, x: Value, y: Value) -> Result<Coercion, Error> {
     fn do_coerce(interp: &mut Artichoke, x: Value, y: Value, depth: u8) -> Result<Coercion, Error> {
         if depth > MAX_COERCE_DEPTH {
-            return Err(SystemStackError::from("stack level too deep").into());
+            return Err(SystemStackError::with_message("stack level too deep").into());
         }
         match (x.ruby_type(), y.ruby_type()) {
             (Ruby::Float, Ruby::Float) => Ok(Coercion::Float(x.try_into(interp)?, y.try_into(interp)?)),
@@ -103,16 +103,16 @@ pub fn coerce(interp: &mut Artichoke, x: Value, y: Value) -> Result<Coercion, Er
                         let coerced = y.funcall(interp, "coerce", &[x], None)?;
                         let coerced: Vec<Value> = interp
                             .try_convert_mut(coerced)
-                            .map_err(|_| TypeError::from("coerce must return [x, y]"))?;
+                            .map_err(|_| TypeError::with_message("coerce must return [x, y]"))?;
                         let mut coerced = coerced.into_iter();
                         let y = coerced
                             .next()
-                            .ok_or_else(|| TypeError::from("coerce must return [x, y]"))?;
+                            .ok_or_else(|| TypeError::with_message("coerce must return [x, y]"))?;
                         let x = coerced
                             .next()
-                            .ok_or_else(|| TypeError::from("coerce must return [x, y]"))?;
+                            .ok_or_else(|| TypeError::with_message("coerce must return [x, y]"))?;
                         if coerced.next().is_some() {
-                            Err(TypeError::from("coerce must return [x, y]").into())
+                            Err(TypeError::with_message("coerce must return [x, y]").into())
                         } else {
                             do_coerce(interp, x, y, depth + 1)
                         }

--- a/artichoke-backend/src/extn/core/random/mod.rs
+++ b/artichoke-backend/src/extn/core/random/mod.rs
@@ -133,7 +133,7 @@ pub fn urandom(size: Int) -> Result<Vec<u8>, Error> {
             spinoso_random::urandom(&mut buf)?;
             Ok(buf)
         }
-        Err(_) => Err(ArgumentError::from("negative string size (or size too big)").into()),
+        Err(_) => Err(ArgumentError::with_message("negative string size (or size too big)").into()),
     }
 }
 
@@ -204,7 +204,7 @@ impl Random {
                 self.fill_bytes(&mut buf);
                 Ok(buf)
             }
-            Err(_) => Err(ArgumentError::from("negative string size (or size too big)").into()),
+            Err(_) => Err(ArgumentError::with_message("negative string size (or size too big)").into()),
         }
     }
 

--- a/artichoke-backend/src/extn/core/regexp/backend/onig.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/onig.rs
@@ -31,7 +31,7 @@ pub struct Onig {
 impl Onig {
     pub fn new(source: Source, config: Config, encoding: Encoding) -> Result<Self, Error> {
         let pattern = str::from_utf8(config.pattern())
-            .map_err(|_| ArgumentError::from("Oniguruma backend for Regexp only supports UTF-8 patterns"))?;
+            .map_err(|_| ArgumentError::with_message("Oniguruma backend for Regexp only supports UTF-8 patterns"))?;
         let regex = match Regex::with_options(pattern, config.options().into(), Syntax::ruby()) {
             Ok(regex) => regex,
             Err(err) if source.is_literal() => return Err(SyntaxError::from(err.description().to_owned()).into()),
@@ -61,7 +61,7 @@ impl RegexpType for Onig {
 
     fn captures(&self, haystack: &[u8]) -> Result<Option<Vec<NilableString>>, Error> {
         let haystack = str::from_utf8(haystack)
-            .map_err(|_| ArgumentError::from("Oniguruma backend for Regexp only supports UTF-8 haystacks"))?;
+            .map_err(|_| ArgumentError::with_message("Oniguruma backend for Regexp only supports UTF-8 haystacks"))?;
         if let Some(captures) = self.regex.captures(haystack) {
             let mut result = Vec::with_capacity(captures.len());
             for capture in captures.iter() {
@@ -96,8 +96,9 @@ impl RegexpType for Onig {
 
     fn captures_len(&self, haystack: Option<&[u8]>) -> Result<usize, Error> {
         let result = if let Some(haystack) = haystack {
-            let haystack = str::from_utf8(haystack)
-                .map_err(|_| ArgumentError::from("Oniguruma backend for Regexp only supports UTF-8 haystacks"))?;
+            let haystack = str::from_utf8(haystack).map_err(|_| {
+                ArgumentError::with_message("Oniguruma backend for Regexp only supports UTF-8 haystacks")
+            })?;
             self.regex
                 .captures(haystack)
                 .map(|captures| captures.len())
@@ -110,7 +111,7 @@ impl RegexpType for Onig {
 
     fn capture0<'a>(&self, haystack: &'a [u8]) -> Result<Option<&'a [u8]>, Error> {
         let haystack = str::from_utf8(haystack)
-            .map_err(|_| ArgumentError::from("Oniguruma backend for Regexp only supports UTF-8 haystacks"))?;
+            .map_err(|_| ArgumentError::with_message("Oniguruma backend for Regexp only supports UTF-8 haystacks"))?;
         let result = self
             .regex
             .captures(haystack)
@@ -169,7 +170,7 @@ impl RegexpType for Onig {
 
     fn case_match(&self, interp: &mut Artichoke, haystack: &[u8]) -> Result<bool, Error> {
         let haystack = str::from_utf8(haystack)
-            .map_err(|_| ArgumentError::from("Oniguruma backend for Regexp only supports UTF-8 haystacks"))?;
+            .map_err(|_| ArgumentError::with_message("Oniguruma backend for Regexp only supports UTF-8 haystacks"))?;
         regexp::clear_capture_globals(interp)?;
         if let Some(captures) = self.regex.captures(haystack) {
             interp.set_active_regexp_globals(captures.len())?;
@@ -201,7 +202,7 @@ impl RegexpType for Onig {
 
     fn is_match(&self, haystack: &[u8], pos: Option<Int>) -> Result<bool, Error> {
         let haystack = str::from_utf8(haystack)
-            .map_err(|_| ArgumentError::from("Oniguruma backend for Regexp only supports UTF-8 haystacks"))?;
+            .map_err(|_| ArgumentError::with_message("Oniguruma backend for Regexp only supports UTF-8 haystacks"))?;
         let haystack_char_len = haystack.chars().count();
         let pos = pos.unwrap_or_default();
         let pos = if let Ok(pos) = usize::try_from(pos) {
@@ -233,7 +234,7 @@ impl RegexpType for Onig {
         block: Option<Block>,
     ) -> Result<Value, Error> {
         let haystack = str::from_utf8(haystack)
-            .map_err(|_| ArgumentError::from("Oniguruma backend for Regexp only supports UTF-8 haystacks"))?;
+            .map_err(|_| ArgumentError::with_message("Oniguruma backend for Regexp only supports UTF-8 haystacks"))?;
         regexp::clear_capture_globals(interp)?;
         let haystack_char_len = haystack.chars().count();
         let pos = pos.unwrap_or_default();
@@ -297,7 +298,7 @@ impl RegexpType for Onig {
 
     fn match_operator(&self, interp: &mut Artichoke, haystack: &[u8]) -> Result<Option<usize>, Error> {
         let haystack = str::from_utf8(haystack)
-            .map_err(|_| ArgumentError::from("Oniguruma backend for Regexp only supports UTF-8 haystacks"))?;
+            .map_err(|_| ArgumentError::with_message("Oniguruma backend for Regexp only supports UTF-8 haystacks"))?;
         regexp::clear_capture_globals(interp)?;
         if let Some(captures) = self.regex.captures(haystack) {
             interp.set_active_regexp_globals(captures.len())?;
@@ -348,7 +349,7 @@ impl RegexpType for Onig {
 
     fn named_captures_for_haystack(&self, haystack: &[u8]) -> Result<Option<HashMap<Vec<u8>, NilableString>>, Error> {
         let haystack = str::from_utf8(haystack)
-            .map_err(|_| ArgumentError::from("Oniguruma backend for Regexp only supports UTF-8 haystacks"))?;
+            .map_err(|_| ArgumentError::with_message("Oniguruma backend for Regexp only supports UTF-8 haystacks"))?;
         if let Some(captures) = self.regex.captures(haystack) {
             let mut map = HashMap::with_capacity(captures.len());
             self.regex.foreach_name(|group, group_indexes| {
@@ -389,14 +390,14 @@ impl RegexpType for Onig {
 
     fn pos(&self, haystack: &[u8], at: usize) -> Result<Option<(usize, usize)>, Error> {
         let haystack = str::from_utf8(haystack)
-            .map_err(|_| ArgumentError::from("Oniguruma backend for Regexp only supports UTF-8 haystacks"))?;
+            .map_err(|_| ArgumentError::with_message("Oniguruma backend for Regexp only supports UTF-8 haystacks"))?;
         let pos = self.regex.captures(haystack).and_then(|captures| captures.pos(at));
         Ok(pos)
     }
 
     fn scan(&self, interp: &mut Artichoke, haystack: &[u8], block: Option<Block>) -> Result<Scan, Error> {
         let haystack = str::from_utf8(haystack)
-            .map_err(|_| ArgumentError::from("Oniguruma backend for Regexp only supports UTF-8 haystacks"))?;
+            .map_err(|_| ArgumentError::with_message("Oniguruma backend for Regexp only supports UTF-8 haystacks"))?;
         regexp::clear_capture_globals(interp)?;
         let mut matchdata = MatchData::new(haystack.into(), Regexp::from(self.box_clone()), ..);
 

--- a/artichoke-backend/src/extn/core/regexp/backend/regex/utf8.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/regex/utf8.rs
@@ -21,8 +21,9 @@ pub struct Utf8 {
 
 impl Utf8 {
     pub fn new(source: Source, config: Config, encoding: Encoding) -> Result<Self, Error> {
-        let pattern = str::from_utf8(config.pattern())
-            .map_err(|_| ArgumentError::from("regex crate utf8 backend for Regexp only supports UTF-8 patterns"))?;
+        let pattern = str::from_utf8(config.pattern()).map_err(|_| {
+            ArgumentError::with_message("regex crate utf8 backend for Regexp only supports UTF-8 patterns")
+        })?;
 
         let mut builder = RegexBuilder::new(pattern);
         builder.case_insensitive(config.options().ignore_case().into());
@@ -59,8 +60,9 @@ impl RegexpType for Utf8 {
     }
 
     fn captures(&self, haystack: &[u8]) -> Result<Option<Vec<NilableString>>, Error> {
-        let haystack = str::from_utf8(haystack)
-            .map_err(|_| ArgumentError::from("regex crate utf8 backend for Regexp only supports UTF-8 haystacks"))?;
+        let haystack = str::from_utf8(haystack).map_err(|_| {
+            ArgumentError::with_message("regex crate utf8 backend for Regexp only supports UTF-8 haystacks")
+        })?;
         if let Some(captures) = self.regex.captures(haystack) {
             let mut result = Vec::with_capacity(captures.len());
             for capture in captures.iter() {
@@ -93,7 +95,7 @@ impl RegexpType for Utf8 {
     fn captures_len(&self, haystack: Option<&[u8]>) -> Result<usize, Error> {
         let result = if let Some(haystack) = haystack {
             let haystack = str::from_utf8(haystack).map_err(|_| {
-                ArgumentError::from("regex crate utf8 backend for Regexp only supports UTF-8 haystacks")
+                ArgumentError::with_message("regex crate utf8 backend for Regexp only supports UTF-8 haystacks")
             })?;
             self.regex
                 .captures(haystack)
@@ -106,8 +108,9 @@ impl RegexpType for Utf8 {
     }
 
     fn capture0<'a>(&self, haystack: &'a [u8]) -> Result<Option<&'a [u8]>, Error> {
-        let haystack = str::from_utf8(haystack)
-            .map_err(|_| ArgumentError::from("regex crate utf8 backend for Regexp only supports UTF-8 haystacks"))?;
+        let haystack = str::from_utf8(haystack).map_err(|_| {
+            ArgumentError::with_message("regex crate utf8 backend for Regexp only supports UTF-8 haystacks")
+        })?;
         let result = self
             .regex
             .captures(haystack)
@@ -167,8 +170,9 @@ impl RegexpType for Utf8 {
     }
 
     fn case_match(&self, interp: &mut Artichoke, haystack: &[u8]) -> Result<bool, Error> {
-        let haystack = str::from_utf8(haystack)
-            .map_err(|_| ArgumentError::from("regex crate utf8 backend for Regexp only supports UTF-8 haystack"))?;
+        let haystack = str::from_utf8(haystack).map_err(|_| {
+            ArgumentError::with_message("regex crate utf8 backend for Regexp only supports UTF-8 haystack")
+        })?;
         regexp::clear_capture_globals(interp)?;
         if let Some(captures) = self.regex.captures(haystack) {
             // per the [docs] for `captures.len()`:
@@ -207,8 +211,9 @@ impl RegexpType for Utf8 {
     }
 
     fn is_match(&self, haystack: &[u8], pos: Option<Int>) -> Result<bool, Error> {
-        let haystack = str::from_utf8(haystack)
-            .map_err(|_| ArgumentError::from("regex crate utf8 backend for Regexp only supports UTF-8 haystack"))?;
+        let haystack = str::from_utf8(haystack).map_err(|_| {
+            ArgumentError::with_message("regex crate utf8 backend for Regexp only supports UTF-8 haystack")
+        })?;
         let haystack_char_len = haystack.chars().count();
         let pos = pos.unwrap_or_default();
         let pos = if let Ok(pos) = usize::try_from(pos) {
@@ -239,8 +244,9 @@ impl RegexpType for Utf8 {
         pos: Option<Int>,
         block: Option<Block>,
     ) -> Result<Value, Error> {
-        let haystack = str::from_utf8(haystack)
-            .map_err(|_| ArgumentError::from("regex crate utf8 backend for Regexp only supports UTF-8 haystacks"))?;
+        let haystack = str::from_utf8(haystack).map_err(|_| {
+            ArgumentError::with_message("regex crate utf8 backend for Regexp only supports UTF-8 haystacks")
+        })?;
         regexp::clear_capture_globals(interp)?;
         let haystack_char_len = haystack.chars().count();
         let pos = pos.unwrap_or_default();
@@ -310,8 +316,9 @@ impl RegexpType for Utf8 {
     }
 
     fn match_operator(&self, interp: &mut Artichoke, haystack: &[u8]) -> Result<Option<usize>, Error> {
-        let haystack = str::from_utf8(haystack)
-            .map_err(|_| ArgumentError::from("regex crate utf8 backend for Regexp only supports UTF-8 haystacks"))?;
+        let haystack = str::from_utf8(haystack).map_err(|_| {
+            ArgumentError::with_message("regex crate utf8 backend for Regexp only supports UTF-8 haystacks")
+        })?;
         regexp::clear_capture_globals(interp)?;
         if let Some(captures) = self.regex.captures(haystack) {
             // per the [docs] for `captures.len()`:
@@ -366,8 +373,9 @@ impl RegexpType for Utf8 {
     }
 
     fn named_captures_for_haystack(&self, haystack: &[u8]) -> Result<Option<HashMap<Vec<u8>, NilableString>>, Error> {
-        let haystack = str::from_utf8(haystack)
-            .map_err(|_| ArgumentError::from("regex crate utf8 backend for Regexp only supports UTF-8 haystacks"))?;
+        let haystack = str::from_utf8(haystack).map_err(|_| {
+            ArgumentError::with_message("regex crate utf8 backend for Regexp only supports UTF-8 haystacks")
+        })?;
         if let Some(captures) = self.regex.captures(haystack) {
             let mut map = HashMap::with_capacity(captures.len());
             for (group, group_indexes) in self.named_captures()? {
@@ -405,8 +413,9 @@ impl RegexpType for Utf8 {
     }
 
     fn pos(&self, haystack: &[u8], at: usize) -> Result<Option<(usize, usize)>, Error> {
-        let haystack = str::from_utf8(haystack)
-            .map_err(|_| ArgumentError::from("regex crate utf8 backend for Regexp only supports UTF-8 haystacks"))?;
+        let haystack = str::from_utf8(haystack).map_err(|_| {
+            ArgumentError::with_message("regex crate utf8 backend for Regexp only supports UTF-8 haystacks")
+        })?;
         let pos = self
             .regex
             .captures(haystack)
@@ -416,8 +425,9 @@ impl RegexpType for Utf8 {
     }
 
     fn scan(&self, interp: &mut Artichoke, haystack: &[u8], block: Option<Block>) -> Result<Scan, Error> {
-        let haystack = str::from_utf8(haystack)
-            .map_err(|_| ArgumentError::from("regex crate utf8 backend for Regexp only supports UTF-8 haystacks"))?;
+        let haystack = str::from_utf8(haystack).map_err(|_| {
+            ArgumentError::with_message("regex crate utf8 backend for Regexp only supports UTF-8 haystacks")
+        })?;
         regexp::clear_capture_globals(interp)?;
         let mut matchdata = MatchData::new(haystack.into(), Regexp::from(self.box_clone()), ..);
 

--- a/artichoke-backend/src/extn/core/regexp/mod.rs
+++ b/artichoke-backend/src/extn/core/regexp/mod.rs
@@ -115,7 +115,7 @@ impl Regexp {
         if let Ok(pattern) = str::from_utf8(pattern) {
             Ok(syntax::escape(pattern))
         } else {
-            Err(ArgumentError::from("invalid encoding (non UTF-8)").into())
+            Err(ArgumentError::with_message("invalid encoding (non UTF-8)").into())
         }
     }
 
@@ -132,7 +132,7 @@ impl Regexp {
                 if let Ok(pattern) = str::from_utf8(bytes) {
                     Ok(syntax::escape(pattern).into_bytes())
                 } else {
-                    Err(ArgumentError::from("invalid encoding (non UTF-8)").into())
+                    Err(ArgumentError::with_message("invalid encoding (non UTF-8)").into())
                 }
             }
         }
@@ -262,7 +262,7 @@ impl Regexp {
                 if let Ok(idx) = Int::try_from(idx) {
                     fixnums.push(idx);
                 } else {
-                    return Err(ArgumentError::from("string too long").into());
+                    return Err(ArgumentError::with_message("string too long").into());
                 }
             }
             converted.push((name, fixnums));

--- a/artichoke-backend/src/extn/core/regexp/trampoline.rs
+++ b/artichoke-backend/src/extn/core/regexp/trampoline.rs
@@ -81,7 +81,7 @@ pub fn match_operator(interp: &mut Artichoke, mut regexp: Value, mut pattern: Va
     let pos = regexp.match_operator(interp, pattern)?;
     match pos.map(Int::try_from) {
         Some(Ok(pos)) => Ok(interp.convert(pos)),
-        Some(Err(_)) => Err(ArgumentError::from("string too long").into()),
+        Some(Err(_)) => Err(ArgumentError::with_message("string too long").into()),
         None => Ok(Value::nil()),
     }
 }

--- a/artichoke-backend/src/extn/core/string/trampoline.rs
+++ b/artichoke-backend/src/extn/core/string/trampoline.rs
@@ -16,8 +16,8 @@ pub fn ord(interp: &mut Artichoke, value: Value) -> Result<Value, Error> {
         // All `char`s are valid `u32`s
         // https://github.com/rust-lang/rust/blob/1.48.0/library/core/src/char/convert.rs#L12-L20
         Some(ch) => u32::from(ch),
-        None if size == 0 => return Err(ArgumentError::from("empty string").into()),
-        None => return Err(ArgumentError::from("invalid byte sequence in UTF-8").into()),
+        None if size == 0 => return Err(ArgumentError::with_message("empty string").into()),
+        None => return Err(ArgumentError::with_message("invalid byte sequence in UTF-8").into()),
     };
     Ok(interp.convert(ord))
 }

--- a/artichoke-backend/src/value.rs
+++ b/artichoke-backend/src/value.rs
@@ -128,7 +128,7 @@ impl Value {
             if let Some(int) = int {
                 int
             } else {
-                return Err(TypeError::from("no implicit conversion from nil to integer"));
+                return Err(TypeError::with_message("no implicit conversion from nil to integer"));
             }
         } else if let Ok(true) = self.respond_to(interp, "to_int") {
             if let Ok(maybe) = self.funcall(interp, "to_int", &[], None) {


### PR DESCRIPTION
For messages that are `&'static str`, use the `<Exception>::with_message`
constructor.

This constructor expresses the intent and type bound that the exception
message is:

- A `&'static str`.
- A UTF-8 string.

`with_message` is also const, whereas the `From` impl is not, which at
least gives `rustc` a chance to do const propagation.

Followup to #958 which introduced this API.