### PR TITLE
Reduce dependabot noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   - package-ecosystem: cargo
     directory: "/"
     schedule:
-      interval: weekly
+      interval: monthly
     allow:
       - dependency-type: "all"
     open-pull-requests-limit: 10
@@ -20,7 +20,7 @@ updates:
   - package-ecosystem: bundler
     directory: "/"
     schedule:
-      interval: weekly
+      interval: monthly
     allow:
       - dependency-type: "all"
     open-pull-requests-limit: 10
@@ -31,7 +31,7 @@ updates:
   - package-ecosystem: cargo
     directory: "/fuzz"
     schedule:
-      interval: weekly
+      interval: monthly
     allow:
       - dependency-type: "all"
     open-pull-requests-limit: 10
@@ -42,7 +42,7 @@ updates:
   - package-ecosystem: cargo
     directory: "/spec-runner"
     schedule:
-      interval: weekly
+      interval: monthly
     allow:
       - dependency-type: "all"
     open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   - package-ecosystem: cargo
     directory: "/"
     schedule:
-      interval: daily
+      interval: weekly
     allow:
       - dependency-type: "all"
     open-pull-requests-limit: 10
@@ -20,7 +20,7 @@ updates:
   - package-ecosystem: bundler
     directory: "/"
     schedule:
-      interval: daily
+      interval: weekly
     allow:
       - dependency-type: "all"
     open-pull-requests-limit: 10
@@ -31,7 +31,7 @@ updates:
   - package-ecosystem: cargo
     directory: "/fuzz"
     schedule:
-      interval: daily
+      interval: weekly
     allow:
       - dependency-type: "all"
     open-pull-requests-limit: 10
@@ -42,7 +42,7 @@ updates:
   - package-ecosystem: cargo
     directory: "/spec-runner"
     schedule:
-      interval: daily
+      interval: weekly
     allow:
       - dependency-type: "all"
     open-pull-requests-limit: 10


### PR DESCRIPTION
With dependabot running every day, there is a lot of noise in the commit log.

Basically, the commit log becomes unusable for anyone interested in seeing what's happening in this project. Real commits drown in dependency updates.

How about changing to monthly or weekly frequency? (I'd strongly prefer monthly, but I put weekly in the PR, since it's a smaller change).

This is an awesome project btw! 🏅 

![image](https://user-images.githubusercontent.com/122287/122026558-9d3c6180-cdca-11eb-9f7a-6e78982b03d1.png)

*Useless commit log.*