### PR TITLE
Disable default-features for spinoso-env and spinoso-math in artichoke-backend

### DIFF
--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -22,9 +22,9 @@ once_cell = "1"
 regex = "1"
 scolapasta-string-escape = { version = "0.2", path = "../scolapasta-string-escape", default-features = false }
 spinoso-array = { version = "0.5", path = "../spinoso-array", default-features = false }
-spinoso-env = { version = "0.1", path = "../spinoso-env", optional = true }
+spinoso-env = { version = "0.1", path = "../spinoso-env", optional = true, default-features = false }
 spinoso-exception = { version = "0.1", path = "../spinoso-exception" }
-spinoso-math = { version = "0.1", path = "../spinoso-math", optional = true }
+spinoso-math = { version = "0.1", path = "../spinoso-math", optional = true, default-features = false, features = ["std"] }
 spinoso-random = { version = "0.1", path = "../spinoso-random", optional = true }
 spinoso-regexp = { version = "0.1", path = "../spinoso-regexp", default-features = false, optional = true }
 spinoso-securerandom = { version = "0.1", path = "../spinoso-securerandom", optional = true }


### PR DESCRIPTION
The `Cargo.toml` in `artichoke-backend` activates optional features in
`spinoso-env` and `spinoso-math` based on its own feature flags. This
means the dependency declarations should disable default features.

This cuts down on compiled code in some feature flag configurations and
fixes a bug where dependent APIs might be exposed even if they are
intended to be disabled.

https://github.com/artichoke/artichoke/blob/f8a62eda2a847c6a38a7b270f68049805424ebe7/artichoke-backend/Cargo.toml#L62-L64