### PR TITLE
Add class name debug interpreter API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,7 +60,7 @@ dependencies = [
 
 [[package]]
 name = "artichoke-core"
-version = "0.6.0"
+version = "0.7.0"
 
 [[package]]
 name = "atty"

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["artichoke", "artichoke-ruby", "mruby", "ruby"]
 categories = ["api-bindings"]
 
 [dependencies]
-artichoke-core = { version = "0.6", path = "../artichoke-core" }
+artichoke-core = { version = "0.7", path = "../artichoke-core" }
 bstr = { version = "0.2, >= 0.2.2", default-features = false, features = ["std"] }
 intaglio = "1.2"
 itoa = "0.4"

--- a/artichoke-backend/src/debug.rs
+++ b/artichoke-backend/src/debug.rs
@@ -13,18 +13,20 @@ impl Debug for Artichoke {
             Ok(Some(true)) => "true",
             Ok(Some(false)) => "false",
             Ok(None) => "nil",
-            Err(_) if matches!(value.ruby_type(), Ruby::Data | Ruby::Object) => {
-                if let Ok(class) = value.funcall(self, "class", &[], None) {
-                    if let Ok(class) = class.funcall(self, "name", &[], None) {
-                        if let Ok(class) = class.try_into_mut(self) {
-                            return class;
-                        }
-                    }
-                }
-                ""
-            }
+            Err(_) if matches!(value.ruby_type(), Ruby::Data | Ruby::Object) => self.class_name_for_value(value),
             Err(_) => value.ruby_type().class_name(),
         }
+    }
+
+    fn class_name_for_value(&mut self, value: Self::Value) -> &str {
+        if let Ok(class) = value.funcall(self, "class", &[], None) {
+            if let Ok(class) = class.funcall(self, "name", &[], None) {
+                if let Ok(class) = class.try_into_mut(self) {
+                    return class;
+                }
+            }
+        }
+        ""
     }
 }
 

--- a/artichoke-core/Cargo.toml
+++ b/artichoke-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "artichoke-core"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2018"
 description = "Core traits for implementing an Artichoke Ruby interpreter"

--- a/artichoke-core/src/debug.rs
+++ b/artichoke-core/src/debug.rs
@@ -7,12 +7,20 @@ pub trait Debug {
     /// Concrete type for return values from eval.
     type Value: Value;
 
-    /// Return a name for thie given value's type suitable for using in an
-    /// `Exception` message.
+    /// Return a name for the given value's type that is suitable for using in
+    /// an `Exception` message.
     ///
     /// Some immediate types like `true`, `false`, and `nil` are shown by value
     /// rather than by class.
     ///
     /// This function suppresses all errors and returns an empty string on error.
     fn inspect_type_name_for_value(&mut self, value: Self::Value) -> &str;
+
+    /// Return the class name for the given value's type.
+    ///
+    /// Even immediate types will have their class name spelled out. For
+    /// example, calling this function with `nil` will return `"NilClass"`.
+    ///
+    /// This function suppresses all errors and returns an empty string on error.
+    fn class_name_for_value(&mut self, value: Self::Value) -> &str;
 }

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "artichoke-core"
-version = "0.6.0"
+version = "0.7.0"
 
 [[package]]
 name = "artichoke-fuzz"

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -57,7 +57,7 @@ dependencies = [
 
 [[package]]
 name = "artichoke-core"
-version = "0.6.0"
+version = "0.7.0"
 
 [[package]]
 name = "atty"

--- a/spinoso-symbol/Cargo.toml
+++ b/spinoso-symbol/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["ident", "intern", "no_std", "spinoso", "symbol"]
 categories = ["data-structures", "no-std", "parser-implementations"]
 
 [dependencies]
-artichoke-core = { version = "0.6", path = "../artichoke-core", default-features = false, optional = true }
+artichoke-core = { version = "0.7", path = "../artichoke-core", default-features = false, optional = true }
 bstr = { version = "0.2", optional = true, default-features = false }
 focaccia = { version = "1.0", optional = true, default-features = false }
 scolapasta-string-escape = { version = "0.1", path = "../scolapasta-string-escape", optional = true }


### PR DESCRIPTION
Add a function to the `Debug` trait in `artichoke-core` for retrieving a
`Value`'s class name.

In some cases during an implicit conversion, the full class name is
formatted into the exception message even for immediates:

```
[2.6.6] > a = [1, 2, 3, 4, 5]
=> [1, 2, 3, 4, 5]
[2.6.6] > class C; def to_int; nil; end; end
=> :to_int
[2.6.6] > a[C.new]
Traceback (most recent call last):
        4: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `<main>'
        3: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `load'
        2: from /usr/local/var/rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
        1: from (irb):7
TypeError (can't convert C to Integer (C#to_int gives NilClass))
[2.6.6] > a[H.new]
Traceback (most recent call last):
        4: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `<main>'
        3: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `load'
        2: from /usr/local/var/rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
        1: from (irb):12
TypeError (can't convert H to Integer (H#to_int gives TrueClass))
```

The new implementation of `Debug::class_name_for_value` has the same
implementation as one branch in `Debug::inspect_type_name_for_value`.
`inspect_type_name_for_value` is refactored to delegate to
`class_name_for_value`.

This addition to `artichoke-core` bumps the crate version to 0.7.0.