### PR TITLE
Add a spec-runner configuration that tests all of Ruby Core

### DIFF
--- a/artichoke-backend/vendor/mruby/src/object.c
+++ b/artichoke-backend/vendor/mruby/src/object.c
@@ -338,7 +338,11 @@ mrb_convert_type(mrb_state *mrb, mrb_value val, enum mrb_vtype type, const char 
   if (mrb_type(val) == type) return val;
   v = convert_type(mrb, val, tname, method, TRUE);
   if (mrb_type(v) != type) {
-    mrb_raisef(mrb, E_TYPE_ERROR, "%v cannot be converted to %s by #%s", val, tname, method);
+    if (type == MRB_TT_STRING) {
+      mrb_raisef(mrb, E_TYPE_ERROR, "value cannot be converted to %s by #%s", tname, method);
+    } else {
+      mrb_raisef(mrb, E_TYPE_ERROR, "%v cannot be converted to %s by #%s", val, tname, method);
+    }
   }
   return v;
 }

--- a/spec-runner/all-core-specs.toml
+++ b/spec-runner/all-core-specs.toml
@@ -1,0 +1,260 @@
+# This config file lists the ruby/specs that should pass for Artichoke Ruby.
+#
+# Valid values for `include` are:
+#
+# - all - run all specs. When `include` is set to `all`, the optional `skip`
+#   field may list specs to skip.
+# - none - run no specs, equivalent to the section not being present in this
+#   config file.
+# - `set` - run an enumerated set of specs. When `include` is set to `set`, the
+#   set of specs must be listed in the required `specs` field, which is a list
+#   of strings.
+
+## Ruby Core
+
+[specs.core.argf]
+include = "all"
+
+[specs.core.array]
+include = "set"
+specs = [
+  "any",
+  "append",
+  "array",
+  "assoc",
+  "at",
+  "clear",
+  "collect",
+  "combination",
+  "compact",
+  "concat",
+  "constructor",
+  "count",
+  "cycle",
+  "delete",
+  "delete_at",
+  "delete_if",
+  "drop",
+  "drop_while",
+  "each",
+  "each_index",
+  "empty",
+  "first",
+  "frozen",
+  "include",
+  "last",
+  "length",
+  "map",
+  "multiply",
+  "plus",
+  "prepend",
+  "push",
+  "rassoc",
+  "replace",
+  "reverse",
+  "reverse_each",
+  "shift",
+  "size",
+  "sort_by",
+  "to_ary",
+  "try_convert",
+  "unshift",
+]
+
+[specs.core.basicobject]
+include = "all"
+
+[specs.core.binding]
+include = "all"
+
+[specs.core.builtin_constants]
+include = "all"
+
+[specs.core.class]
+include = "all"
+
+[specs.core.comparable]
+include = "all"
+
+[specs.core.complex]
+include = "all"
+
+[specs.core.dir]
+include = "all"
+
+[specs.core.encoding]
+include = "all"
+
+[specs.core.enumerable]
+include = "all"
+
+[specs.core.enumerator]
+include = "all"
+
+[specs.core.env]
+include = "all"
+
+[specs.core.exception]
+include = "all"
+
+[specs.core.false]
+include = "all"
+
+[specs.core.fiber]
+include = "all"
+
+[specs.core.file]
+include = "all"
+
+[specs.core.filetest]
+include = "all"
+
+[specs.core.float]
+include = "all"
+
+[specs.core.gc]
+include = "all"
+
+[specs.core.hash]
+include = "all"
+
+[specs.core.integer]
+include = "all"
+
+[specs.core.io]
+include = "none"
+
+[specs.core.kernel]
+include = "none"
+
+[specs.core.main]
+include = "all"
+
+[specs.core.marshal]
+include = "all"
+
+[specs.core.matchdata]
+include = "all"
+
+[specs.core.math]
+include = "all"
+
+[specs.core.method]
+include = "all"
+
+[specs.core.module]
+include = "all"
+
+[specs.core.mutex]
+include = "none"
+
+[specs.core.nil]
+include = "all"
+
+[specs.core.numeric]
+include = "all"
+
+[specs.core.objectspace]
+include = "none"
+
+[specs.core.proc]
+include = "all"
+
+[specs.core.process]
+include = "none"
+
+[specs.core.queue]
+include = "all"
+
+[specs.core.random]
+include = "all"
+
+[specs.core.range]
+include = "all"
+
+[specs.core.rational]
+include = "all"
+
+[specs.core.regexp]
+include = "all"
+
+[specs.core.signal]
+include = "all"
+
+[specs.core.sizedqueue]
+include = "all"
+
+[specs.core.string]
+include = "all"
+
+[specs.core.struct]
+include = "all"
+
+[specs.core.symbol]
+include = "all"
+
+[specs.core.systemexit]
+include = "all"
+
+[specs.core.thread]
+include = "none"
+
+[specs.core.threadgroup]
+include = "none"
+
+[specs.core.time]
+include = "all"
+
+[specs.core.tracepoint]
+include = "none"
+
+[specs.core.true]
+include = "all"
+
+[specs.core.unboundmethod]
+include = "all"
+
+[specs.core.warning]
+include = "all"
+
+## Ruby Standard Library
+
+[specs.library.abbrev]
+include = "all"
+
+[specs.library.base64]
+include = "all"
+
+[specs.library.delegate]
+include = "none"
+
+[specs.library.monitor]
+include = "all"
+
+[specs.library.securerandom]
+include = "all"
+skip = [
+  # specs require ASCII-8BIT / BINARY encoding for `String`s
+  "random_bytes",
+  # missing support for Bignum and Range arguments
+  "random_number",
+]
+
+[specs.library.shellwords]
+include = "all"
+skip = [
+  # missing `String#gsub` support for back references
+  "shellwords",
+]
+
+[specs.library.stringscanner]
+include = "all"
+
+[specs.library.time]
+# missing `date` package
+include = "none"
+
+[specs.library.uri]
+include = "all"
+skip = ["parse"]
+


### PR DESCRIPTION
It runs to completion!

```
Passed 4500, skipped 1097, not implemented 774, failed 5188 specs.
```

Gist with the full error log: https://gist.github.com/lopopolo/d7f758a4482a64ede6bb8a77918baba6.

There are still a few segfaults in there, but as configured, the specs reliably execute to completion.

This change adds a self-referential Hash check to `Hash#inspect` to prevent a stack overflow.

This change modifes `mrb_convert_type` to prevent a recursive attempt to raise a `TypeError` when attempting to convert a type to `String` that doesn't implement `#to_s`. This was fixed upstream in https://github.com/mruby/mruby/commit/01a8d8498fc3c1b107b303661d06b858858fce26.

The `all-core-specs.toml` configuration enables all top-level specs in `spec-runner/vendor/spec/core` except:

- `IO` (attempts to instantiate a binary `Regexp` that aborts the spec-runner)
- `Kernel` (infinite loop somewhere in there)
- `Mutex`
- `ObjectSpace`
- `Process`
- `Thread`
- `ThreadGroup`
- `TracePoint`

This config also copies the permitted spec list from `enforced-specs.toml` for `Array`. `Array#initialize` specs have an exception that crashes the spec-runner.