### PR TITLE
Make Integer and Float wrappers transparent

### DIFF
--- a/artichoke-backend/src/extn/core/float/mod.rs
+++ b/artichoke-backend/src/extn/core/float/mod.rs
@@ -1,51 +1,25 @@
-use std::ffi::CStr;
+use std::fmt;
 
 use crate::extn::core::numeric::{self, Coercion, Outcome};
 use crate::extn::prelude::*;
 
-const FLOAT_CSTR: &CStr = cstr::cstr!("Float");
+pub mod mruby;
 
-pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
-    if interp.is_class_defined::<Float>() {
-        return Ok(());
+#[repr(transparent)]
+#[derive(Default, Clone, Copy, PartialEq, PartialOrd)]
+pub struct Float(Fp);
+
+impl fmt::Debug for Float {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
     }
-    let spec = class::Spec::new("Float", FLOAT_CSTR, None, None)?;
-    interp.def_class::<Float>(spec)?;
-    let _ = interp.eval(&include_bytes!("float.rb")[..])?;
-
-    let dig = interp.convert(Float::DIG);
-    interp.define_class_constant::<Float>("DIG", dig)?;
-    let epsilon = interp.convert_mut(Float::EPSILON);
-    interp.define_class_constant::<Float>("EPSILON", epsilon)?;
-    let infinity = interp.convert_mut(Float::INFINITY);
-    interp.define_class_constant::<Float>("INFINITY", infinity)?;
-    let mant_dig = interp.convert(Float::MANT_DIG);
-    interp.define_class_constant::<Float>("MANT_DIG", mant_dig)?;
-    let max = interp.convert_mut(Float::MAX);
-    interp.define_class_constant::<Float>("MAX", max)?;
-    let max_10_exp = interp.convert(Float::MAX_10_EXP);
-    interp.define_class_constant::<Float>("MAX_10_EXP", max_10_exp)?;
-    let max_exp = interp.convert(Float::MAX_EXP);
-    interp.define_class_constant::<Float>("MAX_EXP", max_exp)?;
-    let min = interp.convert_mut(Float::MIN);
-    interp.define_class_constant::<Float>("MIN", min)?;
-    let min_10_exp = interp.convert(Float::MIN_10_EXP);
-    interp.define_class_constant::<Float>("MIN_10_EXP", min_10_exp)?;
-    let min_exp = interp.convert(Float::MIN_EXP);
-    interp.define_class_constant::<Float>("MIN_EXP", min_exp)?;
-    let nan = interp.convert_mut(Float::NAN);
-    interp.define_class_constant::<Float>("NAN", nan)?;
-    let radix = interp.convert(Float::RADIX);
-    interp.define_class_constant::<Float>("RADIX", radix)?;
-    let rounds = interp.convert(Float::ROUNDS);
-    interp.define_class_constant::<Float>("ROUNDS", rounds)?;
-
-    trace!("Patched Float onto interpreter");
-    Ok(())
 }
 
-#[derive(Default, Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct Float(Fp);
+impl fmt::Display for Float {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
 
 impl ConvertMut<Float, Value> for Artichoke {
     #[inline]

--- a/artichoke-backend/src/extn/core/float/mruby.rs
+++ b/artichoke-backend/src/extn/core/float/mruby.rs
@@ -1,0 +1,45 @@
+use std::ffi::CStr;
+
+use crate::extn::core::float::Float;
+use crate::extn::prelude::*;
+
+const FLOAT_CSTR: &CStr = cstr::cstr!("Float");
+
+pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
+    if interp.is_class_defined::<Float>() {
+        return Ok(());
+    }
+    let spec = class::Spec::new("Float", FLOAT_CSTR, None, None)?;
+    interp.def_class::<Float>(spec)?;
+    let _ = interp.eval(&include_bytes!("float.rb")[..])?;
+
+    let dig = interp.convert(Float::DIG);
+    interp.define_class_constant::<Float>("DIG", dig)?;
+    let epsilon = interp.convert_mut(Float::EPSILON);
+    interp.define_class_constant::<Float>("EPSILON", epsilon)?;
+    let infinity = interp.convert_mut(Float::INFINITY);
+    interp.define_class_constant::<Float>("INFINITY", infinity)?;
+    let mant_dig = interp.convert(Float::MANT_DIG);
+    interp.define_class_constant::<Float>("MANT_DIG", mant_dig)?;
+    let max = interp.convert_mut(Float::MAX);
+    interp.define_class_constant::<Float>("MAX", max)?;
+    let max_10_exp = interp.convert(Float::MAX_10_EXP);
+    interp.define_class_constant::<Float>("MAX_10_EXP", max_10_exp)?;
+    let max_exp = interp.convert(Float::MAX_EXP);
+    interp.define_class_constant::<Float>("MAX_EXP", max_exp)?;
+    let min = interp.convert_mut(Float::MIN);
+    interp.define_class_constant::<Float>("MIN", min)?;
+    let min_10_exp = interp.convert(Float::MIN_10_EXP);
+    interp.define_class_constant::<Float>("MIN_10_EXP", min_10_exp)?;
+    let min_exp = interp.convert(Float::MIN_EXP);
+    interp.define_class_constant::<Float>("MIN_EXP", min_exp)?;
+    let nan = interp.convert_mut(Float::NAN);
+    interp.define_class_constant::<Float>("NAN", nan)?;
+    let radix = interp.convert(Float::RADIX);
+    interp.define_class_constant::<Float>("RADIX", radix)?;
+    let rounds = interp.convert(Float::ROUNDS);
+    interp.define_class_constant::<Float>("ROUNDS", rounds)?;
+
+    trace!("Patched Float onto interpreter");
+    Ok(())
+}

--- a/artichoke-backend/src/extn/core/integer/mod.rs
+++ b/artichoke-backend/src/extn/core/integer/mod.rs
@@ -1,4 +1,5 @@
 use std::convert::TryFrom;
+use std::fmt;
 use std::mem;
 
 use crate::extn::core::numeric::{self, Coercion, Outcome};
@@ -7,8 +8,21 @@ use crate::extn::prelude::*;
 pub mod mruby;
 pub mod trampoline;
 
-#[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(transparent)]
+#[derive(Default, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Integer(Int);
+
+impl fmt::Debug for Integer {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl fmt::Display for Integer {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
 
 impl Convert<Integer, Value> for Artichoke {
     #[inline]

--- a/artichoke-backend/src/extn/core/integer/mruby.rs
+++ b/artichoke-backend/src/extn/core/integer/mruby.rs
@@ -12,13 +12,13 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     }
     let spec = class::Spec::new("Integer", INTEGER_CSTR, None, None)?;
     class::Builder::for_spec(interp, &spec)
-        .add_method("chr", artichoke_integer_chr, sys::mrb_args_opt(1))?
-        .add_method("[]", artichoke_integer_element_reference, sys::mrb_args_req(1))?
-        .add_method("/", artichoke_integer_div, sys::mrb_args_req(1))?
-        .add_method("allbits?", artichoke_integer_is_allbits, sys::mrb_args_req(1))?
-        .add_method("anybits?", artichoke_integer_is_anybits, sys::mrb_args_req(1))?
-        .add_method("nobits?", artichoke_integer_is_nobits, sys::mrb_args_req(1))?
-        .add_method("size", artichoke_integer_size, sys::mrb_args_none())?
+        .add_method("chr", integer_chr, sys::mrb_args_opt(1))?
+        .add_method("[]", integer_element_reference, sys::mrb_args_req(1))?
+        .add_method("/", integer_div, sys::mrb_args_req(1))?
+        .add_method("allbits?", integer_is_allbits, sys::mrb_args_req(1))?
+        .add_method("anybits?", integer_is_anybits, sys::mrb_args_req(1))?
+        .add_method("nobits?", integer_is_nobits, sys::mrb_args_req(1))?
+        .add_method("size", integer_size, sys::mrb_args_none())?
         .define()?;
     interp.def_class::<Integer>(spec)?;
     let _ = interp.eval(&include_bytes!("integer.rb")[..])?;
@@ -26,7 +26,7 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     Ok(())
 }
 
-unsafe extern "C" fn artichoke_integer_chr(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
+unsafe extern "C" fn integer_chr(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
     let encoding = mrb_get_args!(mrb, optional = 1);
     unwrap_interpreter!(mrb, to => guard);
     let value = Value::from(slf);
@@ -38,10 +38,7 @@ unsafe extern "C" fn artichoke_integer_chr(mrb: *mut sys::mrb_state, slf: sys::m
     }
 }
 
-unsafe extern "C" fn artichoke_integer_element_reference(
-    mrb: *mut sys::mrb_state,
-    slf: sys::mrb_value,
-) -> sys::mrb_value {
+unsafe extern "C" fn integer_element_reference(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
     let bit = mrb_get_args!(mrb, required = 1);
     unwrap_interpreter!(mrb, to => guard);
     let value = Value::from(slf);
@@ -53,7 +50,7 @@ unsafe extern "C" fn artichoke_integer_element_reference(
     }
 }
 
-unsafe extern "C" fn artichoke_integer_div(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
+unsafe extern "C" fn integer_div(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
     let denominator = mrb_get_args!(mrb, required = 1);
     unwrap_interpreter!(mrb, to => guard);
     let value = Value::from(slf);
@@ -65,7 +62,7 @@ unsafe extern "C" fn artichoke_integer_div(mrb: *mut sys::mrb_state, slf: sys::m
     }
 }
 
-unsafe extern "C" fn artichoke_integer_is_allbits(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
+unsafe extern "C" fn integer_is_allbits(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
     let mask = mrb_get_args!(mrb, required = 1);
     unwrap_interpreter!(mrb, to => guard);
     let value = Value::from(slf);
@@ -77,7 +74,7 @@ unsafe extern "C" fn artichoke_integer_is_allbits(mrb: *mut sys::mrb_state, slf:
     }
 }
 
-unsafe extern "C" fn artichoke_integer_is_anybits(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
+unsafe extern "C" fn integer_is_anybits(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
     let mask = mrb_get_args!(mrb, required = 1);
     unwrap_interpreter!(mrb, to => guard);
     let value = Value::from(slf);
@@ -89,7 +86,7 @@ unsafe extern "C" fn artichoke_integer_is_anybits(mrb: *mut sys::mrb_state, slf:
     }
 }
 
-unsafe extern "C" fn artichoke_integer_is_nobits(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
+unsafe extern "C" fn integer_is_nobits(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
     let mask = mrb_get_args!(mrb, required = 1);
     unwrap_interpreter!(mrb, to => guard);
     let value = Value::from(slf);
@@ -101,7 +98,7 @@ unsafe extern "C" fn artichoke_integer_is_nobits(mrb: *mut sys::mrb_state, slf: 
     }
 }
 
-unsafe extern "C" fn artichoke_integer_size(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {
+unsafe extern "C" fn integer_size(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {
     mrb_get_args!(mrb, none);
     unwrap_interpreter!(mrb, to => guard);
     let result = trampoline::size(&guard);

--- a/artichoke-backend/src/extn/core/mod.rs
+++ b/artichoke-backend/src/extn/core/mod.rs
@@ -54,7 +54,7 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     hash::init(interp)?;
     numeric::init(interp)?;
     integer::mruby::init(interp)?;
-    float::init(interp)?;
+    float::mruby::init(interp)?;
     kernel::mruby::init(interp)?;
     #[cfg(feature = "core-regexp")]
     matchdata::mruby::init(interp)?;


### PR DESCRIPTION
- Annotate these types with `#[repr(transparent)]`.
- Implement `fmt::Debug` as a passthrough to the inner primitive type.
- Implement `fmt::Display` as a passthrough to the inner primitive type.
- Move `float::init` to a `float::mruby` module.
- Remove `artichoke_` prefix from `Integer` C mruby trampolines.