### PR TITLE
Add Time::at for seconds and microseconds since EPOCH

### DIFF
--- a/artichoke-backend/src/extn/core/time/mruby.rs
+++ b/artichoke-backend/src/extn/core/time/mruby.rs
@@ -18,7 +18,7 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
         .value_is_rust_object()
         // Constructor
         .add_self_method("now", time_self_now, sys::mrb_args_none())?
-        .add_self_method("at", time_self_at, sys::mrb_args_any())?
+        .add_self_method("at", time_self_at, sys::mrb_args_req(1))?
         .add_self_method("utc", time_self_mkutc, sys::mrb_args_any())?
         .add_self_method("gm", time_self_mkutc, sys::mrb_args_any())?
         .add_self_method("local", time_self_mktime, sys::mrb_args_any())?
@@ -112,10 +112,11 @@ unsafe extern "C" fn time_self_now(mrb: *mut sys::mrb_state, _slf: sys::mrb_valu
 }
 
 unsafe extern "C" fn time_self_at(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {
-    let args = mrb_get_args!(mrb, *args);
+    let (seconds, microseconds) = mrb_get_args!(mrb, required = 1, optional = 1);
     unwrap_interpreter!(mrb, to => guard);
-    let args = args.iter().copied().map(Value::from);
-    let result = trampoline::at(&mut guard, args);
+    let seconds = Value::from(seconds);
+    let microseconds = Value::from(microseconds);
+    let result = trampoline::at(&mut guard, seconds, microseconds);
     match result {
         Ok(value) => value.inner(),
         Err(exception) => error::raise(guard, exception),

--- a/artichoke-backend/src/extn/core/time/mruby.rs
+++ b/artichoke-backend/src/extn/core/time/mruby.rs
@@ -115,7 +115,7 @@ unsafe extern "C" fn time_self_at(mrb: *mut sys::mrb_state, _slf: sys::mrb_value
     let (seconds, microseconds) = mrb_get_args!(mrb, required = 1, optional = 1);
     unwrap_interpreter!(mrb, to => guard);
     let seconds = Value::from(seconds);
-    let microseconds = Value::from(microseconds);
+    let microseconds = microseconds.map(Value::from);
     let result = trampoline::at(&mut guard, seconds, microseconds);
     match result {
         Ok(value) => value.inner(),

--- a/spinoso-time/src/lib.rs
+++ b/spinoso-time/src/lib.rs
@@ -71,6 +71,10 @@ pub use time::chrono::{Offset, Time, ToA};
 #[allow(clippy::cast_possible_truncation)] // 1e9 < u32::MAX
 const NANOS_IN_SECOND: u32 = Duration::from_secs(1).as_nanos() as u32;
 
+#[allow(clippy::cast_possible_truncation)] // 1000 < u32::MAX
+/// Number of microseconds in one nano second
+pub const MICROS_IN_NANO: u32 = Duration::from_micros(1).as_nanos() as u32;
+
 /// Error returned when constructing a [`Time`] from a [`ToA`].
 ///
 /// This error is returned when a time component in the `ToA` exeeds the maximum


### PR DESCRIPTION
Adds a partial implementation of `Time::at` to handle passing in an integer `seconds` and optional integer `microseconds` value since the EPOCH to create a new Time object.