### PR TITLE
Mark `UnboxedValueGuard::as_inner_mut` as unsafe

### DIFF
--- a/artichoke-backend/src/extn/core/array/ffi.rs
+++ b/artichoke-backend/src/extn/core/array/ffi.rs
@@ -103,16 +103,21 @@ unsafe extern "C" fn mrb_ary_concat(mrb: *mut sys::mrb_state, ary: sys::mrb_valu
     let mut other = Value::from(other);
     if let Ok(mut array) = Array::unbox_from_value(&mut array, &mut guard) {
         if let Ok(other) = Array::unbox_from_value(&mut other, &mut guard) {
-            array.extend(other.iter());
+            // Safety:
+            //
+            // The array is repacked before any intervening uses of `interp`.
+            // The array is repacked before any intervening mruby allocations.
+            let array_mut = array.as_inner_mut();
+            array_mut.extend(other.iter());
+
+            let inner = array.take();
+            Array::box_into_value(inner, ary.into(), &mut guard).expect("Array reboxing should not fail");
         } else {
             warn!(
                 "Attempted to call mrb_ary_concat with a {:?} argument",
                 other.ruby_type()
             );
         }
-
-        let inner = array.take();
-        Array::box_into_value(inner, ary.into(), &mut guard).expect("Array reboxing should not fail");
 
         let basic = sys::mrb_sys_basic_ptr(ary);
         sys::mrb_write_barrier(mrb, basic);
@@ -125,12 +130,17 @@ unsafe extern "C" fn mrb_ary_pop(mrb: *mut sys::mrb_state, ary: sys::mrb_value) 
     unwrap_interpreter!(mrb, to => guard);
     let mut array = Value::from(ary);
     let result = if let Ok(mut array) = Array::unbox_from_value(&mut array, &mut guard) {
-        let result = guard.convert(array.pop());
+        // Safety:
+        //
+        // The array is repacked before any intervening uses of `interp`.
+        // The array is repacked before any intervening mruby allocations.
+        let array_mut = array.as_inner_mut();
+        let popped = array_mut.pop();
 
         let inner = array.take();
         Array::box_into_value(inner, ary.into(), &mut guard).expect("Array reboxing should not fail");
 
-        result
+        guard.convert(popped)
     } else {
         Value::nil()
     };
@@ -146,7 +156,12 @@ unsafe extern "C" fn mrb_ary_push(mrb: *mut sys::mrb_state, ary: sys::mrb_value,
     let mut array = Value::from(ary);
     let value = Value::from(value);
     if let Ok(mut array) = Array::unbox_from_value(&mut array, &mut guard) {
-        array.push(value);
+        // Safety:
+        //
+        // The array is repacked before any intervening uses of `interp`.
+        // The array is repacked before any intervening mruby allocations.
+        let array_mut = array.as_inner_mut();
+        array_mut.push(value);
 
         let inner = array.take();
         Array::box_into_value(inner, ary.into(), &mut guard).expect("Array reboxing should not fail");
@@ -201,11 +216,16 @@ unsafe extern "C" fn mrb_ary_set(
         };
         // TODO: properly handle self-referential sets.
         if Value::from(ary) != value {
-            array.set(offset, value);
-        }
+            // Safety:
+            //
+            // The array is repacked before any intervening uses of `interp`.
+            // The array is repacked before any intervening mruby allocations.
+            let array_mut = array.as_inner_mut();
+            array_mut.set(offset, value);
 
-        let inner = array.take();
-        Array::box_into_value(inner, ary.into(), &mut guard).expect("Array reboxing should not fail");
+            let inner = array.take();
+            Array::box_into_value(inner, ary.into(), &mut guard).expect("Array reboxing should not fail");
+        }
     }
     let basic = sys::mrb_sys_basic_ptr(ary);
     sys::mrb_write_barrier(mrb, basic);
@@ -217,7 +237,12 @@ unsafe extern "C" fn mrb_ary_shift(mrb: *mut sys::mrb_state, ary: sys::mrb_value
     unwrap_interpreter!(mrb, to => guard);
     let mut array = Value::from(ary);
     let result = if let Ok(mut array) = Array::unbox_from_value(&mut array, &mut guard) {
-        let result = array.shift();
+        // Safety:
+        //
+        // The array is repacked before any intervening uses of `interp`.
+        // The array is repacked before any intervening mruby allocations.
+        let array_mut = array.as_inner_mut();
+        let result = array_mut.shift();
 
         let inner = array.take();
         Array::box_into_value(inner, ary.into(), &mut guard).expect("Array reboxing should not fail");
@@ -241,7 +266,12 @@ unsafe extern "C" fn mrb_ary_unshift(
     unwrap_interpreter!(mrb, to => guard);
     let mut array = Value::from(ary);
     if let Ok(mut array) = Array::unbox_from_value(&mut array, &mut guard) {
-        array.0.unshift(value);
+        // Safety:
+        //
+        // The array is repacked before any intervening uses of `interp`.
+        // The array is repacked before any intervening mruby allocations.
+        let array_mut = array.as_inner_mut();
+        array_mut.0.unshift(value);
 
         let inner = array.take();
         Array::box_into_value(inner, ary.into(), &mut guard).expect("Array reboxing should not fail");

--- a/artichoke-backend/src/extn/core/array/mod.rs
+++ b/artichoke-backend/src/extn/core/array/mod.rs
@@ -2,7 +2,7 @@ use std::convert::TryFrom;
 use std::ffi::c_void;
 use std::fmt::Write;
 use std::iter::FromIterator;
-use std::ops::{Deref, DerefMut};
+use std::ops::Deref;
 use std::slice;
 
 use spinoso_array::Array as SpinosoArray;
@@ -575,23 +575,11 @@ impl<'a> AsRef<Array> for UnboxedValueGuard<'a, Array> {
     }
 }
 
-impl<'a> AsMut<Array> for UnboxedValueGuard<'a, Array> {
-    fn as_mut(&mut self) -> &mut Array {
-        self.as_inner_mut()
-    }
-}
-
 impl<'a> Deref for UnboxedValueGuard<'a, Array> {
     type Target = Array;
 
     fn deref(&self) -> &Self::Target {
         self.as_inner_ref()
-    }
-}
-
-impl<'a> DerefMut for UnboxedValueGuard<'a, Array> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        self.as_inner_mut()
     }
 }
 

--- a/artichoke-backend/src/extn/core/array/trampoline.rs
+++ b/artichoke-backend/src/extn/core/array/trampoline.rs
@@ -3,7 +3,6 @@ use std::convert::TryFrom;
 use crate::convert::{implicitly_convert_to_int, implicitly_convert_to_string};
 use crate::extn::core::array::Array;
 use crate::extn::prelude::*;
-use crate::gc::{MrbGarbageCollection, State as GcState};
 
 pub fn plus(interp: &mut Artichoke, mut ary: Value, mut other: Value) -> Result<Value, Error> {
     let array = unsafe { Array::unbox_from_value(&mut ary, interp)? };
@@ -94,18 +93,16 @@ pub fn element_assignment(
     }
     let mut array = unsafe { Array::unbox_from_value(&mut ary, interp)? };
 
-    let prior_gc_state = interp.disable_gc()?;
-
-    let result = array.element_assignment(interp, first, second, third);
+    // XXX: Ensure that `array_mut` does not allocate in between mruby
+    // allocations.
+    let array_mut = unsafe { array.as_inner_mut() };
+    let result = array_mut.element_assignment(interp, first, second, third);
 
     unsafe {
         let inner = array.take();
         Array::box_into_value(inner, ary, interp)?;
     }
 
-    if let GcState::Enabled = prior_gc_state {
-        interp.enable_gc()?;
-    }
     result
 }
 
@@ -114,9 +111,16 @@ pub fn clear(interp: &mut Artichoke, mut ary: Value) -> Result<Value, Error> {
         return Err(FrozenError::with_message("can't modify frozen Array").into());
     }
     let mut array = unsafe { Array::unbox_from_value(&mut ary, interp)? };
-    array.clear();
 
+    // Safety:
+    //
+    // Clearing a `Vec` does not reallocate it, but it does change it's length.
+    // The array is repacked before any intervening interpreter heap allocations
+    // occur.
     unsafe {
+        let array_mut = array.as_inner_mut();
+        array_mut.clear();
+
         let inner = array.take();
         Array::box_into_value(inner, ary, interp)?;
     }
@@ -210,6 +214,7 @@ pub fn initialize(
     second: Option<Value>,
     block: Option<Block>,
 ) -> Result<Value, Error> {
+    // XXX
     let array = Array::initialize(interp, first, second, block)?;
     Array::box_into_value(array, into, interp)
 }
@@ -251,12 +256,20 @@ pub fn pop(interp: &mut Artichoke, mut ary: Value) -> Result<Value, Error> {
         return Err(FrozenError::with_message("can't modify frozen Array").into());
     }
     let mut array = unsafe { Array::unbox_from_value(&mut ary, interp)? };
-    let result = array.pop();
 
-    unsafe {
+    // Safety:
+    //
+    // The array is repacked before any intervening interpreter heap allocations
+    // occur.
+    let result = unsafe {
+        let array_mut = array.as_inner_mut();
+        let result = array_mut.pop();
+
         let inner = array.take();
         Array::box_into_value(inner, ary, interp)?;
-    }
+
+        result
+    };
 
     Ok(interp.convert(result))
 }
@@ -266,7 +279,13 @@ pub fn push(interp: &mut Artichoke, mut ary: Value, value: Value) -> Result<Valu
         return Err(FrozenError::with_message("can't modify frozen Array").into());
     }
     let mut array = unsafe { Array::unbox_from_value(&mut ary, interp)? };
-    array.push(value);
+
+    // Safety:
+    //
+    // The array is repacked without any intervening interpreter heap
+    // allocations.
+    let array_mut = unsafe { array.as_inner_mut() };
+    array_mut.push(value);
 
     unsafe {
         let inner = array.take();
@@ -288,9 +307,17 @@ pub fn reverse_bang(interp: &mut Artichoke, mut ary: Value) -> Result<Value, Err
         return Err(FrozenError::with_message("can't modify frozen Array").into());
     }
     let mut array = unsafe { Array::unbox_from_value(&mut ary, interp)? };
-    array.reverse();
 
+    // Safety:
+    //
+    // Reversing an `Array` in place does not reallocate it.
+    //
+    // The array is repacked before any intervening interpreter heap allocations
+    // occur.
     unsafe {
+        let array_mut = array.as_inner_mut();
+        array_mut.reverse();
+
         let inner = array.take();
         Array::box_into_value(inner, ary, interp)?;
     }
@@ -306,32 +333,53 @@ pub fn shift(interp: &mut Artichoke, mut ary: Value, count: Option<Value>) -> Re
     if let Some(count) = count {
         let count = implicitly_convert_to_int(interp, count)?;
         let count = usize::try_from(count).map_err(|_| ArgumentError::with_message("negative array size"))?;
-        let shifted = array.shift_n(count);
 
         // Safety:
         //
-        // The call to `Array::shift_n` above has potentially invalidated the
-        // raw parts of `array` stored in `ary`'s `RArray *`.
+        // The call to `Array::shift_n` has potentially invalidated the raw
+        // parts of `array` stored in `ary`'s `RArray *`.
         //
         // The below call to `Array::alloc_value` will trigger an mruby heap
         // allocation which may trigger a garbage collection.
         //
-        // The raw parts in `ary`'s `RArray *` must be fixed up before a
+        // The raw parts in `ary`'s `RArray *` must be repacked before a
         // potential garbage collection, otherwise marking the children in `ary`
         // will have undefined behavior.
-        unsafe {
+        //
+        // The call to `Array::alloc_value` happens outside of this block after
+        // the `Array` has been repacked.
+        let shifted = unsafe {
+            let array_mut = array.as_inner_mut();
+            let shifted = array_mut.shift_n(count);
+
             let inner = array.take();
             Array::box_into_value(inner, ary, interp)?;
-        }
+
+            shifted
+        };
 
         Array::alloc_value(shifted, interp)
     } else {
-        let shifted = array.shift();
+        // Safety:
+        //
+        // The call to `Array::shift` above has potentially invalidated the raw
+        // parts of `array` stored in `ary`'s `RArray *`.
+        //
+        // The raw parts in `ary`'s `RArray *` must be repacked before a
+        // potential garbage collection, otherwise marking the children in `ary`
+        // will have undefined behavior.
+        //
+        // The call to `interp.convert` happens outside of this block after the
+        // `Array` has been repacked.
+        let shifted = unsafe {
+            let array_mut = array.as_inner_mut();
+            let shifted = array_mut.shift();
 
-        unsafe {
             let inner = array.take();
             Array::box_into_value(inner, ary, interp)?;
-        }
+
+            shifted
+        };
 
         Ok(interp.convert(shifted))
     }

--- a/artichoke-backend/src/extn/core/random/trampoline.rs
+++ b/artichoke-backend/src/extn/core/random/trampoline.rs
@@ -22,7 +22,7 @@ pub fn equal(interp: &mut Artichoke, mut rand: Value, mut other: Value) -> Resul
 pub fn bytes(interp: &mut Artichoke, mut rand: Value, size: Value) -> Result<Value, Error> {
     let mut random = unsafe { Rng::unbox_from_value(&mut rand, interp)? };
     let size = implicitly_convert_to_int(interp, size)?;
-    let buf = match random.as_mut() {
+    let buf = match &mut *random {
         Rng::Global => interp.prng_mut()?.bytes(size)?,
         Rng::Value(random) => random.bytes(size)?,
     };
@@ -32,7 +32,7 @@ pub fn bytes(interp: &mut Artichoke, mut rand: Value, size: Value) -> Result<Val
 pub fn rand(interp: &mut Artichoke, mut rand: Value, max: Option<Value>) -> Result<Value, Error> {
     let mut random = unsafe { Rng::unbox_from_value(&mut rand, interp)? };
     let max = interp.try_convert_mut(max)?;
-    let num = match random.as_mut() {
+    let num = match &mut *random {
         Rng::Global => interp.prng_mut()?.rand(max)?,
         Rng::Value(random) => random.rand(max)?,
     };


### PR DESCRIPTION
This PR also removes the `AsMut` and `DerefMut` blanket implementations for `UnboxedValueGuard`. `UnboxedValueGuard` is a proxy object that temporarily reconstructs a Rust object owned by the mruby GC.

Accessing a `&mut T` from `UnboxedValueGuard` is unsafe because accessing `&mut` methods on the underlying `T` may invalidate the raw parts of `T` that are packed into the mruby heap. Callers must ensure these raw parts are valid before the next GC.

Fixes #1324.

This PR also includes safety fixes to box empty arrays into uninitialized MRB_TT_ARRAY before doing init.

This ensures that no uninitialized `MRB_TT_ARRAY` `RBasic *` pointers are seen during a potential intervening GC and mark phase as new values are allocated on the mruby heap.