### PR TITLE
Update rand to 0.8, rand_core to 0.6, and getrandom to 0.2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -201,9 +201,9 @@ jobs:
 
       - name: Check spinoso-random with some features
         run: |
-          cargo check --verbose --no-default-features --features rand-core
+          cargo check --verbose --no-default-features --features rand-traits
           cargo check --verbose --no-default-features --features std
-          cargo check --verbose --no-default-features --features rand
+          cargo check --verbose --no-default-features --features random-rand
         working-directory: "spinoso-random"
 
       - name: Check spinoso-regexp with no default features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,9 +262,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.81"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1482821306169ec4d07f6aca392a4681f66c75c9918aa49641a2595db64053cb"
+checksum = "89203f3fba0a3795506acaad8ebce3c80c0af93f994d5a1d7a0b1eeb23271929"
 
 [[package]]
 name = "libloading"
@@ -462,9 +462,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38cf2c13ed4745de91a5eb834e11c00bcc3709e773173b2ce4c56c9fbde04b9c"
+checksum = "d9251239e129e16308e70d853559389de218ac275b515068abc96829d05b948a"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -474,9 +474,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.21"
+version = "0.6.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b181ba2dcf07aaccad5448e8ead58db5b742cf85dfe035e2227f137a539a189"
+checksum = "b5eb417147ba9860a96cfe72a0b93bf88fee1744b5636ec99ab20c1aa9376581"
 
 [[package]]
 name = "rustc-hash"
@@ -643,9 +643,9 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
+checksum = "bb9bc092d0d51e76b2b19d9d85534ffc9ec2db959a2523cdae0697e2972cd447"
 dependencies = [
  "lazy_static",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,9 +212,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.16"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+checksum = "4060f4657be78b8e766215b02b18a2e862d83745545de804638e2b545e81aee6"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -404,12 +404,11 @@ dependencies = [
 
 [[package]]
 name = "quickcheck"
-version = "0.9.2"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44883e74aa97ad63db83c4bf8ca490f02b2fc02f92575e720c8551e843c945f"
+checksum = "efc008b226fa5bdeabfc788d6679692223e940da371a95e26d87678333dac7c8"
 dependencies = [
  "rand",
- "rand_core",
 ]
 
 [[package]]
@@ -423,11 +422,10 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.7.3"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+checksum = "c24fcd450d3fa2b592732565aa4f17a27a61c65ece4726353e000939b0edee34"
 dependencies = [
- "getrandom",
  "libc",
  "rand_chacha",
  "rand_core",
@@ -436,9 +434,9 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
 dependencies = [
  "ppv-lite86",
  "rand_core",
@@ -446,18 +444,18 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.5.1"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+checksum = "c026d7df8b298d90ccbbc5190bd04d85e159eaf5576caeacf8741da93ccbd2e5"
 dependencies = [
  "getrandom",
 ]
 
 [[package]]
 name = "rand_hc"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
 dependencies = [
  "rand_core",
 ]
@@ -690,9 +688,9 @@ checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
 
 [[package]]
 name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
+version = "0.10.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+checksum = "93c6c3420963c5c64bca373b25e77acb562081b9bb4dd5bb864187742186cea9"
 
 [[package]]
 name = "winapi"

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -35,7 +35,7 @@ default-features = false
 optional = true
 
 [dev-dependencies]
-quickcheck = { version = "0.9", default-features = false }
+quickcheck = { version = "1.0", default-features = false }
 
 [build-dependencies]
 bindgen = { version = "0.56.0", default-features = false, features = ["runtime"] }

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -177,11 +177,11 @@ checksum = "6a2b7597098968fec3b57e0b53de3aed8e0631bb830589260bfb9e81b0376524"
 
 [[package]]
 name = "getrandom"
-version = "0.1.15"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
+checksum = "4060f4657be78b8e766215b02b18a2e862d83745545de804638e2b545e81aee6"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "libc",
  "wasi",
 ]
@@ -367,11 +367,10 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.7.3"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+checksum = "c24fcd450d3fa2b592732565aa4f17a27a61c65ece4726353e000939b0edee34"
 dependencies = [
- "getrandom",
  "libc",
  "rand_chacha",
  "rand_core",
@@ -380,9 +379,9 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
 dependencies = [
  "ppv-lite86",
  "rand_core",
@@ -390,18 +389,18 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.5.1"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+checksum = "c026d7df8b298d90ccbbc5190bd04d85e159eaf5576caeacf8741da93ccbd2e5"
 dependencies = [
  "getrandom",
 ]
 
 [[package]]
 name = "rand_hc"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
 dependencies = [
  "rand_core",
 ]
@@ -551,9 +550,9 @@ checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
 
 [[package]]
 name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
+version = "0.10.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+checksum = "93c6c3420963c5c64bca373b25e77acb562081b9bb4dd5bb864187742186cea9"
 
 [[package]]
 name = "winapi"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -200,9 +200,9 @@ checksum = "da4b877f1da0e0ee602fdbf203184ebd8cc5c5d9175195edafeaccae37b201e6"
 
 [[package]]
 name = "itoa"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
+checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "lazy_static"
@@ -218,9 +218,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.81"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1482821306169ec4d07f6aca392a4681f66c75c9918aa49641a2595db64053cb"
+checksum = "89203f3fba0a3795506acaad8ebce3c80c0af93f994d5a1d7a0b1eeb23271929"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -407,9 +407,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38cf2c13ed4745de91a5eb834e11c00bcc3709e773173b2ce4c56c9fbde04b9c"
+checksum = "d9251239e129e16308e70d853559389de218ac275b515068abc96829d05b948a"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -419,9 +419,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.21"
+version = "0.6.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b181ba2dcf07aaccad5448e8ead58db5b742cf85dfe035e2227f137a539a189"
+checksum = "b5eb417147ba9860a96cfe72a0b93bf88fee1744b5636ec99ab20c1aa9376581"
 
 [[package]]
 name = "rustc-hash"
@@ -529,9 +529,9 @@ checksum = "4ee5a98e506fb7231a304c3a1bd7c132a55016cf65001e0282480665870dfcb9"
 
 [[package]]
 name = "thread_local"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
+checksum = "bb9bc092d0d51e76b2b19d9d85534ffc9ec2db959a2523cdae0697e2972cd447"
 dependencies = [
  "lazy_static",
 ]

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -199,11 +199,11 @@ checksum = "6a2b7597098968fec3b57e0b53de3aed8e0631bb830589260bfb9e81b0376524"
 
 [[package]]
 name = "getrandom"
-version = "0.1.15"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
+checksum = "4060f4657be78b8e766215b02b18a2e862d83745545de804638e2b545e81aee6"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "libc",
  "wasi",
 ]
@@ -388,11 +388,10 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.7.3"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+checksum = "c24fcd450d3fa2b592732565aa4f17a27a61c65ece4726353e000939b0edee34"
 dependencies = [
- "getrandom",
  "libc",
  "rand_chacha",
  "rand_core",
@@ -401,9 +400,9 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
 dependencies = [
  "ppv-lite86",
  "rand_core",
@@ -411,18 +410,18 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.5.1"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+checksum = "c026d7df8b298d90ccbbc5190bd04d85e159eaf5576caeacf8741da93ccbd2e5"
 dependencies = [
  "getrandom",
 ]
 
 [[package]]
 name = "rand_hc"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
 dependencies = [
  "rand_core",
 ]
@@ -713,9 +712,9 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
+version = "0.10.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+checksum = "93c6c3420963c5c64bca373b25e77acb562081b9bb4dd5bb864187742186cea9"
 
 [[package]]
 name = "winapi"

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -231,9 +231,9 @@ checksum = "da4b877f1da0e0ee602fdbf203184ebd8cc5c5d9175195edafeaccae37b201e6"
 
 [[package]]
 name = "itoa"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
+checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "lazy_static"
@@ -249,9 +249,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.81"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1482821306169ec4d07f6aca392a4681f66c75c9918aa49641a2595db64053cb"
+checksum = "89203f3fba0a3795506acaad8ebce3c80c0af93f994d5a1d7a0b1eeb23271929"
 
 [[package]]
 name = "libloading"
@@ -428,9 +428,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38cf2c13ed4745de91a5eb834e11c00bcc3709e773173b2ce4c56c9fbde04b9c"
+checksum = "d9251239e129e16308e70d853559389de218ac275b515068abc96829d05b948a"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -440,9 +440,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.21"
+version = "0.6.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b181ba2dcf07aaccad5448e8ead58db5b742cf85dfe035e2227f137a539a189"
+checksum = "b5eb417147ba9860a96cfe72a0b93bf88fee1744b5636ec99ab20c1aa9376581"
 
 [[package]]
 name = "rust-embed"
@@ -624,9 +624,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "syn"
-version = "1.0.55"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a571a711dddd09019ccc628e1b17fe87c59b09d513c06c026877aa708334f37a"
+checksum = "cc60a3d73ea6594cd712d830cc1f0390fd71542d8c8cd24e70cc54cdfd5e05d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -659,9 +659,9 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
+checksum = "bb9bc092d0d51e76b2b19d9d85534ffc9ec2db959a2523cdae0697e2972cd447"
 dependencies = [
  "lazy_static",
 ]

--- a/spinoso-random/Cargo.toml
+++ b/spinoso-random/Cargo.toml
@@ -21,7 +21,7 @@ rand_core = { version = "0.6", optional = true, default-features = false }
 [features]
 default = ["random-rand", "rand-traits", "std"]
 # Enables range sampling methods for the `rand()` function.
-random-rand = ["rand"]
+random-rand = ["rand", "rand-traits"]
 # Enables implementations of `RngCore` on `Random` and `Mt` types.
 rand-traits = ["rand_core"]
 std = []

--- a/spinoso-random/Cargo.toml
+++ b/spinoso-random/Cargo.toml
@@ -13,17 +13,17 @@ keywords = ["random", "rand", "rng", "mt", "spinoso"]
 categories = ["algorithms", "no-std"]
 
 [dependencies]
-getrandom = { version = "0.1", default-features = false }
+getrandom = { version = "0.2", default-features = false }
 libm = "0.2"
-rand_ = { version = "0.7", optional = true, default-features = false, package = "rand" }
-rand_core_ = { version = "0.5", optional = true, default-features = false, package = "rand_core" }
+rand = { version = "0.8", optional = true, default-features = false }
+rand_core = { version = "0.6", optional = true, default-features = false }
 
 [features]
-default = ["rand", "std"]
+default = ["random-rand", "rand-traits", "std"]
 # Enables range sampling methods for the `rand()` function.
-rand = ["rand_", "rand-core"]
+random-rand = ["rand"]
 # Enables implementations of `RngCore` on `Random` and `Mt` types.
-rand-core = ["rand_core_"]
+rand-traits = ["rand_core"]
 std = []
 
 [package.metadata.docs.rs]

--- a/spinoso-random/README.md
+++ b/spinoso-random/README.md
@@ -66,10 +66,10 @@ crate does not depend on [`alloc`].
 
 All features are enabled by default.
 
-- **rand** - Enables range sampling methods for the `rand()` function.
+- **random-rand** - Enables range sampling methods for the `rand()` function.
   Activating this feature also activates the **rand_core** feature. Dropping
   this feature removes the [`rand`] dependency.
-- **rand_core** - Enables implementations of [`RngCore`] on `Random` and `Mt`
+- **rand-traits** - Enables implementations of [`RngCore`] on `Random` and `Mt`
   types. Dropping this feature removes the [`rand_core`] dependency.
 - **std** - Enables a dependency on the Rust Standard Library. Activating this
   feature enables [`std::error::Error`] impls on error types in this crate.

--- a/spinoso-random/src/lib.rs
+++ b/spinoso-random/src/lib.rs
@@ -88,9 +88,8 @@
 //!
 //! [ruby-random]: https://ruby-doc.org/core-2.6.3/Random.html
 //! [`alloc`]: https://doc.rust-lang.org/alloc/
-//! [`RngCore`]: rand_core_::RngCore
-//! [`rand`]: rand_
-//! [`rand_core`]: rand_core_
+//! [`rand`]: ::rand
+//! [`RngCore`]: rand_core::RngCore
 
 #![no_std]
 

--- a/spinoso-random/src/lib.rs
+++ b/spinoso-random/src/lib.rs
@@ -54,9 +54,9 @@
 //! Generate random numbers in a range:
 //!
 //! ```
-//! # #[cfg(feature = "rand")]
+//! # #[cfg(feature = "random-rand")]
 //! # use spinoso_random::{rand, Error, Max, Rand, Random};
-//! # #[cfg(feature = "rand")]
+//! # #[cfg(feature = "random-rand")]
 //! # fn example() -> Result<(), Error> {
 //! let mut random = Random::new()?;
 //! let max = Max::Integer(10);
@@ -64,7 +64,7 @@
 //! assert!(matches!(rand, Rand::Integer(x) if x < 10));
 //! # Ok(())
 //! # }
-//! # #[cfg(feature = "rand")]
+//! # #[cfg(feature = "random-rand")]
 //! # example().unwrap();
 //! ```
 //!
@@ -77,10 +77,10 @@
 //!
 //! All features are enabled by default.
 //!
-//! - **rand** - Enables range sampling methods for the [`rand()`] function.
-//!   Activating this feature also activates the **rand-core** feature. Dropping
-//!   this feature removes the [`rand`] dependency.
-//! - **rand-core** - Enables implementations of [`RngCore`] on [`Random`] and
+//! - **random-rand** - Enables range sampling methods for the [`rand()`]
+//!   function.  Activating this feature also activates the **rand-traits**
+//!   feature. Dropping this feature removes the [`rand`] dependency.
+//! - **rand-traits** - Enables implementations of [`RngCore`] on [`Random`] and
 //!   [`Mt`] types. Dropping this feature removes the [`rand_core`] dependency.
 //! - **std** - Enables a dependency on the Rust Standard Library. Activating
 //!   this feature enables [`std::error::Error`] impls on error types in this
@@ -101,13 +101,13 @@ use core::fmt;
 #[cfg(feature = "std")]
 use std::error;
 
-#[cfg(feature = "rand")]
+#[cfg(feature = "random-rand")]
 mod rand;
 mod random;
 mod urandom;
 
-#[cfg(feature = "rand")]
-pub use rand::{rand, Max, Rand};
+#[cfg(feature = "random-rand")]
+pub use self::rand::{rand, Max, Rand};
 pub use random::ruby::Mt;
 pub use random::{new_seed, seed_to_key, Random};
 pub use urandom::urandom;
@@ -427,8 +427,8 @@ pub struct ArgumentError(ArgumentErrorInner);
 enum ArgumentErrorInner {
     Default,
     DomainError,
-    #[cfg(feature = "rand")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "rand")))]
+    #[cfg(feature = "random-rand")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "random-rand")))]
     Rand(Max),
 }
 
@@ -474,8 +474,8 @@ impl ArgumentError {
     /// ```
     #[inline]
     #[must_use]
-    #[cfg(feature = "rand")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "rand")))]
+    #[cfg(feature = "random-rand")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "random-rand")))]
     pub const fn with_rand_max(max: Max) -> Self {
         Self(ArgumentErrorInner::Rand(max))
     }
@@ -505,7 +505,7 @@ impl ArgumentError {
         match self.0 {
             ArgumentErrorInner::Default => "ArgumentError",
             ArgumentErrorInner::DomainError => "Numerical argument out of domain",
-            #[cfg(feature = "rand")]
+            #[cfg(feature = "random-rand")]
             ArgumentErrorInner::Rand(_) => "invalid argument",
         }
     }
@@ -535,7 +535,7 @@ impl fmt::Display for ArgumentError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.0 {
             ArgumentErrorInner::Default | ArgumentErrorInner::DomainError => f.write_str(self.message()),
-            #[cfg(feature = "rand")]
+            #[cfg(feature = "random-rand")]
             ArgumentErrorInner::Rand(max) => write!(f, "invalid argument - {}", max),
         }
     }

--- a/spinoso-random/src/rand.rs
+++ b/spinoso-random/src/rand.rs
@@ -5,7 +5,7 @@ use crate::{ArgumentError, Random};
 
 /// A range constraint for generating random numbers.
 ///
-/// This enum is an input to the [`rand`] function. See its documentation for
+/// This enum is an input to the [`rand()`] function. See its documentation for
 /// more details.
 // TODO: Add range variants
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
@@ -43,19 +43,19 @@ impl fmt::Display for Max {
 
 /// A generated random number.
 ///
-/// This enum is returned by the [`rand`] function. See its documentation for
+/// This enum is returned by the [`rand()`] function. See its documentation for
 /// more details.
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
 #[cfg_attr(docsrs, doc(cfg(feature = "random-rand")))]
 pub enum Rand {
     /// A random float.
     ///
-    /// A random float is returned from [`rand`] when given [`Max::Float`] or
+    /// A random float is returned from [`rand()`] when given [`Max::Float`] or
     /// [`Max::None`] max constraint.
     Float(f64),
     /// A random integer.
     ///
-    /// A random integer is returned from [`rand`] when given [`Max::Integer`]
+    /// A random integer is returned from [`rand()`] when given [`Max::Integer`]
     /// max constraint.
     Integer(i64),
 }

--- a/spinoso-random/src/rand.rs
+++ b/spinoso-random/src/rand.rs
@@ -1,5 +1,5 @@
 use core::fmt;
-use rand_::Rng;
+use rand::Rng;
 
 use crate::{ArgumentError, Random};
 
@@ -9,7 +9,7 @@ use crate::{ArgumentError, Random};
 /// more details.
 // TODO: Add range variants
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-#[cfg_attr(docsrs, doc(cfg(feature = "rand")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "random-rand")))]
 pub enum Max {
     /// A maximum float bound.
     ///
@@ -46,7 +46,7 @@ impl fmt::Display for Max {
 /// This enum is returned by the [`rand`] function. See its documentation for
 /// more details.
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-#[cfg_attr(docsrs, doc(cfg(feature = "rand")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "random-rand")))]
 pub enum Rand {
     /// A random float.
     ///
@@ -121,8 +121,8 @@ pub enum Rand {
 ///
 /// When `max` is a non-finite `f64`, `rand` returns a domain error
 /// [`ArgumentError`].
-#[cfg(feature = "rand")]
-#[cfg_attr(docsrs, doc(cfg(feature = "rand")))]
+#[cfg(feature = "random-rand")]
+#[cfg_attr(docsrs, doc(cfg(feature = "random-rand")))]
 pub fn rand(rng: &mut Random, max: Max) -> Result<Rand, ArgumentError> {
     let constraint = max;
     match constraint {
@@ -139,7 +139,7 @@ pub fn rand(rng: &mut Random, max: Max) -> Result<Rand, ArgumentError> {
             Ok(Rand::Float(number))
         }
         Max::Float(max) => {
-            let number = rng.gen_range(0.0, max);
+            let number = rng.gen_range(0.0..max);
             Ok(Rand::Float(number))
         }
         Max::Integer(max) if max < 1 => {
@@ -147,7 +147,7 @@ pub fn rand(rng: &mut Random, max: Max) -> Result<Rand, ArgumentError> {
             Err(err)
         }
         Max::Integer(max) => {
-            let number = rng.gen_range(0, max);
+            let number = rng.gen_range(0..max);
             Ok(Rand::Integer(number))
         }
         Max::None => {

--- a/spinoso-random/src/random/mod.rs
+++ b/spinoso-random/src/random/mod.rs
@@ -3,7 +3,7 @@ use core::mem::size_of;
 
 use crate::{InitializeError, NewSeedError};
 
-#[cfg(feature = "rand-core")]
+#[cfg(feature = "rand-traits")]
 mod rand;
 pub mod ruby;
 

--- a/spinoso-random/src/random/rand.rs
+++ b/spinoso-random/src/random/rand.rs
@@ -11,7 +11,7 @@ impl SeedableRng for Random {
     /// # Examples
     ///
     /// ```
-    /// # use rand_core_::{RngCore, SeedableRng};
+    /// # use rand_core::{RngCore, SeedableRng};
     /// # use spinoso_random::Random;
     /// // Default MT seed
     /// let seed = 5489_u128.to_le_bytes();
@@ -35,7 +35,7 @@ impl RngCore for Random {
     /// # Examples
     ///
     /// ```
-    /// # use rand_core_::RngCore;
+    /// # use rand_core::RngCore;
     /// # use spinoso_random::Random;
     /// let mut random = Random::with_seed(33);
     /// assert_ne!(random.next_u64(), random.next_u64());
@@ -54,7 +54,7 @@ impl RngCore for Random {
     /// # Examples
     ///
     /// ```
-    /// # use rand_core_::RngCore;
+    /// # use rand_core::RngCore;
     /// # use spinoso_random::Random;
     /// let mut random = Random::with_seed(33);
     /// assert_ne!(random.next_u32(), random.next_u32());
@@ -76,7 +76,7 @@ impl RngCore for Random {
     /// # Examples
     ///
     /// ```
-    /// # use rand_core_::RngCore;
+    /// # use rand_core::RngCore;
     /// # use spinoso_random::Random;
     /// let mut random = Random::with_seed(33);
     /// let mut buf = [0; 32];
@@ -104,7 +104,7 @@ impl RngCore for Random {
     /// # Examples
     ///
     /// ```
-    /// # use rand_core_::{Error, RngCore};
+    /// # use rand_core::{Error, RngCore};
     /// # use spinoso_random::Random;
     /// # fn example() -> Result<(), Error> {
     /// let mut random = Random::with_seed(33);

--- a/spinoso-random/src/random/rand.rs
+++ b/spinoso-random/src/random/rand.rs
@@ -1,4 +1,4 @@
-use rand_core_::{Error, RngCore, SeedableRng};
+use rand_core::{Error, RngCore, SeedableRng};
 
 use super::{seed_to_key, Random, DEFAULT_SEED_BYTES};
 use crate::Mt;

--- a/spinoso-random/src/random/ruby/mod.rs
+++ b/spinoso-random/src/random/ruby/mod.rs
@@ -6,7 +6,7 @@ use core::fmt;
 use core::mem::size_of;
 use core::num::Wrapping;
 
-#[cfg(feature = "rand-core")]
+#[cfg(feature = "rand-traits")]
 mod rand;
 
 const N: usize = 624;

--- a/spinoso-random/src/random/ruby/rand.rs
+++ b/spinoso-random/src/random/ruby/rand.rs
@@ -1,5 +1,5 @@
-use rand_core_::impls::next_u64_via_u32;
-use rand_core_::{Error, RngCore, SeedableRng};
+use rand_core::impls::next_u64_via_u32;
+use rand_core::{Error, RngCore, SeedableRng};
 
 use super::Mt;
 use crate::random::{seed_to_key, DEFAULT_SEED_BYTES};

--- a/spinoso-random/src/random/ruby/rand.rs
+++ b/spinoso-random/src/random/ruby/rand.rs
@@ -12,7 +12,7 @@ impl SeedableRng for Mt {
     /// # Examples
     ///
     /// ```
-    /// # use rand_core_::{RngCore, SeedableRng};
+    /// # use rand_core::{RngCore, SeedableRng};
     /// # use spinoso_random::Mt;
     /// // Default MT seed
     /// let seed = 5489_u128.to_le_bytes();
@@ -35,7 +35,7 @@ impl RngCore for Mt {
     /// # Examples
     ///
     /// ```
-    /// # use rand_core_::RngCore;
+    /// # use rand_core::RngCore;
     /// # use spinoso_random::Mt;
     /// let mut mt = Mt::with_seed(5489);
     /// assert_ne!(mt.next_u64(), mt.next_u64());
@@ -54,7 +54,7 @@ impl RngCore for Mt {
     /// # Examples
     ///
     /// ```
-    /// # use rand_core_::RngCore;
+    /// # use rand_core::RngCore;
     /// # use spinoso_random::Mt;
     /// let mut mt = Mt::with_seed(5489);
     /// assert_ne!(mt.next_u32(), mt.next_u32());
@@ -76,7 +76,7 @@ impl RngCore for Mt {
     /// # Examples
     ///
     /// ```
-    /// # use rand_core_::RngCore;
+    /// # use rand_core::RngCore;
     /// # use spinoso_random::Mt;
     /// let mut mt = Mt::with_seed(5489);
     /// let mut buf = [0; 32];
@@ -104,7 +104,7 @@ impl RngCore for Mt {
     /// # Examples
     ///
     /// ```
-    /// # use rand_core_::{Error, RngCore};
+    /// # use rand_core::{Error, RngCore};
     /// # use spinoso_random::Mt;
     /// # fn example() -> Result<(), Error> {
     /// let mut mt = Mt::with_seed(5489);

--- a/spinoso-securerandom/Cargo.toml
+++ b/spinoso-securerandom/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["algorithms"]
 
 [dependencies]
 base64 = "0.13"
-rand = "0.7"
+rand = "0.8"
 
 [dependencies.scolapasta-hex]
 version = "0.1"

--- a/spinoso-securerandom/src/lib.rs
+++ b/spinoso-securerandom/src/lib.rs
@@ -830,6 +830,6 @@ mod tests {
     #[test]
     fn alphanumeric_format() {
         let random = alphanumeric(Some(1024)).unwrap();
-        assert!(random.chars().all(|ch| ch.is_ascii_alphanumeric()));
+        assert!(random.iter().all(|&byte| byte.is_ascii_alphanumeric()));
     }
 }

--- a/spinoso-securerandom/src/lib.rs
+++ b/spinoso-securerandom/src/lib.rs
@@ -533,23 +533,23 @@ pub fn random_number(max: Max) -> Result<Rand, DomainError> {
             Err(DomainError::new())
         }
         Max::Float(max) if max <= 0.0 => {
-            let number = rng.gen_range(0.0, 1.0);
+            let number = rng.gen_range(0.0..1.0);
             Ok(Rand::Float(number))
         }
         Max::Float(max) => {
-            let number = rng.gen_range(0.0, max);
+            let number = rng.gen_range(0.0..max);
             Ok(Rand::Float(number))
         }
         Max::Integer(max) if !max.is_positive() => {
-            let number = rng.gen_range(0.0, 1.0);
+            let number = rng.gen_range(0.0..1.0);
             Ok(Rand::Float(number))
         }
         Max::Integer(max) => {
-            let number = rng.gen_range(0, max);
+            let number = rng.gen_range(0..max);
             Ok(Rand::Integer(number))
         }
         Max::None => {
-            let number = rng.gen_range(0.0, 1.0);
+            let number = rng.gen_range(0.0..1.0);
             Ok(Rand::Float(number))
         }
     }
@@ -655,11 +655,15 @@ pub fn urlsafe_base64(len: Option<i64>, padding: bool) -> Result<String, Error> 
 /// random ASCII alphanumeric bytes. If `len` is [`None`], generate 16 random
 /// alphanumeric bytes.
 ///
+/// The returned [`Vec<u8>`](Vec) is guaranteed to contain only ASCII bytes.
+///
 /// # Examples
 ///
 /// ```rust
-/// # fn example() -> Result<(), spinoso_securerandom::Error> {
+/// # use std::error::Error;
+/// # fn example() -> Result<(), Box<dyn Error>> {
 /// let bytes = spinoso_securerandom::alphanumeric(Some(1024))?;
+/// let bytes = String::from_utf8(bytes)?;
 /// assert_eq!(bytes.len(), 1024);
 /// assert!(bytes.is_ascii());
 /// assert!(bytes.find(|ch: char| !ch.is_ascii_alphanumeric()).is_none());
@@ -675,9 +679,9 @@ pub fn urlsafe_base64(len: Option<i64>, padding: bool) -> Result<String, Error> 
 /// If the underlying source of randomness returns an error, return a
 /// [`RandomBytesError`].
 #[inline]
-pub fn alphanumeric(len: Option<i64>) -> Result<String, ArgumentError> {
+pub fn alphanumeric(len: Option<i64>) -> Result<Vec<u8>, ArgumentError> {
     let len = match len.map(usize::try_from) {
-        Some(Ok(0)) => return Ok(String::new()),
+        Some(Ok(0)) => return Ok(Vec::new()),
         Some(Ok(len)) => len,
         Some(Err(_)) => {
             let err = ArgumentError::with_message("negative string size (or size too big)");


### PR DESCRIPTION
This PR updates the core dependencies in the rand ecosystem to their latest versions. The dependency bumps include:

- `rand` to 0.8.1.
- `rand_core` to 0.6.1.
- `getrandom` to 0.2.1.
- `quickcheck` to 1.0.1.

This PR regenerates and updates all lockfiles.

This commit also refactors and renames the crate features in `spinoso-random` so that the feature names do not shadow the `rand` and `rand_core` dependencies. This makes `spinoso-random` more closely track its related crate `rand_mt`.

Callsites for `Rand::gen_range` have been updated to pass ranges.

`spinoso_securerandom::alphanumeric` has been updated to return a `Vec<u8>`.