### PR TITLE
git -c flags to set git config go before the sub command

### DIFF
--- a/.github/workflows/spec-state.yaml
+++ b/.github/workflows/spec-state.yaml
@@ -125,6 +125,6 @@ jobs:
           Generated with the spec-state.yaml GitHub Actions workflow.
           EOF
           git add reports
-          git commit -c user.name=artichoke-ci -c user.email=ci@artichokeruby.org --file=message.txt --allow-empty
+          git -c user.name=artichoke-ci -c user.email=ci@artichokeruby.org commit --file=message.txt --allow-empty
           git push origin trunk
         working-directory: "spec-state"


### PR DESCRIPTION
Gah! so close.

Fix #1331.