### PR TITLE
Implement Array#concat in Rust

### DIFF
--- a/artichoke-backend/src/extn/core/array/array.rb
+++ b/artichoke-backend/src/extn/core/array/array.rb
@@ -428,41 +428,6 @@ class Array
     reject!(&:nil?)
   end
 
-  def concat(*args)
-    raise FrozenError, "can't modify frozen Array" if frozen?
-    return self if args.length.zero?
-
-    idx = 0
-    len = args.length
-    while idx < len
-      arg = args[idx]
-      args[idx] = arg.dup if arg.equal?(self)
-
-      idx += 1
-    end
-
-    idx = 0
-    while idx < len
-      other = args[idx]
-      ary =
-        if other.is_a?(Array)
-          other
-        elsif other.respond_to?(:to_ary)
-          other = other.to_ary
-          unless other.is_a?(Array)
-            raise TypeError, "can't convert #{classname} to Array (#{classname}#to_ary gives #{other.class})"
-          end
-
-          other
-        else
-          raise TypeError, "no implicit conversion of #{classname} into Array" unless other.is_a?(Array)
-        end
-      self[length, 0] = ary
-      idx += 1
-    end
-    self
-  end
-
   def count(obj = (not_set = true), &block)
     count = 0
     idx = 0

--- a/artichoke-backend/src/extn/core/array/mod.rs
+++ b/artichoke-backend/src/extn/core/array/mod.rs
@@ -376,32 +376,6 @@ impl Array {
         self.0.set_slice(start, drain, src)
     }
 
-    pub fn concat(&mut self, interp: &mut Artichoke, mut other: Value) -> Result<(), Error> {
-        if let Ok(other) = unsafe { Self::unbox_from_value(&mut other, interp) } {
-            self.0.concat(other.0.as_slice());
-        } else if other.respond_to(interp, "to_ary")? {
-            let mut arr = other.funcall(interp, "to_ary", &[], None)?;
-            if let Ok(other) = unsafe { Self::unbox_from_value(&mut arr, interp) } {
-                self.0.concat(other.0.as_slice());
-            } else {
-                let mut message = String::from("can't convert ");
-                let name = interp.inspect_type_name_for_value(other);
-                message.push_str(name);
-                message.push_str(" to Array (");
-                message.push_str(name);
-                message.push_str("#to_ary gives ");
-                message.push_str(interp.inspect_type_name_for_value(arr));
-                return Err(TypeError::from(message).into());
-            }
-        } else {
-            let mut message = String::from("no implicit conversion of ");
-            message.push_str(interp.inspect_type_name_for_value(other));
-            message.push_str(" into Array");
-            return Err(TypeError::from(message).into());
-        };
-        Ok(())
-    }
-
     pub fn pop(&mut self) -> Option<Value> {
         self.0.pop().map(Value::from)
     }

--- a/spec-runner/enforced-specs.toml
+++ b/spec-runner/enforced-specs.toml
@@ -24,6 +24,7 @@ specs = [
   "collect",
   "combination",
   "compact",
+  "concat",
   "count",
   "cycle",
   "delete",


### PR DESCRIPTION
This commit implements `Array#concat` in Rust and works around previous issues regarding concatenating to `self` by allocating a new `Array` and concatenating into it.

This commit moves the core `Array#concat` implementation to the `array::trampoline`, which removes a method which requires the interpreter from the `Array` data structure.