### PR TITLE
Add support for `SOURCE_DATE_EPOCH` when computing `RUBY_RELEASE_DATE`

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,10 @@
-#![deny(clippy::all)]
-#![deny(clippy::pedantic)]
-#![allow(clippy::restriction)]
+#![warn(clippy::all)]
+#![warn(clippy::pedantic)]
+#![warn(clippy::needless_borrow)]
+#![allow(clippy::let_underscore_drop)]
+// https://github.com/rust-lang/rust-clippy/pull/5998#issuecomment-731855891
+#![allow(clippy::map_err_ignore)]
+#![allow(clippy::option_if_let_else)]
 
 use chrono::prelude::*;
 use std::env;


### PR DESCRIPTION
`RUBY_RELEASE_DATE`, `RUBY_RELEASE_YEAR`, `RUBY_RELEASE_MONTH`,
`RUBY_RELEASE_DAY`, and `RUBY_COPYRIGHT` all contain data derived from
the build date.

Prior to this commit, the build date was always computed with the
current UTC timestamp of the build machine. With this commit, one can
choose a fixed timestamp when building Artichoke by setting
`SOURCE_DATE_EPOCH` to a UNIX timestamp (seconds since epoch).

The use of `SOURCE_DATE_EPOCH` is consistent with the spec for
reproducible builds commonly used in Linux distos.

https://reproducible-builds.org/docs/source-date-epoch/

Changes to the `SOURCE_DATE_EPOCH` env variable (or setting/unsetting
it) will result in cargo forcing a rebuild.