### PR TITLE
Consistently order dependency options in `Cargo.toml`s

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ categories = ["command-line-utilities"]
 
 [dependencies]
 clap = { version = "2.33", optional = true }
-rustyline = { version = "8", default-features = false, optional = true }
+rustyline = { version = "8", optional = true, default-features = false }
 termcolor = { version = "1.1", optional = true }
 
 [dependencies.artichoke-backend]

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -19,6 +19,7 @@ intaglio = "1.2"
 itoa = "0.4"
 log = "0.4, >= 0.4.5"
 once_cell = "1"
+onig = { version = "6.2", optional = true, default-features = false }
 regex = "1"
 scolapasta-string-escape = { version = "0.2", path = "../scolapasta-string-escape", default-features = false }
 spinoso-array = { version = "0.5", path = "../spinoso-array", default-features = false }
@@ -26,15 +27,10 @@ spinoso-env = { version = "0.1", path = "../spinoso-env", optional = true, defau
 spinoso-exception = { version = "0.1", path = "../spinoso-exception" }
 spinoso-math = { version = "0.1", path = "../spinoso-math", optional = true, default-features = false, features = ["std"] }
 spinoso-random = { version = "0.1", path = "../spinoso-random", optional = true }
-spinoso-regexp = { version = "0.1", path = "../spinoso-regexp", default-features = false, optional = true }
+spinoso-regexp = { version = "0.1", path = "../spinoso-regexp", optional = true, default-features = false }
 spinoso-securerandom = { version = "0.1", path = "../spinoso-securerandom", optional = true }
 spinoso-symbol = { version = "0.1", path = "../spinoso-symbol" }
 spinoso-time = { version = "0.1", path = "../spinoso-time", optional = true }
-
-[dependencies.onig]
-version = "6.2"
-default-features = false
-optional = true
 
 [dev-dependencies]
 quickcheck = { version = "1.0", default-features = false }

--- a/spinoso-random/Cargo.toml
+++ b/spinoso-random/Cargo.toml
@@ -19,7 +19,7 @@ rand = { version = "0.8", optional = true, default-features = false }
 # 0.6.1 is vulnerable to underfilling a buffer.
 #
 # https://rustsec.org/advisories/RUSTSEC-2021-0023
-rand_core = { version = "0.6, >= 0.6.2", default-features = false, optional = true }
+rand_core = { version = "0.6, >= 0.6.2", optional = true, default-features = false }
 
 [features]
 default = ["random-rand", "rand-traits", "std"]

--- a/spinoso-regexp/Cargo.toml
+++ b/spinoso-regexp/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["data-structures", "parser-implementations"]
 bitflags = "1.2"
 bstr = { version = "0.2, >= 0.2.4", default-features = false }
 itoa = "0.4"
-onig = { version = "6.2", default-features = false, optional = true }
+onig = { version = "6.2", optional = true, default-features = false }
 regex = { version = "1, >= 1.4.3", default-features = false, features = ["std", "unicode-perl"] }
 scolapasta-string-escape = { version = "0.2", path = "../scolapasta-string-escape", default-features = false }
 

--- a/spinoso-symbol/Cargo.toml
+++ b/spinoso-symbol/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["ident", "intern", "no_std", "spinoso", "symbol"]
 categories = ["data-structures", "no-std", "parser-implementations"]
 
 [dependencies]
-artichoke-core = { version = "0.8", path = "../artichoke-core", default-features = false, optional = true }
+artichoke-core = { version = "0.8", path = "../artichoke-core", optional = true, default-features = false }
 bstr = { version = "0.2, >= 0.2.4", optional = true, default-features = false }
 focaccia = { version = "1.0", optional = true, default-features = false }
-scolapasta-string-escape = { version = "0.2", path = "../scolapasta-string-escape", default-features = false, optional = true }
+scolapasta-string-escape = { version = "0.2", path = "../scolapasta-string-escape", optional = true, default-features = false }
 
 [features]
 default = ["artichoke", "std"]


### PR DESCRIPTION
Consistently declare dependencies with this attribute order:

    dep = { version = "1", path = "../dep", optional = true, default-features = false, features = ["std"] }