### PR TITLE
Update minimum regexp version requirement in spinoso-regexp

### DIFF
--- a/spinoso-regexp/Cargo.toml
+++ b/spinoso-regexp/Cargo.toml
@@ -17,7 +17,7 @@ bitflags = "1.2"
 bstr = { version = "0.2, >= 0.2.4", default-features = false }
 itoa = "0.4"
 onig = { version = "6.1", default-features = false, optional = true }
-regex = { version = "1, >= 1.3", default-features = false, features = ["std", "unicode-perl"] }
+regex = { version = "1, >= 1.4.3", default-features = false, features = ["std", "unicode-perl"] }
 scolapasta-string-escape = { version = "0.2", path = "../scolapasta-string-escape", default-features = false }
 
 [features]


### PR DESCRIPTION
rust-lang/regex#735 added missing `fmt::Debug` impls for public
structs and enums, which `spinoso-regexp` requires to impl `fmt::Debug`
on its own iterator types.

This change does not use these `fmt::Debug` impls, just updated the
minimum dependency version.