### PR TITLE
Remove duplicate impls of ByteLiteral and move it to string escape utils

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,7 +515,7 @@ version = "0.1.0"
 
 [[package]]
 name = "scolapasta-string-escape"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "bstr",
 ]

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -19,7 +19,7 @@ itoa = "0.4"
 log = "0.4, >= 0.4.5"
 once_cell = "1"
 regex = "1"
-scolapasta-string-escape = { version = "0.1", path = "../scolapasta-string-escape" }
+scolapasta-string-escape = { version = "0.2", path = "../scolapasta-string-escape", default-features = false }
 spinoso-array = { version = "0.5", path = "../spinoso-array", default-features = false }
 spinoso-env = { version = "0.1", path = "../spinoso-env", optional = true }
 spinoso-exception = { version = "0.1", path = "../spinoso-exception" }

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -440,7 +440,7 @@ version = "0.1.0"
 
 [[package]]
 name = "scolapasta-string-escape"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "bstr",
 ]

--- a/scolapasta-string-escape/Cargo.toml
+++ b/scolapasta-string-escape/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scolapasta-string-escape"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2018"
 description = """
@@ -14,6 +14,12 @@ categories = ["encoding", "no-std", "parser-implementations"]
 
 [dependencies]
 bstr = { version = "0.2, >= 0.2.4", default-features = false }
+
+[features]
+default = ["std"]
+# By default, `scolapasta-string-escape` is `no_std`. This feature enables
+# `std::error::Error` impls.
+std = []
 
 [package.metadata.docs.rs]
 all-features = true

--- a/scolapasta-string-escape/src/lib.rs
+++ b/scolapasta-string-escape/src/lib.rs
@@ -93,6 +93,9 @@
 #[cfg(any(test, doctest))]
 extern crate alloc;
 
+#[cfg(feature = "std")]
+extern crate std;
+
 // Ensure code blocks in README.md compile
 #[cfg(doctest)]
 macro_rules! readme {

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -503,7 +503,7 @@ version = "0.1.0"
 
 [[package]]
 name = "scolapasta-string-escape"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "bstr",
 ]

--- a/spinoso-env/Cargo.toml
+++ b/spinoso-env/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["os", "wasm"]
 
 [dependencies]
 bstr = { version = "0.2, >= 0.2.4", default-features = false }
-scolapasta-string-escape = { version = "0.1", path = "../scolapasta-string-escape" }
+scolapasta-string-escape = { version = "0.2", path = "../scolapasta-string-escape", default-features = false }
 
 [features]
 default = ["system-env"]

--- a/spinoso-exception/Cargo.toml
+++ b/spinoso-exception/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["error", "exception", "no_std", "spinoso"]
 categories = ["rust-patterns"]
 
 [dependencies]
-scolapasta-string-escape = { version = "0.1", path = "../scolapasta-string-escape" }
+scolapasta-string-escape = { version = "0.2", path = "../scolapasta-string-escape", default-features = false }
 
 [features]
 default = ["std"]

--- a/spinoso-regexp/Cargo.toml
+++ b/spinoso-regexp/Cargo.toml
@@ -18,7 +18,7 @@ bstr = { version = "0.2, >= 0.2.4", default-features = false }
 itoa = "0.4"
 onig = { version = "6.1", default-features = false, optional = true }
 regex = { version = "1, >= 1.3", default-features = false, features = ["std", "unicode-perl"] }
-scolapasta-string-escape = { version = "0.1", path = "../scolapasta-string-escape" }
+scolapasta-string-escape = { version = "0.2", path = "../scolapasta-string-escape", default-features = false }
 
 [features]
 default = ["oniguruma", "regex-full"]

--- a/spinoso-symbol/Cargo.toml
+++ b/spinoso-symbol/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["data-structures", "no-std", "parser-implementations"]
 artichoke-core = { version = "0.7", path = "../artichoke-core", default-features = false, optional = true }
 bstr = { version = "0.2, >= 0.2.4", optional = true, default-features = false }
 focaccia = { version = "1.0", optional = true, default-features = false }
-scolapasta-string-escape = { version = "0.1", path = "../scolapasta-string-escape", optional = true }
+scolapasta-string-escape = { version = "0.2", path = "../scolapasta-string-escape", default-features = false, optional = true }
 
 [features]
 default = ["artichoke", "std"]


### PR DESCRIPTION
Both `spinoso-symbol` and `spinoso-regexp` had impls of a `ByteLiteral`
iterator which wrapped `scolapasta_string_escape::Literal` to more
ergonomically deal with multi-byte UTF-8 decoding failures from `bstr`.

This change extracts the best parts of these diverging impls and
relocates them to `scolapasta-string-escape`. The new iterator has a new
name, fallible construction from slices (instead of panicking in a
`From` impl), public constructors, docs, `FusedIterator` and
`DoubleEndedIterator` impls, and an optional `std::error::Error` impl.

This PR adds an on-by-default `std` feature to
`scolapasta-string-escape` and bumps the crate version to 0.2.0. All
workspace deps are updated and disable default features.

All subworkspaces have their lockfiles rebuilt.

This turns out to be the API that consumers of
`scolapasta-string-escape` really wanted. After this refactor, the
`Literal` type is not referenced anywhere in this repo outside of the
string escape crate.