### PR TITLE
Add a RUBYLIB vfs Ruby source loader

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -90,6 +90,9 @@ jobs:
       - name: Check artichoke with all features
         run: cargo check --verbose --all-features --all-targets --profile=test
 
+      - name: Check artichoke with no default features and native fs access
+        run: cargo build --no-default-features --features native-filesystem-access
+
   check-fuzz:
     name: Check fuzz workspace
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,7 @@ backtrace = ["termcolor"]
 kitchen-sink = [
   "core-full",
   "native-filesystem-access",
+  "rubylib-source-loader",
   "stdlib-full",
 ]
 
@@ -120,6 +121,9 @@ core-time = ["artichoke-backend/core-time"]
 # Extend the Artichoke virtual filesystem to have native/host access.
 # This feature enables requiring sources from local disk.
 native-filesystem-access = ["artichoke-backend/native-filesystem-access"]
+# Extend the Artichoke virtual filesystem to search a path separator-delimited
+# list of paths for Ruby sources by parsing the `RUBYLIB` environment variable.
+rubylib-source-loader = ["native-filesystem-access", "artichoke-backend/rubylib-source-loader"]
 # Override the `stdout` and `stdin` streams to write to an in-memory buffer.
 output-strategy-capture = ["artichoke-backend/output-strategy-capture"]
 # Override the `stdout` and `stdin` streams to write to be discarded.

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -68,6 +68,7 @@ core-regexp-oniguruma = ["spinoso-regexp/oniguruma", "onig"]
 core-time = ["spinoso-time"]
 
 native-filesystem-access = []
+rubylib-source-loader = ["native-filesystem-access"]
 output-strategy-capture = []
 output-strategy-null = ["output-strategy-capture"]
 

--- a/artichoke-backend/src/fs.rs
+++ b/artichoke-backend/src/fs.rs
@@ -1,15 +1,16 @@
 //! Virtual filesystem.
 //!
 //! Artichoke proxies all filesystem access through a virtual filesystem. The
-//! filesystem can store Ruby sources and [extension hooks](ExtensionHook) in
-//! memory and will support proxying to the host filesystem for reads and
-//! writes.
+//! filesystem can store Ruby sources and [extension hooks] in memory and will
+//! support proxying to the host filesystem for reads and writes.
 //!
 //! Artichoke uses the virtual filesystem to track metadata about loaded
 //! features.
 //!
 //! Artichoke has several virtual filesystem implementations. Only some of them
 //! support reading from the system fs.
+//!
+//! [extension hooks]: ExtensionHook
 
 use bstr::ByteVec;
 use std::path::{Component, Path, PathBuf};
@@ -18,13 +19,21 @@ use crate::error::Error;
 use crate::ffi::ConvertBytesError;
 use crate::Artichoke;
 
+#[cfg(feature = "native-filesystem-access")]
 mod hybrid;
 mod memory;
+#[cfg(feature = "native-filesystem-access")]
 mod native;
+#[cfg(feature = "rubylib-source-loader")]
+mod rubylib;
 
+#[cfg(feature = "native-filesystem-access")]
 pub use hybrid::Hybrid;
 pub use memory::Memory;
+#[cfg(feature = "native-filesystem-access")]
 pub use native::Native;
+#[cfg(feature = "rubylib-source-loader")]
+pub use rubylib::Rubylib;
 
 /// Directory at which the [in-memory filesystem](Memory) is mounted.
 ///

--- a/artichoke-backend/src/fs/hybrid.rs
+++ b/artichoke-backend/src/fs/hybrid.rs
@@ -2,12 +2,24 @@ use std::borrow::Cow;
 use std::io;
 use std::path::Path;
 
+#[cfg(feature = "rubylib-source-loader")]
+use crate::fs::Rubylib;
 use crate::fs::{ExtensionHook, Memory, Native, MEMORY_FILESYSTEM_MOUNT_POINT};
 
-#[derive(Default, Debug)]
+#[derive(Debug)]
 pub struct Hybrid {
+    #[cfg(feature = "rubylib-source-loader")]
+    rubylib: Option<Rubylib>,
+    #[cfg(not(feature = "rubylib-source-loader"))]
+    rubylib: Option<Native>, // hardcoded to `None`
     memory: Memory,
     native: Native,
+}
+
+impl Default for Hybrid {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl Hybrid {
@@ -17,7 +29,17 @@ impl Hybrid {
     /// filesystem mounted at [`MEMORY_FILESYSTEM_MOUNT_POINT`].
     #[must_use]
     pub fn new() -> Self {
-        Self::default()
+        #[cfg(feature = "rubylib-source-loader")]
+        let rubylib = Rubylib::new();
+        #[cfg(not(feature = "rubylib-source-loader"))]
+        let rubylib = None;
+        let memory = Memory::new();
+        let native = Native::new();
+        Self {
+            rubylib,
+            memory,
+            native,
+        }
     }
 
     /// Check whether `path` points to a file in the virtual filesystem and
@@ -26,9 +48,17 @@ impl Hybrid {
     /// This API is infallible and will return [`None`] for non-existent paths.
     #[must_use]
     pub fn resolve_file(&self, path: &Path) -> Option<Vec<u8>> {
-        self.memory
-            .resolve_file(path)
-            .or_else(|| self.native.resolve_file(path))
+        if let Some(ref rubylib) = self.rubylib {
+            rubylib.resolve_file(path).or_else(|| {
+                self.memory
+                    .resolve_file(path)
+                    .or_else(|| self.native.resolve_file(path))
+            })
+        } else {
+            self.memory
+                .resolve_file(path)
+                .or_else(|| self.native.resolve_file(path))
+        }
     }
 
     /// Check whether `path` points to a file in the virtual filesystem.
@@ -36,6 +66,11 @@ impl Hybrid {
     /// This API is infallible and will return `false` for non-existent paths.
     #[must_use]
     pub fn is_file(&self, path: &Path) -> bool {
+        if let Some(ref rubylib) = self.rubylib {
+            if rubylib.is_file(path) {
+                return true;
+            }
+        }
         if self.memory.is_file(path) {
             true
         } else {
@@ -54,7 +89,13 @@ impl Hybrid {
     /// If `path` does not exist, an [`io::Error`] with error kind
     /// [`io::ErrorKind::NotFound`] is returned.
     pub fn read_file(&self, path: &Path) -> io::Result<Cow<'_, [u8]>> {
-        self.memory.read_file(path).or_else(|_| self.native.read_file(path))
+        if let Some(ref rubylib) = self.rubylib {
+            rubylib
+                .read_file(path)
+                .or_else(|_| self.memory.read_file(path).or_else(|_| self.native.read_file(path)))
+        } else {
+            self.memory.read_file(path).or_else(|_| self.native.read_file(path))
+        }
     }
 
     /// Write file contents into the virtual file system at `path`.
@@ -67,9 +108,17 @@ impl Hybrid {
     /// If access to the [`Native`] filesystem returns an error, the error is
     /// returned. See [`Native::write_file`].
     pub fn write_file(&mut self, path: &Path, buf: Cow<'static, [u8]>) -> io::Result<()> {
-        self.memory
-            .write_file(path, buf.clone())
-            .or_else(|_| self.native.write_file(path, buf))
+        if let Some(ref mut rubylib) = self.rubylib {
+            rubylib.write_file(path, buf.clone()).or_else(|_| {
+                self.memory
+                    .write_file(path, buf.clone())
+                    .or_else(|_| self.native.write_file(path, buf))
+            })
+        } else {
+            self.memory
+                .write_file(path, buf.clone())
+                .or_else(|_| self.native.write_file(path, buf))
+        }
     }
 
     /// Retrieve an extension hook for the file at `path`.
@@ -109,6 +158,11 @@ impl Hybrid {
     /// This API is infallible and will return `false` for non-existent paths.
     #[must_use]
     pub fn is_required(&self, path: &Path) -> bool {
+        if let Some(ref rubylib) = self.rubylib {
+            if rubylib.is_required(path) {
+                return true;
+            }
+        }
         if self.memory.is_required(path) {
             true
         } else {
@@ -127,8 +181,16 @@ impl Hybrid {
     /// If `path` does not exist, an [`io::Error`] with error kind
     /// [`io::ErrorKind::NotFound`] is returned.
     pub fn mark_required(&mut self, path: &Path) -> io::Result<()> {
-        self.memory
-            .mark_required(path)
-            .or_else(|_| self.native.mark_required(path))
+        if let Some(ref mut rubylib) = self.rubylib {
+            rubylib.mark_required(path).or_else(|_| {
+                self.memory
+                    .mark_required(path)
+                    .or_else(|_| self.native.mark_required(path))
+            })
+        } else {
+            self.memory
+                .mark_required(path)
+                .or_else(|_| self.native.mark_required(path))
+        }
     }
 }

--- a/artichoke-backend/src/fs/rubylib.rs
+++ b/artichoke-backend/src/fs/rubylib.rs
@@ -1,0 +1,183 @@
+use bstr::{BString, ByteSlice};
+use std::borrow::Cow;
+use std::collections::HashSet;
+use std::env;
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+use crate::ffi::os_string_to_bytes;
+use crate::fs::{absolutize_relative_to, normalize_slashes, ExtensionHook};
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct Rubylib {
+    load_paths: Vec<PathBuf>,
+    loaded_features: HashSet<BString>,
+}
+
+impl Rubylib {
+    /// Create a new native virtual filesystem that searches the filesystem for
+    /// Ruby sources at the paths specified by the `RUBYLIB` environment
+    /// variable.
+    ///
+    /// This filesystem grants access to the host filesystem.
+    #[must_use]
+    pub fn new() -> Option<Self> {
+        let rubylib = env::var_os("RUBYLIB")?;
+        let cwd = env::current_dir().ok()?;
+        let load_paths = env::split_paths(&rubylib)
+            .map(|load_path| absolutize_relative_to(&load_path, &cwd))
+            .collect::<Vec<_>>();
+        if load_paths.is_empty() {
+            return None;
+        }
+        Some(Self {
+            load_paths,
+            loaded_features: HashSet::default(),
+        })
+    }
+
+    /// Check whether `path` points to a file in the virtual filesystem and
+    /// return the absolute path if it exists.
+    ///
+    /// This API is infallible and will return [`None`] for non-existent paths.
+    #[must_use]
+    pub fn resolve_file(&self, path: &Path) -> Option<Vec<u8>> {
+        for load_path in &self.load_paths {
+            let path = absolutize_relative_to(path, &load_path);
+            if path.exists() {
+                return os_string_to_bytes(path.into()).ok();
+            }
+        }
+        None
+    }
+
+    /// Check whether `path` points to a file in the virtual filesystem.
+    ///
+    /// This API is infallible and will return `false` for non-existent paths.
+    #[must_use]
+    #[allow(clippy::unused_self)]
+    pub fn is_file(&self, path: &Path) -> bool {
+        for load_path in &self.load_paths {
+            let path = absolutize_relative_to(path, &load_path);
+            if let Ok(metadata) = fs::metadata(path) {
+                return !metadata.is_dir();
+            }
+        }
+        false
+    }
+
+    /// Read file contents for the file at `path`.
+    ///
+    /// Returns a byte slice of complete file contents. If `path` is relative,
+    /// it is absolutized relative to the current working directory of the
+    /// virtual file system.
+    ///
+    /// # Errors
+    ///
+    /// If `path` does not exist, an [`io::Error`] with error kind
+    /// [`io::ErrorKind::NotFound`] is returned.
+    #[allow(clippy::unused_self)]
+    pub fn read_file(&self, path: &Path) -> io::Result<Cow<'_, [u8]>> {
+        for load_path in &self.load_paths {
+            let path = absolutize_relative_to(path, &load_path);
+            if let Ok(contents) = fs::read(path) {
+                return Ok(contents.into());
+            }
+        }
+        Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            "path not found in RUBYLIB load paths",
+        ))
+    }
+
+    /// Write file contents into the virtual file system at `path`.
+    ///
+    /// Writes the full file contents. If any file contents already exist at
+    /// `path`, they are replaced. Extension hooks are preserved.
+    ///
+    /// # Errors
+    ///
+    /// If `path` does not exist, an [`io::Error`] with error kind
+    /// [`io::ErrorKind::NotFound`] is returned. See [`fs::write`] for further
+    /// discussion of the error modes of this API.
+    #[allow(clippy::needless_pass_by_value)]
+    #[allow(clippy::unused_self)]
+    pub fn write_file(&mut self, path: &Path, buf: Cow<'static, [u8]>) -> io::Result<()> {
+        let _ = path;
+        let _ = buf;
+
+        Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "writes via the Rubylib filesystem adapter are not permitted",
+        ))
+    }
+
+    /// Retrieve an extension hook for the file at `path`.
+    ///
+    /// This API is infallible and will return `None` for non-existent paths.
+    ///
+    /// The native filesystem does not support extensions. This method always
+    /// returns [`None`].
+    #[must_use]
+    #[allow(clippy::unused_self)]
+    pub fn get_extension(&self, path: &Path) -> Option<ExtensionHook> {
+        let _ = path;
+        None
+    }
+
+    /// Write extension hook into the virtual file system at `path`.
+    ///
+    /// The native filesystem does not support extensions. All given extensions
+    /// result in an error.
+    ///
+    /// # Errors
+    ///
+    /// The native filesystem does not support extensions. All given extensions
+    /// result in an error with `ErrorKind::Other`.
+    #[allow(clippy::unused_self)]
+    pub fn register_extension(&mut self, path: &Path, extension: ExtensionHook) -> io::Result<()> {
+        let _ = path;
+        let _ = extension;
+        Err(io::Error::new(io::ErrorKind::Other, "extensions are unsupported"))
+    }
+
+    /// Check whether a file at `path` has been required already.
+    ///
+    /// This API is infallible and will return `false` for non-existent paths.
+    #[must_use]
+    pub fn is_required(&self, path: &Path) -> bool {
+        for load_path in &self.load_paths {
+            let path = absolutize_relative_to(path, &load_path);
+            if let Ok(path) = normalize_slashes(path) {
+                return self.loaded_features.contains(path.as_bstr());
+            }
+        }
+        false
+    }
+
+    /// Mark a source at `path` as required on the interpreter.
+    ///
+    /// This metadata is used by `Kernel#require` and friends to enforce that
+    /// Ruby sources are only loaded into the interpreter once to limit side
+    /// effects.
+    ///
+    /// # Errors
+    ///
+    /// If `path` does not exist, an [`io::Error`] with error kind
+    /// [`io::ErrorKind::NotFound`] is returned.
+    pub fn mark_required(&mut self, path: &Path) -> io::Result<()> {
+        for load_path in &self.load_paths {
+            let path = absolutize_relative_to(path, &load_path);
+            if path.exists() {
+                let path = normalize_slashes(path).map_err(|err| io::Error::new(io::ErrorKind::NotFound, err))?;
+                self.loaded_features.insert(path.into());
+                return Ok(());
+            }
+        }
+        Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            "file not found in RUBYLIB load path",
+        ))
+    }
+}

--- a/artichoke-backend/src/state/mod.rs
+++ b/artichoke-backend/src/state/mod.rs
@@ -21,7 +21,7 @@ pub mod regexp;
 /// This struct stores all of these components and allows them to be passed
 /// around as one bundle. This is useful in FFI contexts because this `State`
 /// can be [`Box`]ed and stored in a user data pointer.
-#[derive(Default, Debug)]
+#[derive(Debug)]
 pub struct State {
     pub parser: Option<parser::State>,
     pub classes: class::Registry,


### PR DESCRIPTION
Add a new vfs loader that searches the `RUBYLIB` environment variable
for sources in `require` and `relative_require`.

The `RUBYLIB` loader is only activated if the `RUBYLIB` environment file
is set on interpreter boot. The `RUBYLIB` loader has the highest
priority of all vfs loaders.

This patch enables the Artichoke CLI to execute the spec suite without
the `spec-runner` crate and the embedded sources!

```console
$ RUBYLIB=spec-runner/vendor/mspec/lib:spec-runner/src ./target/release/artichoke -e 'require "spec_runner"' -e 'run_specs []'
artichoke 0.1.0-pre.0 (2021-03-20 revision 4242) [x86_64-unknown-linux-gnu]

Passed 0, skipped 0, not implemented 0, failed 0 specs.
```

The `RUBYLIB` loader is gated behind an on-by-default cargo feature. To
disable the `RUBYLIB` loader, build without the `rubylib-source-loader`
feature.