### PR TITLE
Remove `Int` and `Fp` type aliases from artichoke-backend

### DIFF
--- a/artichoke-backend/src/class_registry.rs
+++ b/artichoke-backend/src/class_registry.rs
@@ -5,7 +5,6 @@ use crate::class;
 use crate::error::Error;
 use crate::ffi::InterpreterExtractError;
 use crate::sys;
-use crate::types::Int;
 use crate::value::Value;
 use crate::Artichoke;
 
@@ -98,7 +97,7 @@ impl ClassRegistry for Artichoke {
             return Ok(None);
         };
         let args = args.iter().map(Value::inner).collect::<Vec<_>>();
-        let arglen = if let Ok(len) = Int::try_from(args.len()) {
+        let arglen = if let Ok(len) = sys::mrb_int::try_from(args.len()) {
             len
         } else {
             return Ok(None);

--- a/artichoke-backend/src/coerce_to_numeric.rs
+++ b/artichoke-backend/src/coerce_to_numeric.rs
@@ -5,14 +5,14 @@ use artichoke_core::eval::Eval;
 use artichoke_core::value::Value as _;
 use spinoso_exception::TypeError;
 
-use crate::types::{Fp, Ruby};
+use crate::types::Ruby;
 use crate::value::Value;
 use crate::{Artichoke, Error};
 
 impl CoerceToNumeric for Artichoke {
     type Value = Value;
 
-    type Float = Fp;
+    type Float = f64;
 
     type Error = Error;
 

--- a/artichoke-backend/src/convert/array.rs
+++ b/artichoke-backend/src/convert/array.rs
@@ -4,7 +4,7 @@ use crate::convert::{BoxUnboxVmValue, UnboxRubyError};
 use crate::core::{Convert, ConvertMut, TryConvert, TryConvertMut, Value as _};
 use crate::error::Error;
 use crate::extn::core::array::Array;
-use crate::types::{Int, Ruby, Rust};
+use crate::types::{Ruby, Rust};
 use crate::value::Value;
 use crate::Artichoke;
 
@@ -126,10 +126,10 @@ impl TryConvertMut<&[&str], Value> for Artichoke {
     }
 }
 
-impl TryConvertMut<Vec<Int>, Value> for Artichoke {
+impl TryConvertMut<Vec<i64>, Value> for Artichoke {
     type Error = Error;
 
-    fn try_convert_mut(&mut self, value: Vec<Int>) -> Result<Value, Self::Error> {
+    fn try_convert_mut(&mut self, value: Vec<i64>) -> Result<Value, Self::Error> {
         let iter = value.into_iter().map(|item| self.convert(item));
         let ary = Array::from_iter(iter);
         let value = Array::alloc_value(ary, self)?;
@@ -137,10 +137,10 @@ impl TryConvertMut<Vec<Int>, Value> for Artichoke {
     }
 }
 
-impl TryConvertMut<&[Int], Value> for Artichoke {
+impl TryConvertMut<&[i64], Value> for Artichoke {
     type Error = Error;
 
-    fn try_convert_mut(&mut self, value: &[Int]) -> Result<Value, Self::Error> {
+    fn try_convert_mut(&mut self, value: &[i64]) -> Result<Value, Self::Error> {
         let iter = value.iter().copied().map(|item| self.convert(item));
         let ary = Array::from_iter(iter);
         let value = Array::alloc_value(ary, self)?;
@@ -370,10 +370,10 @@ impl<'a> TryConvertMut<Value, Vec<Option<&'a str>>> for Artichoke {
     }
 }
 
-impl TryConvertMut<Value, Vec<Int>> for Artichoke {
+impl TryConvertMut<Value, Vec<i64>> for Artichoke {
     type Error = Error;
 
-    fn try_convert_mut(&mut self, mut value: Value) -> Result<Vec<Int>, Self::Error> {
+    fn try_convert_mut(&mut self, mut value: Value) -> Result<Vec<i64>, Self::Error> {
         if let Ruby::Array = value.ruby_type() {
             let array = unsafe { Array::unbox_from_value(&mut value, self)? };
             array.iter().map(|elem| self.try_convert(elem)).collect()
@@ -400,7 +400,7 @@ mod tests {
 
     quickcheck! {
         #[allow(clippy::needless_pass_by_value)]
-        fn arr_int_borrowed(arr: Vec<Int>) -> bool {
+        fn arr_int_borrowed(arr: Vec<i64>) -> bool {
             let mut interp = interpreter().unwrap();
             // Borrowed converter
             let value = interp.try_convert_mut(arr.as_slice()).unwrap();
@@ -414,7 +414,7 @@ mod tests {
             if empty != arr.is_empty() {
                 return false;
             }
-            let recovered: Vec<Int> = interp.try_convert_mut(value).unwrap();
+            let recovered: Vec<i64> = interp.try_convert_mut(value).unwrap();
             if recovered != arr {
                 return false;
             }
@@ -422,7 +422,7 @@ mod tests {
         }
 
         #[allow(clippy::needless_pass_by_value)]
-        fn arr_int_owned(arr: Vec<Int>) -> bool {
+        fn arr_int_owned(arr: Vec<i64>) -> bool {
             let mut interp = interpreter().unwrap();
             // Owned converter
             let value = interp.try_convert_mut(arr.to_vec()).unwrap();
@@ -436,7 +436,7 @@ mod tests {
             if empty != arr.is_empty() {
                 return false;
             }
-            let recovered: Vec<Int> = interp.try_convert_mut(value).unwrap();
+            let recovered: Vec<i64> = interp.try_convert_mut(value).unwrap();
             if recovered != arr {
                 return false;
             }

--- a/artichoke-backend/src/convert/float.rs
+++ b/artichoke-backend/src/convert/float.rs
@@ -2,22 +2,22 @@ use crate::convert::UnboxRubyError;
 use crate::core::{ConvertMut, TryConvert, Value as _};
 use crate::error::Error;
 use crate::sys;
-use crate::types::{Fp, Ruby, Rust};
+use crate::types::{Ruby, Rust};
 use crate::value::Value;
 use crate::Artichoke;
 
 // TODO: when ,mruby is gone, float conversion should not allocate.
-impl ConvertMut<Fp, Value> for Artichoke {
-    fn convert_mut(&mut self, value: Fp) -> Value {
+impl ConvertMut<f64, Value> for Artichoke {
+    fn convert_mut(&mut self, value: f64) -> Value {
         let float = unsafe { self.with_ffi_boundary(|mrb| sys::mrb_sys_float_value(mrb, value)) };
         self.protect(Value::from(float.unwrap()))
     }
 }
 
-impl TryConvert<Value, Fp> for Artichoke {
+impl TryConvert<Value, f64> for Artichoke {
     type Error = Error;
 
-    fn try_convert(&self, value: Value) -> Result<Fp, Self::Error> {
+    fn try_convert(&self, value: Value) -> Result<f64, Self::Error> {
         if let Ruby::Float = value.ruby_type() {
             let value = value.inner();
             Ok(unsafe { sys::mrb_sys_float_to_cdouble(value) })
@@ -38,18 +38,18 @@ mod tests {
         let mut interp = interpreter().unwrap();
         // get a Ruby Value that can't be converted to a primitive type.
         let value = interp.eval(b"Object.new").unwrap();
-        let result = value.try_into::<Fp>(&interp);
+        let result = value.try_into::<f64>(&interp);
         assert!(result.is_err());
     }
 
     quickcheck! {
-        fn convert_to_float(f: Fp) -> bool {
+        fn convert_to_float(f: f64) -> bool {
             let mut interp = interpreter().unwrap();
             let value = interp.convert_mut(f);
             value.ruby_type() == Ruby::Float
         }
 
-        fn float_with_value(f: Fp) -> bool {
+        fn float_with_value(f: f64) -> bool {
             let mut interp = interpreter().unwrap();
             let value = interp.convert_mut(f);
             let inner = value.inner();
@@ -60,29 +60,29 @@ mod tests {
                 f.is_infinite() && cdouble.signum() == f.signum()
             } else if cdouble >= f {
                 let difference = cdouble - f;
-                difference < Fp::EPSILON
+                difference < f64::EPSILON
             } else if f >= cdouble {
                 let difference = f - cdouble;
-                difference < Fp::EPSILON
+                difference < f64::EPSILON
             } else {
                 false
             }
         }
 
-        fn roundtrip(f: Fp) -> bool {
+        fn roundtrip(f: f64) -> bool {
             let mut interp = interpreter().unwrap();
             let value = interp.convert_mut(f);
-            let value = value.try_into::<Fp>(&interp).unwrap();
+            let value = value.try_into::<f64>(&interp).unwrap();
             if f.is_nan() {
                 value.is_nan()
             } else if f.is_infinite() {
                 value.is_infinite() && value.signum() == f.signum()
             } else if value >= f {
                 let difference = value - f;
-                difference < Fp::EPSILON
+                difference < f64::EPSILON
             } else if f >= value {
                 let difference = f - value;
-                difference < Fp::EPSILON
+                difference < f64::EPSILON
             } else {
                 false
             }
@@ -91,7 +91,7 @@ mod tests {
         fn roundtrip_err(b: bool) -> bool {
             let interp = interpreter().unwrap();
             let value = interp.convert(b);
-            let value = value.try_into::<Fp>(&interp);
+            let value = value.try_into::<f64>(&interp);
             value.is_err()
         }
     }

--- a/artichoke-backend/src/convert/hash.rs
+++ b/artichoke-backend/src/convert/hash.rs
@@ -6,13 +6,13 @@ use crate::core::{ConvertMut, TryConvertMut, Value as _};
 use crate::error::Error;
 use crate::extn::core::array::Array;
 use crate::sys;
-use crate::types::{Int, Ruby, Rust};
+use crate::types::{Ruby, Rust};
 use crate::value::Value;
 use crate::Artichoke;
 
 impl ConvertMut<Vec<(Value, Value)>, Value> for Artichoke {
     fn convert_mut(&mut self, value: Vec<(Value, Value)>) -> Value {
-        let capa = Int::try_from(value.len()).unwrap_or_default();
+        let capa = sys::mrb_int::try_from(value.len()).unwrap_or_default();
         let hash = unsafe { self.with_ffi_boundary(|mrb| sys::mrb_hash_new_capa(mrb, capa)) };
         let hash = self.protect(Value::from(hash.unwrap()));
         for (key, val) in value {
@@ -24,11 +24,11 @@ impl ConvertMut<Vec<(Value, Value)>, Value> for Artichoke {
     }
 }
 
-impl TryConvertMut<Vec<(Vec<u8>, Vec<Int>)>, Value> for Artichoke {
+impl TryConvertMut<Vec<(Vec<u8>, Vec<i64>)>, Value> for Artichoke {
     type Error = Error;
 
-    fn try_convert_mut(&mut self, value: Vec<(Vec<u8>, Vec<Int>)>) -> Result<Value, Self::Error> {
-        let capa = Int::try_from(value.len()).unwrap_or_default();
+    fn try_convert_mut(&mut self, value: Vec<(Vec<u8>, Vec<i64>)>) -> Result<Value, Self::Error> {
+        let capa = sys::mrb_int::try_from(value.len()).unwrap_or_default();
         let hash = unsafe { self.with_ffi_boundary(|mrb| sys::mrb_hash_new_capa(mrb, capa)) };
         let hash = self.protect(Value::from(hash.unwrap()));
         for (key, val) in value {
@@ -44,7 +44,7 @@ impl TryConvertMut<Vec<(Vec<u8>, Vec<Int>)>, Value> for Artichoke {
 
 impl ConvertMut<HashMap<Vec<u8>, Vec<u8>>, Value> for Artichoke {
     fn convert_mut(&mut self, value: HashMap<Vec<u8>, Vec<u8>>) -> Value {
-        let capa = Int::try_from(value.len()).unwrap_or_default();
+        let capa = sys::mrb_int::try_from(value.len()).unwrap_or_default();
         let hash = unsafe { self.with_ffi_boundary(|mrb| sys::mrb_hash_new_capa(mrb, capa)) };
         let hash = self.protect(Value::from(hash.unwrap()));
         for (key, val) in value {
@@ -61,7 +61,7 @@ impl ConvertMut<HashMap<Vec<u8>, Vec<u8>>, Value> for Artichoke {
 impl ConvertMut<Option<HashMap<Vec<u8>, Option<Vec<u8>>>>, Value> for Artichoke {
     fn convert_mut(&mut self, value: Option<HashMap<Vec<u8>, Option<Vec<u8>>>>) -> Value {
         if let Some(value) = value {
-            let capa = Int::try_from(value.len()).unwrap_or_default();
+            let capa = sys::mrb_int::try_from(value.len()).unwrap_or_default();
             let hash = unsafe { self.with_ffi_boundary(|mrb| sys::mrb_hash_new_capa(mrb, capa)) };
             let hash = self.protect(Value::from(hash.unwrap()));
             for (key, val) in value {

--- a/artichoke-backend/src/convert/implicit.rs
+++ b/artichoke-backend/src/convert/implicit.rs
@@ -3,13 +3,13 @@ use artichoke_core::value::Value as _;
 use spinoso_exception::TypeError;
 
 use crate::error::Error;
-use crate::types::{Int, Ruby};
+use crate::types::Ruby;
 use crate::value::Value;
 use crate::Artichoke;
 
 /// Attempt to implicitly convert a [`Value`] to an integer.
 ///
-/// Attempt to extract an [`Int`] from the given `Value` by trying the following
+/// Attempt to extract an [`i64`] from the given `Value` by trying the following
 /// conversions:
 ///
 /// - If the given value is a Ruby integer, return the inner integer.
@@ -68,8 +68,8 @@ use crate::Artichoke;
 ///   `:to_int` method.
 /// - The given value is not an integer and raises an error in its `:to_int`
 ///   method.
-pub fn implicitly_convert_to_int(interp: &mut Artichoke, value: Value) -> Result<Int, Error> {
-    match value.try_into::<Option<Int>>(interp) {
+pub fn implicitly_convert_to_int(interp: &mut Artichoke, value: Value) -> Result<i64, Error> {
+    match value.try_into::<Option<i64>>(interp) {
         // successful conversion: the given value is an integer.
         Ok(Some(num)) => return Ok(num),
         // `nil` does not implicitly convert to integer:
@@ -106,7 +106,7 @@ pub fn implicitly_convert_to_int(interp: &mut Artichoke, value: Value) -> Result
         // ArgumentError (a message)
         // ```
         let maybe = value.funcall(interp, "to_int", &[], None)?;
-        if let Ok(num) = maybe.try_into::<Int>(interp) {
+        if let Ok(num) = maybe.try_into::<i64>(interp) {
             // successful conversion: `#to_int` returned an integer.
             Ok(num)
         } else {

--- a/artichoke-backend/src/convert/nilable.rs
+++ b/artichoke-backend/src/convert/nilable.rs
@@ -4,7 +4,6 @@
 
 use crate::core::{Convert, ConvertMut, TryConvert, TryConvertMut, Value as _};
 use crate::error::Error;
-use crate::types::Int;
 use crate::value::Value;
 use crate::Artichoke;
 
@@ -14,8 +13,8 @@ impl Convert<Option<Value>, Value> for Artichoke {
     }
 }
 
-impl Convert<Option<Int>, Value> for Artichoke {
-    fn convert(&self, value: Option<Int>) -> Value {
+impl Convert<Option<i64>, Value> for Artichoke {
+    fn convert(&self, value: Option<i64>) -> Value {
         if let Some(value) = value {
             self.convert(value)
         } else {
@@ -114,10 +113,10 @@ impl<'a> TryConvertMut<Value, Option<&'a str>> for Artichoke {
     }
 }
 
-impl TryConvert<Value, Option<Int>> for Artichoke {
+impl TryConvert<Value, Option<i64>> for Artichoke {
     type Error = Error;
 
-    fn try_convert(&self, value: Value) -> Result<Option<Int>, Self::Error> {
+    fn try_convert(&self, value: Value) -> Result<Option<i64>, Self::Error> {
         if value.is_nil() {
             Ok(None)
         } else {

--- a/artichoke-backend/src/extn/core/array/args.rs
+++ b/artichoke-backend/src/extn/core/array/args.rs
@@ -7,8 +7,8 @@ use crate::sys::protect;
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum ElementReference {
     Empty,
-    Index(Int),
-    StartLen(Int, usize),
+    Index(i64),
+    StartLen(i64, usize),
 }
 
 pub fn element_reference(
@@ -28,7 +28,7 @@ pub fn element_reference(
     } else if let Ok(index) = implicitly_convert_to_int(interp, elem) {
         Ok(ElementReference::Index(index))
     } else {
-        let rangelen = Int::try_from(ary_len).map_err(|_| Fatal::from("Range length exceeds Integer max"))?;
+        let rangelen = i64::try_from(ary_len).map_err(|_| Fatal::from("Range length exceeds Integer max"))?;
         if let Some(protect::Range { start, len }) = elem.is_range(interp, rangelen)? {
             if let Ok(len) = usize::try_from(len) {
                 Ok(ElementReference::StartLen(start, len))
@@ -95,7 +95,7 @@ pub fn element_assignment(
             }
         }
     } else {
-        let rangelen = Int::try_from(len).map_err(|_| Fatal::from("Range length exceeds Integer max"))?;
+        let rangelen = i64::try_from(len).map_err(|_| Fatal::from("Range length exceeds Integer max"))?;
         if let Some(protect::Range { start, len }) = first.is_range(interp, rangelen)? {
             let start = usize::try_from(start)
                 .unwrap_or_else(|_| unimplemented!("should throw RangeError (-11..1 out of range)"));

--- a/artichoke-backend/src/extn/core/array/mod.rs
+++ b/artichoke-backend/src/extn/core/array/mod.rs
@@ -192,7 +192,7 @@ impl Array {
     ) -> Result<Self, Error> {
         let vector = match (first, second, block) {
             (Some(mut array_or_len), default, None) => {
-                if let Ok(len) = array_or_len.try_into::<Int>(interp) {
+                if let Ok(len) = array_or_len.try_into::<i64>(interp) {
                     let len = usize::try_from(len).map_err(|_| ArgumentError::with_message("negative array size"))?;
                     let default = default.unwrap_or_else(Value::nil);
                     SpinosoArray::with_len_and_default(len, default.inner())
@@ -225,14 +225,14 @@ impl Array {
                 }
             }
             (Some(mut array_or_len), default, Some(block)) => {
-                if let Ok(len) = array_or_len.try_into::<Int>(interp) {
+                if let Ok(len) = array_or_len.try_into::<i64>(interp) {
                     let len = usize::try_from(len).map_err(|_| ArgumentError::with_message("negative array size"))?;
                     if default.is_some() {
                         interp.warn(b"warning: block supersedes default value argument")?;
                     }
                     let mut buffer = SpinosoArray::with_capacity(len);
                     for idx in 0..len {
-                        let idx = Int::try_from(idx)
+                        let idx = i64::try_from(idx)
                             .map_err(|_| RangeError::with_message("bignum too big to convert into `long'"))?;
                         let idx = interp.convert(idx);
                         let elem = block.yield_arg(interp, &idx)?;
@@ -267,7 +267,7 @@ impl Array {
                         }
                         let mut buffer = SpinosoArray::with_capacity(len);
                         for idx in 0..len {
-                            let idx = Int::try_from(idx)
+                            let idx = i64::try_from(idx)
                                 .map_err(|_| RangeError::with_message("bignum too big to convert into `long'"))?;
                             let idx = interp.convert(idx);
                             let elem = block.yield_arg(interp, &idx)?;

--- a/artichoke-backend/src/extn/core/float/mod.rs
+++ b/artichoke-backend/src/extn/core/float/mod.rs
@@ -7,7 +7,7 @@ pub mod mruby;
 
 #[repr(transparent)]
 #[derive(Default, Clone, Copy, PartialEq, PartialOrd)]
-pub struct Float(Fp);
+pub struct Float(f64);
 
 impl fmt::Debug for Float {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -38,14 +38,14 @@ impl TryConvert<Value, Float> for Artichoke {
     }
 }
 
-impl From<Fp> for Float {
+impl From<f64> for Float {
     #[inline]
-    fn from(flt: Fp) -> Self {
+    fn from(flt: f64) -> Self {
         Self(flt)
     }
 }
 
-impl From<Float> for Fp {
+impl From<Float> for f64 {
     #[inline]
     fn from(flt: Float) -> Self {
         flt.as_f64()
@@ -59,9 +59,9 @@ impl From<Float> for Outcome {
     }
 }
 
-impl From<Fp> for Outcome {
+impl From<f64> for Outcome {
     #[inline]
-    fn from(flt: Fp) -> Self {
+    fn from(flt: f64) -> Self {
         Self::Float(flt)
     }
 }
@@ -71,40 +71,40 @@ impl Float {
     /// floating point.
     ///
     /// Usually defaults to 15.
-    pub const DIG: Int = Fp::DIGITS as Int;
+    pub const DIG: i64 = f64::DIGITS as i64;
 
     /// The difference between 1 and the smallest double-precision floating
     /// point number greater than 1.
     ///
     /// Usually defaults to 2.2204460492503131e-16.
-    pub const EPSILON: Fp = Fp::EPSILON;
+    pub const EPSILON: f64 = f64::EPSILON;
 
     /// An expression representing positive infinity.
-    pub const INFINITY: Fp = Fp::INFINITY;
+    pub const INFINITY: f64 = f64::INFINITY;
 
     /// The minimum number of significant decimal digits in a double-precision
     /// floating point.
     ///
     /// Usually defaults to 15.
-    pub const MANT_DIG: Int = Fp::MANTISSA_DIGITS as Int;
+    pub const MANT_DIG: i64 = f64::MANTISSA_DIGITS as i64;
 
     /// The largest possible integer in a double-precision floating point
     /// number.
     ///
     /// Usually defaults to 1.7976931348623157e+308.
-    pub const MAX: Fp = Fp::MAX;
+    pub const MAX: f64 = f64::MAX;
 
     /// The largest positive exponent in a double-precision floating point where
     /// 10 raised to this power minus 1.
     ///
     /// Usually defaults to 308.
-    pub const MAX_10_EXP: Int = Fp::MAX_10_EXP as Int;
+    pub const MAX_10_EXP: i64 = f64::MAX_10_EXP as i64;
 
     /// The largest possible exponent value in a double-precision floating
     /// point.
     ///
     /// Usually defaults to 1024.
-    pub const MAX_EXP: Int = Fp::MAX_EXP as Int;
+    pub const MAX_EXP: i64 = f64::MAX_EXP as i64;
 
     /// The smallest positive normalized number in a double-precision floating
     /// point.
@@ -114,31 +114,31 @@ impl Float {
     /// If the platform supports denormalized numbers, there are numbers between
     /// zero and [`Float::MIN`]. `0.0.next_float` returns the smallest positive
     /// floating point number including denormalized numbers.
-    pub const MIN: Fp = Fp::MIN;
+    pub const MIN: f64 = f64::MIN;
 
     /// The smallest negative exponent in a double-precision floating point
     /// where 10 raised to this power minus 1.
     ///
     /// Usually defaults to -307.
-    pub const MIN_10_EXP: Int = Fp::MIN_10_EXP as Int;
+    pub const MIN_10_EXP: i64 = f64::MIN_10_EXP as i64;
 
     /// The smallest possible exponent value in a double-precision floating
     /// point.
     ///
     /// Usually defaults to -1021.
-    pub const MIN_EXP: Int = Fp::MIN_EXP as Int;
+    pub const MIN_EXP: i64 = f64::MIN_EXP as i64;
 
     /// An expression representing a value which is "not a number".
-    pub const NAN: Fp = Fp::NAN;
+    pub const NAN: f64 = f64::NAN;
 
-    pub const NEG_INFINITY: Fp = Fp::NEG_INFINITY;
+    pub const NEG_INFINITY: f64 = f64::NEG_INFINITY;
 
     /// The base of the floating point, or number of unique digits used to
     /// represent the number.
     ///
     /// Usually defaults to 2 on most systems, which would represent a base-10
     /// decimal.
-    pub const RADIX: Int = Fp::RADIX as Int;
+    pub const RADIX: i64 = f64::RADIX as i64;
 
     /// Represents the rounding mode for floating point addition.
     ///
@@ -167,7 +167,7 @@ impl Float {
     ///
     /// [stackoverflow]: https://stackoverflow.com/a/28122536
     /// [round]: https://doc.rust-lang.org/1.42.0/std/primitive.f64.html#method.round
-    pub const ROUNDS: Int = -1;
+    pub const ROUNDS: i64 = -1;
 
     /// Construct a new, zero, float.
     #[inline]

--- a/artichoke-backend/src/extn/core/integer/trampoline.rs
+++ b/artichoke-backend/src/extn/core/integer/trampoline.rs
@@ -43,8 +43,8 @@ pub fn is_nobits(interp: &mut Artichoke, value: Value, mask: Value) -> Result<Va
 }
 
 pub fn size(interp: &Artichoke) -> Result<Value, Error> {
-    // This `as` cast is lossless because size_of::<Int> is guaranteed to be
-    // less than `Int::MAX`.
-    let size = Integer::size() as Int;
-    Ok(interp.convert(size))
+    // This `as` cast is lossless because size_of::<i64> is guaranteed to be
+    // less than `i64::MAX`.
+    const SIZE: i64 = Integer::size() as i64;
+    Ok(interp.convert(SIZE))
 }

--- a/artichoke-backend/src/extn/core/kernel/integer.rs
+++ b/artichoke-backend/src/extn/core/kernel/integer.rs
@@ -294,7 +294,7 @@ impl<'a> ParseState<'a> {
     }
 }
 
-pub fn method(arg: IntegerString<'_>, radix: Option<Radix>) -> Result<Int, Error> {
+pub fn method(arg: IntegerString<'_>, radix: Option<Radix>) -> Result<i64, Error> {
     let mut state = ParseState::new(arg);
     let mut chars = arg.inner().chars().skip_while(|c| c.is_whitespace()).peekable();
     let mut prev = None::<char>;
@@ -332,10 +332,10 @@ pub fn method(arg: IntegerString<'_>, radix: Option<Radix>) -> Result<Int, Error
     let (src, src_radix) = state.parse()?;
 
     let parsed_int = match (radix, src_radix) {
-        (Some(x), Some(y)) if x == y => Int::from_str_radix(src.as_str(), x.as_u32()).ok(),
-        (None, None) => Int::from_str(src.as_str()).ok(),
+        (Some(x), Some(y)) if x == y => i64::from_str_radix(src.as_str(), x.as_u32()).ok(),
+        (None, None) => i64::from_str(src.as_str()).ok(),
         (Some(x), None) | (None, Some(x)) if (2..=36).contains(&x.as_u32()) => {
-            Int::from_str_radix(src.as_str(), x.as_u32()).ok()
+            i64::from_str_radix(src.as_str(), x.as_u32()).ok()
         }
         _ => None,
     };

--- a/artichoke-backend/src/extn/core/matchdata/mod.rs
+++ b/artichoke-backend/src/extn/core/matchdata/mod.rs
@@ -78,13 +78,13 @@ impl RangeBounds<usize> for Region {
 
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
 pub enum Capture<'a> {
-    GroupIndex(Int),
+    GroupIndex(i64),
     GroupName(&'a [u8]),
 }
 
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
 pub enum CaptureExtract<'a> {
-    GroupIndex(Int),
+    GroupIndex(i64),
     GroupName(&'a [u8]),
     Symbol(Symbol),
 }
@@ -107,9 +107,9 @@ impl<'a> TryConvertMut<&'a mut Value, CaptureExtract<'a>> for Artichoke {
 
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum CaptureAt<'a> {
-    GroupIndex(Int),
+    GroupIndex(i64),
     GroupName(&'a [u8]),
-    StartLen(Int, Int),
+    StartLen(i64, i64),
 }
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]

--- a/artichoke-backend/src/extn/core/matchdata/trampoline.rs
+++ b/artichoke-backend/src/extn/core/matchdata/trampoline.rs
@@ -16,7 +16,7 @@ pub fn begin(interp: &mut Artichoke, mut value: Value, mut at: Value) -> Result<
         CaptureExtract::Symbol(symbol) => Capture::GroupName(symbol.bytes(interp)),
     };
     let begin = data.begin(capture)?;
-    match begin.map(Int::try_from) {
+    match begin.map(i64::try_from) {
         Some(Ok(begin)) => Ok(interp.convert(begin)),
         Some(Err(_)) => Err(ArgumentError::with_message("input string too long").into()),
         None => Ok(Value::nil()),
@@ -54,7 +54,7 @@ pub fn element_reference(
         // inner regexp.
         let captures_len = data.regexp.inner().captures_len(None)?;
         let rangelen =
-            Int::try_from(captures_len).map_err(|_| ArgumentError::with_message("input string too long"))?;
+            i64::try_from(captures_len).map_err(|_| ArgumentError::with_message("input string too long"))?;
         if let Some(protect::Range { start, len }) = elem.is_range(interp, rangelen)? {
             CaptureAt::StartLen(start, len)
         } else {
@@ -73,7 +73,7 @@ pub fn end(interp: &mut Artichoke, mut value: Value, mut at: Value) -> Result<Va
         CaptureExtract::Symbol(symbol) => Capture::GroupName(symbol.bytes(interp)),
     };
     let end = data.end(capture)?;
-    match end.map(Int::try_from) {
+    match end.map(i64::try_from) {
         Some(Ok(end)) => Ok(interp.convert(end)),
         Some(Err(_)) => Err(ArgumentError::with_message("input string too long").into()),
         None => Ok(Value::nil()),
@@ -83,7 +83,7 @@ pub fn end(interp: &mut Artichoke, mut value: Value, mut at: Value) -> Result<Va
 pub fn length(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
     let data = unsafe { MatchData::unbox_from_value(&mut value, interp)? };
     let len = data.len()?;
-    if let Ok(len) = Int::try_from(len) {
+    if let Ok(len) = i64::try_from(len) {
         Ok(interp.convert(len))
     } else {
         Err(ArgumentError::with_message("input string too long").into())
@@ -110,7 +110,7 @@ pub fn offset(interp: &mut Artichoke, mut value: Value, mut at: Value) -> Result
         CaptureExtract::Symbol(symbol) => Capture::GroupName(symbol.bytes(interp)),
     };
     if let Some([begin, end]) = data.offset(capture)? {
-        if let (Ok(begin), Ok(end)) = (Int::try_from(begin), Int::try_from(end)) {
+        if let (Ok(begin), Ok(end)) = (i64::try_from(begin), i64::try_from(end)) {
             let ary = Array::assoc(interp.convert(begin), interp.convert(end));
             Array::alloc_value(ary, interp)
         } else {

--- a/artichoke-backend/src/extn/core/math/trampoline.rs
+++ b/artichoke-backend/src/extn/core/math/trampoline.rs
@@ -5,98 +5,98 @@ use core::convert::TryFrom;
 use crate::convert::implicitly_convert_to_int;
 use crate::extn::prelude::*;
 
-pub fn acos(interp: &mut Artichoke, value: Value) -> Result<Fp, Error> {
+pub fn acos(interp: &mut Artichoke, value: Value) -> Result<f64, Error> {
     let value = interp.coerce_to_float(value)?;
     let result = spinoso_math::acos(value)?;
     Ok(result)
 }
 
-pub fn acosh(interp: &mut Artichoke, value: Value) -> Result<Fp, Error> {
+pub fn acosh(interp: &mut Artichoke, value: Value) -> Result<f64, Error> {
     let value = interp.coerce_to_float(value)?;
     let result = spinoso_math::acosh(value)?;
     Ok(result)
 }
 
-pub fn asin(interp: &mut Artichoke, value: Value) -> Result<Fp, Error> {
+pub fn asin(interp: &mut Artichoke, value: Value) -> Result<f64, Error> {
     let value = interp.coerce_to_float(value)?;
     let result = spinoso_math::asin(value)?;
     Ok(result)
 }
 
-pub fn asinh(interp: &mut Artichoke, value: Value) -> Result<Fp, Error> {
+pub fn asinh(interp: &mut Artichoke, value: Value) -> Result<f64, Error> {
     let value = interp.coerce_to_float(value)?;
     let result = spinoso_math::asinh(value);
     Ok(result)
 }
 
-pub fn atan(interp: &mut Artichoke, value: Value) -> Result<Fp, Error> {
+pub fn atan(interp: &mut Artichoke, value: Value) -> Result<f64, Error> {
     let value = interp.coerce_to_float(value)?;
     let result = spinoso_math::atan(value);
     Ok(result)
 }
 
-pub fn atan2(interp: &mut Artichoke, value: Value, other: Value) -> Result<Fp, Error> {
+pub fn atan2(interp: &mut Artichoke, value: Value, other: Value) -> Result<f64, Error> {
     let value = interp.coerce_to_float(value)?;
     let other = interp.coerce_to_float(other)?;
     let result = spinoso_math::atan2(value, other);
     Ok(result)
 }
 
-pub fn atanh(interp: &mut Artichoke, value: Value) -> Result<Fp, Error> {
+pub fn atanh(interp: &mut Artichoke, value: Value) -> Result<f64, Error> {
     let value = interp.coerce_to_float(value)?;
     let result = spinoso_math::atanh(value)?;
     Ok(result)
 }
 
-pub fn cbrt(interp: &mut Artichoke, value: Value) -> Result<Fp, Error> {
+pub fn cbrt(interp: &mut Artichoke, value: Value) -> Result<f64, Error> {
     let value = interp.coerce_to_float(value)?;
     let result = spinoso_math::cbrt(value);
     Ok(result)
 }
 
-pub fn cos(interp: &mut Artichoke, value: Value) -> Result<Fp, Error> {
+pub fn cos(interp: &mut Artichoke, value: Value) -> Result<f64, Error> {
     let value = interp.coerce_to_float(value)?;
     let result = spinoso_math::cos(value);
     Ok(result)
 }
 
-pub fn cosh(interp: &mut Artichoke, value: Value) -> Result<Fp, Error> {
+pub fn cosh(interp: &mut Artichoke, value: Value) -> Result<f64, Error> {
     let value = interp.coerce_to_float(value)?;
     let result = spinoso_math::cosh(value);
     Ok(result)
 }
 
-pub fn erf(interp: &mut Artichoke, value: Value) -> Result<Fp, Error> {
+pub fn erf(interp: &mut Artichoke, value: Value) -> Result<f64, Error> {
     let value = interp.coerce_to_float(value)?;
     let result = spinoso_math::erf(value)?;
     Ok(result)
 }
 
-pub fn erfc(interp: &mut Artichoke, value: Value) -> Result<Fp, Error> {
+pub fn erfc(interp: &mut Artichoke, value: Value) -> Result<f64, Error> {
     let value = interp.coerce_to_float(value)?;
     let result = spinoso_math::erfc(value)?;
     Ok(result)
 }
 
-pub fn exp(interp: &mut Artichoke, value: Value) -> Result<Fp, Error> {
+pub fn exp(interp: &mut Artichoke, value: Value) -> Result<f64, Error> {
     let value = interp.coerce_to_float(value)?;
     let result = spinoso_math::exp(value);
     Ok(result)
 }
 
-pub fn frexp(interp: &mut Artichoke, value: Value) -> Result<(Fp, Int), Error> {
+pub fn frexp(interp: &mut Artichoke, value: Value) -> Result<(f64, i64), Error> {
     let value = interp.coerce_to_float(value)?;
     let (fraction, exponent) = spinoso_math::frexp(value)?;
     Ok((fraction, exponent.into()))
 }
 
-pub fn gamma(interp: &mut Artichoke, value: Value) -> Result<Fp, Error> {
+pub fn gamma(interp: &mut Artichoke, value: Value) -> Result<f64, Error> {
     let value = interp.coerce_to_float(value)?;
     let result = spinoso_math::gamma(value)?;
     Ok(result)
 }
 
-pub fn hypot(interp: &mut Artichoke, value: Value, other: Value) -> Result<Fp, Error> {
+pub fn hypot(interp: &mut Artichoke, value: Value, other: Value) -> Result<f64, Error> {
     let value = interp.coerce_to_float(value)?;
     let other = interp.coerce_to_float(other)?;
     let result = spinoso_math::hypot(value, other);
@@ -104,9 +104,9 @@ pub fn hypot(interp: &mut Artichoke, value: Value, other: Value) -> Result<Fp, E
 }
 
 #[allow(clippy::cast_possible_truncation)]
-pub fn ldexp(interp: &mut Artichoke, fraction: Value, exponent: Value) -> Result<Fp, Error> {
+pub fn ldexp(interp: &mut Artichoke, fraction: Value, exponent: Value) -> Result<f64, Error> {
     let fraction = interp.coerce_to_float(fraction)?;
-    let exponent = implicitly_convert_to_int(interp, exponent).map_err(|_| exponent.try_into::<Fp>(interp));
+    let exponent = implicitly_convert_to_int(interp, exponent).map_err(|_| exponent.try_into::<f64>(interp));
     let exponent = match exponent {
         Ok(exp) => exp,
         Err(Ok(exp)) if exp.is_nan() => {
@@ -115,7 +115,7 @@ pub fn ldexp(interp: &mut Artichoke, fraction: Value, exponent: Value) -> Result
         Err(Ok(exp)) => {
             // This saturating cast will be rejected by the `i32::try_from`
             // below if `exp` is too large.
-            exp as Int
+            exp as i64
         }
         Err(Err(err)) => return Err(err),
     };
@@ -139,13 +139,13 @@ pub fn ldexp(interp: &mut Artichoke, fraction: Value, exponent: Value) -> Result
     }
 }
 
-pub fn lgamma(interp: &mut Artichoke, value: Value) -> Result<(Fp, Int), Error> {
+pub fn lgamma(interp: &mut Artichoke, value: Value) -> Result<(f64, i64), Error> {
     let value = interp.coerce_to_float(value)?;
     let (result, sign) = spinoso_math::lgamma(value)?;
     Ok((result, sign.into()))
 }
 
-pub fn log(interp: &mut Artichoke, value: Value, base: Option<Value>) -> Result<Fp, Error> {
+pub fn log(interp: &mut Artichoke, value: Value, base: Option<Value>) -> Result<f64, Error> {
     let value = interp.coerce_to_float(value)?;
     let base = if let Some(base) = base {
         let base = interp.coerce_to_float(base)?;
@@ -157,43 +157,43 @@ pub fn log(interp: &mut Artichoke, value: Value, base: Option<Value>) -> Result<
     Ok(result)
 }
 
-pub fn log10(interp: &mut Artichoke, value: Value) -> Result<Fp, Error> {
+pub fn log10(interp: &mut Artichoke, value: Value) -> Result<f64, Error> {
     let value = interp.coerce_to_float(value)?;
     let result = spinoso_math::log10(value)?;
     Ok(result)
 }
 
-pub fn log2(interp: &mut Artichoke, value: Value) -> Result<Fp, Error> {
+pub fn log2(interp: &mut Artichoke, value: Value) -> Result<f64, Error> {
     let value = interp.coerce_to_float(value)?;
     let result = spinoso_math::log2(value)?;
     Ok(result)
 }
 
-pub fn sin(interp: &mut Artichoke, value: Value) -> Result<Fp, Error> {
+pub fn sin(interp: &mut Artichoke, value: Value) -> Result<f64, Error> {
     let value = interp.coerce_to_float(value)?;
     let result = value.sin();
     Ok(result)
 }
 
-pub fn sinh(interp: &mut Artichoke, value: Value) -> Result<Fp, Error> {
+pub fn sinh(interp: &mut Artichoke, value: Value) -> Result<f64, Error> {
     let value = interp.coerce_to_float(value)?;
     let result = spinoso_math::sinh(value);
     Ok(result)
 }
 
-pub fn sqrt(interp: &mut Artichoke, value: Value) -> Result<Fp, Error> {
+pub fn sqrt(interp: &mut Artichoke, value: Value) -> Result<f64, Error> {
     let value = interp.coerce_to_float(value)?;
     let result = spinoso_math::sqrt(value)?;
     Ok(result)
 }
 
-pub fn tan(interp: &mut Artichoke, value: Value) -> Result<Fp, Error> {
+pub fn tan(interp: &mut Artichoke, value: Value) -> Result<f64, Error> {
     let value = interp.coerce_to_float(value)?;
     let result = spinoso_math::tan(value);
     Ok(result)
 }
 
-pub fn tanh(interp: &mut Artichoke, value: Value) -> Result<Fp, Error> {
+pub fn tanh(interp: &mut Artichoke, value: Value) -> Result<f64, Error> {
     let value = interp.coerce_to_float(value)?;
     let result = spinoso_math::tanh(value);
     Ok(result)

--- a/artichoke-backend/src/extn/core/numeric/mod.rs
+++ b/artichoke-backend/src/extn/core/numeric/mod.rs
@@ -23,8 +23,8 @@ pub struct Numeric;
 
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
 pub enum Outcome {
-    Float(Fp),
-    Integer(Int),
+    Float(f64),
+    Integer(i64),
     // TODO: Complex? Rational?
 }
 
@@ -41,8 +41,8 @@ const MAX_COERCE_DEPTH: u8 = 15;
 
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
 pub enum Coercion {
-    Float(Fp, Fp),
-    Integer(Int, Int),
+    Float(f64, f64),
+    Integer(i64, i64),
     // TODO: Complex? Rational?
 }
 

--- a/artichoke-backend/src/extn/core/random/mod.rs
+++ b/artichoke-backend/src/extn/core/random/mod.rs
@@ -46,7 +46,7 @@ impl HeapAllocatedData for Rng {
 
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Seed {
-    New(Int),
+    New(i64),
     None,
 }
 
@@ -56,8 +56,8 @@ impl Default for Seed {
     }
 }
 
-impl From<Int> for Seed {
-    fn from(seed: Int) -> Seed {
+impl From<i64> for Seed {
+    fn from(seed: i64) -> Seed {
         Seed::New(seed)
     }
 }
@@ -108,15 +108,15 @@ impl TryConvertMut<Option<Value>, Seed> for Artichoke {
 
 #[allow(clippy::cast_sign_loss)]
 #[allow(clippy::cast_possible_wrap)]
-pub fn new_seed() -> Result<Int, Error> {
+pub fn new_seed() -> Result<i64, Error> {
     // TODO: return a bignum instead of truncating.
     let [a, b, _, _] = spinoso_random::new_seed()?;
     let seed = u64::from(a) << 32 | u64::from(b);
-    let seed = seed as Int;
+    let seed = seed as i64;
     Ok(seed)
 }
 
-pub fn srand(interp: &mut Artichoke, seed: Seed) -> Result<Int, Error> {
+pub fn srand(interp: &mut Artichoke, seed: Seed) -> Result<i64, Error> {
     let old_seed = interp.prng()?.seed();
     let new_random = Random::with_array_seed(seed.to_mt_seed())?;
     // "Reseed" by replacing the RNG with a newly seeded one.
@@ -125,7 +125,7 @@ pub fn srand(interp: &mut Artichoke, seed: Seed) -> Result<Int, Error> {
     Ok(old_seed)
 }
 
-pub fn urandom(size: Int) -> Result<Vec<u8>, Error> {
+pub fn urandom(size: i64) -> Result<Vec<u8>, Error> {
     match usize::try_from(size) {
         Ok(0) => Ok(Vec::new()),
         Ok(len) => {
@@ -196,7 +196,7 @@ impl Random {
         Ok(Self(random))
     }
 
-    pub fn bytes(&mut self, size: Int) -> Result<Vec<u8>, Error> {
+    pub fn bytes(&mut self, size: i64) -> Result<Vec<u8>, Error> {
         match usize::try_from(size) {
             Ok(0) => Ok(Vec::new()),
             Ok(len) => {
@@ -216,11 +216,11 @@ impl Random {
     #[must_use]
     #[allow(clippy::cast_sign_loss)]
     #[allow(clippy::cast_possible_wrap)]
-    pub fn seed(&self) -> Int {
+    pub fn seed(&self) -> i64 {
         // TODO: return a bignum instead of truncating.
         let [a, b, _, _] = self.as_ref().seed();
         let seed = u64::from(a) << 32 | u64::from(b);
-        seed as Int
+        seed as i64
     }
 }
 

--- a/artichoke-backend/src/extn/core/regexp/backend/lazy.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/lazy.rs
@@ -113,7 +113,7 @@ impl RegexpType for Lazy {
         self.regexp()?.inner().case_match(interp, haystack)
     }
 
-    fn is_match(&self, haystack: &[u8], pos: Option<Int>) -> Result<bool, Error> {
+    fn is_match(&self, haystack: &[u8], pos: Option<i64>) -> Result<bool, Error> {
         self.regexp()?.inner().is_match(haystack, pos)
     }
 
@@ -121,7 +121,7 @@ impl RegexpType for Lazy {
         &self,
         interp: &mut Artichoke,
         haystack: &[u8],
-        pos: Option<Int>,
+        pos: Option<i64>,
         block: Option<Block>,
     ) -> Result<Value, Error> {
         self.regexp()?.inner().match_(interp, haystack, pos, block)

--- a/artichoke-backend/src/extn/core/regexp/backend/mod.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/mod.rs
@@ -63,13 +63,13 @@ pub trait RegexpType {
 
     fn case_match(&self, interp: &mut Artichoke, haystack: &[u8]) -> Result<bool, Error>;
 
-    fn is_match(&self, haystack: &[u8], pos: Option<Int>) -> Result<bool, Error>;
+    fn is_match(&self, haystack: &[u8], pos: Option<i64>) -> Result<bool, Error>;
 
     fn match_(
         &self,
         interp: &mut Artichoke,
         haystack: &[u8],
-        pos: Option<Int>,
+        pos: Option<i64>,
         block: Option<Block>,
     ) -> Result<Value, Error>;
 

--- a/artichoke-backend/src/extn/core/regexp/backend/onig.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/onig.rs
@@ -200,7 +200,7 @@ impl RegexpType for Onig {
         }
     }
 
-    fn is_match(&self, haystack: &[u8], pos: Option<Int>) -> Result<bool, Error> {
+    fn is_match(&self, haystack: &[u8], pos: Option<i64>) -> Result<bool, Error> {
         let haystack = str::from_utf8(haystack)
             .map_err(|_| ArgumentError::with_message("Oniguruma backend for Regexp only supports UTF-8 haystacks"))?;
         let haystack_char_len = haystack.chars().count();
@@ -230,7 +230,7 @@ impl RegexpType for Onig {
         &self,
         interp: &mut Artichoke,
         haystack: &[u8],
-        pos: Option<Int>,
+        pos: Option<i64>,
         block: Option<Block>,
     ) -> Result<Value, Error> {
         let haystack = str::from_utf8(haystack)

--- a/artichoke-backend/src/extn/core/regexp/backend/regex/utf8.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/regex/utf8.rs
@@ -210,7 +210,7 @@ impl RegexpType for Utf8 {
         }
     }
 
-    fn is_match(&self, haystack: &[u8], pos: Option<Int>) -> Result<bool, Error> {
+    fn is_match(&self, haystack: &[u8], pos: Option<i64>) -> Result<bool, Error> {
         let haystack = str::from_utf8(haystack).map_err(|_| {
             ArgumentError::with_message("regex crate utf8 backend for Regexp only supports UTF-8 haystack")
         })?;
@@ -241,7 +241,7 @@ impl RegexpType for Utf8 {
         &self,
         interp: &mut Artichoke,
         haystack: &[u8],
-        pos: Option<Int>,
+        pos: Option<i64>,
         block: Option<Block>,
     ) -> Result<Value, Error> {
         let haystack = str::from_utf8(haystack).map_err(|_| {

--- a/artichoke-backend/src/extn/core/regexp/enc.rs
+++ b/artichoke-backend/src/extn/core/regexp/enc.rs
@@ -9,7 +9,7 @@ impl TryConvertMut<Value, Encoding> for Artichoke {
     type Error = InvalidEncodingError;
 
     fn try_convert_mut(&mut self, value: Value) -> Result<Encoding, Self::Error> {
-        if let Ok(encoding) = value.try_into::<Int>(self) {
+        if let Ok(encoding) = value.try_into::<i64>(self) {
             Encoding::try_from(encoding)
         } else if let Ok(encoding) = value.try_into_mut::<&[u8]>(self) {
             Encoding::try_from(encoding)

--- a/artichoke-backend/src/extn/core/regexp/mod.rs
+++ b/artichoke-backend/src/extn/core/regexp/mod.rs
@@ -37,7 +37,7 @@ use backend::lazy::Lazy;
 use backend::onig::Onig;
 use backend::regex::utf8::Utf8;
 
-pub type NameToCaptureLocations = Vec<(Vec<u8>, Vec<Int>)>;
+pub type NameToCaptureLocations = Vec<(Vec<u8>, Vec<i64>)>;
 
 pub fn clear_capture_globals(interp: &mut Artichoke) -> Result<(), Error> {
     let mut idx = interp.active_regexp_globals()?;
@@ -228,7 +228,7 @@ impl Regexp {
         }
     }
 
-    pub fn is_match(&self, pattern: Option<&[u8]>, pos: Option<Int>) -> Result<bool, Error> {
+    pub fn is_match(&self, pattern: Option<&[u8]>, pos: Option<i64>) -> Result<bool, Error> {
         if let Some(pattern) = pattern {
             self.0.is_match(pattern, pos)
         } else {
@@ -240,7 +240,7 @@ impl Regexp {
         &self,
         interp: &mut Artichoke,
         pattern: Option<&[u8]>,
-        pos: Option<Int>,
+        pos: Option<i64>,
         block: Option<Block>,
     ) -> Result<Value, Error> {
         if let Some(pattern) = pattern {
@@ -266,7 +266,7 @@ impl Regexp {
         for (name, indexes) in captures {
             let mut fixnums = Vec::with_capacity(indexes.len());
             for idx in indexes {
-                if let Ok(idx) = Int::try_from(idx) {
+                if let Ok(idx) = i64::try_from(idx) {
                     fixnums.push(idx);
                 } else {
                     return Err(ArgumentError::with_message("string too long").into());
@@ -285,10 +285,10 @@ impl Regexp {
 
     #[inline]
     #[must_use]
-    pub fn options(&self) -> Int {
+    pub fn options(&self) -> i64 {
         let options = self.0.source().options().flags();
         let encoding = self.0.encoding().flags();
-        Int::from((options | encoding).bits())
+        i64::from((options | encoding).bits())
     }
 
     #[inline]

--- a/artichoke-backend/src/extn/core/regexp/mruby.rs
+++ b/artichoke-backend/src/extn/core/regexp/mruby.rs
@@ -73,7 +73,7 @@ unsafe extern "C" fn compile(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> s
     // Call `mrb_obj_new` instead of allocating an object of class `slf` and
     // delegating to `trampoline::initialize` to handle cases where subclasses
     // override initialize.
-    if let Ok(argslen) = Int::try_from(args.len()) {
+    if let Ok(argslen) = sys::mrb_int::try_from(args.len()) {
         sys::mrb_obj_new(mrb, sys::mrb_sys_class_ptr(slf), argslen, args.as_ptr())
     } else {
         sys::mrb_sys_nil_value()

--- a/artichoke-backend/src/extn/core/regexp/trampoline.rs
+++ b/artichoke-backend/src/extn/core/regexp/trampoline.rs
@@ -102,7 +102,7 @@ pub fn match_operator(interp: &mut Artichoke, mut regexp: Value, mut pattern: Va
         unsafe { implicitly_convert_to_nilable_string(interp, &mut pattern)? }
     };
     let pos = regexp.match_operator(interp, pattern)?;
-    match pos.map(Int::try_from) {
+    match pos.map(i64::try_from) {
         Some(Ok(pos)) => Ok(interp.convert(pos)),
         Some(Err(_)) => Err(ArgumentError::with_message("string too long").into()),
         None => Ok(Value::nil()),
@@ -125,7 +125,7 @@ pub fn hash(interp: &mut Artichoke, mut regexp: Value) -> Result<Value, Error> {
     let regexp = unsafe { Regexp::unbox_from_value(&mut regexp, interp)? };
     let hash = regexp.hash();
     #[allow(clippy::cast_possible_wrap)]
-    Ok(interp.convert(hash as Int))
+    Ok(interp.convert(hash as i64))
 }
 
 pub fn inspect(interp: &mut Artichoke, mut regexp: Value) -> Result<Value, Error> {

--- a/artichoke-backend/src/extn/core/symbol/trampoline.rs
+++ b/artichoke-backend/src/extn/core/symbol/trampoline.rs
@@ -26,7 +26,7 @@ pub fn ascii_casecmp(interp: &mut Artichoke, mut value: Value, mut other: Value)
     let symbol = unsafe { Symbol::unbox_from_value(&mut value, interp)? };
     if let Ok(other) = unsafe { Symbol::unbox_from_value(&mut other, interp) } {
         let cmp = spinoso_symbol::ascii_casecmp(interp, symbol.id(), other.id())?;
-        Ok(interp.convert(cmp as Int))
+        Ok(interp.convert(cmp as i64))
     } else {
         Ok(Value::nil())
     }

--- a/artichoke-backend/src/extn/mod.rs
+++ b/artichoke-backend/src/extn/mod.rs
@@ -29,7 +29,7 @@ pub fn init(interp: &mut Artichoke, config: ReleaseMetadata<'_>) -> InitializeRe
 
     let patchlevel = config
         .ruby_patchlevel()
-        .parse::<Int>()
+        .parse::<i64>()
         .map_err(|_| NotDefinedError::global_constant("RUBY_PATCHLEVEL"))?;
     let patchlevel = interp.convert(patchlevel);
     interp.define_global_constant("RUBY_PATCHLEVEL", patchlevel)?;
@@ -44,7 +44,7 @@ pub fn init(interp: &mut Artichoke, config: ReleaseMetadata<'_>) -> InitializeRe
 
     let revision = config
         .ruby_revision()
-        .parse::<Int>()
+        .parse::<i64>()
         .map_err(|_| NotDefinedError::global_constant("RUBY_REVISION"))?;
     let revision = interp.convert(revision);
     interp.define_global_constant("RUBY_REVISION", revision)?;

--- a/artichoke-backend/src/extn/prelude.rs
+++ b/artichoke-backend/src/extn/prelude.rs
@@ -26,7 +26,6 @@ pub use crate::module_registry::ModuleRegistry;
 pub use crate::prelude::*;
 pub use crate::string::{format_unicode_debug_into, WriteError};
 pub use crate::sys;
-pub use crate::types::{Fp, Int};
 pub use crate::value::Value;
 
 /// Type alias for errors returned from `init` functions in

--- a/artichoke-backend/src/sys/protect.rs
+++ b/artichoke-backend/src/sys/protect.rs
@@ -4,7 +4,6 @@ use std::mem;
 use std::ptr::{self, NonNull};
 
 use crate::sys;
-use crate::types::Int;
 
 pub unsafe fn funcall(
     mrb: *mut sys::mrb_state,
@@ -80,7 +79,7 @@ impl<'a> Protect for Funcall<'a> {
         // This will always unwrap because we've already checked that we
         // have fewer than `MRB_FUNCALL_ARGC_MAX` args, which is less than
         // i64 max value.
-        let argslen = if let Ok(argslen) = Int::try_from(args.len()) {
+        let argslen = if let Ok(argslen) = i64::try_from(args.len()) {
             argslen
         } else {
             return sys::mrb_sys_nil_value();

--- a/artichoke-backend/src/test/prelude.rs
+++ b/artichoke-backend/src/test/prelude.rs
@@ -24,7 +24,6 @@ pub use crate::prelude::*;
 pub use crate::state::parser::Context;
 pub use crate::string::{format_unicode_debug_into, WriteError};
 pub use crate::sys;
-pub use crate::types::{Fp, Int};
 pub use crate::value::Value;
 
 // This type has a custom `Drop` implementation that automatically closes the

--- a/artichoke-backend/src/types.rs
+++ b/artichoke-backend/src/types.rs
@@ -1,38 +1,5 @@
 use crate::sys;
 
-/// Artichoke native floating point type.
-///
-/// `Fp` is the backend to the [`Float`](crate::extn::core::float::Float) class.
-///
-/// The `Fp` type alias is for the `f64` floating point primitive.
-///
-/// ```
-/// # use std::any::TypeId;
-/// # use std::mem;
-/// # use artichoke_backend::types::Fp;
-/// assert_eq!(mem::size_of::<f64>(), mem::size_of::<Fp>());
-/// assert_eq!(TypeId::of::<f64>(), TypeId::of::<Fp>());
-/// ```
-pub type Fp = f64;
-
-/// Artichoke native integer type.
-///
-/// `Int` is the fixed size (`Fixnum`) backend to the
-/// [`Integer`](crate::extn::core::integer::Integer) class.
-///
-/// The `Int` type alias is for the `i64` integer primitive.
-///
-/// ```
-/// # use std::any::TypeId;
-/// # use std::mem;
-/// # use artichoke_backend::types::Int;
-/// assert_eq!(mem::size_of::<i64>(), mem::size_of::<Int>());
-/// assert_eq!(i64::MIN, Int::MIN);
-/// assert_eq!(i64::MAX, Int::MAX);
-/// assert_eq!(TypeId::of::<i64>(), TypeId::of::<Int>());
-/// ```
-pub type Int = i64;
-
 pub use crate::core::{Ruby, Rust};
 
 /// Parse a [`Ruby`] type classifier from a [`sys::mrb_value`].

--- a/artichoke-backend/src/value.rs
+++ b/artichoke-backend/src/value.rs
@@ -15,7 +15,7 @@ use crate::extn::core::exception::{ArgumentError, Fatal};
 use crate::extn::core::symbol::Symbol;
 use crate::gc::MrbGarbageCollection;
 use crate::sys::{self, protect};
-use crate::types::{self, Int, Ruby};
+use crate::types::{self, Ruby};
 use crate::Artichoke;
 
 /// Max argument count for function calls including initialize and yield.
@@ -112,7 +112,7 @@ impl Value {
         is_dead.unwrap_or_default()
     }
 
-    pub fn is_range(&self, interp: &mut Artichoke, len: Int) -> Result<Option<protect::Range>, Error> {
+    pub fn is_range(&self, interp: &mut Artichoke, len: i64) -> Result<Option<protect::Range>, Error> {
         let mut arena = interp.create_arena_savepoint()?;
         let result = unsafe {
             arena

--- a/artichoke-backend/tests/integration/extension.rs
+++ b/artichoke-backend/tests/integration/extension.rs
@@ -12,7 +12,7 @@ unsafe extern "C" fn container_initialize(mrb: *mut sys::mrb_state, slf: sys::mr
     unwrap_interpreter!(mrb, to => guard);
     let slf = Value::from(slf);
     let inner = Value::from(inner);
-    let inner = inner.try_into::<Int>(&guard).unwrap_or_default();
+    let inner = inner.try_into::<i64>(&guard).unwrap_or_default();
     let container = Box::new(Container(inner));
     let result = Box::<Container>::box_into_value(container, slf, &mut guard).unwrap_or_default();
     result.inner()
@@ -58,11 +58,11 @@ fn define_rust_backed_ruby_class() {
 
     let _ = interp.eval(b"require 'container'").unwrap();
     let result = interp.eval(b"Container.new(15).value").unwrap();
-    let result = result.try_into::<Int>(&interp).unwrap();
+    let result = result.try_into::<i64>(&interp).unwrap();
     assert_eq!(result, 15);
     // Ensure Rc is cloned correctly and still points to valid memory.
     let result = interp.eval(b"Container.new(105).value").unwrap();
-    let result = result.try_into::<Int>(&interp).unwrap();
+    let result = result.try_into::<i64>(&interp).unwrap();
     assert_eq!(result, 105);
 
     interp.close();


### PR DESCRIPTION
artichoke-backend defined type aliases for its interpreter-native
integer and floating point types.

This choice was influenced by mruby which allows switching integer and
float sizes with compile time flags. Artichoke used to allow similar
switching but did so automatically by architecture, specifically using
`i32` integers on `wasm32` targets.

This behavior was removed in #604 becuase it caused numerous compilation
failures when targeting `wasm32`.

Since then, these type aliases have only been indirection and are at
best confusing and obfuscating, so this commit removes them.

Some replacements choose to use `sys::mrb_int` to indictate a conversion
is targeting an FFI callsite.