### PR TITLE
Implement fmt::Debug for Spinoso String with bstr to render conventionally UTF-8 strings

### DIFF
--- a/spinoso-string/src/lib.rs
+++ b/spinoso-string/src/lib.rs
@@ -497,10 +497,19 @@ impl fmt::Display for OrdError {
 #[cfg(feature = "std")]
 impl std::error::Error for OrdError {}
 
-#[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Default, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct String {
     buf: Vec<u8>,
     encoding: Encoding,
+}
+
+impl fmt::Debug for String {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("String")
+            .field("buf", &self.buf.as_bstr())
+            .field("encoding", &self.encoding)
+            .finish()
+    }
 }
 
 // Constructors


### PR DESCRIPTION
This also renders binary content with hex escapes.