### PR TITLE
Concatenate -e flags in CLI before eval

### DIFF
--- a/src/ruby.rs
+++ b/src/ruby.rs
@@ -166,13 +166,20 @@ where
     if let Some(fixture) = fixture {
         setup_fixture_hack(interp, fixture)?;
     }
+    let mut commands = commands.into_iter();
+    let mut buf = if let Some(command) = commands.next() {
+        command
+    } else {
+        return Ok(Ok(()));
+    };
     for command in commands {
-        if let Err(ref exc) = interp.eval_os_str(command.as_os_str()) {
-            backtrace::format_cli_trace_into(error, interp, exc)?;
-            // short circuit, but don't return an error since we already printed it
-            return Ok(Err(()));
-        }
-        interp.add_fetch_lineno(1)?;
+        buf.push("\n");
+        buf.push(command);
+    }
+    if let Err(ref exc) = interp.eval_os_str(&buf) {
+        backtrace::format_cli_trace_into(error, interp, exc)?;
+        // short circuit, but don't return an error since we already printed it
+        return Ok(Err(()));
     }
     Ok(Ok(()))
 }


### PR DESCRIPTION
MRI Ruby's CLI can run multiple `-e` commands even when individual commands have malformed syntax:

```console
$ ruby -e '2.times {' -e 'puts "foo: #{__LINE__}"' -e '}'
foo: 2
foo: 2
```

Artichoke's CLI currently evals each `-e` command one at a time and manually increments the parser line number. This same set of commands fails with a syntax error:

```console
$ cargo -q run --bin artichoke -- -e '2.times {' -e 'puts "foo"' -e '}'
syntax error (SyntaxError)
```

With this patch, Artichoke's Ruby CLI frontend collects all given `-e` commands into a single `OsString`, separating each command with a newline. This results in the correct behavior:

```console
$ cargo -q run --bin artichoke -- -e '2.times {' -e 'puts "foo: #{__LINE__}"' -e '}'
foo: 2
foo: 2
```