### PR TITLE
Pass trailing args when given programfile to program

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ artichoke 0.1.0-pre.0
 Artichoke is a Ruby made with Rust.
 
 USAGE:
-    artichoke [FLAGS] [OPTIONS] [--] [programfile]
+    artichoke [FLAGS] [OPTIONS] [--] [programfile]...
 
 FLAGS:
         --copyright    print the copyright
@@ -110,7 +110,7 @@ OPTIONS:
         --with-fixture <fixture>    file whose contents will be read into the `$fixture` global
 
 ARGS:
-    <programfile>
+    <programfile>...
 ```
 
 ## Design and Goals

--- a/src/bin/artichoke.rs
+++ b/src/bin/artichoke.rs
@@ -42,7 +42,7 @@
 //! ```
 
 use artichoke::ruby::{self, Args};
-use clap::{App, Arg};
+use clap::{App, AppSettings, Arg};
 use std::ffi::OsString;
 use std::io::{self, Write};
 use std::path::PathBuf;
@@ -73,11 +73,12 @@ fn main() {
             .help("file whose contents will be read into the `$fixture` global")
             .long("with-fixture"),
     );
-    let app = app.arg(Arg::with_name("programfile").takes_value(true).multiple(false));
+    let app = app.arg(Arg::with_name("programfile").takes_value(true).multiple(true));
     let app = app.version(env!("CARGO_PKG_VERSION"));
+    let app = app.setting(AppSettings::TrailingVarArg);
 
     let matches = app.get_matches();
-    let args = Args::empty()
+    let mut args = Args::empty()
         .with_copyright(matches.is_present("copyright"))
         .with_commands(
             matches
@@ -86,8 +87,14 @@ fn main() {
                 .flat_map(|v| v.map(OsString::from))
                 .collect(),
         )
-        .with_fixture(matches.value_of_os("fixture").map(PathBuf::from))
-        .with_programfile(matches.value_of_os("programfile").map(PathBuf::from));
+        .with_fixture(matches.value_of_os("fixture").map(PathBuf::from));
+    if let Some(mut positional) = matches.values_of_os("programfile") {
+        if let Some(programfile) = positional.next() {
+            args = args.with_programfile(Some(programfile.into()));
+        }
+        let ruby_program_argv = positional.map(OsString::from).collect::<Vec<_>>();
+        args = args.with_argv(ruby_program_argv);
+    }
 
     let mut stderr = StandardStream::stderr(ColorChoice::Auto);
     match ruby::run(args, io::stdin(), &mut stderr) {

--- a/src/bin/artichoke.rs
+++ b/src/bin/artichoke.rs
@@ -13,20 +13,20 @@
 
 //! `artichoke` is the `ruby` binary frontend to Artichoke.
 //!
-//! `artichoke` supports executing programs via files, stdin, or inline with one or
-//! more `-e` flags.
+//! `artichoke` supports executing programs via files, stdin, or inline with one
+//! or more `-e` flags.
 //!
-//! Artichoke does not yet support reading from the local filesystem. A temporary
-//! workaround is to inject data into the interpreter with the `--with-fixture`
-//! flag, which reads file contents into a `$fixture` global.
+//! Artichoke does not yet support reading from the local filesystem. A
+//! temporary workaround is to inject data into the interpreter with the
+//! `--with-fixture` flag, which reads file contents into a `$fixture` global.
 //!
 //! ```console
-//! $ cargo run --bin artichoke -- --help
-//! artichoke 0.1.0
+//! $ cargo run -q --bin artichoke -- --help
+//! artichoke 0.1.0-pre.0
 //! Artichoke is a Ruby made with Rust.
 //!
 //! USAGE:
-//!     artichoke [FLAGS] [OPTIONS] [--] [programfile]
+//!     artichoke [FLAGS] [OPTIONS] [--] [programfile]...
 //!
 //! FLAGS:
 //!         --copyright    print the copyright
@@ -38,7 +38,7 @@
 //!         --with-fixture <fixture>    file whose contents will be read into the `$fixture` global
 //!
 //! ARGS:
-//!     <programfile>
+//!     <programfile>...
 //! ```
 
 use artichoke::ruby::{self, Args};


### PR DESCRIPTION
For all args that trail the given programfile, e.g.:

    artichoke foo.rb --benchmark danger 28 -vvv

The arguments: `--benchmark danger 28 -vvv`.

The `ARGV` array is not frozen, but the `String` representing each argument is.

Collect these arguments and set them to the ARGV constant in the interpreter on program init.

## Example

### `foo.rb`

```ruby
puts 2222
puts ARGV.inspect
puts "ARGV.frozen?: #{ARGV.frozen?}"
ARGV.each {|a| puts "arg = #{a}, frozen? #{a.frozen?}"}
```

### MRI

```console
$ ruby foo.rb --benchmark danger 28 -vvv
2222
["--benchmark", "danger", "28", "-vvv"]
ARGV.frozen?: false
arg = --benchmark, frozen? true
arg = danger, frozen? true
arg = 28, frozen? true
arg = -vvv, frozen? true
```

### Artichoke

```console
$ cargo run -q --bin artichoke -- foo.rb --benchmark danger 28 -vvv
2222
["--benchmark", "danger", "28", "-vvv"]
ARGV.frozen?: false
arg = --benchmark, frozen? true
arg = danger, frozen? true
arg = 28, frozen? true
arg = -vvv, frozen? true
```

This fix is required to run `optcarrot` in benchmarking mode.