### PR TITLE
Implement mrb_protect and exception raising with panic! and catch_unwind

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -758,7 +758,7 @@ dependencies = [
  "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "mruby-sys 2.0.1-11",
+ "mruby-sys 2.0.1-12",
  "mruby-vfs 0.5.0-alpha",
  "onig 4.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "path_abs 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -786,7 +786,7 @@ dependencies = [
 
 [[package]]
 name = "mruby-sys"
-version = "2.0.1-11"
+version = "2.0.1-12"
 dependencies = [
  "bindgen 0.49.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/mruby-sys/Cargo.toml
+++ b/mruby-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mruby-sys"
-version = "2.0.1-11"
+version = "2.0.1-12"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2018"
 links = "mruby"

--- a/mruby-sys/build.rs
+++ b/mruby-sys/build.rs
@@ -140,6 +140,8 @@ fn main() {
         .clang_arg(format!("-I{}", Build::ext_include_dir()))
         .clang_arg("-DMRB_DISABLE_STDIO")
         .whitelist_function("^mrb.*")
+        .blacklist_function("mrb_protect")
+        .blacklist_function("mrb_exc_raise")
         .whitelist_type("^mrb.*")
         .whitelist_var("^mrb.*")
         .whitelist_var("^MRB.*")

--- a/mruby-sys/mruby-sys/include/mruby-sys/ext.h
+++ b/mruby-sys/mruby-sys/include/mruby-sys/ext.h
@@ -24,6 +24,7 @@
 
 #include <mruby.h>
 #include <mruby/array.h>
+#include <mruby/common.h>
 #include <mruby/class.h>
 #include <mruby/data.h>
 #include <mruby/error.h>
@@ -98,10 +99,7 @@ void mrb_sys_data_init(mrb_value *value, void *ptr, const mrb_data_type *type);
 
 // Raise exceptions and debug info
 
-mrb_noreturn void mrb_sys_raise(struct mrb_state *mrb, const char *eclass,
-                                const char *msg);
-
-void mrb_sys_raise_current_exception(struct mrb_state *mrb);
+mrb_noreturn void mrb_exc_raise(struct mrb_state *mrb, mrb_value exc);
 
 mrb_value mrb_sys_value_debug_str(struct mrb_state *mrb, mrb_value value);
 

--- a/mruby-sys/mruby-sys/src/mruby-sys/ext.c
+++ b/mruby-sys/mruby-sys/src/mruby-sys/ext.c
@@ -147,15 +147,10 @@ void mrb_sys_data_init(mrb_value *value, void *ptr, const mrb_data_type *type) {
 
 // Raise exceptions and debug info
 
-mrb_noreturn void mrb_sys_raise(struct mrb_state *mrb, const char *eclass,
-                                const char *msg) {
-  mrb_raise(mrb, mrb_class_get(mrb, eclass), msg);
-}
+mrb_noreturn void mrb_sys_exc_raise(struct mrb_state *mrb, mrb_value exc);
 
-void mrb_sys_raise_current_exception(struct mrb_state *mrb) {
-  if (mrb->exc) {
-    mrb_exc_raise(mrb, mrb_obj_value(mrb->exc));
-  }
+mrb_noreturn void mrb_exc_raise(struct mrb_state *mrb, mrb_value exc) {
+  mrb_sys_exc_raise(mrb, exc);
 }
 
 // TODO: implement this debug function in Rust

--- a/mruby-sys/src/error.rs
+++ b/mruby-sys/src/error.rs
@@ -1,0 +1,76 @@
+#![allow(warnings)]
+//! Rust implementation of `mrb_raise` that uses `panic` to unwind.
+//!
+//! Use [`panic::catch_unwind`] to protect.
+
+use std::convert::TryFrom;
+use std::ffi::c_void;
+use std::panic::{self, AssertUnwindSafe};
+use std::ptr;
+
+use crate::ffi::*;
+
+/// Wrap calls to the mruby VM to catch panics from [`mrb_raise`].
+#[no_mangle]
+#[unwind(allowed)]
+pub unsafe extern "C" fn mrb_protect(
+    mrb: *mut mrb_state,
+    body: mrb_func_t,
+    data: mrb_value,
+    state: *mut mrb_bool,
+) -> mrb_value {
+    let mut result = mrb_sys_nil_value();
+    if !state.is_null() {
+        state.write(0_u8);
+    }
+    let body = if let Some(body) = body {
+        body
+    } else {
+        return result;
+    };
+    println!("protected");
+    result = if let Ok(result) = panic::catch_unwind(AssertUnwindSafe(|| body(mrb, data))) {
+        result
+    } else {
+        let result = mrb_sys_obj_value((*mrb).exc as *mut c_void);
+        (*mrb).exc = ptr::null_mut();
+        if !state.is_null() {
+            state.write(1_u8);
+        }
+        result
+    };
+    mrb_gc_protect(mrb, result);
+    result
+}
+
+/// Wrap calls to the mruby VM to catch panics from [`mrb_raise`].
+#[no_mangle]
+#[unwind(allowed)]
+pub unsafe extern "C" fn mrb_sys_exc_raise(mrb: *mut mrb_state, exc: mrb_value) -> ! {
+    if mrb_obj_is_kind_of(mrb, exc, mrb_class_get(mrb, b"Exception\0".as_ptr() as *const i8)) == 0_u8 {
+        mrb_raise(
+            mrb,
+            mrb_exc_get(mrb, b"TypeError\0".as_ptr() as *const i8),
+            b"exception object expected\0".as_ptr() as *const i8,
+        );
+    }
+    mrb_exc_set(mrb, exc);
+    panic!("unwinding Ruby exception");
+}
+
+unsafe fn mrb_exc_set(mrb: *mut mrb_state, exc: mrb_value) {
+    println!("exc_set");
+    if mrb_sys_value_is_nil(exc) {
+        (*mrb).exc = ptr::null_mut();
+    } else {
+        (*mrb).exc = mrb_sys_obj_ptr(exc);
+        let idx = mrb_sys_gc_arena_save(mrb);
+        let exc_rbasic = mrb_sys_basic_ptr(exc);
+        if let Ok(offset) = isize::try_from(idx - 1) {
+            let arena_end = (*mrb).gc.arena.offset(offset) as *mut RBasic;
+            if idx > 0 && ptr::eq(exc_rbasic, arena_end) {
+                mrb_sys_gc_arena_restore(mrb, idx - 1);
+            }
+        }
+    }
+}

--- a/mruby-sys/src/error.rs
+++ b/mruby-sys/src/error.rs
@@ -5,7 +5,7 @@
 
 use std::convert::TryFrom;
 use std::ffi::c_void;
-use std::panic::{self, AssertUnwindSafe};
+use std::panic;
 use std::ptr;
 
 use crate::ffi::*;
@@ -22,9 +22,8 @@ pub unsafe extern "C" fn mrb_protect(
     if !state.is_null() {
         state.write(0_u8);
     }
-    let unwind = panic::catch_unwind(AssertUnwindSafe(|| {
-        body.map_or_else(|| mrb_sys_nil_value(), |body| body(mrb, data))
-    }));
+    let unwind =
+        panic::catch_unwind(|| body.map_or_else(|| mrb_sys_nil_value(), |body| body(mrb, data)));
     let result = if let Ok(result) = unwind {
         result
     } else {

--- a/mruby-sys/src/ffi.rs
+++ b/mruby-sys/src/ffi.rs
@@ -1143,9 +1143,6 @@ extern "C" {
     ) -> mrb_value;
 }
 extern "C" {
-    pub fn mrb_exc_raise(mrb: *mut mrb_state, exc: mrb_value);
-}
-extern "C" {
     pub fn mrb_raise(mrb: *mut mrb_state, c: *mut RClass, msg: *const ::std::os::raw::c_char);
 }
 extern "C" {
@@ -2309,14 +2306,6 @@ extern "C" {
     pub fn mrb_f_raise(arg1: *mut mrb_state, arg2: mrb_value) -> mrb_value;
 }
 extern "C" {
-    pub fn mrb_protect(
-        mrb: *mut mrb_state,
-        body: mrb_func_t,
-        data: mrb_value,
-        state: *mut mrb_bool,
-    ) -> mrb_value;
-}
-extern "C" {
     pub fn mrb_ensure(
         mrb: *mut mrb_state,
         body: mrb_func_t,
@@ -3422,16 +3411,6 @@ extern "C" {
         ptr: *mut ::std::os::raw::c_void,
         type_: *const mrb_data_type,
     );
-}
-extern "C" {
-    pub fn mrb_sys_raise(
-        mrb: *mut mrb_state,
-        eclass: *const ::std::os::raw::c_char,
-        msg: *const ::std::os::raw::c_char,
-    );
-}
-extern "C" {
-    pub fn mrb_sys_raise_current_exception(mrb: *mut mrb_state);
 }
 extern "C" {
     pub fn mrb_sys_value_debug_str(mrb: *mut mrb_state, value: mrb_value) -> mrb_value;

--- a/mruby-sys/src/lib.rs
+++ b/mruby-sys/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(unwind_attributes)]
 #![deny(missing_docs, warnings, intra_doc_link_resolution_failure)]
 #![deny(clippy::all, clippy::pedantic)]
 
@@ -8,6 +9,7 @@ use std::ffi::CStr;
 use std::fmt;
 
 mod args;
+mod error;
 #[allow(missing_docs)]
 #[allow(non_camel_case_types)]
 #[allow(non_upper_case_globals)]
@@ -20,6 +22,7 @@ mod ffi;
 mod ffi_tests;
 
 pub use self::args::*;
+pub use self::error::*;
 pub use self::ffi::*;
 
 /// Version metadata `String` for mruby-sys and embedded mruby.

--- a/mruby-sys/sys.gembox
+++ b/mruby-sys/sys.gembox
@@ -10,9 +10,6 @@ MRuby::GemBox.new do |conf|
   # method metaprogramming
   conf.gem core: 'mruby-method'
 
-  # mrb_protect
-  conf.gem core: 'mruby-error'
-
   # Meta-programming features
   conf.gem core: 'mruby-metaprog'
 

--- a/mruby/src/value/mod.rs
+++ b/mruby/src/value/mod.rs
@@ -73,7 +73,7 @@ where
             let ptr = sys::mrb_sys_cptr_ptr(data);
             let args = Rc::from_raw(ptr as *const ProtectArgs);
 
-            let value = sys::mrb_funcall_argv(
+            sys::mrb_funcall_argv(
                 mrb,
                 args.slf,
                 args.func_sym,
@@ -82,9 +82,7 @@ where
                 // than i64 max value.
                 i64::try_from(args.args.len()).unwrap_or_default(),
                 args.args.as_ptr(),
-            );
-            sys::mrb_sys_raise_current_exception(mrb);
-            value
+            )
         }
         // Ensure the borrow is out of scope by the time we eval code since
         // Rust-backed files and types may need to mutably borrow the `Mrb` to
@@ -167,7 +165,7 @@ where
             let ptr = sys::mrb_sys_cptr_ptr(data);
             let args = Rc::from_raw(ptr as *const ProtectArgsWithBlock);
 
-            let value = sys::mrb_funcall_with_block(
+            sys::mrb_funcall_with_block(
                 mrb,
                 args.slf,
                 args.func_sym,
@@ -177,9 +175,7 @@ where
                 i64::try_from(args.args.len()).unwrap_or_default(),
                 args.args.as_ptr(),
                 args.block,
-            );
-            sys::mrb_sys_raise_current_exception(mrb);
-            value
+            )
         }
         // Ensure the borrow is out of scope by the time we eval code since
         // Rust-backed files and types may need to mutably borrow the `Mrb` to


### PR DESCRIPTION
This is a very stale branch (~3000 commits behind trunk) featuring an attempt at implementing mruby exception unwinding in Rust.

This branch results in aborts and is blocked on the C-unwind ABI:

- https://blog.rust-lang.org/inside-rust/2020/02/27/ffi-unwind-design-meeting.html
- https://rust-lang.github.io/rfcs/2945-c-unwind-abi.html
- https://github.com/rust-lang/rust/issues/74990

I have no intention of bringing this branch up to date with trunk or merging this PR. I'm creating a PR to persist the change set and allow deleting this branch.

The current best place for such an implementation to land is the [`artichoke_backend::sys::protect` module](https://github.com/artichoke/artichoke/blob/52d33b49d9e027515720007ed40e37e4e5a4fdfd/artichoke-backend/src/sys/protect.rs).

See also https://github.com/artichoke/artichoke/issues/35.