### PR TITLE
Implement Array#* in Rust

### DIFF
--- a/artichoke-backend/src/extn/core/array/array.rb
+++ b/artichoke-backend/src/extn/core/array/array.rb
@@ -79,17 +79,6 @@ class Array
     array
   end
 
-  def *(other)
-    return join(other) if other.is_a?(String)
-
-    count = Integer(other)
-    ary = []
-    count.times do
-      ary.concat(self)
-    end
-    ary
-  end
-
   def -(other)
     ary = other.to_ary if other.respond_to?(:to_ary)
     classname = other.class

--- a/artichoke-backend/src/extn/core/array/mruby.rs
+++ b/artichoke-backend/src/extn/core/array/mruby.rs
@@ -11,6 +11,7 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     class::Builder::for_spec(interp, &spec)
         .add_self_method("[]", ary_cls_constructor, sys::mrb_args_rest())?
         .add_method("+", ary_plus, sys::mrb_args_req(1))?
+        .add_method("*", ary_mul, sys::mrb_args_req(1))?
         .add_method("[]", ary_element_reference, sys::mrb_args_req_and_opt(1, 1))?
         .add_method("[]=", ary_element_assignment, sys::mrb_args_req_and_opt(2, 1))?
         .add_method("clear", ary_clear, sys::mrb_args_none())?
@@ -62,6 +63,22 @@ unsafe extern "C" fn ary_plus(mrb: *mut sys::mrb_state, ary: sys::mrb_value) -> 
     let array = Value::from(ary);
     let other = Value::from(other);
     let result = trampoline::plus(&mut guard, array, other);
+    match result {
+        Ok(value) => {
+            let basic = sys::mrb_sys_basic_ptr(ary);
+            sys::mrb_write_barrier(mrb, basic);
+            value.inner()
+        }
+        Err(exception) => error::raise(guard, exception),
+    }
+}
+
+unsafe extern "C" fn ary_mul(mrb: *mut sys::mrb_state, ary: sys::mrb_value) -> sys::mrb_value {
+    let joiner = mrb_get_args!(mrb, required = 1);
+    unwrap_interpreter!(mrb, to => guard);
+    let array = Value::from(ary);
+    let joiner = Value::from(joiner);
+    let result = trampoline::mul(&mut guard, array, joiner);
     match result {
         Ok(value) => {
             let basic = sys::mrb_sys_basic_ptr(ary);

--- a/spec-runner/enforced-specs.toml
+++ b/spec-runner/enforced-specs.toml
@@ -42,6 +42,7 @@ specs = [
   "last",
   "length",
   "map",
+  "multiply",
   "plus",
   "prepend",
   "push",

--- a/spinoso-array/src/array/smallvec/mod.rs
+++ b/spinoso-array/src/array/smallvec/mod.rs
@@ -908,14 +908,52 @@ where
     /// # Examples
     ///
     /// ```
-    /// # use spinoso_array::Array;
-    /// let mut ary = Array::from(&[1, 2, 4]);
+    /// # use spinoso_array::SmallArray;
+    /// let mut ary = SmallArray::from(&[1, 2, 4]);
     /// ary.concat(&[7, 8, 9]);
     /// assert_eq!(ary.len(), 6);
     /// ```
     #[inline]
     pub fn concat(&mut self, other: &[T]) {
         self.0.extend_from_slice(other);
+    }
+
+    /// Creates a new array by repeating this array `n` times.
+    ///
+    /// This function will not panic. If the resulting `Array`'s capacity would
+    /// overflow, [`None`] is returned.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// # use spinoso_array::SmallArray;
+    /// # fn example() -> Option<()> {
+    /// let mut ary = SmallArray::from(&[1, 2]);
+    /// let repeated_ary = ary.repeat(3)?;
+    /// assert_eq!(repeated_ary, &[1, 2, 1, 2, 1, 2]);
+    /// # Some(())
+    /// # }
+    /// # example().unwrap();
+    /// ```
+    ///
+    /// [`None`] should be returned on overflow:
+    ///
+    /// ```
+    /// # use spinoso_array::SmallArray;
+    /// let mut ary = SmallArray::from(&[1, 2]);
+    /// let repeated_ary = ary.repeat(usize::MAX);
+    /// assert_eq!(repeated_ary, None);
+    /// ```
+    #[must_use]
+    pub fn repeat(&self, n: usize) -> Option<Self> {
+        let slice = self.0.as_slice();
+        if slice.len().checked_mul(n).is_some() {
+            Some(Self::from(slice.repeat(n)))
+        } else {
+            None
+        }
     }
 
     /// Prepends the elements of `other` to self.

--- a/spinoso-array/src/array/vec/mod.rs
+++ b/spinoso-array/src/array/vec/mod.rs
@@ -975,6 +975,49 @@ where
 
 impl<T> Array<T>
 where
+    T: Copy,
+{
+    /// Creates a new array by repeating this array `n` times.
+    ///
+    /// This function will not panic. If the resulting `Array`'s capacity would
+    /// overflow, [`None`] is returned.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// # use spinoso_array::Array;
+    /// # fn example() -> Option<()> {
+    /// let mut ary = Array::from(&[1, 2]);
+    /// let repeated_ary = ary.repeat(3)?;
+    /// assert_eq!(repeated_ary, &[1, 2, 1, 2, 1, 2]);
+    /// # Some(())
+    /// # }
+    /// # example().unwrap();
+    /// ```
+    ///
+    /// [`None`] should be returned on overflow:
+    ///
+    /// ```
+    /// # use spinoso_array::Array;
+    /// let mut ary = Array::from(&[1, 2]);
+    /// let repeated_ary = ary.repeat(usize::MAX);
+    /// assert_eq!(repeated_ary, None);
+    /// ```
+    #[must_use]
+    pub fn repeat(&self, n: usize) -> Option<Self> {
+        let slice = self.0.as_slice();
+        if slice.len().checked_mul(n).is_some() {
+            Some(Self::from(slice.repeat(n)))
+        } else {
+            None
+        }
+    }
+}
+
+impl<T> Array<T>
+where
     T: Default,
 {
     /// Set element at position `index` within the vector, extending the vector


### PR DESCRIPTION
For large allocations, this takes an array repeat operation from ~infinite time to 2x slower than MRI.