### PR TITLE
Implement `Time#-` for `Time` arguments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -605,7 +605,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-time"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "chrono",
  "chrono-tz",

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -30,7 +30,7 @@ spinoso-random = { version = "0.1", path = "../spinoso-random", optional = true 
 spinoso-regexp = { version = "0.1", path = "../spinoso-regexp", optional = true, default-features = false }
 spinoso-securerandom = { version = "0.1", path = "../spinoso-securerandom", optional = true }
 spinoso-symbol = { version = "0.1", path = "../spinoso-symbol" }
-spinoso-time = { version = "0.1", path = "../spinoso-time", optional = true }
+spinoso-time = { version = "0.2", path = "../spinoso-time", optional = true }
 
 [dev-dependencies]
 quickcheck = { version = "1.0", default-features = false }

--- a/artichoke-backend/src/extn/core/time/trampoline.rs
+++ b/artichoke-backend/src/extn/core/time/trampoline.rs
@@ -186,11 +186,21 @@ pub fn plus(interp: &mut Artichoke, time: Value, other: Value) -> Result<Value, 
     Err(NotImplementedError::new().into())
 }
 
-pub fn minus(interp: &mut Artichoke, time: Value, other: Value) -> Result<Value, Error> {
-    let _ = interp;
-    let _ = time;
-    let _ = other;
-    Err(NotImplementedError::new().into())
+pub fn minus(interp: &mut Artichoke, mut time: Value, mut other: Value) -> Result<Value, Error> {
+    let time = unsafe { Time::unbox_from_value(&mut time, interp)? };
+    let other = if let Ok(other) = unsafe { Time::unbox_from_value(&mut other, interp) } {
+        other
+    } else if let Ok(other) = implicitly_convert_to_int(interp, other) {
+        let _ = other;
+        return Err(NotImplementedError::with_message("Time#- with Integer argument is not implemented").into());
+    } else if let Ok(other) = other.try_into::<f64>(interp) {
+        let _ = other;
+        return Err(NotImplementedError::with_message("Time#- with Float argument is not implemented").into());
+    } else {
+        return Err(TypeError::with_message("can't convert into an exact number").into());
+    };
+    let difference = time.difference(*other);
+    interp.try_convert_mut(difference)
 }
 
 // Coarse math

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -449,7 +449,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-time"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "chrono",
  "chrono-tz",

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-time"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "chrono",
  "chrono-tz",

--- a/spinoso-time/Cargo.toml
+++ b/spinoso-time/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spinoso-time"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2018"
 description = """

--- a/spinoso-time/src/time/chrono/math.rs
+++ b/spinoso-time/src/time/chrono/math.rs
@@ -1,4 +1,5 @@
 use crate::time::chrono::Time;
+use crate::NANOS_IN_SECOND;
 
 impl Time {
     /// Returns a new Time object, one second later than time.
@@ -26,6 +27,18 @@ impl Time {
             timestamp: timestamp + 1,
             sub_second_nanos,
             offset,
+        }
+    }
+
+    /// Returns the difference between two `Time` objects as an `f64` of seconds.
+    #[must_use]
+    #[allow(clippy::cast_precision_loss)]
+    pub fn difference(self, other: Self) -> f64 {
+        if let Some(sub_second_nanos) = self.sub_second_nanos.checked_sub(other.sub_second_nanos) {
+            (self.timestamp - other.timestamp) as f64 + f64::from(sub_second_nanos) / f64::from(NANOS_IN_SECOND)
+        } else {
+            let sub_second_nanos = NANOS_IN_SECOND - (other.sub_second_nanos - self.sub_second_nanos);
+            (self.timestamp - other.timestamp - 1) as f64 + f64::from(sub_second_nanos) / f64::from(NANOS_IN_SECOND)
         }
     }
 }


### PR DESCRIPTION
Allow computing the difference between two `Time` objects as a `Float`.

This commit fleshes out `Time#-`'s trampoline implementation to prepare
for other permissible argument types, but adds in `NotImplementedError`
stubs.

This commit bumps the version of `spinoso-time` crate to 0.2.0.