### PR TITLE
Move LeakSanitizer CI job to scheduled fuzz workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -300,35 +300,6 @@ jobs:
           cargo check
         working-directory: "spec-runner"
 
-  rust-sanitizer:
-    name: Compile and test with sanitizers
-    runs-on: ubuntu-latest
-    env:
-      RUSTFLAGS: -D warnings
-      RUST_BACKTRACE: 1
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
-      - name: Install nightly Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          profile: minimal
-          target: x86_64-unknown-linux-gnu
-          override: true
-
-      - name: Test with leak sanitizer and all features
-        run: cargo test --workspace --all-features --target x86_64-unknown-linux-gnu
-        env:
-          RUSTFLAGS: "-Z sanitizer=leak"
-
-      - name: Test spec-runner with leak sanitizer and all features
-        run: cargo test --workspace --all-features --target x86_64-unknown-linux-gnu
-        working-directory: "spec-runner"
-        env:
-          RUSTFLAGS: "-Z sanitizer=leak"
-
   ruby:
     name: Lint and format Ruby
     runs-on: ubuntu-latest

--- a/.github/workflows/fuzz.yaml
+++ b/.github/workflows/fuzz.yaml
@@ -1,5 +1,5 @@
 ---
-name: Fuzz
+name: Fuzz and Sanitize
 "on":
   push:
     branches:
@@ -7,7 +7,7 @@ name: Fuzz
   schedule:
     - cron: "0 12 * * *"
 jobs:
-  eval:
+  fuzz-eval:
     name: Fuzz eval
     runs-on: ubuntu-latest
     env:
@@ -38,3 +38,28 @@ jobs:
       - name: Fuzz eval
         if: github.event_name == 'schedule'
         run: cargo fuzz run eval -- -max_total_time=1800 # 30 minutes
+
+  leak-san:
+    name: Compile and test with LeakSanitizer
+    runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: -D warnings -Z sanitizer=leak
+      RUST_BACKTRACE: 1
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install nightly Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          profile: minimal
+          target: x86_64-unknown-linux-gnu
+          override: true
+
+      - name: Test with leak sanitizer and all features
+        run: cargo test --workspace --all-features --target x86_64-unknown-linux-gnu
+
+      - name: Test spec-runner with leak sanitizer and all features
+        run: cargo test --workspace --all-features --target x86_64-unknown-linux-gnu
+        working-directory: "spec-runner"


### PR DESCRIPTION
These tests rarely catch bugs and are of the same shape as the fuzzer run. Run them daily on a schedule.