### PR TITLE
Implement mruby value/float numeric conversions in Rust

### DIFF
--- a/artichoke-backend/src/extn/core/float/mod.rs
+++ b/artichoke-backend/src/extn/core/float/mod.rs
@@ -202,11 +202,42 @@ impl Float {
         Self(0.0)
     }
 
+    /// Construct a new `Float` with a given [`f64`].
+    #[inline]
+    #[must_use]
+    pub const fn with_f64(f: f64) -> Self {
+        Self(f)
+    }
+
+    /// Convert self to an `i64` with a saturating cast.
+    #[inline]
+    #[must_use]
+    #[allow(clippy::cast_possible_truncation)]
+    pub const fn as_i64(self) -> i64 {
+        self.0 as i64
+    }
+
     /// Return the inner [`f64`].
     #[inline]
     #[must_use]
     pub const fn as_f64(self) -> f64 {
         self.0
+    }
+
+    #[inline]
+    #[must_use]
+    #[allow(clippy::cast_possible_truncation)]
+    #[allow(clippy::cast_precision_loss)]
+    pub fn try_into_fixnum(self) -> Option<i64> {
+        const FIXABLE_MAX: f64 = 2_i64.pow(f64::MANTISSA_DIGITS) as f64;
+        const FIXABLE_MIN: f64 = -(2_i64.pow(f64::MANTISSA_DIGITS)) as f64;
+
+        match self.0 {
+            x if !x.is_finite() => None,
+            x if x > FIXABLE_MAX => None,
+            x if x < FIXABLE_MIN => None,
+            x => Some(x as i64),
+        }
     }
 
     /// Compute the remainder of self and other.

--- a/artichoke-backend/src/extn/core/numeric/ffi.rs
+++ b/artichoke-backend/src/extn/core/numeric/ffi.rs
@@ -1,0 +1,35 @@
+use crate::extn::core::float::Float;
+use crate::extn::core::integer::Integer;
+use crate::extn::prelude::*;
+
+// ```c
+// MRB_API mrb_float mrb_to_flo(mrb_state *mrb, mrb_value x);
+// ```
+#[no_mangle]
+unsafe extern "C" fn mrb_to_flo(mrb: *mut sys::mrb_state, value: sys::mrb_value) -> sys::mrb_float {
+    unwrap_interpreter!(mrb, to => guard, or_else = 0.0);
+    let value = Value::from(value);
+    let result = value
+        .try_into::<Float>(&guard)
+        .map(Float::as_f64)
+        .or_else(|_| value.try_into::<Integer>(&guard).map(Integer::as_f64));
+    match result {
+        Ok(flt) => flt,
+        Err(exception) => error::raise(guard, exception),
+    }
+}
+
+// ```c
+// MRB_API mrb_value mrb_int_value(mrb_state *mrb, mrb_float f);
+// ```
+#[no_mangle]
+unsafe extern "C" fn mrb_int_value(mrb: *mut sys::mrb_state, f: sys::mrb_float) -> sys::mrb_value {
+    unwrap_interpreter!(mrb, to => guard);
+    let f = Float::with_f64(f);
+    let value = if let Some(fixnum) = f.try_into_fixnum() {
+        guard.convert(fixnum)
+    } else {
+        guard.convert_mut(f)
+    };
+    value.inner()
+}

--- a/artichoke-backend/src/extn/core/numeric/mod.rs
+++ b/artichoke-backend/src/extn/core/numeric/mod.rs
@@ -3,6 +3,8 @@ use std::ffi::CStr;
 use crate::extn::core::integer::Integer;
 use crate::extn::prelude::*;
 
+mod ffi;
+
 const NUMERIC_CSTR: &CStr = cstr::cstr!("Numeric");
 
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {

--- a/artichoke-backend/src/value.rs
+++ b/artichoke-backend/src/value.rs
@@ -25,6 +25,13 @@ pub const MRB_FUNCALL_ARGC_MAX: usize = 16;
 #[derive(Default, Debug, Clone, Copy)]
 pub struct Value(sys::mrb_value);
 
+impl From<Value> for sys::mrb_value {
+    /// Extract the inner [`sys::mrb_value`] from this [`Value`].
+    fn from(value: Value) -> Self {
+        value.0
+    }
+}
+
 impl From<sys::mrb_value> for Value {
     /// Construct a new [`Value`] from a [`sys::mrb_value`].
     fn from(value: sys::mrb_value) -> Self {

--- a/artichoke-backend/vendor/mruby/src/numeric.c
+++ b/artichoke-backend/vendor/mruby/src/numeric.c
@@ -30,6 +30,7 @@
 #endif
 #endif
 
+#ifndef ARTICHOKE
 #ifndef MRB_WITHOUT_FLOAT
 MRB_API mrb_float
 mrb_to_flo(mrb_state *mrb, mrb_value val)
@@ -53,6 +54,7 @@ mrb_int_value(mrb_state *mrb, mrb_float f)
   }
   return mrb_float_value(mrb, f);
 }
+#endif
 #endif
 
 /*


### PR DESCRIPTION
Implement `mrb_to_flo` and `mrb_int_value` in Rust and expose to C via `no_mangle` FFI functions. This commit `ifndef`s these functions out in C when `-DARTICHOKE` is given when compiling.

This commit adds several fixnum conversions to `Float`, notably `Float::try_into_fixnum`, which implements the mruby `FIXABLE_FLOAT` and `FIXABLE` macros.

This code has been sitting on a branch for over a year; before I rebased the mainline commit the branch was based on was 0392cec9f45491fa7135dd2ff8b6f762aaad0ed0. Rather than implement all of `Numeric` all at once, landing just these converters feels like a good first step.