### PR TITLE
Add cargo features for all integrated stdlib packages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,13 @@ cli = ["backtrace", "clap", "rustyline"]
 backtrace = ["termcolor"]
 # Enable all features of Ruby Core, Standard Library, and the underlying VM.
 kitchen-sink = [
+  "core-full",
+  "native-filesystem-access",
+  "stdlib-full",
+]
+
+# Enable every API in Ruby Core
+core-full = [
   "core-env",
   "core-env-system",
   "core-math",
@@ -83,8 +90,6 @@ kitchen-sink = [
   "core-regexp",
   "core-regexp-oniguruma",
   "core-time",
-  "native-filesystem-access",
-  "stdlib-securerandom",
 ]
 # Enable resolving environment variables with the `ENV` core object.
 core-env = ["artichoke-backend/core-env"]
@@ -110,6 +115,7 @@ core-regexp-oniguruma = ["artichoke-backend/core-regexp-oniguruma"]
 # Implement the `Time` core class. This feature adds dependencies on `chrono`
 # and `chrono-tz`.
 core-time = ["artichoke-backend/core-time"]
+
 # Extend the Artichoke virtual filesystem to have native/host access.
 # This feature enables requiring sources from local disk.
 native-filesystem-access = ["artichoke-backend/native-filesystem-access"]
@@ -118,9 +124,40 @@ output-strategy-capture = ["artichoke-backend/output-strategy-capture"]
 # Override the `stdout` and `stdin` streams to write to be discarded.
 # `output-strategy-null` implies the `output-strategy-capture` feature.
 output-strategy-null = ["artichoke-backend/output-strategy-null"]
+
+# Enable every integrated standard library package.
+stdlib-full = [
+  "stdlib-abbrev",
+  "stdlib-base64",
+  "stdlib-cmath",
+  "stdlib-delegate",
+  "stdlib-forwardable",
+  "stdlib-json",
+  "stdlib-monitor",
+  "stdlib-ostruct",
+  "stdlib-securerandom",
+  "stdlib-set",
+  "stdlib-shellwords",
+  "stdlib-strscan",
+  "stdlib-time",
+  "stdlib-uri",
+]
+stdlib-abbrev = ["artichoke-backend/stdlib-abbrev"]
+stdlib-base64 = ["artichoke-backend/stdlib-base64"]
+stdlib-cmath = ["artichoke-backend/stdlib-cmath"]
+stdlib-delegate = ["artichoke-backend/stdlib-delegate"]
+stdlib-forwardable = ["artichoke-backend/stdlib-forwardable"]
+stdlib-json = ["artichoke-backend/stdlib-json"]
+stdlib-monitor = ["artichoke-backend/stdlib-monitor"]
+stdlib-ostruct = ["artichoke-backend/stdlib-ostruct"]
 # Implement the `SecureRandom` Standard Library package. This feature adds
-# dependencies on `base64`, `hex`, `rand`, `rand_core`, and `uuid`.
+# dependencies on `base64`, `rand`, `rand_core`.
 stdlib-securerandom = ["artichoke-backend/stdlib-securerandom"]
+stdlib-set = ["artichoke-backend/stdlib-set"]
+stdlib-shellwords = ["artichoke-backend/stdlib-shellwords"]
+stdlib-strscan = ["artichoke-backend/stdlib-strscan"]
+stdlib-time = ["artichoke-backend/stdlib-time"]
+stdlib-uri = ["artichoke-backend/stdlib-uri"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -44,15 +44,18 @@ target-lexicon = "0.11.1"
 
 [features]
 default = [
+  "core-full",
+  "stdlib-full",
+]
+
+core-full = [
   "core-env",
   "core-env-system",
   "core-math",
   "core-math-full",
   "core-random",
-  "core-regexp",
   "core-regexp-oniguruma",
   "core-time",
-  "stdlib-securerandom"
 ]
 core-env = ["spinoso-env"]
 core-env-system = ["core-env", "spinoso-env/system-env"]
@@ -62,10 +65,41 @@ core-random = ["spinoso-random"]
 core-regexp = ["spinoso-regexp"]
 core-regexp-oniguruma = ["spinoso-regexp/oniguruma", "onig"]
 core-time = ["spinoso-time"]
+
 native-filesystem-access = []
 output-strategy-capture = []
 output-strategy-null = ["output-strategy-capture"]
+
+stdlib-full = [
+  "stdlib-abbrev",
+  "stdlib-base64",
+  "stdlib-cmath",
+  "stdlib-delegate",
+  "stdlib-forwardable",
+  "stdlib-json",
+  "stdlib-monitor",
+  "stdlib-ostruct",
+  "stdlib-securerandom",
+  "stdlib-set",
+  "stdlib-shellwords",
+  "stdlib-strscan",
+  "stdlib-time",
+  "stdlib-uri",
+]
+stdlib-abbrev = []
+stdlib-base64 = []
+stdlib-cmath = []
+stdlib-delegate = []
+stdlib-forwardable = []
+stdlib-json = []
+stdlib-monitor = []
+stdlib-ostruct = []
 stdlib-securerandom = ["spinoso-securerandom"]
+stdlib-set = []
+stdlib-shellwords = []
+stdlib-strscan = []
+stdlib-time = []
+stdlib-uri = []
 
 [package.metadata.docs.rs]
 all-features = true

--- a/artichoke-backend/src/extn/stdlib/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/mod.rs
@@ -1,36 +1,65 @@
 use crate::extn::prelude::*;
 
+#[cfg(feature = "stdlib-abbrev")]
 pub mod abbrev;
+#[cfg(feature = "stdlib-base64")]
 pub mod base64;
+#[cfg(feature = "stdlib-cmath")]
 pub mod cmath;
+#[cfg(feature = "stdlib-delegate")]
 pub mod delegate;
+#[cfg(feature = "stdlib-forwardable")]
 pub mod forwardable;
+#[cfg(feature = "stdlib-json")]
 pub mod json;
+#[cfg(feature = "stdlib-monitor")]
 pub mod monitor;
+#[cfg(feature = "stdlib-ostruct")]
 pub mod ostruct;
 #[cfg(feature = "stdlib-securerandom")]
 pub mod securerandom;
+#[cfg(feature = "stdlib-set")]
 pub mod set;
+#[cfg(feature = "stdlib-shellwords")]
 pub mod shellwords;
+#[cfg(feature = "stdlib-strscan")]
 pub mod strscan;
+#[cfg(feature = "stdlib-time")]
 pub mod time;
+#[cfg(feature = "stdlib-uri")]
 pub mod uri;
 
+#[allow(unused_variables)]
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
+    #[cfg(feature = "stdlib-abbrev")]
     abbrev::init(interp)?;
+    #[cfg(feature = "stdlib-base64")]
     base64::init(interp)?;
+    #[cfg(feature = "stdlib-cmath")]
     cmath::init(interp)?;
+    #[cfg(feature = "stdlib-delegate")]
     delegate::init(interp)?;
+    #[cfg(feature = "stdlib-forwardable")]
     forwardable::init(interp)?;
+    #[cfg(feature = "stdlib-json")]
     json::init(interp)?;
+    #[cfg(feature = "stdlib-monitor")]
     monitor::init(interp)?;
+    #[cfg(feature = "stdlib-ostruct")]
     ostruct::init(interp)?;
     #[cfg(feature = "stdlib-securerandom")]
     securerandom::mruby::init(interp)?;
+    #[cfg(feature = "stdlib-set")]
     set::init(interp)?;
+    #[cfg(feature = "stdlib-shellwords")]
     shellwords::init(interp)?;
+    #[cfg(feature = "stdlib-strscan")]
     strscan::init(interp)?;
+    #[cfg(feature = "stdlib-time")]
     time::init(interp)?;
+    #[cfg(feature = "stdlib-uri")]
     uri::init(interp)?;
+
+    trace!("Patched Ruby standard library onto interpreter");
     Ok(())
 }


### PR DESCRIPTION
Add a cargo feature to `artichoke-backend` and `artichoke` for all currently integrated standard library packages. Each package is now optional.

Closes #16.