### PR TITLE
Fix file not found error when running the spec-runner

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -156,6 +156,10 @@ jobs:
         run: cargo check --locked --all-targets --profile=test
         working-directory: "spec-runner"
 
+      - name: Test spec-runner
+        run: cargo test
+        working-directory: "spec-runner"
+
       - name: Lint spec-runner with Clippy
         run: cargo clippy --workspace --all-features --all-targets
         working-directory: "spec-runner"

--- a/artichoke-backend/src/load_path/memory.rs
+++ b/artichoke-backend/src/load_path/memory.rs
@@ -35,9 +35,17 @@ impl fmt::Debug for Extension {
     }
 }
 
-#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Code {
     content: Cow<'static, [u8]>,
+}
+
+impl fmt::Debug for Code {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Code")
+            .field("content", &self.content.as_bstr())
+            .finish()
+    }
 }
 
 impl Default for Code {

--- a/spec-runner/src/mspec.rs
+++ b/spec-runner/src/mspec.rs
@@ -38,7 +38,7 @@ where
     interp.def_rb_source_file("spec_helper.rb", &b""[..])?;
     interp.def_rb_source_file("spec_runner.rb", &include_bytes!("spec_runner.rb")[..])?;
 
-    interp.eval_file(&virtual_root.join("spec_runner"))?;
+    interp.eval_file(&virtual_root.join("spec_runner.rb"))?;
 
     let specs = interp.try_convert_mut(specs.into_iter().collect::<Vec<_>>())?;
     let result = interp.top_self().funcall(interp, "run_specs", &[specs], None)?;


### PR DESCRIPTION
PR #1299 reworked file loading such that `.rb` suffix appending only
happens in `require`.

The `spec-runner` uses `Eval::eval_file` but supplies a non-existent
path. This PR fixes the bad path and adds a CI step to run the
spec-runner tests in CI.

This breakage made it to master where it failed the LeakSan build for
the `spec-runner`.

```console
$ cargo test
   Compiling artichoke v0.1.0-pre.0 (/Users/lopopolo/dev/artichoke/artichoke)
   Compiling artichoke-backend v0.1.0 (/Users/lopopolo/dev/artichoke/artichoke/artichoke-backend)
   Compiling spec-runner v0.3.0 (/Users/lopopolo/dev/artichoke/artichoke/spec-runner)
    Finished test [unoptimized + debuginfo] target(s) in 7.60s
     Running unittests (target/debug/deps/spec_runner-d0f20a89fc582c2b)

running 1 test
test mspec::tests::mspec_framework_loads ... FAILED

failures:

---- mspec::tests::mspec_framework_loads stdout ----
thread 'mspec::tests::mspec_framework_loads' panicked at 'called `Result::unwrap()` on an `Err` value: Error(IoError(Os { code: 2, kind: NotFound, message: "No such file or directory" }))', src/mspec.rs:55:49
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    mspec::tests::mspec_framework_loads

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.08s

error: test failed, to rerun pass '--bin spec-runner'
```