### PR TITLE
Properly refer to step outputs in spec-state workflow

### DIFF
--- a/.github/workflows/spec-state.yaml
+++ b/.github/workflows/spec-state.yaml
@@ -97,30 +97,30 @@ jobs:
 
       - name: Generate spec tags
         run: |
-          ( ./artichoke/spec-runner/target/debug/spec-runner --format tagger artichoke/spec-runner/all-core-specs.toml || : ) | tee "${{ steps.tagged.yaml }}"
-          ./artichoke/spec-runner/scripts/spec-yaml-to-json.rb "${{ steps.tagged.yaml }}" > "${{ steps.tagged.json }}"
-          mkdir -p "spec-state/reports/tagged/${{ steps.commit.year }}/${{ steps.commit.month }}"
-          cp "${{ steps.tagged.json }}" "spec-state/reports/tagged/${{ steps.commit.year }}/${{ steps.commit.month }}/${{ steps.tagged.json }}"
-          cp "${{ steps.tagged.json }}" "spec-state/reports/tagged/${{ steps.commit.year }}/${{ steps.commit.month }}/latest.json"
-          cp "${{ steps.tagged.json }}" "spec-state/reports/tagged/${{ steps.commit.year }}/latest.json"
-          cp "${{ steps.tagged.json }}" "spec-state/reports/tagged/latest.json"
+          ( ./artichoke/spec-runner/target/debug/spec-runner --format tagger artichoke/spec-runner/all-core-specs.toml || : ) | tee "${{ steps.tagged.outputs.yaml }}"
+          ./artichoke/spec-runner/scripts/spec-yaml-to-json.rb "${{ steps.tagged.outputs.yaml }}" > "${{ steps.tagged.outputs.json }}"
+          mkdir -p "spec-state/reports/tagged/${{ steps.commit.outputs.year }}/${{ steps.commit.outputs.month }}"
+          cp "${{ steps.tagged.outputs.json }}" "spec-state/reports/tagged/${{ steps.commit.outputs.year }}/${{ steps.commit.outputs.month }}/${{ steps.tagged.outputs.json }}"
+          cp "${{ steps.tagged.outputs.json }}" "spec-state/reports/tagged/${{ steps.commit.outputs.year }}/${{ steps.commit.outputs.month }}/latest.json"
+          cp "${{ steps.tagged.outputs.json }}" "spec-state/reports/tagged/${{ steps.commit.outputs.year }}/latest.json"
+          cp "${{ steps.tagged.outputs.json }}" "spec-state/reports/tagged/latest.json"
 
       - name: Generate spec exceptions
         run: |
-          ( ./artichoke/spec-runner/target/debug/spec-runner --format yaml artichoke/spec-runner/all-core-specs.toml || : ) | tee "${{ steps.exceptions.yaml }}"
-          ./artichoke/spec-runner/scripts/spec-yaml-to-json.rb "${{ steps.exceptions.yaml }}" > "${{ steps.exceptions.json }}"
-          mkdir -p "spec-state/reports/exceptions/${{ steps.commit.year }}/${{ steps.commit.month }}"
-          cp "${{ steps.exceptions.json }}" "spec-state/reports/exceptions/${{ steps.commit.year }}/${{ steps.commit.month }}/${{ steps.exceptions.json }}"
-          cp "${{ steps.exceptions.json }}" "spec-state/reports/exceptions/${{ steps.commit.year }}/${{ steps.commit.month }}/latest.json"
-          cp "${{ steps.exceptions.json }}" "spec-state/reports/exceptions/${{ steps.commit.year }}/latest.json"
-          cp "${{ steps.exceptions.json }}" "spec-state/reports/exceptions/latest.json"
+          ( ./artichoke/spec-runner/target/debug/spec-runner --format yaml artichoke/spec-runner/all-core-specs.toml || : ) | tee "${{ steps.exceptions.outputs.yaml }}"
+          ./artichoke/spec-runner/scripts/spec-yaml-to-json.rb "${{ steps.exceptions.outputs.yaml }}" > "${{ steps.exceptions.outputs.json }}"
+          mkdir -p "spec-state/reports/exceptions/${{ steps.commit.outputs.year }}/${{ steps.commit.outputs.month }}"
+          cp "${{ steps.exceptions.outputs.json }}" "spec-state/reports/exceptions/${{ steps.commit.outputs.year }}/${{ steps.commit.outputs.month }}/${{ steps.exceptions.outputs.json }}"
+          cp "${{ steps.exceptions.outputs.json }}" "spec-state/reports/exceptions/${{ steps.commit.outputs.year }}/${{ steps.commit.outputs.month }}/latest.json"
+          cp "${{ steps.exceptions.outputs.json }}" "spec-state/reports/exceptions/${{ steps.commit.outputs.year }}/latest.json"
+          cp "${{ steps.exceptions.outputs.json }}" "spec-state/reports/exceptions/latest.json"
 
       - name: Push spec-state
         run: |
           cat <<EOF > message.txt
           spec-state 💎📈
 
-          As of artichoke/artichoke@${{ steps.commit.hash }}.
+          As of artichoke/artichoke@${{ steps.commit.outputs.hash }}.
 
           Generated with the spec-state.yaml GitHub Actions workflow.
           EOF


### PR DESCRIPTION
Fix for #1328, #1329.