### PR TITLE
Disable mruby generational GC

### DIFF
--- a/artichoke-backend/build.rs
+++ b/artichoke-backend/build.rs
@@ -281,6 +281,7 @@ mod libmruby {
             .define("MRB_NO_STDIO", None)
             .define("MRB_ARY_NO_EMBED", None)
             .define("MRB_INT64", None)
+            .define("MRB_GC_TURN_OFF_GENERATIONAL", None)
             .define("MRB_UTF8_STRING", None)
             .define("DISABLE_GEMS", None)
             .define("ARTICHOKE", None);
@@ -383,6 +384,7 @@ mod libmruby {
             .arg("-DMRB_NO_STDIO")
             .arg("-DMRB_ARY_NO_EMBED")
             .arg("-DMRB_INT64")
+            .arg("-DMRB_GC_TURN_OFF_GENERATIONAL")
             .arg("-DMRB_UTF8_STRING");
         if let Architecture::Wasm32 = target.architecture {
             for include_dir in wasm_include_dirs() {


### PR DESCRIPTION
Compile mruby with the `MRB_GC_TURN_OFF_GENERATIONAL` macro defined. Defining this macro disables the generational GC and does a root scan for every incremental GC.

This works around a bug discussed in artichoke/artichoke#1327 and reported upstream in mruby/mruby#5534.

This commit is cherry picked from d3c746b51c8185b2920a3631ee1e084245d153c4 in artichoke/artichoke#1327.

Fixes https://github.com/artichoke/artichoke/issues/1325.