### PR TITLE
Remove some conditionals from Regexp Flag parsing

### DIFF
--- a/spinoso-regexp/src/encoding.rs
+++ b/spinoso-regexp/src/encoding.rs
@@ -210,6 +210,9 @@ impl fmt::Display for Encoding {
 }
 
 impl Encoding {
+    /// Construct a new [`None`] encoding.
+    ///
+    /// [`None`]: Self::None
     #[must_use]
     pub const fn new() -> Self {
         Self::None

--- a/spinoso-regexp/src/options.rs
+++ b/spinoso-regexp/src/options.rs
@@ -134,15 +134,9 @@ impl From<Option<bool>> for Options {
 impl From<&str> for Options {
     fn from(options: &str) -> Self {
         let mut flags = Flags::empty();
-        if options.contains('m') {
-            flags.set(Flags::MULTILINE, true);
-        }
-        if options.contains('i') {
-            flags.set(Flags::IGNORECASE, true);
-        }
-        if options.contains('x') {
-            flags.set(Flags::EXTENDED, true);
-        }
+        flags.set(Flags::MULTILINE, options.contains('m'));
+        flags.set(Flags::IGNORECASE, options.contains('i'));
+        flags.set(Flags::EXTENDED, options.contains('x'));
         Self { flags }
     }
 }
@@ -150,15 +144,9 @@ impl From<&str> for Options {
 impl From<&[u8]> for Options {
     fn from(options: &[u8]) -> Self {
         let mut flags = Flags::empty();
-        if options.find_byte(b'm').is_some() {
-            flags.set(Flags::MULTILINE, true);
-        }
-        if options.find_byte(b'i').is_some() {
-            flags.set(Flags::IGNORECASE, true);
-        }
-        if options.find_byte(b'x').is_some() {
-            flags.set(Flags::EXTENDED, true);
-        }
+        flags.set(Flags::MULTILINE, options.find_byte(b'm').is_some());
+        flags.set(Flags::IGNORECASE, options.find_byte(b'i').is_some());
+        flags.set(Flags::EXTENDED, options.find_byte(b'x').is_some());
         Self { flags }
     }
 }


### PR DESCRIPTION
Rather than checking whether a condition is true and then setting a bitflag
to true, set the bitflag directly with the result of the boolean expression.