### PR TITLE
Improve spec compliance of implicit conversions

### DIFF
--- a/artichoke-backend/src/convert.rs
+++ b/artichoke-backend/src/convert.rs
@@ -18,10 +18,12 @@ mod bytes;
 mod fixnum;
 mod float;
 mod hash;
+mod implicit;
 mod nilable;
 mod string;
 
 pub use boxing::{BoxUnboxVmValue, HeapAllocated, HeapAllocatedData, Immediate, UnboxedValueGuard};
+pub use implicit::{implicitly_convert_to_int, implicitly_convert_to_nilable_string, implicitly_convert_to_string};
 
 /// Provide a fallible converter for types that implement an infallible
 /// conversion.

--- a/artichoke-backend/src/convert/implicit.rs
+++ b/artichoke-backend/src/convert/implicit.rs
@@ -1,0 +1,102 @@
+use artichoke_core::debug::Debug as _;
+use artichoke_core::value::Value as _;
+use core::mem;
+use spinoso_exception::TypeError;
+
+use crate::convert::BoxUnboxVmValue;
+use crate::extn::core::symbol::Symbol;
+use crate::types::Int;
+use crate::value::Value;
+use crate::Artichoke;
+
+pub fn implicitly_convert_to_int(interp: &mut Artichoke, value: Value) -> Result<Int, TypeError> {
+    match value.try_into::<Option<Int>>(interp) {
+        Ok(Some(num)) => return Ok(num),
+        Ok(None) => return Err(TypeError::with_message("no implicit conversion from nil to integer")),
+        Err(_) => {}
+    }
+    if let Ok(true) = value.respond_to(interp, "to_int") {
+        if let Ok(maybe) = value.funcall(interp, "to_int", &[], None) {
+            if let Ok(num) = maybe.try_into::<Int>(interp) {
+                Ok(num)
+            } else {
+                let mut message = String::from("can't convert ");
+                let name = interp.inspect_type_name_for_value(value);
+                message.push_str(name);
+                message.push_str(" to Integer (");
+                message.push_str(name);
+                message.push_str("#to_int gives ");
+                message.push_str(interp.inspect_type_name_for_value(maybe));
+                message.push(')');
+                Err(TypeError::from(message))
+            }
+        } else {
+            let mut message = String::from("no implicit conversion of ");
+            message.push_str(interp.inspect_type_name_for_value(value));
+            message.push_str(" into Integer");
+            Err(TypeError::from(message))
+        }
+    } else {
+        let mut message = String::from("no implicit conversion of ");
+        message.push_str(interp.inspect_type_name_for_value(value));
+        message.push_str(" into Integer");
+        Err(TypeError::from(message))
+    }
+}
+
+pub unsafe fn implicitly_convert_to_string<'a>(
+    interp: &mut Artichoke,
+    value: &'a mut Value,
+) -> Result<&'a [u8], TypeError> {
+    if let Ok(string) = value.try_into_mut::<&[u8]>(interp) {
+        Ok(string)
+    } else if let Ok(sym) = Symbol::unbox_from_value(value, interp) {
+        let bytes = sym.bytes(interp);
+        // Safety:
+        //
+        // Symbols are valid for the lifetime of the interpreter, which is a
+        // longer lifetime than that of `value`.
+        //
+        // This transmute shrinks the lifetime of the interned bytes to the
+        // lifetime of the given `Value`.
+        Ok(mem::transmute(bytes))
+    } else if let Ok(true) = value.respond_to(interp, "to_str") {
+        if let Ok(maybe) = value.funcall(interp, "to_str", &[], None) {
+            if let Ok(string) = maybe.try_into_mut::<&[u8]>(interp) {
+                Ok(string)
+            } else {
+                let mut message = String::from("can't convert ");
+                let name = interp.inspect_type_name_for_value(*value);
+                message.push_str(name);
+                message.push_str(" to String (");
+                message.push_str(name);
+                message.push_str("#to_str gives ");
+                message.push_str(interp.inspect_type_name_for_value(maybe));
+                message.push(')');
+                Err(TypeError::from(message))
+            }
+        } else {
+            let mut message = String::from("no implicit conversion of ");
+            message.push_str(interp.inspect_type_name_for_value(*value));
+            message.push_str(" into String");
+            Err(TypeError::from(message))
+        }
+    } else {
+        let mut message = String::from("no implicit conversion of ");
+        message.push_str(interp.inspect_type_name_for_value(*value));
+        message.push_str(" into String");
+        Err(TypeError::from(message))
+    }
+}
+
+pub unsafe fn implicitly_convert_to_nilable_string<'a>(
+    interp: &mut Artichoke,
+    value: &'a mut Value,
+) -> Result<Option<&'a [u8]>, TypeError> {
+    if value.is_nil() {
+        Ok(None)
+    } else {
+        let string = implicitly_convert_to_string(interp, value)?;
+        Ok(Some(string))
+    }
+}

--- a/artichoke-backend/src/convert/implicit.rs
+++ b/artichoke-backend/src/convert/implicit.rs
@@ -4,43 +4,194 @@ use core::mem;
 use spinoso_exception::TypeError;
 
 use crate::convert::BoxUnboxVmValue;
+use crate::error::Error;
 use crate::extn::core::symbol::Symbol;
 use crate::types::Int;
 use crate::value::Value;
 use crate::Artichoke;
 
-pub fn implicitly_convert_to_int(interp: &mut Artichoke, value: Value) -> Result<Int, TypeError> {
+/// Attempt to implicitly convert a [`Value`] to an integer.
+///
+/// Attempt to extract an [`Int`] from the given `Value` by trying the following
+/// conversions:
+///
+/// - If the given value is a Ruby integer, return the inner integer.
+/// - If the given value is `nil`, return a [`TypeError`].
+/// - If the given value responds to the `:to_int` method, call `value.to_int`:
+///   - If `value.to_int` raises an exception, propagate that exception.
+///   - If `value.to_int` returns a Ruby integer, return the inner integer.
+///   - If `value.to_int` returs any other type, return a [`TypeError`].
+/// - If the given value does not respond to the `:to_int` method, return a
+///   [`TypeError`].
+///
+/// Floats and other numeric types are not coerced to integer by this implicit
+/// conversion.
+///
+/// # Examples
+///
+/// ```
+/// # use artichoke_backend::prelude::*;
+/// # use artichoke_backend::convert::implicitly_convert_to_int;
+/// # fn example() -> Result<(), Error> {
+/// let mut interp = artichoke_backend::interpreter()?;
+/// // successful conversions
+/// let integer = interp.convert(17);
+/// let a = interp.eval(b"class A; def to_int; 3; end; end; A.new")?;
+///
+/// assert!(matches!(implicitly_convert_to_int(&mut interp, integer), Ok(17)));
+/// assert!(matches!(implicitly_convert_to_int(&mut interp, a), Ok(3)));
+///
+/// // failed conversions
+/// let b = interp.eval(b"class B; end; B.new")?;
+/// let c = interp.eval(b"class C; def to_int; nil; end; end; C.new")?;
+/// let d = interp.eval(b"class D; def to_int; 'not an integer'; end; end; D.new")?;
+/// let e = interp.eval(b"class E; def to_int; 3.2; end; end; E.new")?;
+/// let f = interp.eval(b"class F; def to_int; raise ArgumentError, 'not an integer'; end; end; F.new")?;
+///
+/// assert!(implicitly_convert_to_int(&mut interp, b).is_err());
+/// assert!(implicitly_convert_to_int(&mut interp, c).is_err());
+/// assert!(implicitly_convert_to_int(&mut interp, d).is_err());
+/// assert!(implicitly_convert_to_int(&mut interp, e).is_err());
+/// assert!(implicitly_convert_to_int(&mut interp, f).is_err());
+/// # Ok(())
+/// # }
+/// # example().unwrap();
+/// ```
+///
+/// # Errors
+///
+/// This function returns an error if:
+///
+/// - The given value is `nil`.
+/// - The given value is not an integer and does not respond to `:to_int`.
+/// - The given value is not an integer and returns a non-integer value from its
+///   `:to_int` method.
+/// - The given value is not an integer and raises an error in its `:to_int`
+///   method.
+pub fn implicitly_convert_to_int(interp: &mut Artichoke, value: Value) -> Result<Int, Error> {
     match value.try_into::<Option<Int>>(interp) {
+        // successful conversion: the given value is an integer.
         Ok(Some(num)) => return Ok(num),
-        Ok(None) => return Err(TypeError::with_message("no implicit conversion from nil to integer")),
+        // `nil` does not implicitly convert to integer:
+        //
+        // ```console
+        // [2.6.6] > a = [1, 2, 3, 4, 5]
+        // => [1, 2, 3, 4, 5]
+        // [2.6.6] > a[nil]
+        // Traceback (most recent call last):
+        //         4: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `<main>'
+        //         3: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `load'
+        //         2: from /usr/local/var/rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
+        //         1: from (irb):2
+        // TypeError (no implicit conversion from nil to integer)
+        // ```
+        Ok(None) => return Err(TypeError::with_message("no implicit conversion from nil to integer").into()),
         Err(_) => {}
     }
     if let Ok(true) = value.respond_to(interp, "to_int") {
-        if let Ok(maybe) = value.funcall(interp, "to_int", &[], None) {
-            if let Ok(num) = maybe.try_into::<Int>(interp) {
-                Ok(num)
-            } else {
-                let mut message = String::from("can't convert ");
-                let name = interp.inspect_type_name_for_value(value);
-                message.push_str(name);
-                message.push_str(" to Integer (");
-                message.push_str(name);
-                message.push_str("#to_int gives ");
-                message.push_str(interp.inspect_type_name_for_value(maybe));
-                message.push(')');
-                Err(TypeError::from(message))
-            }
+        // Propagate exceptions raised in `#to_int`:
+        //
+        // ```console
+        // [2.6.6] > a = [1, 2, 3, 4, 5]
+        // => [1, 2, 3, 4, 5]
+        // [2.6.6] > class A; def to_int; raise ArgumentError, 'a message'; end; end
+        // => :to_int
+        // [2.6.6] > a[A.new]
+        // Traceback (most recent call last):
+        //         5: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `<main>'
+        //         4: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `load'
+        //         3: from /usr/local/var/rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
+        //         2: from (irb):3
+        //         1: from (irb):2:in `to_int'
+        // ArgumentError (a message)
+        // ```
+        let maybe = value.funcall(interp, "to_int", &[], None)?;
+        if let Ok(num) = maybe.try_into::<Int>(interp) {
+            // successful conversion: `#to_int` returned an integer.
+            Ok(num)
         } else {
-            let mut message = String::from("no implicit conversion of ");
-            message.push_str(interp.inspect_type_name_for_value(value));
-            message.push_str(" into Integer");
-            Err(TypeError::from(message))
+            // Non integer types returned from `#to_int`, even other numerics,
+            // result in a `TypeError`:
+            //
+            // ```console
+            // [2.6.6] > a = [1, 2, 3, 4, 5]
+            // => [1, 2, 3, 4, 5]
+            // [2.6.6] > class A; def to_int; "another string"; end; end
+            // => :to_int
+            // [2.6.6] > a[A.new]
+            // Traceback (most recent call last):
+            //         4: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `<main>'
+            //         3: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `load'
+            //         2: from /usr/local/var/rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
+            //         1: from (irb):3
+            // TypeError (can't convert A to Integer (A#to_int gives String))
+            // [2.6.6] > class B; def to_int; 3.2; end; end
+            // => :to_int
+            // [2.6.6] > a[B.new]
+            // Traceback (most recent call last):
+            //         4: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `<main>'
+            //         3: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `load'
+            //         2: from /usr/local/var/rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
+            //         1: from (irb):5
+            // TypeError (can't convert B to Integer (B#to_int gives Float))
+            // [2.6.6] > class C; def to_int; nil; end; end
+            // => :to_int
+            // [2.6.6] > a[C.new]
+            // Traceback (most recent call last):
+            //         4: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `<main>'
+            //         3: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `load'
+            //         2: from /usr/local/var/rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
+            //         1: from (irb):7
+            // TypeError (can't convert C to Integer (C#to_int gives NilClass))
+            // [2.6.6] > module X; class Y; class Z; def to_int; "oh no"; end; end; end; end
+            // => :to_int
+            // [2.6.6] > a[X::Y::Z.new]
+            // Traceback (most recent call last):
+            //         4: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `<main>'
+            //         3: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `load'
+            //         2: from /usr/local/var/rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
+            //         1: from (irb):9
+            // TypeError (can't convert X::Y::Z to Integer (X::Y::Z#to_int gives String))
+            // ```
+            let mut message = String::from("can't convert ");
+            let name = interp.inspect_type_name_for_value(value);
+            message.push_str(name);
+            message.push_str(" to Integer (");
+            message.push_str(name);
+            message.push_str("#to_int gives ");
+            message.push_str(interp.class_name_for_value(maybe));
+            message.push(')');
+            Err(TypeError::from(message).into())
         }
     } else {
+        // The given value is not an integer and cannot be converted with
+        // `#to_int`:
+        //
+        // ```console
+        // [2.6.6] > a = [1, 2, 3, 4, 5]
+        // => [1, 2, 3, 4, 5]
+        // [2.6.6] > a[true]
+        // Traceback (most recent call last):
+        //         5: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `<main>'
+        //         4: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `load'
+        //         3: from /usr/local/var/rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
+        //         2: from (irb):10
+        //         1: from (irb):10:in `rescue in irb_binding'
+        // TypeError (no implicit conversion of true into Integer)
+        // [2.6.6] > class A; end
+        // => nil
+        // [2.6.6] > a[A.new]
+        // Traceback (most recent call last):
+        //         4: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `<main>'
+        //         3: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `load'
+        //         2: from /usr/local/var/rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
+        //         1: from (irb):5
+        // TypeError (no implicit conversion of A into Integer)
+        // ```
         let mut message = String::from("no implicit conversion of ");
         message.push_str(interp.inspect_type_name_for_value(value));
         message.push_str(" into Integer");
-        Err(TypeError::from(message))
+        Err(TypeError::from(message).into())
     }
 }
 

--- a/artichoke-backend/src/convert/implicit.rs
+++ b/artichoke-backend/src/convert/implicit.rs
@@ -258,6 +258,10 @@ pub fn implicitly_convert_to_int(interp: &mut Artichoke, value: Value) -> Result
 /// - The given value is not a string and raises an error in its `:to_str`
 ///   method.
 ///
+/// # Safety
+///
+/// Callers must ensure that `value` does not outlive the given interpreter.
+///
 /// [`Symbol`]: crate::extn::core::symbol::Symbol
 pub unsafe fn implicitly_convert_to_string<'a>(
     interp: &mut Artichoke,
@@ -458,6 +462,10 @@ pub unsafe fn implicitly_convert_to_string<'a>(
 ///   `:to_str` method.
 /// - The given value is not a string and raises an error in its `:to_str`
 ///   method.
+///
+/// # Safety
+///
+/// Callers must ensure that `value` does not outlive the given interpreter.
 ///
 /// [`Symbol`]: crate::extn::core::symbol::Symbol
 pub unsafe fn implicitly_convert_to_nilable_string<'a>(

--- a/artichoke-backend/src/convert/implicit.rs
+++ b/artichoke-backend/src/convert/implicit.rs
@@ -1,12 +1,9 @@
 use artichoke_core::debug::Debug as _;
 use artichoke_core::value::Value as _;
-use core::mem;
 use spinoso_exception::TypeError;
 
-use crate::convert::BoxUnboxVmValue;
 use crate::error::Error;
-use crate::extn::core::symbol::Symbol;
-use crate::types::Int;
+use crate::types::{Int, Ruby};
 use crate::value::Value;
 use crate::Artichoke;
 
@@ -32,6 +29,7 @@ use crate::Artichoke;
 /// ```
 /// # use artichoke_backend::prelude::*;
 /// # use artichoke_backend::convert::implicitly_convert_to_int;
+/// # use artichoke_backend::value::Value;
 /// # fn example() -> Result<(), Error> {
 /// let mut interp = artichoke_backend::interpreter()?;
 /// // successful conversions
@@ -42,12 +40,14 @@ use crate::Artichoke;
 /// assert!(matches!(implicitly_convert_to_int(&mut interp, a), Ok(3)));
 ///
 /// // failed conversions
+/// let nil = Value::nil();
 /// let b = interp.eval(b"class B; end; B.new")?;
 /// let c = interp.eval(b"class C; def to_int; nil; end; end; C.new")?;
 /// let d = interp.eval(b"class D; def to_int; 'not an integer'; end; end; D.new")?;
 /// let e = interp.eval(b"class E; def to_int; 3.2; end; end; E.new")?;
 /// let f = interp.eval(b"class F; def to_int; raise ArgumentError, 'not an integer'; end; end; F.new")?;
 ///
+/// assert!(implicitly_convert_to_int(&mut interp, nil).is_err());
 /// assert!(implicitly_convert_to_int(&mut interp, b).is_err());
 /// assert!(implicitly_convert_to_int(&mut interp, c).is_err());
 /// assert!(implicitly_convert_to_int(&mut interp, d).is_err());
@@ -195,55 +195,275 @@ pub fn implicitly_convert_to_int(interp: &mut Artichoke, value: Value) -> Result
     }
 }
 
+/// Attempt to implicitly convert a [`Value`] to a byte slice (Ruby `String`).
+///
+/// Attempt to extract a `&[u8]` from the given `Value` by trying the following
+/// conversions:
+///
+/// - If the given value is a Ruby string, return the inner byte slice.
+/// - If the given value is `nil`, return a [`TypeError`].
+/// - If the given value responds to the `:to_str` method, call `value.to_str`:
+///   - If `value.to_str` raises an exception, propagate that exception.
+///   - If `value.to_str` returns a Ruby string, return the inner byte slice.
+///   - If `value.to_str` returs any other type, return a [`TypeError`].
+/// - If the given value does not respond to the `:to_str` method, return a
+///   [`TypeError`].
+///
+/// [`Symbol`]s are not coerced to byte slice by this implicit conversion.
+///
+/// # Examples
+///
+/// ```
+/// # use artichoke_backend::prelude::*;
+/// # use artichoke_backend::convert::implicitly_convert_to_string;
+/// # use artichoke_backend::value::Value;
+/// # fn example() -> Result<(), Error> {
+/// let mut interp = artichoke_backend::interpreter()?;
+/// // successful conversions
+/// let mut string = interp.convert_mut("artichoke");
+/// let mut a = interp.eval(b"class A; def to_str; 'spinoso'; end; end; A.new")?;
+///
+/// # unsafe {
+/// assert!(matches!(implicitly_convert_to_string(&mut interp, &mut string), Ok(s) if *s == b"artichoke"[..]));
+/// assert!(matches!(implicitly_convert_to_string(&mut interp, &mut a), Ok(s) if *s == b"spinoso"[..]));
+///
+/// // failed conversions
+/// let mut nil = Value::nil();
+/// let mut b = interp.eval(b"class B; end; B.new")?;
+/// let mut c = interp.eval(b"class C; def to_str; nil; end; end; C.new")?;
+/// let mut d = interp.eval(b"class D; def to_str; 17; end; end; D.new")?;
+/// let mut e = interp.eval(b"class E; def to_str; :artichoke; end; end; E.new")?;
+/// let mut f = interp.eval(b"class F; def to_str; raise ArgumentError, 'not a string'; end; end; F.new")?;
+///
+/// assert!(implicitly_convert_to_string(&mut interp, &mut nil).is_err());
+/// assert!(implicitly_convert_to_string(&mut interp, &mut b).is_err());
+/// assert!(implicitly_convert_to_string(&mut interp, &mut c).is_err());
+/// assert!(implicitly_convert_to_string(&mut interp, &mut d).is_err());
+/// assert!(implicitly_convert_to_string(&mut interp, &mut e).is_err());
+/// assert!(implicitly_convert_to_string(&mut interp, &mut f).is_err());
+/// # }
+/// # Ok(())
+/// # }
+/// # example().unwrap();
+/// ```
+///
+/// # Errors
+///
+/// This function returns an error if:
+///
+/// - The given value is `nil`.
+/// - The given value is not a string and does not respond to `:to_str`.
+/// - The given value is not a string and returns a non-string value from its
+///   `:to_str` method.
+/// - The given value is not a string and raises an error in its `:to_str`
+///   method.
+///
+/// [`Symbol`]: crate::extn::core::symbol::Symbol
 pub unsafe fn implicitly_convert_to_string<'a>(
     interp: &mut Artichoke,
     value: &'a mut Value,
-) -> Result<&'a [u8], TypeError> {
-    if let Ok(string) = value.try_into_mut::<&[u8]>(interp) {
-        Ok(string)
-    } else if let Ok(sym) = Symbol::unbox_from_value(value, interp) {
-        let bytes = sym.bytes(interp);
-        // Safety:
+) -> Result<&'a [u8], Error> {
+    match value.try_into_mut::<Option<&'a [u8]>>(interp) {
+        // successful conversion: the given value is an string.
+        Ok(Some(s)) => return Ok(s),
+        // `nil` does not implicitly convert to string:
         //
-        // Symbols are valid for the lifetime of the interpreter, which is a
-        // longer lifetime than that of `value`.
+        // ```console
+        // [2.6.6] > ENV[nil]
+        // Traceback (most recent call last):
+        //         6: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `<main>'
+        //         5: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `load'
+        //         4: from /usr/local/var/rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
+        //         3: from (irb):7
+        //         2: from (irb):7:in `rescue in irb_binding'
+        //         1: from (irb):7:in `[]'
+        // TypeError (no implicit conversion of nil into String)
+        // ```
+        Ok(None) => return Err(TypeError::with_message("no implicit conversion from nil into String").into()),
+        Err(_) => {}
+    }
+    if matches!(value.ruby_type(), Ruby::Symbol) {
+        return Err(TypeError::with_message("no implicit conversion of Symbol into String").into());
+    }
+    if let Ok(true) = value.respond_to(interp, "to_str") {
+        // Propagate exceptions raised in `#to_str`:
         //
-        // This transmute shrinks the lifetime of the interned bytes to the
-        // lifetime of the given `Value`.
-        Ok(mem::transmute(bytes))
-    } else if let Ok(true) = value.respond_to(interp, "to_str") {
-        if let Ok(maybe) = value.funcall(interp, "to_str", &[], None) {
-            if let Ok(string) = maybe.try_into_mut::<&[u8]>(interp) {
-                Ok(string)
-            } else {
-                let mut message = String::from("can't convert ");
-                let name = interp.inspect_type_name_for_value(*value);
-                message.push_str(name);
-                message.push_str(" to String (");
-                message.push_str(name);
-                message.push_str("#to_str gives ");
-                message.push_str(interp.inspect_type_name_for_value(maybe));
-                message.push(')');
-                Err(TypeError::from(message))
-            }
+        // ```console
+        // [2.6.6] >  class A; def to_str; raise ArgumentError, 'a message'; end; end
+        // => :to_str
+        // [2.6.6] > ENV[A.new]
+        // Traceback (most recent call last):
+        //         6: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `<main>'
+        //         5: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `load'
+        //         4: from /usr/local/var/rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
+        //         3: from (irb):10
+        //         2: from (irb):10:in `[]'
+        //         1: from (irb):9:in `to_str'
+        // ArgumentError (a message)
+        // ```
+        let maybe = value.funcall(interp, "to_str", &[], None)?;
+        if let Ok(s) = maybe.try_into_mut::<&[u8]>(interp) {
+            // successful conversion: `#to_str` returned a string.
+            Ok(s)
         } else {
-            let mut message = String::from("no implicit conversion of ");
-            message.push_str(interp.inspect_type_name_for_value(*value));
-            message.push_str(" into String");
-            Err(TypeError::from(message))
+            // Non `String` types returned from `#to_str` result in a
+            // `TypeError`:
+            //
+            // ```console
+            // [2.6.6] > class A; def to_str; 17; end; end
+            // => :to_str
+            // [2.6.6] > ENV[A.new]
+            // Traceback (most recent call last):
+            //         5: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `<main>'
+            //         4: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `load'
+            //         3: from /usr/local/var/rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
+            //         2: from (irb):5
+            //         1: from (irb):5:in `[]'
+            // TypeError (can't convert A to String (A#to_str gives Integer))
+            // [2.6.6] > class B; def to_str; true; end; end
+            // => :to_str
+            // [2.6.6] > ENV[B.new]
+            // Traceback (most recent call last):
+            //         5: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `<main>'
+            //         4: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `load'
+            //         3: from /usr/local/var/rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
+            //         2: from (irb):7
+            //         1: from (irb):7:in `[]'
+            // TypeError (can't convert B to String (B#to_str gives TrueClass))
+            // [2.6.6] > class C; def to_str; nil; end; end
+            // => :to_str
+            // [2.6.6] > ENV[C.new]
+            // Traceback (most recent call last):
+            //         5: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `<main>'
+            //         4: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `load'
+            //         3: from /usr/local/var/rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
+            //         2: from (irb):9
+            //         1: from (irb):9:in `[]'
+            // TypeError (can't convert C to String (C#to_str gives NilClass))
+            // [2.6.6] > module X; class Y; class Z; def to_str; 92; end; end; end; end
+            // => :to_str
+            // [2.6.6] > ENV[X::Y::Z.new]
+            // Traceback (most recent call last):
+            //         5: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `<main>'
+            //         4: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `load'
+            //         3: from /usr/local/var/rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
+            //         2: from (irb):11
+            //         1: from (irb):11:in `[]'
+            // TypeError (can't convert X::Y::Z to String (X::Y::Z#to_str gives Integer))
+            // ```
+            let mut message = String::from("can't convert ");
+            let name = interp.inspect_type_name_for_value(*value);
+            message.push_str(name);
+            message.push_str(" to String (");
+            message.push_str(name);
+            message.push_str("#to_str gives ");
+            message.push_str(interp.class_name_for_value(maybe));
+            message.push(')');
+            Err(TypeError::from(message).into())
         }
     } else {
+        // The given value is not a string and cannot be converted with
+        // `#to_str`:
+        //
+        // ```console
+        // [2.6.6] > ENV[true]
+        // Traceback (most recent call last):
+        //         5: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `<main>'
+        //         4: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `load'
+        //         3: from /usr/local/var/rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
+        //         2: from (irb):1
+        //         1: from (irb):1:in `[]'
+        // TypeError (no implicit conversion of true into String)
+        // [2.6.6] > class A; end
+        // => nil
+        // [2.6.6] > ENV[A.new]
+        // Traceback (most recent call last):
+        //         5: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `<main>'
+        //         4: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `load'
+        //         3: from /usr/local/var/rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
+        //         2: from (irb):3
+        //         1: from (irb):3:in `[]'
+        // TypeError (no implicit conversion of A into String)
+        // ```
         let mut message = String::from("no implicit conversion of ");
         message.push_str(interp.inspect_type_name_for_value(*value));
         message.push_str(" into String");
-        Err(TypeError::from(message))
+        Err(TypeError::from(message).into())
     }
 }
 
+/// Attempt to implicitly convert a [`Value`] to an optional byte slice (nilable
+/// Ruby `String`).
+///
+/// Attempt to extract a `Option<&[u8]>` from the given `Value` by trying the
+/// following conversions:
+///
+/// - If the given value is a Ruby string, return the inner byte slice.
+/// - If the given value is `nil`, return [`None`].
+/// - If the given value responds to the `:to_str` method, call `value.to_str`:
+///   - If `value.to_str` raises an exception, propagate that exception.
+///   - If `value.to_str` returns a Ruby string, return the inner byte slice.
+///   - If `value.to_str` returs any other type, including `nil`, return a
+///     [`TypeError`].
+/// - If the given value does not respond to the `:to_str` method, return a
+///   [`TypeError`].
+///
+/// [`Symbol`]s are not coerced to byte slice by this implicit conversion.
+///
+/// # Examples
+///
+/// ```
+/// # use artichoke_backend::prelude::*;
+/// # use artichoke_backend::convert::implicitly_convert_to_nilable_string;
+/// # use artichoke_backend::value::Value;
+/// # fn example() -> Result<(), Error> {
+/// let mut interp = artichoke_backend::interpreter()?;
+/// // successful conversions
+/// let mut string = interp.convert_mut("artichoke");
+/// let mut nil = Value::nil();
+/// let mut a = interp.eval(b"class A; def to_str; 'spinoso'; end; end; A.new")?;
+///
+/// # unsafe {
+/// assert!(matches!(implicitly_convert_to_nilable_string(&mut interp, &mut string), Ok(Some(s)) if *s == b"artichoke"[..]));
+/// assert!(matches!(implicitly_convert_to_nilable_string(&mut interp, &mut nil), Ok(None)));
+/// assert!(matches!(implicitly_convert_to_nilable_string(&mut interp, &mut a), Ok(Some(s)) if *s == b"spinoso"[..]));
+///
+/// // failed conversions
+/// let mut b = interp.eval(b"class B; end; B.new")?;
+/// let mut c = interp.eval(b"class C; def to_str; nil; end; end; C.new")?;
+/// let mut d = interp.eval(b"class D; def to_str; 17; end; end; D.new")?;
+/// let mut e = interp.eval(b"class E; def to_str; :artichoke; end; end; E.new")?;
+/// let mut f = interp.eval(b"class F; def to_str; raise ArgumentError, 'not a string'; end; end; F.new")?;
+/// let mut g = interp.eval(b"class G; def to_str; nil; end; end; G.new")?;
+///
+/// assert!(implicitly_convert_to_nilable_string(&mut interp, &mut b).is_err());
+/// assert!(implicitly_convert_to_nilable_string(&mut interp, &mut c).is_err());
+/// assert!(implicitly_convert_to_nilable_string(&mut interp, &mut d).is_err());
+/// assert!(implicitly_convert_to_nilable_string(&mut interp, &mut e).is_err());
+/// assert!(implicitly_convert_to_nilable_string(&mut interp, &mut f).is_err());
+/// assert!(implicitly_convert_to_nilable_string(&mut interp, &mut g).is_err());
+/// # }
+/// # Ok(())
+/// # }
+/// # example().unwrap();
+/// ```
+///
+/// # Errors
+///
+/// This function returns an error if:
+///
+/// - The given value is `nil`.
+/// - The given value is not a string and does not respond to `:to_str`.
+/// - The given value is not a string and returns a non-string value from its
+///   `:to_str` method.
+/// - The given value is not a string and raises an error in its `:to_str`
+///   method.
+///
+/// [`Symbol`]: crate::extn::core::symbol::Symbol
 pub unsafe fn implicitly_convert_to_nilable_string<'a>(
     interp: &mut Artichoke,
     value: &'a mut Value,
-) -> Result<Option<&'a [u8]>, TypeError> {
+) -> Result<Option<&'a [u8]>, Error> {
     if value.is_nil() {
         Ok(None)
     } else {

--- a/artichoke-backend/src/convert/implicit.rs
+++ b/artichoke-backend/src/convert/implicit.rs
@@ -283,10 +283,10 @@ pub unsafe fn implicitly_convert_to_string<'a>(
         //         1: from (irb):7:in `[]'
         // TypeError (no implicit conversion of nil into String)
         // ```
-        Ok(None) => return Err(TypeError::with_message("no implicit conversion from nil into String").into()),
+        Ok(None) => return Err(TypeError::with_message("no implicit conversion of nil into String").into()),
         Err(_) => {}
     }
-    if matches!(value.ruby_type(), Ruby::Symbol) {
+    if let Ruby::Symbol = value.ruby_type() {
         return Err(TypeError::with_message("no implicit conversion of Symbol into String").into());
     }
     if let Ok(true) = value.respond_to(interp, "to_str") {

--- a/artichoke-backend/src/extn/core/array/args.rs
+++ b/artichoke-backend/src/extn/core/array/args.rs
@@ -1,5 +1,6 @@
 use std::convert::TryFrom;
 
+use crate::convert::implicitly_convert_to_int;
 use crate::extn::prelude::*;
 use crate::sys::protect;
 
@@ -17,14 +18,14 @@ pub fn element_reference(
     ary_len: usize,
 ) -> Result<ElementReference, Error> {
     if let Some(len) = len {
-        let start = elem.implicitly_convert_to_int(interp)?;
-        let len = len.implicitly_convert_to_int(interp)?;
+        let start = implicitly_convert_to_int(interp, elem)?;
+        let len = implicitly_convert_to_int(interp, len)?;
         if let Ok(len) = usize::try_from(len) {
             Ok(ElementReference::StartLen(start, len))
         } else {
             Ok(ElementReference::Empty)
         }
-    } else if let Ok(index) = elem.implicitly_convert_to_int(interp) {
+    } else if let Ok(index) = implicitly_convert_to_int(interp, elem) {
         Ok(ElementReference::Index(index))
     } else {
         let rangelen = Int::try_from(ary_len).map_err(|_| Fatal::from("Range length exceeds Integer max"))?;
@@ -48,7 +49,7 @@ pub fn element_assignment(
     len: usize,
 ) -> Result<(usize, Option<usize>, Value), Error> {
     if let Some(elem) = third {
-        let start = first.implicitly_convert_to_int(interp)?;
+        let start = implicitly_convert_to_int(interp, first)?;
         let start = if let Ok(start) = usize::try_from(start) {
             start
         } else {
@@ -66,7 +67,7 @@ pub fn element_assignment(
                 return Err(IndexError::from(message).into());
             }
         };
-        let slice_len = second.implicitly_convert_to_int(interp)?;
+        let slice_len = implicitly_convert_to_int(interp, second)?;
         if let Ok(slice_len) = usize::try_from(slice_len) {
             Ok((start, Some(slice_len), elem))
         } else {
@@ -75,7 +76,7 @@ pub fn element_assignment(
             message.push(')');
             Err(IndexError::from(message).into())
         }
-    } else if let Ok(index) = first.implicitly_convert_to_int(interp) {
+    } else if let Ok(index) = implicitly_convert_to_int(interp, first) {
         if let Ok(index) = usize::try_from(index) {
             Ok((index, None, second))
         } else {
@@ -102,9 +103,9 @@ pub fn element_assignment(
             Ok((start, Some(len), second))
         } else {
             let start = first.funcall(interp, "begin", &[], None)?;
-            let start = start.implicitly_convert_to_int(interp)?;
+            let start = implicitly_convert_to_int(interp, start)?;
             let end = first.funcall(interp, "last", &[], None)?;
-            let end = end.implicitly_convert_to_int(interp)?;
+            let end = implicitly_convert_to_int(interp, end)?;
             // TODO: This conditional is probably not doing the right thing
             if start + (end - start) < 0 {
                 let mut message = String::new();

--- a/artichoke-backend/src/extn/core/array/mod.rs
+++ b/artichoke-backend/src/extn/core/array/mod.rs
@@ -5,7 +5,7 @@ use std::iter::FromIterator;
 use std::ops::{Deref, DerefMut};
 use std::slice;
 
-use crate::convert::UnboxedValueGuard;
+use crate::convert::{implicitly_convert_to_int, implicitly_convert_to_string, UnboxedValueGuard};
 use crate::extn::prelude::*;
 
 pub mod args;
@@ -216,7 +216,7 @@ impl Array {
                             return Err(TypeError::from(message).into());
                         }
                     } else {
-                        let len = array_or_len.implicitly_convert_to_int(interp)?;
+                        let len = implicitly_convert_to_int(interp, array_or_len)?;
                         let len =
                             usize::try_from(len).map_err(|_| ArgumentError::with_message("negative array size"))?;
                         let default = default.unwrap_or_else(Value::nil);
@@ -259,7 +259,7 @@ impl Array {
                             return Err(TypeError::from(message).into());
                         }
                     } else {
-                        let len = array_or_len.implicitly_convert_to_int(interp)?;
+                        let len = implicitly_convert_to_int(interp, array_or_len)?;
                         let len =
                             usize::try_from(len).map_err(|_| ArgumentError::with_message("negative array size"))?;
                         if default.is_some() {
@@ -302,7 +302,7 @@ impl Array {
                 for elem in ary.iter() {
                     flatten(interp, elem, out)?;
                 }
-            } else if let Ok(s) = value.implicitly_convert_to_string(interp) {
+            } else if let Ok(s) = unsafe { implicitly_convert_to_string(interp, &mut value) } {
                 out.push(s.to_vec());
             } else {
                 let s = value.to_s(interp);

--- a/artichoke-backend/src/extn/core/env/trampoline.rs
+++ b/artichoke-backend/src/extn/core/env/trampoline.rs
@@ -2,6 +2,7 @@
 
 use std::borrow::Cow;
 
+use crate::convert::{implicitly_convert_to_nilable_string, implicitly_convert_to_string};
 use crate::extn::core::env::Environ;
 use crate::extn::prelude::*;
 
@@ -13,7 +14,7 @@ pub fn initialize(interp: &mut Artichoke, into: Value) -> Result<Value, Error> {
 
 pub fn element_reference(interp: &mut Artichoke, mut environ: Value, mut name: Value) -> Result<Value, Error> {
     let environ = unsafe { Environ::unbox_from_value(&mut environ, interp) }?;
-    let name = name.implicitly_convert_to_string(interp)?;
+    let name = unsafe { implicitly_convert_to_string(interp, &mut name)? };
     let result = environ.get(name)?;
     let mut result = interp.convert_mut(result.as_ref().map(Cow::as_ref));
     result.freeze(interp)?;
@@ -27,8 +28,8 @@ pub fn element_assignment(
     mut value: Value,
 ) -> Result<Value, Error> {
     let mut environ = unsafe { Environ::unbox_from_value(&mut environ, interp) }?;
-    let name = name.implicitly_convert_to_string(interp)?;
-    let env_value = value.implicitly_convert_to_nilable_string(interp)?;
+    let name = unsafe { implicitly_convert_to_string(interp, &mut name)? };
+    let env_value = unsafe { implicitly_convert_to_nilable_string(interp, &mut value)? };
     environ.put(name, env_value)?;
     // Return original object, even if we converted it to a `String`.
     Ok(value)

--- a/artichoke-backend/src/extn/core/integer/trampoline.rs
+++ b/artichoke-backend/src/extn/core/integer/trampoline.rs
@@ -1,3 +1,4 @@
+use crate::convert::implicitly_convert_to_int;
 use crate::extn::core::integer::Integer;
 use crate::extn::prelude::*;
 
@@ -9,7 +10,7 @@ pub fn chr(interp: &mut Artichoke, value: Value, encoding: Option<Value>) -> Res
 
 pub fn element_reference(interp: &mut Artichoke, value: Value, bit: Value) -> Result<Value, Error> {
     let value = value.try_into::<Integer>(interp)?;
-    let bit = bit.implicitly_convert_to_int(interp)?;
+    let bit = implicitly_convert_to_int(interp, bit)?;
     let bit = value.bit(bit)?;
     Ok(interp.convert(bit))
 }

--- a/artichoke-backend/src/extn/core/kernel/integer.rs
+++ b/artichoke-backend/src/extn/core/kernel/integer.rs
@@ -6,6 +6,7 @@ use std::iter::Iterator;
 use std::num::NonZeroU32;
 use std::str::{self, FromStr};
 
+use crate::convert::{implicitly_convert_to_int, implicitly_convert_to_string};
 use crate::extn::prelude::*;
 
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
@@ -57,7 +58,7 @@ impl TryConvertMut<Option<Value>, Option<Radix>> for Artichoke {
 
     fn try_convert_mut(&mut self, value: Option<Value>) -> Result<Option<Radix>, Self::Error> {
         if let Some(value) = value {
-            let num = value.implicitly_convert_to_int(self)?;
+            let num = implicitly_convert_to_int(self, value)?;
             let radix = u32::try_from(num).map_err(|_| ArgumentError::with_message("invalid radix"))?;
             if (2..=36).contains(&radix) {
                 Ok(Radix::new(radix))
@@ -158,7 +159,7 @@ impl<'a> TryConvertMut<&'a mut Value, IntegerString<'a>> for Artichoke {
         message.push_str(self.inspect_type_name_for_value(*value));
         message.push_str(" into Integer");
 
-        if let Ok(arg) = value.implicitly_convert_to_string(self) {
+        if let Ok(arg) = unsafe { implicitly_convert_to_string(self, value) } {
             if let Some(converted) = IntegerString::from_slice(arg) {
                 Ok(converted)
             } else {

--- a/artichoke-backend/src/extn/core/kernel/require.rs
+++ b/artichoke-backend/src/extn/core/kernel/require.rs
@@ -4,6 +4,7 @@ use bstr::ByteSlice;
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 
+use crate::convert::implicitly_convert_to_string;
 use crate::extn::prelude::*;
 use crate::ffi;
 use crate::fs::RUBY_LOAD_PATH;
@@ -12,7 +13,7 @@ use crate::state::parser::Context;
 const RUBY_EXTENSION: &str = "rb";
 
 pub fn load(interp: &mut Artichoke, mut filename: Value) -> Result<bool, Error> {
-    let filename = filename.implicitly_convert_to_string(interp)?;
+    let filename = unsafe { implicitly_convert_to_string(interp, &mut filename)? };
     if filename.find_byte(b'\0').is_some() {
         return Err(ArgumentError::with_message("path name contains null byte").into());
     }
@@ -37,7 +38,7 @@ pub fn load(interp: &mut Artichoke, mut filename: Value) -> Result<bool, Error> 
 }
 
 pub fn require(interp: &mut Artichoke, mut filename: Value, base: Option<RelativePath>) -> Result<bool, Error> {
-    let filename = filename.implicitly_convert_to_string(interp)?;
+    let filename = unsafe { implicitly_convert_to_string(interp, &mut filename)? };
     if filename.find_byte(b'\0').is_some() {
         return Err(ArgumentError::with_message("path name contains null byte").into());
     }

--- a/artichoke-backend/src/extn/core/matchdata/mod.rs
+++ b/artichoke-backend/src/extn/core/matchdata/mod.rs
@@ -15,6 +15,7 @@ use std::convert::TryFrom;
 use std::ops::{Bound, RangeBounds};
 use std::str;
 
+use crate::convert::{implicitly_convert_to_int, implicitly_convert_to_string};
 use crate::extn::core::regexp::backend::NilableString;
 use crate::extn::core::regexp::Regexp;
 use crate::extn::core::symbol::Symbol;
@@ -92,13 +93,13 @@ impl<'a> TryConvertMut<&'a mut Value, CaptureExtract<'a>> for Artichoke {
     type Error = TypeError;
 
     fn try_convert_mut(&mut self, value: &'a mut Value) -> Result<CaptureExtract<'a>, Self::Error> {
-        if let Ok(idx) = value.implicitly_convert_to_int(self) {
+        if let Ok(idx) = implicitly_convert_to_int(self, *value) {
             Ok(CaptureExtract::GroupIndex(idx))
         } else if let Ok(symbol) = unsafe { Symbol::unbox_from_value(value, self) } {
             let sym = symbol.id();
             Ok(CaptureExtract::Symbol(sym.into()))
         } else {
-            let name = value.implicitly_convert_to_string(self)?;
+            let name = unsafe { implicitly_convert_to_string(self, value)? };
             Ok(CaptureExtract::GroupName(name))
         }
     }

--- a/artichoke-backend/src/extn/core/matchdata/mod.rs
+++ b/artichoke-backend/src/extn/core/matchdata/mod.rs
@@ -90,7 +90,7 @@ pub enum CaptureExtract<'a> {
 }
 
 impl<'a> TryConvertMut<&'a mut Value, CaptureExtract<'a>> for Artichoke {
-    type Error = TypeError;
+    type Error = Error;
 
     fn try_convert_mut(&mut self, value: &'a mut Value) -> Result<CaptureExtract<'a>, Self::Error> {
         if let Ok(idx) = implicitly_convert_to_int(self, *value) {

--- a/artichoke-backend/src/extn/core/matchdata/trampoline.rs
+++ b/artichoke-backend/src/extn/core/matchdata/trampoline.rs
@@ -45,10 +45,10 @@ pub fn element_reference(
         CaptureAt::StartLen(start, len)
     } else if let Ok(index) = implicitly_convert_to_int(interp, elem) {
         CaptureAt::GroupIndex(index)
-    } else if let Ok(name) = unsafe { implicitly_convert_to_string(interp, &mut elem) } {
-        CaptureAt::GroupName(name)
     } else if let Ok(symbol) = unsafe { Symbol::unbox_from_value(&mut elem, interp) } {
         CaptureAt::GroupName(symbol.bytes(interp))
+    } else if let Ok(name) = unsafe { implicitly_convert_to_string(interp, &mut elem) } {
+        CaptureAt::GroupName(name)
     } else {
         // NOTE(lopopolo): Encapsulation is broken here by reaching into the
         // inner regexp.

--- a/artichoke-backend/src/extn/core/matchdata/trampoline.rs
+++ b/artichoke-backend/src/extn/core/matchdata/trampoline.rs
@@ -1,5 +1,6 @@
 use std::convert::TryFrom;
 
+use crate::convert::{implicitly_convert_to_int, implicitly_convert_to_string};
 use crate::extn::core::array::Array;
 use crate::extn::core::matchdata::{Capture, CaptureAt, CaptureExtract, MatchData};
 use crate::extn::core::regexp::Regexp;
@@ -39,12 +40,12 @@ pub fn element_reference(
 ) -> Result<Value, Error> {
     let data = unsafe { MatchData::unbox_from_value(&mut value, interp)? };
     let at = if let Some(len) = len {
-        let start = elem.implicitly_convert_to_int(interp)?;
-        let len = len.implicitly_convert_to_int(interp)?;
+        let start = implicitly_convert_to_int(interp, elem)?;
+        let len = implicitly_convert_to_int(interp, len)?;
         CaptureAt::StartLen(start, len)
-    } else if let Ok(index) = elem.implicitly_convert_to_int(interp) {
+    } else if let Ok(index) = implicitly_convert_to_int(interp, elem) {
         CaptureAt::GroupIndex(index)
-    } else if let Ok(name) = elem.implicitly_convert_to_string(interp) {
+    } else if let Ok(name) = unsafe { implicitly_convert_to_string(interp, &mut elem) } {
         CaptureAt::GroupName(name)
     } else if let Ok(symbol) = unsafe { Symbol::unbox_from_value(&mut elem, interp) } {
         CaptureAt::GroupName(symbol.bytes(interp))

--- a/artichoke-backend/src/extn/core/math/trampoline.rs
+++ b/artichoke-backend/src/extn/core/math/trampoline.rs
@@ -2,6 +2,7 @@
 
 use core::convert::TryFrom;
 
+use crate::convert::implicitly_convert_to_int;
 use crate::extn::prelude::*;
 
 pub fn acos(interp: &mut Artichoke, value: Value) -> Result<Fp, Error> {
@@ -105,9 +106,7 @@ pub fn hypot(interp: &mut Artichoke, value: Value, other: Value) -> Result<Fp, E
 #[allow(clippy::cast_possible_truncation)]
 pub fn ldexp(interp: &mut Artichoke, fraction: Value, exponent: Value) -> Result<Fp, Error> {
     let fraction = interp.coerce_to_float(fraction)?;
-    let exponent = exponent
-        .implicitly_convert_to_int(interp)
-        .map_err(|_| exponent.try_into::<Fp>(interp));
+    let exponent = implicitly_convert_to_int(interp, exponent).map_err(|_| exponent.try_into::<Fp>(interp));
     let exponent = match exponent {
         Ok(exp) => exp,
         Err(Ok(exp)) if exp.is_nan() => {

--- a/artichoke-backend/src/extn/core/random/mod.rs
+++ b/artichoke-backend/src/extn/core/random/mod.rs
@@ -85,7 +85,7 @@ impl Seed {
 }
 
 impl TryConvertMut<Value, Seed> for Artichoke {
-    type Error = TypeError;
+    type Error = Error;
 
     fn try_convert_mut(&mut self, value: Value) -> Result<Seed, Self::Error> {
         let seed = implicitly_convert_to_int(self, value)?;
@@ -94,7 +94,7 @@ impl TryConvertMut<Value, Seed> for Artichoke {
 }
 
 impl TryConvertMut<Option<Value>, Seed> for Artichoke {
-    type Error = TypeError;
+    type Error = Error;
 
     fn try_convert_mut(&mut self, value: Option<Value>) -> Result<Seed, Self::Error> {
         if let Some(value) = value {

--- a/artichoke-backend/src/extn/core/random/mod.rs
+++ b/artichoke-backend/src/extn/core/random/mod.rs
@@ -25,7 +25,7 @@ use spinoso_random::{
     ArgumentError as RandomArgumentError, InitializeError, NewSeedError, Random as SpinosoRandom, UrandomError,
 };
 
-use crate::convert::HeapAllocatedData;
+use crate::convert::{implicitly_convert_to_int, HeapAllocatedData};
 use crate::extn::prelude::*;
 
 #[doc(inline)]
@@ -88,7 +88,7 @@ impl TryConvertMut<Value, Seed> for Artichoke {
     type Error = TypeError;
 
     fn try_convert_mut(&mut self, value: Value) -> Result<Seed, Self::Error> {
-        let seed = value.implicitly_convert_to_int(self)?;
+        let seed = implicitly_convert_to_int(self, value)?;
         Ok(Seed::New(seed))
     }
 }
@@ -248,7 +248,7 @@ impl TryConvertMut<Option<Value>, Max> for Artichoke {
                     Ok(Max::Float(max))
                 }
                 _ => {
-                    let max = max.implicitly_convert_to_int(self).map_err(|_| {
+                    let max = implicitly_convert_to_int(self, max).map_err(|_| {
                         let mut message = b"invalid argument - ".to_vec();
                         message.extend(max.inspect(self));
                         ArgumentError::from(message)

--- a/artichoke-backend/src/extn/core/random/trampoline.rs
+++ b/artichoke-backend/src/extn/core/random/trampoline.rs
@@ -1,6 +1,7 @@
 //! Glue between mruby FFI and `ENV` Rust implementation.
 
 use super::{Random, Rng, Seed};
+use crate::convert::implicitly_convert_to_int;
 use crate::extn::prelude::*;
 
 pub fn initialize(interp: &mut Artichoke, seed: Option<Value>, into: Value) -> Result<Value, Error> {
@@ -20,7 +21,7 @@ pub fn equal(interp: &mut Artichoke, mut rand: Value, mut other: Value) -> Resul
 
 pub fn bytes(interp: &mut Artichoke, mut rand: Value, size: Value) -> Result<Value, Error> {
     let mut random = unsafe { Rng::unbox_from_value(&mut rand, interp)? };
-    let size = size.implicitly_convert_to_int(interp)?;
+    let size = implicitly_convert_to_int(interp, size)?;
     let buf = match random.as_mut() {
         Rng::Global => interp.prng_mut()?.bytes(size)?,
         Rng::Value(random) => random.bytes(size)?,
@@ -59,7 +60,7 @@ pub fn srand(interp: &mut Artichoke, seed: Option<Value>) -> Result<Value, Error
 }
 
 pub fn urandom(interp: &mut Artichoke, size: Value) -> Result<Value, Error> {
-    let size = size.implicitly_convert_to_int(interp)?;
+    let size = implicitly_convert_to_int(interp, size)?;
     let buf = super::urandom(size)?;
     Ok(interp.convert_mut(buf))
 }

--- a/artichoke-backend/src/extn/core/regexp/mod.rs
+++ b/artichoke-backend/src/extn/core/regexp/mod.rs
@@ -180,12 +180,8 @@ impl Regexp {
         let pattern_vec;
         let pattern = if matches!(other.ruby_type(), Ruby::Symbol) {
             let symbol = unsafe { Symbol::unbox_from_value(&mut other, interp)? };
-            if let Some(bytes) = interp.lookup_symbol(symbol.id())? {
-                pattern_vec = bytes.to_vec();
-                pattern_vec.as_slice()
-            } else {
-                &[]
-            }
+            pattern_vec = symbol.bytes(interp).to_vec();
+            pattern_vec.as_slice()
         } else if let Ok(pattern) = unsafe { implicitly_convert_to_string(interp, &mut other) } {
             pattern
         } else {

--- a/artichoke-backend/src/extn/core/regexp/opts.rs
+++ b/artichoke-backend/src/extn/core/regexp/opts.rs
@@ -1,6 +1,7 @@
 //! Parse options parameter to `Regexp#initialize` and `Regexp::compile`.
 
 use super::Options;
+use crate::convert::implicitly_convert_to_int;
 use crate::extn::prelude::*;
 
 impl ConvertMut<Value, Options> for Artichoke {
@@ -9,7 +10,7 @@ impl ConvertMut<Value, Options> for Artichoke {
         // Regexp::EXTENDED, Regexp::IGNORECASE, and Regexp::MULTILINE, logically
         // or-ed together. Otherwise, if options is not nil or false, the regexp
         // will be case insensitive.
-        if let Ok(options) = value.implicitly_convert_to_int(self) {
+        if let Ok(options) = implicitly_convert_to_int(self, value) {
             Options::from(options)
         } else if let Ok(options) = value.try_into::<Option<bool>>(self) {
             Options::from(options)

--- a/artichoke-backend/src/extn/core/regexp/trampoline.rs
+++ b/artichoke-backend/src/extn/core/regexp/trampoline.rs
@@ -21,12 +21,8 @@ pub fn escape(interp: &mut Artichoke, mut pattern: Value) -> Result<Value, Error
     let pattern_vec;
     let pattern = if matches!(pattern.ruby_type(), Ruby::Symbol) {
         let symbol = unsafe { Symbol::unbox_from_value(&mut pattern, interp)? };
-        if let Some(bytes) = interp.lookup_symbol(symbol.id())? {
-            pattern_vec = bytes.to_vec();
-            pattern_vec.as_slice()
-        } else {
-            &[]
-        }
+        pattern_vec = symbol.bytes(interp).to_vec();
+        pattern_vec.as_slice()
     } else {
         unsafe { implicitly_convert_to_string(interp, &mut pattern)? }
     };
@@ -70,12 +66,8 @@ pub fn match_(
     let pattern_vec;
     let pattern = if matches!(pattern.ruby_type(), Ruby::Symbol) {
         let symbol = unsafe { Symbol::unbox_from_value(&mut pattern, interp)? };
-        if let Some(bytes) = interp.lookup_symbol(symbol.id())? {
-            pattern_vec = bytes.to_vec();
-            Some(pattern_vec.as_slice())
-        } else {
-            None
-        }
+        pattern_vec = symbol.bytes(interp).to_vec();
+        Some(pattern_vec.as_slice())
     } else {
         unsafe { implicitly_convert_to_nilable_string(interp, &mut pattern)? }
     };
@@ -104,12 +96,8 @@ pub fn match_operator(interp: &mut Artichoke, mut regexp: Value, mut pattern: Va
     let pattern_vec;
     let pattern = if matches!(pattern.ruby_type(), Ruby::Symbol) {
         let symbol = unsafe { Symbol::unbox_from_value(&mut pattern, interp)? };
-        if let Some(bytes) = interp.lookup_symbol(symbol.id())? {
-            pattern_vec = bytes.to_vec();
-            Some(pattern_vec.as_slice())
-        } else {
-            None
-        }
+        pattern_vec = symbol.bytes(interp).to_vec();
+        Some(pattern_vec.as_slice())
     } else {
         unsafe { implicitly_convert_to_nilable_string(interp, &mut pattern)? }
     };

--- a/artichoke-backend/src/extn/core/regexp/trampoline.rs
+++ b/artichoke-backend/src/extn/core/regexp/trampoline.rs
@@ -1,5 +1,6 @@
 use std::convert::TryFrom;
 
+use crate::convert::{implicitly_convert_to_int, implicitly_convert_to_nilable_string, implicitly_convert_to_string};
 use crate::extn::core::regexp::Regexp;
 use crate::extn::prelude::*;
 
@@ -16,7 +17,7 @@ pub fn initialize(
 }
 
 pub fn escape(interp: &mut Artichoke, mut pattern: Value) -> Result<Value, Error> {
-    let pattern = pattern.implicitly_convert_to_string(interp)?;
+    let pattern = unsafe { implicitly_convert_to_string(interp, &mut pattern)? };
     let pattern = Regexp::escape(pattern)?;
     Ok(interp.convert_mut(pattern))
 }
@@ -36,9 +37,9 @@ pub fn is_match(
     pos: Option<Value>,
 ) -> Result<Value, Error> {
     let regexp = unsafe { Regexp::unbox_from_value(&mut regexp, interp)? };
-    let pattern = pattern.implicitly_convert_to_nilable_string(interp)?;
+    let pattern = unsafe { implicitly_convert_to_nilable_string(interp, &mut pattern)? };
     let pos = if let Some(pos) = pos {
-        Some(pos.implicitly_convert_to_int(interp)?)
+        Some(implicitly_convert_to_int(interp, pos)?)
     } else {
         None
     };
@@ -54,9 +55,9 @@ pub fn match_(
     block: Option<Block>,
 ) -> Result<Value, Error> {
     let regexp = unsafe { Regexp::unbox_from_value(&mut regexp, interp)? };
-    let pattern = pattern.implicitly_convert_to_nilable_string(interp)?;
+    let pattern = unsafe { implicitly_convert_to_nilable_string(interp, &mut pattern)? };
     let pos = if let Some(pos) = pos {
-        Some(pos.implicitly_convert_to_int(interp)?)
+        Some(implicitly_convert_to_int(interp, pos)?)
     } else {
         None
     };
@@ -77,7 +78,7 @@ pub fn case_compare(interp: &mut Artichoke, mut regexp: Value, other: Value) -> 
 
 pub fn match_operator(interp: &mut Artichoke, mut regexp: Value, mut pattern: Value) -> Result<Value, Error> {
     let regexp = unsafe { Regexp::unbox_from_value(&mut regexp, interp)? };
-    let pattern = pattern.implicitly_convert_to_nilable_string(interp)?;
+    let pattern = unsafe { implicitly_convert_to_nilable_string(interp, &mut pattern)? };
     let pos = regexp.match_operator(interp, pattern)?;
     match pos.map(Int::try_from) {
         Some(Ok(pos)) => Ok(interp.convert(pos)),

--- a/artichoke-backend/src/extn/core/string/trampoline.rs
+++ b/artichoke-backend/src/extn/core/string/trampoline.rs
@@ -1,5 +1,6 @@
 use bstr::ByteSlice;
 
+use crate::convert::implicitly_convert_to_string;
 #[cfg(feature = "core-regexp")]
 use crate::extn::core::matchdata::MatchData;
 #[cfg(feature = "core-regexp")]
@@ -36,7 +37,7 @@ pub fn scan(interp: &mut Artichoke, value: Value, mut pattern: Value, block: Opt
         return Ok(interp.try_convert_mut(scan)?.unwrap_or(value));
     }
     #[cfg(feature = "core-regexp")]
-    if let Ok(pattern_bytes) = pattern.implicitly_convert_to_string(interp) {
+    if let Ok(pattern_bytes) = unsafe { implicitly_convert_to_string(interp, &mut pattern) } {
         let string = value.try_into_mut::<&[u8]>(interp)?;
         if let Some(ref block) = block {
             let regex = Regexp::lazy(pattern_bytes.to_vec());
@@ -93,7 +94,7 @@ pub fn scan(interp: &mut Artichoke, value: Value, mut pattern: Value, block: Opt
         }
     }
     #[cfg(not(feature = "core-regexp"))]
-    if let Ok(pattern_bytes) = pattern.implicitly_convert_to_string(interp) {
+    if let Ok(pattern_bytes) = unsafe { implicitly_convert_to_string(interp, &mut pattern) } {
         let string = value.try_into_mut::<&[u8]>(interp)?;
         if let Some(ref block) = block {
             let patlen = pattern_bytes.len();

--- a/artichoke-backend/src/extn/stdlib/securerandom/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/securerandom/mod.rs
@@ -16,6 +16,7 @@
 //! [`SecureRandom`]: https://ruby-doc.org/stdlib-2.6.3/libdoc/securerandom/rdoc/SecureRandom.html
 //! [`getrandom`]: https://crates.io/crates/getrandom
 
+use crate::convert::implicitly_convert_to_int;
 use crate::extn::core::exception as exc;
 use crate::extn::prelude::*;
 
@@ -80,9 +81,9 @@ impl TryConvertMut<Option<Value>, Max> for Artichoke {
                     Ok(Max::Float(max))
                 }
                 _ => {
-                    let max = max.implicitly_convert_to_int(self).map_err(|_| {
+                    let max = implicitly_convert_to_int(self, max).map_err(|_| {
                         let mut message = b"invalid argument - ".to_vec();
-                        message.extend(max.inspect(self).as_slice());
+                        message.extend_from_slice(max.inspect(self).as_slice());
                         exc::ArgumentError::from(message)
                     })?;
                     Ok(Max::Integer(max))

--- a/artichoke-backend/src/extn/stdlib/securerandom/trampoline.rs
+++ b/artichoke-backend/src/extn/stdlib/securerandom/trampoline.rs
@@ -1,12 +1,13 @@
 //! Glue between mruby FFI and `securerandom` Rust implementation.
 
+use crate::convert::implicitly_convert_to_int;
 use crate::extn::prelude::*;
 use crate::extn::stdlib::securerandom;
 
 #[inline]
 pub fn alphanumeric(interp: &mut Artichoke, len: Option<Value>) -> Result<Value, Error> {
     let alpha = if let Some(len) = len {
-        let len = len.implicitly_convert_to_int(interp)?;
+        let len = implicitly_convert_to_int(interp, len)?;
         securerandom::alphanumeric(Some(len))?
     } else {
         securerandom::alphanumeric(None)?
@@ -17,7 +18,7 @@ pub fn alphanumeric(interp: &mut Artichoke, len: Option<Value>) -> Result<Value,
 #[inline]
 pub fn base64(interp: &mut Artichoke, len: Option<Value>) -> Result<Value, Error> {
     let base64 = if let Some(len) = len {
-        let len = len.implicitly_convert_to_int(interp)?;
+        let len = implicitly_convert_to_int(interp, len)?;
         securerandom::base64(Some(len))?
     } else {
         securerandom::base64(None)?
@@ -38,7 +39,7 @@ pub fn urlsafe_base64(interp: &mut Artichoke, len: Option<Value>, padding: Optio
         }
     };
     let base64 = if let Some(len) = len {
-        let len = len.implicitly_convert_to_int(interp)?;
+        let len = implicitly_convert_to_int(interp, len)?;
         securerandom::urlsafe_base64(Some(len), padding)?
     } else {
         securerandom::urlsafe_base64(None, padding)?
@@ -49,7 +50,7 @@ pub fn urlsafe_base64(interp: &mut Artichoke, len: Option<Value>, padding: Optio
 #[inline]
 pub fn hex(interp: &mut Artichoke, len: Option<Value>) -> Result<Value, Error> {
     let hex = if let Some(len) = len {
-        let len = len.implicitly_convert_to_int(interp)?;
+        let len = implicitly_convert_to_int(interp, len)?;
         securerandom::hex(Some(len))?
     } else {
         securerandom::hex(None)?
@@ -64,7 +65,7 @@ pub fn random_bytes(interp: &mut Artichoke, len: Option<Value>) -> Result<Value,
         // int.
         //
         // https://github.com/ruby/ruby/blob/v2_6_3/lib/securerandom.rb#L135
-        let len = len.implicitly_convert_to_int(interp)?;
+        let len = implicitly_convert_to_int(interp, len)?;
         securerandom::random_bytes(Some(len))?
     } else {
         securerandom::random_bytes(None)?


### PR DESCRIPTION
This PR moves the implicit conversion functions out of the `Value` impl and into their own module.

The implicit conversions are made to be more compatible with MRI, such as propagating exceptions from `to_int`/`to_str`.

The converters are well commented with REPL snippets from MRI corresponding to each branch. Each branch is tested via doctests. Each implicit conversion function is documented.

Implicit conversions to `String` are unsafe due to concerns about lifetime extension.

Implicit conversions to `String` no longer coerce `Symbol`s to `&[u8]`.

See #310.