### PR TITLE
Add S-archive label

### DIFF
--- a/.github/labels.json
+++ b/.github/labels.json
@@ -235,6 +235,11 @@
     "description": "Target: Support for building on Windows targets like `x86_64-pc-windows-msvc`."
   },
   {
+    "name": "S-archive",
+    "color": "d3dddd",
+    "description": "Status: This pull request exists to archive an unmerged branch."
+  },
+  {
     "name": "S-blocked",
     "color": "d3dddd",
     "description": "Status: Marked as blocked ❌ on something else such as other implementation work."


### PR DESCRIPTION
PRs like https://github.com/artichoke/artichoke/pull/1029 and https://github.com/artichoke/artichoke/pull/1029 exist to provide durable records of long stale, WIP, or speculative implementations that were not merged.

This PR adds an `S-archive` status for such PRs.