### PR TITLE
Add a new spinoso-array backend based on TinyVec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -540,9 +540,10 @@ checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "spinoso-array"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "smallvec",
+ "tinyvec",
 ]
 
 [[package]]
@@ -663,6 +664,21 @@ checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
 dependencies = [
  "once_cell",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "317cca572a0e89c3ce0ca1f1bdc9369547fe318a683418e42ac8f59d14701023"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "unicode-segmentation"

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -20,7 +20,7 @@ log = "0.4, >= 0.4.5"
 once_cell = "1"
 regex = "1"
 scolapasta-string-escape = { version = "0.1", path = "../scolapasta-string-escape" }
-spinoso-array = { version = "0.4", path = "../spinoso-array", default-features = false }
+spinoso-array = { version = "0.5", path = "../spinoso-array", default-features = false }
 spinoso-env = { version = "0.1", path = "../spinoso-env", optional = true }
 spinoso-exception = { version = "0.1", path = "../spinoso-exception" }
 spinoso-math = { version = "0.1", path = "../spinoso-math", optional = true }

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -453,7 +453,7 @@ checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 
 [[package]]
 name = "spinoso-array"
-version = "0.4.0"
+version = "0.5.0"
 
 [[package]]
 name = "spinoso-env"

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -548,7 +548,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-array"
-version = "0.4.0"
+version = "0.5.0"
 
 [[package]]
 name = "spinoso-env"

--- a/spinoso-array/Cargo.toml
+++ b/spinoso-array/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spinoso-array"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2018"
 description = """
@@ -18,12 +18,16 @@ categories = ["data-structures", "no-std"]
 # 1.6.1 fixed a buffer overflow when calling `SmallVec::insert_many`.
 # https://github.com/servo/rust-smallvec/issues/252
 smallvec = { version = "1, >= 1.6.1", optional = true }
+tinyvec = { version = "1.1", optional = true, default-features = false, features = ["alloc"] }
 
 [features]
-default = ["small-array"]
+default = ["small-array", "tiny-array"]
 # Add a `SmallArray` backend that implements the small vector optimization with
 # the `smallvec` crate.
 small-array = ["smallvec"]
+# Add a `TinyArray` backend that implements the small vector optimization with
+# the `tinyvec` crate.
+tiny-array = ["tinyvec"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/spinoso-array/src/array/mod.rs
+++ b/spinoso-array/src/array/mod.rs
@@ -3,6 +3,7 @@
 //! This module contains multiple implementations of a backing store for the
 //! Ruby `Array` core class. [`Array`](vec::Array) is based on the [`Vec`] type
 //! in `std`. [`SmallArray`](smallvec::SmallArray) is based on [`SmallVec`].
+//! [`TinyArray`](tinyvec::TinyArray) is based on [`TinyVec`].
 //!
 //! The smallvec backend uses small vector optimization to store
 //! [some elements][inline-capacity] inline without spilling to the heap.
@@ -13,16 +14,17 @@
 //! [`Array`]: https://ruby-doc.org/core-2.6.3/Array.html
 //! [`Vec`]: alloc::vec::Vec
 //! [`SmallVec`]: ::smallvec::SmallVec
+//! [`TinyVec`]: ::tinyvec::TinyVec
 //! [inline-capacity]: INLINE_CAPACITY
 
 #[cfg(feature = "small-array")]
 pub mod smallvec;
+#[cfg(feature = "tiny-array")]
+pub mod tinyvec;
 pub mod vec;
 
 /// Vectors that implement the small vector optimization can store 8 elements
 /// inline without a heap allocation.
-///
-/// See [`SmallArray`](smallvec::SmallArray).
-#[cfg(feature = "small-array")]
-#[cfg_attr(docsrs, doc(cfg(feature = "small-array")))]
+#[cfg(any(feature = "small-array", feature = "tiny-array"))]
+#[cfg_attr(docsrs, doc(cfg(any(feature = "small-array", feature = "tiny-array"))))]
 pub const INLINE_CAPACITY: usize = 8;

--- a/spinoso-array/src/array/tinyvec/convert.rs
+++ b/spinoso-array/src/array/tinyvec/convert.rs
@@ -1,0 +1,432 @@
+use alloc::borrow::Cow;
+use alloc::boxed::Box;
+use alloc::rc::Rc;
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+use core::iter::FromIterator;
+
+use smallvec::SmallVec;
+
+use crate::array::smallvec::SmallArray;
+use crate::array::vec::Array;
+use crate::array::INLINE_CAPACITY;
+
+impl<T> From<Vec<T>> for SmallArray<T> {
+    #[inline]
+    fn from(values: Vec<T>) -> Self {
+        Self(values.into())
+    }
+}
+
+impl<T> From<SmallArray<T>> for Vec<T> {
+    #[inline]
+    fn from(values: SmallArray<T>) -> Self {
+        values.into_vec()
+    }
+}
+
+impl<'a, T> From<&'a [T]> for SmallArray<T>
+where
+    T: Copy,
+{
+    #[inline]
+    fn from(values: &'a [T]) -> Self {
+        Self(SmallVec::from_slice(values))
+    }
+}
+
+impl<'a, T> From<&'a mut [T]> for SmallArray<T>
+where
+    T: Copy,
+{
+    #[inline]
+    fn from(values: &'a mut [T]) -> Self {
+        Self(SmallVec::from_slice(values))
+    }
+}
+
+impl<T> From<Box<[T]>> for SmallArray<T> {
+    #[inline]
+    fn from(values: Box<[T]>) -> Self {
+        Self(Vec::from(values).into())
+    }
+}
+
+impl<T> From<SmallArray<T>> for Box<[T]> {
+    #[inline]
+    fn from(values: SmallArray<T>) -> Self {
+        values.into_boxed_slice()
+    }
+}
+
+impl<'a, T> From<Cow<'a, [T]>> for SmallArray<T>
+where
+    T: Copy,
+{
+    #[inline]
+    fn from(values: Cow<'a, [T]>) -> Self {
+        match values {
+            Cow::Borrowed(slice) => slice.into(),
+            Cow::Owned(vec) => vec.into(),
+        }
+    }
+}
+
+impl<'a, T> From<SmallArray<T>> for Cow<'a, [T]>
+where
+    T: Clone,
+{
+    #[inline]
+    fn from(values: SmallArray<T>) -> Self {
+        values.into_vec().into()
+    }
+}
+
+impl<T> From<SmallArray<T>> for Rc<[T]> {
+    #[inline]
+    fn from(values: SmallArray<T>) -> Self {
+        values.into_vec().into()
+    }
+}
+
+impl<T> From<SmallArray<T>> for Arc<[T]> {
+    #[inline]
+    fn from(values: SmallArray<T>) -> Self {
+        values.into_vec().into()
+    }
+}
+
+// The below hand-crafted `From` implementations for fixed-sized arrays length 8
+// or shorter relies on the parameterized fixed array of `SmallArray`s
+// underlying `SmallVec` being `[T; 8]` to avoid allocating (and making the
+// hand rolled implementations worthwhile instead of delegating to
+// `<[_]>::to_vec`.
+const _: () = [()][!(INLINE_CAPACITY == 8) as usize];
+
+impl<T> From<[T; 0]> for SmallArray<T> {
+    #[inline]
+    fn from(values: [T; 0]) -> Self {
+        // Values is empty, so it can be ignored.
+        let _ = values;
+        Self::new()
+    }
+}
+
+impl<T> From<&[T; 0]> for SmallArray<T> {
+    #[inline]
+    fn from(values: &[T; 0]) -> Self {
+        // Values is empty, so it can be ignored.
+        let _ = values;
+        Self::new()
+    }
+}
+
+impl<T> From<[T; 1]> for SmallArray<T> {
+    #[inline]
+    fn from(values: [T; 1]) -> Self {
+        let [a] = values;
+        let mut vec = SmallVec::new();
+        vec.push(a);
+        Self(vec)
+    }
+}
+
+impl<T> From<&[T; 1]> for SmallArray<T>
+where
+    T: Copy,
+{
+    #[inline]
+    fn from(values: &[T; 1]) -> Self {
+        let mut vec = SmallVec::new();
+        for value in values.iter().copied() {
+            vec.push(value);
+        }
+        Self(vec)
+    }
+}
+
+impl<T> From<[T; 2]> for SmallArray<T> {
+    #[inline]
+    fn from(values: [T; 2]) -> Self {
+        let [a, b] = values;
+        let mut vec = SmallVec::new();
+        vec.push(a);
+        vec.push(b);
+        Self(vec)
+    }
+}
+
+impl<T> From<&[T; 2]> for SmallArray<T>
+where
+    T: Copy,
+{
+    #[inline]
+    fn from(values: &[T; 2]) -> Self {
+        let mut vec = SmallVec::new();
+        for value in values.iter().copied() {
+            vec.push(value);
+        }
+        Self(vec)
+    }
+}
+
+impl<T> From<[T; 3]> for SmallArray<T> {
+    #[inline]
+    fn from(values: [T; 3]) -> Self {
+        let [a, b, c] = values;
+        let mut vec = SmallVec::new();
+        vec.push(a);
+        vec.push(b);
+        vec.push(c);
+        Self(vec)
+    }
+}
+
+impl<T> From<&[T; 3]> for SmallArray<T>
+where
+    T: Copy,
+{
+    #[inline]
+    fn from(values: &[T; 3]) -> Self {
+        let mut vec = SmallVec::new();
+        for value in values.iter().copied() {
+            vec.push(value);
+        }
+        Self(vec)
+    }
+}
+
+impl<T> From<[T; 4]> for SmallArray<T> {
+    #[inline]
+    fn from(values: [T; 4]) -> Self {
+        let [a, b, c, d] = values;
+        let mut vec = SmallVec::new();
+        vec.push(a);
+        vec.push(b);
+        vec.push(c);
+        vec.push(d);
+        Self(vec)
+    }
+}
+
+impl<T> From<&[T; 4]> for SmallArray<T>
+where
+    T: Copy,
+{
+    #[inline]
+    fn from(values: &[T; 4]) -> Self {
+        let mut vec = SmallVec::new();
+        for value in values.iter().copied() {
+            vec.push(value);
+        }
+        Self(vec)
+    }
+}
+
+impl<T> From<[T; 5]> for SmallArray<T> {
+    #[inline]
+    #[allow(clippy::many_single_char_names)]
+    fn from(values: [T; 5]) -> Self {
+        let [a, b, c, d, e] = values;
+        let mut vec = SmallVec::new();
+        vec.push(a);
+        vec.push(b);
+        vec.push(c);
+        vec.push(d);
+        vec.push(e);
+        Self(vec)
+    }
+}
+
+impl<T> From<&[T; 5]> for SmallArray<T>
+where
+    T: Copy,
+{
+    #[inline]
+    fn from(values: &[T; 5]) -> Self {
+        let mut vec = SmallVec::new();
+        for value in values.iter().copied() {
+            vec.push(value);
+        }
+        Self(vec)
+    }
+}
+
+impl<T> From<[T; 6]> for SmallArray<T> {
+    #[inline]
+    #[allow(clippy::many_single_char_names)]
+    fn from(values: [T; 6]) -> Self {
+        let [a, b, c, d, e, f] = values;
+        let mut vec = SmallVec::new();
+        vec.push(a);
+        vec.push(b);
+        vec.push(c);
+        vec.push(d);
+        vec.push(e);
+        vec.push(f);
+        Self(vec)
+    }
+}
+
+impl<T> From<&[T; 6]> for SmallArray<T>
+where
+    T: Copy,
+{
+    #[inline]
+    fn from(values: &[T; 6]) -> Self {
+        let mut vec = SmallVec::new();
+        for value in values.iter().copied() {
+            vec.push(value);
+        }
+        Self(vec)
+    }
+}
+
+impl<T> From<[T; 7]> for SmallArray<T> {
+    #[inline]
+    #[allow(clippy::many_single_char_names)]
+    fn from(values: [T; 7]) -> Self {
+        let [a, b, c, d, e, f, g] = values;
+        let mut vec = SmallVec::new();
+        vec.push(a);
+        vec.push(b);
+        vec.push(c);
+        vec.push(d);
+        vec.push(e);
+        vec.push(f);
+        vec.push(g);
+        Self(vec)
+    }
+}
+
+impl<T> From<&[T; 7]> for SmallArray<T>
+where
+    T: Copy,
+{
+    #[inline]
+    fn from(values: &[T; 7]) -> Self {
+        let mut vec = SmallVec::new();
+        for value in values.iter().copied() {
+            vec.push(value);
+        }
+        Self(vec)
+    }
+}
+
+impl<T> From<[T; INLINE_CAPACITY]> for SmallArray<T> {
+    #[inline]
+    fn from(values: [T; INLINE_CAPACITY]) -> Self {
+        Self(SmallVec::from(values))
+    }
+}
+
+impl<T> From<&[T; INLINE_CAPACITY]> for SmallArray<T>
+where
+    T: Copy,
+{
+    #[inline]
+    fn from(values: &[T; INLINE_CAPACITY]) -> Self {
+        Self(SmallVec::from(*values))
+    }
+}
+
+macro_rules! __smallarray_T_from_primitive_array {
+    ($len:expr) => {
+        impl<T> From<[T; $len]> for SmallArray<T> {
+            #[inline]
+            fn from(values: [T; $len]) -> Self {
+                Self(SmallVec::from_vec(Vec::from(values)))
+            }
+        }
+
+        impl<T> From<&[T; $len]> for SmallArray<T>
+        where
+            T: Copy,
+        {
+            #[inline]
+            fn from(values: &[T; $len]) -> Self {
+                Self(SmallVec::from_slice(values))
+            }
+        }
+    };
+}
+
+// Skip to avoid a vec allocation because the lengths are less than
+// `INLINE_CAPACITY`.
+// __smallarray_T_from_primitive_array!(1);
+// __smallarray_T_from_primitive_array!(2);
+// __smallarray_T_from_primitive_array!(3);
+// __smallarray_T_from_primitive_array!(4);
+// __smallarray_T_from_primitive_array!(5);
+// __smallarray_T_from_primitive_array!(6);
+// __smallarray_T_from_primitive_array!(7);
+// Skip because we have manually implemented for `INLINE_CAPACITY` arrays.
+// __smallarray_T_from_primitive_array!(8);
+__smallarray_T_from_primitive_array!(9);
+__smallarray_T_from_primitive_array!(10);
+__smallarray_T_from_primitive_array!(11);
+__smallarray_T_from_primitive_array!(12);
+__smallarray_T_from_primitive_array!(13);
+__smallarray_T_from_primitive_array!(14);
+__smallarray_T_from_primitive_array!(15);
+__smallarray_T_from_primitive_array!(16);
+__smallarray_T_from_primitive_array!(17);
+__smallarray_T_from_primitive_array!(18);
+__smallarray_T_from_primitive_array!(19);
+__smallarray_T_from_primitive_array!(20);
+__smallarray_T_from_primitive_array!(21);
+__smallarray_T_from_primitive_array!(22);
+__smallarray_T_from_primitive_array!(23);
+__smallarray_T_from_primitive_array!(24);
+__smallarray_T_from_primitive_array!(25);
+__smallarray_T_from_primitive_array!(26);
+__smallarray_T_from_primitive_array!(27);
+__smallarray_T_from_primitive_array!(28);
+__smallarray_T_from_primitive_array!(29);
+__smallarray_T_from_primitive_array!(30);
+__smallarray_T_from_primitive_array!(31);
+__smallarray_T_from_primitive_array!(32);
+
+impl<T> From<SmallVec<[T; INLINE_CAPACITY]>> for SmallArray<T> {
+    #[inline]
+    fn from(values: SmallVec<[T; INLINE_CAPACITY]>) -> Self {
+        Self(values)
+    }
+}
+
+impl<T> From<SmallArray<T>> for SmallVec<[T; INLINE_CAPACITY]> {
+    #[inline]
+    fn from(values: SmallArray<T>) -> Self {
+        values.into_inner()
+    }
+}
+
+impl<T> From<Array<T>> for SmallArray<T> {
+    #[inline]
+    fn from(values: Array<T>) -> Self {
+        Self::from(values.into_vec())
+    }
+}
+
+impl<T> FromIterator<T> for SmallArray<T> {
+    #[inline]
+    fn from_iter<I>(iter: I) -> Self
+    where
+        I: IntoIterator<Item = T>,
+    {
+        Self(iter.into_iter().collect())
+    }
+}
+
+impl<'a, T> FromIterator<&'a T> for SmallArray<T>
+where
+    T: 'a + Copy,
+{
+    #[inline]
+    fn from_iter<I>(iter: I) -> Self
+    where
+        I: IntoIterator<Item = &'a T>,
+    {
+        Self(iter.into_iter().copied().collect())
+    }
+}

--- a/spinoso-array/src/array/tinyvec/convert.rs
+++ b/spinoso-array/src/array/tinyvec/convert.rs
@@ -11,14 +11,20 @@ use crate::array::tinyvec::TinyArray;
 use crate::array::vec::Array;
 use crate::array::INLINE_CAPACITY;
 
-impl<T> From<Vec<T>> for TinyArray<T> {
+impl<T> From<Vec<T>> for TinyArray<T>
+where
+    T: Default,
+{
     #[inline]
     fn from(values: Vec<T>) -> Self {
         Self(values.into())
     }
 }
 
-impl<T> From<TinyArray<T>> for Vec<T> {
+impl<T> From<TinyArray<T>> for Vec<T>
+where
+    T: Default,
+{
     #[inline]
     fn from(values: TinyArray<T>) -> Self {
         values.into_vec()
@@ -27,7 +33,7 @@ impl<T> From<TinyArray<T>> for Vec<T> {
 
 impl<'a, T> From<&'a [T]> for TinyArray<T>
 where
-    T: Copy,
+    T: Clone + Default,
 {
     #[inline]
     fn from(values: &'a [T]) -> Self {
@@ -37,7 +43,7 @@ where
 
 impl<'a, T> From<&'a mut [T]> for TinyArray<T>
 where
-    T: Copy,
+    T: Clone + Default,
 {
     #[inline]
     fn from(values: &'a mut [T]) -> Self {
@@ -45,14 +51,20 @@ where
     }
 }
 
-impl<T> From<Box<[T]>> for TinyArray<T> {
+impl<T> From<Box<[T]>> for TinyArray<T>
+where
+    T: Default,
+{
     #[inline]
     fn from(values: Box<[T]>) -> Self {
         Self(Vec::from(values).into())
     }
 }
 
-impl<T> From<TinyArray<T>> for Box<[T]> {
+impl<T> From<TinyArray<T>> for Box<[T]>
+where
+    T: Default,
+{
     #[inline]
     fn from(values: TinyArray<T>) -> Self {
         values.into_boxed_slice()
@@ -61,7 +73,7 @@ impl<T> From<TinyArray<T>> for Box<[T]> {
 
 impl<'a, T> From<Cow<'a, [T]>> for TinyArray<T>
 where
-    T: Copy,
+    T: Clone + Default,
 {
     #[inline]
     fn from(values: Cow<'a, [T]>) -> Self {
@@ -74,7 +86,7 @@ where
 
 impl<'a, T> From<TinyArray<T>> for Cow<'a, [T]>
 where
-    T: Clone,
+    T: Clone + Default,
 {
     #[inline]
     fn from(values: TinyArray<T>) -> Self {
@@ -82,14 +94,20 @@ where
     }
 }
 
-impl<T> From<TinyArray<T>> for Rc<[T]> {
+impl<T> From<TinyArray<T>> for Rc<[T]>
+where
+    T: Default,
+{
     #[inline]
     fn from(values: TinyArray<T>) -> Self {
         values.into_vec().into()
     }
 }
 
-impl<T> From<TinyArray<T>> for Arc<[T]> {
+impl<T> From<TinyArray<T>> for Arc<[T]>
+where
+    T: Default,
+{
     #[inline]
     fn from(values: TinyArray<T>) -> Self {
         values.into_vec().into()
@@ -103,7 +121,10 @@ impl<T> From<TinyArray<T>> for Arc<[T]> {
 // `<[_]>::to_vec`.
 const _: () = [()][!(INLINE_CAPACITY == 8) as usize];
 
-impl<T> From<[T; 0]> for TinyArray<T> {
+impl<T> From<[T; 0]> for TinyArray<T>
+where
+    T: Default,
+{
     #[inline]
     fn from(values: [T; 0]) -> Self {
         // Values is empty, so it can be ignored.
@@ -112,7 +133,10 @@ impl<T> From<[T; 0]> for TinyArray<T> {
     }
 }
 
-impl<T> From<&[T; 0]> for TinyArray<T> {
+impl<T> From<&[T; 0]> for TinyArray<T>
+where
+    T: Default,
+{
     #[inline]
     fn from(values: &[T; 0]) -> Self {
         // Values is empty, so it can be ignored.
@@ -121,7 +145,10 @@ impl<T> From<&[T; 0]> for TinyArray<T> {
     }
 }
 
-impl<T> From<[T; 1]> for TinyArray<T> {
+impl<T> From<[T; 1]> for TinyArray<T>
+where
+    T: Default,
+{
     #[inline]
     fn from(values: [T; 1]) -> Self {
         let [a] = values;
@@ -133,19 +160,22 @@ impl<T> From<[T; 1]> for TinyArray<T> {
 
 impl<T> From<&[T; 1]> for TinyArray<T>
 where
-    T: Copy,
+    T: Clone + Default,
 {
     #[inline]
     fn from(values: &[T; 1]) -> Self {
         let mut vec = TinyVec::new();
-        for value in values.iter().copied() {
+        for value in values.iter().cloned() {
             vec.push(value);
         }
         Self(vec)
     }
 }
 
-impl<T> From<[T; 2]> for TinyArray<T> {
+impl<T> From<[T; 2]> for TinyArray<T>
+where
+    T: Default,
+{
     #[inline]
     fn from(values: [T; 2]) -> Self {
         let [a, b] = values;
@@ -158,19 +188,22 @@ impl<T> From<[T; 2]> for TinyArray<T> {
 
 impl<T> From<&[T; 2]> for TinyArray<T>
 where
-    T: Copy,
+    T: Clone + Default,
 {
     #[inline]
     fn from(values: &[T; 2]) -> Self {
         let mut vec = TinyVec::new();
-        for value in values.iter().copied() {
+        for value in values.iter().cloned() {
             vec.push(value);
         }
         Self(vec)
     }
 }
 
-impl<T> From<[T; 3]> for TinyArray<T> {
+impl<T> From<[T; 3]> for TinyArray<T>
+where
+    T: Default,
+{
     #[inline]
     fn from(values: [T; 3]) -> Self {
         let [a, b, c] = values;
@@ -184,19 +217,22 @@ impl<T> From<[T; 3]> for TinyArray<T> {
 
 impl<T> From<&[T; 3]> for TinyArray<T>
 where
-    T: Copy,
+    T: Clone + Default,
 {
     #[inline]
     fn from(values: &[T; 3]) -> Self {
         let mut vec = TinyVec::new();
-        for value in values.iter().copied() {
+        for value in values.iter().cloned() {
             vec.push(value);
         }
         Self(vec)
     }
 }
 
-impl<T> From<[T; 4]> for TinyArray<T> {
+impl<T> From<[T; 4]> for TinyArray<T>
+where
+    T: Default,
+{
     #[inline]
     fn from(values: [T; 4]) -> Self {
         let [a, b, c, d] = values;
@@ -211,19 +247,22 @@ impl<T> From<[T; 4]> for TinyArray<T> {
 
 impl<T> From<&[T; 4]> for TinyArray<T>
 where
-    T: Copy,
+    T: Clone + Default,
 {
     #[inline]
     fn from(values: &[T; 4]) -> Self {
         let mut vec = TinyVec::new();
-        for value in values.iter().copied() {
+        for value in values.iter().cloned() {
             vec.push(value);
         }
         Self(vec)
     }
 }
 
-impl<T> From<[T; 5]> for TinyArray<T> {
+impl<T> From<[T; 5]> for TinyArray<T>
+where
+    T: Default,
+{
     #[inline]
     #[allow(clippy::many_single_char_names)]
     fn from(values: [T; 5]) -> Self {
@@ -240,19 +279,22 @@ impl<T> From<[T; 5]> for TinyArray<T> {
 
 impl<T> From<&[T; 5]> for TinyArray<T>
 where
-    T: Copy,
+    T: Clone + Default,
 {
     #[inline]
     fn from(values: &[T; 5]) -> Self {
         let mut vec = TinyVec::new();
-        for value in values.iter().copied() {
+        for value in values.iter().cloned() {
             vec.push(value);
         }
         Self(vec)
     }
 }
 
-impl<T> From<[T; 6]> for TinyArray<T> {
+impl<T> From<[T; 6]> for TinyArray<T>
+where
+    T: Default,
+{
     #[inline]
     #[allow(clippy::many_single_char_names)]
     fn from(values: [T; 6]) -> Self {
@@ -270,19 +312,22 @@ impl<T> From<[T; 6]> for TinyArray<T> {
 
 impl<T> From<&[T; 6]> for TinyArray<T>
 where
-    T: Copy,
+    T: Clone + Default,
 {
     #[inline]
     fn from(values: &[T; 6]) -> Self {
         let mut vec = TinyVec::new();
-        for value in values.iter().copied() {
+        for value in values.iter().cloned() {
             vec.push(value);
         }
         Self(vec)
     }
 }
 
-impl<T> From<[T; 7]> for TinyArray<T> {
+impl<T> From<[T; 7]> for TinyArray<T>
+where
+    T: Default,
+{
     #[inline]
     #[allow(clippy::many_single_char_names)]
     fn from(values: [T; 7]) -> Self {
@@ -301,19 +346,22 @@ impl<T> From<[T; 7]> for TinyArray<T> {
 
 impl<T> From<&[T; 7]> for TinyArray<T>
 where
-    T: Copy,
+    T: Clone + Default,
 {
     #[inline]
     fn from(values: &[T; 7]) -> Self {
         let mut vec = TinyVec::new();
-        for value in values.iter().copied() {
+        for value in values.iter().cloned() {
             vec.push(value);
         }
         Self(vec)
     }
 }
 
-impl<T> From<[T; INLINE_CAPACITY]> for TinyArray<T> {
+impl<T> From<[T; INLINE_CAPACITY]> for TinyArray<T>
+where
+    T: Default,
+{
     #[inline]
     fn from(values: [T; INLINE_CAPACITY]) -> Self {
         Self(TinyVec::from(values))
@@ -322,7 +370,7 @@ impl<T> From<[T; INLINE_CAPACITY]> for TinyArray<T> {
 
 impl<T> From<&[T; INLINE_CAPACITY]> for TinyArray<T>
 where
-    T: Copy,
+    T: Clone + Default,
 {
     #[inline]
     fn from(values: &[T; INLINE_CAPACITY]) -> Self {
@@ -332,7 +380,10 @@ where
 
 macro_rules! __tinyarray_T_from_primitive_array {
     ($len:expr) => {
-        impl<T> From<[T; $len]> for TinyArray<T> {
+        impl<T> From<[T; $len]> for TinyArray<T>
+        where
+            T: Default,
+        {
             #[inline]
             fn from(values: [T; $len]) -> Self {
                 Self(TinyVec::from_vec(Vec::from(values)))
@@ -341,7 +392,7 @@ macro_rules! __tinyarray_T_from_primitive_array {
 
         impl<T> From<&[T; $len]> for TinyArray<T>
         where
-            T: Copy,
+            T: Clone + Default,
         {
             #[inline]
             fn from(values: &[T; $len]) -> Self {
@@ -387,28 +438,40 @@ __tinyarray_T_from_primitive_array!(30);
 __tinyarray_T_from_primitive_array!(31);
 __tinyarray_T_from_primitive_array!(32);
 
-impl<T> From<TinyVec<[T; INLINE_CAPACITY]>> for TinyArray<T> {
+impl<T> From<TinyVec<[T; INLINE_CAPACITY]>> for TinyArray<T>
+where
+    T: Default,
+{
     #[inline]
     fn from(values: TinyVec<[T; INLINE_CAPACITY]>) -> Self {
         Self(values)
     }
 }
 
-impl<T> From<TinyArray<T>> for TinyVec<[T; INLINE_CAPACITY]> {
+impl<T> From<TinyArray<T>> for TinyVec<[T; INLINE_CAPACITY]>
+where
+    T: Default,
+{
     #[inline]
     fn from(values: TinyArray<T>) -> Self {
         values.into_inner()
     }
 }
 
-impl<T> From<Array<T>> for TinyArray<T> {
+impl<T> From<Array<T>> for TinyArray<T>
+where
+    T: Default,
+{
     #[inline]
     fn from(values: Array<T>) -> Self {
         Self::from(values.into_vec())
     }
 }
 
-impl<T> FromIterator<T> for TinyArray<T> {
+impl<T> FromIterator<T> for TinyArray<T>
+where
+    T: Default,
+{
     #[inline]
     fn from_iter<I>(iter: I) -> Self
     where
@@ -420,13 +483,13 @@ impl<T> FromIterator<T> for TinyArray<T> {
 
 impl<'a, T> FromIterator<&'a T> for TinyArray<T>
 where
-    T: 'a + Copy,
+    T: 'a + Clone + Default,
 {
     #[inline]
     fn from_iter<I>(iter: I) -> Self
     where
         I: IntoIterator<Item = &'a T>,
     {
-        Self(iter.into_iter().copied().collect())
+        Self(iter.into_iter().cloned().collect())
     }
 }

--- a/spinoso-array/src/array/tinyvec/convert.rs
+++ b/spinoso-array/src/array/tinyvec/convert.rs
@@ -17,13 +17,13 @@ where
 {
     #[inline]
     fn from(values: Vec<T>) -> Self {
-        Self(values.into())
+        Self(values.into_iter().collect())
     }
 }
 
 impl<T> From<TinyArray<T>> for Vec<T>
 where
-    T: Default,
+    T: Clone + Default,
 {
     #[inline]
     fn from(values: TinyArray<T>) -> Self {
@@ -37,7 +37,7 @@ where
 {
     #[inline]
     fn from(values: &'a [T]) -> Self {
-        Self(TinyVec::from_slice(values))
+        Self(TinyVec::from(values))
     }
 }
 
@@ -47,7 +47,7 @@ where
 {
     #[inline]
     fn from(values: &'a mut [T]) -> Self {
-        Self(TinyVec::from_slice(values))
+        Self(TinyVec::from(values))
     }
 }
 
@@ -57,13 +57,13 @@ where
 {
     #[inline]
     fn from(values: Box<[T]>) -> Self {
-        Self(Vec::from(values).into())
+        Self(Vec::from(values).into_iter().collect())
     }
 }
 
 impl<T> From<TinyArray<T>> for Box<[T]>
 where
-    T: Default,
+    T: Clone + Default,
 {
     #[inline]
     fn from(values: TinyArray<T>) -> Self {
@@ -96,7 +96,7 @@ where
 
 impl<T> From<TinyArray<T>> for Rc<[T]>
 where
-    T: Default,
+    T: Clone + Default,
 {
     #[inline]
     fn from(values: TinyArray<T>) -> Self {
@@ -106,7 +106,7 @@ where
 
 impl<T> From<TinyArray<T>> for Arc<[T]>
 where
-    T: Default,
+    T: Clone + Default,
 {
     #[inline]
     fn from(values: TinyArray<T>) -> Self {
@@ -374,7 +374,7 @@ where
 {
     #[inline]
     fn from(values: &[T; INLINE_CAPACITY]) -> Self {
-        Self(TinyVec::from(*values))
+        Self(TinyVec::from(&values[..]))
     }
 }
 
@@ -386,7 +386,9 @@ macro_rules! __tinyarray_T_from_primitive_array {
         {
             #[inline]
             fn from(values: [T; $len]) -> Self {
-                Self(TinyVec::from_vec(Vec::from(values)))
+                // TODO: use a by-value array iter once `min_const_generics`
+                // stabilizes.
+                Self(Vec::from(values).into_iter().collect())
             }
         }
 
@@ -396,7 +398,7 @@ macro_rules! __tinyarray_T_from_primitive_array {
         {
             #[inline]
             fn from(values: &[T; $len]) -> Self {
-                Self(TinyVec::from_slice(values))
+                Self(TinyVec::from(&values[..]))
             }
         }
     };

--- a/spinoso-array/src/array/tinyvec/convert.rs
+++ b/spinoso-array/src/array/tinyvec/convert.rs
@@ -5,61 +5,61 @@ use alloc::sync::Arc;
 use alloc::vec::Vec;
 use core::iter::FromIterator;
 
-use smallvec::SmallVec;
+use tinyvec::TinyVec;
 
-use crate::array::smallvec::SmallArray;
+use crate::array::tinyvec::TinyArray;
 use crate::array::vec::Array;
 use crate::array::INLINE_CAPACITY;
 
-impl<T> From<Vec<T>> for SmallArray<T> {
+impl<T> From<Vec<T>> for TinyArray<T> {
     #[inline]
     fn from(values: Vec<T>) -> Self {
         Self(values.into())
     }
 }
 
-impl<T> From<SmallArray<T>> for Vec<T> {
+impl<T> From<TinyArray<T>> for Vec<T> {
     #[inline]
-    fn from(values: SmallArray<T>) -> Self {
+    fn from(values: TinyArray<T>) -> Self {
         values.into_vec()
     }
 }
 
-impl<'a, T> From<&'a [T]> for SmallArray<T>
+impl<'a, T> From<&'a [T]> for TinyArray<T>
 where
     T: Copy,
 {
     #[inline]
     fn from(values: &'a [T]) -> Self {
-        Self(SmallVec::from_slice(values))
+        Self(TinyVec::from_slice(values))
     }
 }
 
-impl<'a, T> From<&'a mut [T]> for SmallArray<T>
+impl<'a, T> From<&'a mut [T]> for TinyArray<T>
 where
     T: Copy,
 {
     #[inline]
     fn from(values: &'a mut [T]) -> Self {
-        Self(SmallVec::from_slice(values))
+        Self(TinyVec::from_slice(values))
     }
 }
 
-impl<T> From<Box<[T]>> for SmallArray<T> {
+impl<T> From<Box<[T]>> for TinyArray<T> {
     #[inline]
     fn from(values: Box<[T]>) -> Self {
         Self(Vec::from(values).into())
     }
 }
 
-impl<T> From<SmallArray<T>> for Box<[T]> {
+impl<T> From<TinyArray<T>> for Box<[T]> {
     #[inline]
-    fn from(values: SmallArray<T>) -> Self {
+    fn from(values: TinyArray<T>) -> Self {
         values.into_boxed_slice()
     }
 }
 
-impl<'a, T> From<Cow<'a, [T]>> for SmallArray<T>
+impl<'a, T> From<Cow<'a, [T]>> for TinyArray<T>
 where
     T: Copy,
 {
@@ -72,38 +72,38 @@ where
     }
 }
 
-impl<'a, T> From<SmallArray<T>> for Cow<'a, [T]>
+impl<'a, T> From<TinyArray<T>> for Cow<'a, [T]>
 where
     T: Clone,
 {
     #[inline]
-    fn from(values: SmallArray<T>) -> Self {
+    fn from(values: TinyArray<T>) -> Self {
         values.into_vec().into()
     }
 }
 
-impl<T> From<SmallArray<T>> for Rc<[T]> {
+impl<T> From<TinyArray<T>> for Rc<[T]> {
     #[inline]
-    fn from(values: SmallArray<T>) -> Self {
+    fn from(values: TinyArray<T>) -> Self {
         values.into_vec().into()
     }
 }
 
-impl<T> From<SmallArray<T>> for Arc<[T]> {
+impl<T> From<TinyArray<T>> for Arc<[T]> {
     #[inline]
-    fn from(values: SmallArray<T>) -> Self {
+    fn from(values: TinyArray<T>) -> Self {
         values.into_vec().into()
     }
 }
 
 // The below hand-crafted `From` implementations for fixed-sized arrays length 8
-// or shorter relies on the parameterized fixed array of `SmallArray`s
-// underlying `SmallVec` being `[T; 8]` to avoid allocating (and making the
+// or shorter relies on the parameterized fixed array of `TinyArray`s
+// underlying `TinyVec` being `[T; 8]` to avoid allocating (and making the
 // hand rolled implementations worthwhile instead of delegating to
 // `<[_]>::to_vec`.
 const _: () = [()][!(INLINE_CAPACITY == 8) as usize];
 
-impl<T> From<[T; 0]> for SmallArray<T> {
+impl<T> From<[T; 0]> for TinyArray<T> {
     #[inline]
     fn from(values: [T; 0]) -> Self {
         // Values is empty, so it can be ignored.
@@ -112,7 +112,7 @@ impl<T> From<[T; 0]> for SmallArray<T> {
     }
 }
 
-impl<T> From<&[T; 0]> for SmallArray<T> {
+impl<T> From<&[T; 0]> for TinyArray<T> {
     #[inline]
     fn from(values: &[T; 0]) -> Self {
         // Values is empty, so it can be ignored.
@@ -121,23 +121,23 @@ impl<T> From<&[T; 0]> for SmallArray<T> {
     }
 }
 
-impl<T> From<[T; 1]> for SmallArray<T> {
+impl<T> From<[T; 1]> for TinyArray<T> {
     #[inline]
     fn from(values: [T; 1]) -> Self {
         let [a] = values;
-        let mut vec = SmallVec::new();
+        let mut vec = TinyVec::new();
         vec.push(a);
         Self(vec)
     }
 }
 
-impl<T> From<&[T; 1]> for SmallArray<T>
+impl<T> From<&[T; 1]> for TinyArray<T>
 where
     T: Copy,
 {
     #[inline]
     fn from(values: &[T; 1]) -> Self {
-        let mut vec = SmallVec::new();
+        let mut vec = TinyVec::new();
         for value in values.iter().copied() {
             vec.push(value);
         }
@@ -145,24 +145,24 @@ where
     }
 }
 
-impl<T> From<[T; 2]> for SmallArray<T> {
+impl<T> From<[T; 2]> for TinyArray<T> {
     #[inline]
     fn from(values: [T; 2]) -> Self {
         let [a, b] = values;
-        let mut vec = SmallVec::new();
+        let mut vec = TinyVec::new();
         vec.push(a);
         vec.push(b);
         Self(vec)
     }
 }
 
-impl<T> From<&[T; 2]> for SmallArray<T>
+impl<T> From<&[T; 2]> for TinyArray<T>
 where
     T: Copy,
 {
     #[inline]
     fn from(values: &[T; 2]) -> Self {
-        let mut vec = SmallVec::new();
+        let mut vec = TinyVec::new();
         for value in values.iter().copied() {
             vec.push(value);
         }
@@ -170,11 +170,11 @@ where
     }
 }
 
-impl<T> From<[T; 3]> for SmallArray<T> {
+impl<T> From<[T; 3]> for TinyArray<T> {
     #[inline]
     fn from(values: [T; 3]) -> Self {
         let [a, b, c] = values;
-        let mut vec = SmallVec::new();
+        let mut vec = TinyVec::new();
         vec.push(a);
         vec.push(b);
         vec.push(c);
@@ -182,13 +182,13 @@ impl<T> From<[T; 3]> for SmallArray<T> {
     }
 }
 
-impl<T> From<&[T; 3]> for SmallArray<T>
+impl<T> From<&[T; 3]> for TinyArray<T>
 where
     T: Copy,
 {
     #[inline]
     fn from(values: &[T; 3]) -> Self {
-        let mut vec = SmallVec::new();
+        let mut vec = TinyVec::new();
         for value in values.iter().copied() {
             vec.push(value);
         }
@@ -196,11 +196,11 @@ where
     }
 }
 
-impl<T> From<[T; 4]> for SmallArray<T> {
+impl<T> From<[T; 4]> for TinyArray<T> {
     #[inline]
     fn from(values: [T; 4]) -> Self {
         let [a, b, c, d] = values;
-        let mut vec = SmallVec::new();
+        let mut vec = TinyVec::new();
         vec.push(a);
         vec.push(b);
         vec.push(c);
@@ -209,13 +209,13 @@ impl<T> From<[T; 4]> for SmallArray<T> {
     }
 }
 
-impl<T> From<&[T; 4]> for SmallArray<T>
+impl<T> From<&[T; 4]> for TinyArray<T>
 where
     T: Copy,
 {
     #[inline]
     fn from(values: &[T; 4]) -> Self {
-        let mut vec = SmallVec::new();
+        let mut vec = TinyVec::new();
         for value in values.iter().copied() {
             vec.push(value);
         }
@@ -223,12 +223,12 @@ where
     }
 }
 
-impl<T> From<[T; 5]> for SmallArray<T> {
+impl<T> From<[T; 5]> for TinyArray<T> {
     #[inline]
     #[allow(clippy::many_single_char_names)]
     fn from(values: [T; 5]) -> Self {
         let [a, b, c, d, e] = values;
-        let mut vec = SmallVec::new();
+        let mut vec = TinyVec::new();
         vec.push(a);
         vec.push(b);
         vec.push(c);
@@ -238,13 +238,13 @@ impl<T> From<[T; 5]> for SmallArray<T> {
     }
 }
 
-impl<T> From<&[T; 5]> for SmallArray<T>
+impl<T> From<&[T; 5]> for TinyArray<T>
 where
     T: Copy,
 {
     #[inline]
     fn from(values: &[T; 5]) -> Self {
-        let mut vec = SmallVec::new();
+        let mut vec = TinyVec::new();
         for value in values.iter().copied() {
             vec.push(value);
         }
@@ -252,12 +252,12 @@ where
     }
 }
 
-impl<T> From<[T; 6]> for SmallArray<T> {
+impl<T> From<[T; 6]> for TinyArray<T> {
     #[inline]
     #[allow(clippy::many_single_char_names)]
     fn from(values: [T; 6]) -> Self {
         let [a, b, c, d, e, f] = values;
-        let mut vec = SmallVec::new();
+        let mut vec = TinyVec::new();
         vec.push(a);
         vec.push(b);
         vec.push(c);
@@ -268,13 +268,13 @@ impl<T> From<[T; 6]> for SmallArray<T> {
     }
 }
 
-impl<T> From<&[T; 6]> for SmallArray<T>
+impl<T> From<&[T; 6]> for TinyArray<T>
 where
     T: Copy,
 {
     #[inline]
     fn from(values: &[T; 6]) -> Self {
-        let mut vec = SmallVec::new();
+        let mut vec = TinyVec::new();
         for value in values.iter().copied() {
             vec.push(value);
         }
@@ -282,12 +282,12 @@ where
     }
 }
 
-impl<T> From<[T; 7]> for SmallArray<T> {
+impl<T> From<[T; 7]> for TinyArray<T> {
     #[inline]
     #[allow(clippy::many_single_char_names)]
     fn from(values: [T; 7]) -> Self {
         let [a, b, c, d, e, f, g] = values;
-        let mut vec = SmallVec::new();
+        let mut vec = TinyVec::new();
         vec.push(a);
         vec.push(b);
         vec.push(c);
@@ -299,13 +299,13 @@ impl<T> From<[T; 7]> for SmallArray<T> {
     }
 }
 
-impl<T> From<&[T; 7]> for SmallArray<T>
+impl<T> From<&[T; 7]> for TinyArray<T>
 where
     T: Copy,
 {
     #[inline]
     fn from(values: &[T; 7]) -> Self {
-        let mut vec = SmallVec::new();
+        let mut vec = TinyVec::new();
         for value in values.iter().copied() {
             vec.push(value);
         }
@@ -313,39 +313,39 @@ where
     }
 }
 
-impl<T> From<[T; INLINE_CAPACITY]> for SmallArray<T> {
+impl<T> From<[T; INLINE_CAPACITY]> for TinyArray<T> {
     #[inline]
     fn from(values: [T; INLINE_CAPACITY]) -> Self {
-        Self(SmallVec::from(values))
+        Self(TinyVec::from(values))
     }
 }
 
-impl<T> From<&[T; INLINE_CAPACITY]> for SmallArray<T>
+impl<T> From<&[T; INLINE_CAPACITY]> for TinyArray<T>
 where
     T: Copy,
 {
     #[inline]
     fn from(values: &[T; INLINE_CAPACITY]) -> Self {
-        Self(SmallVec::from(*values))
+        Self(TinyVec::from(*values))
     }
 }
 
-macro_rules! __smallarray_T_from_primitive_array {
+macro_rules! __tinyarray_T_from_primitive_array {
     ($len:expr) => {
-        impl<T> From<[T; $len]> for SmallArray<T> {
+        impl<T> From<[T; $len]> for TinyArray<T> {
             #[inline]
             fn from(values: [T; $len]) -> Self {
-                Self(SmallVec::from_vec(Vec::from(values)))
+                Self(TinyVec::from_vec(Vec::from(values)))
             }
         }
 
-        impl<T> From<&[T; $len]> for SmallArray<T>
+        impl<T> From<&[T; $len]> for TinyArray<T>
         where
             T: Copy,
         {
             #[inline]
             fn from(values: &[T; $len]) -> Self {
-                Self(SmallVec::from_slice(values))
+                Self(TinyVec::from_slice(values))
             }
         }
     };
@@ -353,62 +353,62 @@ macro_rules! __smallarray_T_from_primitive_array {
 
 // Skip to avoid a vec allocation because the lengths are less than
 // `INLINE_CAPACITY`.
-// __smallarray_T_from_primitive_array!(1);
-// __smallarray_T_from_primitive_array!(2);
-// __smallarray_T_from_primitive_array!(3);
-// __smallarray_T_from_primitive_array!(4);
-// __smallarray_T_from_primitive_array!(5);
-// __smallarray_T_from_primitive_array!(6);
-// __smallarray_T_from_primitive_array!(7);
+// __tinyarray_T_from_primitive_array!(1);
+// __tinyarray_T_from_primitive_array!(2);
+// __tinyarray_T_from_primitive_array!(3);
+// __tinyarray_T_from_primitive_array!(4);
+// __tinyarray_T_from_primitive_array!(5);
+// __tinyarray_T_from_primitive_array!(6);
+// __tinyarray_T_from_primitive_array!(7);
 // Skip because we have manually implemented for `INLINE_CAPACITY` arrays.
-// __smallarray_T_from_primitive_array!(8);
-__smallarray_T_from_primitive_array!(9);
-__smallarray_T_from_primitive_array!(10);
-__smallarray_T_from_primitive_array!(11);
-__smallarray_T_from_primitive_array!(12);
-__smallarray_T_from_primitive_array!(13);
-__smallarray_T_from_primitive_array!(14);
-__smallarray_T_from_primitive_array!(15);
-__smallarray_T_from_primitive_array!(16);
-__smallarray_T_from_primitive_array!(17);
-__smallarray_T_from_primitive_array!(18);
-__smallarray_T_from_primitive_array!(19);
-__smallarray_T_from_primitive_array!(20);
-__smallarray_T_from_primitive_array!(21);
-__smallarray_T_from_primitive_array!(22);
-__smallarray_T_from_primitive_array!(23);
-__smallarray_T_from_primitive_array!(24);
-__smallarray_T_from_primitive_array!(25);
-__smallarray_T_from_primitive_array!(26);
-__smallarray_T_from_primitive_array!(27);
-__smallarray_T_from_primitive_array!(28);
-__smallarray_T_from_primitive_array!(29);
-__smallarray_T_from_primitive_array!(30);
-__smallarray_T_from_primitive_array!(31);
-__smallarray_T_from_primitive_array!(32);
+// __tinyarray_T_from_primitive_array!(8);
+__tinyarray_T_from_primitive_array!(9);
+__tinyarray_T_from_primitive_array!(10);
+__tinyarray_T_from_primitive_array!(11);
+__tinyarray_T_from_primitive_array!(12);
+__tinyarray_T_from_primitive_array!(13);
+__tinyarray_T_from_primitive_array!(14);
+__tinyarray_T_from_primitive_array!(15);
+__tinyarray_T_from_primitive_array!(16);
+__tinyarray_T_from_primitive_array!(17);
+__tinyarray_T_from_primitive_array!(18);
+__tinyarray_T_from_primitive_array!(19);
+__tinyarray_T_from_primitive_array!(20);
+__tinyarray_T_from_primitive_array!(21);
+__tinyarray_T_from_primitive_array!(22);
+__tinyarray_T_from_primitive_array!(23);
+__tinyarray_T_from_primitive_array!(24);
+__tinyarray_T_from_primitive_array!(25);
+__tinyarray_T_from_primitive_array!(26);
+__tinyarray_T_from_primitive_array!(27);
+__tinyarray_T_from_primitive_array!(28);
+__tinyarray_T_from_primitive_array!(29);
+__tinyarray_T_from_primitive_array!(30);
+__tinyarray_T_from_primitive_array!(31);
+__tinyarray_T_from_primitive_array!(32);
 
-impl<T> From<SmallVec<[T; INLINE_CAPACITY]>> for SmallArray<T> {
+impl<T> From<TinyVec<[T; INLINE_CAPACITY]>> for TinyArray<T> {
     #[inline]
-    fn from(values: SmallVec<[T; INLINE_CAPACITY]>) -> Self {
+    fn from(values: TinyVec<[T; INLINE_CAPACITY]>) -> Self {
         Self(values)
     }
 }
 
-impl<T> From<SmallArray<T>> for SmallVec<[T; INLINE_CAPACITY]> {
+impl<T> From<TinyArray<T>> for TinyVec<[T; INLINE_CAPACITY]> {
     #[inline]
-    fn from(values: SmallArray<T>) -> Self {
+    fn from(values: TinyArray<T>) -> Self {
         values.into_inner()
     }
 }
 
-impl<T> From<Array<T>> for SmallArray<T> {
+impl<T> From<Array<T>> for TinyArray<T> {
     #[inline]
     fn from(values: Array<T>) -> Self {
         Self::from(values.into_vec())
     }
 }
 
-impl<T> FromIterator<T> for SmallArray<T> {
+impl<T> FromIterator<T> for TinyArray<T> {
     #[inline]
     fn from_iter<I>(iter: I) -> Self
     where
@@ -418,7 +418,7 @@ impl<T> FromIterator<T> for SmallArray<T> {
     }
 }
 
-impl<'a, T> FromIterator<&'a T> for SmallArray<T>
+impl<'a, T> FromIterator<&'a T> for TinyArray<T>
 where
     T: 'a + Copy,
 {

--- a/spinoso-array/src/array/tinyvec/eq.rs
+++ b/spinoso-array/src/array/tinyvec/eq.rs
@@ -8,7 +8,8 @@ use crate::array::INLINE_CAPACITY;
 
 impl<T, U> PartialEq<TinyVec<[U; INLINE_CAPACITY]>> for TinyArray<T>
 where
-    T: PartialEq<U>,
+    T: PartialEq<U> + Default,
+    U: Default,
 {
     #[inline]
     fn eq(&self, other: &TinyVec<[U; INLINE_CAPACITY]>) -> bool {
@@ -18,7 +19,8 @@ where
 
 impl<T, U> PartialEq<TinyArray<U>> for TinyVec<[T; INLINE_CAPACITY]>
 where
-    T: PartialEq<U>,
+    T: PartialEq<U> + Default,
+    U: Default,
 {
     #[inline]
     fn eq(&self, other: &TinyArray<U>) -> bool {
@@ -28,7 +30,7 @@ where
 
 impl<T, U> PartialEq<Vec<U>> for TinyArray<T>
 where
-    T: PartialEq<U>,
+    T: PartialEq<U> + Default,
 {
     #[inline]
     fn eq(&self, other: &Vec<U>) -> bool {
@@ -39,6 +41,7 @@ where
 impl<T, U> PartialEq<TinyArray<U>> for Vec<T>
 where
     T: PartialEq<U>,
+    U: Default,
 {
     #[inline]
     fn eq(&self, other: &TinyArray<U>) -> bool {
@@ -48,7 +51,7 @@ where
 
 impl<T, U> PartialEq<[U]> for TinyArray<T>
 where
-    T: PartialEq<U>,
+    T: PartialEq<U> + Default,
 {
     #[inline]
     fn eq(&self, other: &[U]) -> bool {
@@ -59,6 +62,7 @@ where
 impl<T, U> PartialEq<TinyArray<U>> for [T]
 where
     T: PartialEq<U>,
+    U: Default,
 {
     #[inline]
     fn eq(&self, other: &TinyArray<U>) -> bool {
@@ -68,7 +72,7 @@ where
 
 impl<T, U> PartialEq<Box<[U]>> for TinyArray<T>
 where
-    T: PartialEq<U>,
+    T: PartialEq<U> + Default,
 {
     #[inline]
     fn eq(&self, other: &Box<[U]>) -> bool {
@@ -79,6 +83,7 @@ where
 impl<T, U> PartialEq<TinyArray<U>> for Box<[T]>
 where
     T: PartialEq<U>,
+    U: Default,
 {
     #[inline]
     fn eq(&self, other: &TinyArray<U>) -> bool {
@@ -89,6 +94,7 @@ where
 impl<T, U> PartialEq<TinyArray<U>> for Array<T>
 where
     T: PartialEq<U>,
+    U: Default,
 {
     #[inline]
     fn eq(&self, other: &TinyArray<U>) -> bool {
@@ -98,7 +104,7 @@ where
 
 impl<T, U> PartialEq<Array<U>> for TinyArray<T>
 where
-    T: PartialEq<U>,
+    T: PartialEq<U> + Default,
 {
     #[inline]
     fn eq(&self, other: &Array<U>) -> bool {
@@ -110,7 +116,7 @@ macro_rules! __tinyarray_T_eq_primitive_array {
     ($len:expr) => {
         impl<T, U> PartialEq<[U; $len]> for TinyArray<T>
         where
-            T: PartialEq<U>,
+            T: PartialEq<U> + Default,
         {
             #[inline]
             fn eq(&self, other: &[U; $len]) -> bool {
@@ -121,6 +127,7 @@ macro_rules! __tinyarray_T_eq_primitive_array {
         impl<T, U> PartialEq<TinyArray<U>> for [T; $len]
         where
             T: PartialEq<U>,
+            U: Default,
         {
             #[inline]
             fn eq(&self, other: &TinyArray<U>) -> bool {
@@ -130,7 +137,7 @@ macro_rules! __tinyarray_T_eq_primitive_array {
 
         impl<T, U> PartialEq<&[U; $len]> for TinyArray<T>
         where
-            T: PartialEq<U>,
+            T: PartialEq<U> + Default,
         {
             #[inline]
             fn eq(&self, other: &&[U; $len]) -> bool {
@@ -141,6 +148,7 @@ macro_rules! __tinyarray_T_eq_primitive_array {
         impl<T, U> PartialEq<TinyArray<U>> for &[T; $len]
         where
             T: PartialEq<U>,
+            U: Default,
         {
             #[inline]
             fn eq(&self, other: &TinyArray<U>) -> bool {

--- a/spinoso-array/src/array/tinyvec/eq.rs
+++ b/spinoso-array/src/array/tinyvec/eq.rs
@@ -1,32 +1,32 @@
 use alloc::boxed::Box;
 use alloc::vec::Vec;
-use smallvec::SmallVec;
+use tinyvec::TinyVec;
 
-use crate::array::smallvec::SmallArray;
+use crate::array::tinyvec::TinyArray;
 use crate::array::vec::Array;
 use crate::array::INLINE_CAPACITY;
 
-impl<T, U> PartialEq<SmallVec<[U; INLINE_CAPACITY]>> for SmallArray<T>
+impl<T, U> PartialEq<TinyVec<[U; INLINE_CAPACITY]>> for TinyArray<T>
 where
     T: PartialEq<U>,
 {
     #[inline]
-    fn eq(&self, other: &SmallVec<[U; INLINE_CAPACITY]>) -> bool {
+    fn eq(&self, other: &TinyVec<[U; INLINE_CAPACITY]>) -> bool {
         self[..] == other[..]
     }
 }
 
-impl<T, U> PartialEq<SmallArray<U>> for SmallVec<[T; INLINE_CAPACITY]>
+impl<T, U> PartialEq<TinyArray<U>> for TinyVec<[T; INLINE_CAPACITY]>
 where
     T: PartialEq<U>,
 {
     #[inline]
-    fn eq(&self, other: &SmallArray<U>) -> bool {
+    fn eq(&self, other: &TinyArray<U>) -> bool {
         self[..] == other[..]
     }
 }
 
-impl<T, U> PartialEq<Vec<U>> for SmallArray<T>
+impl<T, U> PartialEq<Vec<U>> for TinyArray<T>
 where
     T: PartialEq<U>,
 {
@@ -36,17 +36,17 @@ where
     }
 }
 
-impl<T, U> PartialEq<SmallArray<U>> for Vec<T>
+impl<T, U> PartialEq<TinyArray<U>> for Vec<T>
 where
     T: PartialEq<U>,
 {
     #[inline]
-    fn eq(&self, other: &SmallArray<U>) -> bool {
+    fn eq(&self, other: &TinyArray<U>) -> bool {
         self[..] == other[..]
     }
 }
 
-impl<T, U> PartialEq<[U]> for SmallArray<T>
+impl<T, U> PartialEq<[U]> for TinyArray<T>
 where
     T: PartialEq<U>,
 {
@@ -56,17 +56,17 @@ where
     }
 }
 
-impl<T, U> PartialEq<SmallArray<U>> for [T]
+impl<T, U> PartialEq<TinyArray<U>> for [T]
 where
     T: PartialEq<U>,
 {
     #[inline]
-    fn eq(&self, other: &SmallArray<U>) -> bool {
+    fn eq(&self, other: &TinyArray<U>) -> bool {
         self[..] == other[..]
     }
 }
 
-impl<T, U> PartialEq<Box<[U]>> for SmallArray<T>
+impl<T, U> PartialEq<Box<[U]>> for TinyArray<T>
 where
     T: PartialEq<U>,
 {
@@ -76,27 +76,27 @@ where
     }
 }
 
-impl<T, U> PartialEq<SmallArray<U>> for Box<[T]>
+impl<T, U> PartialEq<TinyArray<U>> for Box<[T]>
 where
     T: PartialEq<U>,
 {
     #[inline]
-    fn eq(&self, other: &SmallArray<U>) -> bool {
+    fn eq(&self, other: &TinyArray<U>) -> bool {
         self[..] == other[..]
     }
 }
 
-impl<T, U> PartialEq<SmallArray<U>> for Array<T>
+impl<T, U> PartialEq<TinyArray<U>> for Array<T>
 where
     T: PartialEq<U>,
 {
     #[inline]
-    fn eq(&self, other: &SmallArray<U>) -> bool {
+    fn eq(&self, other: &TinyArray<U>) -> bool {
         self[..] == other[..]
     }
 }
 
-impl<T, U> PartialEq<Array<U>> for SmallArray<T>
+impl<T, U> PartialEq<Array<U>> for TinyArray<T>
 where
     T: PartialEq<U>,
 {
@@ -106,9 +106,9 @@ where
     }
 }
 
-macro_rules! __smallarray_T_eq_primitive_array {
+macro_rules! __tinyarray_T_eq_primitive_array {
     ($len:expr) => {
-        impl<T, U> PartialEq<[U; $len]> for SmallArray<T>
+        impl<T, U> PartialEq<[U; $len]> for TinyArray<T>
         where
             T: PartialEq<U>,
         {
@@ -118,17 +118,17 @@ macro_rules! __smallarray_T_eq_primitive_array {
             }
         }
 
-        impl<T, U> PartialEq<SmallArray<U>> for [T; $len]
+        impl<T, U> PartialEq<TinyArray<U>> for [T; $len]
         where
             T: PartialEq<U>,
         {
             #[inline]
-            fn eq(&self, other: &SmallArray<U>) -> bool {
+            fn eq(&self, other: &TinyArray<U>) -> bool {
                 self[..] == other[..]
             }
         }
 
-        impl<T, U> PartialEq<&[U; $len]> for SmallArray<T>
+        impl<T, U> PartialEq<&[U; $len]> for TinyArray<T>
         where
             T: PartialEq<U>,
         {
@@ -138,48 +138,48 @@ macro_rules! __smallarray_T_eq_primitive_array {
             }
         }
 
-        impl<T, U> PartialEq<SmallArray<U>> for &[T; $len]
+        impl<T, U> PartialEq<TinyArray<U>> for &[T; $len]
         where
             T: PartialEq<U>,
         {
             #[inline]
-            fn eq(&self, other: &SmallArray<U>) -> bool {
+            fn eq(&self, other: &TinyArray<U>) -> bool {
                 self[..] == other[..]
             }
         }
     };
 }
 
-__smallarray_T_eq_primitive_array!(0);
-__smallarray_T_eq_primitive_array!(1);
-__smallarray_T_eq_primitive_array!(2);
-__smallarray_T_eq_primitive_array!(3);
-__smallarray_T_eq_primitive_array!(4);
-__smallarray_T_eq_primitive_array!(5);
-__smallarray_T_eq_primitive_array!(6);
-__smallarray_T_eq_primitive_array!(7);
-__smallarray_T_eq_primitive_array!(8);
-__smallarray_T_eq_primitive_array!(9);
-__smallarray_T_eq_primitive_array!(10);
-__smallarray_T_eq_primitive_array!(11);
-__smallarray_T_eq_primitive_array!(12);
-__smallarray_T_eq_primitive_array!(13);
-__smallarray_T_eq_primitive_array!(14);
-__smallarray_T_eq_primitive_array!(15);
-__smallarray_T_eq_primitive_array!(16);
-__smallarray_T_eq_primitive_array!(17);
-__smallarray_T_eq_primitive_array!(18);
-__smallarray_T_eq_primitive_array!(19);
-__smallarray_T_eq_primitive_array!(20);
-__smallarray_T_eq_primitive_array!(21);
-__smallarray_T_eq_primitive_array!(22);
-__smallarray_T_eq_primitive_array!(23);
-__smallarray_T_eq_primitive_array!(24);
-__smallarray_T_eq_primitive_array!(25);
-__smallarray_T_eq_primitive_array!(26);
-__smallarray_T_eq_primitive_array!(27);
-__smallarray_T_eq_primitive_array!(28);
-__smallarray_T_eq_primitive_array!(29);
-__smallarray_T_eq_primitive_array!(30);
-__smallarray_T_eq_primitive_array!(31);
-__smallarray_T_eq_primitive_array!(32);
+__tinyarray_T_eq_primitive_array!(0);
+__tinyarray_T_eq_primitive_array!(1);
+__tinyarray_T_eq_primitive_array!(2);
+__tinyarray_T_eq_primitive_array!(3);
+__tinyarray_T_eq_primitive_array!(4);
+__tinyarray_T_eq_primitive_array!(5);
+__tinyarray_T_eq_primitive_array!(6);
+__tinyarray_T_eq_primitive_array!(7);
+__tinyarray_T_eq_primitive_array!(8);
+__tinyarray_T_eq_primitive_array!(9);
+__tinyarray_T_eq_primitive_array!(10);
+__tinyarray_T_eq_primitive_array!(11);
+__tinyarray_T_eq_primitive_array!(12);
+__tinyarray_T_eq_primitive_array!(13);
+__tinyarray_T_eq_primitive_array!(14);
+__tinyarray_T_eq_primitive_array!(15);
+__tinyarray_T_eq_primitive_array!(16);
+__tinyarray_T_eq_primitive_array!(17);
+__tinyarray_T_eq_primitive_array!(18);
+__tinyarray_T_eq_primitive_array!(19);
+__tinyarray_T_eq_primitive_array!(20);
+__tinyarray_T_eq_primitive_array!(21);
+__tinyarray_T_eq_primitive_array!(22);
+__tinyarray_T_eq_primitive_array!(23);
+__tinyarray_T_eq_primitive_array!(24);
+__tinyarray_T_eq_primitive_array!(25);
+__tinyarray_T_eq_primitive_array!(26);
+__tinyarray_T_eq_primitive_array!(27);
+__tinyarray_T_eq_primitive_array!(28);
+__tinyarray_T_eq_primitive_array!(29);
+__tinyarray_T_eq_primitive_array!(30);
+__tinyarray_T_eq_primitive_array!(31);
+__tinyarray_T_eq_primitive_array!(32);

--- a/spinoso-array/src/array/tinyvec/eq.rs
+++ b/spinoso-array/src/array/tinyvec/eq.rs
@@ -1,0 +1,185 @@
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+use smallvec::SmallVec;
+
+use crate::array::smallvec::SmallArray;
+use crate::array::vec::Array;
+use crate::array::INLINE_CAPACITY;
+
+impl<T, U> PartialEq<SmallVec<[U; INLINE_CAPACITY]>> for SmallArray<T>
+where
+    T: PartialEq<U>,
+{
+    #[inline]
+    fn eq(&self, other: &SmallVec<[U; INLINE_CAPACITY]>) -> bool {
+        self[..] == other[..]
+    }
+}
+
+impl<T, U> PartialEq<SmallArray<U>> for SmallVec<[T; INLINE_CAPACITY]>
+where
+    T: PartialEq<U>,
+{
+    #[inline]
+    fn eq(&self, other: &SmallArray<U>) -> bool {
+        self[..] == other[..]
+    }
+}
+
+impl<T, U> PartialEq<Vec<U>> for SmallArray<T>
+where
+    T: PartialEq<U>,
+{
+    #[inline]
+    fn eq(&self, other: &Vec<U>) -> bool {
+        self[..] == other[..]
+    }
+}
+
+impl<T, U> PartialEq<SmallArray<U>> for Vec<T>
+where
+    T: PartialEq<U>,
+{
+    #[inline]
+    fn eq(&self, other: &SmallArray<U>) -> bool {
+        self[..] == other[..]
+    }
+}
+
+impl<T, U> PartialEq<[U]> for SmallArray<T>
+where
+    T: PartialEq<U>,
+{
+    #[inline]
+    fn eq(&self, other: &[U]) -> bool {
+        self[..] == other[..]
+    }
+}
+
+impl<T, U> PartialEq<SmallArray<U>> for [T]
+where
+    T: PartialEq<U>,
+{
+    #[inline]
+    fn eq(&self, other: &SmallArray<U>) -> bool {
+        self[..] == other[..]
+    }
+}
+
+impl<T, U> PartialEq<Box<[U]>> for SmallArray<T>
+where
+    T: PartialEq<U>,
+{
+    #[inline]
+    fn eq(&self, other: &Box<[U]>) -> bool {
+        self[..] == other[..]
+    }
+}
+
+impl<T, U> PartialEq<SmallArray<U>> for Box<[T]>
+where
+    T: PartialEq<U>,
+{
+    #[inline]
+    fn eq(&self, other: &SmallArray<U>) -> bool {
+        self[..] == other[..]
+    }
+}
+
+impl<T, U> PartialEq<SmallArray<U>> for Array<T>
+where
+    T: PartialEq<U>,
+{
+    #[inline]
+    fn eq(&self, other: &SmallArray<U>) -> bool {
+        self[..] == other[..]
+    }
+}
+
+impl<T, U> PartialEq<Array<U>> for SmallArray<T>
+where
+    T: PartialEq<U>,
+{
+    #[inline]
+    fn eq(&self, other: &Array<U>) -> bool {
+        self[..] == other[..]
+    }
+}
+
+macro_rules! __smallarray_T_eq_primitive_array {
+    ($len:expr) => {
+        impl<T, U> PartialEq<[U; $len]> for SmallArray<T>
+        where
+            T: PartialEq<U>,
+        {
+            #[inline]
+            fn eq(&self, other: &[U; $len]) -> bool {
+                self[..] == other[..]
+            }
+        }
+
+        impl<T, U> PartialEq<SmallArray<U>> for [T; $len]
+        where
+            T: PartialEq<U>,
+        {
+            #[inline]
+            fn eq(&self, other: &SmallArray<U>) -> bool {
+                self[..] == other[..]
+            }
+        }
+
+        impl<T, U> PartialEq<&[U; $len]> for SmallArray<T>
+        where
+            T: PartialEq<U>,
+        {
+            #[inline]
+            fn eq(&self, other: &&[U; $len]) -> bool {
+                self[..] == other[..]
+            }
+        }
+
+        impl<T, U> PartialEq<SmallArray<U>> for &[T; $len]
+        where
+            T: PartialEq<U>,
+        {
+            #[inline]
+            fn eq(&self, other: &SmallArray<U>) -> bool {
+                self[..] == other[..]
+            }
+        }
+    };
+}
+
+__smallarray_T_eq_primitive_array!(0);
+__smallarray_T_eq_primitive_array!(1);
+__smallarray_T_eq_primitive_array!(2);
+__smallarray_T_eq_primitive_array!(3);
+__smallarray_T_eq_primitive_array!(4);
+__smallarray_T_eq_primitive_array!(5);
+__smallarray_T_eq_primitive_array!(6);
+__smallarray_T_eq_primitive_array!(7);
+__smallarray_T_eq_primitive_array!(8);
+__smallarray_T_eq_primitive_array!(9);
+__smallarray_T_eq_primitive_array!(10);
+__smallarray_T_eq_primitive_array!(11);
+__smallarray_T_eq_primitive_array!(12);
+__smallarray_T_eq_primitive_array!(13);
+__smallarray_T_eq_primitive_array!(14);
+__smallarray_T_eq_primitive_array!(15);
+__smallarray_T_eq_primitive_array!(16);
+__smallarray_T_eq_primitive_array!(17);
+__smallarray_T_eq_primitive_array!(18);
+__smallarray_T_eq_primitive_array!(19);
+__smallarray_T_eq_primitive_array!(20);
+__smallarray_T_eq_primitive_array!(21);
+__smallarray_T_eq_primitive_array!(22);
+__smallarray_T_eq_primitive_array!(23);
+__smallarray_T_eq_primitive_array!(24);
+__smallarray_T_eq_primitive_array!(25);
+__smallarray_T_eq_primitive_array!(26);
+__smallarray_T_eq_primitive_array!(27);
+__smallarray_T_eq_primitive_array!(28);
+__smallarray_T_eq_primitive_array!(29);
+__smallarray_T_eq_primitive_array!(30);
+__smallarray_T_eq_primitive_array!(31);
+__smallarray_T_eq_primitive_array!(32);

--- a/spinoso-array/src/array/tinyvec/impls.rs
+++ b/spinoso-array/src/array/tinyvec/impls.rs
@@ -6,49 +6,70 @@ use tinyvec::TinyVec;
 use crate::array::tinyvec::TinyArray;
 use crate::array::INLINE_CAPACITY;
 
-impl<T> AsRef<TinyVec<[T; INLINE_CAPACITY]>> for TinyArray<T> {
+impl<T> AsRef<TinyVec<[T; INLINE_CAPACITY]>> for TinyArray<T>
+where
+    T: Default,
+{
     #[inline]
     fn as_ref(&self) -> &TinyVec<[T; INLINE_CAPACITY]> {
         &self.0
     }
 }
 
-impl<T> AsRef<[T]> for TinyArray<T> {
+impl<T> AsRef<[T]> for TinyArray<T>
+where
+    T: Default,
+{
     #[inline]
     fn as_ref(&self) -> &[T] {
         self.0.as_ref()
     }
 }
 
-impl<T> AsMut<TinyVec<[T; INLINE_CAPACITY]>> for TinyArray<T> {
+impl<T> AsMut<TinyVec<[T; INLINE_CAPACITY]>> for TinyArray<T>
+where
+    T: Default,
+{
     #[inline]
     fn as_mut(&mut self) -> &mut TinyVec<[T; INLINE_CAPACITY]> {
         &mut self.0
     }
 }
 
-impl<T> AsMut<[T]> for TinyArray<T> {
+impl<T> AsMut<[T]> for TinyArray<T>
+where
+    T: Default,
+{
     #[inline]
     fn as_mut(&mut self) -> &mut [T] {
         self.0.as_mut()
     }
 }
 
-impl<T> Borrow<[T]> for TinyArray<T> {
+impl<T> Borrow<[T]> for TinyArray<T>
+where
+    T: Default,
+{
     #[inline]
     fn borrow(&self) -> &[T] {
         self.0.borrow()
     }
 }
 
-impl<T> BorrowMut<[T]> for TinyArray<T> {
+impl<T> BorrowMut<[T]> for TinyArray<T>
+where
+    T: Default,
+{
     #[inline]
     fn borrow_mut(&mut self) -> &mut [T] {
         self.0.borrow_mut()
     }
 }
 
-impl<T> Deref for TinyArray<T> {
+impl<T> Deref for TinyArray<T>
+where
+    T: Default,
+{
     type Target = [T];
 
     #[inline]
@@ -57,14 +78,20 @@ impl<T> Deref for TinyArray<T> {
     }
 }
 
-impl<T> DerefMut for TinyArray<T> {
+impl<T> DerefMut for TinyArray<T>
+where
+    T: Default,
+{
     #[inline]
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.0.as_mut_slice()
     }
 }
 
-impl<T> Extend<T> for TinyArray<T> {
+impl<T> Extend<T> for TinyArray<T>
+where
+    T: Default,
+{
     #[inline]
     fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
         self.0.extend(iter.into_iter())
@@ -73,17 +100,18 @@ impl<T> Extend<T> for TinyArray<T> {
 
 impl<'a, T> Extend<&'a T> for TinyArray<T>
 where
-    T: 'a + Copy,
+    T: 'a + Clone + Default,
 {
     #[inline]
     fn extend<I: IntoIterator<Item = &'a T>>(&mut self, iter: I) {
-        self.0.extend(iter.into_iter().copied())
+        self.0.extend(iter.into_iter().cloned())
     }
 }
 
 impl<T, I> Index<I> for TinyArray<T>
 where
     I: SliceIndex<[T]>,
+    T: Default,
 {
     type Output = I::Output;
 
@@ -96,6 +124,7 @@ where
 impl<T, I> IndexMut<I> for TinyArray<T>
 where
     I: SliceIndex<[T]>,
+    T: Default,
 {
     #[inline]
     fn index_mut(&mut self, index: I) -> &mut I::Output {
@@ -103,7 +132,10 @@ where
     }
 }
 
-impl<'a, T> IntoIterator for &'a TinyArray<T> {
+impl<'a, T> IntoIterator for &'a TinyArray<T>
+where
+    T: Default,
+{
     type Item = &'a T;
     type IntoIter = Iter<'a, T>;
 
@@ -113,7 +145,10 @@ impl<'a, T> IntoIterator for &'a TinyArray<T> {
     }
 }
 
-impl<'a, T> IntoIterator for &'a mut TinyArray<T> {
+impl<'a, T> IntoIterator for &'a mut TinyArray<T>
+where
+    T: Default,
+{
     type Item = &'a mut T;
     type IntoIter = IterMut<'a, T>;
 

--- a/spinoso-array/src/array/tinyvec/impls.rs
+++ b/spinoso-array/src/array/tinyvec/impls.rs
@@ -1,0 +1,124 @@
+use core::borrow::{Borrow, BorrowMut};
+use core::ops::{Deref, DerefMut, Index, IndexMut};
+use core::slice::{Iter, IterMut, SliceIndex};
+use smallvec::SmallVec;
+
+use crate::array::smallvec::SmallArray;
+use crate::array::INLINE_CAPACITY;
+
+impl<T> AsRef<SmallVec<[T; INLINE_CAPACITY]>> for SmallArray<T> {
+    #[inline]
+    fn as_ref(&self) -> &SmallVec<[T; INLINE_CAPACITY]> {
+        &self.0
+    }
+}
+
+impl<T> AsRef<[T]> for SmallArray<T> {
+    #[inline]
+    fn as_ref(&self) -> &[T] {
+        self.0.as_ref()
+    }
+}
+
+impl<T> AsMut<SmallVec<[T; INLINE_CAPACITY]>> for SmallArray<T> {
+    #[inline]
+    fn as_mut(&mut self) -> &mut SmallVec<[T; INLINE_CAPACITY]> {
+        &mut self.0
+    }
+}
+
+impl<T> AsMut<[T]> for SmallArray<T> {
+    #[inline]
+    fn as_mut(&mut self) -> &mut [T] {
+        self.0.as_mut()
+    }
+}
+
+impl<T> Borrow<[T]> for SmallArray<T> {
+    #[inline]
+    fn borrow(&self) -> &[T] {
+        self.0.borrow()
+    }
+}
+
+impl<T> BorrowMut<[T]> for SmallArray<T> {
+    #[inline]
+    fn borrow_mut(&mut self) -> &mut [T] {
+        self.0.borrow_mut()
+    }
+}
+
+impl<T> Deref for SmallArray<T> {
+    type Target = [T];
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        self.0.as_slice()
+    }
+}
+
+impl<T> DerefMut for SmallArray<T> {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.0.as_mut_slice()
+    }
+}
+
+impl<T> Extend<T> for SmallArray<T> {
+    #[inline]
+    fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
+        self.0.extend(iter.into_iter())
+    }
+}
+
+impl<'a, T> Extend<&'a T> for SmallArray<T>
+where
+    T: 'a + Copy,
+{
+    #[inline]
+    fn extend<I: IntoIterator<Item = &'a T>>(&mut self, iter: I) {
+        self.0.extend(iter.into_iter().copied())
+    }
+}
+
+impl<T, I> Index<I> for SmallArray<T>
+where
+    I: SliceIndex<[T]>,
+{
+    type Output = I::Output;
+
+    #[inline]
+    fn index(&self, index: I) -> &I::Output {
+        &self.0[index]
+    }
+}
+
+impl<T, I> IndexMut<I> for SmallArray<T>
+where
+    I: SliceIndex<[T]>,
+{
+    #[inline]
+    fn index_mut(&mut self, index: I) -> &mut I::Output {
+        &mut self.0[index]
+    }
+}
+
+impl<'a, T> IntoIterator for &'a SmallArray<T> {
+    type Item = &'a T;
+    type IntoIter = Iter<'a, T>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter()
+    }
+}
+
+impl<'a, T> IntoIterator for &'a mut SmallArray<T> {
+    type Item = &'a mut T;
+    type IntoIter = IterMut<'a, T>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter_mut()
+    }
+}

--- a/spinoso-array/src/array/tinyvec/impls.rs
+++ b/spinoso-array/src/array/tinyvec/impls.rs
@@ -1,54 +1,54 @@
 use core::borrow::{Borrow, BorrowMut};
 use core::ops::{Deref, DerefMut, Index, IndexMut};
 use core::slice::{Iter, IterMut, SliceIndex};
-use smallvec::SmallVec;
+use tinyvec::TinyVec;
 
-use crate::array::smallvec::SmallArray;
+use crate::array::tinyvec::TinyArray;
 use crate::array::INLINE_CAPACITY;
 
-impl<T> AsRef<SmallVec<[T; INLINE_CAPACITY]>> for SmallArray<T> {
+impl<T> AsRef<TinyVec<[T; INLINE_CAPACITY]>> for TinyArray<T> {
     #[inline]
-    fn as_ref(&self) -> &SmallVec<[T; INLINE_CAPACITY]> {
+    fn as_ref(&self) -> &TinyVec<[T; INLINE_CAPACITY]> {
         &self.0
     }
 }
 
-impl<T> AsRef<[T]> for SmallArray<T> {
+impl<T> AsRef<[T]> for TinyArray<T> {
     #[inline]
     fn as_ref(&self) -> &[T] {
         self.0.as_ref()
     }
 }
 
-impl<T> AsMut<SmallVec<[T; INLINE_CAPACITY]>> for SmallArray<T> {
+impl<T> AsMut<TinyVec<[T; INLINE_CAPACITY]>> for TinyArray<T> {
     #[inline]
-    fn as_mut(&mut self) -> &mut SmallVec<[T; INLINE_CAPACITY]> {
+    fn as_mut(&mut self) -> &mut TinyVec<[T; INLINE_CAPACITY]> {
         &mut self.0
     }
 }
 
-impl<T> AsMut<[T]> for SmallArray<T> {
+impl<T> AsMut<[T]> for TinyArray<T> {
     #[inline]
     fn as_mut(&mut self) -> &mut [T] {
         self.0.as_mut()
     }
 }
 
-impl<T> Borrow<[T]> for SmallArray<T> {
+impl<T> Borrow<[T]> for TinyArray<T> {
     #[inline]
     fn borrow(&self) -> &[T] {
         self.0.borrow()
     }
 }
 
-impl<T> BorrowMut<[T]> for SmallArray<T> {
+impl<T> BorrowMut<[T]> for TinyArray<T> {
     #[inline]
     fn borrow_mut(&mut self) -> &mut [T] {
         self.0.borrow_mut()
     }
 }
 
-impl<T> Deref for SmallArray<T> {
+impl<T> Deref for TinyArray<T> {
     type Target = [T];
 
     #[inline]
@@ -57,21 +57,21 @@ impl<T> Deref for SmallArray<T> {
     }
 }
 
-impl<T> DerefMut for SmallArray<T> {
+impl<T> DerefMut for TinyArray<T> {
     #[inline]
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.0.as_mut_slice()
     }
 }
 
-impl<T> Extend<T> for SmallArray<T> {
+impl<T> Extend<T> for TinyArray<T> {
     #[inline]
     fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
         self.0.extend(iter.into_iter())
     }
 }
 
-impl<'a, T> Extend<&'a T> for SmallArray<T>
+impl<'a, T> Extend<&'a T> for TinyArray<T>
 where
     T: 'a + Copy,
 {
@@ -81,7 +81,7 @@ where
     }
 }
 
-impl<T, I> Index<I> for SmallArray<T>
+impl<T, I> Index<I> for TinyArray<T>
 where
     I: SliceIndex<[T]>,
 {
@@ -93,7 +93,7 @@ where
     }
 }
 
-impl<T, I> IndexMut<I> for SmallArray<T>
+impl<T, I> IndexMut<I> for TinyArray<T>
 where
     I: SliceIndex<[T]>,
 {
@@ -103,7 +103,7 @@ where
     }
 }
 
-impl<'a, T> IntoIterator for &'a SmallArray<T> {
+impl<'a, T> IntoIterator for &'a TinyArray<T> {
     type Item = &'a T;
     type IntoIter = Iter<'a, T>;
 
@@ -113,7 +113,7 @@ impl<'a, T> IntoIterator for &'a SmallArray<T> {
     }
 }
 
-impl<'a, T> IntoIterator for &'a mut SmallArray<T> {
+impl<'a, T> IntoIterator for &'a mut TinyArray<T> {
     type Item = &'a mut T;
     type IntoIter = IterMut<'a, T>;
 

--- a/spinoso-array/src/array/tinyvec/mod.rs
+++ b/spinoso-array/src/array/tinyvec/mod.rs
@@ -1,0 +1,1752 @@
+//! Ruby `Array` based on [`SmallVec`].
+
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+use core::cmp;
+use core::slice::{Iter, IterMut};
+use smallvec::SmallVec;
+
+use crate::array::INLINE_CAPACITY;
+
+mod convert;
+mod eq;
+mod impls;
+
+/// A contiguous growable array type based on
+/// [`SmallVec<[T; INLINE_CAPACITY]>`](SmallVec) that implements the small vector
+/// optimization.
+///
+/// `SmallArray` is an alternate implementation of [`Array`] that implements the
+/// small vector optimization. For `SmallArray`s less then [`INLINE_CAPACITY`]
+/// elements long, there is no heap allocation.
+///
+/// `SmallArray` provides a nearly identical API to the one in [`Array`]. There
+/// are two important differences:
+///
+/// 1. `SmallVec<[T; INLINE_CAPACITY]>` is used in some places where
+///    [`Vec<T>`](Vec) would have been used.
+/// 2. Trait bounds on some methods are more restrictive and require elements to
+///    be [`Copy`].
+///
+/// Similar to `Array`, `SmallArray` implements indexing and mutating APIs that
+/// make an ideal backend for the [Ruby `Array` core class][ruby-array]. In
+/// practice, this results in less generic, more single-use APIs. For example,
+/// instead of [`Vec::drain`], `SmallArray` implements [`shift`], [`shift_n`],
+/// [`pop`], and [`pop_n`].
+///
+/// Similarly, slicing APIs are more specialized, such as [`first_n`] and
+/// [`last_n`]. Slicing APIs do not return [`Option`], instead preferring to
+/// return an empty slice.
+///
+/// # Examples
+///
+/// ```
+/// # use spinoso_array::SmallArray;
+/// let mut ary = SmallArray::new();
+/// ary.push(1);
+/// ary.push(2);
+///
+/// assert_eq!(ary.len(), 2);
+/// assert_eq!(ary[0], 1);
+///
+/// assert_eq!(ary.pop(), Some(2));
+/// assert_eq!(ary.len(), 1);
+///
+/// ary[0] = 7;
+/// assert_eq!(ary[0], 7);
+///
+/// ary.extend([1, 2, 3].iter().copied());
+///
+/// for x in &ary {
+///     println!("{}", x);
+/// }
+/// assert_eq!(ary, &[7, 1, 2, 3]);
+/// ```
+///
+/// [`Array`]: crate::Array
+/// [ruby-array]: https://ruby-doc.org/core-2.6.3/Array.html
+/// [`shift`]: SmallArray::shift
+/// [`shift_n`]: SmallArray::shift_n
+/// [`drop_n`]: SmallArray::drop_n
+/// [`pop`]: SmallArray::pop
+/// [`pop_n`]: SmallArray::pop_n
+/// [`first_n`]: SmallArray::first_n
+/// [`last_n`]: SmallArray::last_n
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(docsrs, doc(cfg(feature = "small-array")))]
+pub struct SmallArray<T>(SmallVec<[T; INLINE_CAPACITY]>);
+
+impl<T> Default for SmallArray<T> {
+    #[inline]
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T> SmallArray<T> {
+    /// Construct a new, empty `SmallArray<T>`.
+    ///
+    /// The vector will not allocate until more than [`INLINE_CAPACITY`]
+    /// elements are pushed into it.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use spinoso_array::{INLINE_CAPACITY, SmallArray};
+    /// let ary: SmallArray<i32> = SmallArray::new();
+    /// assert!(ary.is_empty());
+    /// assert_eq!(ary.capacity(), INLINE_CAPACITY);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn new() -> Self {
+        Self(SmallVec::new())
+    }
+
+    /// Construct a new, empty `SmallArray<T>` with the specified capacity.
+    ///
+    /// The vector will be able to hold `max(capacity, INLINE_CAPACITY)`
+    /// elements without reallocating. If `capacity` is less than or equal to
+    /// [`INLINE_CAPACITY`], the vector will not allocate.
+    ///
+    /// It is important to note that although the returned vector has the
+    /// _capacity_ specified, the vector will have a zero _length_.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::SmallArray;
+    /// let mut ary: SmallArray<i32> = SmallArray::with_capacity(10);
+    /// assert_eq!(ary.len(), 0);
+    /// assert_eq!(ary.capacity(), 10);
+    ///
+    /// // These are pushes all done without reallocating...
+    /// for i in 0..10 {
+    ///     ary.push(i);
+    /// }
+    ///
+    /// // ...but this may make the vector reallocate
+    /// ary.push(11);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self(SmallVec::with_capacity(capacity))
+    }
+
+    /// Constuct a new two-element `SmallArray` from the given arguments.
+    ///
+    /// The vector is constructed without a heap allocation.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use spinoso_array::{INLINE_CAPACITY, SmallArray};
+    /// let ary = SmallArray::assoc(0, 100);
+    /// assert_eq!(ary.capacity(), INLINE_CAPACITY);
+    /// assert_eq!(ary.len(), 2);
+    /// assert_eq!(ary[0], 0);
+    /// assert_eq!(ary[1], 100);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn assoc(first: T, second: T) -> Self {
+        let pair: [T; 2] = [first, second];
+        Self::from(pair)
+    }
+
+    /// Returns an iterator over the slice.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::SmallArray;
+    /// let ary = SmallArray::from(&[1, 2, 4]);
+    /// let mut iterator = ary.iter();
+    ///
+    /// assert_eq!(iterator.next(), Some(&1));
+    /// assert_eq!(iterator.next(), Some(&2));
+    /// assert_eq!(iterator.next(), Some(&4));
+    /// assert_eq!(iterator.next(), None);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn iter(&self) -> Iter<'_, T> {
+        self.into_iter()
+    }
+
+    /// Returns an iterator that allows modifying each value.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::SmallArray;
+    /// let mut ary = SmallArray::from(&[1, 2, 4]);
+    /// for elem in ary.iter_mut() {
+    ///     *elem += 2;
+    /// }
+    ///
+    /// assert_eq!(ary, &[3, 4, 6]);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn iter_mut(&mut self) -> IterMut<'_, T> {
+        self.into_iter()
+    }
+
+    /// Extracts a slice containing the entire vector.
+    ///
+    /// Equivalent to `&ary[..]`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::SmallArray;
+    /// let ary = SmallArray::from(&[1, 2, 4]);
+    /// let four_index = ary.as_slice().binary_search(&4);
+    /// assert_eq!(four_index, Ok(2));
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn as_slice(&self) -> &[T] {
+        self.0.as_slice()
+    }
+
+    /// Extracts a mutable slice containing the entire vector.
+    ///
+    /// Equivalent to `&mut ary[..]`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::SmallArray;
+    /// let mut ary = SmallArray::from(&[2, 1, 4]);
+    /// ary.as_mut_slice().sort();
+    /// assert_eq!(ary, &[1, 2, 4]);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn as_mut_slice(&mut self) -> &mut [T] {
+        self.0.as_mut_slice()
+    }
+
+    /// Returns a raw pointer to the vector's buffer.
+    ///
+    /// The caller must ensure that the vector outlives the pointer this
+    /// function returns, or else it will end up pointing to garbage. Modifying
+    /// the vector may cause its buffer to be reallocated, which would also make
+    /// any pointers to it invalid.
+    ///
+    /// The caller must also ensure that the memory the pointer
+    /// (non-transitively) points to is never written to (except inside an
+    /// `UnsafeCell`) using this pointer or any pointer derived from it. If you
+    /// need to mutate the contents of the slice, use
+    /// [`as_mut_ptr`](Self::as_mut_ptr).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::SmallArray;
+    /// let ary = SmallArray::from(&[1, 2, 4]);
+    /// let ary_ptr = ary.as_ptr();
+    ///
+    /// unsafe {
+    ///     for i in 0..ary.len() {
+    ///         assert_eq!(*ary_ptr.add(i), 1 << i);
+    ///     }
+    /// }
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn as_ptr(&self) -> *const T {
+        self.0.as_ptr()
+    }
+
+    /// Returns an unsafe mutable pointer to the vector's buffer.
+    ///
+    /// The caller must ensure that the vector outlives the pointer this
+    /// function returns, or else it will end up pointing to garbage.
+    /// Modifying the vector may cause its buffer to be reallocated, which would
+    /// also make any pointers to it invalid.
+    ///
+    /// # Examples
+    ///
+    /// This method is primarily used when mutating a `Array` via a raw pointer
+    /// passed over FFI.
+    ///
+    /// See the [`ARY_PTR`] macro in mruby.
+    ///
+    /// [`ARY_PTR`]: https://github.com/artichoke/mruby/blob/d66440864d08f1c3ac5820d45f11df031b7d43c6/include/mruby/array.h#L52
+    #[inline]
+    #[must_use]
+    pub fn as_mut_ptr(&mut self) -> *mut T {
+        self.0.as_mut_ptr()
+    }
+
+    /// Set the vector's length without dropping or moving out elements
+    ///
+    /// This method is unsafe because it changes the notion of the number of
+    /// "valid" elements in the vector. Use with care.
+    ///
+    /// # Safety
+    ///
+    /// - `new_len` must be less than or equal to capacity().
+    /// - The elements at `old_len..new_len` must be initialized.
+    ///
+    /// # Examples
+    ///
+    /// This method is primarily used when mutating a `Array` via a raw pointer
+    /// passed over FFI.
+    ///
+    /// See the [`ARY_PTR`] macro in mruby.
+    ///
+    /// [`ARY_PTR`]: https://github.com/artichoke/mruby/blob/d66440864d08f1c3ac5820d45f11df031b7d43c6/include/mruby/array.h#L52
+    #[inline]
+    pub unsafe fn set_len(&mut self, new_len: usize) {
+        self.0.set_len(new_len);
+    }
+
+    /// Consume the array and return the inner
+    /// [`SmallVec<[T; INLINE_CAPACITY]>`](SmallVec).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use smallvec::SmallVec;
+    /// use spinoso_array::{INLINE_CAPACITY, SmallArray};
+    /// let ary = SmallArray::from(&[1, 2, 4]);
+    /// let vec: SmallVec<[i32; INLINE_CAPACITY]> = ary.into_inner();
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn into_inner(self) -> SmallVec<[T; INLINE_CAPACITY]> {
+        self.0
+    }
+
+    /// Consume the array and return its elements as a [`Vec<T>`].
+    ///
+    /// For `SmallArray`s with `len() > INLINE_CAPACITY`, this is a cheap
+    /// operation that unwraps the spilled `Vec` from the `SmallVec`. For
+    /// shorter arrays, this method will allocate.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::SmallArray;
+    /// let ary = SmallArray::from(&[1, 2, 4]);
+    /// let vec: Vec<i32> = ary.into_vec();
+    /// ```
+    ///
+    /// [`Vec<T>`]: alloc::vec::Vec
+    #[inline]
+    #[must_use]
+    pub fn into_vec(self) -> Vec<T> {
+        self.0.into_vec()
+    }
+
+    /// Converts the vector into [`Box<[T]>`](Box).
+    ///
+    /// This will drop any excess capacity.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::SmallArray;
+    /// let ary = SmallArray::from(&[1, 2, 4]);
+    /// let slice: Box<[i32]> = ary.into_boxed_slice();
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn into_boxed_slice(self) -> Box<[T]> {
+        self.0.into_boxed_slice()
+    }
+
+    /// Returns the number of elements the vector can hold without reallocating.
+    ///
+    /// The minimum capacity of a `SmallArray` is [`INLINE_CAPACITY`].
+    /// `SmallArray`s with capacity less than or equal to `INLINE_CAPACITY` are
+    /// not allocated on the heap.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use spinoso_array::{INLINE_CAPACITY, SmallArray};
+    /// let ary: SmallArray<i32> = SmallArray::with_capacity(1);
+    /// assert_eq!(ary.capacity(), INLINE_CAPACITY);
+    ///
+    /// let ary: SmallArray<i32> = SmallArray::with_capacity(10);
+    /// assert_eq!(ary.capacity(), 10);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn capacity(&self) -> usize {
+        self.0.capacity()
+    }
+
+    /// Reserves capacity for at least `additional` more elements to be inserted
+    /// in the given `SmallArray<T>`. The collection may reserve more space to
+    /// avoid frequent reallocations. After calling reserve, capacity will be
+    /// greater than or equal to `self.len() + additional`. Does nothing if
+    /// capacity is already sufficient.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the new capacity overflows `usize`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::SmallArray;
+    /// let mut ary = SmallArray::from(&[1]);
+    /// ary.reserve(10);
+    /// assert!(ary.capacity() >= 11);
+    /// ```
+    #[inline]
+    pub fn reserve(&mut self, additional: usize) {
+        self.0.reserve(additional);
+    }
+
+    /// Shrinks the capacity of the vector as much as possible.
+    ///
+    /// It will drop down as close as possible to the length but the allocator
+    /// may still inform the vector that there is space for a few more elements.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::SmallArray;
+    /// let mut ary = SmallArray::with_capacity(10);
+    /// ary.extend([1, 2, 3].iter().copied());
+    /// assert_eq!(ary.capacity(), 10);
+    /// ary.shrink_to_fit();
+    /// assert!(ary.capacity() >= 3);
+    /// ```
+    #[inline]
+    pub fn shrink_to_fit(&mut self) {
+        self.0.shrink_to_fit();
+    }
+
+    /// Clears the vector, removing all values.
+    ///
+    /// Note that this method has no effect on the allocated capacity of the
+    /// vector.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::SmallArray;
+    /// let mut ary = SmallArray::from(&[1, 2, 4]);
+    /// let capacity = ary.capacity();
+    /// ary.clear();
+    /// assert!(ary.is_empty());
+    /// assert_eq!(ary.capacity(), capacity);
+    /// ```
+    #[inline]
+    pub fn clear(&mut self) {
+        self.0.clear();
+    }
+
+    /// Returns the number of elements in the vector, also referred to as its
+    /// 'length'.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::SmallArray;
+    /// let ary = SmallArray::from(&[1, 2, 4]);
+    /// assert_eq!(ary.len(), 3);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Returns `true` if the vector contains no elements.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use spinoso_array::SmallArray;
+    /// let mut ary = SmallArray::new();
+    /// assert!(ary.is_empty());
+    /// ary.push(1);
+    /// assert!(!ary.is_empty());
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Returns a reference to an element at the index.
+    ///
+    /// Unlike [`Vec`], this method does not support indexing with a range.  See
+    /// the [`slice`](Self::slice) method for retrieving a sub-slice from the
+    /// array.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::SmallArray;
+    /// let ary = SmallArray::from(&[1, 2, 4]);
+    /// assert_eq!(ary.get(1), Some(&2));
+    /// assert_eq!(ary.get(3), None);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn get(&self, index: usize) -> Option<&T> {
+        self.0.get(index)
+    }
+
+    /// Deletes the element at the specified `index`, returning that element, or
+    /// [`None`] if the `index` is out of range.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::SmallArray;
+    /// let mut ary = SmallArray::from(&[1, 2, 4]);
+    /// assert_eq!(ary.delete_at(1), Some(2));
+    /// assert_eq!(ary.delete_at(10), None);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn delete_at(&mut self, index: usize) -> Option<T> {
+        if index < self.0.len() {
+            Some(self.0.remove(index))
+        } else {
+            None
+        }
+    }
+
+    /// Returns the first element from the vector, or [`None`] if the vector is
+    /// empty.
+    ///
+    /// To retrieve a slice of the first elements in the vector, use
+    /// [`first_n`](Self::first_n).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::SmallArray;
+    /// let mut ary = SmallArray::new();
+    /// assert_eq!(ary.first(), None);
+    /// ary.push(1);
+    /// assert_eq!(ary.first(), Some(&1));
+    /// ary.push(2);
+    /// assert_eq!(ary.first(), Some(&1));
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn first(&self) -> Option<&T> {
+        self.0.first()
+    }
+
+    /// Returns up to `n` of the first elements from the vector, or `&[]` if the
+    /// vector is empty.
+    ///
+    /// To retrieve only the first element in the vector, use
+    /// [`first`](Self::first).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::SmallArray;
+    /// let mut ary = SmallArray::new();
+    /// assert_eq!(ary.first_n(0), &[]);
+    /// assert_eq!(ary.first_n(4), &[]);
+    ///
+    /// ary.push(1);
+    /// ary.push(2);
+    /// assert_eq!(ary.first_n(0), &[]);
+    /// assert_eq!(ary.first_n(4), &[1, 2]);
+    ///
+    /// ary.concat(&[3, 4, 5, 6, 7, 8, 9, 10]);
+    /// assert_eq!(ary.first_n(0), &[]);
+    /// assert_eq!(ary.first_n(4), &[1, 2, 3, 4]);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn first_n(&self, n: usize) -> &[T] {
+        self.0.get(..n).unwrap_or_else(|| &self.0[..])
+    }
+
+    /// Returns the last element from the vector, or [`None`] if the vector is
+    /// empty.
+    ///
+    /// To retrieve a slice of the last elements in the vector, use
+    /// [`last_n`](Self::last_n).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::SmallArray;
+    /// let mut ary = SmallArray::new();
+    /// assert_eq!(ary.last(), None);
+    /// ary.push(1);
+    /// assert_eq!(ary.last(), Some(&1));
+    /// ary.push(2);
+    /// assert_eq!(ary.last(), Some(&2));
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn last(&self) -> Option<&T> {
+        self.0.last()
+    }
+
+    /// Returns up to `n` of the last elements from the vector, or `&[]` if the
+    /// vector is empty.
+    ///
+    /// To retrieve only the last element in the vector, use
+    /// [`last`](Self::last).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::SmallArray;
+    /// let mut ary = SmallArray::new();
+    /// assert_eq!(ary.last_n(0), &[]);
+    /// assert_eq!(ary.last_n(4), &[]);
+    ///
+    /// ary.push(1);
+    /// ary.push(2);
+    /// assert_eq!(ary.last_n(0), &[]);
+    /// assert_eq!(ary.last_n(4), &[1, 2]);
+    ///
+    /// ary.concat(&[3, 4, 5, 6, 7, 8, 9, 10]);
+    /// assert_eq!(ary.last_n(0), &[]);
+    /// assert_eq!(ary.last_n(4), &[7, 8, 9, 10]);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn last_n(&self, n: usize) -> &[T] {
+        let begin = self.len().checked_sub(n).unwrap_or_default();
+        &self.0[begin..]
+    }
+
+    /// Returns a slice of the underlying vector that includes only the first
+    /// `n` elements.
+    ///
+    /// If `n` is greater than or equal to the length of the vector, `&self[..]`
+    /// is returned.
+    ///
+    /// The inverse of this operation is [`drop_n`](Self::drop_n).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::SmallArray;
+    /// let ary = SmallArray::from(&[1, 2, 4, 7, 8, 9]);
+    /// assert_eq!(ary.take_n(0), &[]);
+    /// assert_eq!(ary.take_n(2), &[1, 2]);
+    /// assert_eq!(ary.take_n(10), &[1, 2, 4, 7, 8, 9]);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn take_n(&self, n: usize) -> &[T] {
+        self.0.get(..n).unwrap_or_else(|| &self.0[..])
+    }
+
+    /// Returns a slice of the underlying vector that excludes the first `n`
+    /// elements.
+    ///
+    /// If `n` is greater than or equal to the length of the vector, `&[]` is
+    /// returned.
+    ///
+    /// The inverse of this operation is [`take_n`](Self::take_n).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::SmallArray;
+    /// let ary = SmallArray::from(&[1, 2, 4, 7, 8, 9]);
+    /// assert_eq!(ary.drop_n(0), &[1, 2, 4, 7, 8, 9]);
+    /// assert_eq!(ary.drop_n(4), &[8, 9]);
+    /// assert_eq!(ary.drop_n(10), &[]);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn drop_n(&self, n: usize) -> &[T] {
+        self.0.get(n..).unwrap_or_else(|| &[])
+    }
+
+    /// Removes the last element from the vector and returns it, or [`None`] if
+    /// the vector is empty.
+    ///
+    /// To pop more than one element from the end of the vector, use
+    /// [`pop_n`](Self::pop_n).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::SmallArray;
+    /// let mut ary = SmallArray::from(&[1, 2, 4]);
+    /// assert_eq!(ary.pop(), Some(4));
+    /// assert_eq!(ary, &[1, 2]);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn pop(&mut self) -> Option<T> {
+        self.0.pop()
+    }
+
+    /// Removes the last `n` elements from the vector.
+    ///
+    /// To pop a single element from the end of the vector, use
+    /// [`pop`](Self::pop).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::SmallArray;
+    /// let mut ary = SmallArray::from(&[1, 2, 4, 7, 8, 9]);
+    /// assert_eq!(ary.pop_n(0), &[]);
+    /// assert_eq!(ary, &[1, 2, 4, 7, 8, 9]);
+    ///
+    /// assert_eq!(ary.pop_n(3), &[7, 8, 9]);
+    /// assert_eq!(ary, &[1, 2, 4]);
+    ///
+    /// assert_eq!(ary.pop_n(100), &[1, 2, 4]);
+    /// assert!(ary.is_empty());
+    ///
+    /// assert_eq!(ary.pop_n(1), &[]);
+    /// assert!(ary.is_empty());
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn pop_n(&mut self, n: usize) -> Self {
+        if n == 0 {
+            return Self::new();
+        }
+        let begin = self.len().checked_sub(n).unwrap_or_default();
+        self.0.drain(begin..).collect()
+    }
+
+    /// Appends an element to the back of the vector.
+    ///
+    /// To push more than one element to the end of the vector, use
+    /// [`concat`](Self::concat) or `extend`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the number of elements in the vector overflows a `usize`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::SmallArray;
+    /// let mut ary = SmallArray::from(&[1, 2]);
+    /// ary.push(3);
+    /// assert_eq!(ary, &[1, 2, 3]);
+    /// ```
+    #[inline]
+    pub fn push(&mut self, elem: T) {
+        self.0.push(elem);
+    }
+
+    /// Reverses the order of elements of the vector, in place.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::SmallArray;
+    /// let mut ary = SmallArray::from(&[1, 2, 4]);
+    /// ary.reverse();
+    /// assert_eq!(ary, &[4, 2, 1]);
+    /// ```
+    #[inline]
+    pub fn reverse(&mut self) {
+        self.0.reverse();
+    }
+
+    /// Removes the first element of the vector and returns it (shifting all
+    /// other elements down by one). Returns [`None`] if the vector is empty.
+    ///
+    /// This operation is also known as "pop front".
+    ///
+    /// To remove more than one element from the front of the vector, use
+    /// [`shift_n`](Self::shift_n).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::SmallArray;
+    /// let mut ary = SmallArray::from(&[1, 2]);
+    /// assert_eq!(ary.shift(), Some(1));
+    /// assert_eq!(ary.shift(), Some(2));
+    /// assert_eq!(ary.shift(), None);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn shift(&mut self) -> Option<T> {
+        if self.is_empty() {
+            None
+        } else {
+            Some(self.0.remove(0))
+        }
+    }
+
+    /// Removes the first `n` elements from the vector.
+    ///
+    /// To shift a single element from the front of the vector, use
+    /// [`shift`](Self::shift).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::SmallArray;
+    /// let mut ary = SmallArray::from(&[1, 2, 4, 7, 8, 9]);
+    /// assert_eq!(ary.shift_n(0), &[]);
+    /// assert_eq!(ary, &[1, 2, 4, 7, 8, 9]);
+    ///
+    /// assert_eq!(ary.shift_n(3), &[1, 2, 4]);
+    /// assert_eq!(ary, &[7, 8, 9]);
+    ///
+    /// assert_eq!(ary.shift_n(100), &[7, 8, 9]);
+    /// assert!(ary.is_empty());
+    ///
+    /// assert_eq!(ary.shift_n(1), &[]);
+    /// assert!(ary.is_empty());
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn shift_n(&mut self, n: usize) -> Self {
+        match n {
+            0 => Self::new(),
+            n if n < self.0.len() => self.0.drain(..n).collect(),
+            _ => self.0.drain(..).collect(),
+        }
+    }
+
+    /// Inserts an element to the front of the vector.
+    ///
+    /// To insert more than one element to the front of the vector, use
+    /// [`unshift_n`](Self::unshift_n).
+    ///
+    /// This operation is also known as "prepend".
+    ///
+    /// # Panics
+    ///
+    /// Panics if the number of elements in the vector overflows a `usize`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::SmallArray;
+    /// let mut ary = SmallArray::from(&[1, 2]);
+    /// ary.unshift(3);
+    /// assert_eq!(ary, &[3, 1, 2]);
+    /// ```
+    #[inline]
+    pub fn unshift(&mut self, elem: T) {
+        self.0.insert(0, elem);
+    }
+
+    /// Return a reference to a subslice of the vector.
+    ///
+    /// This function always returns a slice. If the range specified by `start`
+    /// and `end` overlaps the vector (even if only partially), the overlapping
+    /// slice is returned. If the range does not overlap the vector, an empty
+    /// slice is returned.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::SmallArray;
+    /// let empty: SmallArray<i32> = SmallArray::new();
+    /// assert_eq!(empty.slice(0, 0), &[]);
+    /// assert_eq!(empty.slice(0, 4), &[]);
+    /// assert_eq!(empty.slice(2, 4), &[]);
+    ///
+    /// let ary = SmallArray::from(&[1, 2, 3]);
+    /// assert_eq!(ary.slice(0, 0), &[]);
+    /// assert_eq!(ary.slice(0, 4), &[1, 2, 3]);
+    /// assert_eq!(ary.slice(2, 0), &[]);
+    /// assert_eq!(ary.slice(2, 4), &[3]);
+    /// assert_eq!(ary.slice(10, 100), &[]);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn slice(&self, start: usize, len: usize) -> &[T] {
+        if self.0.is_empty() || len == 0 {
+            return &[];
+        }
+        self.0
+            .get(start..start + len)
+            .or_else(|| self.0.get(start..))
+            .unwrap_or_default()
+    }
+}
+
+impl<T> SmallArray<T>
+where
+    T: Copy,
+{
+    /// Construct a new `SmallArray<T>` with length `len` and all elements set
+    /// to `default`. The `SmallArray` will have capacity at least `len`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::SmallArray;
+    /// let ary: SmallArray<&str> = SmallArray::with_len_and_default(3, "spinoso");
+    /// assert_eq!(ary.len(), 3);
+    /// assert!(ary.capacity() >= 3);
+    /// assert_eq!(ary, &["spinoso", "spinoso", "spinoso"]);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn with_len_and_default(len: usize, default: T) -> Self {
+        Self(SmallVec::from_elem(default, len))
+    }
+
+    /// Appends the elements of `other` to self.
+    ///
+    /// Slice version of `extend`. This operation is analogous to "push n".
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::SmallArray;
+    /// let mut ary = SmallArray::from(&[1, 2, 4]);
+    /// ary.concat(&[7, 8, 9]);
+    /// assert_eq!(ary.len(), 6);
+    /// ```
+    #[inline]
+    pub fn concat(&mut self, other: &[T]) {
+        self.0.extend_from_slice(other);
+    }
+
+    /// Creates a new array by repeating this array `n` times.
+    ///
+    /// This function will not panic. If the resulting `Array`'s capacity would
+    /// overflow, [`None`] is returned.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// # use spinoso_array::SmallArray;
+    /// # fn example() -> Option<()> {
+    /// let mut ary = SmallArray::from(&[1, 2]);
+    /// let repeated_ary = ary.repeat(3)?;
+    /// assert_eq!(repeated_ary, &[1, 2, 1, 2, 1, 2]);
+    /// # Some(())
+    /// # }
+    /// # example().unwrap();
+    /// ```
+    ///
+    /// [`None`] should be returned on overflow:
+    ///
+    /// ```
+    /// # use spinoso_array::SmallArray;
+    /// let mut ary = SmallArray::from(&[1, 2]);
+    /// let repeated_ary = ary.repeat(usize::MAX);
+    /// assert_eq!(repeated_ary, None);
+    /// ```
+    #[must_use]
+    pub fn repeat(&self, n: usize) -> Option<Self> {
+        let slice = self.0.as_slice();
+        if slice.len().checked_mul(n).is_some() {
+            Some(Self::from(slice.repeat(n)))
+        } else {
+            None
+        }
+    }
+
+    /// Prepends the elements of `other` to self.
+    ///
+    /// To insert one element to the front of the vector, use
+    /// [`unshift`](Self::unshift).
+    ///
+    /// This operation is also known as "prepend".
+    ///
+    /// # Panics
+    ///
+    /// Panics if the number of elements in the vector overflows a `usize`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::SmallArray;
+    /// let mut ary = SmallArray::from(&[1, 2]);
+    /// ary.unshift_n(&[0, 5, 9]);
+    /// assert_eq!(ary, &[0, 5, 9, 1, 2]);
+    /// ```
+    #[inline]
+    pub fn unshift_n(&mut self, other: &[T]) {
+        self.0.reserve(other.len());
+        self.0.insert_from_slice(0, other);
+    }
+}
+
+impl<T> SmallArray<T>
+where
+    T: Default,
+{
+    /// Set element at position `index` within the vector, extending the vector
+    /// with `T::default()` if `index` is out of bounds.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::SmallArray;
+    /// let mut ary = SmallArray::from(&[1, 2 ,4]);
+    /// ary.set(1, 11);
+    /// assert_eq!(ary, &[1, 11, 4]);
+    /// ary.set(5, 263);
+    /// assert_eq!(ary, &[1, 11, 4, 0, 0, 263]);
+    /// ```
+    #[inline]
+    pub fn set(&mut self, index: usize, elem: T) {
+        if let Some(cell) = self.0.get_mut(index) {
+            *cell = elem;
+        } else {
+            let buflen = self.len();
+            // index is *at least* buflen, so this calculation never underflows
+            // and ensures we allocate an additional slot.
+            self.0.reserve(index + 1 - buflen);
+            for _ in buflen..index {
+                self.0.push(T::default());
+            }
+            self.0.push(elem);
+        }
+    }
+
+    /// Insert element at position `start` within the vector and remove the
+    /// following `drain` elements. If `start` is out of bounds, the vector will
+    /// be extended with `T::default()`.
+    ///
+    /// This method sets a slice of the `SmallArray` to a single element,
+    /// including the zero-length slice. It is similar in intent to calling
+    /// [`Vec::splice`] with a one-element iterator.
+    ///
+    /// `set_with_drain` will only drain up to the end of the vector.
+    ///
+    /// To set a single element without draining, use [`set`](Self::set).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::SmallArray;
+    /// let mut ary = SmallArray::from(&[1, 2, 4]);
+    /// ary.set_with_drain(1, 0, 10);
+    /// assert_eq!(ary, &[1, 10, 2, 4]);
+    /// ary.set_with_drain(2, 5, 20);
+    /// assert_eq!(ary, &[1, 10, 20]);
+    /// ary.set_with_drain(5, 5, 30);
+    /// assert_eq!(ary, &[1, 10, 20, 0, 0, 30]);
+    /// ```
+    #[inline]
+    pub fn set_with_drain(&mut self, start: usize, drain: usize, elem: T) -> usize {
+        let buflen = self.0.len();
+        let drained = cmp::min(buflen.checked_sub(start).unwrap_or_default(), drain);
+
+        if let Some(cell) = self.0.get_mut(start) {
+            match drain {
+                0 => self.0.insert(start, elem),
+                1 => *cell = elem,
+                _ => {
+                    *cell = elem;
+                    let drain_end_idx = cmp::min(start + drain, buflen);
+                    self.0.drain(start + 1..drain_end_idx);
+                }
+            }
+        } else {
+            // start is *at least* buflen, so this calculation never underflows
+            // and ensures we allocate an additional slot.
+            self.0.reserve(start + 1 - buflen);
+            for _ in buflen..start {
+                self.0.push(T::default());
+            }
+            self.0.push(elem);
+        }
+
+        drained
+    }
+}
+
+impl<T> SmallArray<T>
+where
+    T: Default + Copy,
+{
+    /// Insert the elements from a slice at a position `index` in the vector,
+    /// extending the vector with `T::default()` if `index` is out of bounds.
+    ///
+    /// This method is similar to [`Vec::splice`] when called with a zero-length
+    /// range.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::SmallArray;
+    /// let mut ary = SmallArray::from(&[1, 2, 4]);
+    /// ary.insert_slice(1, &[7, 8, 9]);
+    /// assert_eq!(ary, &[1, 7, 8, 9, 2, 4]);
+    /// ary.insert_slice(8, &[100, 200]);
+    /// assert_eq!(ary, &[1, 7, 8, 9, 2, 4, 0, 0, 100, 200]);
+    /// ```
+    #[inline]
+    pub fn insert_slice(&mut self, index: usize, values: &[T]) {
+        let additional = index.checked_sub(self.0.len()).unwrap_or_default() + values.len();
+        self.0.reserve(additional);
+
+        for _ in self.0.len()..index {
+            self.0.push(T::default());
+        }
+        self.0.insert_from_slice(index, values);
+    }
+
+    /// Insert the elements from a slice at a position `index` in the vector and
+    /// remove the following `drain` elements. The vector is extended with
+    /// `T::default()` if `index` is out of bounds.
+    ///
+    /// This method is similar to [`Vec::splice`] when called with a
+    /// nonzero-length range.
+    ///
+    /// When called with `drain == 0`, this method is equivalent to
+    /// [`insert_slice`](Self::insert_slice).
+    ///
+    /// If `drain >= src.len()` or the tail of the vector is replaced, this
+    /// method is efficient. Otherwise, a temporary buffer is used to move the
+    /// elements.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_array::SmallArray;
+    /// let mut ary = SmallArray::from(&[1, 2, 4]);
+    /// ary.set_slice(1, 5, &[7, 8, 9]);
+    /// assert_eq!(ary, &[1, 7, 8, 9]);
+    /// ary.set_slice(6, 1, &[100, 200]);
+    /// assert_eq!(ary, &[1, 7, 8, 9, 0, 0, 100, 200]);
+    /// ary.set_slice(4, 2, &[88, 99]);
+    /// assert_eq!(ary, &[1, 7, 8, 9, 88, 99, 100, 200]);
+    /// ary.set_slice(6, 2, &[1000, 2000, 3000, 4000]);
+    /// assert_eq!(ary, &[1, 7, 8, 9, 88, 99, 1000, 2000, 3000, 4000]);
+    /// ```
+    #[inline]
+    pub fn set_slice(&mut self, index: usize, drain: usize, values: &[T]) -> usize {
+        let additional = index.checked_sub(self.0.len()).unwrap_or_default() + values.len();
+        self.0.reserve(additional);
+
+        // Extend the vector to account for out of bounds `index`.
+        for _ in self.0.len()..index {
+            self.0.push(T::default());
+        }
+        // `self.len()` is at least `index` so the below sub can never overflow.
+        let tail = self.len() - index;
+        // This is a direct append to the end of the vector, either because the
+        // given `index` was the vector's length or because we have extended the
+        // vector from an out of bounds index.
+        if tail == 0 {
+            self.0.extend_from_slice(values);
+            return 0;
+        }
+        // If the tail of the vector is shorter than or as long as the number of
+        // elements to drain, we can truncate and extend the underlying vector.
+        // `truncate` does not affect the existing capacity of the vector.
+        if tail <= drain {
+            self.0.truncate(index);
+            self.0.extend_from_slice(values);
+            return tail;
+        }
+
+        // Short circuit to a direct insert if `drain == 0`.
+        if drain == 0 {
+            self.0.insert_from_slice(index, values);
+            return 0;
+        }
+
+        // At this point, `index + drain` is guaranteed to be a valid index
+        // within the vector. There are two cases:
+        //
+        // - If `values.len() == drain`, we can drain elements by overwriting
+        //   them in the vector.
+        // - If `values.len() >= drain`, we can drain elements by overwriting
+        //   them in the vector and inserting the remainder.
+        // - Otherwise, overwrite `values` into the vector and remove the
+        //   remaining elements we must drain.
+        match values.len() {
+            0 => {
+                self.0.drain(index..index + drain);
+            }
+            len if len == drain => {
+                let slice = &mut self.0[index..index + drain];
+                slice.copy_from_slice(values);
+            }
+            len if len > drain => {
+                let slice = &mut self.0[index..index + drain];
+                let (overwrite, insert) = values.split_at(drain);
+                slice.copy_from_slice(overwrite);
+                self.0.insert_from_slice(index + drain, insert);
+            }
+            len => {
+                let slice = &mut self.0[index..index + len];
+                slice.copy_from_slice(values);
+                // Drain the remaining elements.
+                self.0.drain(index + len..index + drain);
+            }
+        }
+
+        drain
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::array::smallvec::SmallArray;
+
+    // `insert_slice`
+
+    #[test]
+    fn non_empty_array_insert_slice_end_empty() {
+        let mut ary = SmallArray::from([1, 2, 3, 4, 5]);
+        ary.insert_slice(5, &[]);
+        assert_eq!(ary, [1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn non_empty_array_insert_slice_out_of_bounds_empty() {
+        let mut ary = SmallArray::from([1, 2, 3, 4, 5]);
+        ary.insert_slice(10, &[]);
+        assert_eq!(ary, [1, 2, 3, 4, 5, 0, 0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn non_empty_array_insert_slice_interior_empty() {
+        let mut ary = SmallArray::from([1, 2, 3, 4, 5]);
+        ary.insert_slice(2, &[]);
+        assert_eq!(ary, [1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn non_empty_array_insert_slice_begin_empty() {
+        let mut ary = SmallArray::from([1, 2, 3, 4, 5]);
+        ary.insert_slice(0, &[]);
+        assert_eq!(ary, [1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn empty_array_insert_slice_end_empty() {
+        let mut ary = SmallArray::<i32>::new();
+        ary.insert_slice(0, &[]);
+        assert_eq!(ary, []);
+    }
+
+    #[test]
+    fn empty_array_insert_slice_out_of_bounds_empty() {
+        let mut ary = SmallArray::<i32>::new();
+        ary.insert_slice(10, &[]);
+        assert_eq!(ary, [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn empty_array_insert_slice_begin_empty() {
+        let mut ary = SmallArray::<i32>::new();
+        ary.insert_slice(0, &[]);
+        assert_eq!(ary, []);
+    }
+
+    #[test]
+    fn non_empty_array_insert_slice_end() {
+        let mut ary = SmallArray::from([1, 2, 3, 4, 5]);
+        ary.insert_slice(5, &[8, 9, 10]);
+        assert_eq!(ary, [1, 2, 3, 4, 5, 8, 9, 10]);
+    }
+
+    #[test]
+    fn non_empty_array_insert_slice_out_of_bounds() {
+        let mut ary = SmallArray::from([1, 2, 3, 4, 5]);
+        ary.insert_slice(10, &[8, 9, 10]);
+        assert_eq!(ary, [1, 2, 3, 4, 5, 0, 0, 0, 0, 0, 8, 9, 10]);
+    }
+
+    #[test]
+    fn non_empty_array_insert_slice_interior() {
+        let mut ary = SmallArray::from([1, 2, 3, 4, 5]);
+        ary.insert_slice(2, &[8, 9, 10]);
+        assert_eq!(ary, [1, 2, 8, 9, 10, 3, 4, 5]);
+    }
+
+    #[test]
+    fn non_empty_array_insert_slice_begin() {
+        let mut ary = SmallArray::from([1, 2, 3, 4, 5]);
+        ary.insert_slice(0, &[8, 9, 10]);
+        assert_eq!(ary, [8, 9, 10, 1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn empty_array_insert_slice_end() {
+        let mut ary = SmallArray::<i32>::new();
+        ary.insert_slice(0, &[8, 9, 10]);
+        assert_eq!(ary, [8, 9, 10]);
+    }
+
+    #[test]
+    fn empty_array_insert_slice_out_of_bounds() {
+        let mut ary = SmallArray::<i32>::new();
+        ary.insert_slice(10, &[8, 9, 10]);
+        assert_eq!(ary, [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 8, 9, 10]);
+    }
+
+    #[test]
+    fn empty_array_insert_slice_begin() {
+        let mut ary = SmallArray::<i32>::new();
+        ary.insert_slice(0, &[8, 9, 10]);
+        assert_eq!(ary, [8, 9, 10]);
+    }
+
+    // `set_slice`
+
+    #[test]
+    fn non_empty_array_set_slice_end_empty_drain_0() {
+        let mut ary = SmallArray::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(5, 0, &[]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_end_empty_drain_less_than_insert_length() {
+        let mut ary = SmallArray::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(5, 0, &[]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_end_empty_drain_equal_to_insert_length() {
+        let mut ary = SmallArray::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(5, 0, &[]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_end_empty_drain_greater_than_insert_length() {
+        let mut ary = SmallArray::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(5, 5, &[]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_out_of_bounds_empty_drain_0() {
+        let mut ary = SmallArray::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(10, 0, &[]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [1, 2, 3, 4, 5, 0, 0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_out_of_bounds_empty_drain_less_than_insert_length() {
+        let mut ary = SmallArray::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(10, 0, &[]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [1, 2, 3, 4, 5, 0, 0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_out_of_bounds_empty_drain_equal_to_insert_length() {
+        let mut ary = SmallArray::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(10, 0, &[]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [1, 2, 3, 4, 5, 0, 0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_out_of_bounds_empty_drain_greater_than_insert_length() {
+        let mut ary = SmallArray::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(10, 0, &[]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [1, 2, 3, 4, 5, 0, 0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_interior_empty_drain_0() {
+        let mut ary = SmallArray::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(1, 0, &[]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_interior_empty_drain_less_than_insert_length() {
+        let mut ary = SmallArray::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(1, 0, &[]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_interior_empty_drain_equal_to_insert_length() {
+        let mut ary = SmallArray::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(1, 0, &[]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_interior_empty_drain_greater_than_insert_length() {
+        let mut ary = SmallArray::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(1, 2, &[]);
+        assert_eq!(drained, 2);
+        assert_eq!(ary, [1, 4, 5]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_interior_empty_drain_greater_than_insert_length_to_end() {
+        let mut ary = SmallArray::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(1, 4, &[]);
+        assert_eq!(drained, 4);
+        assert_eq!(ary, [1]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_interior_empty_drain_greater_than_insert_length_overrun_end() {
+        let mut ary = SmallArray::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(1, 10, &[]);
+        assert_eq!(drained, 4);
+        assert_eq!(ary, [1]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_end_non_empty_drain_0() {
+        let mut ary = SmallArray::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(5, 0, &[7, 8, 9]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [1, 2, 3, 4, 5, 7, 8, 9]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_end_non_empty_drain_less_than_insert_length() {
+        let mut ary = SmallArray::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(5, 2, &[7, 8, 9]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [1, 2, 3, 4, 5, 7, 8, 9]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_end_non_empty_drain_equal_to_insert_length() {
+        let mut ary = SmallArray::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(5, 3, &[7, 8, 9]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [1, 2, 3, 4, 5, 7, 8, 9]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_end_non_empty_drain_greater_than_insert_length() {
+        let mut ary = SmallArray::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(5, 5, &[7, 8, 9]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [1, 2, 3, 4, 5, 7, 8, 9]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_out_of_bounds_non_empty_drain_0() {
+        let mut ary = SmallArray::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(10, 0, &[7, 8, 9]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [1, 2, 3, 4, 5, 0, 0, 0, 0, 0, 7, 8, 9]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_out_of_bounds_non_empty_drain_less_than_insert_length() {
+        let mut ary = SmallArray::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(10, 2, &[7, 8, 9]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [1, 2, 3, 4, 5, 0, 0, 0, 0, 0, 7, 8, 9]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_out_of_bounds_non_empty_drain_equal_to_insert_length() {
+        let mut ary = SmallArray::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(10, 3, &[7, 8, 9]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [1, 2, 3, 4, 5, 0, 0, 0, 0, 0, 7, 8, 9]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_out_of_bounds_non_empty_drain_greater_than_insert_length() {
+        let mut ary = SmallArray::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(10, 5, &[7, 8, 9]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [1, 2, 3, 4, 5, 0, 0, 0, 0, 0, 7, 8, 9]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_interior_non_empty_drain_0() {
+        let mut ary = SmallArray::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(1, 0, &[7, 8, 9]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [1, 7, 8, 9, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_interior_non_empty_drain_less_than_insert_length() {
+        let mut ary = SmallArray::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(1, 2, &[7, 8, 9]);
+        assert_eq!(drained, 2);
+        assert_eq!(ary, [1, 7, 8, 9, 4, 5]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_interior_non_empty_drain_equal_to_insert_length() {
+        let mut ary = SmallArray::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(1, 3, &[7, 8, 9]);
+        assert_eq!(drained, 3);
+        assert_eq!(ary, [1, 7, 8, 9, 5]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_interior_non_empty_drain_greater_than_insert_length() {
+        let mut ary = SmallArray::from([1, 2, 3, 4, 5, 6]);
+        let drained = ary.set_slice(1, 4, &[7, 8, 9]);
+        assert_eq!(drained, 4);
+        assert_eq!(ary, [1, 7, 8, 9, 6]);
+        assert_eq!(ary.len(), 5);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_interior_non_empty_drain_equal_to_insert_length_to_tail() {
+        let mut ary = SmallArray::from([1, 2, 3, 4]);
+        let drained = ary.set_slice(1, 3, &[7, 8, 9]);
+        assert_eq!(drained, 3);
+        assert_eq!(ary, [1, 7, 8, 9]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_interior_non_empty_drain_greater_than_insert_length_to_tail() {
+        let mut ary = SmallArray::from([1, 2, 3, 4]);
+        let drained = ary.set_slice(1, 10, &[7, 8, 9]);
+        assert_eq!(drained, 3);
+        assert_eq!(ary, [1, 7, 8, 9]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_interior_non_empty_drain_less_than_insert_length_overrun_tail() {
+        let mut ary = SmallArray::from([1, 2, 3, 4]);
+        let drained = ary.set_slice(3, 2, &[7, 8, 9]);
+        assert_eq!(drained, 1);
+        assert_eq!(ary, [1, 2, 3, 7, 8, 9]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_interior_non_empty_drain_equal_to_insert_length_overrun_tail() {
+        let mut ary = SmallArray::from([1, 2, 3, 4]);
+        let drained = ary.set_slice(3, 3, &[7, 8, 9]);
+        assert_eq!(drained, 1);
+        assert_eq!(ary, [1, 2, 3, 7, 8, 9]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_interior_non_empty_drain_greater_than_insert_length_overrun_tail() {
+        let mut ary = SmallArray::from([1, 2, 3, 4]);
+        let drained = ary.set_slice(3, 10, &[7, 8, 9]);
+        assert_eq!(drained, 1);
+        assert_eq!(ary, [1, 2, 3, 7, 8, 9]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_begin_non_empty_drain_0() {
+        let mut ary = SmallArray::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(0, 0, &[7, 8, 9]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [7, 8, 9, 1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_begin_non_empty_drain_less_than_insert_length() {
+        let mut ary = SmallArray::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(0, 2, &[7, 8, 9]);
+        assert_eq!(drained, 2);
+        assert_eq!(ary, [7, 8, 9, 3, 4, 5]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_begin_non_empty_drain_equal_to_insert_length() {
+        let mut ary = SmallArray::from([1, 2, 3, 4, 5]);
+        let drained = ary.set_slice(0, 3, &[7, 8, 9]);
+        assert_eq!(drained, 3);
+        assert_eq!(ary, [7, 8, 9, 4, 5]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_begin_non_empty_drain_greater_than_insert_length() {
+        let mut ary = SmallArray::from([1, 2, 3, 4, 5, 6]);
+        let drained = ary.set_slice(0, 4, &[7, 8, 9]);
+        assert_eq!(drained, 4);
+        assert_eq!(ary, [7, 8, 9, 5, 6]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_begin_non_empty_drain_equal_to_insert_length_to_tail() {
+        let mut ary = SmallArray::from([1, 2, 3, 4]);
+        let drained = ary.set_slice(0, 4, &[7, 8, 9, 10]);
+        assert_eq!(drained, 4);
+        assert_eq!(ary, [7, 8, 9, 10]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_begin_non_empty_drain_greater_than_insert_length_to_tail() {
+        let mut ary = SmallArray::from([1, 2, 3, 4]);
+        let drained = ary.set_slice(0, 10, &[7, 8, 9, 10]);
+        assert_eq!(drained, 4);
+        assert_eq!(ary, [7, 8, 9, 10]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_begin_non_empty_drain_less_than_insert_length_overrun_tail() {
+        let mut ary = SmallArray::from([1, 2, 3, 4]);
+        let drained = ary.set_slice(0, 4, &[7, 8, 9, 10, 11]);
+        assert_eq!(drained, 4);
+        assert_eq!(ary, [7, 8, 9, 10, 11]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_begin_non_empty_drain_equal_to_insert_length_overrun_tail() {
+        let mut ary = SmallArray::from([1, 2, 3, 4]);
+        let drained = ary.set_slice(0, 5, &[7, 8, 9, 10, 11]);
+        assert_eq!(drained, 4);
+        assert_eq!(ary, [7, 8, 9, 10, 11]);
+    }
+
+    #[test]
+    fn non_empty_array_set_slice_begin_non_empty_drain_greater_than_insert_length_overrun_tail() {
+        let mut ary = SmallArray::from([1, 2, 3, 4]);
+        let drained = ary.set_slice(0, 10, &[7, 8, 9, 10, 11]);
+        assert_eq!(drained, 4);
+        assert_eq!(ary, [7, 8, 9, 10, 11]);
+    }
+
+    #[test]
+    fn empty_array_set_slice_non_empty_drain_0() {
+        let mut ary = SmallArray::<i32>::new();
+        let drained = ary.set_slice(0, 0, &[7, 8, 9]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [7, 8, 9]);
+    }
+
+    #[test]
+    fn empty_array_set_slice_non_empty_drain_less_than_insert_length() {
+        let mut ary = SmallArray::<i32>::new();
+        let drained = ary.set_slice(0, 1, &[7, 8, 9]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [7, 8, 9]);
+    }
+
+    #[test]
+    fn empty_array_set_slice_non_empty_drain_equal_to_insert_length() {
+        let mut ary = SmallArray::<i32>::new();
+        let drained = ary.set_slice(0, 3, &[7, 8, 9]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [7, 8, 9]);
+    }
+
+    #[test]
+    fn empty_array_set_slice_begin_non_empty_drain_greater_than_insert_length() {
+        let mut ary = SmallArray::<i32>::new();
+        let drained = ary.set_slice(0, 10, &[7, 8, 9]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [7, 8, 9]);
+    }
+
+    #[test]
+    fn empty_array_set_slice_out_of_bounds_non_empty_drain_0() {
+        let mut ary = SmallArray::<i32>::new();
+        let drained = ary.set_slice(5, 0, &[7, 8, 9]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [0, 0, 0, 0, 0, 7, 8, 9]);
+    }
+
+    #[test]
+    fn empty_array_set_slice_out_of_bounds_non_empty_drain_less_than_insert_length() {
+        let mut ary = SmallArray::<i32>::new();
+        let drained = ary.set_slice(5, 1, &[7, 8, 9]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [0, 0, 0, 0, 0, 7, 8, 9]);
+    }
+
+    #[test]
+    fn empty_array_set_slice_out_of_bounds_non_empty_drain_equal_to_insert_length() {
+        let mut ary = SmallArray::<i32>::new();
+        let drained = ary.set_slice(5, 3, &[7, 8, 9]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [0, 0, 0, 0, 0, 7, 8, 9]);
+    }
+
+    #[test]
+    fn empty_array_set_slice_out_of_bounds_non_empty_drain_greater_than_insert_length() {
+        let mut ary = SmallArray::<i32>::new();
+        let drained = ary.set_slice(5, 10, &[7, 8, 9]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [0, 0, 0, 0, 0, 7, 8, 9]);
+    }
+
+    #[test]
+    fn empty_array_set_slice_empty_drain_0() {
+        let mut ary = SmallArray::<i32>::new();
+        let drained = ary.set_slice(0, 0, &[]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, []);
+    }
+
+    #[test]
+    fn empty_array_set_slice_empty_drain_less_than_insert_length() {
+        let mut ary = SmallArray::<i32>::new();
+        let drained = ary.set_slice(0, 0, &[]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, []);
+    }
+
+    #[test]
+    fn empty_array_set_slice_empty_drain_equal_to_insert_length() {
+        let mut ary = SmallArray::<i32>::new();
+        let drained = ary.set_slice(0, 0, &[]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, []);
+    }
+
+    #[test]
+    fn empty_array_set_slice_begin_empty_drain_greater_than_insert_length() {
+        let mut ary = SmallArray::<i32>::new();
+        let drained = ary.set_slice(0, 10, &[]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, []);
+    }
+
+    #[test]
+    fn empty_array_set_slice_out_of_bounds_empty_drain_0() {
+        let mut ary = SmallArray::<i32>::new();
+        let drained = ary.set_slice(5, 0, &[]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [0, 0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn empty_array_set_slice_out_of_bounds_empty_drain_less_than_insert_length() {
+        let mut ary = SmallArray::<i32>::new();
+        let drained = ary.set_slice(5, 1, &[]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [0, 0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn empty_array_set_slice_out_of_bounds_empty_drain_equal_to_insert_length() {
+        let mut ary = SmallArray::<i32>::new();
+        let drained = ary.set_slice(5, 3, &[]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [0, 0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn empty_array_set_slice_out_of_bounds_empty_drain_greater_than_insert_length() {
+        let mut ary = SmallArray::<i32>::new();
+        let drained = ary.set_slice(5, 10, &[]);
+        assert_eq!(drained, 0);
+        assert_eq!(ary, [0, 0, 0, 0, 0]);
+    }
+}

--- a/spinoso-array/src/array/tinyvec/mod.rs
+++ b/spinoso-array/src/array/tinyvec/mod.rs
@@ -1,3 +1,5 @@
+#![forbid(unsafe_code)]
+
 //! Ruby `Array` based on [`TinyVec`].
 
 use alloc::boxed::Box;

--- a/spinoso-array/src/array/tinyvec/mod.rs
+++ b/spinoso-array/src/array/tinyvec/mod.rs
@@ -74,16 +74,22 @@ mod impls;
 /// [`last_n`]: TinyArray::last_n
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(docsrs, doc(cfg(feature = "small-array")))]
-pub struct TinyArray<T>(TinyVec<[T; INLINE_CAPACITY]>);
+pub struct TinyArray<T: Default>(TinyVec<[T; INLINE_CAPACITY]>);
 
-impl<T> Default for TinyArray<T> {
+impl<T> Default for TinyArray<T>
+where
+    T: Default,
+{
     #[inline]
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<T> TinyArray<T> {
+impl<T> TinyArray<T>
+where
+    T: Default,
+{
     /// Construct a new, empty `TinyArray<T>`.
     ///
     /// The vector will not allocate until more than [`INLINE_CAPACITY`]
@@ -881,7 +887,7 @@ impl<T> TinyArray<T> {
 
 impl<T> TinyArray<T>
 where
-    T: Copy,
+    T: Clone + Default,
 {
     /// Construct a new `TinyArray<T>` with length `len` and all elements set
     /// to `default`. The `TinyArray` will have capacity at least `len`.
@@ -1070,7 +1076,7 @@ where
 
 impl<T> TinyArray<T>
 where
-    T: Default + Copy,
+    T: Default + Clone,
 {
     /// Insert the elements from a slice at a position `index` in the vector,
     /// extending the vector with `T::default()` if `index` is out of bounds.

--- a/spinoso-array/src/lib.rs
+++ b/spinoso-array/src/lib.rs
@@ -39,7 +39,11 @@
 //!   library. This Spinoso array type is enabled by default.
 //! - [`SmallArray`] is based on [`SmallVec`] and implements the small vector
 //!   optimization – small arrays are stored inline without a heap allocation.
-//!   This Spinoso array type requires the `small-array` Cargo feature.
+//!   This Spinoso array type requires the **small-array** Cargo feature.
+//! - [`TinyArray`] is based on [`TinyVec`] and implements the small vector
+//!   optimization – small arrays are stored inline without a heap allocation.
+//!   This Spinoso array type requires the **tiny-array** Cargo feature.
+//!
 //!
 //! # `no_std`
 //!
@@ -119,6 +123,7 @@
 //! [Artichoke Ruby]: https://www.artichokeruby.org/
 //! [`Vec`]: alloc::vec::Vec
 //! [`SmallVec`]: smallvec::SmallVec
+//! [`TinyVec`]: tinyvec::TinyVec
 //! [`From`]: core::convert::From
 //! [`FromIterator`]: core::iter::FromIterator
 //! [`Index`]: core::ops::Index
@@ -155,7 +160,9 @@ mod array;
 
 #[cfg(feature = "small-array")]
 pub use array::smallvec::SmallArray;
-#[cfg(feature = "small-array")]
+#[cfg(feature = "tiny-array")]
+pub use array::tinyvec::TinyArray;
+#[cfg(any(feature = "small-array", feature = "tiny-array"))]
 pub use array::INLINE_CAPACITY;
 
 pub use array::vec::Array;


### PR DESCRIPTION
This backend started as a port of the `SmallArray` backend. `TinyVec` imposes a `Default` and sometimes `Clone` bound; several commits consist of nothing but going through modules and updating trait bounds.

Several simpler method implementations were able to be backported from the `Vec`-based `Array` backend because `TinyVec` offers more `Vec` API compatibility than `SmallVec`.

1935c05 is where the magic of adapting the existing `SmallArray` port to `TinyVec` happens.