### PR TITLE
Remove dependency on StructOpt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,8 +24,8 @@ version = "0.1.0-pre.0"
 dependencies = [
  "artichoke-backend",
  "chrono",
+ "clap",
  "rustyline",
- "structopt",
  "target-lexicon",
  "termcolor",
 ]
@@ -229,15 +229,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
-name = "heck"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cbf45460356b7deeb5e3415b5563308c0a9b057c85e12b06ad551f98d0a6ac"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
 name = "hermit-abi"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -402,30 +393,6 @@ name = "ppv-lite86"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
 
 [[package]]
 name = "proc-macro2"
@@ -663,30 +630,6 @@ name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "structopt"
-version = "0.3.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5277acd7ee46e63e5168a80734c9f6ee81b1367a7d8772a2d765df2a3705d28c"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ba9cdfda491b814720b6b06e0cac513d922fc407582032e8706e9f137976f90"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,8 @@ keywords = ["artichoke", "artichoke-ruby", "mri", "cruby", "ruby"]
 categories = ["command-line-utilities"]
 
 [dependencies]
+clap = { version = "2.33", optional = true }
 rustyline = { version = "7", default-features = false, optional = true }
-structopt = { version = "0.3", optional = true }
 termcolor = { version = "1.1", optional = true }
 
 [dependencies.artichoke-backend]
@@ -64,12 +64,13 @@ lto = true
 
 [features]
 default = [
+  "backtrace",
   "cli",
   "kitchen-sink",
 ]
 # Enable a CLI frontend for Artichoke, including a `ruby`-equivalent CLI and
 # REPL.
-cli = ["backtrace", "rustyline", "structopt"]
+cli = ["backtrace", "clap", "rustyline"]
 # Enable a module for formtting backtraces from Ruby exceptions.
 backtrace = ["termcolor"]
 # Enable all features of Ruby Core, Standard Library, and the underlying VM.

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -215,15 +215,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
-name = "heck"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cbf45460356b7deeb5e3415b5563308c0a9b057c85e12b06ad551f98d0a6ac"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
 name = "hermit-abi"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -376,30 +367,6 @@ name = "ppv-lite86"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
 
 [[package]]
 name = "proc-macro2"
@@ -568,9 +535,9 @@ name = "spec-runner"
 version = "0.3.0"
 dependencies = [
  "artichoke",
+ "clap",
  "rust-embed",
  "serde",
- "structopt",
  "termcolor",
  "toml",
 ]
@@ -657,30 +624,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
-name = "structopt"
-version = "0.3.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5277acd7ee46e63e5168a80734c9f6ee81b1367a7d8772a2d765df2a3705d28c"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ba9cdfda491b814720b6b06e0cac513d922fc407582032e8706e9f137976f90"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "syn"
 version = "1.0.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -732,12 +675,6 @@ checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
 dependencies = [
  "serde",
 ]
-
-[[package]]
-name = "unicode-segmentation"
-version = "1.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796"
 
 [[package]]
 name = "unicode-width"

--- a/spec-runner/Cargo.toml
+++ b/spec-runner/Cargo.toml
@@ -12,9 +12,9 @@ categories = ["development-tools::testing"]
 
 [dependencies]
 artichoke = { path = "..", default-features = false, features = ["backtrace", "kitchen-sink"] }
+clap = "2.33"
 rust-embed = "5.8.0"
 serde = { version = "1.0", features = ["derive"] }
-structopt = "0.3"
 termcolor = "1.1"
 toml = { version = "0.5", default-features = false }
 

--- a/src/bin/artichoke.rs
+++ b/src/bin/artichoke.rs
@@ -41,14 +41,56 @@
 //!     <programfile>
 //! ```
 
-use artichoke::ruby;
+use artichoke::ruby::{self, Args};
+use clap::{App, Arg};
+use std::ffi::OsString;
 use std::io::{self, Write};
+use std::path::PathBuf;
 use std::process;
 use termcolor::{ColorChoice, StandardStream, WriteColor};
 
 fn main() {
+    let app = App::new("artichoke");
+    let app = app.about("Artichoke is a Ruby made with Rust.");
+    let app = app.arg(
+        Arg::with_name("copyright")
+            .takes_value(false)
+            .multiple(false)
+            .help("print the copyright")
+            .long("copyright"),
+    );
+    let app = app.arg(
+        Arg::with_name("commands")
+            .takes_value(true)
+            .multiple(true)
+            .help(r"one line of script. Several -e's allowed. Omit [programfile]")
+            .short("e"),
+    );
+    let app = app.arg(
+        Arg::with_name("fixture")
+            .takes_value(true)
+            .multiple(false)
+            .help("file whose contents will be read into the `$fixture` global")
+            .long("with-fixture"),
+    );
+    let app = app.arg(Arg::with_name("programfile").takes_value(true).multiple(false));
+    let app = app.version(env!("CARGO_PKG_VERSION"));
+
+    let matches = app.get_matches();
+    let args = Args::empty()
+        .with_copyright(matches.is_present("copyright"))
+        .with_commands(
+            matches
+                .values_of_os("commands")
+                .into_iter()
+                .flat_map(|v| v.map(OsString::from))
+                .collect(),
+        )
+        .with_fixture(matches.value_of_os("fixture").map(PathBuf::from))
+        .with_programfile(matches.value_of_os("programfile").map(PathBuf::from));
+
     let mut stderr = StandardStream::stderr(ColorChoice::Auto);
-    match ruby::entrypoint(io::stdin(), &mut stderr) {
+    match ruby::entrypoint(args, io::stdin(), &mut stderr) {
         Ok(Ok(())) => {}
         Ok(Err(())) => process::exit(1),
         Err(err) => {


### PR DESCRIPTION
Using the output of `cargo-expand`, replace `StructOpt` derive macro
with generated and partially handwritten code.

The resulting code to manually configure `Arg`s for `clap` is not too
scary. This drops several proc macro deps.

The only remaining dependency on `syn` is `quickcheck_macros`.