### PR TITLE
Update Rakefile and RuboCop configuration to work on Windows machines

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,6 +8,8 @@ AllCops:
     - "**/node_modules/**/*"
     - "**/target/**/*"
     - "**/vendor/**/*"
+Layout/EndOfLine:
+  EnforcedStyle: lf
 Layout/LineLength:
   Enabled: true
   Exclude:

--- a/BUILD.md
+++ b/BUILD.md
@@ -46,6 +46,12 @@ brew install rustup-init
 rustup-init
 ```
 
+On Windows, you can install rustup from the official site and follow the
+prompts: <https://rustup.rs/>. This requires a download of Visual Studio (the
+[Community Edition][vs-community] is sufficient) and several C++ packages
+selected through the VS component installer. (I'm not sure which packages are
+required; I selected them all.)
+
 Once you have rustup, you can install the Rust toolchain needed to compile
 Artichoke.
 
@@ -73,6 +79,9 @@ compiler.
 
 Artichoke specifically requires clang. WebAssembly targets require clang-8 or
 newer.
+
+On Windows, install the latest LLVM distribution from GitHub and add LLVM to
+your PATH: <https://github.com/llvm/llvm-project/releases>.
 
 #### `cc` Crate
 
@@ -122,6 +131,7 @@ bundle install
 [artichoke/playground]: https://github.com/artichoke/playground
 [rustup]: https://rustup.rs/
 [homebrew]: https://docs.brew.sh/Installation
+[vs-community]: https://visualstudio.microsoft.com/vs/community/
 [`onig`]: https://crates.io/crates/onig
 [`cc` crate]: https://crates.io/crates/cc
 [platform-dependent c compiler]:

--- a/Rakefile
+++ b/Rakefile
@@ -58,7 +58,7 @@ namespace :format do
 
   desc 'Format text, YAML, and Markdown sources with prettier'
   task :text do
-    sh "npx prettier --write '**/*'"
+    sh 'npx prettier --write "**/*"'
   end
 
   desc 'Format .c and .h sources with clang-format'
@@ -81,7 +81,7 @@ namespace :fmt do
 
   desc 'Format text, YAML, and Markdown sources with prettier'
   task :text do
-    sh "npx prettier --write '**/*'"
+    sh 'npx prettier --write "**/*"'
   end
 
   desc 'Format .c and .h sources with clang-format'


### PR DESCRIPTION
- Force line feed endings in RuboCop configuration instead of the default "native" endings.
- Fix quotes for prettier globs so they work in Windows Terminal and PowerShell.
- Add docs on how to set up a toolchain on Windows to `BUILD.md`.