### PR TITLE
Bump target-lexicon to 0.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -660,9 +660,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "target-lexicon"
-version = "0.11.2"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "422045212ea98508ae3d28025bc5aaa2bd4a9cdaecd442a08da2ee620ee9ea95"
+checksum = "64ae3b39281e4b14b8123bdbaddd472b7dfe215e444181f2f9d2443c2444f834"
 
 [[package]]
 name = "termcolor"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ default-features = false
 
 [build-dependencies]
 chrono = { version = "0.4.19", default-features = false, features = ["clock"] }
-target-lexicon = "0.11.2"
+target-lexicon = "0.12"
 
 [[bin]]
 name = "airb"

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -41,7 +41,7 @@ quickcheck = { version = "1.0", default-features = false }
 [build-dependencies]
 bindgen = { version = "0.57.0", default-features = false, features = ["runtime"] }
 cc = "1.0"
-target-lexicon = "0.11.2"
+target-lexicon = "0.12"
 
 [features]
 default = [

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -528,9 +528,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.11.2"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "422045212ea98508ae3d28025bc5aaa2bd4a9cdaecd442a08da2ee620ee9ea95"
+checksum = "64ae3b39281e4b14b8123bdbaddd472b7dfe215e444181f2f9d2443c2444f834"
 
 [[package]]
 name = "thread_local"

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -640,9 +640,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.11.2"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "422045212ea98508ae3d28025bc5aaa2bd4a9cdaecd442a08da2ee620ee9ea95"
+checksum = "64ae3b39281e4b14b8123bdbaddd472b7dfe215e444181f2f9d2443c2444f834"
 
 [[package]]
 name = "termcolor"


### PR DESCRIPTION
Supersedes #1132, which was yanked in bytecodealliance/target-lexicon#71.

This PR relaxes the target lexicon version constraint to only specify
the minor version.