### PR TITLE
Propagate `fmt::Error` and `io::Error` in more places

### DIFF
--- a/artichoke-backend/src/state/output.rs
+++ b/artichoke-backend/src/state/output.rs
@@ -16,14 +16,15 @@ pub trait Output: Send + Sync {
 
     fn write_stderr<T: AsRef<[u8]>>(&mut self, bytes: T) -> io::Result<()>;
 
-    fn print<T: AsRef<[u8]>>(&mut self, bytes: T) {
-        let _ = self.write_stdout(bytes);
+    fn print<T: AsRef<[u8]>>(&mut self, bytes: T) -> io::Result<()> {
+        self.write_stdout(bytes)?;
+        Ok(())
     }
 
-    fn puts<T: AsRef<[u8]>>(&mut self, bytes: T) {
-        if self.write_stdout(bytes).is_ok() {
-            let _ = self.write_stdout(b"\n");
-        }
+    fn puts<T: AsRef<[u8]>>(&mut self, bytes: T) -> io::Result<()> {
+        self.write_stdout(bytes)?;
+        self.write_stdout(b"\n")?;
+        Ok(())
     }
 }
 

--- a/artichoke-backend/src/warn.rs
+++ b/artichoke-backend/src/warn.rs
@@ -8,6 +8,7 @@ use crate::extn::core::warning::Warning;
 use crate::ffi::InterpreterExtractError;
 use crate::module_registry::ModuleRegistry;
 use crate::state::output::Output;
+use crate::string::WriteError;
 use crate::Artichoke;
 
 impl Warn for Artichoke {
@@ -17,24 +18,24 @@ impl Warn for Artichoke {
         let state = self.state.as_deref_mut().ok_or_else(InterpreterExtractError::new)?;
         if let Err(err) = state.output.write_stderr(b"rb warning: ") {
             let mut message = String::from("Failed to write warning to $stderr: ");
-            let _ = write!(&mut message, "{}", err);
+            write!(&mut message, "{}", err).map_err(WriteError::from)?;
             return Err(IOError::from(message).into());
         }
         if let Err(err) = state.output.write_stderr(message) {
             let mut message = String::from("Failed to write warning to $stderr: ");
-            let _ = write!(&mut message, "{}", err);
+            write!(&mut message, "{}", err).map_err(WriteError::from)?;
             return Err(IOError::from(message).into());
         }
         if let Err(err) = state.output.write_stderr(b"\n") {
             let mut message = String::from("Failed to write warning to $stderr: ");
-            let _ = write!(&mut message, "{}", err);
+            write!(&mut message, "{}", err).map_err(WriteError::from)?;
             return Err(IOError::from(message).into());
         }
         let warning = self
             .module_of::<Warning>()?
             .ok_or_else(|| NotDefinedError::module("Warning"))?;
         let message = self.convert_mut(message);
-        let _ = warning.funcall(self, "warn", &[message], None)?;
+        warning.funcall(self, "warn", &[message], None)?;
         Ok(())
     }
 }

--- a/spec-runner/src/main.rs
+++ b/spec-runner/src/main.rs
@@ -142,6 +142,8 @@ pub fn main() {
     let formatter = match formatter {
         Ok(f) => f,
         Err(err) => {
+            // Suppress all errors at this point (e.g. from a broken pipe) since
+            // we're exiting with an error code anyway.
             let _ = writeln!(&mut stderr, "{}", err);
             process::exit(1);
         }
@@ -153,6 +155,8 @@ pub fn main() {
             formatter,
         }
     } else {
+        // Suppress all errors at this point (e.g. from a broken pipe) since
+        // we're exiting with an error code anyway.
         let _ = writeln!(&mut stderr, "Missing required spec configuration");
         process::exit(1);
     };
@@ -161,6 +165,8 @@ pub fn main() {
         Ok(true) => process::exit(0),
         Ok(false) => process::exit(1),
         Err(err) => {
+            // Suppress all errors at this point (e.g. from a broken pipe) since
+            // we're exiting with an error code anyway.
             let _ = writeln!(&mut stderr, "{}", err);
             process::exit(1);
         }

--- a/src/bin/airb.rs
+++ b/src/bin/airb.rs
@@ -27,15 +27,19 @@
 #![doc(html_favicon_url = "https://www.artichokeruby.org/favicon-32x32.png")]
 #![doc(html_logo_url = "https://www.artichokeruby.org/artichoke-logo.svg")]
 
-use artichoke::repl;
 use std::io::{self, Write};
 use std::process;
+
+use artichoke::repl;
 use termcolor::{ColorChoice, StandardStream, WriteColor};
 
 fn main() {
     let mut stderr = StandardStream::stderr(ColorChoice::Auto);
     if let Err(err) = repl::run(io::stdout(), &mut stderr, None) {
-        // reset colors
+        // Reset colors and write the error message to stderr.
+        //
+        // Suppress all errors at this point (e.g. from a broken pipe) since
+        // we're exiting with an error code anyway.
         let _ = stderr.reset();
         let _ = writeln!(stderr, "{}", err);
         process::exit(1);

--- a/src/bin/artichoke.rs
+++ b/src/bin/artichoke.rs
@@ -41,14 +41,15 @@
 //!     <programfile>...
 //! ```
 
-use artichoke::ruby::{self, Args};
-use clap::{App, AppSettings, Arg, ArgMatches};
 use std::env;
 use std::error;
 use std::ffi::OsString;
 use std::io::{self, Write};
 use std::path::PathBuf;
 use std::process;
+
+use artichoke::ruby::{self, Args};
+use clap::{App, AppSettings, Arg, ArgMatches};
 use termcolor::{ColorChoice, StandardStream, WriteColor};
 
 type Result<T> = ::std::result::Result<T, Box<dyn error::Error>>;


### PR DESCRIPTION
Sometimes code in `artichoke-backend` suppresses `io::Error` and
`fmt::Error` from the `write!` macro despite the error occuring in a
fallible function. Change these functions to convert the error to an
`artichoke-backend` `WriteError` or `IoError` so these failures are
surfaced as exceptions.

This commit also makes `Output::print` and `Output::puts` return
`io::Result`.

For cases where suppressing errors from `write!` is intentional, add
comments documenting why the error suppression is present.

This commit includes some tactical cleanups for import grouping style.