### PR TITLE
Add YAML and Summary formatters to `spec-runner` output

### DIFF
--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -512,7 +512,7 @@ dependencies = [
 
 [[package]]
 name = "spec-runner"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "artichoke",
  "clap",

--- a/spec-runner/Cargo.toml
+++ b/spec-runner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spec-runner"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2018"
 description = "Binary for running Ruby Specs with Artichoke Ruby"

--- a/spec-runner/src/mspec.rs
+++ b/spec-runner/src/mspec.rs
@@ -1,6 +1,7 @@
 //! Embedded `MSpec` framework.
 
 use std::path::Path;
+use std::str::FromStr;
 
 use artichoke::backend::load_path::RUBY_LOAD_PATH;
 use artichoke::prelude::*;
@@ -24,12 +25,52 @@ pub fn init(interp: &mut Artichoke) -> Result<(), Error> {
 #[folder = "vendor/mspec/lib"]
 pub struct Sources;
 
+/// `MSpec` formatter strategy.
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Formatter {
+    // Artichoke's `RSpec`-style dot and it block format.
+    Artichoke,
+    /// Output exceptions and summary information in plaintext readable format.
+    Summary,
+    /// Output exceptions and spec summary information in YAML format.
+    Yaml,
+}
+
+impl Default for Formatter {
+    fn default() -> Self {
+        Self::Artichoke
+    }
+}
+
+impl FromStr for Formatter {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            _ if s.eq_ignore_ascii_case("Artichoke") => Ok(Self::Artichoke),
+            _ if s.eq_ignore_ascii_case("Summary") => Ok(Self::Summary),
+            _ if s.eq_ignore_ascii_case("Yaml") => Ok(Self::Yaml),
+            _ => Err("invalid formatter"),
+        }
+    }
+}
+
+impl Formatter {
+    fn into_ruby_class(self) -> &'static str {
+        match self {
+            Self::Artichoke => "Artichoke::Spec::Formatter::Artichoke",
+            Self::Summary => "Artichoke::Spec::Formatter::Summary",
+            Self::Yaml => "Artichoke::Spec::Formatter::Yaml",
+        }
+    }
+}
+
 /// Load the Artichoke `MSpec` entry point end execute the specs.
 ///
 /// # Errors
 ///
 /// If an exception is raised on the Artichoke interpreter, it is returned.
-pub fn run<'a, T>(interp: &mut Artichoke, specs: T) -> Result<bool, Error>
+pub fn run<'a, T>(interp: &mut Artichoke, formatter: Formatter, specs: T) -> Result<bool, Error>
 where
     T: IntoIterator<Item = &'a str>,
 {
@@ -40,19 +81,51 @@ where
 
     interp.eval_file(&virtual_root.join("spec_runner.rb"))?;
 
+    let artichoke_spec_formatter = interp.eval(formatter.into_ruby_class().as_bytes())?;
+
     let specs = interp.try_convert_mut(specs.into_iter().collect::<Vec<_>>())?;
-    let result = interp.top_self().funcall(interp, "run_specs", &[specs], None)?;
+
+    let result = artichoke_spec_formatter.funcall(interp, "run_specs", &[specs], None)?;
     interp.try_convert(result)
 }
 
 #[cfg(test)]
 mod tests {
+    use super::{init, run, Formatter};
+
     #[test]
     fn mspec_framework_loads() {
         let mut interp = artichoke::interpreter().unwrap();
-        super::init(&mut interp).unwrap();
+        init(&mut interp).unwrap();
         // should not panic
-        assert!(super::run(&mut interp, vec![]).unwrap());
+        assert!(run(&mut interp, Formatter::default(), vec![]).unwrap());
+        interp.close();
+    }
+
+    #[test]
+    fn artichoke_formatter_succeeds() {
+        let mut interp = artichoke::interpreter().unwrap();
+        init(&mut interp).unwrap();
+        // should not panic
+        assert!(run(&mut interp, Formatter::Artichoke, vec![]).unwrap());
+        interp.close();
+    }
+
+    #[test]
+    fn summary_formatter_succeeds() {
+        let mut interp = artichoke::interpreter().unwrap();
+        init(&mut interp).unwrap();
+        // should not panic
+        assert!(run(&mut interp, Formatter::Summary, vec![]).unwrap());
+        interp.close();
+    }
+
+    #[test]
+    fn yaml_formatter_succeeds() {
+        let mut interp = artichoke::interpreter().unwrap();
+        init(&mut interp).unwrap();
+        // should not panic
+        assert!(run(&mut interp, Formatter::Yaml, vec![]).unwrap());
         interp.close();
     }
 }

--- a/spec-runner/src/spec_runner.rb
+++ b/spec-runner/src/spec_runner.rb
@@ -7,7 +7,15 @@ if $PROGRAM_NAME == __FILE__
 end
 
 class StubIO
+  def initialize(is_stderr: false)
+    @is_stderr = is_stderr
+  end
+
   def puts(*args)
+    if @is_stderr
+      Kernel.warn(*args)
+      return
+    end
     Kernel.puts(*args)
   end
 
@@ -31,7 +39,7 @@ class StubIO
 end
 
 STDOUT = StubIO.new unless Object.const_defined?(:STDOUT)
-STDERR = StubIO.new unless Object.const_defined?(:STDERR)
+STDERR = StubIO.new(is_stderr: true) unless Object.const_defined?(:STDERR)
 $stdout ||= STDOUT # rubocop:disable Style/GlobalStdStream
 $stderr ||= STDERR # rubocop:disable Style/GlobalStdStream
 

--- a/spec-runner/src/spec_runner.rb
+++ b/spec-runner/src/spec_runner.rb
@@ -7,6 +7,18 @@ if $PROGRAM_NAME == __FILE__
 end
 
 class StubIO
+  def puts(*args)
+    Kernel.puts(*args)
+  end
+
+  def print(*args)
+    Kernel.print(*args)
+  end
+
+  def flush
+    Kernel.puts ''
+  end
+
   def method_missing(method, *args, &block)
     super
   rescue NoMethodError
@@ -20,174 +32,221 @@ end
 
 STDOUT = StubIO.new unless Object.const_defined?(:STDOUT)
 STDERR = StubIO.new unless Object.const_defined?(:STDERR)
+$stdout ||= STDOUT # rubocop:disable Style/GlobalStdStream
+$stderr ||= STDERR # rubocop:disable Style/GlobalStdStream
+
 RUBY_EXE = '/usr/bin/true'
 
 require 'mspec'
 require 'mspec/utils/script'
 
-class SpecCollector
-  RED = "\e[31m"
-  GREEN = "\e[32m"
-  YELLOW = "\e[33m"
-  PLAIN = "\e[0m"
+module Artichoke
+  module Spec
+    module Formatter
+      class Artichoke
+        RED = "\e[31m"
+        GREEN = "\e[32m"
+        YELLOW = "\e[33m"
+        PLAIN = "\e[0m"
 
-  def initialize
-    @errors = []
-    @total = 0
-    @successes = 0
-    @failures = 0
-    @skipped = 0
-    @not_implemented = 0
-    @current_description = nil
-    @spec_state = nil
-  end
+        def self.run_specs(*specs)
+          specs = specs.flatten
+          MSpec.register_files(specs)
 
-  def success?
-    @errors.empty?
-  end
+          collector = new
 
-  def start
-    MSpecScript.set(:backtrace_filter, %r{/lib/mspec/})
-  end
+          MSpec.register(:start, collector)
+          MSpec.register(:enter, collector)
+          MSpec.register(:before, collector)
+          MSpec.register(:after, collector)
+          MSpec.register(:exception, collector)
+          MSpec.register(:finish, collector)
 
-  def enter(description)
-    print "\n", description, ': '
-    @description = description
-  end
+          MSpec.process
 
-  def before(_state)
-    @total += 1
-    @spec_state = nil
-    print '.'
-  end
+          collector.success?
+        end
 
-  def after(_state)
-    print @spec_state if @spec_state
-  end
+        def initialize
+          @errors = []
+          @total = 0
+          @successes = 0
+          @failures = 0
+          @skipped = 0
+          @not_implemented = 0
+          @current_description = nil
+          @spec_state = nil
+        end
 
-  def exception(state)
-    skipped = false
-    case state.exception
-    when ArgumentError
-      skipped = true if state.message =~ /Oniguruma.*UTF-8/
-    when NoMethodError
-      skipped = true if state.message =~ /'allocate'/
-      skipped = true if state.message =~ /'encoding'/
-      skipped = true if state.message =~ /'private_instance_methods'/
-      if state.message =~ /'size'/
-        # Enumerable#size is not implemented on mruby
-        skipped = true
+        def success?
+          @errors.empty?
+        end
+
+        def start
+          MSpecScript.set(:backtrace_filter, %r{/lib/mspec/})
+        end
+
+        def enter(description)
+          print "\n", description, ': '
+          @description = description
+        end
+
+        def before(_state)
+          @total += 1
+          @spec_state = nil
+          print '.'
+        end
+
+        def after(_state)
+          print @spec_state if @spec_state
+        end
+
+        def exception(state)
+          skipped = false
+          case state.exception
+          when ArgumentError
+            skipped = true if state.message =~ /Oniguruma.*UTF-8/
+          when NoMethodError
+            skipped = true if state.message =~ /'allocate'/
+            skipped = true if state.message =~ /'encoding'/
+            skipped = true if state.message =~ /'private_instance_methods'/
+            if state.message =~ /'size'/
+              # Enumerable#size is not implemented on mruby
+              skipped = true
+            end
+            skipped = true if state.message =~ /'taint'/
+            skipped = true if state.message =~ /'tainted\?'/
+            skipped = true if state.message =~ /'untrust'/
+            skipped = true if state.message =~ /'untrusted\?'/
+            skipped = true if state.message =~ /undefined method 'Rational'/
+          when NameError
+            skipped = true if state.message =~ /uninitialized constant Bignum/
+          when SpecExpectationNotMetError
+            skipped = true if state.it =~ /encoding/
+            skipped = true if state.it =~ /ASCII/
+            skipped = true if state.it =~ /is too big/ # mruby does not have Bignum
+            skipped = true if state.it =~ /hexadecimal digits/
+          when SyntaxError
+            skipped = true if state.it =~ /ASCII/
+            skipped = true if state.it =~ /hexadecimal digits/
+            skipped = true if state.message =~ /Regexp pattern/
+          when TypeError
+            skipped = true if state.it =~ /encoding/
+          when NotImplementedError
+            @not_implemented += 1
+            @spec_state = "\b#{YELLOW}N#{PLAIN}"
+            return
+          when RuntimeError
+            skipped = true if state.message =~ /invalid UTF-8/
+          end
+          skipped = true if state.it == 'does not add a URI method to Object instances'
+          skipped = true if state.it == 'is multi-byte character sensitive'
+          skipped = true if state.it =~ /UTF-8/
+          skipped = true if state.it =~ /\\u/
+
+          skipped = true if state.describe == 'Regexp#initialize'
+
+          skipped = true if state.it =~ /Bignum/
+
+          if skipped
+            @skipped += 1
+            @spec_state = "\b#{YELLOW}S#{PLAIN}"
+          else
+            @errors << state
+            @spec_state = "\b#{RED}X#{PLAIN}"
+          end
+          nil
+        end
+
+        def finish
+          failures = @errors.length
+          successes = @total - @skipped - @not_implemented - failures
+          successes = 0 if successes.negative?
+          puts "\n"
+
+          if failures.zero?
+            report(
+              color: GREEN,
+              successes: successes,
+              skipped: @skipped,
+              not_implemented: @not_implemented,
+              failed: failures
+            )
+            return
+          end
+
+          report(
+            color: RED,
+            successes: successes,
+            skipped: @skipped,
+            not_implemented: @not_implemented,
+            failed: failures
+          )
+          @errors.each do |state|
+            puts '',
+                 "#{RED}#{state.description}#{PLAIN}",
+                 "#{RED}#{state.exception.class}: #{state.exception}#{PLAIN}"
+            puts '', state.backtrace unless state.exception.is_a?(SystemStackError)
+          end
+          puts ''
+          report(
+            color: RED,
+            successes: successes,
+            skipped: @skipped,
+            not_implemented: @not_implemented,
+            failed: failures
+          )
+        end
+
+        def report(color:, successes:, skipped:, not_implemented:, failed:)
+          print color
+          print "Passed #{successes}, "
+          print "skipped #{skipped}, "
+          print "not implemented #{not_implemented}, "
+          print "failed #{failed} specs."
+          print PLAIN, "\n"
+        end
       end
-      skipped = true if state.message =~ /'taint'/
-      skipped = true if state.message =~ /'tainted\?'/
-      skipped = true if state.message =~ /'untrust'/
-      skipped = true if state.message =~ /'untrusted\?'/
-      skipped = true if state.message =~ /undefined method 'Rational'/
-    when NameError
-      skipped = true if state.message =~ /uninitialized constant Bignum/
-    when SpecExpectationNotMetError
-      skipped = true if state.it =~ /encoding/
-      skipped = true if state.it =~ /ASCII/
-      skipped = true if state.it =~ /is too big/ # mruby does not have Bignum
-      skipped = true if state.it =~ /hexadecimal digits/
-    when SyntaxError
-      skipped = true if state.it =~ /ASCII/
-      skipped = true if state.it =~ /hexadecimal digits/
-      skipped = true if state.message =~ /Regexp pattern/
-    when TypeError
-      skipped = true if state.it =~ /encoding/
-    when NotImplementedError
-      @not_implemented += 1
-      @spec_state = "\b#{YELLOW}N#{PLAIN}"
-      return
-    when RuntimeError
-      skipped = true if state.message =~ /invalid UTF-8/
+
+      class Summary
+        def self.run_specs(*specs)
+          specs = specs.flatten
+          MSpec.register_files(specs)
+
+          MSpecScript.set(:backtrace_filter, %r{/lib/mspec/})
+
+          formatter = SummaryFormatter.new
+          formatter.register
+
+          MSpec.process
+
+          return false unless formatter.tally.counter.failures.zero?
+          return false unless formatter.tally.counter.errors.zero?
+
+          true
+        end
+      end
+
+      class Yaml
+        def self.run_specs(*specs)
+          specs = specs.flatten
+          MSpec.register_files(specs)
+
+          MSpecScript.set(:backtrace_filter, %r{/lib/mspec/})
+
+          formatter = YamlFormatter.new
+          formatter.register
+
+          MSpec.process
+
+          return false unless formatter.tally.counter.failures.zero?
+          return false unless formatter.tally.counter.errors.zero?
+
+          true
+        end
+      end
     end
-    skipped = true if state.it == 'does not add a URI method to Object instances'
-    skipped = true if state.it == 'is multi-byte character sensitive'
-    skipped = true if state.it =~ /UTF-8/
-    skipped = true if state.it =~ /\\u/
-
-    skipped = true if state.describe == 'Regexp#initialize'
-
-    skipped = true if state.it =~ /Bignum/
-
-    if skipped
-      @skipped += 1
-      @spec_state = "\b#{YELLOW}S#{PLAIN}"
-    else
-      @errors << state
-      @spec_state = "\b#{RED}X#{PLAIN}"
-    end
-    nil
   end
-
-  def finish
-    failures = @errors.length
-    successes = @total - @skipped - @not_implemented - failures
-    successes = 0 if successes.negative?
-    puts "\n"
-
-    if failures.zero?
-      report(
-        color: GREEN,
-        successes: successes,
-        skipped: @skipped,
-        not_implemented: @not_implemented,
-        failed: failures
-      )
-      return
-    end
-
-    report(
-      color: RED,
-      successes: successes,
-      skipped: @skipped,
-      not_implemented: @not_implemented,
-      failed: failures
-    )
-    @errors.each do |state|
-      puts '',
-           "#{RED}#{state.description}#{PLAIN}",
-           "#{RED}#{state.exception.class}: #{state.exception}#{PLAIN}"
-      puts '', state.backtrace unless state.exception.is_a?(SystemStackError)
-    end
-    puts ''
-    report(
-      color: RED,
-      successes: successes,
-      skipped: @skipped,
-      not_implemented: @not_implemented,
-      failed: failures
-    )
-  end
-
-  def report(color:, successes:, skipped:, not_implemented:, failed:)
-    print color
-    print "Passed #{successes}, "
-    print "skipped #{skipped}, "
-    print "not implemented #{not_implemented}, "
-    print "failed #{failed} specs."
-    print PLAIN, "\n"
-  end
-end
-
-def run_specs(*specs)
-  specs = specs.flatten
-  MSpec.register_files(specs)
-
-  collector = SpecCollector.new
-
-  MSpec.register(:start, collector)
-  MSpec.register(:enter, collector)
-  MSpec.register(:before, collector)
-  MSpec.register(:after, collector)
-  MSpec.register(:exception, collector)
-  MSpec.register(:finish, collector)
-
-  MSpec.process
-
-  collector.success?
 end
 
 if $PROGRAM_NAME == __FILE__
@@ -198,5 +257,5 @@ if $PROGRAM_NAME == __FILE__
 
     false
   end
-  run_specs(*specs)
+  Artichoke::Spec::Formatter::Artichoke.run_specs(*specs)
 end


### PR DESCRIPTION
This commit adds an optional `--format` flag to the `spec-runner` which
allows for different output formats. In addition to the existing
`artichoke` formatter, this commit adds support for a `summary`
formatter and a `yaml` formatter.

The `summary` and `yaml` formatters are based off of the built-in
formatters in `MSpec`. These formatters output raised exceptions and
backtraces as well as summary statistics (including elapsed time as
enabled by #1318).

The `summary` and `yaml` formatters do not do any exception filtering
for known failing cases like the `artichoke` formatter does. This makes
these formatters appropriate for computing historical spec pass rates.