### PR TITLE
Cherry-pick fix for mismatched prototype when building on emscripten targets

### DIFF
--- a/artichoke-backend/vendor/mruby/src/state.c
+++ b/artichoke-backend/vendor/mruby/src/state.c
@@ -177,7 +177,7 @@ mrb_free_context(mrb_state *mrb, struct mrb_context *c)
   mrb_free(mrb, c);
 }
 
-int mrb_protect_atexit(mrb_state *mrb);
+void mrb_protect_atexit(mrb_state *mrb);
 
   MRB_API void
 mrb_close(mrb_state *mrb)


### PR DESCRIPTION
This commit revendors Artichoke's fork of mruby as of artichoke/mruby@16f07e36dd45ffb80bad554a81c799f0b7f07d1d.

This commit fixes an incorrectly redeclared prototype for a private function. This prototype mismatch fails to link on emscripten when compiling the playground.

See artichoke/mruby#2 and mruby/mruby#5411.