### PR TITLE
Improve performance and overflow safety in spinoso-array

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -590,7 +590,7 @@ checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "spinoso-array"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "smallvec",
  "tinyvec",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -455,7 +455,7 @@ checksum = "42a568c8f2cd051a4d283bd6eb0343ac214c1b0f1ac19f93e1175b2dee38c73d"
 
 [[package]]
 name = "spinoso-array"
-version = "0.5.1"
+version = "0.5.2"
 
 [[package]]
 name = "spinoso-env"

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -549,7 +549,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-array"
-version = "0.5.1"
+version = "0.5.2"
 
 [[package]]
 name = "spinoso-env"

--- a/spinoso-array/Cargo.toml
+++ b/spinoso-array/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spinoso-array"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2018"
 description = """


### PR DESCRIPTION
Use `resize` and `resize_with` for `nil` filling buffers when setting
out of bounds indexes instead of `push`ing in a loop.

Add tests for `set` with an out of bounds index.

Use checked addition when given an index and length that might overflow
`usize::MAX`. Some cases are replaced with saturating adds or indexing
to the end of the buffer; some cases are replaced with capacity overflow
panics.

Bump `spinoso-array` to 0.5.2.