### PR TITLE
Extract OsString utilities to their own moule in artichoke_backend

### DIFF
--- a/artichoke-backend/src/convert/bytes.rs
+++ b/artichoke-backend/src/convert/bytes.rs
@@ -6,7 +6,7 @@ use std::slice;
 use crate::convert::UnboxRubyError;
 use crate::core::{ConvertMut, TryConvertMut, Value as _};
 use crate::error::Error;
-use crate::ffi;
+use crate::platform_string::{os_str_to_bytes, os_string_to_bytes};
 use crate::sys;
 use crate::types::{Ruby, Rust};
 use crate::value::Value;
@@ -44,7 +44,7 @@ impl TryConvertMut<OsString, Value> for Artichoke {
     type Error = Error;
 
     fn try_convert_mut(&mut self, value: OsString) -> Result<Value, Self::Error> {
-        let bytes = ffi::os_str_to_bytes(&*value)?;
+        let bytes = os_string_to_bytes(value)?;
         Ok(self.convert_mut(bytes))
     }
 }
@@ -53,7 +53,7 @@ impl TryConvertMut<&OsStr, Value> for Artichoke {
     type Error = Error;
 
     fn try_convert_mut(&mut self, value: &OsStr) -> Result<Value, Self::Error> {
-        let bytes = ffi::os_str_to_bytes(value)?;
+        let bytes = os_str_to_bytes(value)?;
         Ok(self.convert_mut(bytes))
     }
 }
@@ -64,11 +64,11 @@ impl<'a> TryConvertMut<Cow<'a, OsStr>, Value> for Artichoke {
     fn try_convert_mut(&mut self, value: Cow<'a, OsStr>) -> Result<Value, Self::Error> {
         match value {
             Cow::Borrowed(value) => {
-                let bytes = ffi::os_str_to_bytes(value)?;
+                let bytes = os_str_to_bytes(value)?;
                 Ok(self.convert_mut(bytes))
             }
             Cow::Owned(value) => {
-                let bytes = ffi::os_string_to_bytes(value)?;
+                let bytes = os_string_to_bytes(value)?;
                 Ok(self.convert_mut(bytes))
             }
         }

--- a/artichoke-backend/src/eval.rs
+++ b/artichoke-backend/src/eval.rs
@@ -6,7 +6,8 @@ use crate::core::{Eval, LoadSources, Parser, Value as _};
 use crate::error::Error;
 use crate::exception_handler;
 use crate::extn::core::exception::{ArgumentError, Fatal};
-use crate::ffi::{self, InterpreterExtractError};
+use crate::ffi::InterpreterExtractError;
+use crate::platform_string::os_str_to_bytes;
 use crate::state::parser::Context;
 use crate::sys;
 use crate::sys::protect;
@@ -52,12 +53,12 @@ impl Eval for Artichoke {
     }
 
     fn eval_os_str(&mut self, code: &OsStr) -> Result<Self::Value, Self::Error> {
-        let code = ffi::os_str_to_bytes(code)?;
+        let code = os_str_to_bytes(code)?;
         self.eval(code)
     }
 
     fn eval_file(&mut self, file: &Path) -> Result<Self::Value, Self::Error> {
-        let context = Context::new(ffi::os_str_to_bytes(file.as_os_str())?.to_vec())
+        let context = Context::new(os_str_to_bytes(file.as_os_str())?.to_vec())
             .ok_or_else(|| ArgumentError::with_message("path name contains null byte"))?;
         self.push_context(context)?;
         let code = self.read_source_file_contents(file)?.into_owned();

--- a/artichoke-backend/src/extn/core/kernel/require.rs
+++ b/artichoke-backend/src/extn/core/kernel/require.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 
 use crate::convert::implicitly_convert_to_string;
 use crate::extn::prelude::*;
-use crate::ffi;
+use crate::platform_string::bytes_to_os_str;
 use crate::state::parser::Context;
 
 pub fn load(interp: &mut Artichoke, mut filename: Value) -> Result<bool, Error> {
@@ -20,7 +20,7 @@ pub fn load(interp: &mut Artichoke, mut filename: Value) -> Result<bool, Error> 
         return Err(ArgumentError::with_message("path name contains null byte").into());
     }
     let filename = filename.to_vec();
-    let file = ffi::bytes_to_os_str(&filename)?;
+    let file = bytes_to_os_str(&filename)?;
     let path = Path::new(file);
 
     if let Some(mut context) = interp.resolve_source_path(&path)? {
@@ -53,7 +53,7 @@ pub fn require(interp: &mut Artichoke, mut filename: Value) -> Result<bool, Erro
         return Err(ArgumentError::with_message("path name contains null byte").into());
     }
     let filename = filename.to_vec();
-    let file = ffi::bytes_to_os_str(&filename)?;
+    let file = bytes_to_os_str(&filename)?;
     let path = Path::new(file);
 
     if let Some(mut context) = interp.resolve_source_path(&path)? {
@@ -87,7 +87,7 @@ pub fn require_relative(interp: &mut Artichoke, mut filename: Value, base: Relat
         return Err(ArgumentError::with_message("path name contains null byte").into());
     }
     let filename = filename.to_vec();
-    let file = ffi::bytes_to_os_str(&filename)?;
+    let file = bytes_to_os_str(&filename)?;
     let path = base.join(Path::new(file));
 
     if let Some(mut context) = interp.resolve_source_path(&path)? {
@@ -144,7 +144,7 @@ impl RelativePath {
         let context = interp
             .peek_context()?
             .ok_or_else(|| Fatal::from("relative require with no context stack"))?;
-        let path = ffi::bytes_to_os_str(context.filename())?;
+        let path = bytes_to_os_str(context.filename())?;
         let path = Path::new(path);
         if let Some(base) = path.parent() {
             Ok(Self::from(base))

--- a/artichoke-backend/src/ffi.rs
+++ b/artichoke-backend/src/ffi.rs
@@ -2,18 +2,17 @@
 //!
 //! These functions are unsafe. Use them carefully.
 
-use bstr::{ByteSlice, ByteVec};
 use std::borrow::Cow;
 use std::error;
-use std::ffi::{OsStr, OsString};
 use std::fmt;
 use std::mem;
 use std::ptr::{self, NonNull};
 
+use spinoso_exception::Fatal;
+
 use crate::class_registry::ClassRegistry;
 use crate::core::ConvertMut;
 use crate::error::{Error, RubyException};
-use crate::extn::core::exception::{ArgumentError, Fatal};
 use crate::state::State;
 use crate::sys;
 use crate::Artichoke;
@@ -123,96 +122,6 @@ impl From<InterpreterExtractError> for Box<dyn RubyException> {
 
 impl From<Box<InterpreterExtractError>> for Box<dyn RubyException> {
     fn from(exception: Box<InterpreterExtractError>) -> Box<dyn RubyException> {
-        exception
-    }
-}
-
-/// Convert a byte slice to a platform-specific [`OsStr`].
-///
-/// Unsupported platforms fallback to converting through `str`.
-#[inline]
-pub fn bytes_to_os_str(value: &[u8]) -> Result<&OsStr, ConvertBytesError> {
-    value.to_os_str().map_err(|_| ConvertBytesError::new())
-}
-
-/// Convert a platform-specific [`OsStr`] to a byte slice.
-///
-/// Unsupported platforms fallback to converting through `str`.
-#[inline]
-pub fn os_str_to_bytes(value: &OsStr) -> Result<&[u8], ConvertBytesError> {
-    <[u8]>::from_os_str(value).ok_or_else(ConvertBytesError::new)
-}
-
-/// Convert a platform-specific [`OsString`] to a byte vec.
-///
-/// Unsupported platforms fallback to converting through `String`.
-#[inline]
-pub fn os_string_to_bytes(value: OsString) -> Result<Vec<u8>, ConvertBytesError> {
-    Vec::from_os_string(value).map_err(|_| ConvertBytesError::new())
-}
-
-#[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct ConvertBytesError {
-    _private: (),
-}
-
-impl ConvertBytesError {
-    /// Constructs a new, default `ConvertBytesError`.
-    #[must_use]
-    pub const fn new() -> Self {
-        Self { _private: () }
-    }
-}
-
-impl fmt::Display for ConvertBytesError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str("Could not convert between bytes and platform string")
-    }
-}
-
-impl error::Error for ConvertBytesError {}
-
-impl RubyException for ConvertBytesError {
-    fn message(&self) -> Cow<'_, [u8]> {
-        Cow::Borrowed(b"invalid byte sequence")
-    }
-
-    fn name(&self) -> Cow<'_, str> {
-        "ArgumentError".into()
-    }
-
-    fn vm_backtrace(&self, interp: &mut Artichoke) -> Option<Vec<Vec<u8>>> {
-        let _ = interp;
-        None
-    }
-
-    fn as_mrb_value(&self, interp: &mut Artichoke) -> Option<sys::mrb_value> {
-        let message = interp.convert_mut(self.message());
-        let value = interp.new_instance::<ArgumentError>(&[message]).ok().flatten()?;
-        Some(value.inner())
-    }
-}
-
-impl From<ConvertBytesError> for Error {
-    fn from(exception: ConvertBytesError) -> Self {
-        Self::from(Box::<dyn RubyException>::from(exception))
-    }
-}
-
-impl From<Box<ConvertBytesError>> for Error {
-    fn from(exception: Box<ConvertBytesError>) -> Self {
-        Self::from(Box::<dyn RubyException>::from(exception))
-    }
-}
-
-impl From<ConvertBytesError> for Box<dyn RubyException> {
-    fn from(exception: ConvertBytesError) -> Box<dyn RubyException> {
-        Box::new(exception)
-    }
-}
-
-impl From<Box<ConvertBytesError>> for Box<dyn RubyException> {
-    fn from(exception: Box<ConvertBytesError>) -> Box<dyn RubyException> {
         exception
     }
 }

--- a/artichoke-backend/src/lib.rs
+++ b/artichoke-backend/src/lib.rs
@@ -148,6 +148,7 @@ pub mod method;
 pub mod module;
 pub mod module_registry;
 mod parser;
+pub mod platform_string;
 #[cfg(feature = "core-random")]
 mod prng;
 mod regexp;

--- a/artichoke-backend/src/load_path.rs
+++ b/artichoke-backend/src/load_path.rs
@@ -16,7 +16,7 @@ use bstr::ByteVec;
 use std::path::{Component, Path, PathBuf};
 
 use crate::error::Error;
-use crate::ffi::ConvertBytesError;
+use crate::platform_string::ConvertBytesError;
 use crate::Artichoke;
 
 #[cfg(feature = "load-path-native-filesystem-loader")]

--- a/artichoke-backend/src/load_path/native.rs
+++ b/artichoke-backend/src/load_path/native.rs
@@ -7,7 +7,7 @@ use std::io;
 use std::path::Path;
 
 use super::{absolutize_relative_to, normalize_slashes};
-use crate::ffi::os_str_to_bytes;
+use crate::platform_string::os_str_to_bytes;
 
 #[derive(Default, Debug, PartialEq, Eq)]
 pub struct Native {

--- a/artichoke-backend/src/load_path/rubylib.rs
+++ b/artichoke-backend/src/load_path/rubylib.rs
@@ -7,7 +7,7 @@ use std::io;
 use std::path::{Path, PathBuf};
 
 use super::{absolutize_relative_to, normalize_slashes};
-use crate::ffi::os_string_to_bytes;
+use crate::platform_string::os_string_to_bytes;
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Rubylib {

--- a/artichoke-backend/src/platform_string.rs
+++ b/artichoke-backend/src/platform_string.rs
@@ -1,0 +1,158 @@
+//! Conversions between [platform strings] and bytes.
+//!
+//! [platform strings]: OsString
+
+use core::fmt;
+use std::error;
+use std::ffi::{OsStr, OsString};
+
+use bstr::{ByteSlice, ByteVec, Utf8Error};
+
+mod impls;
+
+/// Convert a byte slice to a platform-specific [`OsStr`].
+///
+/// Unsupported platforms fallback to converting through [`str`].
+///
+/// # Examples
+///
+/// ```
+/// # use std::ffi::OsStr;
+/// # use artichoke_backend::platform_string::bytes_to_os_str;
+/// let bytes: &[u8] = b"/etc/passwd";
+/// assert_eq!(bytes_to_os_str(bytes), Ok(OsStr::new("/etc/passwd")));
+/// ```
+///
+/// # Errors
+///
+/// On unix-like platforms, this function is infallible.
+///
+/// On Windows, if the given byte slice does not contain valid UTF-8, an error
+/// is returned.
+#[inline]
+pub fn bytes_to_os_str(value: &[u8]) -> Result<&OsStr, ConvertBytesError> {
+    let platform_string = value.to_os_str()?;
+    Ok(platform_string)
+}
+
+/// Convert a platform-specific [`OsStr`] to a byte slice.
+///
+/// Unsupported platforms fallback to converting through [`str`].
+///
+/// # Examples
+///
+/// ```
+/// # use std::ffi::OsStr;
+/// # use artichoke_backend::platform_string::os_str_to_bytes;
+/// let platform_string: &OsStr = OsStr::new("/etc/passwd");
+/// assert_eq!(os_str_to_bytes(platform_string), Ok(&b"/etc/passwd"[..]));
+/// ```
+///
+/// # Errors
+///
+/// On unix-like platforms, this function is infallible.
+///
+/// On Windows, if the given byte slice does not contain valid UTF-8, an error
+/// is returned.
+#[inline]
+pub fn os_str_to_bytes(value: &OsStr) -> Result<&[u8], ConvertBytesError> {
+    <[u8]>::from_os_str(value).ok_or_else(ConvertBytesError::new)
+}
+
+/// Convert a platform-specific [`OsString`] to a byte vec.
+///
+/// Unsupported platforms fallback to converting through [`String`].
+///
+/// # Examples
+///
+/// ```
+/// # use std::ffi::OsString;
+/// # use artichoke_backend::platform_string::os_string_to_bytes;
+/// let platform_string: OsString = OsString::from("/etc/passwd");
+/// assert_eq!(os_string_to_bytes(platform_string), Ok(b"/etc/passwd".to_vec()));
+/// ```
+///
+/// # Errors
+///
+/// On unix-like platforms, this function is infallible.
+///
+/// On Windows, if the given byte slice does not contain valid UTF-8, an error
+/// is returned.
+#[inline]
+pub fn os_string_to_bytes(value: OsString) -> Result<Vec<u8>, ConvertBytesError> {
+    let bytes = Vec::from_os_string(value)?;
+    Ok(bytes)
+}
+
+/// Error returned when a [platform string] cannot be converted to a byte
+/// vector or a byte vector cannot be converted to a [platform string].
+///
+/// On unix-like platforms, this error is never returned. On Windows platforms,
+/// platform strings can only be converted to byte vectors (and vice versa) when
+/// they contain valid UTF-8 contents.
+///
+/// This error is returned by [`bytes_to_os_str`], [`os_string_to_bytes`] and
+/// [`os_str_to_bytes`]. See their documentation for more details.
+///
+/// [platform string]: OsString
+#[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ConvertBytesError {
+    _private: (),
+}
+
+impl ConvertBytesError {
+    /// Constructs a new, default `ConvertBytesError`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use artichoke_backend::platform_string::ConvertBytesError;
+    /// const ERR: ConvertBytesError = ConvertBytesError::new();
+    /// assert_eq!(ERR.message(), "Could not convert between bytes and platform string");
+    /// ```
+    #[inline]
+    #[must_use]
+    pub const fn new() -> Self {
+        Self { _private: () }
+    }
+
+    /// Retrieve the exception message associated with this convert bytes error.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use artichoke_backend::platform_string::ConvertBytesError;
+    /// let err = ConvertBytesError::new();
+    /// assert_eq!(err.message(), "Could not convert between bytes and platform string");
+    /// ```
+    #[inline]
+    #[must_use]
+    #[allow(clippy::unused_self)]
+    pub const fn message(self) -> &'static str {
+        "Could not convert between bytes and platform string"
+    }
+}
+
+impl fmt::Display for ConvertBytesError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.message())
+    }
+}
+
+impl error::Error for ConvertBytesError {}
+
+impl From<Utf8Error> for ConvertBytesError {
+    #[inline]
+    fn from(err: Utf8Error) -> Self {
+        let _ = err;
+        Self { _private: () }
+    }
+}
+
+impl From<OsString> for ConvertBytesError {
+    #[inline]
+    fn from(err: OsString) -> Self {
+        let _ = err;
+        Self { _private: () }
+    }
+}

--- a/artichoke-backend/src/platform_string/impls.rs
+++ b/artichoke-backend/src/platform_string/impls.rs
@@ -33,7 +33,7 @@ impl RubyException for ConvertBytesError {
 
 impl From<ConvertBytesError> for Error {
     fn from(exception: ConvertBytesError) -> Self {
-        Self::from(Box::new(exception))
+        Self::from(Box::<dyn RubyException>::from(exception))
     }
 }
 
@@ -52,5 +52,18 @@ impl From<ConvertBytesError> for Box<dyn RubyException> {
 impl From<Box<ConvertBytesError>> for Box<dyn RubyException> {
     fn from(exception: Box<ConvertBytesError>) -> Box<dyn RubyException> {
         exception
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ConvertBytesError;
+    use crate::error::{Error, RubyException};
+
+    #[test]
+    fn box_convert() {
+        // Prevents regressing on a stack overflow caused by a mutual recursion.
+        let err = Error::from(ConvertBytesError::new());
+        assert_eq!(err.name(), "ArgumentError");
     }
 }

--- a/artichoke-backend/src/platform_string/impls.rs
+++ b/artichoke-backend/src/platform_string/impls.rs
@@ -1,0 +1,56 @@
+use std::borrow::Cow;
+
+use artichoke_core::convert::ConvertMut;
+use spinoso_exception::ArgumentError;
+
+use crate::class_registry::ClassRegistry;
+use crate::error::{Error, RubyException};
+use crate::sys;
+use crate::Artichoke;
+
+use super::ConvertBytesError;
+
+impl RubyException for ConvertBytesError {
+    fn message(&self) -> Cow<'_, [u8]> {
+        Cow::Borrowed(b"invalid byte sequence")
+    }
+
+    fn name(&self) -> Cow<'_, str> {
+        "ArgumentError".into()
+    }
+
+    fn vm_backtrace(&self, interp: &mut Artichoke) -> Option<Vec<Vec<u8>>> {
+        let _ = interp;
+        None
+    }
+
+    fn as_mrb_value(&self, interp: &mut Artichoke) -> Option<sys::mrb_value> {
+        let message = interp.convert_mut(self.message());
+        let value = interp.new_instance::<ArgumentError>(&[message]).ok().flatten()?;
+        Some(value.inner())
+    }
+}
+
+impl From<ConvertBytesError> for Error {
+    fn from(exception: ConvertBytesError) -> Self {
+        Self::from(Box::new(exception))
+    }
+}
+
+impl From<Box<ConvertBytesError>> for Error {
+    fn from(exception: Box<ConvertBytesError>) -> Self {
+        Self::from(*exception)
+    }
+}
+
+impl From<ConvertBytesError> for Box<dyn RubyException> {
+    fn from(exception: ConvertBytesError) -> Box<dyn RubyException> {
+        Box::new(exception)
+    }
+}
+
+impl From<Box<ConvertBytesError>> for Box<dyn RubyException> {
+    fn from(exception: Box<ConvertBytesError>) -> Box<dyn RubyException> {
+        exception
+    }
+}

--- a/src/ruby.rs
+++ b/src/ruby.rs
@@ -10,7 +10,7 @@ use std::io;
 use std::path::{Path, PathBuf};
 use termcolor::WriteColor;
 
-use crate::backend::ffi;
+use crate::backend::platform_string::os_str_to_bytes;
 use crate::backend::state::parser::Context;
 use crate::backend::string::format_unicode_debug_into;
 use crate::backtrace;
@@ -121,7 +121,7 @@ where
     // Inject ARGV global.
     let mut ruby_program_argv = Vec::new();
     for argument in &args.argv {
-        let argument = ffi::os_str_to_bytes(argument)?;
+        let argument = os_str_to_bytes(argument)?;
         let mut argument = interp.try_convert_mut(argument)?;
         argument.freeze(interp)?;
         ruby_program_argv.push(argument);
@@ -206,7 +206,7 @@ where
 fn load_error<P: AsRef<OsStr>>(file: P, message: &str) -> Result<String, Error> {
     let mut buf = String::from(message);
     buf.push_str(" -- ");
-    let path = ffi::os_str_to_bytes(file.as_ref())?;
+    let path = os_str_to_bytes(file.as_ref())?;
     format_unicode_debug_into(&mut buf, path)?;
     Ok(buf)
 }


### PR DESCRIPTION
This PR also removes a needless copy in the `OsString` converter.