### PR TITLE
Fix interpreter memory leaks in REPL and Ruby frontends

### DIFF
--- a/src/bin/artichoke.rs
+++ b/src/bin/artichoke.rs
@@ -90,7 +90,7 @@ fn main() {
         .with_programfile(matches.value_of_os("programfile").map(PathBuf::from));
 
     let mut stderr = StandardStream::stderr(ColorChoice::Auto);
-    match ruby::entrypoint(args, io::stdin(), &mut stderr) {
+    match ruby::run(args, io::stdin(), &mut stderr) {
         Ok(Ok(())) => {}
         Ok(Err(())) => process::exit(1),
         Err(err) => {


### PR DESCRIPTION
Neither `airb` nor `artichoke` binary frontends closed the `Artichoke`
interpreter, which leaks the interpreter and its heap. This does not
have many consequences since the program is exiting anyway, but it does
prevent destructors for Ruby values from being called.

This fix restructures the `ruby` and `repl` modules so they create an
interpreter at the top level and pass a `&mut Artichoke` to the
entrypoint implementation. This allows all short circuit `Err` returns
to be caught so the interpreter can be closed before passing the
`Result` back to `main`.