### PR TITLE
Prefer `resize_with` in `spinoso-array` vectors

### DIFF
--- a/spinoso-array/src/array/smallvec/mod.rs
+++ b/spinoso-array/src/array/smallvec/mod.rs
@@ -1099,7 +1099,7 @@ where
         if let Some(overflow) = index.checked_sub(self.0.len()) {
             let additional = overflow.checked_add(values.len()).expect("capacity overflow");
             self.0.reserve(additional);
-            self.0.resize(index, T::default());
+            self.0.resize_with(index, T::default);
         } else {
             self.0.reserve(values.len());
         }
@@ -1140,7 +1140,7 @@ where
         if let Some(overflow) = index.checked_sub(self.0.len()) {
             let additional = overflow.saturating_add(values.len());
             self.0.reserve(additional);
-            self.0.resize(index, T::default());
+            self.0.resize_with(index, T::default);
         }
         // `self.len()` is at least `index` so the below sub can never overflow.
         let tail = self.len() - index;

--- a/spinoso-array/src/array/tinyvec/mod.rs
+++ b/spinoso-array/src/array/tinyvec/mod.rs
@@ -1102,7 +1102,7 @@ where
         if let Some(overflow) = index.checked_sub(self.0.len()) {
             let additional = overflow.checked_add(values.len()).expect("capacity overflow");
             self.0.reserve(additional);
-            self.0.resize(index, T::default());
+            self.0.resize_with(index, T::default);
         } else {
             self.0.reserve(values.len());
         }
@@ -1151,7 +1151,7 @@ where
         if let Some(overflow) = index.checked_sub(self.0.len()) {
             let additional = overflow.checked_add(values.len()).expect("capacity overflow");
             self.0.reserve(additional);
-            self.0.resize(index, T::default());
+            self.0.resize_with(index, T::default);
         }
         if index == self.0.len() {
             self.0.extend_from_slice(values);

--- a/spinoso-array/src/array/vec/mod.rs
+++ b/spinoso-array/src/array/vec/mod.rs
@@ -1133,7 +1133,7 @@ where
         if let Some(overflow) = index.checked_sub(self.0.len()) {
             let additional = overflow.checked_add(values.len()).expect("capacity overflow");
             self.0.reserve(additional);
-            self.0.resize(index, T::default());
+            self.0.resize_with(index, T::default);
         } else {
             self.0.reserve(values.len());
         }
@@ -1178,7 +1178,7 @@ where
         if let Some(overflow) = index.checked_sub(self.0.len()) {
             let additional = overflow.saturating_add(values.len());
             self.0.reserve(additional);
-            self.0.resize(index, T::default());
+            self.0.resize_with(index, T::default);
         }
         if index == self.0.len() {
             self.0.extend_from_slice(values);


### PR DESCRIPTION
Use `resize_with` with `T::default` rather than `resize` with
`T::default()` to defer an allocation and not require `Clone`.