### PR TITLE
Implement `String` in Rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,6 +56,7 @@ dependencies = [
  "spinoso-random",
  "spinoso-regexp",
  "spinoso-securerandom",
+ "spinoso-string",
  "spinoso-symbol",
  "spinoso-time",
  "target-lexicon",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "artichoke-backend"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "artichoke-core",
  "artichoke-load-path",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ rustyline = { version = "9", optional = true, default-features = false }
 termcolor = { version = "1.1", optional = true }
 
 [dependencies.artichoke-backend]
-version = "0.4"
+version = "0.5"
 path = "artichoke-backend"
 default-features = false
 

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "artichoke-backend"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2021"
 description = "Embeddable VM implementation for Artichoke Ruby"

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -29,6 +29,7 @@ spinoso-math = { version = "0.2", path = "../spinoso-math", optional = true, def
 spinoso-random = { version = "0.2", path = "../spinoso-random", optional = true }
 spinoso-regexp = { version = "0.2", path = "../spinoso-regexp", optional = true, default-features = false }
 spinoso-securerandom = { version = "0.1", path = "../spinoso-securerandom", optional = true }
+spinoso-string = { version = "0.10", path = "../spinoso-string" }
 spinoso-symbol = { version = "0.1", path = "../spinoso-symbol" }
 spinoso-time = { version = "0.2", path = "../spinoso-time", optional = true }
 

--- a/artichoke-backend/mruby-sys/include/mruby-sys/ext.h
+++ b/artichoke-backend/mruby-sys/include/mruby-sys/ext.h
@@ -109,6 +109,14 @@ MRB_API mrb_value mrb_sys_alloc_rarray(struct mrb_state *mrb, mrb_value *ptr, mr
 
 MRB_API void mrb_sys_repack_into_rarray(mrb_value *ptr, mrb_int len, mrb_int capa, mrb_value into);
 
+// Manipulate String `mrb_value`s
+
+MRB_API mrb_value mrb_sys_alloc_rstring(struct mrb_state *mrb, char *ptr, mrb_int len,
+                                        mrb_int capa);
+
+MRB_API struct RString *mrb_sys_repack_into_rstring(char *ptr, mrb_int len, mrb_int capa,
+                                                    mrb_value into);
+
 // Manage the mruby garbage collector (GC)
 
 /**

--- a/artichoke-backend/mruby-sys/src/mruby-sys/ext.c
+++ b/artichoke-backend/mruby-sys/src/mruby-sys/ext.c
@@ -311,6 +311,34 @@ mrb_ary_subseq(mrb_state *mrb, mrb_value ary, mrb_int beg, mrb_int len)
   return mrb_ary_new_from_values(mrb, len, ARY_PTR(a) + beg);
 }
 
+// Manipulate String `mrb_value`s
+
+MRB_API mrb_value
+mrb_sys_alloc_rstring(struct mrb_state *mrb, char *ptr, mrb_int len, mrb_int capa)
+{
+  struct RString *s;
+
+  s = (struct RString *)mrb_obj_alloc(mrb, MRB_TT_STRING, mrb->string_class);
+
+  s->as.heap.ptr = ptr;
+  s->as.heap.len = len;
+  s->as.heap.aux.capa = capa;
+
+  return mrb_obj_value(s);
+}
+
+MRB_API struct RString *
+mrb_sys_repack_into_rstring(char *ptr, mrb_int len, mrb_int capa, mrb_value into)
+{
+  struct RString *s = RSTRING(into);
+
+  s->as.heap.ptr = ptr;
+  s->as.heap.len = len;
+  s->as.heap.aux.capa = capa;
+
+  return s;
+}
+
 // Manage the mruby garbage collector (GC)
 
 MRB_API int

--- a/artichoke-backend/mruby-sys/src/mruby-sys/ext.c
+++ b/artichoke-backend/mruby-sys/src/mruby-sys/ext.c
@@ -16,6 +16,9 @@
 
 #include <mruby.h>
 #include <mruby/array.h>
+#include <mruby/class.h>
+#include <mruby/numeric.h>
+#include <mruby/presym.h>
 #include <mruby/range.h>
 #include <mruby/string.h>
 #include <mruby/value.h>
@@ -337,6 +340,87 @@ mrb_sys_repack_into_rstring(char *ptr, mrb_int len, mrb_int capa, mrb_value into
   s->as.heap.aux.capa = capa;
 
   return s;
+}
+
+MRB_API mrb_int
+mrb_str_strlen(mrb_state *mrb, struct RString *s)
+{
+  mrb_int i, max = RSTR_LEN(s);
+  char *p = RSTR_PTR(s);
+
+  if (!p) return 0;
+  for (i = 0; i < max; i++) {
+    if (p[i] == '\0') {
+      mrb_raise(mrb, E_ARGUMENT_ERROR, "string contains null byte");
+    }
+  }
+  return max;
+}
+
+MRB_API void
+mrb_str_modify_keep_ascii(mrb_state *mrb, struct RString *s)
+{
+  mrb_check_frozen(mrb, s);
+}
+
+MRB_API void
+mrb_str_modify(mrb_state *mrb, struct RString *s)
+{
+  mrb_str_modify_keep_ascii(mrb, s);
+}
+
+MRB_API void
+mrb_str_concat(mrb_state *mrb, mrb_value self, mrb_value other)
+{
+  other = mrb_obj_as_string(mrb, other);
+  mrb_str_cat_str(mrb, self, other);
+}
+
+MRB_API mrb_value
+mrb_str_intern(mrb_state *mrb, mrb_value self)
+{
+  return mrb_symbol_value(mrb_intern_str(mrb, self));
+}
+
+MRB_API mrb_value
+mrb_obj_as_string(mrb_state *mrb, mrb_value obj)
+{
+  switch (mrb_type(obj)) {
+    case MRB_TT_STRING:
+      return obj;
+    case MRB_TT_SYMBOL:
+      return mrb_sym_str(mrb, mrb_symbol(obj));
+    case MRB_TT_INTEGER:
+      return mrb_fixnum_to_str(mrb, obj, 10);
+    case MRB_TT_SCLASS:
+    case MRB_TT_CLASS:
+    case MRB_TT_MODULE:
+      return mrb_mod_to_s(mrb, obj);
+    default:
+      return mrb_type_convert(mrb, obj, MRB_TT_STRING, MRB_SYM(to_s));
+  }
+}
+
+MRB_API mrb_value
+mrb_str_cat_cstr(mrb_state *mrb, mrb_value str, const char *ptr)
+{
+  return mrb_str_cat(mrb, str, ptr, ptr ? strlen(ptr) : 0);
+}
+
+MRB_API mrb_value
+mrb_str_cat_str(mrb_state *mrb, mrb_value str, mrb_value str2)
+{
+  if (mrb_str_ptr(str) == mrb_str_ptr(str2)) {
+    mrb_str_modify(mrb, mrb_str_ptr(str));
+  }
+  return mrb_str_cat(mrb, str, RSTRING_PTR(str2), RSTRING_LEN(str2));
+}
+
+MRB_API mrb_value
+mrb_str_append(mrb_state *mrb, mrb_value str1, mrb_value str2)
+{
+  mrb_to_str(mrb, str2);
+  return mrb_str_cat_str(mrb, str1, str2);
 }
 
 // Manage the mruby garbage collector (GC)

--- a/artichoke-backend/src/convert/string.rs
+++ b/artichoke-backend/src/convert/string.rs
@@ -61,8 +61,6 @@ impl<'a> TryConvertMut<Value, &'a str> for Artichoke {
 
 #[cfg(test)]
 mod tests {
-    use std::slice;
-
     use quickcheck::quickcheck;
 
     use crate::test::prelude::*;
@@ -81,16 +79,7 @@ mod tests {
         fn convert_to_string(s: String) -> bool {
             let mut interp = interpreter().unwrap();
             let value = interp.try_convert_mut(s.clone()).unwrap();
-            let string = unsafe {
-                interp
-                    .with_ffi_boundary(|mrb| {
-                        let ptr = sys::mrb_string_value_ptr(mrb, value.inner());
-                        let len = sys::mrb_string_value_len(mrb, value.inner());
-                        let len = usize::try_from(len).unwrap();
-                        slice::from_raw_parts(ptr.cast::<u8>(), len)
-                    })
-                    .unwrap()
-            };
+            let string: Vec<u8> = interp.try_convert_mut(value).unwrap();
             s.as_bytes() == string
         }
 

--- a/artichoke-backend/src/extn/core/matchdata/matchdata.rb
+++ b/artichoke-backend/src/extn/core/matchdata/matchdata.rb
@@ -23,7 +23,7 @@ class MatchData
       end
     else
       names.each do |name|
-        s << %( #{name}:"#{self[name] || nil.inspect}")
+        s << %( #{name}:#{self[name].inspect})
       end
     end
     s << '>'

--- a/artichoke-backend/src/extn/core/string/ffi.rs
+++ b/artichoke-backend/src/extn/core/string/ffi.rs
@@ -272,13 +272,10 @@ unsafe extern "C" fn mrb_str_dup(mrb: *mut sys::mrb_state, s: sys::mrb_value) ->
             let dup_basic = sys::mrb_sys_basic_ptr(value).cast::<sys::RString>();
             (*dup_basic).c = class;
 
-            value
-        } else {
-            Value::nil().into()
+            return value;
         }
-    } else {
-        Value::nil().into()
     }
+    Value::nil().into()
 }
 
 // MRB_API mrb_value mrb_str_substr(mrb_state *mrb, mrb_value str, mrb_int beg, mrb_int len)

--- a/artichoke-backend/src/extn/core/string/ffi.rs
+++ b/artichoke-backend/src/extn/core/string/ffi.rs
@@ -305,8 +305,7 @@ unsafe extern "C" fn mrb_str_substr(
     };
 
     if let Some(slice) = string.get(offset..) {
-        let mut substr = String::with_capacity_and_encoding(slice.len(), string.encoding());
-        substr.extend_from_slice(slice);
+        let substr = String::with_bytes_and_encoding(slice.to_vec(), string.encoding());
         String::alloc_value(substr, &mut guard).unwrap_or_default().into()
     } else {
         Value::nil().into()

--- a/artichoke-backend/src/extn/core/string/ffi.rs
+++ b/artichoke-backend/src/extn/core/string/ffi.rs
@@ -5,6 +5,7 @@ use core::ptr;
 use core::slice;
 use core::str;
 use std::ffi::{c_void, CStr};
+use std::io::Write as _;
 use std::os::raw::{c_double, c_int};
 
 use artichoke_core::convert::Convert;
@@ -316,7 +317,8 @@ unsafe extern "C" fn mrb_str_substr(
 #[no_mangle]
 unsafe extern "C" fn mrb_ptr_to_str(mrb: *mut sys::mrb_state, p: *mut c_void) -> sys::mrb_value {
     unwrap_interpreter!(mrb, to => guard);
-    let s = String::from(format!("{:p}", p));
+    let mut s = String::with_capacity(16 + 2);
+    let _ignore = write!(s, "{:p}", p);
     String::alloc_value(s, &mut guard).unwrap_or_default().into()
 }
 

--- a/artichoke-backend/src/extn/core/string/ffi.rs
+++ b/artichoke-backend/src/extn/core/string/ffi.rs
@@ -1,0 +1,566 @@
+use core::char;
+use core::convert::TryFrom;
+use core::hash::{BuildHasher, Hash, Hasher};
+use core::ptr;
+use core::slice;
+use core::str;
+use std::ffi::{c_void, CStr};
+use std::os::raw::{c_double, c_int};
+
+use artichoke_core::convert::Convert;
+use artichoke_core::hash::Hash as _;
+use bstr::ByteSlice;
+use spinoso_exception::ArgumentError;
+use spinoso_string::String;
+
+use crate::convert::BoxUnboxVmValue;
+use crate::error;
+use crate::sys;
+use crate::value::Value;
+
+// MRB_API mrb_value mrb_str_new_capa(mrb_state *mrb, size_t capa)
+#[no_mangle]
+unsafe extern "C" fn mrb_str_new_capa(mrb: *mut sys::mrb_state, capa: usize) -> sys::mrb_value {
+    unwrap_interpreter!(mrb, to => guard);
+    let result = String::with_capacity(capa);
+    let result = String::alloc_value(result, &mut guard);
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => error::raise(guard, exception),
+    }
+}
+
+// MRB_API mrb_value mrb_str_new(mrb_state *mrb, const char *p, size_t len)
+#[no_mangle]
+unsafe extern "C" fn mrb_str_new(mrb: *mut sys::mrb_state, p: *const i8, len: usize) -> sys::mrb_value {
+    unwrap_interpreter!(mrb, to => guard);
+    let bytes = slice::from_raw_parts(p.cast::<u8>(), len);
+    let bytes = bytes.to_vec();
+    let result = String::utf8(bytes);
+    let result = String::alloc_value(result, &mut guard);
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => error::raise(guard, exception),
+    }
+}
+
+// MRB_API mrb_value mrb_str_new_cstr(mrb_state *mrb, const char *p)
+#[no_mangle]
+unsafe extern "C" fn mrb_str_new_cstr(mrb: *mut sys::mrb_state, p: *const i8) -> sys::mrb_value {
+    unwrap_interpreter!(mrb, to => guard);
+    let cstr = CStr::from_ptr(p);
+    let bytes = cstr.to_bytes().to_vec();
+    let result = String::utf8(bytes);
+    let result = String::alloc_value(result, &mut guard);
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => error::raise(guard, exception),
+    }
+}
+
+// MRB_API mrb_value mrb_str_new_static(mrb_state *mrb, const char *p, size_t len)
+#[no_mangle]
+unsafe extern "C" fn mrb_str_new_static(mrb: *mut sys::mrb_state, p: *const i8, len: usize) -> sys::mrb_value {
+    // Artichoke doesn't have a static string optimization.
+    mrb_str_new(mrb, p, len)
+}
+
+// MRB_API mrb_int mrb_str_index(mrb_state *mrb, mrb_value str, const char *sptr, mrb_int slen, mrb_int offset)
+#[no_mangle]
+unsafe extern "C" fn mrb_str_index(
+    mrb: *mut sys::mrb_state,
+    s: sys::mrb_value,
+    sptr: *const i8,
+    slen: sys::mrb_int,
+    offset: sys::mrb_int,
+) -> sys::mrb_int {
+    unwrap_interpreter!(mrb, to => guard, or_else = -1);
+    let mut value = s.into();
+    let string = if let Ok(string) = String::unbox_from_value(&mut value, &mut guard) {
+        string
+    } else {
+        return -1;
+    };
+
+    let offset = if let Ok(offset) = usize::try_from(offset) {
+        offset
+    } else {
+        let offset = offset
+            .checked_neg()
+            .and_then(|offset| usize::try_from(offset).ok())
+            .and_then(|offset| offset.checked_sub(string.len()));
+        if let Some(offset) = offset {
+            offset
+        } else {
+            return -1;
+        }
+    };
+    let haystack = if let Some(haystack) = string.get(offset..) {
+        haystack
+    } else {
+        return -1;
+    };
+    let needle = slice::from_raw_parts(sptr.cast::<u8>(), usize::try_from(slen).unwrap_or_default());
+    if needle.is_empty() {
+        return offset as sys::mrb_int;
+    }
+    haystack.find(needle).map_or(-1, |pos| pos as sys::mrb_int)
+}
+
+// MRB_API mrb_int mrb_str_strlen(mrb_state *mrb, struct RString *s)
+//
+// NOTE: Implemented in C in `mruby-sys/src/mruby-sys/ext.c`.
+
+// MRB_API void mrb_str_modify_keep_ascii(mrb_state *mrb, struct RString *s)
+//
+// MRB_API void mrb_str_modify(mrb_state *mrb, struct RString *s)
+//
+// NOTE: Implemented in C in `mruby-sys/src/mruby-sys/ext.c`.
+
+// MRB_API mrb_value mrb_str_resize(mrb_state *mrb, mrb_value str, mrb_int len)
+#[no_mangle]
+unsafe extern "C" fn mrb_str_resize(mrb: *mut sys::mrb_state, s: sys::mrb_value, len: sys::mrb_int) -> sys::mrb_value {
+    unwrap_interpreter!(mrb, to => guard, or_else = s);
+    let mut value = s.into();
+    if let Ok(mut string) = String::unbox_from_value(&mut value, &mut guard) {
+        let additional = usize::try_from(len)
+            .ok()
+            .and_then(|len| len.checked_sub(string.len()))
+            .unwrap_or(0);
+
+        // Safety:
+        //
+        // The string is repacked before any intervening use of the interpreter.
+        // The string is repacked before any intervening mruby heap allocations.
+        let string_mut = string.as_inner_mut();
+        if additional > 0 {
+            string_mut.reserve(additional);
+        }
+        let inner = string.take();
+        let value = String::box_into_value(inner, value, &mut guard).expect("String reboxing should not fail");
+
+        value.inner()
+    } else {
+        s
+    }
+}
+
+// MRB_API char* mrb_str_to_cstr(mrb_state *mrb, mrb_value str0)
+//
+// NOTE: Not implemented.
+
+// MRB_API void mrb_str_concat(mrb_state *mrb, mrb_value self, mrb_value other)
+//
+// NOTE: Implemented in C in `mruby-sys/src/mruby-sys/ext.c`.
+//
+// #[no_mangle]
+// unsafe extern "C" mrb_str_concat(mrb: *mut sys::mrb_state, this: sys::mrb_value, other: sys::mrb_value) {
+//     unwrap_interpreter!(mrb, to => guard, or_else = ());
+// }
+
+// MRB_API mrb_value mrb_str_plus(mrb_state *mrb, mrb_value a, mrb_value b)
+#[no_mangle]
+unsafe extern "C" fn mrb_str_plus(mrb: *mut sys::mrb_state, a: sys::mrb_value, b: sys::mrb_value) -> sys::mrb_value {
+    unwrap_interpreter!(mrb, to => guard);
+    let mut a = Value::from(a);
+    let mut b = Value::from(b);
+
+    let a = if let Ok(a) = String::unbox_from_value(&mut a, &mut guard) {
+        a
+    } else {
+        return Value::nil().into();
+    };
+    let b = if let Ok(b) = String::unbox_from_value(&mut b, &mut guard) {
+        b
+    } else {
+        return Value::nil().into();
+    };
+
+    let mut s = String::with_capacity_and_encoding(a.len() + b.len(), a.encoding());
+
+    s.extend_from_slice(a.as_slice());
+    s.extend_from_slice(b.as_slice());
+
+    let s = String::alloc_value(s, &mut guard).unwrap_or_default();
+    s.into()
+}
+
+// MRB_API int mrb_str_cmp(mrb_state *mrb, mrb_value str1, mrb_value str2)
+#[no_mangle]
+unsafe extern "C" fn mrb_str_cmp(mrb: *mut sys::mrb_state, str1: sys::mrb_value, str2: sys::mrb_value) -> c_int {
+    unwrap_interpreter!(mrb, to => guard, or_else = -1);
+    let mut a = Value::from(str1);
+    let mut b = Value::from(str2);
+
+    let a = if let Ok(a) = String::unbox_from_value(&mut a, &mut guard) {
+        a
+    } else {
+        return -1;
+    };
+    let b = if let Ok(b) = String::unbox_from_value(&mut b, &mut guard) {
+        b
+    } else {
+        return -1;
+    };
+
+    a.cmp(&*b) as c_int
+}
+
+// MRB_API mrb_bool mrb_str_equal(mrb_state *mrb, mrb_value str1, mrb_value str2)
+#[no_mangle]
+unsafe extern "C" fn mrb_str_equal(
+    mrb: *mut sys::mrb_state,
+    str1: sys::mrb_value,
+    str2: sys::mrb_value,
+) -> sys::mrb_bool {
+    unwrap_interpreter!(mrb, to => guard, or_else = false as sys::mrb_bool);
+    let mut a = Value::from(str1);
+    let mut b = Value::from(str2);
+
+    let a = if let Ok(a) = String::unbox_from_value(&mut a, &mut guard) {
+        a
+    } else {
+        return false as sys::mrb_bool;
+    };
+    let b = if let Ok(b) = String::unbox_from_value(&mut b, &mut guard) {
+        b
+    } else {
+        return false as sys::mrb_bool;
+    };
+
+    (*a == *b) as sys::mrb_bool
+}
+
+// MRB_API const char* mrb_string_value_ptr(mrb_state *mrb, mrb_value str)
+//
+// obsolete: use RSTRING_PTR()
+//
+// NOTE: not implemented
+
+// MRB_API mrb_int mrb_string_value_len(mrb_state *mrb, mrb_value ptr)
+//
+// obsolete: use RSTRING_LEN()
+//
+// NOTE: not implemented
+
+// MRB_API mrb_value mrb_str_dup(mrb_state *mrb, mrb_value str)
+#[no_mangle]
+unsafe extern "C" fn mrb_str_dup(mrb: *mut sys::mrb_state, s: sys::mrb_value) -> sys::mrb_value {
+    unwrap_interpreter!(mrb, to => guard);
+    let mut string = Value::from(s);
+    let basic = sys::mrb_sys_basic_ptr(s).cast::<sys::RString>();
+    let class = (*basic).c;
+
+    if let Ok(string) = String::unbox_from_value(&mut string, &mut guard) {
+        let dup = string.clone();
+        if let Ok(value) = String::alloc_value(dup, &mut guard) {
+            let value = value.inner();
+
+            // dup'd strings keep the class of the source `String`.
+            let dup_basic = sys::mrb_sys_basic_ptr(value).cast::<sys::RString>();
+            (*dup_basic).c = class;
+
+            value
+        } else {
+            Value::nil().into()
+        }
+    } else {
+        Value::nil().into()
+    }
+}
+
+// MRB_API mrb_value mrb_str_substr(mrb_state *mrb, mrb_value str, mrb_int beg, mrb_int len)
+#[no_mangle]
+unsafe extern "C" fn mrb_str_substr(
+    mrb: *mut sys::mrb_state,
+    s: sys::mrb_value,
+    beg: sys::mrb_int,
+    len: sys::mrb_int,
+) -> sys::mrb_value {
+    if len < 0 {
+        return Value::nil().into();
+    }
+    unwrap_interpreter!(mrb, to => guard);
+
+    let mut string = Value::from(s);
+    let string = if let Ok(string) = String::unbox_from_value(&mut string, &mut guard) {
+        string
+    } else {
+        return Value::nil().into();
+    };
+
+    let offset = if let Ok(offset) = usize::try_from(beg) {
+        offset
+    } else {
+        let offset = beg
+            .checked_neg()
+            .and_then(|offset| usize::try_from(offset).ok())
+            .and_then(|offset| offset.checked_sub(string.len()));
+        if let Some(offset) = offset {
+            offset
+        } else {
+            return Value::nil().into();
+        }
+    };
+
+    if let Some(slice) = string.get(offset..) {
+        let mut substr = String::with_capacity_and_encoding(slice.len(), string.encoding());
+        substr.extend_from_slice(slice);
+        String::alloc_value(substr, &mut guard).unwrap_or_default().into()
+    } else {
+        Value::nil().into()
+    }
+}
+
+// MRB_API mrb_value mrb_ptr_to_str(mrb_state *mrb, void *p)
+#[no_mangle]
+unsafe extern "C" fn mrb_ptr_to_str(mrb: *mut sys::mrb_state, p: *mut c_void) -> sys::mrb_value {
+    unwrap_interpreter!(mrb, to => guard);
+    let s = String::from(format!("{:p}", p));
+    String::alloc_value(s, &mut guard).unwrap_or_default().into()
+}
+
+// MRB_API mrb_value mrb_cstr_to_inum(mrb_state *mrb, const char *str, mrb_int base, mrb_bool badcheck)
+//
+// NOTE: not implemented.
+
+// MRB_API const char* mrb_string_value_cstr(mrb_state *mrb, mrb_value *ptr)
+//
+// obsolete: use RSTRING_CSTR() or mrb_string_cstr()
+#[no_mangle]
+unsafe extern "C" fn mrb_string_value_cstr(mrb: *mut sys::mrb_state, ptr: *mut sys::mrb_value) -> *const i8 {
+    unwrap_interpreter!(mrb, to => guard, or_else = ptr::null());
+    let mut s = Value::from(*ptr);
+    let mut string = if let Ok(string) = String::unbox_from_value(&mut s, &mut guard) {
+        if let Some(b'\0') = string.last() {
+            return string.as_ptr().cast::<i8>();
+        }
+        string
+    } else {
+        return ptr::null();
+    };
+    // Safety:
+    //
+    // The string is repacked before any intervening use of the interpreter.
+    // The string is repacked before any intervening mruby heap allocations.
+    let string_mut = string.as_inner_mut();
+    string_mut.push_byte(b'\0');
+    // Safety:
+    //
+    // This raw pointer will not be invalidated since we rebox this `String`
+    // into the mruby heap where the GC will keep it alive.
+    let cstr = string.as_ptr().cast::<i8>();
+
+    let inner = string.take();
+    String::box_into_value(inner, s, &mut guard).expect("String reboxing should not fail");
+
+    cstr
+}
+
+// MRB_API const char* mrb_string_cstr(mrb_state *mrb, mrb_value str)
+#[no_mangle]
+unsafe extern "C" fn mrb_string_cstr(mrb: *mut sys::mrb_state, s: sys::mrb_value) -> *const i8 {
+    unwrap_interpreter!(mrb, to => guard, or_else = ptr::null());
+    let mut s = Value::from(s);
+    let mut string = if let Ok(string) = String::unbox_from_value(&mut s, &mut guard) {
+        if let Some(b'\0') = string.last() {
+            return string.as_ptr().cast::<i8>();
+        }
+        string
+    } else {
+        return ptr::null();
+    };
+    // Safety:
+    //
+    // The string is repacked before any intervening use of the interpreter.
+    // The string is repacked before any intervening mruby heap allocations.
+    let string_mut = string.as_inner_mut();
+    string_mut.push_byte(b'\0');
+    // Safety:
+    //
+    // This raw pointer will not be invalidated since we rebox this `String`
+    // into the mruby heap where the GC will keep it alive.
+    let cstr = string.as_ptr().cast::<i8>();
+
+    let inner = string.take();
+    String::box_into_value(inner, s, &mut guard).expect("String reboxing should not fail");
+
+    cstr
+}
+
+// MRB_API mrb_value mrb_str_to_inum(mrb_state *mrb, mrb_value str, mrb_int base, mrb_bool badcheck)
+//
+// This function converts a numeric string to numeric mrb_value with the given base.
+#[no_mangle]
+#[allow(clippy::cast_sign_loss)]
+#[allow(clippy::cast_possible_truncation)]
+unsafe extern "C" fn mrb_str_to_inum(
+    mrb: *mut sys::mrb_state,
+    s: sys::mrb_value,
+    base: sys::mrb_int,
+    badcheck: sys::mrb_bool,
+) -> sys::mrb_value {
+    unwrap_interpreter!(mrb, to => guard);
+    let badcheck = badcheck != 0;
+
+    let mut s = Value::from(s);
+    let s = if let Ok(s) = String::unbox_from_value(&mut s, &mut guard) {
+        s
+    } else if badcheck {
+        let err = ArgumentError::with_message("not a string");
+        error::raise(guard, err);
+    } else {
+        return guard.convert(0_i64).into();
+    };
+    let num = if let Ok(s) = str::from_utf8(s.as_slice()) {
+        if let Ok(num) = s.parse::<i64>() {
+            num
+        } else if badcheck {
+            let err = ArgumentError::with_message("invalid number");
+            error::raise(guard, err);
+        } else {
+            return guard.convert(0_i64).into();
+        }
+    } else if badcheck {
+        let err = ArgumentError::with_message("invalid number");
+        error::raise(guard, err);
+    } else {
+        return guard.convert(0_i64).into();
+    };
+    let radix = match u32::try_from(base) {
+        Ok(base) if (2..=36).contains(&base) => base,
+        Ok(_) | Err(_) => {
+            let err = ArgumentError::with_message("illegal radix");
+            error::raise(guard, err);
+        }
+    };
+    let mut result = vec![];
+    let mut x = num;
+
+    loop {
+        let m = x % base;
+        x /= base;
+
+        // will panic if you use a bad radix (< 2 or > 36).
+        result.push(char::from_digit(m as u32, radix).unwrap());
+        if x == 0 {
+            break;
+        }
+    }
+    let int = result.into_iter().rev().collect::<String>();
+    String::alloc_value(int, &mut guard).unwrap_or_default().into()
+}
+
+// MRB_API double mrb_cstr_to_dbl(mrb_state *mrb, const char *s, mrb_bool badcheck)
+//
+// NOTE: not implemented
+
+// MRB_API double mrb_str_to_dbl(mrb_state *mrb, mrb_value str, mrb_bool badcheck)
+#[no_mangle]
+unsafe extern "C" fn mrb_str_to_dbl(mrb: *mut sys::mrb_state, s: sys::mrb_value, badcheck: sys::mrb_bool) -> c_double {
+    unwrap_interpreter!(mrb, to => guard, or_else = 0.0);
+    let badcheck = badcheck != 0;
+
+    let mut s = Value::from(s);
+    let s = if let Ok(s) = String::unbox_from_value(&mut s, &mut guard) {
+        s
+    } else if badcheck {
+        let err = ArgumentError::with_message("not a string");
+        error::raise(guard, err);
+    } else {
+        return 0.0;
+    };
+    if let Ok(s) = str::from_utf8(s.as_slice()) {
+        if let Ok(num) = s.parse::<c_double>() {
+            num
+        } else if badcheck {
+            let err = ArgumentError::with_message("invalid number");
+            error::raise(guard, err);
+        } else {
+            0.0
+        }
+    } else if badcheck {
+        let err = ArgumentError::with_message("invalid number");
+        error::raise(guard, err);
+    } else {
+        0.0
+    }
+}
+
+// MRB_API mrb_value mrb_str_cat(mrb_state *mrb, mrb_value str, const char *ptr, size_t len)
+#[no_mangle]
+unsafe extern "C" fn mrb_str_cat(
+    mrb: *mut sys::mrb_state,
+    s: sys::mrb_value,
+    ptr: *const i8,
+    len: usize,
+) -> sys::mrb_value {
+    unwrap_interpreter!(mrb, to => guard, or_else = s);
+    let mut s = Value::from(s);
+    if let Ok(mut string) = String::unbox_from_value(&mut s, &mut guard) {
+        let slice = slice::from_raw_parts(ptr.cast::<u8>(), len);
+
+        // Safety:
+        //
+        // The string is repacked before any intervening use of the interpreter.
+        // The string is repacked before any intervening mruby heap allocations.
+        let string_mut = string.as_inner_mut();
+        string_mut.extend_from_slice(slice);
+        let inner = string.take();
+        let value = String::box_into_value(inner, s, &mut guard).expect("String reboxing should not fail");
+
+        value.inner()
+    } else {
+        s.inner()
+    }
+}
+
+// MRB_API mrb_value mrb_str_cat_cstr(mrb_state *mrb, mrb_value str, const char *ptr)
+//
+// MRB_API mrb_value mrb_str_cat_str(mrb_state *mrb, mrb_value str, mrb_value str2)
+//
+// MRB_API mrb_value mrb_str_append(mrb_state *mrb, mrb_value str1, mrb_value str2)
+//
+// NOTE: Implemented in C in `mruby-sys/src/mruby-sys/ext.c`.
+
+// MRB_API double mrb_float_read(const char *string, char **endPtr)
+//
+// NOTE: impl kept in C.
+
+// uint32_t mrb_str_hash(mrb_state *mrb, mrb_value str);
+#[no_mangle]
+unsafe extern "C" fn mrb_str_hash(mrb: *mut sys::mrb_state, s: sys::mrb_value) -> u32 {
+    unwrap_interpreter!(mrb, to => guard, or_else = 0);
+    let mut s = Value::from(s);
+    let mut hasher = if let Ok(build_hasher) = guard.build_hasher() {
+        build_hasher.build_hasher()
+    } else {
+        return 0;
+    };
+
+    let s = if let Ok(s) = String::unbox_from_value(&mut s, &mut guard) {
+        s
+    } else {
+        return 0;
+    };
+    s.as_slice().hash(&mut hasher);
+    #[allow(clippy::cast_possible_truncation)]
+    let hash = hasher.finish() as u32;
+    hash
+}
+
+#[no_mangle]
+#[allow(clippy::cast_possible_truncation)]
+#[allow(clippy::cast_sign_loss)]
+unsafe extern "C" fn mrb_gc_free_str(mrb: *mut sys::mrb_state, string: *mut sys::RString) {
+    let _ = mrb;
+
+    let ptr = (*string).as_.heap.ptr;
+    let len = (*string).as_.heap.len as usize;
+    let capacity = (*string).as_.heap.aux.capa as usize;
+
+    // we don't need to free the encoding since `Encoding` is `Copy` and we pack
+    // it into the `RString` flags as a `u32`.
+
+    drop(String::from_raw_parts(ptr.cast::<u8>(), len, capacity));
+}

--- a/artichoke-backend/src/extn/core/string/ffi.rs
+++ b/artichoke-backend/src/extn/core/string/ffi.rs
@@ -139,13 +139,11 @@ unsafe extern "C" fn mrb_str_resize(mrb: *mut sys::mrb_state, s: sys::mrb_value,
         // The string is repacked before any intervening mruby heap allocations.
         let string_mut = string.as_inner_mut();
 
-        if let Some(additional) = len.checked_sub(string_mut.len()) {
-            if additional > 0 {
-                string_mut.reserve(additional);
-            }
-        } else {
+        match len.checked_sub(string_mut.len()) {
+            Some(0) => return s,
+            Some(additional) => string_mut.reserve(additional),
             // If the given length is less than the length of the `String`, truncate.
-            string_mut.truncate(len);
+            None => string_mut.truncate(len),
         }
 
         let inner = string.take();

--- a/artichoke-backend/src/extn/core/string/mod.rs
+++ b/artichoke-backend/src/extn/core/string/mod.rs
@@ -104,10 +104,10 @@ impl BoxUnboxVmValue for String {
             )
         };
         unsafe {
-            string
-                .as_mut()
-                .unwrap()
-                .set_flags(u32::from(encoding.to_flag()) << ENCODING_FLAG_BITPOS);
+            let flags = string.as_ref().unwrap().flags();
+            let encoding_bits = encoding.to_flag();
+            let flags_with_encoding = flags | (u32::from(encoding_bits) << ENCODING_FLAG_BITPOS);
+            string.as_mut().unwrap().set_flags(flags_with_encoding);
         }
 
         Ok(interp.protect(into))

--- a/artichoke-backend/src/extn/core/string/mod.rs
+++ b/artichoke-backend/src/extn/core/string/mod.rs
@@ -13,6 +13,7 @@ use crate::types::Ruby;
 use crate::value::Value;
 use crate::Artichoke;
 
+mod ffi;
 pub mod mruby;
 pub mod trampoline;
 

--- a/artichoke-backend/src/extn/core/string/mod.rs
+++ b/artichoke-backend/src/extn/core/string/mod.rs
@@ -1,8 +1,143 @@
+use core::ops::Deref;
+use std::ffi::c_void;
+
+use artichoke_core::value::Value as _;
+use spinoso_exception::TypeError;
+#[doc(inline)]
+use spinoso_string::{Encoding, String};
+
+use crate::convert::{BoxUnboxVmValue, UnboxedValueGuard};
+use crate::error::Error;
+use crate::sys;
+use crate::types::Ruby;
+use crate::value::Value;
+use crate::Artichoke;
+
 pub mod mruby;
 pub mod trampoline;
 
-#[derive(Debug, Clone, Copy)]
-pub struct String;
+const ENCODING_FLAG_BITPOS: usize = 5;
+
+impl BoxUnboxVmValue for String {
+    type Unboxed = Self;
+    type Guarded = String;
+
+    const RUBY_TYPE: &'static str = "String";
+
+    #[allow(clippy::cast_possible_truncation)]
+    #[allow(clippy::cast_sign_loss)]
+    unsafe fn unbox_from_value<'a>(
+        value: &'a mut Value,
+        interp: &mut Artichoke,
+    ) -> Result<UnboxedValueGuard<'a, Self::Guarded>, Error> {
+        let _ = interp;
+
+        // Make sure we have a String otherwise extraction will fail.
+        // This check is critical to the safety of accessing the `value` union.
+        if value.ruby_type() != Ruby::String {
+            let mut message = std::string::String::from("uninitialized ");
+            message.push_str(Self::RUBY_TYPE);
+            return Err(TypeError::from(message).into());
+        }
+
+        // Safety:
+        //
+        // The above check on the data type ensures the `value` union holds an
+        // `RString` in the `p` variant.
+        let value = value.inner();
+        let string = sys::mrb_sys_basic_ptr(value).cast::<sys::RString>();
+
+        let ptr = (*string).as_.heap.ptr;
+        let len = (*string).as_.heap.len as usize;
+        let capacity = (*string).as_.heap.aux.capa as usize;
+
+        // the encoding flag is 4 bits wide.
+        let flags = string.as_ref().unwrap().flags();
+        let encoding_flag = flags & (0b1111 << ENCODING_FLAG_BITPOS);
+        let encoding = (encoding_flag >> ENCODING_FLAG_BITPOS) as u8;
+        let encoding = Encoding::try_from_flag(encoding).map_err(|_| TypeError::with_message("Unknown encoding"))?;
+
+        let mut s = String::from_raw_parts(ptr.cast::<u8>(), len, capacity);
+        s.set_encoding(encoding);
+        let s = UnboxedValueGuard::new(s);
+
+        Ok(s)
+    }
+
+    fn alloc_value(value: Self::Unboxed, interp: &mut Artichoke) -> Result<Value, Error> {
+        let encoding = value.encoding();
+        let (ptr, len, capacity) = String::into_raw_parts(value);
+        let value = unsafe {
+            interp.with_ffi_boundary(|mrb| {
+                sys::mrb_sys_alloc_rstring(mrb, ptr.cast::<i8>(), len as sys::mrb_int, capacity as sys::mrb_int)
+            })?
+        };
+        let string = unsafe { sys::mrb_sys_basic_ptr(value).cast::<sys::RString>() };
+        unsafe {
+            let flags = string.as_ref().unwrap().flags();
+            let encoding_bits = encoding.to_flag();
+            let flags_with_encoding = flags | (u32::from(encoding_bits) << ENCODING_FLAG_BITPOS);
+            string.as_mut().unwrap().set_flags(flags_with_encoding);
+        }
+        Ok(interp.protect(value.into()))
+    }
+
+    fn box_into_value(value: Self::Unboxed, into: Value, interp: &mut Artichoke) -> Result<Value, Error> {
+        let _ = interp;
+
+        // Make sure we have an String otherwise boxing will produce undefined
+        // behavior.
+        //
+        // This check is critical to the memory safety of future runs of the
+        // garbage collector.
+        if into.ruby_type() != Ruby::String {
+            panic!("Tried to box String into {:?} value", into.ruby_type());
+        }
+
+        let encoding = value.encoding();
+        let (ptr, len, capacity) = String::into_raw_parts(value);
+        let string = unsafe {
+            sys::mrb_sys_repack_into_rstring(
+                ptr.cast::<i8>(),
+                len as sys::mrb_int,
+                capacity as sys::mrb_int,
+                into.inner(),
+            )
+        };
+        unsafe {
+            string
+                .as_mut()
+                .unwrap()
+                .set_flags(u32::from(encoding.to_flag()) << ENCODING_FLAG_BITPOS);
+        }
+
+        Ok(interp.protect(into))
+    }
+
+    fn free(data: *mut c_void) {
+        // this function is never called. `String` is freed directly in the VM
+        // by calling `mrb_gc_free_str` which is defined in
+        // `extn/core/string/ffi.rs`.
+        //
+        // `String` should not have a destructor registered in the class
+        // registry.
+        let _ = data;
+    }
+}
+
+impl<'a> AsRef<String> for UnboxedValueGuard<'a, String> {
+    fn as_ref(&self) -> &String {
+        self.as_inner_ref()
+    }
+}
+
+impl<'a> Deref for UnboxedValueGuard<'a, String> {
+    type Target = String;
+
+    fn deref(&self) -> &Self::Target {
+        self.as_inner_ref()
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/artichoke-backend/src/extn/core/string/mod.rs
+++ b/artichoke-backend/src/extn/core/string/mod.rs
@@ -84,8 +84,6 @@ impl BoxUnboxVmValue for String {
     }
 
     fn box_into_value(value: Self::Unboxed, into: Value, interp: &mut Artichoke) -> Result<Value, Error> {
-        let _ = interp;
-
         // Make sure we have an String otherwise boxing will produce undefined
         // behavior.
         //

--- a/artichoke-backend/src/extn/core/string/mruby.rs
+++ b/artichoke-backend/src/extn/core/string/mruby.rs
@@ -201,10 +201,12 @@ unsafe extern "C" fn string_bytesize(mrb: *mut sys::mrb_state, slf: sys::mrb_val
 }
 
 unsafe extern "C" fn string_byteslice(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
-    mrb_get_args!(mrb, none);
+    let (index, length) = mrb_get_args!(mrb, required = 1, optional = 1);
     unwrap_interpreter!(mrb, to => guard);
     let value = Value::from(slf);
-    let result = trampoline::byteslice(&mut guard, value);
+    let index = Value::from(index);
+    let length = length.map(Value::from);
+    let result = trampoline::byteslice(&mut guard, value, index, length);
     match result {
         Ok(value) => value.inner(),
         Err(exception) => error::raise(guard, exception),

--- a/artichoke-backend/src/extn/core/string/mruby.rs
+++ b/artichoke-backend/src/extn/core/string/mruby.rs
@@ -54,10 +54,12 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
         .add_method("replace", string_replace, sys::mrb_args_req(1))?
         .add_method("reverse", string_reverse, sys::mrb_args_none())?
         .add_method("reverse!", string_reverse_bang, sys::mrb_args_none())?
+        .add_method("rindex", string_rindex, sys::mrb_args_req_and_opt(1, 1))?
         .add_method("scan", string_scan, sys::mrb_args_req(1))?
         .add_method("setbyte", string_setbyte, sys::mrb_args_req(2))?
         .add_method("size", string_length, sys::mrb_args_none())?
         .add_method("slice", string_aref, sys::mrb_args_req(1))?
+        .add_method("slice!", string_slice_bang, sys::mrb_args_req(1))?
         .add_method("split", string_split, sys::mrb_args_opt(2))?
         .add_method("to_f", string_to_f, sys::mrb_args_none())?
         .add_method("to_i", string_to_i, sys::mrb_args_opt(1))?
@@ -565,6 +567,17 @@ unsafe extern "C" fn string_reverse_bang(mrb: *mut sys::mrb_state, slf: sys::mrb
     }
 }
 
+unsafe extern "C" fn string_rindex(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
+    mrb_get_args!(mrb, none);
+    unwrap_interpreter!(mrb, to => guard);
+    let value = Value::from(slf);
+    let result = trampoline::index(&mut guard, value);
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => error::raise(guard, exception),
+    }
+}
+
 unsafe extern "C" fn string_scan(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
     let (pattern, block) = mrb_get_args!(mrb, required = 1, &block);
     unwrap_interpreter!(mrb, to => guard);
@@ -582,6 +595,17 @@ unsafe extern "C" fn string_setbyte(mrb: *mut sys::mrb_state, slf: sys::mrb_valu
     unwrap_interpreter!(mrb, to => guard);
     let value = Value::from(slf);
     let result = trampoline::setbyte(&mut guard, value);
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => error::raise(guard, exception),
+    }
+}
+
+unsafe extern "C" fn string_slice_bang(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
+    mrb_get_args!(mrb, none);
+    unwrap_interpreter!(mrb, to => guard);
+    let value = Value::from(slf);
+    let result = trampoline::slice_bang(&mut guard, value);
     match result {
         Ok(value) => value.inner(),
         Err(exception) => error::raise(guard, exception),

--- a/artichoke-backend/src/extn/core/string/mruby.rs
+++ b/artichoke-backend/src/extn/core/string/mruby.rs
@@ -69,7 +69,7 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
         .add_method("valid_encoding?", string_valid_encoding, sys::mrb_args_none())?
         .define()?;
     interp.def_class::<string::String>(spec)?;
-    // interp.eval(&include_bytes!("string.rb")[..])?;
+    interp.eval(&include_bytes!("string.rb")[..])?;
     trace!("Patched String onto interpreter");
     Ok(())
 }

--- a/artichoke-backend/src/extn/core/string/mruby.rs
+++ b/artichoke-backend/src/extn/core/string/mruby.rs
@@ -13,6 +13,7 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     class::Builder::for_spec(interp, &spec)
         .add_method("ord", string_ord, sys::mrb_args_none())?
         .add_method("scan", string_scan, sys::mrb_args_req(1))?
+        .add_method("to_s", string_to_s, sys::mrb_args_none())?
         .define()?;
     interp.def_class::<string::String>(spec)?;
     // interp.eval(&include_bytes!("string.rb")[..])?;
@@ -40,4 +41,9 @@ unsafe extern "C" fn string_scan(mrb: *mut sys::mrb_state, slf: sys::mrb_value) 
         Ok(result) => result.inner(),
         Err(exception) => error::raise(guard, exception),
     }
+}
+
+unsafe extern "C" fn string_to_s(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
+    let _ = mrb;
+    slf
 }

--- a/artichoke-backend/src/extn/core/string/mruby.rs
+++ b/artichoke-backend/src/extn/core/string/mruby.rs
@@ -459,10 +459,11 @@ unsafe extern "C" fn string_index(mrb: *mut sys::mrb_state, slf: sys::mrb_value)
 }
 
 unsafe extern "C" fn string_initialize(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
-    mrb_get_args!(mrb, none);
+    let s = mrb_get_args!(mrb, optional = 1);
     unwrap_interpreter!(mrb, to => guard);
     let value = Value::from(slf);
-    let result = trampoline::initialize(&mut guard, value);
+    let s = s.map(Value::from);
+    let result = trampoline::initialize(&mut guard, value, s);
     match result {
         Ok(value) => value.inner(),
         Err(exception) => error::raise(guard, exception),
@@ -470,10 +471,11 @@ unsafe extern "C" fn string_initialize(mrb: *mut sys::mrb_state, slf: sys::mrb_v
 }
 
 unsafe extern "C" fn string_initialize_copy(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
-    mrb_get_args!(mrb, none);
+    let other = mrb_get_args!(mrb, required = 1);
     unwrap_interpreter!(mrb, to => guard);
     let value = Value::from(slf);
-    let result = trampoline::initialize_copy(&mut guard, value);
+    let other = Value::from(other);
+    let result = trampoline::initialize_copy(&mut guard, value, other);
     match result {
         Ok(value) => value.inner(),
         Err(exception) => error::raise(guard, exception),
@@ -525,10 +527,11 @@ unsafe extern "C" fn string_ord(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -
 }
 
 unsafe extern "C" fn string_replace(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
-    mrb_get_args!(mrb, none);
+    let other = mrb_get_args!(mrb, required = 1);
     unwrap_interpreter!(mrb, to => guard);
     let value = Value::from(slf);
-    let result = trampoline::replace(&mut guard, value);
+    let other = Value::from(other);
+    let result = trampoline::replace(&mut guard, value, other);
     match result {
         Ok(value) => value.inner(),
         Err(exception) => error::raise(guard, exception),

--- a/artichoke-backend/src/extn/core/string/mruby.rs
+++ b/artichoke-backend/src/extn/core/string/mruby.rs
@@ -66,6 +66,7 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
         .add_method("to_sym", string_intern, sys::mrb_args_none())?
         .add_method("upcase", string_upcase, sys::mrb_args_any())?
         .add_method("upcase!", string_upcase_bang, sys::mrb_args_any())?
+        .add_method("valid_encoding?", string_valid_encoding, sys::mrb_args_none())?
         .define()?;
     interp.def_class::<string::String>(spec)?;
     // interp.eval(&include_bytes!("string.rb")[..])?;
@@ -651,6 +652,17 @@ unsafe extern "C" fn string_upcase_bang(mrb: *mut sys::mrb_state, slf: sys::mrb_
     unwrap_interpreter!(mrb, to => guard);
     let value = Value::from(slf);
     let result = trampoline::upcase_bang(&mut guard, value);
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => error::raise(guard, exception),
+    }
+}
+
+unsafe extern "C" fn string_valid_encoding(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
+    mrb_get_args!(mrb, none);
+    unwrap_interpreter!(mrb, to => guard);
+    let value = Value::from(slf);
+    let result = trampoline::is_valid_encoding(&mut guard, value);
     match result {
         Ok(value) => value.inner(),
         Err(exception) => error::raise(guard, exception),

--- a/artichoke-backend/src/extn/core/string/mruby.rs
+++ b/artichoke-backend/src/extn/core/string/mruby.rs
@@ -288,10 +288,11 @@ unsafe extern "C" fn string_chars(mrb: *mut sys::mrb_state, slf: sys::mrb_value)
 }
 
 unsafe extern "C" fn string_chomp(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
-    mrb_get_args!(mrb, none);
+    let separator = mrb_get_args!(mrb, optional = 1);
     unwrap_interpreter!(mrb, to => guard);
     let value = Value::from(slf);
-    let result = trampoline::chomp(&mut guard, value);
+    let separator = separator.map(Value::from);
+    let result = trampoline::chomp(&mut guard, value, separator);
     match result {
         Ok(value) => value.inner(),
         Err(exception) => error::raise(guard, exception),
@@ -299,10 +300,11 @@ unsafe extern "C" fn string_chomp(mrb: *mut sys::mrb_state, slf: sys::mrb_value)
 }
 
 unsafe extern "C" fn string_chomp_bang(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
-    mrb_get_args!(mrb, none);
+    let separator = mrb_get_args!(mrb, optional = 1);
     unwrap_interpreter!(mrb, to => guard);
     let value = Value::from(slf);
-    let result = trampoline::chomp_bang(&mut guard, value);
+    let separator = separator.map(Value::from);
+    let result = trampoline::chomp_bang(&mut guard, value, separator);
     match result {
         Ok(value) => value.inner(),
         Err(exception) => error::raise(guard, exception),
@@ -635,10 +637,11 @@ unsafe extern "C" fn string_to_f(mrb: *mut sys::mrb_state, slf: sys::mrb_value) 
 }
 
 unsafe extern "C" fn string_to_i(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
-    mrb_get_args!(mrb, none);
+    let base = mrb_get_args!(mrb, optional = 1);
     unwrap_interpreter!(mrb, to => guard);
     let value = Value::from(slf);
-    let result = trampoline::to_i(&mut guard, value);
+    let base = base.map(Value::from);
+    let result = trampoline::to_i(&mut guard, value, base);
     match result {
         Ok(value) => value.inner(),
         Err(exception) => error::raise(guard, exception),

--- a/artichoke-backend/src/extn/core/string/mruby.rs
+++ b/artichoke-backend/src/extn/core/string/mruby.rs
@@ -597,10 +597,12 @@ unsafe extern "C" fn string_scan(mrb: *mut sys::mrb_state, slf: sys::mrb_value) 
 }
 
 unsafe extern "C" fn string_setbyte(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
-    mrb_get_args!(mrb, none);
+    let (index, byte) = mrb_get_args!(mrb, required = 2);
     unwrap_interpreter!(mrb, to => guard);
     let value = Value::from(slf);
-    let result = trampoline::setbyte(&mut guard, value);
+    let index = Value::from(index);
+    let byte = Value::from(byte);
+    let result = trampoline::setbyte(&mut guard, value, index, byte);
     match result {
         Ok(value) => value.inner(),
         Err(exception) => error::raise(guard, exception),

--- a/artichoke-backend/src/extn/core/string/mruby.rs
+++ b/artichoke-backend/src/extn/core/string/mruby.rs
@@ -456,10 +456,12 @@ unsafe extern "C" fn string_include(mrb: *mut sys::mrb_state, slf: sys::mrb_valu
 }
 
 unsafe extern "C" fn string_index(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
-    mrb_get_args!(mrb, none);
+    let (needle, offset) = mrb_get_args!(mrb, required = 1, optional = 1);
     unwrap_interpreter!(mrb, to => guard);
     let value = Value::from(slf);
-    let result = trampoline::index(&mut guard, value);
+    let needle = Value::from(needle);
+    let offset = offset.map(Value::from);
+    let result = trampoline::index(&mut guard, value, needle, offset);
     match result {
         Ok(value) => value.inner(),
         Err(exception) => error::raise(guard, exception),
@@ -572,7 +574,7 @@ unsafe extern "C" fn string_rindex(mrb: *mut sys::mrb_state, slf: sys::mrb_value
     mrb_get_args!(mrb, none);
     unwrap_interpreter!(mrb, to => guard);
     let value = Value::from(slf);
-    let result = trampoline::index(&mut guard, value);
+    let result = trampoline::rindex(&mut guard, value);
     match result {
         Ok(value) => value.inner(),
         Err(exception) => error::raise(guard, exception),

--- a/artichoke-backend/src/extn/core/string/mruby.rs
+++ b/artichoke-backend/src/extn/core/string/mruby.rs
@@ -133,6 +133,28 @@ unsafe extern "C" fn string_equals_equals(mrb: *mut sys::mrb_state, slf: sys::mr
     }
 }
 
+unsafe extern "C" fn string_aref(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
+    mrb_get_args!(mrb, none);
+    unwrap_interpreter!(mrb, to => guard);
+    let value = Value::from(slf);
+    let result = trampoline::aref(&mut guard, value);
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => error::raise(guard, exception),
+    }
+}
+
+unsafe extern "C" fn string_aset(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
+    mrb_get_args!(mrb, none);
+    unwrap_interpreter!(mrb, to => guard);
+    let value = Value::from(slf);
+    let result = trampoline::aset(&mut guard, value);
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => error::raise(guard, exception),
+    }
+}
+
 unsafe extern "C" fn string_ascii_only(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
     mrb_get_args!(mrb, none);
     unwrap_interpreter!(mrb, to => guard);
@@ -171,6 +193,17 @@ unsafe extern "C" fn string_bytesize(mrb: *mut sys::mrb_state, slf: sys::mrb_val
     unwrap_interpreter!(mrb, to => guard);
     let value = Value::from(slf);
     let result = trampoline::bytesize(&mut guard, value);
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => error::raise(guard, exception),
+    }
+}
+
+unsafe extern "C" fn string_byteslice(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
+    mrb_get_args!(mrb, none);
+    unwrap_interpreter!(mrb, to => guard);
+    let value = Value::from(slf);
+    let result = trampoline::byteslice(&mut guard, value);
     match result {
         Ok(value) => value.inner(),
         Err(exception) => error::raise(guard, exception),
@@ -236,6 +269,138 @@ unsafe extern "C" fn string_center(mrb: *mut sys::mrb_state, slf: sys::mrb_value
     }
 }
 
+unsafe extern "C" fn string_chars(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
+    mrb_get_args!(mrb, none);
+    unwrap_interpreter!(mrb, to => guard);
+    let value = Value::from(slf);
+    let result = trampoline::chars(&mut guard, value);
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => error::raise(guard, exception),
+    }
+}
+
+unsafe extern "C" fn string_chomp(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
+    mrb_get_args!(mrb, none);
+    unwrap_interpreter!(mrb, to => guard);
+    let value = Value::from(slf);
+    let result = trampoline::chomp(&mut guard, value);
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => error::raise(guard, exception),
+    }
+}
+
+unsafe extern "C" fn string_chomp_bang(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
+    mrb_get_args!(mrb, none);
+    unwrap_interpreter!(mrb, to => guard);
+    let value = Value::from(slf);
+    let result = trampoline::chomp_bang(&mut guard, value);
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => error::raise(guard, exception),
+    }
+}
+
+unsafe extern "C" fn string_chop(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
+    mrb_get_args!(mrb, none);
+    unwrap_interpreter!(mrb, to => guard);
+    let value = Value::from(slf);
+    let result = trampoline::chop(&mut guard, value);
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => error::raise(guard, exception),
+    }
+}
+
+unsafe extern "C" fn string_chop_bang(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
+    mrb_get_args!(mrb, none);
+    unwrap_interpreter!(mrb, to => guard);
+    let value = Value::from(slf);
+    let result = trampoline::chop_bang(&mut guard, value);
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => error::raise(guard, exception),
+    }
+}
+
+unsafe extern "C" fn string_chr(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
+    mrb_get_args!(mrb, none);
+    unwrap_interpreter!(mrb, to => guard);
+    let value = Value::from(slf);
+    let result = trampoline::chr(&mut guard, value);
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => error::raise(guard, exception),
+    }
+}
+
+unsafe extern "C" fn string_clear(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
+    mrb_get_args!(mrb, none);
+    unwrap_interpreter!(mrb, to => guard);
+    let value = Value::from(slf);
+    let result = trampoline::clear(&mut guard, value);
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => error::raise(guard, exception),
+    }
+}
+
+unsafe extern "C" fn string_codepoints(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
+    mrb_get_args!(mrb, none);
+    unwrap_interpreter!(mrb, to => guard);
+    let value = Value::from(slf);
+    let result = trampoline::codepoints(&mut guard, value);
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => error::raise(guard, exception),
+    }
+}
+
+unsafe extern "C" fn string_concat(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
+    mrb_get_args!(mrb, none);
+    unwrap_interpreter!(mrb, to => guard);
+    let value = Value::from(slf);
+    let result = trampoline::concat(&mut guard, value);
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => error::raise(guard, exception),
+    }
+}
+
+unsafe extern "C" fn string_downcase(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
+    mrb_get_args!(mrb, none);
+    unwrap_interpreter!(mrb, to => guard);
+    let value = Value::from(slf);
+    let result = trampoline::downcase(&mut guard, value);
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => error::raise(guard, exception),
+    }
+}
+
+unsafe extern "C" fn string_downcase_bang(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
+    mrb_get_args!(mrb, none);
+    unwrap_interpreter!(mrb, to => guard);
+    let value = Value::from(slf);
+    let result = trampoline::downcase_bang(&mut guard, value);
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => error::raise(guard, exception),
+    }
+}
+
+unsafe extern "C" fn string_empty(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
+    mrb_get_args!(mrb, none);
+    unwrap_interpreter!(mrb, to => guard);
+    let value = Value::from(slf);
+    let result = trampoline::is_empty(&mut guard, value);
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => error::raise(guard, exception),
+    }
+}
+
 unsafe extern "C" fn string_eql(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
     let other = mrb_get_args!(mrb, required = 1);
     unwrap_interpreter!(mrb, to => guard);
@@ -248,11 +413,88 @@ unsafe extern "C" fn string_eql(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -
     }
 }
 
+unsafe extern "C" fn string_getbyte(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
+    mrb_get_args!(mrb, none);
+    unwrap_interpreter!(mrb, to => guard);
+    let value = Value::from(slf);
+    let result = trampoline::getbyte(&mut guard, value);
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => error::raise(guard, exception),
+    }
+}
+
+unsafe extern "C" fn string_hash(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
+    mrb_get_args!(mrb, none);
+    unwrap_interpreter!(mrb, to => guard);
+    let value = Value::from(slf);
+    let result = trampoline::hash(&mut guard, value);
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => error::raise(guard, exception),
+    }
+}
+
+unsafe extern "C" fn string_include(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
+    mrb_get_args!(mrb, none);
+    unwrap_interpreter!(mrb, to => guard);
+    let value = Value::from(slf);
+    let result = trampoline::include(&mut guard, value);
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => error::raise(guard, exception),
+    }
+}
+
+unsafe extern "C" fn string_index(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
+    mrb_get_args!(mrb, none);
+    unwrap_interpreter!(mrb, to => guard);
+    let value = Value::from(slf);
+    let result = trampoline::index(&mut guard, value);
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => error::raise(guard, exception),
+    }
+}
+
+unsafe extern "C" fn string_initialize(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
+    mrb_get_args!(mrb, none);
+    unwrap_interpreter!(mrb, to => guard);
+    let value = Value::from(slf);
+    let result = trampoline::initialize(&mut guard, value);
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => error::raise(guard, exception),
+    }
+}
+
+unsafe extern "C" fn string_initialize_copy(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
+    mrb_get_args!(mrb, none);
+    unwrap_interpreter!(mrb, to => guard);
+    let value = Value::from(slf);
+    let result = trampoline::initialize_copy(&mut guard, value);
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => error::raise(guard, exception),
+    }
+}
+
 unsafe extern "C" fn string_inspect(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
     mrb_get_args!(mrb, none);
     unwrap_interpreter!(mrb, to => guard);
     let value = Value::from(slf);
     let result = trampoline::inspect(&mut guard, value);
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => error::raise(guard, exception),
+    }
+}
+
+unsafe extern "C" fn string_intern(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
+    mrb_get_args!(mrb, none);
+    unwrap_interpreter!(mrb, to => guard);
+    let value = Value::from(slf);
+    let result = trampoline::intern(&mut guard, value);
     match result {
         Ok(value) => value.inner(),
         Err(exception) => error::raise(guard, exception),
@@ -281,6 +523,39 @@ unsafe extern "C" fn string_ord(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -
     }
 }
 
+unsafe extern "C" fn string_replace(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
+    mrb_get_args!(mrb, none);
+    unwrap_interpreter!(mrb, to => guard);
+    let value = Value::from(slf);
+    let result = trampoline::replace(&mut guard, value);
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => error::raise(guard, exception),
+    }
+}
+
+unsafe extern "C" fn string_reverse(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
+    mrb_get_args!(mrb, none);
+    unwrap_interpreter!(mrb, to => guard);
+    let value = Value::from(slf);
+    let result = trampoline::reverse(&mut guard, value);
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => error::raise(guard, exception),
+    }
+}
+
+unsafe extern "C" fn string_reverse_bang(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
+    mrb_get_args!(mrb, none);
+    unwrap_interpreter!(mrb, to => guard);
+    let value = Value::from(slf);
+    let result = trampoline::reverse_bang(&mut guard, value);
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => error::raise(guard, exception),
+    }
+}
+
 unsafe extern "C" fn string_scan(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
     let (pattern, block) = mrb_get_args!(mrb, required = 1, &block);
     unwrap_interpreter!(mrb, to => guard);
@@ -293,8 +568,91 @@ unsafe extern "C" fn string_scan(mrb: *mut sys::mrb_state, slf: sys::mrb_value) 
     }
 }
 
+unsafe extern "C" fn string_setbyte(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
+    mrb_get_args!(mrb, none);
+    unwrap_interpreter!(mrb, to => guard);
+    let value = Value::from(slf);
+    let result = trampoline::setbyte(&mut guard, value);
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => error::raise(guard, exception),
+    }
+}
+
+unsafe extern "C" fn string_split(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
+    mrb_get_args!(mrb, none);
+    unwrap_interpreter!(mrb, to => guard);
+    let value = Value::from(slf);
+    let result = trampoline::split(&mut guard, value);
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => error::raise(guard, exception),
+    }
+}
+
+unsafe extern "C" fn string_to_f(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
+    mrb_get_args!(mrb, none);
+    unwrap_interpreter!(mrb, to => guard);
+    let value = Value::from(slf);
+    let result = trampoline::to_f(&mut guard, value);
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => error::raise(guard, exception),
+    }
+}
+
+unsafe extern "C" fn string_to_i(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
+    mrb_get_args!(mrb, none);
+    unwrap_interpreter!(mrb, to => guard);
+    let value = Value::from(slf);
+    let result = trampoline::to_i(&mut guard, value);
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => error::raise(guard, exception),
+    }
+}
+
 unsafe extern "C" fn string_to_s(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
     mrb_get_args!(mrb, none);
+    unwrap_interpreter!(mrb, to => guard);
+    let value = Value::from(slf);
     // TODO: dup `slf` when slf is a subclass of `String`.
-    slf
+    let result = trampoline::to_s(&mut guard, value);
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => error::raise(guard, exception),
+    }
+}
+
+unsafe extern "C" fn string_to_str(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
+    mrb_get_args!(mrb, none);
+    unwrap_interpreter!(mrb, to => guard);
+    let value = Value::from(slf);
+    let result = trampoline::to_str(&mut guard, value);
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => error::raise(guard, exception),
+    }
+}
+
+unsafe extern "C" fn string_upcase(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
+    mrb_get_args!(mrb, none);
+    unwrap_interpreter!(mrb, to => guard);
+    let value = Value::from(slf);
+    let result = trampoline::upcase(&mut guard, value);
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => error::raise(guard, exception),
+    }
+}
+
+unsafe extern "C" fn string_upcase_bang(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
+    mrb_get_args!(mrb, none);
+    unwrap_interpreter!(mrb, to => guard);
+    let value = Value::from(slf);
+    let result = trampoline::upcase_bang(&mut guard, value);
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => error::raise(guard, exception),
+    }
 }

--- a/artichoke-backend/src/extn/core/string/mruby.rs
+++ b/artichoke-backend/src/extn/core/string/mruby.rs
@@ -11,9 +11,18 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     }
     let spec = class::Spec::new("String", STRING_CSTR, None, None)?;
     class::Builder::for_spec(interp, &spec)
+        .add_method("<=>", string_cmp_rocket, sys::mrb_args_req(1))?
+        .add_method("==", string_equals_equals, sys::mrb_args_req(1))?
+        .add_method("+", string_add, sys::mrb_args_req(1))?
+        .add_method("*", string_mul, sys::mrb_args_req(1))?
+        .add_method("bytes", string_bytes, sys::mrb_args_none())?
+        .add_method("bytesize", string_bytesize, sys::mrb_args_none())?
+        .add_method("eql?", string_eql, sys::mrb_args_req(1))?
         .add_method("inspect", string_inspect, sys::mrb_args_none())?
+        .add_method("length", string_length, sys::mrb_args_none())?
         .add_method("ord", string_ord, sys::mrb_args_none())?
         .add_method("scan", string_scan, sys::mrb_args_req(1))?
+        .add_method("size", string_length, sys::mrb_args_none())?
         .add_method("to_s", string_to_s, sys::mrb_args_none())?
         .define()?;
     interp.def_class::<string::String>(spec)?;
@@ -22,10 +31,100 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     Ok(())
 }
 
+unsafe extern "C" fn string_cmp_rocket(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
+    let other = mrb_get_args!(mrb, required = 1);
+    unwrap_interpreter!(mrb, to => guard);
+    let value = Value::from(slf);
+    let other = Value::from(other);
+    let result = trampoline::cmp_rocket(&mut guard, value, other);
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => error::raise(guard, exception),
+    }
+}
+
+unsafe extern "C" fn string_equals_equals(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
+    let other = mrb_get_args!(mrb, required = 1);
+    unwrap_interpreter!(mrb, to => guard);
+    let value = Value::from(slf);
+    let other = Value::from(other);
+    let result = trampoline::equals_equals(&mut guard, value, other);
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => error::raise(guard, exception),
+    }
+}
+
+unsafe extern "C" fn string_add(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
+    let other = mrb_get_args!(mrb, required = 1);
+    unwrap_interpreter!(mrb, to => guard);
+    let value = Value::from(slf);
+    let other = Value::from(other);
+    let result = trampoline::add(&mut guard, value, other);
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => error::raise(guard, exception),
+    }
+}
+
+unsafe extern "C" fn string_mul(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
+    let other = mrb_get_args!(mrb, required = 1);
+    unwrap_interpreter!(mrb, to => guard);
+    let value = Value::from(slf);
+    let other = Value::from(other);
+    let result = trampoline::mul(&mut guard, value, other);
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => error::raise(guard, exception),
+    }
+}
+
+unsafe extern "C" fn string_bytes(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
+    unwrap_interpreter!(mrb, to => guard);
+    let value = Value::from(slf);
+    let result = trampoline::bytes(&mut guard, value);
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => error::raise(guard, exception),
+    }
+}
+
+unsafe extern "C" fn string_bytesize(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
+    unwrap_interpreter!(mrb, to => guard);
+    let value = Value::from(slf);
+    let result = trampoline::bytesize(&mut guard, value);
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => error::raise(guard, exception),
+    }
+}
+
+unsafe extern "C" fn string_eql(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
+    let other = mrb_get_args!(mrb, required = 1);
+    unwrap_interpreter!(mrb, to => guard);
+    let value = Value::from(slf);
+    let other = Value::from(other);
+    let result = trampoline::eql(&mut guard, value, other);
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => error::raise(guard, exception),
+    }
+}
+
 unsafe extern "C" fn string_inspect(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
     unwrap_interpreter!(mrb, to => guard);
     let value = Value::from(slf);
     let result = trampoline::inspect(&mut guard, value);
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => error::raise(guard, exception),
+    }
+}
+
+unsafe extern "C" fn string_length(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
+    unwrap_interpreter!(mrb, to => guard);
+    let value = Value::from(slf);
+    let result = trampoline::length(&mut guard, value);
     match result {
         Ok(value) => value.inner(),
         Err(exception) => error::raise(guard, exception),
@@ -56,5 +155,6 @@ unsafe extern "C" fn string_scan(mrb: *mut sys::mrb_state, slf: sys::mrb_value) 
 
 unsafe extern "C" fn string_to_s(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
     let _ = mrb;
+    // TODO: dup `slf` when slf is a subclass of `String`.
     slf
 }

--- a/artichoke-backend/src/extn/core/string/mruby.rs
+++ b/artichoke-backend/src/extn/core/string/mruby.rs
@@ -64,7 +64,6 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
         .add_method("to_f", string_to_f, sys::mrb_args_none())?
         .add_method("to_i", string_to_i, sys::mrb_args_opt(1))?
         .add_method("to_s", string_to_s, sys::mrb_args_none())?
-        .add_method("to_str", string_to_str, sys::mrb_args_none())?
         .add_method("to_sym", string_intern, sys::mrb_args_none())?
         .add_method("upcase", string_upcase, sys::mrb_args_any())?
         .add_method("upcase!", string_upcase_bang, sys::mrb_args_any())?
@@ -654,17 +653,6 @@ unsafe extern "C" fn string_to_s(mrb: *mut sys::mrb_state, slf: sys::mrb_value) 
     let value = Value::from(slf);
     // TODO: dup `slf` when slf is a subclass of `String`.
     let result = trampoline::to_s(&mut guard, value);
-    match result {
-        Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
-    }
-}
-
-unsafe extern "C" fn string_to_str(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
-    mrb_get_args!(mrb, none);
-    unwrap_interpreter!(mrb, to => guard);
-    let value = Value::from(slf);
-    let result = trampoline::to_str(&mut guard, value);
     match result {
         Ok(value) => value.inner(),
         Err(exception) => error::raise(guard, exception),

--- a/artichoke-backend/src/extn/core/string/mruby.rs
+++ b/artichoke-backend/src/extn/core/string/mruby.rs
@@ -11,19 +11,60 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     }
     let spec = class::Spec::new("String", STRING_CSTR, None, None)?;
     class::Builder::for_spec(interp, &spec)
+        .add_method("<<", string_push, sys::mrb_args_req(1))?
         .add_method("<=>", string_cmp_rocket, sys::mrb_args_req(1))?
         .add_method("==", string_equals_equals, sys::mrb_args_req(1))?
         .add_method("+", string_add, sys::mrb_args_req(1))?
         .add_method("*", string_mul, sys::mrb_args_req(1))?
+        .add_method("[]", string_aref, sys::mrb_args_req(1))?
+        .add_method("[]=", string_aset, sys::mrb_args_any())?
+        .add_method("ascii_only?", string_ascii_only, sys::mrb_args_none())?
+        .add_method("b", string_b, sys::mrb_args_none())?
         .add_method("bytes", string_bytes, sys::mrb_args_none())?
         .add_method("bytesize", string_bytesize, sys::mrb_args_none())?
+        .add_method("byteslice", string_byteslice, sys::mrb_args_req_and_opt(1, 1))?
+        .add_method("capitalize", string_capitalize, sys::mrb_args_any())?
+        .add_method("capitalize!", string_capitalize_bang, sys::mrb_args_any())?
+        .add_method("casecmp", string_casecmp, sys::mrb_args_req(1))?
+        .add_method("casecmp?", string_casecmp_unicode, sys::mrb_args_req(1))?
+        .add_method("center", string_center, sys::mrb_args_req_and_opt(1, 1))?
+        .add_method("chars", string_chars, sys::mrb_args_none())?
+        .add_method("chomp", string_chomp, sys::mrb_args_opt(1))?
+        .add_method("chomp!", string_chomp_bang, sys::mrb_args_opt(1))?
+        .add_method("chop", string_chop, sys::mrb_args_none())?
+        .add_method("chop!", string_chop_bang, sys::mrb_args_none())?
+        .add_method("chr", string_chr, sys::mrb_args_none())?
+        .add_method("clear", string_clear, sys::mrb_args_none())?
+        .add_method("concat", string_concat, sys::mrb_args_any())?
+        .add_method("downcase", string_downcase, sys::mrb_args_any())?
+        .add_method("downcase!", string_downcase_bang, sys::mrb_args_any())?
+        .add_method("empty?", string_empty, sys::mrb_args_none())?
         .add_method("eql?", string_eql, sys::mrb_args_req(1))?
+        .add_method("getbyte", string_getbyte, sys::mrb_args_req(1))?
+        .add_method("hash", string_hash, sys::mrb_args_none())?
+        .add_method("include?", string_include, sys::mrb_args_req(1))?
+        .add_method("index", string_index, sys::mrb_args_req_and_opt(1, 1))?
+        .add_method("initialize", string_initialize, sys::mrb_args_opt(1))? // TODO: support encoding and capacity kwargs
+        .add_method("initialize_copy", string_initialize_copy, sys::mrb_args_req(1))?
         .add_method("inspect", string_inspect, sys::mrb_args_none())?
+        .add_method("intern", string_intern, sys::mrb_args_none())?
         .add_method("length", string_length, sys::mrb_args_none())?
         .add_method("ord", string_ord, sys::mrb_args_none())?
+        .add_method("replace", string_replace, sys::mrb_args_req(1))?
+        .add_method("reverse", string_reverse, sys::mrb_args_none())?
+        .add_method("reverse!", string_reverse_bang, sys::mrb_args_none())?
         .add_method("scan", string_scan, sys::mrb_args_req(1))?
+        .add_method("setbyte", string_setbyte, sys::mrb_args_req(2))?
         .add_method("size", string_length, sys::mrb_args_none())?
+        .add_method("slice", string_aref, sys::mrb_args_req(1))?
+        .add_method("split", string_split, sys::mrb_args_opt(2))?
+        .add_method("to_f", string_to_f, sys::mrb_args_none())?
+        .add_method("to_i", string_to_i, sys::mrb_args_opt(1))?
         .add_method("to_s", string_to_s, sys::mrb_args_none())?
+        .add_method("to_str", string_to_str, sys::mrb_args_none())?
+        .add_method("to_sym", string_intern, sys::mrb_args_none())?
+        .add_method("upcase", string_upcase, sys::mrb_args_any())?
+        .add_method("upcase!", string_upcase_bang, sys::mrb_args_any())?
         .define()?;
     interp.def_class::<string::String>(spec)?;
     // interp.eval(&include_bytes!("string.rb")[..])?;

--- a/artichoke-backend/src/extn/core/string/mruby.rs
+++ b/artichoke-backend/src/extn/core/string/mruby.rs
@@ -441,10 +441,11 @@ unsafe extern "C" fn string_hash(mrb: *mut sys::mrb_state, slf: sys::mrb_value) 
 }
 
 unsafe extern "C" fn string_include(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
-    mrb_get_args!(mrb, none);
+    let other = mrb_get_args!(mrb, required = 1);
     unwrap_interpreter!(mrb, to => guard);
     let value = Value::from(slf);
-    let result = trampoline::include(&mut guard, value);
+    let other = Value::from(other);
+    let result = trampoline::include(&mut guard, value, other);
     match result {
         Ok(value) => value.inner(),
         Err(exception) => error::raise(guard, exception),

--- a/artichoke-backend/src/extn/core/string/mruby.rs
+++ b/artichoke-backend/src/extn/core/string/mruby.rs
@@ -15,7 +15,7 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
         .add_method("scan", string_scan, sys::mrb_args_req(1))?
         .define()?;
     interp.def_class::<string::String>(spec)?;
-    interp.eval(&include_bytes!("string.rb")[..])?;
+    // interp.eval(&include_bytes!("string.rb")[..])?;
     trace!("Patched String onto interpreter");
     Ok(())
 }

--- a/artichoke-backend/src/extn/core/string/mruby.rs
+++ b/artichoke-backend/src/extn/core/string/mruby.rs
@@ -422,10 +422,11 @@ unsafe extern "C" fn string_eql(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -
 }
 
 unsafe extern "C" fn string_getbyte(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
-    mrb_get_args!(mrb, none);
+    let index = mrb_get_args!(mrb, required = 1);
     unwrap_interpreter!(mrb, to => guard);
     let value = Value::from(slf);
-    let result = trampoline::getbyte(&mut guard, value);
+    let index = Value::from(index);
+    let result = trampoline::getbyte(&mut guard, value, index);
     match result {
         Ok(value) => value.inner(),
         Err(exception) => error::raise(guard, exception),

--- a/artichoke-backend/src/extn/core/string/mruby.rs
+++ b/artichoke-backend/src/extn/core/string/mruby.rs
@@ -571,10 +571,12 @@ unsafe extern "C" fn string_reverse_bang(mrb: *mut sys::mrb_state, slf: sys::mrb
 }
 
 unsafe extern "C" fn string_rindex(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
-    mrb_get_args!(mrb, none);
+    let (needle, offset) = mrb_get_args!(mrb, required = 1, optional = 1);
     unwrap_interpreter!(mrb, to => guard);
     let value = Value::from(slf);
-    let result = trampoline::rindex(&mut guard, value);
+    let needle = Value::from(needle);
+    let offset = offset.map(Value::from);
+    let result = trampoline::rindex(&mut guard, value, needle, offset);
     match result {
         Ok(value) => value.inner(),
         Err(exception) => error::raise(guard, exception),

--- a/artichoke-backend/src/extn/core/string/mruby.rs
+++ b/artichoke-backend/src/extn/core/string/mruby.rs
@@ -135,10 +135,12 @@ unsafe extern "C" fn string_equals_equals(mrb: *mut sys::mrb_state, slf: sys::mr
 }
 
 unsafe extern "C" fn string_aref(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
-    mrb_get_args!(mrb, none);
+    let (first, second) = mrb_get_args!(mrb, required = 1, optional = 1);
     unwrap_interpreter!(mrb, to => guard);
     let value = Value::from(slf);
-    let result = trampoline::aref(&mut guard, value);
+    let first = Value::from(first);
+    let second = second.map(Value::from);
+    let result = trampoline::aref(&mut guard, value, first, second);
     match result {
         Ok(value) => value.inner(),
         Err(exception) => error::raise(guard, exception),

--- a/artichoke-backend/src/extn/core/string/mruby.rs
+++ b/artichoke-backend/src/extn/core/string/mruby.rs
@@ -223,6 +223,19 @@ unsafe extern "C" fn string_casecmp_unicode(mrb: *mut sys::mrb_state, slf: sys::
     }
 }
 
+unsafe extern "C" fn string_center(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
+    let (width, padstr) = mrb_get_args!(mrb, required = 1, optional = 1);
+    unwrap_interpreter!(mrb, to => guard);
+    let value = Value::from(slf);
+    let width = Value::from(width);
+    let padstr = padstr.map(Value::from);
+    let result = trampoline::center(&mut guard, value, width, padstr);
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => error::raise(guard, exception),
+    }
+}
+
 unsafe extern "C" fn string_eql(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
     let other = mrb_get_args!(mrb, required = 1);
     unwrap_interpreter!(mrb, to => guard);

--- a/artichoke-backend/src/extn/core/string/string.rb
+++ b/artichoke-backend/src/extn/core/string/string.rb
@@ -974,10 +974,11 @@ class String
   # def to_s; end
 
   # https://ruby-doc.org/core-3.0.2/String.html#method-i-to_str
-  #
-  # NOTE: Implemented in native code.
-  #
-  # def to_str; end
+  def to_str
+    return self if self.class == String
+
+    String.new(self)
+  end
 
   # https://ruby-doc.org/core-3.0.2/String.html#method-i-to_sym
   #

--- a/artichoke-backend/src/extn/core/string/string.rb
+++ b/artichoke-backend/src/extn/core/string/string.rb
@@ -655,10 +655,4 @@ class String
     end
     self
   end
-
-  def valid_encoding?
-    # mruby does not support encoding, all Strings are UTF-8. This method is a
-    # NOOP and is here for compatibility.
-    true
-  end
 end

--- a/artichoke-backend/src/extn/core/string/string.rb
+++ b/artichoke-backend/src/extn/core/string/string.rb
@@ -902,7 +902,10 @@ class String
           return chunks
         end
         chunks << s[0, match.begin(0)]
-        s = s[match.end(0)..-1]
+        advance_to = match.end(0)
+        advance_to += 1 if (match.end(0) - match.begin(0)).zero?
+
+        s = s[advance_to..-1]
 
         return chunks if s.nil?
       end

--- a/artichoke-backend/src/extn/core/string/string.rb
+++ b/artichoke-backend/src/extn/core/string/string.rb
@@ -862,8 +862,22 @@ class String
   # def split(pattern=nil, [limit], &block); end
 
   # https://ruby-doc.org/core-3.0.2/String.html#method-i-squeeze
-  def squeeze(*_args)
-    raise NotImplementedError
+  def squeeze(*other_str)
+    return "" if empty?
+    raise NotImplementedError, "String#squeeze with arguments is not implemented" unless other_str.empty?
+
+    iter = chars
+    head, *tail = iter
+    runs = [head]
+    last_seen = head
+
+    tail.each do |ch|
+      next if ch == last_seen
+
+      last_seen = ch
+      runs << ch
+    end
+    runs.join
   end
 
   # https://ruby-doc.org/core-3.0.2/String.html#method-i-squeeze-21

--- a/artichoke-backend/src/extn/core/string/string.rb
+++ b/artichoke-backend/src/extn/core/string/string.rb
@@ -356,7 +356,7 @@ class String
 
   # https://ruby-doc.org/core-3.0.2/String.html#method-i-crypt
   def crypt(_salt_str)
-    raise NotImplementedError, "String#crypt uses an insecure algorithm and is deprecated"
+    raise NotImplementedError, 'String#crypt uses an insecure algorithm and is deprecated'
   end
 
   # https://ruby-doc.org/core-3.0.2/String.html#method-i-delete
@@ -367,7 +367,7 @@ class String
   # https://ruby-doc.org/core-3.0.2/String.html#method-i-delete-21
   def delete!(*args)
     replaced = delete(*args)
-    self.replace(replaced) unless self == replaced
+    replace(replaced) unless self == replaced
   end
 
   # https://ruby-doc.org/core-3.0.2/String.html#method-i-delete_prefix
@@ -381,7 +381,7 @@ class String
   # https://ruby-doc.org/core-3.0.2/String.html#method-i-delete_prefix-21
   def delete_prefix!(prefix)
     replaced = delete_prefix(prefix)
-    self.replace(replaced) unless self == replaced
+    replace(replaced) unless self == replaced
   end
 
   # https://ruby-doc.org/core-3.0.2/String.html#method-i-delete_suffix
@@ -396,7 +396,7 @@ class String
   # https://ruby-doc.org/core-3.0.2/String.html#method-i-delete_suffix-21
   def delete_suffix!(prefix)
     replaced = delete_suffix(prefix)
-    self.replace(replaced) unless self == replaced
+    replace(replaced) unless self == replaced
   end
 
   # https://ruby-doc.org/core-3.0.2/String.html#method-i-downcase
@@ -611,7 +611,7 @@ class String
   # https://ruby-doc.org/core-3.0.2/String.html#method-i-gsub-21
   def gsub!(pattern, replacement = nil, &blk)
     replaced = gsub(pattern, replacement, &blk)
-    self.replace(replaced) unless self == replaced
+    replace(replaced) unless self == replaced
   end
 
   # https://ruby-doc.org/core-3.0.2/String.html#method-i-hash
@@ -710,7 +710,7 @@ class String
   # https://ruby-doc.org/core-3.0.2/String.html#method-i-lstrip-21
   def lstrip!
     replaced = lstrip
-    self.replace(replaced) unless self == replaced
+    replace(replaced) unless self == replaced
   end
 
   # https://ruby-doc.org/core-3.0.2/String.html#method-i-match
@@ -830,7 +830,7 @@ class String
   # https://ruby-doc.org/core-3.0.2/String.html#method-i-rstrip-21
   def rstrip!
     replaced = rstrip
-    self.replace(replaced) unless self == replaced
+    replace(replaced) unless self == replaced
   end
 
   # https://ruby-doc.org/core-3.0.2/String.html#method-i-scan
@@ -879,18 +879,18 @@ class String
   #
   # XXX: This should probably be implemented in native code.
   # TODO: Lots of branches are not implemented.
-  def split(pattern=nil, limit = (limit_not_set = true), &block)
+  def split(pattern = nil, limit = (limit_not_set = true), &block)
     return [] if empty?
     return [dup] if limit == 1
 
-    raise NotImplementedError, "String#split with block is not supported" unless block.nil?
+    raise NotImplementedError, 'String#split with block is not supported' unless block.nil?
 
     limit = -1 if limit_not_set
 
     if pattern.is_a?(Regexp)
       s = self
       chunks = []
-      while !s.empty?
+      until s.empty?
         match = pattern.match(s)
         if match.nil?
           chunks << s
@@ -907,9 +907,11 @@ class String
     pattern = $; if pattern.nil? # rubocop:disable Style/SpecialGlobalVars
     pattern = ' ' if pattern.nil?
 
-    if !pattern.is_a?(String)
+    unless pattern.is_a?(String)
       converted = pattern.to_str
-      raise TypeError, "can't convert #{pattern.class} to String (#{pattern.class}#to_str gives #{converted.class})" unless converted.is_a?(String)
+      unless converted.is_a?(String)
+        raise TypeError, "can't convert #{pattern.class} to String (#{pattern.class}#to_str gives #{converted.class})"
+      end
 
       pattern = converted
     end
@@ -917,7 +919,7 @@ class String
 
     s = self
     chunks = []
-    while !s.empty?
+    until s.empty?
       if limit.positive? && chunks.length == limit - 1
         chunks << s
         return chunks
@@ -931,14 +933,14 @@ class String
       chunks << s[0, index]
       s = s[index + pattern.length..-1]
     end
-    chunks << ""
+    chunks << ''
     chunks
   end
 
   # https://ruby-doc.org/core-3.0.2/String.html#method-i-squeeze
   def squeeze(*other_str)
-    return "" if empty?
-    raise NotImplementedError, "String#squeeze with arguments is not implemented" unless other_str.empty?
+    return '' if empty?
+    raise NotImplementedError, 'String#squeeze with arguments is not implemented' unless other_str.empty?
 
     iter = chars
     head, *tail = iter
@@ -957,7 +959,7 @@ class String
   # https://ruby-doc.org/core-3.0.2/String.html#method-i-squeeze-21
   def squeeze!(*other_str)
     replaced = squeeze(*other_str)
-    self.replace(replaced) unless self == replaced
+    replace(replaced) unless self == replaced
   end
 
   # https://ruby-doc.org/core-3.0.2/String.html#method-i-start_with-3F
@@ -978,7 +980,7 @@ class String
   # https://ruby-doc.org/core-3.0.2/String.html#method-i-strip-21
   def strip!
     replaced = strip
-    self.replace(replaced) unless self == replaced
+    replace(replaced) unless self == replaced
   end
 
   # https://ruby-doc.org/core-3.0.2/String.html#method-i-sub
@@ -1010,7 +1012,7 @@ class String
   # https://ruby-doc.org/core-3.0.2/String.html#method-i-sub-21
   def sub!(pattern, replacement = nil, &blk)
     replaced = sub(pattern, replacement, &blk)
-    self.replace(replaced) unless self == replaced
+    replace(replaced) unless self == replaced
   end
 
   # https://ruby-doc.org/core-3.0.2/String.html#method-i-sum
@@ -1030,7 +1032,7 @@ class String
 
   # https://ruby-doc.org/core-3.0.2/String.html#method-i-to_a
   def to_a
-    split('')
+    chars
   end
 
   # https://ruby-doc.org/core-3.0.2/String.html#method-i-to_c
@@ -1063,7 +1065,7 @@ class String
 
   # https://ruby-doc.org/core-3.0.2/String.html#method-i-to_str
   def to_str
-    return self if self.class == String
+    return self if instance_of?(String)
 
     String.new(self)
   end
@@ -1084,7 +1086,7 @@ class String
     raise FrozenError if frozen?
 
     replaced = tr(from_str, to_str)
-    self.replace(replaced) unless self == replaced
+    replace(replaced) unless self == replaced
   end
 
   # https://ruby-doc.org/core-3.0.2/String.html#method-i-tr_s
@@ -1097,7 +1099,7 @@ class String
     raise FrozenError if frozen?
 
     replaced = tr_s(from_str, to_str)
-    self.replace(replaced) unless self == replaced
+    replace(replaced) unless self == replaced
   end
 
   # https://ruby-doc.org/core-3.0.2/String.html#method-i-undump

--- a/artichoke-backend/src/extn/core/string/string.rb
+++ b/artichoke-backend/src/extn/core/string/string.rb
@@ -234,12 +234,28 @@ class String
     self
   end
 
+  def each_char(&block)
+    return to_enum(:each_char, &block) unless block
+
+    chars = self.chars
+    pos = 0
+    while pos < chars.size
+      block.call(chars[pos])
+      pos += 1
+    end
+    self
+  end
+
   def each_codepoint
     return to_enum(:each_codepoint) unless block_given?
 
-    chars do |c|
-      yield c.ord
+    codepoints = self.codepoints
+    pos = 0
+    while pos < codepoints.size
+      block.call(codepoints[pos])
+      pos += 1
     end
+    self
   end
 
   def each_grapheme_cluster

--- a/artichoke-backend/src/extn/core/string/string.rb
+++ b/artichoke-backend/src/extn/core/string/string.rb
@@ -62,6 +62,7 @@ module Artichoke
   end
 end
 
+# TODO: Properly implement this class now that Artichoke has encoding support.
 class Encoding
   class CompatibilityError < StandardError; end
 
@@ -127,22 +128,31 @@ class Encoding
   end
 end
 
+# https://ruby-doc.org/core-3.0.2/String.html
 class String
   include Comparable
 
-  def self.try_convert(obj = nil)
-    raise ArgumentError if obj.nil?
+  # https://ruby-doc.org/core-3.0.2/String.html#method-c-new
+  #
+  # NOTE: Implemented in native code.
+  #
+  # def self.new(string, **kwargs); end
+
+  # https://ruby-doc.org/core-3.0.2/String.html#method-c-try_convert
+  def self.try_convert(obj)
+    return nil if obj.nil?
     return obj if obj.is_a?(String)
 
     str = obj.to_str
     return nil if str.nil?
-    raise TypeError unless str.is_a?(String)
+    return str if str.is_a?(String)
 
-    str
+    raise TypeError, "can't convert #{obj.class} to String (#{obj.class}#to_str gives #{str.class})"
   rescue NoMethodError
     nil
   end
 
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-25
   def %(other)
     if other.is_a?(Array)
       sprintf(self, *other) # rubocop:disable Style/FormatString
@@ -151,19 +161,61 @@ class String
     end
   end
 
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-2A
+  #
+  # NOTE: Implemented in native code.
+  #
+  # def *(integer); end
+
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-2B
+  #
+  # NOTE: Implemented in native code.
+  #
+  # def +(other_string); end
+
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-2B-40
   def +@
     return dup if frozen?
 
     self
   end
 
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-2D-40
   def -@
+    # TODO: check to see if the string does not have any ivars defined on it.
     return self if frozen?
 
     dup.freeze
   end
 
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-2F
+  alias / split
+
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-3C-3C
+  #
+  # NOTE: Implemented in native code.
+  #
+  # def <<(object); end
+
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-3C-3D-3E
+  #
+  # NOTE: Implemented in native code.
+  #
+  # def <=>(other_string); end
+
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-3D-3D
+  #
+  # NOTE: Implemented in native code.
+  #
+  # def ==(other_string); end
+
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-3D-3D-3D
+  alias === ==
+
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-3D-7E
   def =~(other)
+    # TODO: This implementation does not "also updates Regexp-related global
+    # variables" like MRI does.
     return other.match(self)&.begin(0) if other.is_a?(Regexp)
     raise TypeError, "type mismatch: #{other.class} given" if other.is_a?(String)
     return other =~ self if other.respond_to?(:=~)
@@ -171,36 +223,168 @@ class String
     nil
   end
 
-  def count
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-5B-5D
+  #
+  # NOTE: Implemented in native code.
+  #
+  # def [](*args); end
+
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-5B-5D-3D
+  #
+  # NOTE: Implemented in native code.
+  #
+  # def []=(*args); end
+
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-ascii_only-3F
+  #
+  # NOTE: Implemented in native code.
+  #
+  # def ascii_only?; end
+
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-b
+  #
+  # NOTE: Implemented in native code.
+  #
+  # def b; end
+
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-bytes
+  #
+  # NOTE: Implemented in native code.
+  #
+  # def bytes; end
+
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-bytesize
+  #
+  # NOTE: Implemented in native code.
+  #
+  # def bytesize; end
+
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-byteslice
+  #
+  # NOTE: Implemented in native code.
+  #
+  # def bytesize(integer, *args); end
+
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-capitalize
+  #
+  # NOTE: Implemented in native code.
+  #
+  # def capitalize; end
+
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-capitalize-21
+  #
+  # NOTE: Implemented in native code.
+  #
+  # def capitalize!; end
+
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-casecmp
+  #
+  # NOTE: Implemented in native code.
+  #
+  # def casecmp(other_str); end
+
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-casecmp-3F
+  #
+  # NOTE: Implemented in native code.
+  #
+  # def casecmp?(other_string); end
+
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-center
+  #
+  # NOTE: Implemented in native code.
+  #
+  # def center(width, padstr=' '); end
+
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-chars
+  #
+  # NOTE: Implemented in native code.
+  #
+  # def chars; end
+
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-chomp
+  #
+  # NOTE: Implemented in native code.
+  #
+  # def chomp(separator=$/); end
+
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-chomp-21
+  #
+  # NOTE: Implemented in native code.
+  #
+  # def chomp!(separator=$/); end
+
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-chop
+  #
+  # NOTE: Implemented in native code.
+  #
+  # def chop; end
+
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-chop-21
+  #
+  # NOTE: Implemented in native code.
+  #
+  # def chop!; end
+
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-chr
+  #
+  # NOTE: Implemented in native code.
+  #
+  # def chr; end
+
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-clear
+  #
+  # NOTE: Implemented in native code.
+  #
+  # def clear; end
+
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-codepoints
+  #
+  # NOTE: Implemented in native code.
+  #
+  # def codepoints; end
+
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-concat
+  #
+  # NOTE: Implemented in native code.
+  #
+  # def concat(*objects); end
+
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-count
+  def count(other_str, *rest)
     raise NotImplementedError
   end
 
-  def crypt(_salt)
-    raise NotImplementedError
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-crypt
+  def crypt(_salt_str)
+    raise NotImplementedError, "String#crypt uses an insecure algorithm and is deprecated"
   end
 
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-delete
   def delete(*args)
     args.inject(self) { |string, pattern| string.tr(pattern, '') }
   end
 
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-delete-21
   def delete!(*args)
     replaced = delete(*args)
-    self[0..-1] = replaced unless self == replaced
+    self.replace(replaced) unless self == replaced
   end
 
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-delete_prefix
   def delete_prefix(prefix)
     raise TypeError, "no implicit conversion of #{prefix.class} into String" unless prefix.is_a?(String)
-
     return self[prefix.length..-1] if start_with?(prefix)
 
     dup
   end
 
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-delete_prefix-21
   def delete_prefix!(prefix)
     replaced = delete_prefix(prefix)
-    self[0..-1] = replaced unless self == replaced
+    self.replace(replaced) unless self == replaced
   end
 
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-delete_suffix
   def delete_suffix(suffix)
     raise TypeError, "no implicit conversion of #{suffix.class} into String" unless suffix.is_a?(String)
 
@@ -209,15 +393,30 @@ class String
     dup
   end
 
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-delete_suffix-21
   def delete_suffix!(prefix)
     replaced = delete_suffix(prefix)
-    self[0..-1] = replaced unless self == replaced
+    self.replace(replaced) unless self == replaced
   end
 
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-downcase
+  #
+  # NOTE: Implemented in native code.
+  #
+  # def downcase; end
+
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-downcase-21
+  #
+  # NOTE: Implemented in native code.
+  #
+  # def downcase!; end
+
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-dump
   def dump
     raise NotImplementedError
   end
 
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-each_byte
   def each_byte(&block)
     return to_enum(:each_byte, &block) unless block
 
@@ -230,6 +429,7 @@ class String
     self
   end
 
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-each_char
   def each_char(&block)
     return to_enum(:each_char, &block) unless block
 
@@ -242,6 +442,7 @@ class String
     self
   end
 
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-each_codepoint
   def each_codepoint
     return to_enum(:each_codepoint) unless block_given?
 
@@ -254,10 +455,12 @@ class String
     self
   end
 
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-each_grapheme_cluster
   def each_grapheme_cluster
     raise NotImplementedError
   end
 
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-each_line
   def each_line(separator = $/, getline_args = nil) # rubocop:disable Style/SpecialGlobalVars
     return to_enum(:each_line, separator, getline_args) unless block_given?
 
@@ -299,24 +502,40 @@ class String
     self
   end
 
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-empty-3F
+  #
+  # NOTE: Implemented in native code.
+  #
+  # def empty?; end
+
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-encode
+  #
+  # TODO: Properly implement this method now that Artichoke has encoding support.
   def encode(*_args)
     # mruby does not support encoding, all Strings are UTF-8. This method is a
     # NOOP and is here for compatibility.
     dup
   end
 
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-encode-21
+  #
+  # TODO: Properly implement this method now that Artichoke has encoding support.
   def encode!(*_args)
     # mruby does not support encoding, all Strings are UTF-8. This method is a
     # NOOP and is here for compatibility.
     self
   end
 
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-encoding
+  #
+  # TODO: Properly implement this method now that Artichoke has encoding support.
   def encoding
     # mruby does not support encoding, all Strings are UTF-8. This method is a
     # stub and is here for compatibility.
     Encoding::UTF_8
   end
 
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-end_with-3F
   def end_with?(*suffixes)
     suffixes.each do |suffix|
       return true if self[-suffix.length..-1] == suffix
@@ -324,16 +543,40 @@ class String
     false
   end
 
-  def force_encoding(*_args)
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-eql-3F
+  #
+  # NOTE: Implemented in native code.
+  #
+  # def eql?(object); end
+
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-force_encoding
+  #
+  # TODO: Properly implement this method now that Artichoke has encoding support.
+  def force_encoding(_encoding)
     # mruby does not support encoding, all Strings are UTF-8. This method is a
     # NOOP and is here for compatibility.
     self
   end
 
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-freeze
+  #
+  # NOTE: Implemented in native code.
+  #
+  # def freeze(); end
+
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-getbyte
+  #
+  # NOTE: Implemented in native code.
+  #
+  # def getbyte(index); end
+
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-grapheme_clusters
   def grapheme_clusters
     each_grapheme_cluster.to_a
   end
 
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-gsub
+  #
   # TODO: Support backrefs
   #
   #   "hello".gsub(/([aeiou])/, '<\1>')             #=> "h<e>ll<o>"
@@ -365,16 +608,42 @@ class String
     buf << remainder
   end
 
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-gsub-21
   def gsub!(pattern, replacement = nil, &blk)
     replaced = gsub(pattern, replacement, &blk)
-    self[0..-1] = replaced unless self == replaced
-    self
+    self.replace(replaced) unless self == replaced
   end
 
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-hash
+  #
+  # NOTE: Implemented in native code.
+  #
+  # def hash; end
+
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-hex
   def hex
     raise NotImplementedError
   end
 
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-include-3F
+  #
+  # NOTE: Implemented in native code.
+  #
+  # def include? other_str; end
+
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-index
+  #
+  # NOTE: Implemented in native code.
+  #
+  # def index(*args); end
+
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-initialize_copy
+  #
+  # NOTE: Implemented in native code.
+  #
+  # def replace(other_str); end
+
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-insert
   def insert(index, other_str)
     return self << other_str if index == -1
 
@@ -384,10 +653,30 @@ class String
     self
   end
 
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-inspect
+  #
+  # NOTE: Implemented in native code.
+  #
+  # def inspect; end
+
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-intern
+  #
+  # NOTE: Implemented in native code.
+  #
+  # def intern; end
+
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-length
+  #
+  # NOTE: Implemented in native code.
+  #
+  # def length; end
+
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-lines
   def lines(*args)
     each_line(*args).to_a
   end
 
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-ljust
   def ljust(integer, padstr = ' ')
     raise ArgumentError, 'zero width padding' if padstr == ''
 
@@ -398,6 +687,7 @@ class String
     "#{self}#{padding}"
   end
 
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-lstrip
   def lstrip
     strip_pointer = 0
     string_end = length - 1
@@ -407,17 +697,20 @@ class String
     dup[strip_pointer..string_end]
   end
 
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-lstrip-21
   def lstrip!
     replaced = lstrip
-    self[0..-1] = replaced unless self == replaced
+    self.replace(replaced) unless self == replaced
   end
 
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-match
   def match(pattern, pos = 0)
     pattern = Regexp.compile(Regexp.escape(pattern)) if pattern.is_a?(String)
 
     pattern.match(self[pos..-1])
   end
 
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-match-3F
   def match?(pattern, pos = 0)
     pattern = Regexp.compile(Regexp.escape(pattern)) if pattern.is_a?(String)
 
@@ -425,20 +718,30 @@ class String
     pattern.match?(self[pos..-1])
   end
 
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-next
   def next
     raise NotImplementedError
   end
   alias succ next
 
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-next-21
   def next!
     raise NotImplementedError
   end
   alias succ! next!
 
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-oct
   def oct
     raise NotImplementedError
   end
 
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-ord
+  #
+  # NOTE: Implemented in native code.
+  #
+  # def ord; end
+
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-partition
   def partition(pattern)
     pattern = Regexp.compile(Regexp.escape(pattern)) if pattern.is_a?(String)
 
@@ -446,10 +749,36 @@ class String
     [match.pre_match, match[0], match.post_match]
   end
 
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-prepend
   def prepend(*args)
     insert(0, args.join)
   end
 
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-replace
+  #
+  # NOTE: Implemented in native code.
+  #
+  # def replace(other_str); end
+
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-reverse
+  #
+  # NOTE: Implemented in native code.
+  #
+  # def reverse; end
+
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-reverse-21
+  #
+  # NOTE: Implemented in native code.
+  #
+  # def reverse!; end
+
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-rindex
+  #
+  # NOTE: Implemented in native code.
+  #
+  # def rindex(*args); end
+
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-rjust
   def rjust(integer, padstr = ' ')
     raise ArgumentError, 'zero width padding' if padstr == ''
 
@@ -460,6 +789,7 @@ class String
     "#{padding}#{self}"
   end
 
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-rpartition
   def rpartition(pattern)
     pattern = Regexp.compile(Regexp.escape(pattern)) if pattern.is_a?(String)
 
@@ -467,6 +797,7 @@ class String
     raise NotImplementedError
   end
 
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-rstrip
   def rstrip
     strip_pointer = length - 1
     string_start = 0
@@ -476,25 +807,72 @@ class String
     dup[string_start..strip_pointer]
   end
 
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-rstrip-21
   def rstrip!
     replaced = rstrip
-    self[0..-1] = replaced unless self == replaced
+    self.replace(replaced) unless self == replaced
   end
 
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-scan
+  #
+  # NOTE: Implemented in native code.
+  #
+  # def scan(pattern, &block); end
+
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-scrub
   def scrub
     # TODO: This is a stub. Implement scrub correctly.
     self
   end
 
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-scrub-21
   def scrub!
     # TODO: This is a stub. Implement scrub! correctly.
     self
   end
 
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-setbyte
+  #
+  # NOTE: Implemented in native code.
+  #
+  # def setbyte(index, integer); end
+
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-size
+  #
+  # NOTE: Implemented in native code.
+  #
+  # def length; end
+
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-slice
+  #
+  # NOTE: Implemented in native code.
+  #
+  # def [](*args); end
+
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-slice-21
+  #
+  # NOTE: Implemented in native code.
+  #
+  # def slice!(*args); end
+
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-split
+  #
+  # NOTE: Implemented in native code.
+  #
+  # def split(pattern=nil, [limit], &block); end
+
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-squeeze
   def squeeze(*_args)
     raise NotImplementedError
   end
 
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-squeeze-21
+  def squeeze!(*other_str)
+    replaced = squeeze(*other_str)
+    self.replace(replaced) unless self == replaced
+  end
+
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-start_with-3F
   def start_with?(*prefixes)
     prefixes.each do |prefix|
       return true if self[0...prefix.length] == prefix
@@ -502,17 +880,20 @@ class String
     false
   end
 
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-strip
   def strip
     result = lstrip
     result = self if result.nil?
     result.rstrip
   end
 
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-strip-21
   def strip!
     replaced = strip
-    self[0..-1] = replaced unless self == replaced
+    self.replace(replaced) unless self == replaced
   end
 
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-sub
   def sub(pattern, replacement = nil)
     return to_enum(:sub, pattern, replacement) if replacement.nil? && !block_given?
 
@@ -538,69 +919,143 @@ class String
     buf
   end
 
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-sub-21
   def sub!(pattern, replacement = nil, &blk)
     replaced = sub(pattern, replacement, &blk)
-    self[0..-1] = replaced unless self == replaced
+    self.replace(replaced) unless self == replaced
   end
 
-  def sum
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-sum
+  def sum(n_bits = 16)
     raise NotImplementedError
   end
 
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-swapcase
   def swapcase(*_args)
     raise NotImplementedError
   end
 
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-swapcase-21
   def swapcase!(*_args)
     raise NotImplementedError
   end
 
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-to_a
+  def to_a
+    split('')
+  end
+
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-to_c
   def to_c
     raise NotImplementedError
   end
 
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-to_f
+  #
+  # NOTE: Implemented in native code.
+  #
+  # def to_f; end
+
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-to_i
+  #
+  # NOTE: Implemented in native code.
+  #
+  # def to_i; end
+
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-to_r
   def to_r
     raise NotImplementedError
   end
 
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-to_s
+  #
+  # NOTE: Implemented in native code.
+  #
+  # def to_s; end
+
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-to_str
+  #
+  # NOTE: Implemented in native code.
+  #
+  # def to_str; end
+
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-to_sym
+  #
+  # NOTE: Implemented in native code.
+  #
+  # def to_sym; end
+
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-tr
   def tr(from_str, to_str)
     Artichoke::String.tr(self, from_str, to_str, false)
   end
 
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-tr-21
   def tr!(from_str, to_str)
     raise FrozenError if frozen?
 
     replaced = tr(from_str, to_str)
-    self[0..-1] = replaced unless self == replaced
+    self.replace(replaced) unless self == replaced
   end
 
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-tr_s
   def tr_s(from_str, to_str)
     Artichoke::String.tr(self, from_str, to_str, true)
   end
 
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-tr_s-21
   def tr_s!(from_str, to_str)
     raise FrozenError if frozen?
 
     replaced = tr_s(from_str, to_str)
-    self[0..-1] = replaced unless self == replaced
+    self.replace(replaced) unless self == replaced
   end
 
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-undump
   def undump
     raise NotImplementedError
   end
 
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-unicode_normalize
   def unicode_normalize(_form = :nfc)
     raise NotImplementedError
   end
 
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-unicode_normalize-21
   def unicode_normalize!(_form = :nfc)
     raise NotImplementedError
   end
 
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-unicode_normalized-3F
   def unicode_normalized?(_form = :nfc)
     raise NotImplementedError
   end
 
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-unpack
+  #
+  # NOTE: Implemented in native code.
+  #
+  # def unpack; end
+
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-unpack1
+  #
+  # NOTE: Implemented in native code in `mruby-pack` mrbgem.
+  #
+  # def unpack1; end
+
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-upcase
+  #
+  # NOTE: Implemented in native code.
+  #
+  # def upcase; end
+
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-upcase-21
+  #
+  # NOTE: Implemented in native code.
+  #
+  # def upccase!; end
+
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-upto
   def upto(max, exclusive = false, &block) # rubocop:disable Style/OptionalBooleanParameter
     return to_enum(:upto, max, exclusive) unless block
     raise TypeError, "no implicit conversion of #{max.class} into String" unless max.is_a?(String)
@@ -647,4 +1102,10 @@ class String
     end
     self
   end
+
+  # https://ruby-doc.org/core-3.0.2/String.html#method-i-valid_encoding-3F
+  #
+  # NOTE: Implemented in native code.
+  #
+  # def valid_encoding?; end
 end

--- a/artichoke-backend/src/extn/core/string/string.rb
+++ b/artichoke-backend/src/extn/core/string/string.rb
@@ -885,6 +885,8 @@ class String
 
     raise NotImplementedError, "String#split with block is not supported" unless block.nil?
 
+    limit = -1 if limit_not_set
+
     if pattern.is_a?(Regexp)
       s = self
       chunks = []
@@ -902,7 +904,7 @@ class String
       return chunks
     end
 
-    pattern = $; if pattern.nil?
+    pattern = $; if pattern.nil? # rubocop:disable Style/SpecialGlobalVars
     pattern = ' ' if pattern.nil?
 
     if !pattern.is_a?(String)
@@ -916,7 +918,7 @@ class String
     s = self
     chunks = []
     while !s.empty?
-      if limit&.positive? && chunks.length == limit - 1
+      if limit.positive? && chunks.length == limit - 1
         chunks << s
         return chunks
       end

--- a/artichoke-backend/src/extn/core/string/string.rb
+++ b/artichoke-backend/src/extn/core/string/string.rb
@@ -691,7 +691,17 @@ class String
   def lstrip
     strip_pointer = 0
     string_end = length - 1
-    strip_pointer += 1 while strip_pointer <= string_end && " \f\n\r\t\v".include?(self[strip_pointer])
+
+    # Whitespace is defined as any of the following characters:
+    #
+    # - null
+    # - horizontal tab
+    # - line feed
+    # - vertical tab
+    # - form feed
+    # - carriage return
+    # - space
+    strip_pointer += 1 while strip_pointer <= string_end && "\x00\t\n\v\f\r ".include?(self[strip_pointer])
     return '' if string_end.zero?
 
     dup[strip_pointer..string_end]
@@ -801,7 +811,17 @@ class String
   def rstrip
     strip_pointer = length - 1
     string_start = 0
-    strip_pointer -= 1 while strip_pointer >= string_start && " \f\n\r\t\v".include?(self[strip_pointer])
+
+    # Whitespace is defined as any of the following characters:
+    #
+    # - null
+    # - horizontal tab
+    # - line feed
+    # - vertical tab
+    # - form feed
+    # - carriage return
+    # - space
+    strip_pointer -= 1 while strip_pointer >= string_start && "\x00\t\n\v\f\r ".include?(self[strip_pointer])
     return '' if strip_pointer.zero?
 
     dup[string_start..strip_pointer]

--- a/artichoke-backend/src/extn/core/string/string.rb
+++ b/artichoke-backend/src/extn/core/string/string.rb
@@ -888,16 +888,21 @@ class String
     limit = -1 if limit_not_set
 
     if pattern.is_a?(Regexp)
-      s = self
+      s = dup
       chunks = []
       until s.empty?
+        if limit.positive? && chunks.length == limit - 1
+          chunks << s
+          return chunks
+        end
+
         match = pattern.match(s)
         if match.nil?
           chunks << s
           return chunks
         end
         chunks << s[0, match.begin(0)]
-        s = s[match.end(0), -1]
+        s = s[match.end(0)..-1]
 
         return chunks if s.nil?
       end
@@ -917,7 +922,7 @@ class String
     end
     return chars if pattern.empty?
 
-    s = self
+    s = dup
     chunks = []
     until s.empty?
       if limit.positive? && chunks.length == limit - 1

--- a/artichoke-backend/src/extn/core/string/string.rb
+++ b/artichoke-backend/src/extn/core/string/string.rb
@@ -171,10 +171,6 @@ class String
     nil
   end
 
-  def codepoints
-    each_codepoint.to_a
-  end
-
   def count
     raise NotImplementedError
   end
@@ -565,10 +561,6 @@ class String
 
   def to_r
     raise NotImplementedError
-  end
-
-  def to_str
-    dup
   end
 
   def tr(from_str, to_str)

--- a/artichoke-backend/src/extn/core/string/trampoline.rs
+++ b/artichoke-backend/src/extn/core/string/trampoline.rs
@@ -269,11 +269,8 @@ pub fn aref(
         // [3.0.1] > s[4]
         // => nil
         // ```
-        //
-        // NOTE: Index out a single byte rather than a slice to avoid having
-        // to do an overflow check on the addition.
-        if let Some(&byte) = s.get(index) {
-            let s = super::String::with_bytes_and_encoding(vec![byte], s.encoding());
+        if let Some(bytes) = s.get_char(index) {
+            let s = super::String::with_bytes_and_encoding(bytes.to_vec(), s.encoding());
             return super::String::alloc_value(s, interp);
         }
     }

--- a/artichoke-backend/src/extn/core/string/trampoline.rs
+++ b/artichoke-backend/src/extn/core/string/trampoline.rs
@@ -954,9 +954,34 @@ pub fn reverse_bang(interp: &mut Artichoke, mut value: Value) -> Result<Value, E
     }
 }
 
-pub fn rindex(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
-    let _s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
-    Err(NotImplementedError::new().into())
+pub fn rindex(
+    interp: &mut Artichoke,
+    mut value: Value,
+    mut needle: Value,
+    offset: Option<Value>,
+) -> Result<Value, Error> {
+    let s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
+    #[cfg(feature = "core-regexp")]
+    if let Ok(_pattern) = unsafe { Regexp::unbox_from_value(&mut needle, interp) } {
+        return Err(NotImplementedError::from("String#index with Regexp pattern").into());
+    }
+    let needle = unsafe { implicitly_convert_to_string(interp, &mut needle)? };
+    let index = if let Some(offset) = offset {
+        let offset = implicitly_convert_to_int(interp, offset)?;
+        let offset = if let Ok(offset) = usize::try_from(offset) {
+            Some(offset)
+        } else {
+            offset
+                .checked_neg()
+                .and_then(|offset| usize::try_from(offset).ok())
+                .and_then(|offset| s.len().checked_sub(offset))
+        };
+        s.rindex(needle, offset)
+    } else {
+        s.rindex(needle, None)
+    };
+    let index = index.and_then(|index| i64::try_from(index).ok());
+    interp.try_convert(index)
 }
 
 pub fn scan(interp: &mut Artichoke, value: Value, mut pattern: Value, block: Option<Block>) -> Result<Value, Error> {

--- a/artichoke-backend/src/extn/core/string/trampoline.rs
+++ b/artichoke-backend/src/extn/core/string/trampoline.rs
@@ -364,6 +364,16 @@ pub fn b(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
     super::String::alloc_value(dup, interp)
 }
 
+pub fn bytes(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
+    let s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
+    let bytes = s
+        .bytes()
+        .map(i64::from)
+        .map(|byte| interp.convert(byte))
+        .collect::<Array>();
+    Array::alloc_value(bytes, interp)
+}
+
 pub fn bytesize(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
     let s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
     let bytesize = s.bytesize();
@@ -548,16 +558,6 @@ pub fn byteslice(
         }
     }
     Ok(Value::nil())
-}
-
-pub fn bytes(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
-    let s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
-    let bytes = s
-        .bytes()
-        .map(i64::from)
-        .map(|byte| interp.convert(byte))
-        .collect::<Array>();
-    Array::alloc_value(bytes, interp)
 }
 
 pub fn capitalize(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
@@ -904,6 +904,11 @@ pub fn reverse_bang(interp: &mut Artichoke, mut value: Value) -> Result<Value, E
     }
 }
 
+pub fn rindex(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
+    let _s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
+    Err(NotImplementedError::new().into())
+}
+
 pub fn scan(interp: &mut Artichoke, value: Value, mut pattern: Value, block: Option<Block>) -> Result<Value, Error> {
     if let Ruby::Symbol = pattern.ruby_type() {
         let mut message = String::from("wrong argument type ");
@@ -1022,6 +1027,11 @@ pub fn scan(interp: &mut Artichoke, value: Value, mut pattern: Value, block: Opt
 }
 
 pub fn setbyte(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
+    let _s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
+    Err(NotImplementedError::new().into())
+}
+
+pub fn slice_bang(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
     let _s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
     Err(NotImplementedError::new().into())
 }

--- a/artichoke-backend/src/extn/core/string/trampoline.rs
+++ b/artichoke-backend/src/extn/core/string/trampoline.rs
@@ -674,9 +674,11 @@ pub fn hash(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
     Ok(interp.convert(hash))
 }
 
-pub fn include(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
-    let _s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
-    Err(NotImplementedError::new().into())
+pub fn include(interp: &mut Artichoke, mut value: Value, mut other: Value) -> Result<Value, Error> {
+    let s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
+    let other_str = unsafe { implicitly_convert_to_string(interp, &mut other)? };
+    let includes = s.index(other_str, None).is_some();
+    Ok(interp.convert(includes))
 }
 
 pub fn index(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {

--- a/artichoke-backend/src/extn/core/string/trampoline.rs
+++ b/artichoke-backend/src/extn/core/string/trampoline.rs
@@ -39,6 +39,8 @@ pub fn add(interp: &mut Artichoke, mut value: Value, mut other: Value) -> Result
     let to_append = unsafe { implicitly_convert_to_string(interp, &mut other)? };
 
     let mut concatenated = s.clone();
+    // XXX: This call doesn't do a check to see if we'll exceed the max allocation
+    //    size and may panic.
     concatenated.extend_from_slice(to_append);
     super::String::alloc_value(concatenated, interp)
 }
@@ -57,6 +59,8 @@ pub fn push(interp: &mut Artichoke, mut value: Value, mut other: Value) -> Resul
     // The string is reboxed without any intervening mruby allocations.
     unsafe {
         let string_mut = s.as_inner_mut();
+        // XXX: This call doesn't do a check to see if we'll exceed the max allocation
+        //    size and may panic.
         string_mut.extend_from_slice(other);
 
         let s = s.take();

--- a/artichoke-backend/src/extn/core/string/trampoline.rs
+++ b/artichoke-backend/src/extn/core/string/trampoline.rs
@@ -882,13 +882,26 @@ pub fn replace(interp: &mut Artichoke, value: Value, other: Value) -> Result<Val
 }
 
 pub fn reverse(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
-    let _s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
-    Err(NotImplementedError::new().into())
+    let s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
+    let mut reversed = s.clone();
+    reversed.reverse();
+    super::String::alloc_value(reversed, interp)
 }
 
 pub fn reverse_bang(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
-    let _s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
-    Err(NotImplementedError::new().into())
+    let mut s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
+    // Safety:
+    //
+    // The string is reboxed before any intervening operations on the
+    // interpreter.
+    // The string is reboxed without any intervening mruby allocations.
+    unsafe {
+        let string_mut = s.as_inner_mut();
+        string_mut.reverse();
+
+        let s = s.take();
+        super::String::box_into_value(s, value, interp)
+    }
 }
 
 pub fn scan(interp: &mut Artichoke, value: Value, mut pattern: Value, block: Option<Block>) -> Result<Value, Error> {

--- a/artichoke-backend/src/extn/core/string/trampoline.rs
+++ b/artichoke-backend/src/extn/core/string/trampoline.rs
@@ -95,9 +95,189 @@ pub fn equals_equals(interp: &mut Artichoke, mut value: Value, mut other: Value)
     }
 }
 
-pub fn aref(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
-    let _s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
-    Err(NotImplementedError::new().into())
+#[allow(unused_mut)]
+pub fn aref(
+    interp: &mut Artichoke,
+    mut value: Value,
+    mut first: Value,
+    second: Option<Value>,
+) -> Result<Value, Error> {
+    let s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
+    if let Some(second) = second {
+        #[cfg(feature = "core-regexp")]
+        if let Ok(_regexp) = unsafe { Regexp::unbox_from_value(&mut first, interp) } {
+            return Err(NotImplementedError::with_message("String#[] with Regexp argument and capture group").into());
+        }
+        let index = implicitly_convert_to_int(interp, first)?;
+        let length = implicitly_convert_to_int(interp, second)?;
+
+        // ```
+        // [3.0.1] > s = "abc"
+        // => "abc"
+        // [3.0.1] > s[-2, 10]
+        // => "bc"
+        // [3.0.1] > s[-3, 10]
+        // => "abc"
+        // [3.0.1] > s[-4, 10]
+        // => nil
+        // ```
+        let index = if let Ok(index) = usize::try_from(index) {
+            Some(index)
+        } else {
+            index
+                .checked_neg()
+                .and_then(|index| usize::try_from(index).ok())
+                .and_then(|index| s.len().checked_sub(index))
+        };
+        let index = match index {
+            None => return Ok(Value::nil()),
+            // Short circuit with `nil` if index > len.
+            //
+            // ```
+            // [3.0.1] > s = "abc"
+            // => "abc"
+            // [3.0.1] > s[3, 10]
+            // => ""
+            // [3.0.1] > s[4, 10]
+            // => nil
+            // ```
+            //
+            // Don't specialize on the case where index == len because the provided
+            // length can change the result. Even if the length argument is not
+            // given, we still need to preserve the encoding of the source string,
+            // so fall through to the happy path below.
+            Some(index) if index > s.len() => return Ok(Value::nil()),
+            Some(index) => index,
+        };
+
+        // ```
+        // [3.0.1] > s = "abc"
+        // => "abc"
+        // [3.0.1] > s[1, -1]
+        // => nil
+        // ```
+        if let Ok(length) = usize::try_from(length) {
+            // ```
+            // [3.0.1] > s = "abc"
+            // => "abc"
+            // [3.0.1] > s[2**64, 2**64]
+            // (irb):26:in `[]': bignum too big to convert into `long' (RangeError)
+            // 	from (irb):26:in `<main>'
+            // 	from /usr/local/var/rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/irb-1.3.5/exe/irb:11:in `<top (required)>'
+            // 	from /usr/local/var/rbenv/versions/3.0.1/bin/irb:23:in `load'
+            // 	from /usr/local/var/rbenv/versions/3.0.1/bin/irb:23:in `<main>'
+            // ```
+            let end = index
+                .checked_add(length)
+                .ok_or_else(|| RangeError::with_message("bignum too big to convert into `long'"))?;
+            if let Some(slice) = s.get(index..end) {
+                // Encoding from the source string is preserved.
+                //
+                // ```
+                // [3.0.1] > s = "abc"
+                // => "abc"
+                // [3.0.1] > s.encoding
+                // => #<Encoding:UTF-8>
+                // [3.0.1] > s[1, 2].encoding
+                // => #<Encoding:UTF-8>
+                // [3.0.1] > t = s.force_encoding(Encoding::ASCII)
+                // => "abc"
+                // [3.0.1] > t[1, 2].encoding
+                // => #<Encoding:US-ASCII>
+                // ```
+                let s = super::String::with_bytes_and_encoding(slice.to_vec(), s.encoding());
+                // ```
+                // [3.0.1] > class S < String; end
+                // => nil
+                // [3.0.1] > S.new("abc")[1, 2].class
+                // => String
+                // ```
+                //
+                // The returned `String` is never frozen:
+                //
+                // ```
+                // [3.0.1] > s = "abc"
+                // => "abc"
+                // [3.0.1] > s.frozen?
+                // => false
+                // [3.0.1] > s[1, 2].frozen?
+                // => false
+                // [3.0.1] > t = "abc".freeze
+                // => "abc"
+                // [3.0.1] > t[1, 2].frozen?
+                // => false
+                // ```
+                return super::String::alloc_value(s, interp);
+            }
+        }
+        return Ok(Value::nil());
+    }
+    #[cfg(feature = "core-regexp")]
+    if let Ok(_regexp) = unsafe { Regexp::unbox_from_value(&mut first, interp) } {
+        return Err(NotImplementedError::with_message("String#[] with Regexp argument").into());
+    }
+    // The overload of `String#[]` that takes a `String` **only** takes `String`s.
+    // No implicit conversion is performed.
+    //
+    // ```
+    // [3.0.1] > s = "abc"
+    // => "abc"
+    // [3.0.1] > s["bc"]
+    // => "bc"
+    // [3.0.1] > class X; def to_str; "bc"; end; end
+    // => :to_str
+    // [3.0.1] > s[X.new]
+    // (irb):4:in `[]': no implicit conversion of X into Integer (TypeError)
+    // 	from (irb):4:in `<main>'
+    // 	from /usr/local/var/rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/irb-1.3.5/exe/irb:11:in `<top (required)>'
+    // 	from /usr/local/var/rbenv/versions/3.0.1/bin/irb:23:in `load'
+    // 	from /usr/local/var/rbenv/versions/3.0.1/bin/irb:23:in `<main>'
+    // 	```
+    if let Ok(_substring) = unsafe { super::String::unbox_from_value(&mut first, interp) } {
+        return Err(NotImplementedError::with_message("String#[] with String argument").into());
+    }
+    let index = implicitly_convert_to_int(interp, first)?;
+
+    // ```
+    // [3.0.1] > s = "abc"
+    // => "abc"
+    // [3.0.1] > s[-2]
+    // => "b"
+    // [3.0.1] > s[-3]
+    // => "a"
+    // [3.0.1] > s[-4]
+    // => nil
+    // ```
+    let index = if let Ok(index) = usize::try_from(index) {
+        Some(index)
+    } else {
+        index
+            .checked_neg()
+            .and_then(|index| usize::try_from(index).ok())
+            .and_then(|index| s.len().checked_sub(index))
+    };
+    if let Some(index) = index {
+        // Index the byte, non existent indexes return `nil`.
+        //
+        // ```
+        // [3.0.1] > s = "abc"
+        // => "abc"
+        // [3.0.1] > s[2]
+        // => "c"
+        // [3.0.1] > s[3]
+        // => nil
+        // [3.0.1] > s[4]
+        // => nil
+        // ```
+        //
+        // NOTE: Index out a single byte rather than a slice to avoid having
+        // to do an overflow check on the addition.
+        if let Some(&byte) = s.get(index) {
+            let s = super::String::with_bytes_and_encoding(vec![byte], s.encoding());
+            return super::String::alloc_value(s, interp);
+        }
+    }
+    Ok(Value::nil())
 }
 
 pub fn aset(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {

--- a/artichoke-backend/src/extn/core/string/trampoline.rs
+++ b/artichoke-backend/src/extn/core/string/trampoline.rs
@@ -552,3 +552,8 @@ pub fn upcase_bang(interp: &mut Artichoke, mut value: Value) -> Result<Value, Er
     let _s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
     Err(NotImplementedError::new().into())
 }
+
+pub fn is_valid_encoding(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
+    let s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
+    Ok(interp.convert(s.is_valid_encoding()))
+}

--- a/artichoke-backend/src/extn/core/string/trampoline.rs
+++ b/artichoke-backend/src/extn/core/string/trampoline.rs
@@ -85,7 +85,6 @@ pub fn bytesize(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error
 pub fn bytes(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
     let s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
     let bytes = s
-        .clone()
         .bytes()
         .map(i64::from)
         .map(|byte| interp.convert(byte))

--- a/artichoke-backend/src/extn/core/string/trampoline.rs
+++ b/artichoke-backend/src/extn/core/string/trampoline.rs
@@ -1,5 +1,7 @@
 use core::convert::TryFrom;
+use core::hash::{BuildHasher, Hash, Hasher};
 
+use artichoke_core::hash::Hash as _;
 use bstr::ByteSlice;
 
 use crate::convert::implicitly_convert_to_int;
@@ -92,6 +94,16 @@ pub fn equals_equals(interp: &mut Artichoke, mut value: Value, mut other: Value)
     }
 }
 
+pub fn aref(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
+    let _s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
+    Err(NotImplementedError::new().into())
+}
+
+pub fn aset(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
+    let _s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
+    Err(NotImplementedError::new().into())
+}
+
 pub fn is_ascii_only(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
     let s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
     let is_ascii_only = s.is_ascii_only();
@@ -109,6 +121,11 @@ pub fn bytesize(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error
     let s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
     let bytesize = s.bytesize();
     interp.try_convert(bytesize)
+}
+
+pub fn byteslice(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
+    let _s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
+    Err(NotImplementedError::new().into())
 }
 
 pub fn bytes(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
@@ -171,12 +188,7 @@ pub fn casecmp_unicode(interp: &mut Artichoke, mut value: Value, mut other: Valu
     }
 }
 
-pub fn center(
-    interp: &mut Artichoke,
-    mut value: Value,
-    width: Value,
-    mut padstr: Option<Value>,
-) -> Result<Value, Error> {
+pub fn center(interp: &mut Artichoke, mut value: Value, width: Value, padstr: Option<Value>) -> Result<Value, Error> {
     let s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
     let width = implicitly_convert_to_int(interp, width)?;
     let width = if let Ok(width) = usize::try_from(width) {
@@ -199,19 +211,79 @@ pub fn center(
     };
     // Safety:
     //
-    // The byteslice is immediately discarded after extraction. There are no
-    // intervening interpreter accesses.
-    let padstr = if let Some(padstr) = padstr {
+    // The byteslice is immediately discarded after extraction and turned into
+    // an owned value. There are no intervening interpreter accesses.
+    let padstr = if let Some(mut padstr) = padstr {
         let padstr = unsafe { implicitly_convert_to_string(interp, &mut padstr)? };
-        Some(padstr)
+        Some(padstr.to_vec())
     } else {
         None
     };
     let centered = s
-        .center(width, padstr)
+        .center(width, padstr.as_deref())
         .map_err(|e| ArgumentError::with_message(e.message()))?
         .collect::<super::String>();
     super::String::alloc_value(centered, interp)
+}
+
+pub fn chars(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
+    let _s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
+    Err(NotImplementedError::new().into())
+}
+
+pub fn chomp(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
+    let _s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
+    Err(NotImplementedError::new().into())
+}
+
+pub fn chomp_bang(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
+    let _s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
+    Err(NotImplementedError::new().into())
+}
+
+pub fn chop(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
+    let _s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
+    Err(NotImplementedError::new().into())
+}
+
+pub fn chop_bang(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
+    let _s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
+    Err(NotImplementedError::new().into())
+}
+
+pub fn chr(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
+    let _s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
+    Err(NotImplementedError::new().into())
+}
+
+pub fn clear(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
+    let _s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
+    Err(NotImplementedError::new().into())
+}
+
+pub fn codepoints(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
+    let _s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
+    Err(NotImplementedError::new().into())
+}
+
+pub fn concat(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
+    let _s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
+    Err(NotImplementedError::new().into())
+}
+
+pub fn downcase(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
+    let _s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
+    Err(NotImplementedError::new().into())
+}
+
+pub fn downcase_bang(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
+    let _s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
+    Err(NotImplementedError::new().into())
+}
+
+pub fn is_empty(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
+    let s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
+    Ok(interp.convert(s.is_empty()))
 }
 
 pub fn eql(interp: &mut Artichoke, mut value: Value, mut other: Value) -> Result<Value, Error> {
@@ -224,10 +296,48 @@ pub fn eql(interp: &mut Artichoke, mut value: Value, mut other: Value) -> Result
     }
 }
 
+pub fn getbyte(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
+    let _s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
+    Err(NotImplementedError::new().into())
+}
+
+pub fn hash(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
+    let s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
+    let mut hasher = interp.build_hasher()?.build_hasher();
+    s.as_slice().hash(&mut hasher);
+    let hash = hasher.finish() as i64;
+    Ok(interp.convert(hash))
+}
+
+pub fn include(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
+    let _s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
+    Err(NotImplementedError::new().into())
+}
+
+pub fn index(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
+    let _s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
+    Err(NotImplementedError::new().into())
+}
+
+pub fn initialize(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
+    let _s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
+    Err(NotImplementedError::new().into())
+}
+
+pub fn initialize_copy(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
+    let _s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
+    Err(NotImplementedError::new().into())
+}
+
 pub fn inspect(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
     let s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
     let inspect = s.inspect().collect::<super::String>();
     super::String::alloc_value(inspect, interp)
+}
+
+pub fn intern(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
+    let _s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
+    Err(NotImplementedError::new().into())
 }
 
 pub fn length(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
@@ -250,6 +360,21 @@ pub fn ord(interp: &mut Artichoke, value: Value) -> Result<Value, Error> {
         None => return Err(ArgumentError::with_message("invalid byte sequence in UTF-8").into()),
     };
     Ok(interp.convert(ord))
+}
+
+pub fn replace(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
+    let _s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
+    Err(NotImplementedError::new().into())
+}
+
+pub fn reverse(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
+    let _s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
+    Err(NotImplementedError::new().into())
+}
+
+pub fn reverse_bang(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
+    let _s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
+    Err(NotImplementedError::new().into())
 }
 
 pub fn scan(interp: &mut Artichoke, value: Value, mut pattern: Value, block: Option<Block>) -> Result<Value, Error> {
@@ -367,4 +492,44 @@ pub fn scan(interp: &mut Artichoke, value: Value, mut pattern: Value, block: Opt
     message.push_str(interp.inspect_type_name_for_value(pattern));
     message.push_str(" (expected Regexp)");
     Err(TypeError::from(message).into())
+}
+
+pub fn setbyte(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
+    let _s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
+    Err(NotImplementedError::new().into())
+}
+
+pub fn split(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
+    let _s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
+    Err(NotImplementedError::new().into())
+}
+
+pub fn to_f(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
+    let _s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
+    Err(NotImplementedError::new().into())
+}
+
+pub fn to_i(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
+    let _s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
+    Err(NotImplementedError::new().into())
+}
+
+pub fn to_s(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
+    let _s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
+    Ok(value)
+}
+
+pub fn to_str(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
+    let _s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
+    Err(NotImplementedError::new().into())
+}
+
+pub fn upcase(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
+    let _s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
+    Err(NotImplementedError::new().into())
+}
+
+pub fn upcase_bang(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
+    let _s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
+    Err(NotImplementedError::new().into())
 }

--- a/artichoke-backend/src/extn/core/string/trampoline.rs
+++ b/artichoke-backend/src/extn/core/string/trampoline.rs
@@ -110,6 +110,9 @@ pub fn aref(
         #[cfg(feature = "core-regexp")]
         if let Ok(regexp) = unsafe { Regexp::unbox_from_value(&mut first, interp) } {
             let match_data = regexp.match_(interp, Some(s.as_slice()), None, None)?;
+            if match_data.is_nil() {
+                return Ok(Value::nil());
+            }
             return matchdata::trampoline::element_reference(interp, match_data, second, None);
         }
         let index = implicitly_convert_to_int(interp, first)?;
@@ -219,6 +222,9 @@ pub fn aref(
     #[cfg(feature = "core-regexp")]
     if let Ok(regexp) = unsafe { Regexp::unbox_from_value(&mut first, interp) } {
         let match_data = regexp.match_(interp, Some(s.as_slice()), None, None)?;
+        if match_data.is_nil() {
+            return Ok(Value::nil());
+        }
         return matchdata::trampoline::element_reference(interp, match_data, interp.convert(0), None);
     }
     if let Some(protect::Range { start: index, len }) = first.is_range(interp, s.char_len() as i64)? {

--- a/artichoke-backend/src/extn/core/string/trampoline.rs
+++ b/artichoke-backend/src/extn/core/string/trampoline.rs
@@ -170,7 +170,7 @@ pub fn aref(
             let end = index
                 .checked_add(length)
                 .ok_or_else(|| RangeError::with_message("bignum too big to convert into `long'"))?;
-            if let Some(slice) = s.get(index..end) {
+            if let Some(slice) = s.get_char_slice(index..end) {
                 // Encoding from the source string is preserved.
                 //
                 // ```

--- a/artichoke-backend/src/extn/core/string/trampoline.rs
+++ b/artichoke-backend/src/extn/core/string/trampoline.rs
@@ -1115,11 +1115,6 @@ pub fn to_s(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
     Ok(value)
 }
 
-pub fn to_str(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
-    let _s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
-    Err(NotImplementedError::new().into())
-}
-
 pub fn upcase(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
     let _s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
     Err(NotImplementedError::new().into())

--- a/artichoke-backend/src/extn/core/string/trampoline.rs
+++ b/artichoke-backend/src/extn/core/string/trampoline.rs
@@ -7,6 +7,12 @@ use crate::extn::core::matchdata::MatchData;
 use crate::extn::core::regexp::{self, Regexp};
 use crate::extn::prelude::*;
 
+pub fn inspect(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
+    let s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
+    let inspect = s.inspect().collect::<super::String>();
+    super::String::alloc_value(inspect, interp)
+}
+
 pub fn ord(interp: &mut Artichoke, value: Value) -> Result<Value, Error> {
     let string = value.try_convert_into_mut::<&[u8]>(interp)?;
     // NOTE: This implementation assumes all `String`s have encoding =

--- a/artichoke-backend/src/extn/core/string/trampoline.rs
+++ b/artichoke-backend/src/extn/core/string/trampoline.rs
@@ -688,13 +688,26 @@ pub fn chomp_bang(interp: &mut Artichoke, mut value: Value, separator: Option<Va
 }
 
 pub fn chop(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
-    let _s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
-    Err(NotImplementedError::new().into())
+    let s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
+    let mut dup = s.clone();
+    let _ = dup.chop();
+    super::String::alloc_value(dup, interp)
 }
 
 pub fn chop_bang(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
-    let _s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
-    Err(NotImplementedError::new().into())
+    let mut s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
+    if s.is_empty() {
+        return Ok(Value::nil());
+    }
+    unsafe {
+        let string_mut = s.as_inner_mut();
+        let modified = string_mut.chop();
+        if modified {
+            let s = s.take();
+            return super::String::box_into_value(s, value, interp);
+        }
+    }
+    Ok(value)
 }
 
 pub fn chr(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {

--- a/artichoke-backend/src/extn/core/string/trampoline.rs
+++ b/artichoke-backend/src/extn/core/string/trampoline.rs
@@ -733,8 +733,12 @@ pub fn clear(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
 }
 
 pub fn codepoints(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
-    let _s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
-    Err(NotImplementedError::new().into())
+    let s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
+    let codepoints = s
+        .codepoints()
+        .map_err(|err| ArgumentError::with_message(err.message()))?;
+    let codepoints = codepoints.map(|ch| interp.convert(ch)).collect::<Array>();
+    Array::alloc_value(codepoints, interp)
 }
 
 pub fn concat(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {

--- a/artichoke-backend/src/extn/core/string/trampoline.rs
+++ b/artichoke-backend/src/extn/core/string/trampoline.rs
@@ -650,8 +650,9 @@ pub fn center(interp: &mut Artichoke, mut value: Value, width: Value, padstr: Op
 }
 
 pub fn chars(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
-    let _s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
-    Err(NotImplementedError::new().into())
+    let s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
+    let chars = s.chars().collect::<Vec<&[u8]>>();
+    interp.try_convert_mut(chars)
 }
 
 pub fn chomp(interp: &mut Artichoke, mut value: Value, separator: Option<Value>) -> Result<Value, Error> {

--- a/artichoke-backend/src/extn/core/string/trampoline.rs
+++ b/artichoke-backend/src/extn/core/string/trampoline.rs
@@ -698,8 +698,9 @@ pub fn chop_bang(interp: &mut Artichoke, mut value: Value) -> Result<Value, Erro
 }
 
 pub fn chr(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
-    let _s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
-    Err(NotImplementedError::new().into())
+    let s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
+    let chr = s.chr();
+    interp.try_convert_mut(chr)
 }
 
 pub fn clear(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {

--- a/artichoke-backend/src/extn/stdlib/securerandom/trampoline.rs
+++ b/artichoke-backend/src/extn/stdlib/securerandom/trampoline.rs
@@ -12,7 +12,8 @@ pub fn alphanumeric(interp: &mut Artichoke, len: Option<Value>) -> Result<Value,
     } else {
         securerandom::alphanumeric(None)?
     };
-    interp.try_convert_mut(alpha)
+    let alpha = spinoso_string::String::ascii(alpha);
+    spinoso_string::String::alloc_value(alpha, interp)
 }
 
 #[inline]
@@ -23,7 +24,8 @@ pub fn base64(interp: &mut Artichoke, len: Option<Value>) -> Result<Value, Error
     } else {
         securerandom::base64(None)?
     };
-    interp.try_convert_mut(base64)
+    let base64 = spinoso_string::String::ascii(base64.into_bytes());
+    spinoso_string::String::alloc_value(base64, interp)
 }
 
 #[inline]
@@ -44,7 +46,8 @@ pub fn urlsafe_base64(interp: &mut Artichoke, len: Option<Value>, padding: Optio
     } else {
         securerandom::urlsafe_base64(None, padding)?
     };
-    interp.try_convert_mut(base64)
+    let base64 = spinoso_string::String::ascii(base64.into_bytes());
+    spinoso_string::String::alloc_value(base64, interp)
 }
 
 #[inline]
@@ -55,7 +58,8 @@ pub fn hex(interp: &mut Artichoke, len: Option<Value>) -> Result<Value, Error> {
     } else {
         securerandom::hex(None)?
     };
-    interp.try_convert_mut(hex)
+    let hex = spinoso_string::String::ascii(hex.into_bytes());
+    spinoso_string::String::alloc_value(hex, interp)
 }
 
 #[inline]
@@ -70,18 +74,20 @@ pub fn random_bytes(interp: &mut Artichoke, len: Option<Value>) -> Result<Value,
     } else {
         securerandom::random_bytes(None)?
     };
-    interp.try_convert_mut(bytes)
+    let bytes = spinoso_string::String::binary(bytes);
+    spinoso_string::String::alloc_value(bytes, interp)
 }
 
 #[inline]
 pub fn random_number(interp: &mut Artichoke, max: Option<Value>) -> Result<Value, Error> {
     let max = interp.try_convert_mut(max)?;
     let num = securerandom::random_number(max)?;
-    Ok(interp.convert_mut(num))
+    interp.try_convert_mut(num)
 }
 
 #[inline]
 pub fn uuid(interp: &mut Artichoke) -> Result<Value, Error> {
     let uuid = securerandom::uuid()?;
-    interp.try_convert_mut(uuid)
+    let uuid = spinoso_string::String::ascii(uuid.into_bytes());
+    spinoso_string::String::alloc_value(uuid, interp)
 }

--- a/artichoke-backend/src/value.rs
+++ b/artichoke-backend/src/value.rs
@@ -584,7 +584,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "core-regexp")]
     fn funcall_string_split_regexp() {
         let mut interp = interpreter().unwrap();
 
@@ -620,7 +619,7 @@ mod tests {
             .unwrap_err();
         assert_eq!("TypeError", err.name().as_ref());
         assert_eq!(
-            b"nil cannot be converted to String".as_bstr(),
+            b"no implicit conversion of nil into String".as_bstr(),
             err.message().as_ref().as_bstr()
         );
     }

--- a/artichoke-backend/vendor/mruby/src/string.c
+++ b/artichoke-backend/vendor/mruby/src/string.c
@@ -24,13 +24,19 @@
 #include <mruby/numeric.h>
 #include <mruby/presym.h>
 
+#ifndef ARTICHOKE
+
 typedef struct mrb_shared_string {
   int refcnt;
   mrb_ssize capa;
   char *ptr;
 } mrb_shared_string;
 
+#endif
+
 const char mrb_digitmap[] = "0123456789abcdefghijklmnopqrstuvwxyz";
+
+#ifndef ARTICHOKE
 
 #define mrb_obj_alloc_string(mrb) ((struct RString*)mrb_obj_alloc((mrb), MRB_TT_STRING, (mrb)->string_class))
 
@@ -2877,18 +2883,23 @@ mrb_str_byteslice(mrb_state *mrb, mrb_value str)
   }
 }
 
+#endif
+
 /* ---------------------------*/
 void
 mrb_init_string(mrb_state *mrb)
 {
   struct RClass *s;
 
+#ifndef ARTICHOKE
   mrb_static_assert(RSTRING_EMBED_LEN_MAX < (1 << MRB_STR_EMBED_LEN_BIT),
                     "pointer size too big for embedded string");
+#endif
 
   mrb->string_class = s = mrb_define_class(mrb, "String", mrb->object_class);             /* 15.2.10 */
   MRB_SET_INSTANCE_TT(s, MRB_TT_STRING);
 
+#ifndef ARTICHOKE
   mrb_define_method(mrb, s, "bytesize",        mrb_str_bytesize,        MRB_ARGS_NONE());
 
   mrb_define_method(mrb, s, "<=>",             mrb_str_cmp_m,           MRB_ARGS_REQ(1)); /* 15.2.10.5.1  */
@@ -2938,6 +2949,7 @@ mrb_init_string(mrb_state *mrb)
   mrb_define_method(mrb, s, "getbyte",         mrb_str_getbyte,         MRB_ARGS_REQ(1));
   mrb_define_method(mrb, s, "setbyte",         mrb_str_setbyte,         MRB_ARGS_REQ(2));
   mrb_define_method(mrb, s, "byteslice",       mrb_str_byteslice,       MRB_ARGS_ARG(1,1));
+#endif
 }
 
 #ifndef MRB_NO_FLOAT

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -49,6 +49,7 @@ dependencies = [
  "spinoso-random",
  "spinoso-regexp",
  "spinoso-securerandom",
+ "spinoso-string",
  "spinoso-symbol",
  "spinoso-time",
  "target-lexicon",
@@ -99,6 +100,12 @@ checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "bytecount"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72feb31ffc86498dacdbd0fcebb56138e7177a8cc5cea4516031d15ae85a742e"
 
 [[package]]
 name = "cc"
@@ -444,6 +451,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simdutf8"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c970da16e7c682fa90a261cf0724dee241c9f7831635ecc4e988ae8f3b505559"
+
+[[package]]
 name = "siphasher"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -508,6 +521,17 @@ dependencies = [
  "base64",
  "rand",
  "scolapasta-hex",
+]
+
+[[package]]
+name = "spinoso-string"
+version = "0.10.0"
+dependencies = [
+ "bstr",
+ "bytecount",
+ "focaccia",
+ "scolapasta-string-escape",
+ "simdutf8",
 ]
 
 [[package]]

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "artichoke-backend"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "artichoke-core",
  "artichoke-load-path",

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -32,7 +32,7 @@ dependencies = [
 
 [[package]]
 name = "artichoke-backend"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "artichoke-core",
  "artichoke-load-path",

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -53,6 +53,7 @@ dependencies = [
  "spinoso-random",
  "spinoso-regexp",
  "spinoso-securerandom",
+ "spinoso-string",
  "spinoso-symbol",
  "spinoso-time",
  "target-lexicon",
@@ -115,6 +116,12 @@ checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "bytecount"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72feb31ffc86498dacdbd0fcebb56138e7177a8cc5cea4516031d15ae85a742e"
 
 [[package]]
 name = "cc"
@@ -574,6 +581,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simdutf8"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c970da16e7c682fa90a261cf0724dee241c9f7831635ecc4e988ae8f3b505559"
+
+[[package]]
 name = "siphasher"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -651,6 +664,17 @@ dependencies = [
  "base64",
  "rand",
  "scolapasta-hex",
+]
+
+[[package]]
+name = "spinoso-string"
+version = "0.10.0"
+dependencies = [
+ "bstr",
+ "bytecount",
+ "focaccia",
+ "scolapasta-string-escape",
+ "simdutf8",
 ]
 
 [[package]]

--- a/spec-runner/all-library-specs.toml
+++ b/spec-runner/all-library-specs.toml
@@ -27,8 +27,6 @@ include = "all"
 [specs.library.securerandom]
 include = "all"
 skip = [
-  # specs require ASCII-8BIT / BINARY encoding for `String`s
-  "random_bytes",
   # missing support for Bignum and Range arguments
   "random_number",
 ]

--- a/spec-runner/enforced-specs.toml
+++ b/spec-runner/enforced-specs.toml
@@ -132,8 +132,6 @@ include = "all"
 [specs.library.securerandom]
 include = "all"
 skip = [
-  # specs require ASCII-8BIT / BINARY encoding for `String`s
-  "random_bytes",
   # missing support for Bignum and Range arguments
   "random_number",
 ]

--- a/spec-runner/src/spec_runner.rb
+++ b/spec-runner/src/spec_runner.rb
@@ -115,6 +115,7 @@ module Artichoke
           case state.exception
           when ArgumentError
             skipped = true if state.message =~ /Oniguruma.*UTF-8/
+            skipped = true if state.message =~ /invalid encoding.*UTF-8/
           when NoMethodError
             skipped = true if state.message =~ /'allocate'/
             skipped = true if state.message =~ /'encoding'/


### PR DESCRIPTION
**Implement the `String` class from Ruby core in Rust with `spinoso-string` in `artichoke-backend`.** 💎 🎉 💎 🎉 💎

[All 144 APIs available on `String`][ruby-core-string] in MRI 3.0.2 are either implemented or stubbed to raise `NotImplementedError`.

[ruby-core-string]: https://ruby-doc.org/core-3.0.2/String.html

## Design

Artichoke's `String` is based on [`spinoso_string::String`][spinoso-string-doc]. `String` is a byte buffer and associated encoding. `String` supports UTF-8, ASCII, and binary encodings. Encodings are conventional (a UTF-8 `String` may contain invalid UTF-8 byte sequences, an ASCII `String` may contain bytes greater than `0x7F`).

Character oriented APIs like `String::center`, `String::get_char` and `String::char_len` are implemented according to the `String`'s conventional encoding.

Unlike `String` in MRI, Artichoke's `String` does not cache whether a `String`'s encoding is valid, nor does it cache whether the `String` is `ascii_only`. These enhancements are expected to come in a future set of changes. I've [discussed how I would like to restructure `String`'s internals][twitter-string-nirvana] to make this happen on Twitter

`spinoso-string` uses state of the art Rust dependencies for encoding-oriented operations with first-class SIMD implementations. `spinoso-string` is built on top of `bstr` (ASCII and UTF-8 decoding, `find`-oriented APIs), `simdutf8` (UTF-8 validity checks), and `bytecount` (UTF-8 character length).

[spinoso-string-doc]: https://artichoke.github.io/artichoke/spinoso_string/struct.String.html
[twitter-string-nirvana]: https://twitter.com/artichokeruby/status/1464117285002440707

### mruby FFI Compatibility

Much like earlier work on `Array`, the `MRB_API` functions for strings are used heavily in the VM in addition to being exposed to Ruby code. The mruby VM treats strings as memory managed byte buffers and uses them extensively in its internals.

It is not sufficient to `#ifdef` out the C API since it is used outside of the `string.c` compilation unit.

Artichoke includes several reimplementations of mruby C APIs, mostly in Rust and some in the `mruby-sys` C extension.

During the development of these FFI compat functions, I encountered 1 segfault and 1 buffer overrun, both documented in the commits that address them:

- 7a13a30cf7d232fe9f7aefa8ab1d8f26073f9fd1
- 279c698b11ba885843e86561301f4951ecd16641

See https://twitter.com/artichokeruby/status/1463024367948812293 for some more color around these bugs.

## API Coverage

Artichoke implements the following String APIs in mostly native code with some pure Ruby implementations and the `mruby-pack` mrbgem:

### Native Rust Implementations

- `String#*`
- `String#+`
- `String#<<`
- `String#<=>`
- `String#==`
- `String#[]`
- `String#[]=` (stubbed, raises `NotImplementedError`)
- `String#ascii_only?`
- `String#b`
- `String#bytes`
- `String#bytesize`
- `String#byteslice`
- `String#capitalize`
- `String#capitalize!`
- `String#casecmp`
- `String#casecmp?`
- `String#center`
- `String#chars`
- `String#chomp`
- `String#chomp!`
- `String#chop`
- `String#chop!`
- `String#chr`
- `String#clear`
- `String#codepoints`
- `String#concat` (stubbed, raises `NotImplementedError`)
- `String#downcase`
- `String#downcase!`
- `String#empty?`
- `String#eql?`
- `String#getbyte`
- `String#hash`
- `String#include?`
- `String#index` (only supports `String` patterns)
- `String#initialize`
- `String#initialize_copy`
- `String#inspect`
- `String#intern`
- `String#length`
- `String#ord`
- `String#replace`
- `String#reverse`
- `String#reverse!`
- `String#rindex` (only supports `String` patterns)
- `String#scan`
- `String#setbyte`
- `String#size`
- `String#slice`
- `String#slice!` (stubbed, raises `NotImplementedError`)
- `String#to_f` (stubbed, raises `NotImplementedError`)
- `String#to_i`
- `String#to_s`
- `String#to_sym`
- `String#upcase`
- `String#upcase!`
- `String#valid_encoding?`

### Pure Ruby Implementations

- `String::try_convert`
- `String#%`
- `String#+@`
- `String#-@`
- `String#/`
- `String#===`
- `String#=~`
- `String#count` (stubbed, raises `NotImplementedError`)
- `String#crypt` (stubbed, raises `NotImplementedError`, not intended to be implemented for security considerations)
- `String#delete`
- `String#delete!`
- `String#delete_prefix`
- `String#delete_suffix`
- `String#delete_suffix!`
- `String#dump` (stubbed, raises `NotImplementedError`)
- `String#each_byte`
- `String#each_char`
- `String#each_codepoint`
- `String#each_grapheme_cluster` (stubbed, raises `NotImplementedError`)
- `String#each_line`
- `String#encode` (stubbed, pending completion of #183)
- `String#encode!` (stubbed, pending completion of #183)
- `String#encoding` (stubbed, pending completion of #183)
- `String#end_with?`
- `String#force_encoding` (stubbed, pending completion of #183)
- `String#grapheme_clusters` (stubbed, raises `NotImplementedError`)
- `String#gsub`
- `String#gsub!`
- `String#hex` (stubbed, raises `NotImplementedError`)
- `String#insert`
- `String#lines`
- `String#ljust`
- `String#lstrip`
- `String#lstrip!`
- `String#match`
- `String#match?`
- `String#next` (stubbed, raises `NotImplementedError`)
- `String#next!` (stubbed, raises `NotImplementedError`)
- `String#oct` (stubbed, raises `NotImplementedError`)
- `String#partition`
- `String#prepend`
- `String#rjust`
- `String#rpartition` (stubbed, raises `NotImplementedError`)
- `String#rstrip`
- `String#rstrip!`
- `String#scrub` (stubbed, raises `NotImplementedError`, this should be implemented in native code)
- `String#scrub!` (stubbed, raises `NotImplementedError`, this should be implemented in native code)
- `String#split` (partial implementation, buggy, does not support block arguments)
- `String#squeeze` (partial implementation, does not support character set arguments)
- `String#squeeze!` (partial implementation, does not support character set arguments)
- `String#start_with?`
- `String#strip`
- `String#strip!`
- `String#sub`
- `String#sub!`
- `String#succ` (stubbed, raises `NotImplementedError`)
- `String#succ!` (stubbed, raises `NotImplementedError`)
- `String#sum` (stubbed, raises `NotImplementedError`)
- `String#swapcase` (stubbed, raises `NotImplementedError`)
- `String#swapcase!` (stubbed, raises `NotImplementedError`)
- `String#to_a`
- `String#to_c` (stubbed, raises `NotImplementedError`, Artichoke does not support `Complex` numbers)
- `String#to_r` (stubbed, raises `NotImplementedError`, Artichoke does not support `Rational` numbers)
- `String#to_str`
- `String#tr`
- `String#tr!`
- `String#tr_s`
- `String#tr_s!`
- `String#undump` (stubbed, raises `NotImplementedError`)
- `String#unicode_normalize` (stubbed, raises `NotImplementedError`)
- `String#unicode_normalize!` (stubbed, raises `NotImplementedError`)
- `String#unicode_normalized?` (stubbed, raises `NotImplementedError`)
- `String#upto`

### mruby mrbgem C extension

- `String#unpack`
- `String#unpack1`

## ruby/spec compliance

This PR improves ruby/spec compliance for Artichoke 📈 🚀 

On current trunk, when running `rake spec`, Artichoke has the following stats:

```
Passed 1837, skipped 238, not implemented 14, failed 0 specs.
```

On the tip of #1222, when running `rake spec`, Artichoke has the following stats:

```
Passed 1845, skipped 238, not implemented 14, failed 0 specs.
```

This PR additionally allows for `SecureRandom#random_bytes` specs to pass since the returned `String` can properly declare their binary encoding. Previously, the returned `String`s had UTF-8 encoding which meant that if the random bytes happened to contain a multi-byte UTF-8 character byte sequence, the reported length would be less than `bytesize`. See:

- fac36b9f45b036ef2535673a95064afcc2776f73

## Future Work

- Implement `String#[]=`.
- Add fast paths when `String`s of any encoding are valid per their encoding.
- Add fast paths when `String`s of any encoding are ASCII only.
- Remove dependency on `mruby-pack`.
- Expose `Encoding` in Ruby, see #183.
- Use encoding-aware `String` constructors in native APIs where possible/required per ruby/spec.

## Linked Issues

Closes https://github.com/artichoke/artichoke/issues/184.
Partially addresses https://github.com/artichoke/artichoke/issues/183.

These PRs were foundational to getting this PR to a mergeable state:

- https://github.com/artichoke/artichoke/pull/1012, thanks @ekroon 
- https://github.com/artichoke/artichoke/pull/1045
- https://github.com/artichoke/artichoke/pull/1047
- https://github.com/artichoke/artichoke/pull/1048
- https://github.com/artichoke/artichoke/pull/1049
- https://github.com/artichoke/artichoke/pull/1051
- https://github.com/artichoke/artichoke/pull/1088
- https://github.com/artichoke/artichoke/pull/1141
- https://github.com/artichoke/artichoke/pull/1271
- https://github.com/artichoke/artichoke/pull/1348
- https://github.com/artichoke/artichoke/pull/1349
- https://github.com/artichoke/artichoke/pull/1353
- https://github.com/artichoke/artichoke/pull/1357
- https://github.com/artichoke/artichoke/pull/1402
- https://github.com/artichoke/artichoke/pull/1403
- https://github.com/artichoke/artichoke/pull/1449
- https://github.com/artichoke/artichoke/pull/1450#issuecomment-975414054 and https://github.com/artichoke/artichoke/pull/1510, thanks @rurban
- https://github.com/artichoke/artichoke/pull/1451
- https://github.com/artichoke/artichoke/pull/1488, thanks @masonforest 
- https://github.com/artichoke/artichoke/pull/1489
- https://github.com/artichoke/artichoke/pull/1490
- https://github.com/artichoke/artichoke/pull/1491
- https://github.com/artichoke/artichoke/pull/1505, thanks @briankung 
- https://github.com/artichoke/artichoke/pull/1512
- https://github.com/artichoke/artichoke/pull/1513
- https://github.com/artichoke/artichoke/pull/1514
- https://github.com/artichoke/artichoke/pull/1515
- https://github.com/artichoke/artichoke/pull/1516
- https://github.com/artichoke/artichoke/pull/1517
- https://github.com/artichoke/artichoke/pull/1519