### PR TITLE
Add `--quiet` flag to spec-runner to suppress failing exit codes on spec failure

### DIFF
--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -512,7 +512,7 @@ dependencies = [
 
 [[package]]
 name = "spec-runner"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "artichoke",
  "clap",

--- a/spec-runner/Cargo.toml
+++ b/spec-runner/Cargo.toml
@@ -23,6 +23,9 @@ toml = { version = "0.5", default-features = false }
 [workspace]
 members = ["."]
 
+[profile.release]
+debug = true
+
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]

--- a/spec-runner/Cargo.toml
+++ b/spec-runner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spec-runner"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2018"
 description = "Binary for running Ruby Specs with Artichoke Ruby"

--- a/spec-runner/src/main.rs
+++ b/spec-runner/src/main.rs
@@ -51,14 +51,15 @@
 //!
 //! ```console
 //! $ cargo run -q -p spec-runner -- --help
-//! spec-runner 0.5.0
+//! spec-runner 0.6.0
 //! ruby/spec runner for Artichoke.
 //!
 //! USAGE:
-//!     spec-runner [OPTIONS] <config>
+//!     spec-runner [FLAGS] [OPTIONS] <config>
 //!
 //! FLAGS:
 //!     -h, --help       Prints help information
+//!     -q, --quiet      Suppress spec failures when exiting
 //!     -V, --version    Prints version information
 //!
 //! OPTIONS:
@@ -122,6 +123,13 @@ pub fn main() {
             .help("Output spec results in YAML"),
     );
     let app = app.arg(
+        Arg::with_name("quiet")
+            .long("quiet")
+            .short("q")
+            .required(false)
+            .help("Suppress spec failures when exiting"),
+    );
+    let app = app.arg(
         Arg::with_name("config")
             .takes_value(true)
             .multiple(false)
@@ -148,6 +156,7 @@ pub fn main() {
             process::exit(1);
         }
     };
+    let quiet = matches.is_present("quiet");
 
     let args = if let Some(config) = matches.value_of_os("config") {
         Args {
@@ -163,7 +172,7 @@ pub fn main() {
 
     match try_main(&mut stderr, &args) {
         Ok(true) => process::exit(0),
-        Ok(false) => process::exit(1),
+        Ok(false) => process::exit(if quiet { 0 } else { 1 }),
         Err(err) => {
             // Suppress all errors at this point (e.g. from a broken pipe) since
             // we're exiting with an error code anyway.


### PR DESCRIPTION
Add debug symbols on spec-runner release build to aid in debugging.

When given the `--quiet` flag, the spec-runner will exit with a success exit code even if some specs failed. This will enable CI to differentiate between a clean run with failures and a SIGSEGV.