### PR TITLE
Fix minimum bstr version, make scolapasta-string-escape no-std

### DIFF
--- a/scolapasta-string-escape/Cargo.toml
+++ b/scolapasta-string-escape/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["artichoke", "escape", "no_std", "ruby"]
 categories = ["encoding", "no-std", "parser-implementations"]
 
 [dependencies]
-bstr = { version = "0.2", default-features = false }
+bstr = { version = "0.2, >= 0.2.4", default-features = false }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/scolapasta-string-escape/src/lib.rs
+++ b/scolapasta-string-escape/src/lib.rs
@@ -86,6 +86,8 @@
 //! [`Symbol#inspect`]: https://ruby-doc.org/core-2.6.3/Symbol.html#method-i-inspect
 //! [`alloc`]: https://doc.rust-lang.org/alloc/
 
+#![no_std]
+
 // Having access to `String` in tests is convenient to collect `Inspect`
 // iterators for whole content comparisons.
 #[cfg(any(test, doctest))]

--- a/scolapasta-string-escape/src/string.rs
+++ b/scolapasta-string-escape/src/string.rs
@@ -63,7 +63,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::format_debug_escape_into;
-    use alloc::string::String;
+    use alloc::string::{String, ToString};
 
     #[test]
     fn format_ascii_message() {

--- a/spinoso-env/Cargo.toml
+++ b/spinoso-env/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["artichoke", "env", "environ", "spinoso"]
 categories = ["os", "wasm"]
 
 [dependencies]
-bstr = { version = "0.2", default-features = false }
+bstr = { version = "0.2, >= 0.2.4", default-features = false }
 scolapasta-string-escape = { version = "0.1", path = "../scolapasta-string-escape" }
 
 [features]

--- a/spinoso-regexp/Cargo.toml
+++ b/spinoso-regexp/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["data-structures", "parser-implementations"]
 
 [dependencies]
 bitflags = "1.2"
-bstr = { version = "0.2, >= 0.2.2", default-features = false }
+bstr = { version = "0.2, >= 0.2.4", default-features = false }
 itoa = "0.4"
 onig = { version = "6.1", default-features = false, optional = true }
 regex = { version = "1, >= 1.3", default-features = false, features = ["std", "unicode-perl"] }

--- a/spinoso-symbol/Cargo.toml
+++ b/spinoso-symbol/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["data-structures", "no-std", "parser-implementations"]
 
 [dependencies]
 artichoke-core = { version = "0.7", path = "../artichoke-core", default-features = false, optional = true }
-bstr = { version = "0.2", optional = true, default-features = false }
+bstr = { version = "0.2, >= 0.2.4", optional = true, default-features = false }
 focaccia = { version = "1.0", optional = true, default-features = false }
 scolapasta-string-escape = { version = "0.1", path = "../scolapasta-string-escape", optional = true }
 


### PR DESCRIPTION
For crates that depend on bstr without its std feature, require at least 0.2.4 to pull in BurntSushi/bstr@83e8f27ee6cef1a026dc8e38f8de2fca909cce39.