### PR TITLE
Add `--all-targets` flag to `cargo check` calls in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -80,13 +80,13 @@ jobs:
           args: --workspace --all-features --all-targets
 
       - name: Check artichoke with locked Cargo.lock
-        run: cargo check --locked --all-targets
+        run: cargo check --locked --all-targets --profile=test
 
       - name: Check artichoke with no default features
-        run: cargo check --verbose --no-default-features --all-targets
+        run: cargo check --verbose --no-default-features --all-targets --profile=test
 
       - name: Check artichoke with all features
-        run: cargo check --verbose --all-features --all-targets
+        run: cargo check --verbose --all-features --all-targets --profile=test
 
   check-fuzz:
     name: Check fuzz workspace
@@ -113,7 +113,7 @@ jobs:
           working-directory: "fuzz"
 
       - name: Check fuzz with locked Cargo.lock
-        run: cargo check --locked --all-targets
+        run: cargo check --locked --all-targets --profile=test
         working-directory: "fuzz"
 
   check-spec-runner:
@@ -150,7 +150,7 @@ jobs:
         working-directory: "spec-runner"
 
       - name: Check spec-runner with locked Cargo.lock
-        run: cargo check --locked --all-targets
+        run: cargo check --locked --all-targets --profile=test
         working-directory: "spec-runner"
 
   check-sub-crates:
@@ -176,111 +176,111 @@ jobs:
       - uses: Swatinem/rust-cache@v1
 
       - name: Check spinoso-array with no default features
-        run: cargo check --verbose --no-default-features --all-targets
+        run: cargo check --verbose --no-default-features --all-targets --profile=test
         working-directory: "spinoso-array"
 
       - name: Check spinoso-array with all features
-        run: cargo check --verbose --all-features --all-targets
+        run: cargo check --verbose --all-features --all-targets --profile=test
         working-directory: "spinoso-array"
 
       - name: Check spinoso-env with no default features
-        run: cargo check --verbose --no-default-features --all-targets
+        run: cargo check --verbose --no-default-features --all-targets --profile=test
         working-directory: "spinoso-env"
 
       - name: Check spinoso-env with all features
-        run: cargo check --verbose --all-features --all-targets
+        run: cargo check --verbose --all-features --all-targets --profile=test
         working-directory: "spinoso-env"
 
       - name: Check spinoso-exception with no default features
-        run: cargo check --verbose --no-default-features --all-targets
+        run: cargo check --verbose --no-default-features --all-targets --profile=test
         working-directory: "spinoso-exception"
 
       - name: Check spinoso-exception with all features
-        run: cargo check --verbose --all-features --all-targets
+        run: cargo check --verbose --all-features --all-targets --profile=test
         working-directory: "spinoso-exception"
 
       - name: Check spinoso-math with no default features
-        run: cargo check --verbose --no-default-features --all-targets
+        run: cargo check --verbose --no-default-features --all-targets --profile=test
         working-directory: "spinoso-math"
 
       - name: Check spinoso-math with all features
-        run: cargo check --verbose --all-features --all-targets
+        run: cargo check --verbose --all-features --all-targets --profile=test
         working-directory: "spinoso-math"
 
       - name: Check spinoso-random with no default features
-        run: cargo check --verbose --no-default-features --all-targets
+        run: cargo check --verbose --no-default-features --all-targets --profile=test
         working-directory: "spinoso-random"
 
       - name: Check spinoso-random with all features
-        run: cargo check --verbose --all-features --all-targets
+        run: cargo check --verbose --all-features --all-targets --profile=test
         working-directory: "spinoso-random"
 
       - name: Check spinoso-random with some features
         run: |
-          cargo check --verbose --no-default-features --features rand-traits --all-targets
-          cargo check --verbose --no-default-features --features std --all-targets
-          cargo check --verbose --no-default-features --features random-rand --all-targets
+          cargo check --verbose --no-default-features --features rand-traits --all-targets --profile=test
+          cargo check --verbose --no-default-features --features std --all-targets --profile=test
+          cargo check --verbose --no-default-features --features random-rand --all-targets --profile=test
         working-directory: "spinoso-random"
 
       - name: Check spinoso-regexp with no default features
-        run: cargo check --verbose --no-default-features --all-targets
+        run: cargo check --verbose --no-default-features --all-targets --profile=test
         working-directory: "spinoso-regexp"
 
       - name: Check spinoso-regexp with all features
-        run: cargo check --verbose --all-features --all-targets
+        run: cargo check --verbose --all-features --all-targets --profile=test
         working-directory: "spinoso-regexp"
 
       - name: Check spinoso-securerandom with no default features
-        run: cargo check --verbose --no-default-features --all-targets
+        run: cargo check --verbose --no-default-features --all-targets --profile=test
         working-directory: "spinoso-securerandom"
 
       - name: Check spinoso-securerandom with all features
-        run: cargo check --verbose --all-features --all-targets
+        run: cargo check --verbose --all-features --all-targets --profile=test
         working-directory: "spinoso-securerandom"
 
       - name: Check spinoso-symbol with no default features
-        run: cargo check --verbose --no-default-features --all-targets
+        run: cargo check --verbose --no-default-features --all-targets --profile=test
         working-directory: "spinoso-symbol"
 
       - name: Check spinoso-symbol with all features
-        run: cargo check --verbose --all-features --all-targets
+        run: cargo check --verbose --all-features --all-targets --profile=test
         working-directory: "spinoso-symbol"
 
       - name: Compile spinoso-symbol with some features
         run: |
-          cargo check --verbose --no-default-features --features ident-parser --all-targets
-          cargo check --verbose --no-default-features --features inspect --all-targets
-          cargo check --verbose --no-default-features --features inspect,artichoke --all-targets
+          cargo check --verbose --no-default-features --features ident-parser --all-targets --profile=test
+          cargo check --verbose --no-default-features --features inspect --all-targets --profile=test
+          cargo check --verbose --no-default-features --features inspect,artichoke --all-targets --profile=test
         working-directory: "spinoso-symbol"
 
       - name: Check spinoso-time with no default features
-        run: cargo check --verbose --no-default-features --all-targets
+        run: cargo check --verbose --no-default-features --all-targets --profile=test
         working-directory: "spinoso-time"
 
       - name: Check spinoso-time with all features
-        run: cargo check --verbose --all-features --all-targets
+        run: cargo check --verbose --all-features --all-targets --profile=test
         working-directory: "spinoso-time"
 
       - name: Compile scolapasta-hex with no default features
-        run: cargo check --verbose --no-default-features --all-targets
+        run: cargo check --verbose --no-default-features --all-targets --profile=test
         working-directory: "scolapasta-hex"
 
       - name: Compile scolapasta-hex with all features
-        run: cargo check --verbose --all-features --all-targets
+        run: cargo check --verbose --all-features --all-targets --profile=test
         working-directory: "scolapasta-hex"
 
       - name: Compile scolapasta-hex with some features
         run: |
-          cargo check --verbose --no-default-features --features alloc --all-targets
-          cargo check --verbose --no-default-features --features alloc,std --all-targets
+          cargo check --verbose --no-default-features --features alloc --all-targets --profile=test
+          cargo check --verbose --no-default-features --features alloc,std --all-targets --profile=test
         working-directory: "scolapasta-hex"
 
       - name: Compile scolapasta-string-escape with no default features
-        run: cargo check --verbose --no-default-features --all-targets
+        run: cargo check --verbose --no-default-features --all-targets --profile=test
         working-directory: "scolapasta-string-escape"
 
       - name: Compile scolapasta-string-escape with all features
-        run: cargo check --verbose --all-features --all-targets
+        run: cargo check --verbose --all-features --all-targets --profile=test
         working-directory: "scolapasta-string-escape"
 
   rust-minimal-versions:
@@ -315,12 +315,12 @@ jobs:
       - name: Check artichoke with minimal versions
         run: |
           cargo +nightly generate-lockfile -Z minimal-versions
-          cargo check --all-targets
+          cargo check --all-targets --profile=test
 
       - name: Check spec-runner with minimal versions
         run: |
           cargo +nightly generate-lockfile -Z minimal-versions
-          cargo check --all-targets
+          cargo check --all-targets --profile=test
         working-directory: "spec-runner"
 
   ruby:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -80,13 +80,13 @@ jobs:
           args: --workspace --all-features --all-targets
 
       - name: Check artichoke with locked Cargo.lock
-        run: cargo check --locked
+        run: cargo check --locked --all-targets
 
       - name: Check artichoke with no default features
-        run: cargo check --verbose --no-default-features
+        run: cargo check --verbose --no-default-features --all-targets
 
       - name: Check artichoke with all features
-        run: cargo check --verbose --all-features
+        run: cargo check --verbose --all-features --all-targets
 
   check-fuzz:
     name: Check fuzz workspace
@@ -113,7 +113,7 @@ jobs:
           working-directory: "fuzz"
 
       - name: Check fuzz with locked Cargo.lock
-        run: cargo check --locked
+        run: cargo check --locked --all-targets
         working-directory: "fuzz"
 
   check-spec-runner:
@@ -150,7 +150,7 @@ jobs:
         working-directory: "spec-runner"
 
       - name: Check spec-runner with locked Cargo.lock
-        run: cargo check --locked
+        run: cargo check --locked --all-targets
         working-directory: "spec-runner"
 
   check-sub-crates:
@@ -176,111 +176,111 @@ jobs:
       - uses: Swatinem/rust-cache@v1
 
       - name: Check spinoso-array with no default features
-        run: cargo check --verbose --no-default-features
+        run: cargo check --verbose --no-default-features --all-targets
         working-directory: "spinoso-array"
 
       - name: Check spinoso-array with all features
-        run: cargo check --verbose --all-features
+        run: cargo check --verbose --all-features --all-targets
         working-directory: "spinoso-array"
 
       - name: Check spinoso-env with no default features
-        run: cargo check --verbose --no-default-features
+        run: cargo check --verbose --no-default-features --all-targets
         working-directory: "spinoso-env"
 
       - name: Check spinoso-env with all features
-        run: cargo check --verbose --all-features
+        run: cargo check --verbose --all-features --all-targets
         working-directory: "spinoso-env"
 
       - name: Check spinoso-exception with no default features
-        run: cargo check --verbose --no-default-features
+        run: cargo check --verbose --no-default-features --all-targets
         working-directory: "spinoso-exception"
 
       - name: Check spinoso-exception with all features
-        run: cargo check --verbose --all-features
+        run: cargo check --verbose --all-features --all-targets
         working-directory: "spinoso-exception"
 
       - name: Check spinoso-math with no default features
-        run: cargo check --verbose --no-default-features
+        run: cargo check --verbose --no-default-features --all-targets
         working-directory: "spinoso-math"
 
       - name: Check spinoso-math with all features
-        run: cargo check --verbose --all-features
+        run: cargo check --verbose --all-features --all-targets
         working-directory: "spinoso-math"
 
       - name: Check spinoso-random with no default features
-        run: cargo check --verbose --no-default-features
+        run: cargo check --verbose --no-default-features --all-targets
         working-directory: "spinoso-random"
 
       - name: Check spinoso-random with all features
-        run: cargo check --verbose --all-features
+        run: cargo check --verbose --all-features --all-targets
         working-directory: "spinoso-random"
 
       - name: Check spinoso-random with some features
         run: |
-          cargo check --verbose --no-default-features --features rand-traits
-          cargo check --verbose --no-default-features --features std
-          cargo check --verbose --no-default-features --features random-rand
+          cargo check --verbose --no-default-features --features rand-traits --all-targets
+          cargo check --verbose --no-default-features --features std --all-targets
+          cargo check --verbose --no-default-features --features random-rand --all-targets
         working-directory: "spinoso-random"
 
       - name: Check spinoso-regexp with no default features
-        run: cargo check --verbose --no-default-features
+        run: cargo check --verbose --no-default-features --all-targets
         working-directory: "spinoso-regexp"
 
       - name: Check spinoso-regexp with all features
-        run: cargo check --verbose --all-features
+        run: cargo check --verbose --all-features --all-targets
         working-directory: "spinoso-regexp"
 
       - name: Check spinoso-securerandom with no default features
-        run: cargo check --verbose --no-default-features
+        run: cargo check --verbose --no-default-features --all-targets
         working-directory: "spinoso-securerandom"
 
       - name: Check spinoso-securerandom with all features
-        run: cargo check --verbose --all-features
+        run: cargo check --verbose --all-features --all-targets
         working-directory: "spinoso-securerandom"
 
       - name: Check spinoso-symbol with no default features
-        run: cargo check --verbose --no-default-features
+        run: cargo check --verbose --no-default-features --all-targets
         working-directory: "spinoso-symbol"
 
       - name: Check spinoso-symbol with all features
-        run: cargo check --verbose --all-features
+        run: cargo check --verbose --all-features --all-targets
         working-directory: "spinoso-symbol"
 
       - name: Compile spinoso-symbol with some features
         run: |
-          cargo check --verbose --no-default-features --features ident-parser
-          cargo check --verbose --no-default-features --features inspect
-          cargo check --verbose --no-default-features --features inspect,artichoke
+          cargo check --verbose --no-default-features --features ident-parser --all-targets
+          cargo check --verbose --no-default-features --features inspect --all-targets
+          cargo check --verbose --no-default-features --features inspect,artichoke --all-targets
         working-directory: "spinoso-symbol"
 
       - name: Check spinoso-time with no default features
-        run: cargo check --verbose --no-default-features
+        run: cargo check --verbose --no-default-features --all-targets
         working-directory: "spinoso-time"
 
       - name: Check spinoso-time with all features
-        run: cargo check --verbose --all-features
+        run: cargo check --verbose --all-features --all-targets
         working-directory: "spinoso-time"
 
       - name: Compile scolapasta-hex with no default features
-        run: cargo check --verbose --no-default-features
+        run: cargo check --verbose --no-default-features --all-targets
         working-directory: "scolapasta-hex"
 
       - name: Compile scolapasta-hex with all features
-        run: cargo check --verbose --all-features
+        run: cargo check --verbose --all-features --all-targets
         working-directory: "scolapasta-hex"
 
       - name: Compile scolapasta-hex with some features
         run: |
-          cargo check --verbose --no-default-features --features alloc
-          cargo check --verbose --no-default-features --features alloc,std
+          cargo check --verbose --no-default-features --features alloc --all-targets
+          cargo check --verbose --no-default-features --features alloc,std --all-targets
         working-directory: "scolapasta-hex"
 
       - name: Compile scolapasta-string-escape with no default features
-        run: cargo check --verbose --no-default-features
+        run: cargo check --verbose --no-default-features --all-targets
         working-directory: "scolapasta-string-escape"
 
       - name: Compile scolapasta-string-escape with all features
-        run: cargo check --verbose --all-features
+        run: cargo check --verbose --all-features --all-targets
         working-directory: "scolapasta-string-escape"
 
   rust-minimal-versions:
@@ -315,12 +315,12 @@ jobs:
       - name: Check artichoke with minimal versions
         run: |
           cargo +nightly generate-lockfile -Z minimal-versions
-          cargo check
+          cargo check --all-targets
 
       - name: Check spec-runner with minimal versions
         run: |
           cargo +nightly generate-lockfile -Z minimal-versions
-          cargo check
+          cargo check --all-targets
         working-directory: "spec-runner"
 
   ruby:


### PR DESCRIPTION
Closes #1009 

Should we also add `--profile=test` to `cargo check` calls?
It seems that it could check unit tests according to this [Cargo doc](https://doc.rust-lang.org/cargo/commands/cargo-check.html#examples).