### PR TITLE
Remove a clone from the vfs write file path

### DIFF
--- a/artichoke-backend/src/fs/hybrid.rs
+++ b/artichoke-backend/src/fs/hybrid.rs
@@ -107,17 +107,18 @@ impl Hybrid {
     ///
     /// If access to the [`Native`] filesystem returns an error, the error is
     /// returned. See [`Native::write_file`].
+    #[allow(clippy::needless_pass_by_value)]
     pub fn write_file(&mut self, path: &Path, buf: Cow<'static, [u8]>) -> io::Result<()> {
         if let Some(ref mut rubylib) = self.rubylib {
-            rubylib.write_file(path, buf.clone()).or_else(|_| {
+            rubylib.write_file(path, &buf).or_else(|_| {
                 self.memory
                     .write_file(path, buf.clone())
-                    .or_else(|_| self.native.write_file(path, buf))
+                    .or_else(|_| self.native.write_file(path, &buf))
             })
         } else {
             self.memory
                 .write_file(path, buf.clone())
-                .or_else(|_| self.native.write_file(path, buf))
+                .or_else(|_| self.native.write_file(path, &buf))
         }
     }
 

--- a/artichoke-backend/src/fs/native.rs
+++ b/artichoke-backend/src/fs/native.rs
@@ -77,7 +77,7 @@ impl Native {
     /// [`io::ErrorKind::NotFound`] is returned. See [`fs::write`] for further
     /// discussion of the error modes of this API.
     #[allow(clippy::unused_self)]
-    pub fn write_file(&mut self, path: &Path, buf: Cow<'static, [u8]>) -> io::Result<()> {
+    pub fn write_file(&mut self, path: &Path, buf: &[u8]) -> io::Result<()> {
         fs::write(path, buf)
     }
 

--- a/artichoke-backend/src/fs/rubylib.rs
+++ b/artichoke-backend/src/fs/rubylib.rs
@@ -101,9 +101,8 @@ impl Rubylib {
     /// If `path` does not exist, an [`io::Error`] with error kind
     /// [`io::ErrorKind::NotFound`] is returned. See [`fs::write`] for further
     /// discussion of the error modes of this API.
-    #[allow(clippy::needless_pass_by_value)]
     #[allow(clippy::unused_self)]
-    pub fn write_file(&mut self, path: &Path, buf: Cow<'static, [u8]>) -> io::Result<()> {
+    pub fn write_file(&mut self, path: &Path, buf: &[u8]) -> io::Result<()> {
         let _ = path;
         let _ = buf;
 


### PR DESCRIPTION
The Rubylib and Native loaders don't own their bytes, so only pass a slice into these loaders.

Followup to https://github.com/artichoke/artichoke/pull/1138.