### PR TITLE
Fix broken subshell invocations in spec-state workflow

### DIFF
--- a/.github/workflows/spec-state.yaml
+++ b/.github/workflows/spec-state.yaml
@@ -47,9 +47,9 @@ jobs:
         id: commit
         run: |
           commit_date="$(git show --no-patch --format="%cs")"
-          commit_year="(git show --no-patch --date="format:%Y" --format="%cd")"
-          commit_month="(git show --no-patch --date="format:%m" --format="%cd")"
-          commit_hash="(git show --no-patch --format="%H")"
+          commit_year="$(git show --no-patch --date="format:%Y" --format="%cd")"
+          commit_month="$(git show --no-patch --date="format:%m" --format="%cd")"
+          commit_hash="$(git show --no-patch --format="%H")"
 
           echo "Commit date: ${commit_date}"
           echo "Commit year: ${commit_year}"


### PR DESCRIPTION
Once more!

Fix for #1328, #1329, #1330, #1331, #1332.