### PR TITLE
Add Rust compiler artifact caching to GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,6 +34,10 @@ jobs:
         with:
           ruby-version: ".ruby-version"
 
+      - uses: Swatinem/rust-cache@v1
+        with:
+          key: v3
+
       - name: Compile
         run: cargo build --workspace --verbose
 
@@ -63,6 +67,8 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ".ruby-version"
+
+      - uses: Swatinem/rust-cache@v1
 
       - name: Check artichoke formatting
         run: cargo fmt -- --check --color=auto
@@ -102,6 +108,10 @@ jobs:
         with:
           ruby-version: ".ruby-version"
 
+      - uses: Swatinem/rust-cache@v1
+        with:
+          working-directory: "fuzz"
+
       - name: Check fuzz with locked Cargo.lock
         run: cargo check --locked
         working-directory: "fuzz"
@@ -126,6 +136,10 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ".ruby-version"
+
+      - uses: Swatinem/rust-cache@v1
+        with:
+          working-directory: "spec-runner"
 
       - name: Check spec-runner formatting
         run: cargo fmt -- --check --color=auto
@@ -158,6 +172,8 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ".ruby-version"
+
+      - uses: Swatinem/rust-cache@v1
 
       - name: Check spinoso-array with no default features
         run: cargo check --verbose --no-default-features
@@ -288,6 +304,13 @@ jobs:
         with:
           toolchain: nightly
           profile: minimal
+
+      - uses: Swatinem/rust-cache@v1
+
+      - uses: Swatinem/rust-cache@v1
+        with:
+          working-directory: "spec-runner"
+          key: spec-runner
 
       - name: Check artichoke with minimal versions
         run: |

--- a/.github/workflows/fuzz.yaml
+++ b/.github/workflows/fuzz.yaml
@@ -57,6 +57,11 @@ jobs:
           target: x86_64-unknown-linux-gnu
           override: true
 
+      - name: Install Ruby toolchain
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ".ruby-version"
+
       - name: Test with leak sanitizer and all features
         run: cargo test --workspace --all-features --target x86_64-unknown-linux-gnu
 


### PR DESCRIPTION
Add caching using the `Swatinem/rust-cache@v1` GitHub Action for all CI
jobs that use a stable compiler.

`rustdoc`, `fuzz`, and `leak-san` jobs use a nightly compiler which is
updated daily and will not get much reuse out of the `rust-cache`-generated
cache keys which include the rustc compiler hash on nightlies.

This GitHub Action was introduced successfully in the playground in
artichoke/playground#299.

This commit is a reimplementation of the failed PR #1016 that works
around actions/cache#403.