### PR TITLE
Update SmallVec to 1.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -531,9 +531,9 @@ checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 
 [[package]]
 name = "smallvec"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a55ca5f3b68e41c979bf8c46a6f1da892ca4db8f94023ce0bd32407573b1ac0"
+checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "spinoso-array"

--- a/spinoso-array/Cargo.toml
+++ b/spinoso-array/Cargo.toml
@@ -15,7 +15,9 @@ categories = ["data-structures", "no-std"]
 [dependencies]
 # 1.4.1 fixed UB when allocating zero-bytes for ZST element types.
 # https://github.com/servo/rust-smallvec/releases/tag/v1.4.1
-smallvec = { version = "1, >= 1.4.1", optional = true }
+# 1.6.1 fixed a buffer overflow when calling `SmallVec::insert_many`.
+# https://github.com/servo/rust-smallvec/issues/252
+smallvec = { version = "1, >= 1.6.1", optional = true }
 
 [features]
 default = ["small-array"]


### PR DESCRIPTION
Fixes a buffer overflow: servo/rust-smallvec#252.

`spinoso-array` is not impacted because it does not use the vulnerable
`SmallVec::insert_many` API.

RUSTSEC vulnerability notice: https://rustsec.org/advisories/RUSTSEC-2021-0003.