### PR TITLE
Use &'static CStr for Ruby class and module names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,6 +38,7 @@ dependencies = [
  "bindgen",
  "bstr",
  "cc",
+ "cstr",
  "intaglio",
  "itoa",
  "log",
@@ -186,6 +187,16 @@ dependencies = [
  "textwrap",
  "unicode-width",
  "vec_map",
+]
+
+[[package]]
+name = "cstr"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c11a39d776a3b35896711da8a04dc1835169dcd36f710878187637314e47941b"
+dependencies = [
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["api-bindings"]
 [dependencies]
 artichoke-core = { version = "0.7", path = "../artichoke-core" }
 bstr = { version = "0.2, >= 0.2.2", default-features = false, features = ["std"] }
+cstr = "0.2.8"
 intaglio = "1.2"
 itoa = "0.4"
 log = "0.4, >= 0.4.5"

--- a/artichoke-backend/src/convert/boxing.rs
+++ b/artichoke-backend/src/convert/boxing.rs
@@ -305,7 +305,13 @@ mod tests {
     #[test]
     fn convert_obj_roundtrip() {
         let mut interp = interpreter().unwrap();
-        let spec = class::Spec::new("Container", None, Some(def::box_unbox_free::<Container>)).unwrap();
+        let spec = class::Spec::new(
+            "Container",
+            cstr::cstr!("Container"),
+            None,
+            Some(def::box_unbox_free::<Container>),
+        )
+        .unwrap();
         class::Builder::for_spec(&mut interp, &spec)
             .value_is_rust_object()
             .add_method("value", container_value, sys::mrb_args_none())
@@ -335,7 +341,13 @@ mod tests {
     fn convert_obj_not_data() {
         let mut interp = interpreter().unwrap();
 
-        let spec = class::Spec::new("Container", None, Some(def::box_unbox_free::<Container>)).unwrap();
+        let spec = class::Spec::new(
+            "Container",
+            cstr::cstr!("Container"),
+            None,
+            Some(def::box_unbox_free::<Container>),
+        )
+        .unwrap();
         class::Builder::for_spec(&mut interp, &spec)
             .value_is_rust_object()
             .add_method("value", container_value, sys::mrb_args_none())
@@ -344,7 +356,13 @@ mod tests {
             .unwrap();
         interp.def_class::<Container>(spec).unwrap();
 
-        let spec = class::Spec::new("Flag", None, Some(def::box_unbox_free::<Box<Flag>>)).unwrap();
+        let spec = class::Spec::new(
+            "Flag",
+            cstr::cstr!("Flag"),
+            None,
+            Some(def::box_unbox_free::<Box<Flag>>),
+        )
+        .unwrap();
         class::Builder::for_spec(&mut interp, &spec)
             .value_is_rust_object()
             .define()

--- a/artichoke-backend/src/eval.rs
+++ b/artichoke-backend/src/eval.rs
@@ -122,7 +122,7 @@ mod tests {
             type Error = Error;
 
             fn require(interp: &mut Artichoke) -> Result<(), Self::Error> {
-                let spec = module::Spec::new(interp, "NestedEval", None)?;
+                let spec = module::Spec::new(interp, "NestedEval", cstr::cstr!("NestedEval"), None)?;
                 module::Builder::for_spec(interp, &spec)
                     .add_self_method("file", nested_eval_file, sys::mrb_args_none())?
                     .define()?;

--- a/artichoke-backend/src/extn/core/array/mruby.rs
+++ b/artichoke-backend/src/extn/core/array/mruby.rs
@@ -1,13 +1,16 @@
 use std::convert::TryFrom;
+use std::ffi::CStr;
 
 use crate::extn::core::array::{trampoline, Array};
 use crate::extn::prelude::*;
+
+const ARRAY_CSTR: &CStr = cstr::cstr!("Array");
 
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     if interp.is_class_defined::<Array>() {
         return Ok(());
     }
-    let spec = class::Spec::new("Array", None, Some(def::box_unbox_free::<Array>))?;
+    let spec = class::Spec::new("Array", ARRAY_CSTR, None, Some(def::box_unbox_free::<Array>))?;
     class::Builder::for_spec(interp, &spec)
         .add_self_method("[]", ary_cls_constructor, sys::mrb_args_rest())?
         .add_method("+", ary_plus, sys::mrb_args_req(1))?

--- a/artichoke-backend/src/extn/core/artichoke/mod.rs
+++ b/artichoke-backend/src/extn/core/artichoke/mod.rs
@@ -1,10 +1,14 @@
+use std::ffi::CStr;
+
 use crate::extn::prelude::*;
+
+const ARTICHOKE_CSTR: &CStr = cstr::cstr!("Artichoke");
 
 pub fn init(interp: &mut crate::Artichoke) -> InitializeResult<()> {
     if interp.is_module_defined::<Artichoke>() {
         return Ok(());
     }
-    let spec = module::Spec::new(interp, "Artichoke", None)?;
+    let spec = module::Spec::new(interp, "Artichoke", ARTICHOKE_CSTR, None)?;
     module::Builder::for_spec(interp, &spec).define()?;
     interp.def_module::<Artichoke>(spec)?;
     trace!("Patched Artichoke onto interpreter");

--- a/artichoke-backend/src/extn/core/comparable/mod.rs
+++ b/artichoke-backend/src/extn/core/comparable/mod.rs
@@ -1,10 +1,14 @@
+use std::ffi::CStr;
+
 use crate::extn::prelude::*;
+
+const COMPARABLE_CSTR: &CStr = cstr::cstr!("Comparable");
 
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     if interp.is_module_defined::<Comparable>() {
         return Ok(());
     }
-    let spec = module::Spec::new(interp, "Comparable", None)?;
+    let spec = module::Spec::new(interp, "Comparable", COMPARABLE_CSTR, None)?;
     module::Builder::for_spec(interp, &spec).define()?;
     interp.def_module::<Comparable>(spec)?;
     let _ = interp.eval(&include_bytes!("comparable.rb")[..])?;

--- a/artichoke-backend/src/extn/core/enumerable/mod.rs
+++ b/artichoke-backend/src/extn/core/enumerable/mod.rs
@@ -1,10 +1,14 @@
+use std::ffi::CStr;
+
 use crate::extn::prelude::*;
+
+const ENUMERABLE_CSTR: &CStr = cstr::cstr!("Enumerable");
 
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     if interp.is_module_defined::<Enumerable>() {
         return Ok(());
     }
-    let spec = module::Spec::new(interp, "Enumerable", None)?;
+    let spec = module::Spec::new(interp, "Enumerable", ENUMERABLE_CSTR, None)?;
     module::Builder::for_spec(interp, &spec).define()?;
     interp.def_module::<Enumerable>(spec)?;
     let _ = interp.eval(&include_bytes!("enumerable.rb")[..])?;

--- a/artichoke-backend/src/extn/core/enumerator/mod.rs
+++ b/artichoke-backend/src/extn/core/enumerator/mod.rs
@@ -1,10 +1,14 @@
+use std::ffi::CStr;
+
 use crate::extn::prelude::*;
+
+const ENUMERATOR_CSTR: &CStr = cstr::cstr!("Enumerator");
 
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     if interp.is_class_defined::<Enumerator>() {
         return Ok(());
     }
-    let spec = class::Spec::new("Enumerator", None, None)?;
+    let spec = class::Spec::new("Enumerator", ENUMERATOR_CSTR, None, None)?;
     interp.def_class::<Enumerator>(spec)?;
     let _ = interp.eval(&include_bytes!("enumerator.rb")[..])?;
     let _ = interp.eval(&include_bytes!("lazy.rb")[..])?;

--- a/artichoke-backend/src/extn/core/exception/mod.rs
+++ b/artichoke-backend/src/extn/core/exception/mod.rs
@@ -146,7 +146,7 @@ mod tests {
         type Error = Error;
 
         fn require(interp: &mut Artichoke) -> Result<(), Self::Error> {
-            let spec = class::Spec::new("Run", None, None).unwrap();
+            let spec = class::Spec::new("Run", cstr::cstr!("Run"), None, None).unwrap();
             class::Builder::for_spec(interp, &spec)
                 .add_self_method("run", run_run, sys::mrb_args_none())?
                 .define()?;

--- a/artichoke-backend/src/extn/core/exception/mruby.rs
+++ b/artichoke-backend/src/extn/core/exception/mruby.rs
@@ -1,207 +1,244 @@
 //! FFI glue between the Rust trampolines and the mruby C interpreter.
 
+use std::ffi::CStr;
+
 use crate::extn::prelude::*;
 
+const EXCEPTION_CSTR: &CStr = cstr::cstr!("Exception");
+const NO_MEMORY_CSTR: &CStr = cstr::cstr!("NoMemoryError");
+const SCRIPT_CSTR: &CStr = cstr::cstr!("ScriptError");
+const LOAD_CSTR: &CStr = cstr::cstr!("LoadError");
+const NOT_IMPLEMENTED_CSTR: &CStr = cstr::cstr!("NotImplementedError");
+const SYNTAX_CSTR: &CStr = cstr::cstr!("SyntaxError");
+const SECURITY_CSTR: &CStr = cstr::cstr!("SecurityError");
+const SIGNAL_CSTR: &CStr = cstr::cstr!("SignalException");
+const INTERRUPT_CSTR: &CStr = cstr::cstr!("Interrupt");
+const STANDARD_CSTR: &CStr = cstr::cstr!("StandardError");
+const ARGUMENT_CSTR: &CStr = cstr::cstr!("ArgumentError");
+const UNCAUGHT_THROW_CSTR: &CStr = cstr::cstr!("UncaughtThrowError");
+const ENCODING_CSTR: &CStr = cstr::cstr!("EncodingError");
+const FIBER_CSTR: &CStr = cstr::cstr!("FiberError");
+const IO_CSTR: &CStr = cstr::cstr!("IOError");
+const EOF_CSTR: &CStr = cstr::cstr!("EOFError");
+const INDEX_CSTR: &CStr = cstr::cstr!("IndexError");
+const KEY_CSTR: &CStr = cstr::cstr!("KeyError");
+const STOP_ITERATION_CSTR: &CStr = cstr::cstr!("StopIteration");
+const LOCAL_JUMP_CSTR: &CStr = cstr::cstr!("LocalJumpError");
+const NAME_CSTR: &CStr = cstr::cstr!("NameError");
+const NO_METHOD_CSTR: &CStr = cstr::cstr!("NoMethodError");
+const RANGE_CSTR: &CStr = cstr::cstr!("RangeError");
+const FLOAT_DOMAIN_CSTR: &CStr = cstr::cstr!("FloatDomainError");
+const REGEXP_CSTR: &CStr = cstr::cstr!("RegexpError");
+const RUNTIME_CSTR: &CStr = cstr::cstr!("RuntimeError");
+const FROZEN_CSTR: &CStr = cstr::cstr!("FrozenError");
+const SYSTEM_CALL_CSTR: &CStr = cstr::cstr!("SystemCallError");
+const THREAD_CSTR: &CStr = cstr::cstr!("ThreadError");
+const TYPE_CSTR: &CStr = cstr::cstr!("TypeError");
+const ZERO_DIVISION_CSTR: &CStr = cstr::cstr!("ZeroDivisionError");
+const SYSTEM_EXIT_CSTR: &CStr = cstr::cstr!("SystemExit");
+const SYSTEM_STACK_CSTR: &CStr = cstr::cstr!("SystemStackError");
+const FATAL_CSTR: &CStr = cstr::cstr!("fatal");
+
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
-    let exception_spec = class::Spec::new("Exception", None, None)?;
+    let exception_spec = class::Spec::new("Exception", EXCEPTION_CSTR, None, None)?;
     class::Builder::for_spec(interp, &exception_spec).define()?;
     interp.def_class::<Exception>(exception_spec)?;
 
-    let nomemory_spec = class::Spec::new("NoMemoryError", None, None)?;
+    let nomemory_spec = class::Spec::new("NoMemoryError", NO_MEMORY_CSTR, None, None)?;
     class::Builder::for_spec(interp, &nomemory_spec)
         .with_super_class::<Exception, _>("Exception")?
         .define()?;
     interp.def_class::<NoMemoryError>(nomemory_spec)?;
 
-    let script_spec = class::Spec::new("ScriptError", None, None)?;
+    let script_spec = class::Spec::new("ScriptError", SCRIPT_CSTR, None, None)?;
     class::Builder::for_spec(interp, &script_spec)
         .with_super_class::<Exception, _>("Exception")?
         .define()?;
     interp.def_class::<ScriptError>(script_spec)?;
 
-    let load_spec = class::Spec::new("LoadError", None, None)?;
+    let load_spec = class::Spec::new("LoadError", LOAD_CSTR, None, None)?;
     class::Builder::for_spec(interp, &load_spec)
         .with_super_class::<ScriptError, _>("ScriptError")?
         .define()?;
     interp.def_class::<LoadError>(load_spec)?;
 
-    let notimplemented_spec = class::Spec::new("NotImplementedError", None, None)?;
+    let notimplemented_spec = class::Spec::new("NotImplementedError", NOT_IMPLEMENTED_CSTR, None, None)?;
     class::Builder::for_spec(interp, &notimplemented_spec)
         .with_super_class::<ScriptError, _>("ScriptError")?
         .define()?;
     interp.def_class::<NotImplementedError>(notimplemented_spec)?;
 
-    let syntax_spec = class::Spec::new("SyntaxError", None, None)?;
+    let syntax_spec = class::Spec::new("SyntaxError", SYNTAX_CSTR, None, None)?;
     class::Builder::for_spec(interp, &syntax_spec)
         .with_super_class::<ScriptError, _>("ScriptError")?
         .define()?;
     interp.def_class::<SyntaxError>(syntax_spec)?;
 
-    let security_spec = class::Spec::new("SecurityError", None, None)?;
+    let security_spec = class::Spec::new("SecurityError", SECURITY_CSTR, None, None)?;
     class::Builder::for_spec(interp, &security_spec)
         .with_super_class::<Exception, _>("Exception")?
         .define()?;
     interp.def_class::<SecurityError>(security_spec)?;
 
-    let signal_spec = class::Spec::new("SignalException", None, None)?;
+    let signal_spec = class::Spec::new("SignalException", SIGNAL_CSTR, None, None)?;
     class::Builder::for_spec(interp, &signal_spec)
         .with_super_class::<Exception, _>("Exception")?
         .define()?;
     interp.def_class::<SignalException>(signal_spec)?;
 
-    let interrupt_spec = class::Spec::new("Interrupt", None, None)?;
+    let interrupt_spec = class::Spec::new("Interrupt", INTERRUPT_CSTR, None, None)?;
     class::Builder::for_spec(interp, &interrupt_spec)
         .with_super_class::<SignalException, _>("SignalException")?
         .define()?;
     interp.def_class::<Interrupt>(interrupt_spec)?;
 
     // Default for `rescue`.
-    let standard_spec = class::Spec::new("StandardError", None, None)?;
+    let standard_spec = class::Spec::new("StandardError", STANDARD_CSTR, None, None)?;
     class::Builder::for_spec(interp, &standard_spec)
         .with_super_class::<Exception, _>("Exception")?
         .define()?;
     interp.def_class::<StandardError>(standard_spec)?;
 
-    let argument_spec = class::Spec::new("ArgumentError", None, None)?;
+    let argument_spec = class::Spec::new("ArgumentError", ARGUMENT_CSTR, None, None)?;
     class::Builder::for_spec(interp, &argument_spec)
         .with_super_class::<StandardError, _>("StandardError")?
         .define()?;
     interp.def_class::<ArgumentError>(argument_spec)?;
 
-    let uncaughthrow_spec = class::Spec::new("UncaughtThrowError", None, None)?;
+    let uncaughthrow_spec = class::Spec::new("UncaughtThrowError", UNCAUGHT_THROW_CSTR, None, None)?;
     class::Builder::for_spec(interp, &uncaughthrow_spec)
         .with_super_class::<ArgumentError, _>("ArgumentError")?
         .define()?;
     interp.def_class::<UncaughtThrowError>(uncaughthrow_spec)?;
 
-    let encoding_spec = class::Spec::new("EncodingError", None, None)?;
+    let encoding_spec = class::Spec::new("EncodingError", ENCODING_CSTR, None, None)?;
     class::Builder::for_spec(interp, &encoding_spec)
         .with_super_class::<StandardError, _>("StandardError")?
         .define()?;
     interp.def_class::<EncodingError>(encoding_spec)?;
 
-    let fiber_spec = class::Spec::new("FiberError", None, None)?;
+    let fiber_spec = class::Spec::new("FiberError", FIBER_CSTR, None, None)?;
     class::Builder::for_spec(interp, &fiber_spec)
         .with_super_class::<StandardError, _>("StandardError")?
         .define()?;
     interp.def_class::<FiberError>(fiber_spec)?;
 
-    let io_spec = class::Spec::new("IOError", None, None)?;
+    let io_spec = class::Spec::new("IOError", IO_CSTR, None, None)?;
     class::Builder::for_spec(interp, &io_spec)
         .with_super_class::<StandardError, _>("StandardError")?
         .define()?;
     interp.def_class::<IOError>(io_spec)?;
 
-    let eof_spec = class::Spec::new("EOFError", None, None)?;
+    let eof_spec = class::Spec::new("EOFError", EOF_CSTR, None, None)?;
     class::Builder::for_spec(interp, &eof_spec)
         .with_super_class::<IOError, _>("IOError")?
         .define()?;
     interp.def_class::<EOFError>(eof_spec)?;
 
-    let index_spec = class::Spec::new("IndexError", None, None)?;
+    let index_spec = class::Spec::new("IndexError", INDEX_CSTR, None, None)?;
     class::Builder::for_spec(interp, &index_spec)
         .with_super_class::<StandardError, _>("StandardError")?
         .define()?;
     interp.def_class::<IndexError>(index_spec)?;
 
-    let key_spec = class::Spec::new("KeyError", None, None)?;
+    let key_spec = class::Spec::new("KeyError", KEY_CSTR, None, None)?;
     class::Builder::for_spec(interp, &key_spec)
         .with_super_class::<IndexError, _>("IndexError")?
         .define()?;
     interp.def_class::<KeyError>(key_spec)?;
 
-    let stopiteration_spec = class::Spec::new("StopIteration", None, None)?;
+    let stopiteration_spec = class::Spec::new("StopIteration", STOP_ITERATION_CSTR, None, None)?;
     class::Builder::for_spec(interp, &stopiteration_spec)
         .with_super_class::<IndexError, _>("IndexError")?
         .define()?;
     interp.def_class::<StopIteration>(stopiteration_spec)?;
 
-    let localjump_spec = class::Spec::new("LocalJumpError", None, None)?;
+    let localjump_spec = class::Spec::new("LocalJumpError", LOCAL_JUMP_CSTR, None, None)?;
     class::Builder::for_spec(interp, &localjump_spec)
         .with_super_class::<StandardError, _>("StandardError")?
         .define()?;
     interp.def_class::<LocalJumpError>(localjump_spec)?;
 
-    let name_spec = class::Spec::new("NameError", None, None)?;
+    let name_spec = class::Spec::new("NameError", NAME_CSTR, None, None)?;
     class::Builder::for_spec(interp, &name_spec)
         .with_super_class::<StandardError, _>("StandardError")?
         .define()?;
     interp.def_class::<NameError>(name_spec)?;
 
-    let nomethod_spec = class::Spec::new("NoMethodError", None, None)?;
+    let nomethod_spec = class::Spec::new("NoMethodError", NO_METHOD_CSTR, None, None)?;
     class::Builder::for_spec(interp, &nomethod_spec)
         .with_super_class::<NameError, _>("NameError")?
         .define()?;
     interp.def_class::<NoMethodError>(nomethod_spec)?;
 
-    let range_spec = class::Spec::new("RangeError", None, None)?;
+    let range_spec = class::Spec::new("RangeError", RANGE_CSTR, None, None)?;
     class::Builder::for_spec(interp, &range_spec)
         .with_super_class::<StandardError, _>("StandardError")?
         .define()?;
     interp.def_class::<RangeError>(range_spec)?;
 
-    let floatdomain_spec = class::Spec::new("FloatDomainError", None, None)?;
+    let floatdomain_spec = class::Spec::new("FloatDomainError", FLOAT_DOMAIN_CSTR, None, None)?;
     class::Builder::for_spec(interp, &floatdomain_spec)
         .with_super_class::<RangeError, _>("RangeError")?
         .define()?;
     interp.def_class::<FloatDomainError>(floatdomain_spec)?;
 
-    let regexp_spec = class::Spec::new("RegexpError", None, None)?;
+    let regexp_spec = class::Spec::new("RegexpError", REGEXP_CSTR, None, None)?;
     class::Builder::for_spec(interp, &regexp_spec)
         .with_super_class::<StandardError, _>("StandardError")?
         .define()?;
     interp.def_class::<RegexpError>(regexp_spec)?;
 
     // Default `Exception` type for `raise`.
-    let runtime_spec = class::Spec::new("RuntimeError", None, None)?;
+    let runtime_spec = class::Spec::new("RuntimeError", RUNTIME_CSTR, None, None)?;
     class::Builder::for_spec(interp, &runtime_spec)
         .with_super_class::<StandardError, _>("StandardError")?
         .define()?;
     interp.def_class::<RuntimeError>(runtime_spec)?;
 
-    let frozen_spec = class::Spec::new("FrozenError", None, None)?;
+    let frozen_spec = class::Spec::new("FrozenError", FROZEN_CSTR, None, None)?;
     class::Builder::for_spec(interp, &frozen_spec)
         .with_super_class::<RuntimeError, _>("RuntimeError")?
         .define()?;
     interp.def_class::<FrozenError>(frozen_spec)?;
 
-    let systemcall_spec = class::Spec::new("SystemCallError", None, None)?;
+    let systemcall_spec = class::Spec::new("SystemCallError", SYSTEM_CALL_CSTR, None, None)?;
     class::Builder::for_spec(interp, &systemcall_spec)
         .with_super_class::<StandardError, _>("StandardError")?
         .define()?;
     interp.def_class::<SystemCallError>(systemcall_spec)?;
 
-    let thread_spec = class::Spec::new("ThreadError", None, None)?;
+    let thread_spec = class::Spec::new("ThreadError", THREAD_CSTR, None, None)?;
     class::Builder::for_spec(interp, &thread_spec)
         .with_super_class::<StandardError, _>("StandardError")?
         .define()?;
     interp.def_class::<ThreadError>(thread_spec)?;
 
-    let type_spec = class::Spec::new("TypeError", None, None)?;
+    let type_spec = class::Spec::new("TypeError", TYPE_CSTR, None, None)?;
     class::Builder::for_spec(interp, &type_spec)
         .with_super_class::<StandardError, _>("StandardError")?
         .define()?;
     interp.def_class::<TypeError>(type_spec)?;
 
-    let zerodivision_spec = class::Spec::new("ZeroDivisionError", None, None)?;
+    let zerodivision_spec = class::Spec::new("ZeroDivisionError", ZERO_DIVISION_CSTR, None, None)?;
     class::Builder::for_spec(interp, &zerodivision_spec)
         .with_super_class::<StandardError, _>("StandardError")?
         .define()?;
     interp.def_class::<ZeroDivisionError>(zerodivision_spec)?;
 
-    let systemexit_spec = class::Spec::new("SystemExit", None, None)?;
+    let systemexit_spec = class::Spec::new("SystemExit", SYSTEM_EXIT_CSTR, None, None)?;
     class::Builder::for_spec(interp, &systemexit_spec)
         .with_super_class::<Exception, _>("Exception")?
         .define()?;
     interp.def_class::<SystemExit>(systemexit_spec)?;
 
-    let systemstack_spec = class::Spec::new("SystemStackError", None, None)?;
+    let systemstack_spec = class::Spec::new("SystemStackError", SYSTEM_STACK_CSTR, None, None)?;
     class::Builder::for_spec(interp, &systemstack_spec)
         .with_super_class::<Exception, _>("Exception")?
         .define()?;
     interp.def_class::<SystemStackError>(systemstack_spec)?;
 
-    let fatal_spec = class::Spec::new("fatal", None, None)?;
+    let fatal_spec = class::Spec::new("fatal", FATAL_CSTR, None, None)?;
     class::Builder::for_spec(interp, &fatal_spec)
         .with_super_class::<Exception, _>("Exception")?
         .define()?;

--- a/artichoke-backend/src/extn/core/float/mod.rs
+++ b/artichoke-backend/src/extn/core/float/mod.rs
@@ -1,11 +1,15 @@
+use std::ffi::CStr;
+
 use crate::extn::core::numeric::{self, Coercion, Outcome};
 use crate::extn::prelude::*;
+
+const FLOAT_CSTR: &CStr = cstr::cstr!("Float");
 
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     if interp.is_class_defined::<Float>() {
         return Ok(());
     }
-    let spec = class::Spec::new("Float", None, None)?;
+    let spec = class::Spec::new("Float", FLOAT_CSTR, None, None)?;
     interp.def_class::<Float>(spec)?;
     let _ = interp.eval(&include_bytes!("float.rb")[..])?;
 

--- a/artichoke-backend/src/extn/core/hash/mod.rs
+++ b/artichoke-backend/src/extn/core/hash/mod.rs
@@ -1,10 +1,14 @@
+use std::ffi::CStr;
+
 use crate::extn::prelude::*;
+
+const HASH_CSTR: &CStr = cstr::cstr!("Hash");
 
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     if interp.is_class_defined::<Hash>() {
         return Ok(());
     }
-    let spec = class::Spec::new("Hash", None, None)?;
+    let spec = class::Spec::new("Hash", HASH_CSTR, None, None)?;
     interp.def_class::<Hash>(spec)?;
     let _ = interp.eval(&include_bytes!("hash.rb")[..])?;
     trace!("Patched Hash onto interpreter");

--- a/artichoke-backend/src/extn/core/integer/mruby.rs
+++ b/artichoke-backend/src/extn/core/integer/mruby.rs
@@ -1,12 +1,16 @@
+use std::ffi::CStr;
+
 use crate::extn::core::integer::trampoline;
 use crate::extn::core::integer::Integer;
 use crate::extn::prelude::*;
+
+const INTEGER_CSTR: &CStr = cstr::cstr!("Integer");
 
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     if interp.is_class_defined::<Integer>() {
         return Ok(());
     }
-    let spec = class::Spec::new("Integer", None, None)?;
+    let spec = class::Spec::new("Integer", INTEGER_CSTR, None, None)?;
     class::Builder::for_spec(interp, &spec)
         .add_method("chr", artichoke_integer_chr, sys::mrb_args_opt(1))?
         .add_method("[]", artichoke_integer_element_reference, sys::mrb_args_req(1))?

--- a/artichoke-backend/src/extn/core/kernel/mruby.rs
+++ b/artichoke-backend/src/extn/core/kernel/mruby.rs
@@ -1,12 +1,16 @@
+use std::ffi::CStr;
+
 use crate::extn::core::artichoke;
 use crate::extn::core::kernel::{self, trampoline};
 use crate::extn::prelude::*;
+
+const KERNEL_CSTR: &CStr = cstr::cstr!("Kernel");
 
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     if interp.is_module_defined::<kernel::Kernel>() {
         return Ok(());
     }
-    let spec = module::Spec::new(interp, "Kernel", None)?;
+    let spec = module::Spec::new(interp, "Kernel", KERNEL_CSTR, None)?;
     module::Builder::for_spec(interp, &spec)
         .add_method("require", artichoke_kernel_require, sys::mrb_args_rest())?
         .add_method(
@@ -31,7 +35,7 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
         .module_spec::<artichoke::Artichoke>()?
         .map(EnclosingRubyScope::module)
         .ok_or_else(|| NotDefinedError::module("Artichoke"))?;
-    let spec = module::Spec::new(interp, "Kernel", Some(scope))?;
+    let spec = module::Spec::new(interp, "Kernel", KERNEL_CSTR, Some(scope))?;
     module::Builder::for_spec(interp, &spec)
         .add_method("Integer", artichoke_kernel_integer, sys::mrb_args_req_and_opt(1, 1))?
         .add_self_method("Integer", artichoke_kernel_integer, sys::mrb_args_req_and_opt(1, 1))?

--- a/artichoke-backend/src/extn/core/matchdata/mruby.rs
+++ b/artichoke-backend/src/extn/core/matchdata/mruby.rs
@@ -1,12 +1,20 @@
+use std::ffi::CStr;
+
 use crate::extn::core::matchdata::{self, trampoline};
 use crate::extn::prelude::*;
-use crate::sys;
+
+const MATCH_DATA_CSTR: &CStr = cstr::cstr!("MatchData");
 
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     if interp.is_class_defined::<matchdata::MatchData>() {
         return Ok(());
     }
-    let spec = class::Spec::new("MatchData", None, Some(def::box_unbox_free::<matchdata::MatchData>))?;
+    let spec = class::Spec::new(
+        "MatchData",
+        MATCH_DATA_CSTR,
+        None,
+        Some(def::box_unbox_free::<matchdata::MatchData>),
+    )?;
     class::Builder::for_spec(interp, &spec)
         .value_is_rust_object()
         .add_method("begin", artichoke_matchdata_begin, sys::mrb_args_req(1))?

--- a/artichoke-backend/src/extn/core/method/mod.rs
+++ b/artichoke-backend/src/extn/core/method/mod.rs
@@ -1,10 +1,14 @@
+use std::ffi::CStr;
+
 use crate::extn::prelude::*;
+
+const METHOD_CSTR: &CStr = cstr::cstr!("Method");
 
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     if interp.is_class_defined::<Method>() {
         return Ok(());
     }
-    let spec = class::Spec::new("Method", None, None)?;
+    let spec = class::Spec::new("Method", METHOD_CSTR, None, None)?;
     interp.def_class::<Method>(spec)?;
     let _ = interp.eval(&include_bytes!("method.rb")[..])?;
     trace!("Patched Method onto interpreter");

--- a/artichoke-backend/src/extn/core/module/mod.rs
+++ b/artichoke-backend/src/extn/core/module/mod.rs
@@ -1,10 +1,14 @@
+use std::ffi::CStr;
+
 use crate::extn::prelude::*;
+
+const MODULE_CSTR: &CStr = cstr::cstr!("Module");
 
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     if interp.is_class_defined::<Module>() {
         return Ok(());
     }
-    let spec = class::Spec::new("Module", None, None)?;
+    let spec = class::Spec::new("Module", MODULE_CSTR, None, None)?;
     interp.def_class::<Module>(spec)?;
     let _ = interp.eval(&include_bytes!("module.rb")[..])?;
     trace!("Patched Module onto interpreter");

--- a/artichoke-backend/src/extn/core/numeric/mod.rs
+++ b/artichoke-backend/src/extn/core/numeric/mod.rs
@@ -1,11 +1,15 @@
+use std::ffi::CStr;
+
 use crate::extn::core::integer::Integer;
 use crate::extn::prelude::*;
+
+const NUMERIC_CSTR: &CStr = cstr::cstr!("Numeric");
 
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     if interp.is_class_defined::<Numeric>() {
         return Ok(());
     }
-    let spec = class::Spec::new("Numeric", None, None)?;
+    let spec = class::Spec::new("Numeric", NUMERIC_CSTR, None, None)?;
     interp.def_class::<Numeric>(spec)?;
     let _ = interp.eval(&include_bytes!("numeric.rb")[..])?;
     trace!("Patched Numeric onto interpreter");

--- a/artichoke-backend/src/extn/core/object/mod.rs
+++ b/artichoke-backend/src/extn/core/object/mod.rs
@@ -1,10 +1,14 @@
+use std::ffi::CStr;
+
 use crate::extn::prelude::*;
+
+const OBJECT_CSTR: &CStr = cstr::cstr!("Object");
 
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     if interp.is_class_defined::<Object>() {
         return Ok(());
     }
-    let spec = class::Spec::new("Object", None, None)?;
+    let spec = class::Spec::new("Object", OBJECT_CSTR, None, None)?;
     interp.def_class::<Object>(spec)?;
     let _ = interp.eval(&include_bytes!("object.rb")[..])?;
     trace!("Patched Object onto interpreter");

--- a/artichoke-backend/src/extn/core/proc/mod.rs
+++ b/artichoke-backend/src/extn/core/proc/mod.rs
@@ -1,10 +1,14 @@
+use std::ffi::CStr;
+
 use crate::extn::prelude::*;
+
+const PROC_CSTR: &CStr = cstr::cstr!("Proc");
 
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     if interp.is_class_defined::<Proc>() {
         return Ok(());
     }
-    let spec = class::Spec::new("Proc", None, None)?;
+    let spec = class::Spec::new("Proc", PROC_CSTR, None, None)?;
     interp.def_class::<Proc>(spec)?;
     let _ = interp.eval(&include_bytes!("proc.rb")[..])?;
     trace!("Patched Proc onto interpreter");

--- a/artichoke-backend/src/extn/core/random/mruby.rs
+++ b/artichoke-backend/src/extn/core/random/mruby.rs
@@ -1,13 +1,17 @@
 //! FFI glue between the Rust trampolines and the mruby C interpreter.
 
+use std::ffi::CStr;
+
 use super::{trampoline, Rng};
 use crate::extn::prelude::*;
+
+const RANDOM_CSTR: &CStr = cstr::cstr!("Random");
 
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     if interp.is_class_defined::<Rng>() {
         return Ok(());
     }
-    let spec = class::Spec::new("Random", None, Some(def::box_unbox_free::<Rng>))?;
+    let spec = class::Spec::new("Random", RANDOM_CSTR, None, Some(def::box_unbox_free::<Rng>))?;
     class::Builder::for_spec(interp, &spec)
         .value_is_rust_object()
         .add_self_method("new_seed", random_self_new_seed, sys::mrb_args_req(1))?

--- a/artichoke-backend/src/extn/core/range/mod.rs
+++ b/artichoke-backend/src/extn/core/range/mod.rs
@@ -1,10 +1,14 @@
+use std::ffi::CStr;
+
 use crate::extn::prelude::*;
+
+const RANGE_CSTR: &CStr = cstr::cstr!("Range");
 
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     if interp.is_class_defined::<Range>() {
         return Ok(());
     }
-    let spec = class::Spec::new("Range", None, None)?;
+    let spec = class::Spec::new("Range", RANGE_CSTR, None, None)?;
     interp.def_class::<Range>(spec)?;
     let _ = interp.eval(&include_bytes!("range.rb")[..])?;
     trace!("Patched Range onto interpreter");

--- a/artichoke-backend/src/extn/core/regexp/mruby.rs
+++ b/artichoke-backend/src/extn/core/regexp/mruby.rs
@@ -1,14 +1,16 @@
 use std::convert::TryFrom;
+use std::ffi::CStr;
 
 use super::{trampoline, Flags, Regexp};
 use crate::extn::prelude::*;
-use crate::sys;
+
+const REGEXP_CSTR: &CStr = cstr::cstr!("Regexp");
 
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     if interp.is_class_defined::<Regexp>() {
         return Ok(());
     }
-    let spec = class::Spec::new("Regexp", None, Some(def::box_unbox_free::<Regexp>))?;
+    let spec = class::Spec::new("Regexp", REGEXP_CSTR, None, Some(def::box_unbox_free::<Regexp>))?;
     class::Builder::for_spec(interp, &spec)
         .value_is_rust_object()
         .add_method("initialize", initialize, sys::mrb_args_req_and_opt(1, 2))?

--- a/artichoke-backend/src/extn/core/string/mruby.rs
+++ b/artichoke-backend/src/extn/core/string/mruby.rs
@@ -1,11 +1,15 @@
+use std::ffi::CStr;
+
 use crate::extn::core::string::{self, trampoline};
 use crate::extn::prelude::*;
+
+const STRING_CSTR: &CStr = cstr::cstr!("String");
 
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     if interp.is_class_defined::<string::String>() {
         return Ok(());
     }
-    let spec = class::Spec::new("String", None, None)?;
+    let spec = class::Spec::new("String", STRING_CSTR, None, None)?;
     class::Builder::for_spec(interp, &spec)
         .add_method("ord", artichoke_string_ord, sys::mrb_args_none())?
         .add_method("scan", artichoke_string_scan, sys::mrb_args_req(1))?

--- a/artichoke-backend/src/extn/core/symbol/mruby.rs
+++ b/artichoke-backend/src/extn/core/symbol/mruby.rs
@@ -1,11 +1,15 @@
+use std::ffi::CStr;
+
 use crate::extn::core::symbol::{self, trampoline};
 use crate::extn::prelude::*;
+
+const SYMBOL_CSTR: &CStr = cstr::cstr!("Symbol");
 
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     if interp.is_class_defined::<symbol::Symbol>() {
         return Ok(());
     }
-    let spec = class::Spec::new("Symbol", None, None)?;
+    let spec = class::Spec::new("Symbol", SYMBOL_CSTR, None, None)?;
     class::Builder::for_spec(interp, &spec)
         .add_self_method("all_symbols", symbol_all_symbols, sys::mrb_args_none())?
         .add_method("==", symbol_equal_equal, sys::mrb_args_req(1))?

--- a/artichoke-backend/src/extn/core/thread/mod.rs
+++ b/artichoke-backend/src/extn/core/thread/mod.rs
@@ -1,4 +1,9 @@
+use std::ffi::CStr;
+
 use crate::extn::prelude::*;
+
+const THREAD_CSTR: &CStr = cstr::cstr!("Thread");
+const MUTEX_CSTR: &CStr = cstr::cstr!("Mutex");
 
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     if interp.is_class_defined::<Thread>() {
@@ -7,9 +12,9 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     if interp.is_class_defined::<Mutex>() {
         return Ok(());
     }
-    let spec = class::Spec::new("Thread", None, None)?;
+    let spec = class::Spec::new("Thread", THREAD_CSTR, None, None)?;
     interp.def_class::<Thread>(spec)?;
-    let spec = class::Spec::new("Mutex", None, None)?;
+    let spec = class::Spec::new("Mutex", MUTEX_CSTR, None, None)?;
     interp.def_class::<Mutex>(spec)?;
     interp.def_rb_source_file("thread.rb", &include_bytes!("thread.rb")[..])?;
     // Thread is loaded by default, so eval it on interpreter initialization

--- a/artichoke-backend/src/extn/core/time/mruby.rs
+++ b/artichoke-backend/src/extn/core/time/mruby.rs
@@ -1,13 +1,17 @@
 //! FFI glue between the Rust trampolines and the mruby C interpreter.
 
+use std::ffi::CStr;
+
 use crate::extn::core::time::{self, trampoline};
 use crate::extn::prelude::*;
+
+const TIME_CSTR: &CStr = cstr::cstr!("Time");
 
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     if interp.is_class_defined::<time::Time>() {
         return Ok(());
     }
-    let spec = class::Spec::new("Time", None, Some(def::box_unbox_free::<time::Time>))?;
+    let spec = class::Spec::new("Time", TIME_CSTR, None, Some(def::box_unbox_free::<time::Time>))?;
     // NOTE: The ordering of method declarations in the builder below is the
     // same as in `Init_Time` in MRI `time.c`.
     class::Builder::for_spec(interp, &spec)

--- a/artichoke-backend/src/extn/core/warning/mod.rs
+++ b/artichoke-backend/src/extn/core/warning/mod.rs
@@ -1,10 +1,14 @@
+use std::ffi::CStr;
+
 use crate::extn::prelude::*;
+
+const WARNING_CSTR: &CStr = cstr::cstr!("Warning");
 
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     if interp.is_module_defined::<Warning>() {
         return Ok(());
     }
-    let spec = module::Spec::new(interp, "Warning", None)?;
+    let spec = module::Spec::new(interp, "Warning", WARNING_CSTR, None)?;
     module::Builder::for_spec(interp, &spec).define()?;
     interp.def_module::<Warning>(spec)?;
     let _ = interp.eval(&include_bytes!("warning.rb")[..])?;

--- a/artichoke-backend/src/extn/stdlib/abbrev/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/abbrev/mod.rs
@@ -1,7 +1,11 @@
+use std::ffi::CStr;
+
 use crate::extn::prelude::*;
 
+const ABBREV_CSTR: &CStr = cstr::cstr!("Abbrev");
+
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
-    let spec = module::Spec::new(interp, "Abbrev", None)?;
+    let spec = module::Spec::new(interp, "Abbrev", ABBREV_CSTR, None)?;
     interp.def_module::<Abbrev>(spec)?;
     interp.def_rb_source_file("abbrev.rb", &include_bytes!("vendor/abbrev.rb")[..])?;
     Ok(())

--- a/artichoke-backend/src/extn/stdlib/base64/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/base64/mod.rs
@@ -1,7 +1,11 @@
+use std::ffi::CStr;
+
 use crate::extn::prelude::*;
 
+const BASE64_CSTR: &CStr = cstr::cstr!("Base64");
+
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
-    let spec = crate::module::Spec::new(interp, "Base64", None)?;
+    let spec = crate::module::Spec::new(interp, "Base64", BASE64_CSTR, None)?;
     interp.def_module::<Base64>(spec)?;
     interp.def_rb_source_file("base64.rb", &include_bytes!("vendor/base64.rb")[..])?;
 

--- a/artichoke-backend/src/extn/stdlib/cmath/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/cmath/mod.rs
@@ -1,7 +1,11 @@
+use std::ffi::CStr;
+
 use crate::extn::prelude::*;
 
+const CMATH_CSTR: &CStr = cstr::cstr!("CMath");
+
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
-    let spec = module::Spec::new(interp, "CMath", None)?;
+    let spec = module::Spec::new(interp, "CMath", CMATH_CSTR, None)?;
     interp.def_module::<CMath>(spec)?;
     interp.def_rb_source_file("cmath.rb", &include_bytes!("vendor/cmath.rb")[..])?;
     Ok(())

--- a/artichoke-backend/src/extn/stdlib/delegate/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/delegate/mod.rs
@@ -1,9 +1,14 @@
+use std::ffi::CStr;
+
 use crate::extn::prelude::*;
 
+const DELEGATOR_CSTR: &CStr = cstr::cstr!("Delegator");
+const SIMPLE_DELEGATOR_CSTR: &CStr = cstr::cstr!("SimpleDelegator");
+
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
-    let spec = class::Spec::new("Delegator", None, None)?;
+    let spec = class::Spec::new("Delegator", DELEGATOR_CSTR, None, None)?;
     interp.def_class::<Delegator>(spec)?;
-    let spec = class::Spec::new("SimpleDelegator", None, None)?;
+    let spec = class::Spec::new("SimpleDelegator", SIMPLE_DELEGATOR_CSTR, None, None)?;
     interp.def_class::<SimpleDelegator>(spec)?;
     interp.def_rb_source_file("delegate.rb", &include_bytes!("vendor/delegate.rb")[..])?;
     Ok(())

--- a/artichoke-backend/src/extn/stdlib/forwardable/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/forwardable/mod.rs
@@ -1,7 +1,11 @@
+use std::ffi::CStr;
+
 use crate::extn::prelude::*;
 
+const FORWARDABLE_CSTR: &CStr = cstr::cstr!("Forwardable");
+
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
-    let spec = module::Spec::new(interp, "Forwardable", None)?;
+    let spec = module::Spec::new(interp, "Forwardable", FORWARDABLE_CSTR, None)?;
     interp.def_module::<Forwardable>(spec)?;
     interp.def_rb_source_file("forwardable.rb", &include_bytes!("vendor/forwardable.rb")[..])?;
     interp.def_rb_source_file("forwardable/impl.rb", &include_bytes!("vendor/forwardable/impl.rb")[..])?;

--- a/artichoke-backend/src/extn/stdlib/json/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/json/mod.rs
@@ -1,7 +1,11 @@
+use std::ffi::CStr;
+
 use crate::extn::prelude::*;
 
+const JSON_CSTR: &CStr = cstr::cstr!("JSON");
+
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
-    let spec = module::Spec::new(interp, "JSON", None)?;
+    let spec = module::Spec::new(interp, "JSON", JSON_CSTR, None)?;
     interp.def_module::<Json>(spec)?;
     // NOTE(lopopolo): This setup of the JSON gem in the vfs does not include
     // any of the `json/add` sources for serializing "extra" types like `Time`

--- a/artichoke-backend/src/extn/stdlib/monitor/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/monitor/mod.rs
@@ -1,7 +1,11 @@
+use std::ffi::CStr;
+
 use crate::extn::prelude::*;
 
+const MONITOR_CSTR: &CStr = cstr::cstr!("Monitor");
+
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
-    let spec = class::Spec::new("Monitor", None, None)?;
+    let spec = class::Spec::new("Monitor", MONITOR_CSTR, None, None)?;
     interp.def_class::<Monitor>(spec)?;
     interp.def_rb_source_file("monitor.rb", &include_bytes!("vendor/monitor.rb")[..])?;
     Ok(())

--- a/artichoke-backend/src/extn/stdlib/ostruct/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/ostruct/mod.rs
@@ -1,7 +1,11 @@
+use std::ffi::CStr;
+
 use crate::extn::prelude::*;
 
+const OPEN_STRUCT_CSTR: &CStr = cstr::cstr!("OpenStruct");
+
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
-    let spec = class::Spec::new("OpenStruct", None, None)?;
+    let spec = class::Spec::new("OpenStruct", OPEN_STRUCT_CSTR, None, None)?;
     interp.def_class::<OpenStruct>(spec)?;
     interp.def_rb_source_file("ostruct.rb", &include_bytes!("vendor/ostruct.rb")[..])?;
     Ok(())

--- a/artichoke-backend/src/extn/stdlib/securerandom/mruby.rs
+++ b/artichoke-backend/src/extn/stdlib/securerandom/mruby.rs
@@ -1,7 +1,11 @@
 //! FFI glue between the Rust trampolines and the mruby C interpreter.
 
+use std::ffi::CStr;
+
 use crate::extn::prelude::*;
 use crate::extn::stdlib::securerandom::{self, trampoline};
+
+const SECURE_RANDOM_CSTR: &CStr = cstr::cstr!("SecureRandom");
 
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     interp.def_file_for_type::<_, SecureRandomFile>("securerandom.rb")?;
@@ -22,7 +26,7 @@ impl File for SecureRandomFile {
         if interp.is_module_defined::<securerandom::SecureRandom>() {
             return Ok(());
         }
-        let spec = module::Spec::new(interp, "SecureRandom", None)?;
+        let spec = module::Spec::new(interp, "SecureRandom", SECURE_RANDOM_CSTR, None)?;
         module::Builder::for_spec(interp, &spec)
             .add_self_method("alphanumeric", securerandom_alphanumeric, sys::mrb_args_opt(1))?
             .add_self_method("base64", securerandom_base64, sys::mrb_args_opt(1))?

--- a/artichoke-backend/src/extn/stdlib/set/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/set/mod.rs
@@ -1,9 +1,14 @@
+use std::ffi::CStr;
+
 use crate::extn::prelude::*;
 
+const SET_CSTR: &CStr = cstr::cstr!("Set");
+const SORTED_SET_CSTR: &CStr = cstr::cstr!("SortedSet");
+
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
-    let spec = class::Spec::new("Set", None, None)?;
+    let spec = class::Spec::new("Set", SET_CSTR, None, None)?;
     interp.def_class::<Set>(spec)?;
-    let spec = class::Spec::new("SortedSet", None, None)?;
+    let spec = class::Spec::new("SortedSet", SORTED_SET_CSTR, None, None)?;
     interp.def_class::<SortedSet>(spec)?;
     interp.def_rb_source_file("set.rb", &include_bytes!("vendor/set.rb")[..])?;
     Ok(())

--- a/artichoke-backend/src/extn/stdlib/shellwords/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/shellwords/mod.rs
@@ -1,7 +1,11 @@
+use std::ffi::CStr;
+
 use crate::extn::prelude::*;
 
+const SHELLWORDS_CSTR: &CStr = cstr::cstr!("Shellwords");
+
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
-    let spec = module::Spec::new(interp, "Shellwords", None)?;
+    let spec = module::Spec::new(interp, "Shellwords", SHELLWORDS_CSTR, None)?;
     interp.def_module::<Shellwords>(spec)?;
     interp.def_rb_source_file("shellwords.rb", &include_bytes!("vendor/shellwords.rb")[..])?;
     Ok(())

--- a/artichoke-backend/src/extn/stdlib/strscan/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/strscan/mod.rs
@@ -1,7 +1,11 @@
+use std::ffi::CStr;
+
 use crate::extn::prelude::*;
 
+const STRING_SCANNER_CSTR: &CStr = cstr::cstr!("StringScanner");
+
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
-    let spec = class::Spec::new("StringScanner", None, None)?;
+    let spec = class::Spec::new("StringScanner", STRING_SCANNER_CSTR, None, None)?;
     interp.def_class::<StringScanner>(spec)?;
     interp.def_rb_source_file("strscan.rb", &include_bytes!("strscan.rb")[..])?;
     Ok(())

--- a/artichoke-backend/src/extn/stdlib/uri/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/uri/mod.rs
@@ -1,13 +1,19 @@
+use std::ffi::CStr;
+
 use crate::extn::prelude::*;
 
+const IP_SOCKET_CSTR: &CStr = cstr::cstr!("IPSocket");
+const IP_ADDR_CSTR: &CStr = cstr::cstr!("IPAddr");
+const URI_CSTR: &CStr = cstr::cstr!("URI");
+
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
-    let spec = class::Spec::new("IPSocket", None, None)?;
+    let spec = class::Spec::new("IPSocket", IP_SOCKET_CSTR, None, None)?;
     interp.def_class::<IpSocket>(spec)?;
 
-    let spec = class::Spec::new("IPAddr", None, None)?;
+    let spec = class::Spec::new("IPAddr", IP_ADDR_CSTR, None, None)?;
     interp.def_class::<IpAddr>(spec)?;
 
-    let spec = module::Spec::new(interp, "URI", None)?;
+    let spec = module::Spec::new(interp, "URI", URI_CSTR, None)?;
     interp.def_module::<Uri>(spec)?;
 
     interp.def_rb_source_file("uri.rb", &include_bytes!("vendor/uri.rb")[..])?;

--- a/artichoke-backend/tests/leak_mrb_tt_data_rc.rs
+++ b/artichoke-backend/tests/leak_mrb_tt_data_rc.rs
@@ -49,7 +49,12 @@ impl File for Container {
     type Error = Error;
 
     fn require(interp: &mut Artichoke) -> Result<(), Self::Error> {
-        let spec = class::Spec::new("Container", None, Some(def::box_unbox_free::<Self>))?;
+        let spec = class::Spec::new(
+            "Container",
+            cstr::cstr!("Container"),
+            None,
+            Some(def::box_unbox_free::<Self>),
+        )?;
         class::Builder::for_spec(interp, &spec)
             .value_is_rust_object()
             .add_method("initialize", container_initialize, sys::mrb_args_req(1))?

--- a/artichoke-backend/tests/manual.rs
+++ b/artichoke-backend/tests/manual.rs
@@ -41,7 +41,12 @@ impl File for Container {
     type Error = Error;
 
     fn require(interp: &mut Artichoke) -> Result<(), Self::Error> {
-        let spec = class::Spec::new("Container", None, Some(def::box_unbox_free::<Box<Self>>))?;
+        let spec = class::Spec::new(
+            "Container",
+            cstr::cstr!("Container"),
+            None,
+            Some(def::box_unbox_free::<Box<Self>>),
+        )?;
         class::Builder::for_spec(interp, &spec)
             .value_is_rust_object()
             .add_method("initialize", container_initialize, sys::mrb_args_req(1))?

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -32,6 +32,7 @@ dependencies = [
  "bindgen",
  "bstr",
  "cc",
+ "cstr",
  "intaglio",
  "itoa",
  "log",
@@ -161,6 +162,16 @@ dependencies = [
  "glob",
  "libc",
  "libloading",
+]
+
+[[package]]
+name = "cstr"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c11a39d776a3b35896711da8a04dc1835169dcd36f710878187637314e47941b"
+dependencies = [
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -36,6 +36,7 @@ dependencies = [
  "bindgen",
  "bstr",
  "cc",
+ "cstr",
  "intaglio",
  "itoa",
  "log",
@@ -183,6 +184,16 @@ dependencies = [
  "textwrap",
  "unicode-width",
  "vec_map",
+]
+
+[[package]]
+name = "cstr"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c11a39d776a3b35896711da8a04dc1835169dcd36f710878187637314e47941b"
+dependencies = [
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]


### PR DESCRIPTION
Add a dependency on the (awesome) `cstr` crate, which exposes a
const-compatible proc macro for generating C strings at compile time
with static lifetime.

This aligns `artichoke-backend` more closely with how mruby expects to
construct `mrb_data_type`s. mruby expects these to be statics in C
sources.