### PR TITLE
Update Cargo.toml version declarations for spec-runner

### DIFF
--- a/spec-runner/Cargo.toml
+++ b/spec-runner/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["development-tools::testing"]
 [dependencies]
 artichoke = { path = "..", default-features = false, features = ["backtrace", "kitchen-sink"] }
 rust-embed = "5.7.0"
-serde = { version = "1.0, >= 1.0.7", features = ["derive"] }
+serde = { version = "1.0", features = ["derive"] }
 structopt = "0.3"
 termcolor = "1.1"
 toml = { version = "0.5", default-features = false }


### PR DESCRIPTION
`toml` 0.5.0 and 0.5.1 have been yanked which removes versions that
incorrectly declare their minimal version dependency on `serde`.
See alexcrichton/toml-rs#412.

This change in the package registry allows removing the bound on the
serde version in `spec-runner`'s `Cargo.toml`.