### PR TITLE
Escape email from example docs for ReleaseMetadata::ruby_copyright

### DIFF
--- a/artichoke-core/src/release_metadata.rs
+++ b/artichoke-core/src/release_metadata.rs
@@ -15,7 +15,7 @@ pub trait ReleaseMetadata {
     ///
     /// # Examples
     ///
-    /// > artichoke - Copyright (c) 2019-2020 Ryan Lopopolo <rjl@hyperbo.la>
+    /// > artichoke - Copyright (c) 2019-2020 Ryan Lopopolo \<rjl@hyperbo.la\>
     fn ruby_copyright(&self) -> &str;
 
     /// A description of the current build.


### PR DESCRIPTION
This broke in the latest nightly with this error:

```
error: unknown disambiguator `rjl`
  --> artichoke-core/src/release_metadata.rs:18:62
   |
18 |     /// > artichoke - Copyright (c) 2019-2020 Ryan Lopopolo <rjl@hyperbo.la>
   |                                                              ^^^
   |
   = note: requested on the command line with `-D rustdoc::broken-intra-doc-links`
```