### PR TITLE
Refactor alternate require path resolution into LoadSources impl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,7 +61,7 @@ dependencies = [
 
 [[package]]
 name = "artichoke-core"
-version = "0.7.0"
+version = "0.8.0"
 
 [[package]]
 name = "atty"

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["artichoke", "artichoke-ruby", "mruby", "ruby"]
 categories = ["api-bindings"]
 
 [dependencies]
-artichoke-core = { version = "0.7", path = "../artichoke-core" }
+artichoke-core = { version = "0.8", path = "../artichoke-core" }
 bstr = { version = "0.2, >= 0.2.2", default-features = false, features = ["std"] }
 cstr = "0.2.8"
 intaglio = "1.2"

--- a/artichoke-backend/src/extn/core/kernel/trampoline.rs
+++ b/artichoke-backend/src/extn/core/kernel/trampoline.rs
@@ -81,12 +81,12 @@ where
 }
 
 pub fn require(interp: &mut Artichoke, path: Value) -> Result<Value, Error> {
-    let success = kernel::require::require(interp, path, None)?;
+    let success = kernel::require::require(interp, path)?;
     Ok(interp.convert(success))
 }
 
 pub fn require_relative(interp: &mut Artichoke, path: Value) -> Result<Value, Error> {
     let relative_base = RelativePath::try_from_interp(interp)?;
-    let success = kernel::require::require(interp, path, Some(relative_base))?;
+    let success = kernel::require::require_relative(interp, path, relative_base)?;
     Ok(interp.convert(success))
 }

--- a/artichoke-backend/src/fs/memory.rs
+++ b/artichoke-backend/src/fs/memory.rs
@@ -266,6 +266,19 @@ impl Memory {
         }
     }
 
+    /// Check whether `path` points to a file in the virtual filesystem and
+    /// return the absolute path if it exists.
+    ///
+    /// This API is infallible and will return [`None`] for non-existent paths.
+    #[must_use]
+    pub fn resolve_file(&self, path: &Path) -> Option<Vec<u8>> {
+        let path = absolutize_relative_to(path, &self.cwd);
+        match normalize_slashes(path) {
+            Ok(path) if self.fs.contains_key(path.as_bstr()) => Some(path),
+            _ => None,
+        }
+    }
+
     /// Check whether `path` points to a file in the virtual filesystem.
     ///
     /// This API is infallible and will return `false` for non-existent paths.

--- a/artichoke-backend/src/fs/native.rs
+++ b/artichoke-backend/src/fs/native.rs
@@ -6,6 +6,7 @@ use std::fs;
 use std::io;
 use std::path::Path;
 
+use crate::ffi::os_str_to_bytes;
 use crate::fs::{absolutize_relative_to, normalize_slashes, ExtensionHook};
 
 #[derive(Default, Debug, PartialEq, Eq)]
@@ -20,6 +21,21 @@ impl Native {
     #[must_use]
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Check whether `path` points to a file in the virtual filesystem and
+    /// return the absolute path if it exists.
+    ///
+    /// This API is infallible and will return [`None`] for non-existent paths.
+    #[must_use]
+    #[allow(clippy::unused_self)]
+    pub fn resolve_file(&self, path: &Path) -> Option<Vec<u8>> {
+        if path.exists() {
+            let file = os_str_to_bytes(path.as_os_str()).ok()?;
+            Some(file.to_vec())
+        } else {
+            None
+        }
     }
 
     /// Check whether `path` points to a file in the virtual filesystem.

--- a/artichoke-backend/src/load.rs
+++ b/artichoke-backend/src/load.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::ffi::OsStr;
 use std::path::Path;
 
 use crate::core::{Eval, File, LoadSources};
@@ -6,6 +7,8 @@ use crate::error::Error;
 use crate::ffi::InterpreterExtractError;
 use crate::fs::RUBY_LOAD_PATH;
 use crate::Artichoke;
+
+const RUBY_EXTENSION: &str = "rb";
 
 impl LoadSources for Artichoke {
     type Artichoke = Self;
@@ -21,6 +24,10 @@ impl LoadSources for Artichoke {
         let mut path = path.as_ref();
         let absolute_path;
         if path.is_relative() {
+            // All extension hooks added to the interpreter are placed in the
+            // default Ruby load path. This ensures that alternate load paths,
+            // such as those defined by the `RUBYLIB` environment variable are
+            // not written to.
             absolute_path = Path::new(RUBY_LOAD_PATH).join(path);
             path = &absolute_path;
         }
@@ -38,6 +45,10 @@ impl LoadSources for Artichoke {
         let mut path = path.as_ref();
         let absolute_path;
         if path.is_relative() {
+            // All source files added to the interpreter are placed in the
+            // default Ruby load path. This ensures that alternate load paths,
+            // such as those defined by the `RUBYLIB` environment variable are
+            // not written to.
             absolute_path = Path::new(RUBY_LOAD_PATH).join(path);
             path = &absolute_path;
         }
@@ -46,34 +57,92 @@ impl LoadSources for Artichoke {
         Ok(())
     }
 
+    fn resolve_source_path<P>(&self, path: P) -> Result<Option<Vec<u8>>, Self::Error>
+    where
+        P: AsRef<Path>,
+    {
+        let state = self.state.as_deref().ok_or_else(InterpreterExtractError::new)?;
+        let path = path.as_ref();
+        if let Some(path) = state.vfs.resolve_file(path) {
+            return Ok(Some(path));
+        }
+        // If the given path did not end in `.rb`, try again with a `.rb` file
+        // extension.
+        if !matches!(path.extension(), Some(ext) if *ext == *OsStr::new(RUBY_EXTENSION)) {
+            let mut path = path.to_owned();
+            path.set_extension(RUBY_EXTENSION);
+            return Ok(state.vfs.resolve_file(&path));
+        }
+        Ok(None)
+    }
+
     fn source_is_file<P>(&self, path: P) -> Result<bool, Self::Error>
     where
         P: AsRef<Path>,
     {
         let state = self.state.as_deref().ok_or_else(InterpreterExtractError::new)?;
-        let is_file = state.vfs.is_file(path.as_ref());
-        Ok(is_file)
+        let path = path.as_ref();
+        if state.vfs.is_file(path) {
+            return Ok(true);
+        }
+        // If the given path did not end in `.rb`, try again with a `.rb` file
+        // extension.
+        if !matches!(path.extension(), Some(ext) if *ext == *OsStr::new(RUBY_EXTENSION)) {
+            let mut path = path.to_owned();
+            path.set_extension(RUBY_EXTENSION);
+            if state.vfs.is_file(&path) {
+                return Ok(true);
+            }
+        }
+        Ok(false)
     }
 
     fn load_source<P>(&mut self, path: P) -> Result<bool, Self::Error>
     where
         P: AsRef<Path>,
     {
-        {
+        let path = path.as_ref();
+        let mut alternate_path;
+        let path = {
             let state = self.state.as_deref_mut().ok_or_else(InterpreterExtractError::new)?;
-            // Load Rust `File` first because an File may define classes and
+            // If a file is already required, short circuit.
+            if state.vfs.is_required(path) {
+                return Ok(false);
+            }
+            // Require Rust `File` first because an File may define classes and
             // modules with `LoadSources` and Ruby files can require arbitrary
             // other files, including some child sources that may depend on these
             // module definitions.
-            let hook = state.vfs.get_extension(path.as_ref());
-            if let Some(hook) = hook {
-                // dynamic, Rust-backed `File` require
-                hook(self)?;
+            match state.vfs.get_extension(path) {
+                Some(hook) => {
+                    // dynamic, Rust-backed `File` require
+                    hook(self)?;
+                    path
+                }
+                None if matches!(path.extension(), Some(ext) if *ext == *OsStr::new(RUBY_EXTENSION)) => path,
+                None => {
+                    alternate_path = path.to_owned();
+                    alternate_path.set_extension(RUBY_EXTENSION);
+                    // If a file is already required, short circuit.
+                    if state.vfs.is_required(&alternate_path) {
+                        return Ok(false);
+                    }
+                    if let Some(hook) = state.vfs.get_extension(&alternate_path) {
+                        // dynamic, Rust-backed `File` require
+                        hook(self)?;
+                        // This ensures that if we load the hook at an alternate
+                        // path, we use that alternate path to load the Ruby
+                        // source.
+                        &alternate_path
+                    } else {
+                        path
+                    }
+                }
             }
-        }
-        let contents = self.read_source_file_contents(path.as_ref())?.into_owned();
+        };
+        let contents = self.read_source_file_contents(path)?.into_owned();
         self.eval(contents.as_ref())?;
-        trace!(r#"Successful load of {}"#, path.as_ref().display());
+        trace!("Successful load of {}", path.display());
         Ok(true)
     }
 
@@ -81,27 +150,50 @@ impl LoadSources for Artichoke {
     where
         P: AsRef<Path>,
     {
-        {
+        let path = path.as_ref();
+        let mut alternate_path;
+        let path = {
             let state = self.state.as_deref_mut().ok_or_else(InterpreterExtractError::new)?;
             // If a file is already required, short circuit.
-            if state.vfs.is_required(path.as_ref()) {
+            if state.vfs.is_required(path) {
                 return Ok(false);
             }
             // Require Rust `File` first because an File may define classes and
             // modules with `LoadSources` and Ruby files can require arbitrary
             // other files, including some child sources that may depend on these
             // module definitions.
-            let hook = state.vfs.get_extension(path.as_ref());
-            if let Some(hook) = hook {
-                // dynamic, Rust-backed `File` require
-                hook(self)?;
+            match state.vfs.get_extension(path) {
+                Some(hook) => {
+                    // dynamic, Rust-backed `File` require
+                    hook(self)?;
+                    path
+                }
+                None if matches!(path.extension(), Some(ext) if *ext == *OsStr::new(RUBY_EXTENSION)) => path,
+                None => {
+                    alternate_path = path.to_owned();
+                    alternate_path.set_extension(RUBY_EXTENSION);
+                    // If a file is already required, short circuit.
+                    if state.vfs.is_required(&alternate_path) {
+                        return Ok(false);
+                    }
+                    if let Some(hook) = state.vfs.get_extension(&alternate_path) {
+                        // dynamic, Rust-backed `File` require
+                        hook(self)?;
+                        // This ensures that if we load the hook at an alternate
+                        // path, we use that alternate path to load the Ruby
+                        // source.
+                        &alternate_path
+                    } else {
+                        path
+                    }
+                }
             }
-        }
-        let contents = self.read_source_file_contents(path.as_ref())?.into_owned();
+        };
+        let contents = self.read_source_file_contents(path)?.into_owned();
         self.eval(contents.as_ref())?;
         let state = self.state.as_deref_mut().ok_or_else(InterpreterExtractError::new)?;
         state.vfs.mark_required(path.as_ref())?;
-        trace!(r#"Successful require of {}"#, path.as_ref().display());
+        trace!("Successful require of {}", path.display());
         Ok(true)
     }
 
@@ -110,7 +202,23 @@ impl LoadSources for Artichoke {
         P: AsRef<Path>,
     {
         let state = self.state.as_deref().ok_or_else(InterpreterExtractError::new)?;
-        let contents = state.vfs.read_file(path.as_ref())?;
+        let path = path.as_ref();
+        let contents = match state.vfs.read_file(path) {
+            Ok(contents) => contents,
+            // If we failed to read the source file and it already has a `.rb`
+            // extension, return the error since there are no alternative paths
+            // we can try.
+            Err(err) if matches!(path.extension(), Some(ext) if *ext == *OsStr::new(RUBY_EXTENSION)) => {
+                return Err(err.into());
+            }
+            // Retry the read with an alternative file path that has a `.rb`
+            // extension.
+            Err(_) => {
+                let mut path = path.to_owned();
+                path.set_extension(RUBY_EXTENSION);
+                state.vfs.read_file(&path)?
+            }
+        };
         Ok(contents.to_vec().into())
     }
 }

--- a/artichoke-core/Cargo.toml
+++ b/artichoke-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "artichoke-core"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2018"
 description = "Core traits for implementing an Artichoke Ruby interpreter"

--- a/artichoke-core/src/load.rs
+++ b/artichoke-core/src/load.rs
@@ -1,6 +1,7 @@
 //! Load Ruby and Rust sources into the VM.
 
 use alloc::borrow::Cow;
+use alloc::vec::Vec;
 
 #[cfg(feature = "std")]
 type Path = std::path::Path;
@@ -56,6 +57,22 @@ pub trait LoadSources {
     where
         P: AsRef<Path>,
         T: Into<Cow<'static, [u8]>>;
+
+    /// Test for a source file at a path and return the absolute path of the
+    /// resolved file.
+    ///
+    /// Query the underlying virtual filesystem to check if `path` points to a
+    /// source file.
+    ///
+    /// This function returns [`None`] if `path` does not exist in the virtual
+    /// filesystem.
+    ///
+    /// # Errors
+    ///
+    /// If the underlying filesystem is inaccessible, an error is returned.
+    fn resolve_source_path<P>(&self, path: P) -> Result<Option<Vec<u8>>, Self::Error>
+    where
+        P: AsRef<Path>;
 
     /// Test for a source file at a path.
     ///

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -54,7 +54,7 @@ dependencies = [
 
 [[package]]
 name = "artichoke-core"
-version = "0.7.0"
+version = "0.8.0"
 
 [[package]]
 name = "artichoke-fuzz"

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -58,7 +58,7 @@ dependencies = [
 
 [[package]]
 name = "artichoke-core"
-version = "0.7.0"
+version = "0.8.0"
 
 [[package]]
 name = "atty"

--- a/spinoso-symbol/Cargo.toml
+++ b/spinoso-symbol/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["ident", "intern", "no_std", "spinoso", "symbol"]
 categories = ["data-structures", "no-std", "parser-implementations"]
 
 [dependencies]
-artichoke-core = { version = "0.7", path = "../artichoke-core", default-features = false, optional = true }
+artichoke-core = { version = "0.8", path = "../artichoke-core", default-features = false, optional = true }
 bstr = { version = "0.2, >= 0.2.4", optional = true, default-features = false }
 focaccia = { version = "1.0", optional = true, default-features = false }
 scolapasta-string-escape = { version = "0.2", path = "../scolapasta-string-escape", default-features = false, optional = true }


### PR DESCRIPTION
The functions that implement `require` and `require_relative` in `extn`
manage retries by adding a missing `.rb` extension to the file path.

The `LoadSources` trait that is implemented by `Artichoke` in
`artichoke-backend` is meant to fully encapsulate the loading of Ruby
sources from the underlying virtual filesystem.

As I have attempted to add support for extending Artichoke's
`$LOAD_PATH` via the `RUBYLIB` environment variable, I ran into issues
with the `Hybrid` vfs. The hybrid backend does not allow its component
backends to absolutize paths relative to their own current working
directory.

This deficiency shows up in the `require` and `require_relative` impls
in that they manually absolutized paths relative to the `Memory`
`RUBY_LOAD_PATH` constant. With the future addition of a `Rubylib` vfs
backend, it is no longer a valid assumption to hardcode the `Memory`
backend's current working directory.

This commit transitions the vfs backend to a loader style in which
individual backends are allowed to resolve relative paths as they see
fit.

To allow `require` to continue to set the `__FILE__` magic constant,
this commit adds a new API to `artichoke_core::load::LoadSources` for
resolving the absolute path name from the vfs if it exists, which allows
individual vfs backends to perform absolutizing.

The require flow as of this commit looks like this:

- `require` resolves the absolute file path for the resource it would
  like to load via the `LoadSources::resolve_source_path` method.
- `LoadSources::resolve_source_path` delegates to the `resolve_file`
  methods in the vfs backends, which should absolutize paths relative to
  their own internal working directroy.
- `require` sets the parser `Context` with the resolved path.
- `require` requires the file via the `LoadSources::require_source`
  method.
- `LoadSources::require_source` delegates to the vfs backends which
  aboslutize the path relative to their own internal working directory.

This commit bumps the version of `artichoke-core` to 0.8.0.