### PR TITLE
Remove `std` feature from `spinoso-math`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -548,7 +548,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-math"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "libm",
 ]

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -25,7 +25,7 @@ scolapasta-string-escape = { version = "0.2", path = "../scolapasta-string-escap
 spinoso-array = { version = "0.5", path = "../spinoso-array", default-features = false }
 spinoso-env = { version = "0.1", path = "../spinoso-env", optional = true, default-features = false }
 spinoso-exception = { version = "0.1", path = "../spinoso-exception" }
-spinoso-math = { version = "0.1", path = "../spinoso-math", optional = true, default-features = false, features = ["std"] }
+spinoso-math = { version = "0.2", path = "../spinoso-math", optional = true, default-features = false }
 spinoso-random = { version = "0.1", path = "../spinoso-random", optional = true }
 spinoso-regexp = { version = "0.1", path = "../spinoso-regexp", optional = true, default-features = false }
 spinoso-securerandom = { version = "0.1", path = "../spinoso-securerandom", optional = true }

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -401,7 +401,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-math"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "libm",
 ]

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -543,7 +543,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-math"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "libm",
 ]

--- a/spinoso-math/Cargo.toml
+++ b/spinoso-math/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spinoso-math"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2018"
 description = """
@@ -16,13 +16,10 @@ categories = ["algorithms", "no-std"]
 libm = { version = "0.2", optional = true }
 
 [features]
-default = ["full", "std"]
+default = ["full"]
 # Implement the full Ruby `Math` API by including external crates for missing
-# `core` APIs.
+# `std` APIs.
 full = ["libm"]
-# By default, `spinoso-math` is `no_std`. This feature enables
-# `std::error::Error` impls.
-std = []
 
 [package.metadata.docs.rs]
 all-features = true

--- a/spinoso-math/README.md
+++ b/spinoso-math/README.md
@@ -30,7 +30,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-spinoso-math = "0.1"
+spinoso-math = "0.2"
 ```
 
 Compute the hypotenuse:
@@ -55,11 +55,6 @@ assert!(math::log10(-0.1).is_err());
 assert!(matches!(math::log10(f64::NAN), Ok(result) if result.is_nan()));
 ```
 
-## `no_std`
-
-This crate is `no_std` compatible when built without the `std` feature. This
-crate does not depend on [`alloc`].
-
 ## Crate features
 
 All features are enabled by default.
@@ -67,8 +62,6 @@ All features are enabled by default.
 - **full** - Enables implementations of math functions that do not have
   implementations in Rust [`core`]. Dropping this feature removes the [`libm`]
   dependency.
-- **std** - Enables a dependency on the Rust Standard Library. Activating this
-  feature enables [`std::error::Error`] impls on error types in this crate.
 
 ## License
 
@@ -78,6 +71,3 @@ All features are enabled by default.
 [`core`]: https://doc.rust-lang.org/core/
 [`nan`]: https://doc.rust-lang.org/std/primitive.f64.html#associatedconstant.NAN
 [`f64`]: https://doc.rust-lang.org/std/primitive.f64.html
-[`alloc`]: https://doc.rust-lang.org/alloc/
-[`alloc`]: https://doc.rust-lang.org/alloc/
-[`std::error::error`]: https://doc.rust-lang.org/std/error/trait.Error.html

--- a/spinoso-math/src/lib.rs
+++ b/spinoso-math/src/lib.rs
@@ -58,11 +58,6 @@
 //! assert!(matches!(math::log10(f64::NAN), Ok(result) if result.is_nan()));
 //! ```
 //!
-//! # `no_std`
-//!
-//! This crate is `no_std` compatible when built without the `std` feature. This
-//! crate does not depend on [`alloc`].
-//!
 //! # Crate features
 //!
 //! All features are enabled by default.
@@ -70,9 +65,6 @@
 //! - **full** - Enables implementations of math functions that do not have
 //!   implementations in Rust [`core`]. Dropping this feature removes the
 //!   [`libm`] dependency.
-//! - **std** - Enables a dependency on the Rust Standard Library. Activating
-//!   this feature enables [`std::error::Error`] impls on error types in this
-//!   crate.
 //!
 //! [`Float`]: https://ruby-doc.org/core-2.6.3/Float.html
 //! [`NaN`]: f64::NAN
@@ -84,7 +76,6 @@
 mod readme {}
 
 use core::fmt;
-#[cfg(feature = "std")]
 use std::error;
 
 #[doc(inline)]
@@ -197,7 +188,6 @@ impl fmt::Display for Error {
     }
 }
 
-#[cfg(feature = "std")]
 impl error::Error for Error {
     fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match self {
@@ -302,7 +292,6 @@ impl fmt::Display for DomainError {
     }
 }
 
-#[cfg(feature = "std")]
 impl error::Error for DomainError {}
 
 /// Error that indicates a `Math` module function is not implemented.
@@ -403,5 +392,4 @@ impl fmt::Display for NotImplementedError {
     }
 }
 
-#[cfg(feature = "std")]
 impl error::Error for NotImplementedError {}


### PR DESCRIPTION
`spinoso-math` documents itself to be `no_std` and has a `std` feature, but the crate did not declare the `#![no_std]` pragma.

Many `f64` math functions require `std` and are not available in `core`. Despite missing support in `core`, without the crate properly declaring itself as `no_std`, tests with `--no-default-features` incorrectly passed since `std` is still linked in.

It does not seem likely that `f64` math will be enabled in `core` any time soon, so make `spinoso-math` require `std`. See rust-lang/rust#63455.

This commit bumps the version of `spinoso-math` to 0.2.0 since removing a feature is a breaking change (and did break the build of `artichoke-backend`).