### PR TITLE
Fix use-after-free when invoking `implicitly_convert_to_string`

### DIFF
--- a/artichoke-backend/src/convert/implicit.rs
+++ b/artichoke-backend/src/convert/implicit.rs
@@ -262,6 +262,10 @@ pub fn implicitly_convert_to_int(interp: &mut Artichoke, value: Value) -> Result
 ///
 /// Callers must ensure that `value` does not outlive the given interpreter.
 ///
+/// If a garbage collection can possibly run between calling this function and
+/// using the returned slice, callers should convert the slice to an owned byte
+/// vec.
+///
 /// [`Symbol`]: crate::extn::core::symbol::Symbol
 pub unsafe fn implicitly_convert_to_string<'a>(
     interp: &mut Artichoke,

--- a/artichoke-backend/src/extn/core/array/mod.rs
+++ b/artichoke-backend/src/extn/core/array/mod.rs
@@ -316,6 +316,11 @@ impl Array {
                     out.push(formatted.into_bytes());
                 }
                 _ => {
+                    // Safety:
+                    //
+                    // `s` is converted to an owned byte vec immediately before
+                    // any intervening operaitons on the VM which may cause a
+                    // garbage collection of the `RString` that backs `value`.
                     if let Ok(s) = unsafe { implicitly_convert_to_string(interp, &mut value) } {
                         out.push(s.to_vec());
                     } else {

--- a/artichoke-backend/src/extn/core/array/trampoline.rs
+++ b/artichoke-backend/src/extn/core/array/trampoline.rs
@@ -40,8 +40,13 @@ pub fn plus(interp: &mut Artichoke, mut ary: Value, mut other: Value) -> Result<
 
 pub fn mul(interp: &mut Artichoke, mut ary: Value, mut joiner: Value) -> Result<Value, Error> {
     let array = unsafe { Array::unbox_from_value(&mut ary, interp)? };
+    // Safety:
+    //
+    // Convert separator to an owned byte vec to ensure the `RString` backing
+    // `joiner` is not garbage collected when invoking `to_s` during `join`.
     if let Ok(separator) = unsafe { implicitly_convert_to_string(interp, &mut joiner) } {
-        let s = array.join(interp, separator)?;
+        let separator = separator.to_vec();
+        let s = array.join(interp, &separator)?;
         Ok(interp.convert_mut(s))
     } else {
         let n = implicitly_convert_to_int(interp, joiner)?;

--- a/artichoke-backend/src/extn/core/kernel/integer.rs
+++ b/artichoke-backend/src/extn/core/kernel/integer.rs
@@ -159,6 +159,10 @@ impl<'a> TryConvertMut<&'a mut Value, IntegerString<'a>> for Artichoke {
         message.push_str(self.inspect_type_name_for_value(*value));
         message.push_str(" into Integer");
 
+        // Safety:
+        //
+        // There is no use of an `Artichoke` in this module, which means a
+        // garbage collection of `value` cannot be triggered.
         if let Ok(arg) = unsafe { implicitly_convert_to_string(self, value) } {
             if let Some(converted) = IntegerString::from_slice(arg) {
                 Ok(converted)

--- a/artichoke-backend/src/extn/core/kernel/trampoline.rs
+++ b/artichoke-backend/src/extn/core/kernel/trampoline.rs
@@ -4,8 +4,12 @@ use crate::extn::prelude::*;
 
 pub fn integer(interp: &mut Artichoke, mut arg: Value, base: Option<Value>) -> Result<Value, Error> {
     let base = base.and_then(|base| interp.convert(base));
-    let arg = interp.try_convert_mut(&mut arg)?;
+    // Safety:
+    //
+    // Extract the `Copy` radix integer first since implicit conversions can
+    // trigger garbage collections.
     let base = interp.try_convert_mut(base)?;
+    let arg = interp.try_convert_mut(&mut arg)?;
     let integer = kernel::integer::method(arg, base)?;
     Ok(interp.convert(integer))
 }

--- a/artichoke-backend/src/extn/core/regexp/trampoline.rs
+++ b/artichoke-backend/src/extn/core/regexp/trampoline.rs
@@ -24,7 +24,12 @@ pub fn escape(interp: &mut Artichoke, mut pattern: Value) -> Result<Value, Error
         pattern_vec = symbol.bytes(interp).to_vec();
         pattern_vec.as_slice()
     } else {
-        unsafe { implicitly_convert_to_string(interp, &mut pattern)? }
+        // Safety:
+        //
+        // Convert the bytes to an owned vec to prevent the underlying `RString`
+        // backing `pattern` from being freed during a garbage collection.
+        pattern_vec = unsafe { implicitly_convert_to_string(interp, &mut pattern)?.to_vec() };
+        pattern_vec.as_slice()
     };
     let pattern = Regexp::escape(pattern)?;
     Ok(interp.convert_mut(pattern))

--- a/artichoke-backend/src/extn/core/string/trampoline.rs
+++ b/artichoke-backend/src/extn/core/string/trampoline.rs
@@ -37,32 +37,38 @@ pub fn scan(interp: &mut Artichoke, value: Value, mut pattern: Value, block: Opt
         return Ok(interp.try_convert_mut(scan)?.unwrap_or(value));
     }
     #[cfg(feature = "core-regexp")]
+    // Safety:
+    //
+    // Convert `pattern_bytes` to an owned byte vec to ensure the underlying
+    // `RString` is not garbage collected when yielding matches.
     if let Ok(pattern_bytes) = unsafe { implicitly_convert_to_string(interp, &mut pattern) } {
+        let pattern_bytes = pattern_bytes.to_vec();
+
         let string = value.try_into_mut::<&[u8]>(interp)?;
         if let Some(ref block) = block {
-            let regex = Regexp::lazy(pattern_bytes.to_vec());
+            let regex = Regexp::lazy(pattern_bytes.clone());
             let matchdata = MatchData::new(string.to_vec(), regex, ..);
             let patlen = pattern_bytes.len();
-            if let Some(pos) = string.find(pattern_bytes) {
+            if let Some(pos) = string.find(&pattern_bytes) {
                 let mut data = matchdata.clone();
                 data.set_region(pos..pos + patlen);
                 let data = MatchData::alloc_value(data, interp)?;
                 interp.set_global_variable(regexp::LAST_MATCH, &data)?;
 
-                let block_arg = interp.convert_mut(pattern_bytes);
+                let block_arg = interp.convert_mut(pattern_bytes.as_slice());
                 let _ = block.yield_arg(interp, &block_arg)?;
 
                 interp.set_global_variable(regexp::LAST_MATCH, &data)?;
 
                 let offset = pos + patlen;
                 let string = string.get(offset..).unwrap_or_default();
-                for pos in string.find_iter(pattern_bytes) {
+                for pos in string.find_iter(&pattern_bytes) {
                     let mut data = matchdata.clone();
                     data.set_region(offset + pos..offset + pos + patlen);
                     let data = MatchData::alloc_value(data, interp)?;
                     interp.set_global_variable(regexp::LAST_MATCH, &data)?;
 
-                    let block_arg = interp.convert_mut(pattern_bytes);
+                    let block_arg = interp.convert_mut(pattern_bytes.as_slice());
                     let _ = block.yield_arg(interp, &block_arg)?;
 
                     interp.set_global_variable(regexp::LAST_MATCH, &data)?;
@@ -73,17 +79,17 @@ pub fn scan(interp: &mut Artichoke, value: Value, mut pattern: Value, block: Opt
             return Ok(value);
         }
         let (matches, last_pos) = string
-            .find_iter(pattern_bytes)
+            .find_iter(&pattern_bytes)
             .enumerate()
             .last()
             .map(|(m, p)| (m + 1, p))
             .unwrap_or_default();
         let mut result = Vec::with_capacity(matches);
         for _ in 0..matches {
-            result.push(interp.convert_mut(pattern_bytes));
+            result.push(interp.convert_mut(pattern_bytes.as_slice()));
         }
         if matches > 0 {
-            let regex = Regexp::lazy(pattern_bytes.to_vec());
+            let regex = Regexp::lazy(pattern_bytes.clone());
             let matchdata = MatchData::new(string.to_vec(), regex, last_pos..last_pos + pattern_bytes.len());
             let data = MatchData::alloc_value(matchdata, interp)?;
             interp.set_global_variable(regexp::LAST_MATCH, &data)?;
@@ -93,32 +99,38 @@ pub fn scan(interp: &mut Artichoke, value: Value, mut pattern: Value, block: Opt
         return interp.try_convert_mut(result);
     }
     #[cfg(not(feature = "core-regexp"))]
+    // Safety:
+    //
+    // Convert `pattern_bytes` to an owned byte vec to ensure the underlying
+    // `RString` is not garbage collected when yielding matches.
     if let Ok(pattern_bytes) = unsafe { implicitly_convert_to_string(interp, &mut pattern) } {
+        let pattern_bytes = pattern_bytes.to_vec();
+
         let string = value.try_into_mut::<&[u8]>(interp)?;
         if let Some(ref block) = block {
             let patlen = pattern_bytes.len();
-            if let Some(pos) = string.find(pattern_bytes) {
-                let block_arg = interp.convert_mut(pattern_bytes);
+            if let Some(pos) = string.find(&pattern_bytes) {
+                let block_arg = interp.convert_mut(pattern_bytes.as_slice());
                 let _ = block.yield_arg(interp, &block_arg)?;
 
                 let offset = pos + patlen;
                 let string = string.get(offset..).unwrap_or_default();
-                for _ in string.find_iter(pattern_bytes) {
-                    let block_arg = interp.convert_mut(pattern_bytes);
+                for _ in string.find_iter(&pattern_bytes) {
+                    let block_arg = interp.convert_mut(pattern_bytes.as_slice());
                     let _ = block.yield_arg(interp, &block_arg)?;
                 }
             }
             return Ok(value);
         }
         let matches = string
-            .find_iter(pattern_bytes)
+            .find_iter(&pattern_bytes)
             .enumerate()
             .last()
             .map(|(m, _)| m + 1)
             .unwrap_or_default();
         let mut result = Vec::with_capacity(matches);
         for _ in 0..matches {
-            result.push(interp.convert_mut(pattern_bytes));
+            result.push(interp.convert_mut(pattern_bytes.as_slice()));
         }
         return interp.try_convert_mut(result);
     }


### PR DESCRIPTION
`implicitly_convert_to_string` returns a byte slice view into an
underlying `mrb_value` backed by an `RString`. This function is marked
`unsafe` because it returns a borrowed value that *may be garbage
collected*.

This commit audits all call sites to check if the VM is invoked between
implicit conversion and final use, which may cause the `RString` to be
garbage collected.

This bug was found when debug logging paths into `Memory` load path
loader which showed garbage bytes.

This commit adds additional safety documentation to
`implicitly_convert_to_string` and adds safety comments to all unsafe
blocks that invoke this function.