### PR TITLE
Make more `MrbGarbageCollection` trait APIs fallible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "artichoke-backend"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "artichoke-core",
  "artichoke-load-path",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ rustyline = { version = "8", optional = true, default-features = false }
 termcolor = { version = "1.1", optional = true }
 
 [dependencies.artichoke-backend]
-version = "0.1"
+version = "0.2"
 path = "artichoke-backend"
 default-features = false
 

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "artichoke-backend"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2018"
 description = "Embeddable VM implementation for Artichoke Ruby"

--- a/artichoke-backend/src/extn/core/array/trampoline.rs
+++ b/artichoke-backend/src/extn/core/array/trampoline.rs
@@ -94,7 +94,7 @@ pub fn element_assignment(
     }
     let mut array = unsafe { Array::unbox_from_value(&mut ary, interp)? };
 
-    let prior_gc_state = interp.disable_gc();
+    let prior_gc_state = interp.disable_gc()?;
 
     let result = array.element_assignment(interp, first, second, third);
 
@@ -104,7 +104,7 @@ pub fn element_assignment(
     }
 
     if let GcState::Enabled = prior_gc_state {
-        interp.enable_gc();
+        interp.enable_gc()?;
     }
     result
 }

--- a/artichoke-backend/src/interpreter.rs
+++ b/artichoke-backend/src/interpreter.rs
@@ -51,7 +51,7 @@ pub fn interpreter_with_config(config: ReleaseMetadata<'_>) -> Result<Artichoke,
     // mruby garbage collection relies on a fully initialized Array, which we
     // won't have until after `extn::core` is initialized. Disable GC before
     // init and clean up afterward.
-    let prior_gc_state = interp.disable_gc();
+    let prior_gc_state = interp.disable_gc()?;
 
     // Initialize Artichoke Core and Standard Library runtime
     debug!("Begin initializing Artichoke Core and Standard Library");
@@ -77,8 +77,8 @@ pub fn interpreter_with_config(config: ReleaseMetadata<'_>) -> Result<Artichoke,
     interp.create_arena_savepoint()?.interp().eval(&[])?;
 
     if let GcState::Enabled = prior_gc_state {
-        interp.enable_gc();
-        interp.full_gc();
+        interp.enable_gc()?;
+        interp.full_gc()?;
     }
 
     Ok(interp)

--- a/artichoke-backend/src/value.rs
+++ b/artichoke-backend/src/value.rs
@@ -506,7 +506,7 @@ mod tests {
         let dead = live;
         let live = arena.eval(b"'live'").unwrap();
         arena.restore();
-        interp.full_gc();
+        interp.full_gc().unwrap();
         // unreachable objects are dead after a full garbage collection
         assert!(dead.is_dead(&mut interp));
         // the result of the most recent eval is always live even after a full
@@ -523,7 +523,7 @@ mod tests {
         let immediate = live;
         let live = arena.eval(b"64").unwrap();
         arena.restore();
-        interp.full_gc();
+        interp.full_gc().unwrap();
         // immediate objects are never dead
         assert!(!immediate.is_dead(&mut interp));
         // the result of the most recent eval is always live even after a full

--- a/artichoke-backend/tests/integration/gc.rs
+++ b/artichoke-backend/tests/integration/gc.rs
@@ -17,7 +17,7 @@ const ITERATIONS: usize = 10_000;
 fn full_gc_repeatedly() {
     let mut interp = artichoke_backend::interpreter().unwrap();
     for _ in 0..ITERATIONS {
-        interp.full_gc();
+        interp.full_gc().unwrap();
     }
     interp.close();
 }
@@ -26,8 +26,8 @@ fn full_gc_repeatedly() {
 fn incremental_gc_repeatedly() {
     let mut interp = artichoke_backend::interpreter().unwrap();
     for _ in 0..ITERATIONS {
-        interp.incremental_gc();
+        interp.incremental_gc().unwrap();
     }
-    interp.full_gc();
+    interp.full_gc().unwrap();
     interp.close();
 }

--- a/artichoke-backend/tests/integration/leak/arena_growth.rs
+++ b/artichoke-backend/tests/integration/leak/arena_growth.rs
@@ -33,7 +33,7 @@ fn unbounded_arena_growth_leak_current_exception() {
         assert_eq!(expected, backtrace);
         drop(result);
         arena.restore();
-        interp.incremental_gc();
+        interp.incremental_gc().unwrap();
     }
     interp.close();
 }
@@ -47,11 +47,10 @@ fn unbounded_arena_growth_leak_to_s() {
         let result = arena.eval(b"'a' * 1024 * 1024").unwrap();
         let display = result.to_s(&mut arena);
         assert_eq!(display, expected.as_bytes());
-        let _ = result;
         arena.restore();
-        interp.incremental_gc();
+        interp.incremental_gc().unwrap();
     }
-    interp.full_gc();
+    interp.full_gc().unwrap();
     interp.close();
 }
 
@@ -69,10 +68,9 @@ fn unbounded_arena_growth_leak_inspect() {
         let result = arena.eval(b"'a' * 1024 * 1024").unwrap();
         let debug = result.inspect(&mut arena);
         assert_eq!(debug, expected);
-        let _ = result;
         arena.restore();
-        interp.incremental_gc();
+        interp.incremental_gc().unwrap();
     }
-    interp.full_gc();
+    interp.full_gc().unwrap();
     interp.close();
 }

--- a/artichoke-backend/tests/integration/leak/funcall.rs
+++ b/artichoke-backend/tests/integration/leak/funcall.rs
@@ -27,7 +27,7 @@ fn arena() {
         let inspect = s.funcall(&mut interp, "inspect", &[], None).unwrap();
         let inspect = inspect.try_into_mut::<String>(&mut interp).unwrap();
         assert_eq!(inspect, expected);
-        interp.incremental_gc();
+        interp.incremental_gc().unwrap();
     }
     interp.close();
 }

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "artichoke-backend"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "artichoke-core",
  "artichoke-load-path",

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -32,7 +32,7 @@ dependencies = [
 
 [[package]]
 name = "artichoke-backend"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "artichoke-core",
  "artichoke-load-path",

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -264,7 +264,7 @@ where
                 }
                 // Eval successful, so reset the REPL state for the next
                 // expression.
-                interp.incremental_gc();
+                interp.incremental_gc()?;
                 buf.clear();
             }
             // Reset the buf and present the user with a fresh prompt


### PR DESCRIPTION
Many methods in `MrbGarbageCollection` must call raw `mrb` FFI functions. Using these functions with a raw `*mut mrb_state` requires using a fallible proxy API on `Artichoke`.

These GC related trait methods always surpressed these errors, but there is no need to do so. Change the APIs so they return `Result` and propagate errors where the GC functions are used.

In fbcb79a4f5bf27c48c962a888a955a8d0e89d731, the `MrbGarbageCollection` trait had some backwards incompatible changes to the return types on some methods.

Bump `artichoke-backend` to v0.2.0 to reflect this breakage. This version bump is consistent with other bumps that have been made in `artichoke-core` when traits change.