### PR TITLE
CMath stdlib package depends on core Math module

### DIFF
--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -88,7 +88,7 @@ stdlib-full = [
 ]
 stdlib-abbrev = []
 stdlib-base64 = []
-stdlib-cmath = []
+stdlib-cmath = ["core-math"]
 stdlib-delegate = []
 stdlib-forwardable = []
 stdlib-json = []


### PR DESCRIPTION
`CMath` includes `Math`, so reflect this dependency in the cargo features of `artichoke-backend`.

https://github.com/artichoke/artichoke/blob/44b60ed9a8f3922cfac6c8e07ecc343e3091bc3e/artichoke-backend/src/extn/stdlib/cmath/vendor/cmath.rb#L23-L28