### PR TITLE
Improve parsing of radix parameter for `Kernel::Integer`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,6 +31,7 @@ GEM
 
 PLATFORMS
   ruby
+  x64-mingw32
 
 DEPENDENCIES
   bundler-audit (~> 0.8)

--- a/artichoke-backend/src/extn/core/kernel/integer.rs
+++ b/artichoke-backend/src/extn/core/kernel/integer.rs
@@ -361,6 +361,26 @@ mod tests {
     use super::{method as integer, Radix};
 
     #[test]
+    fn radix_new_validates_radix_is_nonzero() {
+        let radix = Radix::new(0);
+        assert!(radix.is_none());
+    }
+
+    #[test]
+    fn radix_new_parses_valid_radixes() {
+        for r in 2..=36 {
+            let radix = Radix::new(r);
+            assert!(radix.is_some());
+        }
+    }
+
+    #[test]
+    fn radix_new_rejects_too_large_radixes() {
+        let radix = Radix::new(12000);
+        assert!(radix.is_none());
+    }
+
+    #[test]
     fn no_digits_with_base_prefix() {
         let result = integer("0x".into(), None);
         assert!(result.is_err());

--- a/artichoke-backend/src/extn/core/kernel/integer.rs
+++ b/artichoke-backend/src/extn/core/kernel/integer.rs
@@ -73,10 +73,8 @@ impl TryConvertMut<Option<Value>, Option<Radix>> for Artichoke {
                     .checked_neg()
                     .ok_or_else(|| ArgumentError::with_message("invalid radix"))?;
                 match u32::try_from(num) {
-                    // Safety `10` is a valid radix since it is between 2 and 36.
-                    //
                     // See https://github.com/ruby/ruby/blob/v2_6_3/bignum.c#L4106-L4110
-                    Ok(1) => return unsafe { Ok(Some(Radix::new_unchecked(10))) },
+                    Ok(1) => return Ok(Some(Radix::default())),
                     Ok(radix) => radix,
                     Err(_) => {
                         let mut message = String::from("invalid radix ");


### PR DESCRIPTION
- Move validation for proper radix range of `[2, 36]` to `Radix::new` constructor.
- Add tests for `Radix::new` constructor.
- Fix `should_panic` test so it is properly implemented and passes without the `should_panic` annotation.
- Handle -1 radix which should be parsed to `Some(10)`.
- Handle `[-36, -2]` radixes which should be parsed as if they were positive.
- Add tests for `TryConvertMut` impl for `Radix`.
- Add tests for converting `i64::MAX` and `i64::MIN` to check for panics from improper negation.