### PR TITLE
Centralize frontend filename constants into a single module

### DIFF
--- a/src/filename.rs
+++ b/src/filename.rs
@@ -1,0 +1,41 @@
+/// Filename for inline code executed on the `ruby` frontend with the `-e`
+/// switch.
+///
+/// # Examples
+///
+/// ```console
+/// $ ruby -e 'puts RUBY_VERSION' -e 'puts __FILE__'
+/// 2.6.3
+/// -e
+/// ```
+pub const INLINE_EVAL_SWITCH: &[u8] = b"-e";
+
+/// Filename for code executed on the REPL frontend with the `irb` command.
+///
+/// # Examples
+///
+/// ```console
+/// $ irb
+/// [2.6.3] > RUBY_VERSION
+/// => "2.6.3"
+/// [2.6.3] > __FILE__
+/// => "(irb)"
+/// ```
+pub const REPL: &[u8] = b"(airb)";
+
+// These tests assert that the filename constants do not contain NUL bytes which
+// makes them safe to use with `Context::new_unchecked`.
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn inline_eval_switch_filename_does_not_contain_nul_byte() {
+        let contains_nul_byte = super::INLINE_EVAL_SWITCH.contains(&b'\0');
+        assert!(!contains_nul_byte);
+    }
+
+    #[test]
+    fn repl_filename_does_not_contain_nul_byte() {
+        let contains_nul_byte = super::REPL.contains(&b'\0');
+        assert!(!contains_nul_byte);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,6 +97,8 @@ pub use artichoke_backend as backend;
 
 #[cfg(feature = "backtrace")]
 pub mod backtrace;
+#[cfg(feature = "cli")]
+mod filename;
 pub mod parser;
 #[cfg(feature = "cli")]
 pub mod repl;

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -13,19 +13,9 @@ use termcolor::WriteColor;
 
 use crate::backend::state::parser::Context;
 use crate::backtrace;
+use crate::filename::REPL;
 use crate::parser::{Parser, State};
 use crate::prelude::{Parser as _, *};
-
-const REPL_FILENAME: &[u8] = b"(airb)";
-
-#[cfg(test)]
-mod filename_test {
-    #[test]
-    fn repl_filename_does_not_contain_nul_byte() {
-        let contains_nul_byte = super::REPL_FILENAME.iter().copied().any(|b| b == b'\0');
-        assert!(!contains_nul_byte);
-    }
-}
 
 /// Failed to initialize parser during REPL boot.
 ///
@@ -220,12 +210,12 @@ where
     writeln!(output, "{}", preamble(interp)?)?;
 
     interp.reset_parser()?;
-    // safety:
+    // Safety:
     //
     // - `Context::new_unchecked` requires that its argument has no NUL bytes.
-    // - `REPL_FILENAME` is controlled by this crate.
-    // - A test asserts that `REPL_FILENAME` has no NUL bytes.
-    let context = unsafe { Context::new_unchecked(REPL_FILENAME.to_vec()) };
+    // - `REPL` is controlled by this crate.
+    // - A test asserts that `REPL` has no NUL bytes.
+    let context = unsafe { Context::new_unchecked(REPL.to_vec()) };
     interp.push_context(context)?;
     let mut parser = Parser::new(interp).ok_or_else(ParserAllocError::new)?;
 

--- a/src/ruby.rs
+++ b/src/ruby.rs
@@ -14,18 +14,8 @@ use crate::backend::ffi;
 use crate::backend::state::parser::Context;
 use crate::backend::string::format_unicode_debug_into;
 use crate::backtrace;
+use crate::filename::INLINE_EVAL_SWITCH;
 use crate::prelude::*;
-
-const INLINE_EVAL_SWITCH_FILENAME: &[u8] = b"-e";
-
-#[cfg(test)]
-mod filename_test {
-    #[test]
-    fn inline_eval_switch_filename_does_not_contain_nul_byte() {
-        let contains_nul_byte = super::INLINE_EVAL_SWITCH_FILENAME.iter().copied().any(|b| b == b'\0');
-        assert!(!contains_nul_byte);
-    }
-}
 
 /// Command line arguments for Artichoke `ruby` frontend.
 #[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
@@ -141,12 +131,12 @@ where
     W: io::Write + WriteColor,
 {
     interp.pop_context()?;
-    // safety:
+    // Safety:
     //
     // - `Context::new_unchecked` requires that its argument has no NUL bytes.
-    // - `INLINE_EVAL_SWITCH_FILENAME` is controlled by this crate.
-    // - A test asserts that `INLINE_EVAL_SWITCH_FILENAME` has no NUL bytes.
-    let context = unsafe { Context::new_unchecked(INLINE_EVAL_SWITCH_FILENAME) };
+    // - `INLINE_EVAL_SWITCH` is controlled by this crate.
+    // - A test asserts that `INLINE_EVAL_SWITCH` has no NUL bytes.
+    let context = unsafe { Context::new_unchecked(INLINE_EVAL_SWITCH) };
     interp.push_context(context)?;
     if let Some(fixture) = fixture {
         setup_fixture_hack(interp, fixture)?;


### PR DESCRIPTION
This moves all the tests for NUL bytes to one place.