### PR TITLE
Remove dependency on quickcheck_macros

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,7 +44,6 @@ dependencies = [
  "once_cell",
  "onig",
  "quickcheck",
- "quickcheck_macros",
  "regex",
  "scolapasta-string-escape",
  "spinoso-array",
@@ -414,17 +413,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quickcheck_macros"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608c156fd8e97febc07dc9c2e2c80bf74cfc6ef26893eae3daf8bc2bc94a4b7f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -630,17 +618,6 @@ name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "syn"
-version = "1.0.55"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a571a711dddd09019ccc628e1b17fe87c59b09d513c06c026877aa708334f37a"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-xid",
-]
 
 [[package]]
 name = "target-lexicon"

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -36,7 +36,6 @@ optional = true
 
 [dev-dependencies]
 quickcheck = { version = "0.9", default-features = false }
-quickcheck_macros = "0.9"
 
 [build-dependencies]
 bindgen = { version = "0.56.0", default-features = false, features = ["runtime"] }

--- a/artichoke-backend/src/convert/array.rs
+++ b/artichoke-backend/src/convert/array.rs
@@ -385,7 +385,7 @@ impl TryConvertMut<Value, Vec<Int>> for Artichoke {
 
 #[cfg(test)]
 mod tests {
-    use quickcheck_macros::quickcheck;
+    use quickcheck::quickcheck;
 
     use crate::test::prelude::*;
 
@@ -398,149 +398,144 @@ mod tests {
         assert!(result.is_err());
     }
 
-    #[quickcheck]
-    #[allow(clippy::needless_pass_by_value)]
-    fn arr_int_borrowed(arr: Vec<Int>) -> bool {
-        let mut interp = interpreter().unwrap();
-        // Borrowed converter
-        let value = interp.try_convert_mut(arr.as_slice()).unwrap();
-        let len = value.funcall(&mut interp, "length", &[], None).unwrap();
-        let len = len.try_into::<usize>(&interp).unwrap();
-        if len != arr.len() {
-            return false;
+    quickcheck! {
+        #[allow(clippy::needless_pass_by_value)]
+        fn arr_int_borrowed(arr: Vec<Int>) -> bool {
+            let mut interp = interpreter().unwrap();
+            // Borrowed converter
+            let value = interp.try_convert_mut(arr.as_slice()).unwrap();
+            let len = value.funcall(&mut interp, "length", &[], None).unwrap();
+            let len = len.try_into::<usize>(&interp).unwrap();
+            if len != arr.len() {
+                return false;
+            }
+            let empty = value.funcall(&mut interp, "empty?", &[], None).unwrap();
+            let empty = empty.try_into::<bool>(&interp).unwrap();
+            if empty != arr.is_empty() {
+                return false;
+            }
+            let recovered: Vec<Int> = interp.try_convert_mut(value).unwrap();
+            if recovered != arr {
+                return false;
+            }
+            true
         }
-        let empty = value.funcall(&mut interp, "empty?", &[], None).unwrap();
-        let empty = empty.try_into::<bool>(&interp).unwrap();
-        if empty != arr.is_empty() {
-            return false;
-        }
-        let recovered: Vec<Int> = interp.try_convert_mut(value).unwrap();
-        if recovered != arr {
-            return false;
-        }
-        true
-    }
 
-    #[quickcheck]
-    #[allow(clippy::needless_pass_by_value)]
-    fn arr_int_owned(arr: Vec<Int>) -> bool {
-        let mut interp = interpreter().unwrap();
-        // Owned converter
-        let value = interp.try_convert_mut(arr.to_vec()).unwrap();
-        let len = value.funcall(&mut interp, "length", &[], None).unwrap();
-        let len = len.try_into::<usize>(&interp).unwrap();
-        if len != arr.len() {
-            return false;
+        #[allow(clippy::needless_pass_by_value)]
+        fn arr_int_owned(arr: Vec<Int>) -> bool {
+            let mut interp = interpreter().unwrap();
+            // Owned converter
+            let value = interp.try_convert_mut(arr.to_vec()).unwrap();
+            let len = value.funcall(&mut interp, "length", &[], None).unwrap();
+            let len = len.try_into::<usize>(&interp).unwrap();
+            if len != arr.len() {
+                return false;
+            }
+            let empty = value.funcall(&mut interp, "empty?", &[], None).unwrap();
+            let empty = empty.try_into::<bool>(&interp).unwrap();
+            if empty != arr.is_empty() {
+                return false;
+            }
+            let recovered: Vec<Int> = interp.try_convert_mut(value).unwrap();
+            if recovered != arr {
+                return false;
+            }
+            true
         }
-        let empty = value.funcall(&mut interp, "empty?", &[], None).unwrap();
-        let empty = empty.try_into::<bool>(&interp).unwrap();
-        if empty != arr.is_empty() {
-            return false;
-        }
-        let recovered: Vec<Int> = interp.try_convert_mut(value).unwrap();
-        if recovered != arr {
-            return false;
-        }
-        true
-    }
 
-    #[quickcheck]
-    #[allow(clippy::needless_pass_by_value)]
-    fn arr_utf8_borrowed(arr: Vec<String>) -> bool {
-        let mut interp = interpreter().unwrap();
-        // Borrowed converter
-        let value = interp.try_convert_mut(arr.as_slice()).unwrap();
-        let len = value.funcall(&mut interp, "length", &[], None).unwrap();
-        let len = len.try_into::<usize>(&interp).unwrap();
-        if len != arr.len() {
-            return false;
+        #[allow(clippy::needless_pass_by_value)]
+        fn arr_utf8_borrowed(arr: Vec<String>) -> bool {
+            let mut interp = interpreter().unwrap();
+            // Borrowed converter
+            let value = interp.try_convert_mut(arr.as_slice()).unwrap();
+            let len = value.funcall(&mut interp, "length", &[], None).unwrap();
+            let len = len.try_into::<usize>(&interp).unwrap();
+            if len != arr.len() {
+                return false;
+            }
+            let empty = value.funcall(&mut interp, "empty?", &[], None).unwrap();
+            let empty = empty.try_into::<bool>(&interp).unwrap();
+            if empty != arr.is_empty() {
+                return false;
+            }
+            let recovered: Vec<String> = interp.try_convert_mut(value).unwrap();
+            if recovered != arr {
+                return false;
+            }
+            true
         }
-        let empty = value.funcall(&mut interp, "empty?", &[], None).unwrap();
-        let empty = empty.try_into::<bool>(&interp).unwrap();
-        if empty != arr.is_empty() {
-            return false;
-        }
-        let recovered: Vec<String> = interp.try_convert_mut(value).unwrap();
-        if recovered != arr {
-            return false;
-        }
-        true
-    }
 
-    #[quickcheck]
-    #[allow(clippy::needless_pass_by_value)]
-    fn arr_utf8_owned(arr: Vec<String>) -> bool {
-        let mut interp = interpreter().unwrap();
-        // Owned converter
-        let value = interp.try_convert_mut(arr.to_vec()).unwrap();
-        let len = value.funcall(&mut interp, "length", &[], None).unwrap();
-        let len = len.try_into::<usize>(&interp).unwrap();
-        if len != arr.len() {
-            return false;
+        #[allow(clippy::needless_pass_by_value)]
+        fn arr_utf8_owned(arr: Vec<String>) -> bool {
+            let mut interp = interpreter().unwrap();
+            // Owned converter
+            let value = interp.try_convert_mut(arr.to_vec()).unwrap();
+            let len = value.funcall(&mut interp, "length", &[], None).unwrap();
+            let len = len.try_into::<usize>(&interp).unwrap();
+            if len != arr.len() {
+                return false;
+            }
+            let empty = value.funcall(&mut interp, "empty?", &[], None).unwrap();
+            let empty = empty.try_into::<bool>(&interp).unwrap();
+            if empty != arr.is_empty() {
+                return false;
+            }
+            let recovered: Vec<String> = interp.try_convert_mut(value).unwrap();
+            if recovered != arr {
+                return false;
+            }
+            true
         }
-        let empty = value.funcall(&mut interp, "empty?", &[], None).unwrap();
-        let empty = empty.try_into::<bool>(&interp).unwrap();
-        if empty != arr.is_empty() {
-            return false;
-        }
-        let recovered: Vec<String> = interp.try_convert_mut(value).unwrap();
-        if recovered != arr {
-            return false;
-        }
-        true
-    }
 
-    #[quickcheck]
-    #[allow(clippy::needless_pass_by_value)]
-    fn arr_nilable_bstr_borrowed(arr: Vec<Option<Vec<u8>>>) -> bool {
-        let mut interp = interpreter().unwrap();
-        // Borrowed converter
-        let value = interp.try_convert_mut(arr.as_slice()).unwrap();
-        let len = value.funcall(&mut interp, "length", &[], None).unwrap();
-        let len = len.try_into::<usize>(&interp).unwrap();
-        if len != arr.len() {
-            return false;
+        #[allow(clippy::needless_pass_by_value)]
+        fn arr_nilable_bstr_borrowed(arr: Vec<Option<Vec<u8>>>) -> bool {
+            let mut interp = interpreter().unwrap();
+            // Borrowed converter
+            let value = interp.try_convert_mut(arr.as_slice()).unwrap();
+            let len = value.funcall(&mut interp, "length", &[], None).unwrap();
+            let len = len.try_into::<usize>(&interp).unwrap();
+            if len != arr.len() {
+                return false;
+            }
+            let empty = value.funcall(&mut interp, "empty?", &[], None).unwrap();
+            let empty = empty.try_into::<bool>(&interp).unwrap();
+            if empty != arr.is_empty() {
+                return false;
+            }
+            let recovered: Vec<Option<Vec<u8>>> = interp.try_convert_mut(value).unwrap();
+            if recovered != arr {
+                return false;
+            }
+            true
         }
-        let empty = value.funcall(&mut interp, "empty?", &[], None).unwrap();
-        let empty = empty.try_into::<bool>(&interp).unwrap();
-        if empty != arr.is_empty() {
-            return false;
-        }
-        let recovered: Vec<Option<Vec<u8>>> = interp.try_convert_mut(value).unwrap();
-        if recovered != arr {
-            return false;
-        }
-        true
-    }
 
-    #[quickcheck]
-    #[allow(clippy::needless_pass_by_value)]
-    fn arr_nilable_bstr_owned(arr: Vec<Option<Vec<u8>>>) -> bool {
-        let mut interp = interpreter().unwrap();
-        // Owned converter
-        let value = interp.try_convert_mut(arr.to_vec()).unwrap();
-        let len = value.funcall(&mut interp, "length", &[], None).unwrap();
-        let len = len.try_into::<usize>(&interp).unwrap();
-        if len != arr.len() {
-            return false;
+        #[allow(clippy::needless_pass_by_value)]
+        fn arr_nilable_bstr_owned(arr: Vec<Option<Vec<u8>>>) -> bool {
+            let mut interp = interpreter().unwrap();
+            // Owned converter
+            let value = interp.try_convert_mut(arr.to_vec()).unwrap();
+            let len = value.funcall(&mut interp, "length", &[], None).unwrap();
+            let len = len.try_into::<usize>(&interp).unwrap();
+            if len != arr.len() {
+                return false;
+            }
+            let empty = value.funcall(&mut interp, "empty?", &[], None).unwrap();
+            let empty = empty.try_into::<bool>(&interp).unwrap();
+            if empty != arr.is_empty() {
+                return false;
+            }
+            let recovered: Vec<Option<Vec<u8>>> = interp.try_convert_mut(value).unwrap();
+            if recovered != arr {
+                return false;
+            }
+            true
         }
-        let empty = value.funcall(&mut interp, "empty?", &[], None).unwrap();
-        let empty = empty.try_into::<bool>(&interp).unwrap();
-        if empty != arr.is_empty() {
-            return false;
-        }
-        let recovered: Vec<Option<Vec<u8>>> = interp.try_convert_mut(value).unwrap();
-        if recovered != arr {
-            return false;
-        }
-        true
-    }
 
-    #[quickcheck]
-    fn roundtrip_err(i: i64) -> bool {
-        let mut interp = interpreter().unwrap();
-        let value = interp.convert(i);
-        let value = value.try_into_mut::<Vec<Value>>(&mut interp);
-        value.is_err()
+        fn roundtrip_err(i: i64) -> bool {
+            let mut interp = interpreter().unwrap();
+            let value = interp.convert(i);
+            let value = value.try_into_mut::<Vec<Value>>(&mut interp);
+            value.is_err()
+        }
     }
 }

--- a/artichoke-backend/src/convert/fixnum.rs
+++ b/artichoke-backend/src/convert/fixnum.rs
@@ -171,7 +171,7 @@ impl TryConvert<Value, usize> for Artichoke {
 
 #[cfg(test)]
 mod tests {
-    use quickcheck_macros::quickcheck;
+    use quickcheck::quickcheck;
 
     use crate::test::prelude::*;
 
@@ -184,36 +184,34 @@ mod tests {
         assert!(result.is_err());
     }
 
-    #[quickcheck]
-    fn convert_to_fixnum(i: Int) -> bool {
-        let interp = interpreter().unwrap();
-        let value = interp.convert(i);
-        value.ruby_type() == Ruby::Fixnum
-    }
+    quickcheck! {
+        fn convert_to_fixnum(i: Int) -> bool {
+            let interp = interpreter().unwrap();
+            let value = interp.convert(i);
+            value.ruby_type() == Ruby::Fixnum
+        }
 
-    #[quickcheck]
-    fn fixnum_with_value(i: Int) -> bool {
-        let interp = interpreter().unwrap();
-        let value = interp.convert(i);
-        let inner = value.inner();
-        let cint = unsafe { sys::mrb_sys_fixnum_to_cint(inner) };
-        cint == i
-    }
+        fn fixnum_with_value(i: Int) -> bool {
+            let interp = interpreter().unwrap();
+            let value = interp.convert(i);
+            let inner = value.inner();
+            let cint = unsafe { sys::mrb_sys_fixnum_to_cint(inner) };
+            cint == i
+        }
 
-    #[quickcheck]
-    fn roundtrip(i: Int) -> bool {
-        let interp = interpreter().unwrap();
-        let value = interp.convert(i);
-        let value = value.try_into::<Int>(&interp).unwrap();
-        value == i
-    }
+        fn roundtrip(i: Int) -> bool {
+            let interp = interpreter().unwrap();
+            let value = interp.convert(i);
+            let value = value.try_into::<Int>(&interp).unwrap();
+            value == i
+        }
 
-    #[quickcheck]
-    fn roundtrip_err(b: bool) -> bool {
-        let interp = interpreter().unwrap();
-        let value = interp.convert(b);
-        let value = value.try_into::<Int>(&interp);
-        value.is_err()
+        fn roundtrip_err(b: bool) -> bool {
+            let interp = interpreter().unwrap();
+            let value = interp.convert(b);
+            let value = value.try_into::<Int>(&interp);
+            value.is_err()
+        }
     }
 
     #[test]

--- a/artichoke-backend/src/convert/float.rs
+++ b/artichoke-backend/src/convert/float.rs
@@ -29,7 +29,7 @@ impl TryConvert<Value, Fp> for Artichoke {
 
 #[cfg(test)]
 mod tests {
-    use quickcheck_macros::quickcheck;
+    use quickcheck::quickcheck;
 
     use crate::test::prelude::*;
 
@@ -42,35 +42,33 @@ mod tests {
         assert!(result.is_err());
     }
 
-    #[quickcheck]
-    fn convert_to_float(f: Fp) -> bool {
-        let mut interp = interpreter().unwrap();
-        let value = interp.convert_mut(f);
-        value.ruby_type() == Ruby::Float
-    }
+    quickcheck! {
+        fn convert_to_float(f: Fp) -> bool {
+            let mut interp = interpreter().unwrap();
+            let value = interp.convert_mut(f);
+            value.ruby_type() == Ruby::Float
+        }
 
-    #[quickcheck]
-    fn float_with_value(f: Fp) -> bool {
-        let mut interp = interpreter().unwrap();
-        let value = interp.convert_mut(f);
-        let inner = value.inner();
-        let cdouble = unsafe { sys::mrb_sys_float_to_cdouble(inner) };
-        (cdouble - f).abs() < Fp::EPSILON
-    }
+        fn float_with_value(f: Fp) -> bool {
+            let mut interp = interpreter().unwrap();
+            let value = interp.convert_mut(f);
+            let inner = value.inner();
+            let cdouble = unsafe { sys::mrb_sys_float_to_cdouble(inner) };
+            (cdouble - f).abs() < Fp::EPSILON
+        }
 
-    #[quickcheck]
-    fn roundtrip(f: Fp) -> bool {
-        let mut interp = interpreter().unwrap();
-        let value = interp.convert_mut(f);
-        let value = value.try_into::<Fp>(&interp).unwrap();
-        (value - f).abs() < Fp::EPSILON
-    }
+        fn roundtrip(f: Fp) -> bool {
+            let mut interp = interpreter().unwrap();
+            let value = interp.convert_mut(f);
+            let value = value.try_into::<Fp>(&interp).unwrap();
+            (value - f).abs() < Fp::EPSILON
+        }
 
-    #[quickcheck]
-    fn roundtrip_err(b: bool) -> bool {
-        let interp = interpreter().unwrap();
-        let value = interp.convert(b);
-        let value = value.try_into::<Fp>(&interp);
-        value.is_err()
+        fn roundtrip_err(b: bool) -> bool {
+            let interp = interpreter().unwrap();
+            let value = interp.convert(b);
+            let value = value.try_into::<Fp>(&interp);
+            value.is_err()
+        }
     }
 }


### PR DESCRIPTION
Replace the `quickcheck_macros` attribute macro with the `quickcheck`
`macro_rules` macro.

Together with #1018, this removes `artichoke`'s dependency on `syn`.