### PR TITLE
Improve quality of `no_std` crates

### DIFF
--- a/artichoke-core/src/lib.rs
+++ b/artichoke-core/src/lib.rs
@@ -81,7 +81,7 @@
 //! [`Regexp`]: https://ruby-doc.org/core-2.6.3/Regexp.html#class-Regexp-label-Special+global+variables
 //! [convert]: crate::convert
 
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 #![doc(html_root_url = "https://artichoke.github.io/artichoke/artichoke_core")]
 #![doc(html_favicon_url = "https://www.artichokeruby.org/favicon.ico")]
 #![doc(html_logo_url = "https://www.artichokeruby.org/artichoke-logo.svg")]
@@ -101,6 +101,8 @@ macro_rules! readme {
 readme!();
 
 extern crate alloc;
+#[cfg(feature = "std")]
+extern crate std;
 
 pub mod coerce_to_numeric;
 pub mod constant;

--- a/scolapasta-hex/src/lib.rs
+++ b/scolapasta-hex/src/lib.rs
@@ -71,13 +71,14 @@
 //! [Base 16 encoding]: https://tools.ietf.org/html/rfc4648#section-8
 //! [`io::Write`]: https://doc.rust-lang.org/std/io/trait.Write.html
 
-// `scolapasta-hex` is a `no_std` crate unless the `std` feature is enabled.
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 
 // Having access to `String` in tests is convenient to collect `Inspect`
 // iterators for whole content comparisons.
-#[cfg(any(feature = "alloc", test, doctest))]
+#[cfg(any(feature = "alloc"))]
 extern crate alloc;
+#[cfg(any(feature = "std", test, doctest))]
+extern crate std;
 
 // Ensure code blocks in README.md compile
 #[cfg(doctest)]

--- a/scolapasta-hex/src/lib.rs
+++ b/scolapasta-hex/src/lib.rs
@@ -40,7 +40,10 @@
 //! ```
 //! let data = b"Artichoke Ruby";
 //! let mut buf = String::new();
+//! # #[cfg(feature = "alloc")]
 //! scolapasta_hex::encode_into(data, &mut buf);
+//! # #[cfg(not(feature = "alloc"))]
+//! # buf.push_str("4172746963686f6b652052756279");
 //! assert_eq!(buf, "4172746963686f6b652052756279");
 //! ```
 //!
@@ -91,7 +94,7 @@ macro_rules! readme {
         readme!(include_str!("../README.md"));
     };
 }
-#[cfg(doctest)]
+#[cfg(all(feature = "std", doctest))]
 readme!();
 
 #[cfg(feature = "alloc")]

--- a/scolapasta-hex/src/lib.rs
+++ b/scolapasta-hex/src/lib.rs
@@ -723,7 +723,7 @@ impl FusedIterator for EscapedByte {}
 
 #[cfg(test)]
 mod tests {
-    use super::{encode, encode_into, format_into, write_into, EscapedByte, Hex};
+    use crate::EscapedByte;
 
     #[test]
     fn literal_exhaustive() {
@@ -776,105 +776,191 @@ mod tests {
         }
     }
 
-    // https://tools.ietf.org/html/rfc4648#section-10
-    #[test]
-    fn rfc4648_test_vectors() {
-        // BASE16("") = ""
-        assert_eq!(encode(""), "");
-        assert_eq!(Hex::from("").collect::<String>(), "");
-        let mut s = String::new();
-        encode_into("", &mut s);
-        assert_eq!(s, "");
-        assert_eq!(s.capacity(), 0);
-        let mut fmt = String::new();
-        format_into("", &mut fmt).unwrap();
-        assert_eq!(fmt, "");
-        let mut write = Vec::new();
-        write_into("", &mut write).unwrap();
-        assert_eq!(write, b"".to_vec());
+    #[cfg(feature = "alloc")]
+    mod alloc {
+        use alloc::string::String;
 
-        // BASE16("f") = "66"
-        assert_eq!(encode("f"), "66");
-        assert_eq!(Hex::from("f").collect::<String>(), "66");
-        let mut s = String::new();
-        encode_into("f", &mut s);
-        assert_eq!(s, "66");
-        assert!(s.capacity() >= 2);
-        let mut fmt = String::new();
-        format_into("f", &mut fmt).unwrap();
-        assert_eq!(fmt, "66");
-        let mut write = Vec::new();
-        write_into("f", &mut write).unwrap();
-        assert_eq!(write, b"66".to_vec());
+        use crate::{encode, encode_into, format_into, Hex};
 
-        // BASE16("fo") = "666F"
-        assert_eq!(encode("fo"), "666f");
-        assert_eq!(Hex::from("fo").collect::<String>(), "666f");
-        let mut s = String::new();
-        encode_into("fo", &mut s);
-        assert_eq!(s, "666f");
-        assert!(s.capacity() >= 4);
-        let mut fmt = String::new();
-        format_into("fo", &mut fmt).unwrap();
-        assert_eq!(fmt, "666f");
-        let mut write = Vec::new();
-        write_into("fo", &mut write).unwrap();
-        assert_eq!(write, b"666f".to_vec());
+        // https://tools.ietf.org/html/rfc4648#section-10
+        #[test]
+        fn rfc4648_test_vectors_encode() {
+            // BASE16("") = ""
+            assert_eq!(encode(""), "");
 
-        // BASE16("foo") = "666F6F"
-        assert_eq!(encode("foo"), "666f6f");
-        assert_eq!(Hex::from("foo").collect::<String>(), "666f6f");
-        let mut s = String::new();
-        encode_into("foo", &mut s);
-        assert_eq!(s, "666f6f");
-        assert!(s.capacity() >= 6);
-        let mut fmt = String::new();
-        format_into("foo", &mut fmt).unwrap();
-        assert_eq!(fmt, "666f6f");
-        let mut write = Vec::new();
-        write_into("foo", &mut write).unwrap();
-        assert_eq!(write, b"666f6f".to_vec());
+            // BASE16("f") = "66"
+            assert_eq!(encode("f"), "66");
 
-        // BASE16("foob") = "666F6F62"
-        assert_eq!(encode("foob"), "666f6f62");
-        assert_eq!(Hex::from("foob").collect::<String>(), "666f6f62");
-        let mut s = String::new();
-        encode_into("foob", &mut s);
-        assert_eq!(s, "666f6f62");
-        assert!(s.capacity() >= 8);
-        let mut fmt = String::new();
-        format_into("foob", &mut fmt).unwrap();
-        assert_eq!(fmt, "666f6f62");
-        let mut write = Vec::new();
-        write_into("foob", &mut write).unwrap();
-        assert_eq!(write, b"666f6f62".to_vec());
+            // BASE16("fo") = "666F"
+            assert_eq!(encode("fo"), "666f");
 
-        // BASE16("fooba") = "666F6F6261"
-        assert_eq!(encode("fooba"), "666f6f6261");
-        assert_eq!(Hex::from("fooba").collect::<String>(), "666f6f6261");
-        let mut s = String::new();
-        encode_into("fooba", &mut s);
-        assert_eq!(s, "666f6f6261");
-        assert!(s.capacity() >= 10);
-        let mut fmt = String::new();
-        format_into("fooba", &mut fmt).unwrap();
-        assert_eq!(fmt, "666f6f6261");
-        let mut write = Vec::new();
-        write_into("fooba", &mut write).unwrap();
-        assert_eq!(write, b"666f6f6261".to_vec());
+            // BASE16("foo") = "666F6F"
+            assert_eq!(encode("foo"), "666f6f");
 
-        // BASE16("foobar") = "666F6F626172"
-        assert_eq!(encode("foobar"), "666f6f626172");
-        assert_eq!(Hex::from("foobar").collect::<String>(), "666f6f626172");
-        let mut s = String::new();
-        encode_into("foobar", &mut s);
-        assert_eq!(s, "666f6f626172");
-        assert!(s.capacity() >= 12);
-        let mut fmt = String::new();
-        format_into("foobar", &mut fmt).unwrap();
-        assert_eq!(fmt, "666f6f626172");
-        let mut write = Vec::new();
-        write_into("foobar", &mut write).unwrap();
-        assert_eq!(write, b"666f6f626172".to_vec());
+            // BASE16("foob") = "666F6F62"
+            assert_eq!(encode("foob"), "666f6f62");
+
+            // BASE16("fooba") = "666F6F6261"
+            assert_eq!(encode("fooba"), "666f6f6261");
+
+            // BASE16("foobar") = "666F6F626172"
+            assert_eq!(encode("foobar"), "666f6f626172");
+        }
+
+        // https://tools.ietf.org/html/rfc4648#section-10
+        #[test]
+        fn rfc4648_test_vectors_hex_iter() {
+            // BASE16("") = ""
+            assert_eq!(Hex::from("").collect::<String>(), "");
+
+            // BASE16("f") = "66"
+            assert_eq!(Hex::from("f").collect::<String>(), "66");
+
+            // BASE16("fo") = "666F"
+            assert_eq!(Hex::from("fo").collect::<String>(), "666f");
+
+            // BASE16("foo") = "666F6F"
+            assert_eq!(Hex::from("foo").collect::<String>(), "666f6f");
+
+            // BASE16("foob") = "666F6F62"
+            assert_eq!(Hex::from("foob").collect::<String>(), "666f6f62");
+
+            // BASE16("fooba") = "666F6F6261"
+            assert_eq!(Hex::from("fooba").collect::<String>(), "666f6f6261");
+
+            // BASE16("foobar") = "666F6F626172"
+            assert_eq!(Hex::from("foobar").collect::<String>(), "666f6f626172");
+        }
+
+        // https://tools.ietf.org/html/rfc4648#section-10
+        #[test]
+        fn rfc4648_test_vectors_encode_into_string() {
+            // BASE16("") = ""
+            let mut s = String::new();
+            encode_into("", &mut s);
+            assert_eq!(s, "");
+            assert_eq!(s.capacity(), 0);
+
+            // BASE16("f") = "66"
+            let mut s = String::new();
+            encode_into("f", &mut s);
+            assert_eq!(s, "66");
+            assert!(s.capacity() >= 2);
+
+            // BASE16("fo") = "666F"
+            let mut s = String::new();
+            encode_into("fo", &mut s);
+            assert_eq!(s, "666f");
+            assert!(s.capacity() >= 4);
+
+            // BASE16("foo") = "666F6F"
+            let mut s = String::new();
+            encode_into("foo", &mut s);
+            assert_eq!(s, "666f6f");
+            assert!(s.capacity() >= 6);
+
+            // BASE16("foob") = "666F6F62"
+            let mut s = String::new();
+            encode_into("foob", &mut s);
+            assert_eq!(s, "666f6f62");
+            assert!(s.capacity() >= 8);
+
+            // BASE16("fooba") = "666F6F6261"
+            let mut s = String::new();
+            encode_into("fooba", &mut s);
+            assert_eq!(s, "666f6f6261");
+            assert!(s.capacity() >= 10);
+
+            // BASE16("foobar") = "666F6F626172"
+            let mut s = String::new();
+            encode_into("foobar", &mut s);
+            assert_eq!(s, "666f6f626172");
+            assert!(s.capacity() >= 12);
+        }
+
+        // https://tools.ietf.org/html/rfc4648#section-10
+        #[test]
+        fn rfc4648_test_vectors_format_into() {
+            // BASE16("") = ""
+            let mut fmt = String::new();
+            format_into("", &mut fmt).unwrap();
+            assert_eq!(fmt, "");
+
+            // BASE16("f") = "66"
+            let mut fmt = String::new();
+            format_into("f", &mut fmt).unwrap();
+            assert_eq!(fmt, "66");
+
+            // BASE16("fo") = "666F"
+            let mut fmt = String::new();
+            format_into("fo", &mut fmt).unwrap();
+            assert_eq!(fmt, "666f");
+
+            // BASE16("foo") = "666F6F"
+            let mut fmt = String::new();
+            format_into("foo", &mut fmt).unwrap();
+            assert_eq!(fmt, "666f6f");
+
+            // BASE16("foob") = "666F6F62"
+            let mut fmt = String::new();
+            format_into("foob", &mut fmt).unwrap();
+            assert_eq!(fmt, "666f6f62");
+
+            // BASE16("fooba") = "666F6F6261"
+            let mut fmt = String::new();
+            format_into("fooba", &mut fmt).unwrap();
+            assert_eq!(fmt, "666f6f6261");
+
+            // BASE16("foobar") = "666F6F626172"
+            let mut fmt = String::new();
+            format_into("foobar", &mut fmt).unwrap();
+            assert_eq!(fmt, "666f6f626172");
+        }
+    }
+
+    #[cfg(feature = "std")]
+    mod std {
+        use std::vec::Vec;
+
+        use crate::write_into;
+
+        // https://tools.ietf.org/html/rfc4648#section-10
+        #[test]
+        fn rfc4648_test_vectors_write_into() {
+            // BASE16("") = ""
+            let mut write = Vec::new();
+            write_into("", &mut write).unwrap();
+            assert_eq!(write, b"".to_vec());
+
+            // BASE16("f") = "66"
+            let mut write = Vec::new();
+            write_into("f", &mut write).unwrap();
+            assert_eq!(write, b"66".to_vec());
+
+            // BASE16("fo") = "666F"
+            let mut write = Vec::new();
+            write_into("fo", &mut write).unwrap();
+            assert_eq!(write, b"666f".to_vec());
+
+            // BASE16("foo") = "666F6F"
+            let mut write = Vec::new();
+            write_into("foo", &mut write).unwrap();
+            assert_eq!(write, b"666f6f".to_vec());
+
+            // BASE16("foob") = "666F6F62"
+            let mut write = Vec::new();
+            write_into("foob", &mut write).unwrap();
+            assert_eq!(write, b"666f6f62".to_vec());
+
+            // BASE16("fooba") = "666F6F6261"
+            let mut write = Vec::new();
+            write_into("fooba", &mut write).unwrap();
+            assert_eq!(write, b"666f6f6261".to_vec());
+
+            // BASE16("foobar") = "666F6F626172"
+            let mut write = Vec::new();
+            write_into("foobar", &mut write).unwrap();
+            assert_eq!(write, b"666f6f626172".to_vec());
+        }
     }
 }

--- a/spinoso-exception/src/lib.rs
+++ b/spinoso-exception/src/lib.rs
@@ -119,9 +119,11 @@
 //! [`SystemExit`]: https://ruby-doc.org/core-2.6.3/SystemExit.html
 //! [`SystemStackError`]: https://ruby-doc.org/core-2.6.3/SystemStackError.html
 
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 
 extern crate alloc;
+#[cfg(feature = "std")]
+extern crate std;
 
 use alloc::borrow::Cow;
 

--- a/spinoso-random/src/lib.rs
+++ b/spinoso-random/src/lib.rs
@@ -54,7 +54,9 @@
 //! Generate random numbers in a range:
 //!
 //! ```
+//! # #[cfg(feature = "rand")]
 //! # use spinoso_random::{rand, Error, Max, Rand, Random};
+//! # #[cfg(feature = "rand")]
 //! # fn example() -> Result<(), Error> {
 //! let mut random = Random::new()?;
 //! let max = Max::Integer(10);
@@ -62,6 +64,7 @@
 //! assert!(matches!(rand, Rand::Integer(x) if x < 10));
 //! # Ok(())
 //! # }
+//! # #[cfg(feature = "rand")]
 //! # example().unwrap();
 //! ```
 //!
@@ -120,7 +123,7 @@ macro_rules! readme {
         readme!(include_str!("../README.md"));
     };
 }
-#[cfg(doctest)]
+#[cfg(all(feature = "rand", doctest))]
 readme!();
 
 /// Sum type of all errors possibly returned from `Random` functions.

--- a/spinoso-random/src/lib.rs
+++ b/spinoso-random/src/lib.rs
@@ -89,7 +89,10 @@
 //! [`rand`]: rand_
 //! [`rand_core`]: rand_core_
 
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
+
+#[cfg(any(feature = "std", test, doctest))]
+extern crate std;
 
 use core::fmt;
 #[cfg(feature = "std")]

--- a/spinoso-random/src/random/mod.rs
+++ b/spinoso-random/src/random/mod.rs
@@ -345,6 +345,8 @@ pub fn new_seed() -> Result<[u32; DEFAULT_SEED_CNT], NewSeedError> {
 
 #[cfg(test)]
 mod tests {
+    use std::format;
+
     use super::Random;
 
     #[test]

--- a/spinoso-random/src/random/ruby/mod.rs
+++ b/spinoso-random/src/random/ruby/mod.rs
@@ -298,6 +298,7 @@ const fn temper(mut x: u32) -> u32 {
 #[cfg(test)]
 mod tests {
     use core::iter;
+    use std::format;
 
     use super::Mt;
 

--- a/spinoso-symbol/src/all_symbols.rs
+++ b/spinoso-symbol/src/all_symbols.rs
@@ -205,10 +205,11 @@ impl FusedIterator for AllSymbols {}
 
 #[cfg(test)]
 mod tests {
+    use artichoke_core::intern::Intern;
+    use std::borrow::Cow;
+
     use super::InternerAllSymbols;
     use crate::Symbol;
-    use alloc::borrow::Cow;
-    use artichoke_core::intern::Intern;
 
     #[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
     struct Interner(u32);

--- a/spinoso-symbol/src/fixtures/mod.rs
+++ b/spinoso-symbol/src/fixtures/mod.rs
@@ -1,5 +1,6 @@
 //! Fixtures for tests.
 
+#[cfg(feature = "ident-parser")]
 pub static IDENTS: &[&str] = &[
     r##"!"##,
     r##"%"##,
@@ -1816,6 +1817,7 @@ pub static IDENTS: &[&str] = &[
     r##"$-a"##,
 ];
 
+#[cfg(feature = "inspect")]
 pub static IDENT_INSPECTS: &[&str] = &[
     r##":!"##,
     r##":%"##,

--- a/spinoso-symbol/src/inspect.rs
+++ b/spinoso-symbol/src/inspect.rs
@@ -456,8 +456,9 @@ impl<'a> FusedIterator for State<'a> {}
 
 #[cfg(test)]
 mod tests {
+    use std::string::String;
+
     use super::Inspect;
-    use alloc::string::String;
 
     #[test]
     fn empty() {
@@ -753,8 +754,9 @@ mod tests {
 
 #[cfg(test)]
 mod specs {
+    use std::string::String;
+
     use super::{Flags, Inspect};
-    use alloc::string::String;
 
     #[test]
     fn flags_ident() {
@@ -1014,6 +1016,8 @@ mod specs {
 /// ```
 #[cfg(test)]
 mod functionals {
+    use std::string::String;
+
     use super::Inspect;
     use crate::fixtures::{IDENTS, IDENT_INSPECTS};
 

--- a/spinoso-symbol/src/lib.rs
+++ b/spinoso-symbol/src/lib.rs
@@ -92,7 +92,7 @@ macro_rules! readme {
         readme!(include_str!("../README.md"));
     };
 }
-#[cfg(doctest)]
+#[cfg(all(feature = "inspect", doctest))]
 readme!();
 
 #[cfg(feature = "artichoke")]

--- a/spinoso-symbol/src/lib.rs
+++ b/spinoso-symbol/src/lib.rs
@@ -76,13 +76,10 @@
 //! [`alloc`]: https://doc.rust-lang.org/alloc/
 //! [`std::error::Error`]: https://doc.rust-lang.org/std/error/trait.Error.html
 
-// `spinoso-symbol` is a `no_std` crate unless the `std` feature is enabled.
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 
-// Having access to `String` in tests is convenient to collect `Inspect`
-// iterators for whole content comparisons.
-#[cfg(test)]
-extern crate alloc;
+#[cfg(any(feature = "std", test, doctest))]
+extern crate std;
 
 // Ensure code blocks in README.md compile
 #[cfg(doctest)]


### PR DESCRIPTION
This PR unconditionally enables the `#![no_std]` crate-level attribute for no-std crates in this workspace, removing the `cfg_attr`. The `std` feature links to `std` using an `extern crate` declaration. All dependencies from `std` must always be imported.

This PR ensures all no-std crates build and test successfully with all combinations of feature flags. This involved adjusting some doctests to include `cfg` metas and restructuring test modules to be feature-aware.