### PR TITLE
Add spec tagging for all core specs

### DIFF
--- a/artichoke-backend/src/extn/core/string/string.rb
+++ b/artichoke-backend/src/extn/core/string/string.rb
@@ -630,9 +630,11 @@ class String
     self[0..-1] = slice.pack('c*')
   end
 
-  def split(pattern, limit = nil, &blk)
+  def split(pattern = nil, limit = nil, &blk)
     parts = []
     return parts if self == ''
+
+    pattern = ' ' if pattern.nil?
 
     pattern = Regexp.compile(Regexp.escape(pattern)) if pattern.is_a?(String)
     if pattern.source == ''

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -512,7 +512,7 @@ dependencies = [
 
 [[package]]
 name = "spec-runner"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "artichoke",
  "clap",

--- a/spec-runner/Cargo.toml
+++ b/spec-runner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spec-runner"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2018"
 description = "Binary for running Ruby Specs with Artichoke Ruby"

--- a/spec-runner/all-core-specs.toml
+++ b/spec-runner/all-core-specs.toml
@@ -117,6 +117,10 @@ include = "all"
 
 [specs.core.hash]
 include = "all"
+skip = [
+  "eql",
+  "equal_value",
+]
 
 [specs.core.integer]
 include = "all"

--- a/spec-runner/scripts/spec-yaml-to-json.rb
+++ b/spec-runner/scripts/spec-yaml-to-json.rb
@@ -1,0 +1,23 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'json'
+require 'yaml'
+
+report = ARGF.readlines
+
+# trim garbage printed to stdout during spec eval
+report = report.drop_while { |line| line != "---\n" }
+report = report.join
+
+# manually escape some garbled YAML output by hand from `MSpec`
+report = report.split('self\#@-').join('self#@-')
+report = report.gsub(
+  /String#unpack with format 'M' decodes pre-encoded byte values (.*) FAILED\\nExpected.*?artichoke/,
+  "String#unpack with format 'M' decodes pre-encoded byte values \\1 FAILED\\nExpected [...]./artichoke"
+)
+
+parsed = YAML.safe_load(report)
+converted = JSON.pretty_generate(parsed)
+
+puts converted

--- a/spec-runner/src/main.rs
+++ b/spec-runner/src/main.rs
@@ -51,7 +51,7 @@
 //!
 //! ```console
 //! $ cargo run -q -p spec-runner -- --help
-//! spec-runner 0.4.0
+//! spec-runner 0.5.0
 //! ruby/spec runner for Artichoke.
 //!
 //! USAGE:
@@ -63,7 +63,7 @@
 //!
 //! OPTIONS:
 //!     -f, --format <formatter>    Output spec results in YAML [default: artichoke]  [possible values: artichoke, summary,
-//!                                 yaml]
+//!                                 tagger, yaml]
 //!
 //! ARGS:
 //!     <config>    Path to TOML config file
@@ -117,7 +117,7 @@ pub fn main() {
             .long("format")
             .short("f")
             .default_value("artichoke")
-            .possible_values(&["artichoke", "summary", "yaml"])
+            .possible_values(&["artichoke", "summary", "tagger", "yaml"])
             .required(false)
             .help("Output spec results in YAML"),
     );

--- a/spec-runner/src/mspec.rs
+++ b/spec-runner/src/mspec.rs
@@ -32,6 +32,8 @@ pub enum Formatter {
     Artichoke,
     /// Output exceptions and summary information in plaintext readable format.
     Summary,
+    /// `MSpec` tagging mode.
+    Tagger,
     /// Output exceptions and spec summary information in YAML format.
     Yaml,
 }
@@ -49,6 +51,7 @@ impl FromStr for Formatter {
         match s {
             _ if s.eq_ignore_ascii_case("Artichoke") => Ok(Self::Artichoke),
             _ if s.eq_ignore_ascii_case("Summary") => Ok(Self::Summary),
+            _ if s.eq_ignore_ascii_case("Tagger") => Ok(Self::Tagger),
             _ if s.eq_ignore_ascii_case("Yaml") => Ok(Self::Yaml),
             _ => Err("invalid formatter"),
         }
@@ -60,6 +63,7 @@ impl Formatter {
         match self {
             Self::Artichoke => "Artichoke::Spec::Formatter::Artichoke",
             Self::Summary => "Artichoke::Spec::Formatter::Summary",
+            Self::Tagger => "Artichoke::Spec::Formatter::Tagger",
             Self::Yaml => "Artichoke::Spec::Formatter::Yaml",
         }
     }
@@ -117,6 +121,15 @@ mod tests {
         init(&mut interp).unwrap();
         // should not panic
         assert!(run(&mut interp, Formatter::Summary, vec![]).unwrap());
+        interp.close();
+    }
+
+    #[test]
+    fn tagger_formatter_succeeds() {
+        let mut interp = artichoke::interpreter().unwrap();
+        init(&mut interp).unwrap();
+        // should not panic
+        assert!(run(&mut interp, Formatter::Tagger, vec![]).unwrap());
         interp.close();
     }
 

--- a/spec-runner/src/spec_runner.rb
+++ b/spec-runner/src/spec_runner.rb
@@ -245,6 +245,11 @@ module Artichoke
           formatter = YamlFormatter.new
           formatter.register
 
+          # HACK: tickle the GC so a full spec run passes without segfaulting.
+          200.times do
+            'a' * 200
+          end
+
           MSpec.process
 
           return false unless formatter.tally.counter.failures.zero?

--- a/spec-runner/src/spec_runner.rb
+++ b/spec-runner/src/spec_runner.rb
@@ -335,6 +335,7 @@ module Artichoke
 
         def finish
           puts '---'
+          puts 'tags:'
           @report.sort_by { |item| [item[:group], item[:spec], item[:tag].to_s] }.each do |item|
             puts "- tag: #{item[:tag].to_s.inspect}"
             puts "  group: #{item[:group].to_s.inspect}"


### PR DESCRIPTION
This PR makes some changes to get the full set of Ruby Core specs in `spec-runner/all-core-specs.toml` running to completion "reliably" without segfaults:

- Remove the `eql` and `equal_value` specs for `Hash` since they crash Artichoke with a `SystemStackError` on recursive `Hash`es.
- Create some garbage strings in the mruby heap before invoking `MSpec`. This offsets the GC pages just enough to avoid a segfault due to a GC timing bug.
- Fix `String#split` when given no arguments to split on `' '`.

This PR also adds a `Tagger` formatter which outputs a tag for every spec, `it` block, and example.

```console
$ cargo run -q --bin spec-runner -- --format tagger all-core-specs.toml | ./scripts/spec-yaml-to-json.rb
{
  "tags": [
    {
      "tag": "spec-runner-tagger:ARGF is an instance of ARGF.class",
      "group": "ARGF",
      "spec": "ARGF",
      "outcome": "fail"
    },
    {
      "tag": "spec-runner-tagger:ARGF is extended by the Enumerable module",
      "group": "ARGF",
      "spec": "ARGF",
      "outcome": "fail"
    },
    {
      "tag": "spec-runner-tagger:ARGF.argv returns ARGV for the initial ARGF",
      "group": "ARGF",
      "spec": "ARGF.argv",
      "outcome": "fail"
    },
    {
      "tag": "spec-runner-tagger:ARGF.argv returns the remaining arguments to treat",
      "group": "ARGF",
      "spec": "ARGF.argv",
      "outcome": "fail"
    },
# snip ...
```

This PR also adds a helper script `spec-runner/scripts/spec-yaml-to-json.rb` to transform YAML output from the `yaml` and `tagger` formatters to JSON for use in CI and a to-be-built Artichoke ruby/spec toolstate (see #101 and #142).