### PR TITLE
Persist legacy artichoke design docs

### DIFF
--- a/design/README.md
+++ b/design/README.md
@@ -1,0 +1,18 @@
+# Artichoke Ruby VM Design
+
+Artichoke aims to be a source-compatible, [ruby/spec](/spec-runner/spec/ruby)
+compliant implementation of Ruby 2.6.3 written in safe Rust (excluding crate
+dependencies).
+
+These documents discuss the design of the Artichoke VM.
+
+## Design Document Index
+
+- [Value Representation](value.md)
+- [String and Encoding](string.md)
+- [Memory Management](memory-management.md): the heap and using Rust memory
+  management to get a reference counting GC for free.
+- [Threading and Concurrency](threading-and-concurrency.md): True concurrency
+  with no GIL.
+- [Parser](parser.md)
+- [AST](ast.md)

--- a/design/README.md
+++ b/design/README.md
@@ -1,8 +1,7 @@
 # Artichoke Ruby VM Design
 
-Artichoke aims to be a source-compatible, [ruby/spec](/spec-runner/spec/ruby)
-compliant implementation of Ruby 2.6.3 written in safe Rust (excluding crate
-dependencies).
+Artichoke aims to be a source-compatible, [ruby/spec] compliant implementation
+of Ruby 2.6.3 written in safe Rust (excluding crate dependencies).
 
 These documents discuss the design of the Artichoke VM.
 
@@ -16,3 +15,5 @@ These documents discuss the design of the Artichoke VM.
   with no GIL.
 - [Parser](parser.md)
 - [AST](ast.md)
+
+[ruby/spec]: https://github.com/artichoke/spec

--- a/design/ast.md
+++ b/design/ast.md
@@ -1,0 +1,3 @@
+# Artichoke Ruby AST
+
+WIP

--- a/design/memory-management.md
+++ b/design/memory-management.md
@@ -1,0 +1,234 @@
+# Artichoke Ruby Memory Management
+
+Artichoke has no garbage collector and relies on
+[Rust's built-in memory management](https://pcwalton.github.io/2013/03/18/an-overview-of-memory-management-in-rust.html)
+to reclaim memory when Ruby [`Value`](value.md)s are no longer reachable from
+the VM.
+
+This document refers to data structures with backticks if it is refering to a
+specific implementation, for example, [`Value`](value.md). If the data structure
+is not formatted as code, the document is referring to the general concept, for
+example, HashMap does not refer to
+[`HashMap`](https://doc.rust-lang.org/std/collections/struct.HashMap.html), but
+rather the concept of a hash table.
+
+## `BasicObject#object_id`
+
+`BasicObject` is the root of the class hierarchy in Ruby. All
+[`Value`](value.md)s inherit from `BasicObject`. Every `BasicObject` must have a
+unique `object_id`, which is a `u64`. There are some wrinkles to this, but for
+now we can assume that every `Value` that the VM allocates will have a unique
+`object_id`.
+
+In the VM, `object_id` is represented by the following struct:
+
+```rust
+#[derive(Clone, Debug)]
+pub struct ObjectId {
+    // reference to the VM
+    interp: Artichoke,
+    // opaque and immutable identifier
+    id: u64,
+}
+
+impl Hash for ObjectId {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.id.hash(state);
+    }
+}
+
+impl PartialEq for ObjectId {
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id
+    }
+}
+
+impl Eq for ObjectId {}
+```
+
+`ObjectId` is useful as a pointer. By having a reference to an `ObjectId`,
+components of the VM can retrieve `Value`s from the heap.
+
+Mediating access to the underlying `Value`s via the `ObjectId` allows us to
+centrally implement guards around mutability. For example, `Value`s can be
+marked immutable with
+[`Object#freeze`](https://ruby-doc.org/core-2.6.3/Object.html#method-i-freeze).
+`ObjectId` implements
+[`Deref`](https://doc.rust-lang.org/std/ops/trait.Deref.html) and
+[`DerefMut`](https://doc.rust-lang.org/std/ops/trait.DerefMut.html) that resolve
+a `Value` on the heap via its `ObjectId` and enforces mutability guarantees of
+the VM.
+
+## The Heap
+
+The heap is a HashMap from `ObjectId` to a sharable `Value` representation. The
+_shareable `Value` representation_ is a wrapper around `Value` that enables it
+to have shared ownership. The specifics of the wrapper depend on VM context (for
+example, values are wrapped differently if they are shared by multiple threads),
+but conceptually the wrapper behaves like an `Rc<RefCell<Value>>`. The wrapper
+can have multiple owners, supports weak references, and allows the `Value` to be
+mutated.
+
+The heap stores weak references to `Value`. When a `Value` takes an owned
+reference to another, it resolves the value wrapper via the heap and upgrades
+the weak reference into a strong reference.
+
+Eventually, a `Value` may become unreachable, the strong count on the `Rc` that
+wraps it will drop to zero, the memory will be reclaimed, and the weak reference
+becomes invalid. To optimize access times for the heap and prevent the heap from
+growing unbounded, a background thread will periodically compact the heap by
+removing `ObjectId`s that point to invalid weak references.
+
+## Shared References and Reference Counting
+
+A `Value` can be referenced by many other `Value`s. For example, in the below
+program, the String `'artichoke'` is reachable from six locations.
+
+```ruby
+x = 'artichoke'
+# name binding
+y = x
+# collection item
+ary = [x, x]
+# captured variable
+f = proc { x }
+# self-referential structure
+x.instance_variable_set :@a, x
+```
+
+Because instance variables are publically settable, every `Value` can hold a
+reference other `Value`s, including cyclical ones.
+
+Ignoring cycles, when a `Value` takes a reference to another value, we can call
+[`Rc::clone`](https://doc.rust-lang.org/std/rc/struct.Rc.html#impl-Clone). This
+takes a strong reference to a `Value` and increases the ref count on the smart
+pointer. When the `Value` is deallocated, Rust will drop the references on the
+smart pointers it ownes.
+
+For example, an Array is backed by a `Vec<Rc<RefCell<Value>>>` and the symbol
+table of instance variables on an object is a
+`HashMap<Identifier, Rc<RefCell<Value>>>`.
+
+Things are trickier if we need to handle cycles. Consider the following code:
+
+```ruby
+class Container
+  attr_accessor :inner
+
+  def initialize(inner)
+    @inner = inner
+  end
+end
+
+def make_cycle
+  a = Container.new(nil) # ObjectId(100)
+  b = Container.new(a)   # ObjectId(200)
+  c = Container.new(b)   # ObjectId(300)
+  d = Container.new(c)   # ObjectId(400)
+  a.inner = d
+  a
+end
+
+ring = make_cycle
+```
+
+Here's what happens from the perspective of the VM:
+
+1. The `a` binding holds a strong reference to `ObjectId(100)`
+2. `ObjectId(200)` holds a strong reference to `ObjectId(100)`
+3. The `b` binding holds a strong reference to `ObjectId(200)`
+4. `ObjectId(300)` holds a strong reference to `ObjectId(200)`
+5. The `c` binding holds a strong reference to `ObjectId(300)`
+6. `ObjectId(400)` holds a strong reference to `ObjectId(300)`
+7. The `d` binding holds a strong reference to `ObjectId(400)`
+
+At this point the strong counts look like this:
+
+| `ObjectId` | Strong Count |
+| ---------- | ------------ |
+| 100        | 2            |
+| 200        | 2            |
+| 300        | 2            |
+| 400        | 1            |
+
+Assigning `ObjectId(400)` to the `@inner` instance variable of `ObjectId(100)`
+makes these four `Value`s form a cycle.
+
+### Detecting Cycles
+
+Each `Value` can answer the question: Can I reach an `ObjectId`?
+
+```rust
+impl ObjectId {
+    pub fn can_reach_object(&self, other: Self, &mut checked: HashSet<Self>) -> HashSet<Self> {
+        unimplemented!();
+    }
+}
+```
+
+`Value` asks this question of all its strong references when attempting to take
+a strong reference to another `Value`. If the returned `HashSet` is empty, the
+`Value` takes a strong reference. If the returned `HashSet` is non-empty, these
+`ObjectId`s are added to a VM-tracked `Cycle`. The cycle group holds a weak
+reference to the shared `Value` wrapper and and rather than hold a
+`Rc<RefCell<Value>>`, the `Value`s in the cycle hold a reference to the cycle
+group which can resolve an `ObjectId` into a strong value wrapper reference
+temporarily.
+
+```rust
+pub enum ValueReference {
+    Strong(Rc<RefCell<Value>>),
+    CycleWeak(Rc<RefCell<Cycle<Value>>>),
+}
+
+pub struct Cycle<T> {
+    value: Weak<RefCell<Value>>,
+    group: HashSet<ObjectId>,
+}
+```
+
+Back to our example: when `ObjectId(400)` is assigned to `@inner` on
+`ObjectId(100)`, the VM detects a cycle because `ObjectId(100)` is reachable by
+the chain of `ObjectId(400) -> ObjectId(300) -> ObjectId(200) -> ObjectId(100)`.
+The `ObjectId`s are reachable in these ways:
+
+| `ObjectId` | Binding              |
+| ---------- | -------------------- |
+| 100        | `a`, `ObjectId(200)` |
+| 200        | `b`, `ObjectId(300)` |
+| 300        | `c`, `ObjectId(400)` |
+| 400        | `d`, `ObjectId(100)` |
+
+Once we return from the function, the variable bindings get dropped:
+
+| `ObjectId` | Binding                 |
+| ---------- | ----------------------- |
+| 100        | `ring`, `ObjectId(200)` |
+| 200        | `ObjectId(300)`         |
+| 300        | `ObjectId(400)`         |
+| 400        | `ObjectId(100)`         |
+
+But even if `ring` is dropped or reassigned, memory will not be reclaimed.
+
+### Escape Analysis
+
+All `ObjectId`s in the cycle will hold `CycleWeak` references. This is safe
+because the Weak references are only invalid if the cycle is unreachable by any
+other `Value`s in the VM.
+
+If the `ObjectId` owning the reference is not in the cycle, it will hold a
+`Strong` reference. The cycle is unreachable unless it is referenced by an
+`ObjectId` outside of the cycle.
+
+If the reference is bound to a name (whether a local in a function, class
+context, module context, proc, or top self, captured variable in a proc, or a
+constant binding), the name will hold a `Strong` reference.
+
+If the reference is captured by a proc, the proc will hold a `CycleStrong`
+reference.
+
+### Breaking Cycles
+
+If the VM changes the value of a binding that points to a `CycleWeak`, the cycle
+is broken. The VM will replace the reachable `CycleWeak`s with strong
+references.

--- a/design/memory-management.md
+++ b/design/memory-management.md
@@ -103,7 +103,7 @@ Ignoring cycles, when a `Value` takes a reference to another value, we can call
 [`Rc::clone`](https://doc.rust-lang.org/std/rc/struct.Rc.html#impl-Clone). This
 takes a strong reference to a `Value` and increases the ref count on the smart
 pointer. When the `Value` is deallocated, Rust will drop the references on the
-smart pointers it ownes.
+smart pointers it owns.
 
 For example, an Array is backed by a `Vec<Rc<RefCell<Value>>>` and the symbol
 table of instance variables on an object is a
@@ -178,7 +178,7 @@ temporarily.
 ```rust
 pub enum ValueReference {
     Strong(Rc<RefCell<Value>>),
-    CycleWeak(Rc<RefCell<Cycle<Value>>>),
+    CycleWeak(Rc<Cycle<Value>>),
 }
 
 pub struct Cycle<T> {
@@ -224,8 +224,7 @@ If the reference is bound to a name (whether a local in a function, class
 context, module context, proc, or top self, captured variable in a proc, or a
 constant binding), the name will hold a `Strong` reference.
 
-If the reference is captured by a proc, the proc will hold a `CycleStrong`
-reference.
+If the reference is captured by a proc, the proc will hold a `Strong` reference.
 
 ### Breaking Cycles
 

--- a/design/memory-management.md
+++ b/design/memory-management.md
@@ -46,7 +46,7 @@ impl Hash for ObjectId {
 
 impl PartialEq for ObjectId {
     fn eq(&self, other: &Self) -> bool {
-        self.id == other.id
+        self.interp == other.interp && self.id == other.id
     }
 }
 

--- a/design/memory-management.md
+++ b/design/memory-management.md
@@ -1,17 +1,15 @@
 # Artichoke Ruby Memory Management
 
-Artichoke has no garbage collector and relies on
-[Rust's built-in memory management](https://pcwalton.github.io/2013/03/18/an-overview-of-memory-management-in-rust.html)
-and a [cycle-aware reference-counted smart pointer](/cactusref) of its own
+Artichoke has no garbage collector and relies on [Rust's built-in memory
+management] and a [cycle-aware reference-counted smart pointer] of its own
 invention to reclaim memory when Ruby [`Value`](value.md)s are no longer
 reachable from the VM.
 
 This document refers to data structures with backticks if it is refering to a
 specific implementation, for example, [`Value`](value.md). If the data structure
 is not formatted as code, the document is referring to the general concept, for
-example, HashMap does not refer to
-[`HashMap`](https://doc.rust-lang.org/std/collections/struct.HashMap.html), but
-rather the concept of a hash table.
+example, HashMap does not refer to [`HashMap`], but rather the concept of a hash
+table.
 
 ## `BasicObject#object_id`
 
@@ -58,13 +56,9 @@ components of the VM can retrieve `Value`s from the heap.
 
 Mediating access to the underlying `Value`s via the `ObjectId` allows us to
 centrally implement guards around mutability. For example, `Value`s can be
-marked immutable with
-[`Object#freeze`](https://ruby-doc.org/core-2.6.3/Object.html#method-i-freeze).
-`ObjectId` implements
-[`Deref`](https://doc.rust-lang.org/std/ops/trait.Deref.html) and
-[`DerefMut`](https://doc.rust-lang.org/std/ops/trait.DerefMut.html) that resolve
-a `Value` on the heap via its `ObjectId` and enforces mutability guarantees of
-the VM.
+marked immutable with [`Object#freeze`]. `ObjectId` implements [`Deref`] and
+[`DerefMut`] that resolve a `Value` on the heap via its `ObjectId` and enforces
+mutability guarantees of the VM.
 
 ## The Heap
 
@@ -215,3 +209,12 @@ Once we return from the function, the variable bindings get dropped:
 
 When `ring` is dropped or reassigned, `CactusRef` detects an orphaned cycle and
 will deallocate all of the `Value`s.
+
+[rust's built-in memory management]:
+  https://pcwalton.github.io/2013/03/18/an-overview-of-memory-management-in-rust.html
+[cycle-aware reference-counted smart pointer]:
+  https://github.com/artichoke/cactusref
+[`hashmap`]: https://doc.rust-lang.org/std/collections/struct.HashMap.html
+[`object#freeze`]: https://ruby-doc.org/core-2.6.3/Object.html#method-i-freeze
+[`deref`]: https://doc.rust-lang.org/std/ops/trait.Deref.html
+[`derefmut`]: https://doc.rust-lang.org/std/ops/trait.DerefMut.html

--- a/design/parser.md
+++ b/design/parser.md
@@ -1,0 +1,3 @@
+# Artichoke Ruby Parser
+
+WIP

--- a/design/string.md
+++ b/design/string.md
@@ -1,0 +1,3 @@
+# Artichoke Ruby String and Encoding
+
+WIP

--- a/design/threading-and-concurrency.md
+++ b/design/threading-and-concurrency.md
@@ -1,0 +1,3 @@
+# Artichoke Ruby Threading and Concurrency
+
+WIP

--- a/design/value.md
+++ b/design/value.md
@@ -1,0 +1,3 @@
+# Artichoke Ruby Value Representation
+
+WIP


### PR DESCRIPTION
This PR adds a durable record of the `artichoke-design` branch, which I would like to delete.

This PR is a rebase of the original branch, which was started in July 2019 from https://github.com/artichoke/artichoke/commit/72aae0fffc9eb25a4303092e53a61ac757cf957f.

This PR from current trunk fast forwards the branch base by 2972 commits.

These design documents are legacy and do not represent the current state of the project, but creating a PR allows them to be recorded for posterity.

[Rendered](https://github.com/artichoke/artichoke/blob/b4ddb33c3d57ee21a85aa5adacabb48d2c414ff5/design/README.md)