### PR TITLE
Bump minimum version of rand_core to address RUSTSEC-2021-0023

### DIFF
--- a/spinoso-random/Cargo.toml
+++ b/spinoso-random/Cargo.toml
@@ -16,7 +16,10 @@ categories = ["algorithms", "no-std"]
 getrandom = { version = "0.2", default-features = false }
 libm = "0.2"
 rand = { version = "0.8", optional = true, default-features = false }
-rand_core = { version = "0.6", optional = true, default-features = false }
+# 0.6.1 is vulnerable to underfilling a buffer.
+#
+# https://rustsec.org/advisories/RUSTSEC-2021-0023
+rand_core = { version = "0.6, >= 0.6.2", default-features = false, optional = true }
 
 [features]
 default = ["random-rand", "rand-traits", "std"]


### PR DESCRIPTION
https://rustsec.org/advisories/RUSTSEC-2021-0023

```
error[A001]: Incorrect check on buffer length when seeding RNGs
   ┌─ /home/lopopolo/dev/artichoke/rand_mt/Cargo.lock:13:1
   │
13 │ rand_core 0.6.1 registry+https://github.com/rust-lang/crates.io-index
   │ --------------------------------------------------------------------- security vulnerability detected
   │
   = ID: RUSTSEC-2021-0023
   = Advisory: https://rustsec.org/advisories/RUSTSEC-2021-0023
   = Summary: rand_core::le::read_u32_into and read_u64_into have incorrect checks on the source buffer length, allowing the destination buffer to be under-filled.

     Implications: some downstream RNGs, including Hc128Rng (but not the more widely used ChaCha*Rng), allow seeding using the SeedableRng::from_seed trait-function with too short keys.
   = Announcement: https://github.com/rust-random/rand/pull/1096
   = Solution: Upgrade to >=0.6.2
   = rand_core v0.6.1
     └── rand_mt v4.0.0
```