### PR TITLE
Add a GitHub Actions workflow that runs the spec-runner under Pernosco

### DIFF
--- a/.github/workflows/crash.yaml
+++ b/.github/workflows/crash.yaml
@@ -1,0 +1,72 @@
+---
+name: Crash
+"on":
+  pull_request:
+    branches:
+      - trunk
+jobs:
+  crash:
+    name: Crash
+    runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: -D warnings
+      RUST_BACKTRACE: 1
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+
+      - name: Install Ruby toolchain
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ".ruby-version"
+          bundler-cache: true
+
+      - uses: Swatinem/rust-cache@v1
+        with:
+          key: v3
+          working-directory: "spec-runner"
+
+      - name: Compile debug
+        run: cargo build --verbose --bin spec-runner
+        working-directory: "spec-runner"
+
+      - name: Compile release
+        run: cargo build --verbose --bin spec-runner --release
+        working-directory: "spec-runner"
+
+      - name: Run specs
+        run: |
+          ./target/debug/spec-runner --quiet --format artichoke all-core-specs.toml > /dev/null
+          ./target/debug/spec-runner --quiet --format summary all-core-specs.toml > /dev/null
+          ./target/debug/spec-runner --quiet --format tagger all-core-specs.toml > /dev/null
+          ./target/debug/spec-runner --quiet --format yaml all-core-specs.toml > /dev/null
+        working-directory: "spec-runner"
+
+      - name: Run specs
+        run: |
+          ./target/debug/spec-runner --quiet --format artichoke spec-state.toml > /dev/null
+          ./target/debug/spec-runner --quiet --format summary spec-state.toml > /dev/null
+          ./target/debug/spec-runner --quiet --format tagger spec-state.toml > /dev/null
+          ./target/debug/spec-runner --quiet --format yaml spec-state.toml > /dev/null
+        working-directory: "spec-runner"
+
+      - name: Run specs
+        run: |
+          ./target/release/spec-runner --quiet --format artichoke all-core-specs.toml > /dev/null
+          ./target/release/spec-runner --quiet --format summary all-core-specs.toml > /dev/null
+          ./target/release/spec-runner --quiet --format tagger all-core-specs.toml > /dev/null
+          ./target/release/spec-runner --quiet --format yaml all-core-specs.toml > /dev/null
+        working-directory: "spec-runner"
+
+      - name: Run specs
+        run: |
+          ./target/release/spec-runner --quiet --format artichoke spec-state.toml > /dev/null
+          ./target/release/spec-runner --quiet --format summary spec-state.toml > /dev/null
+          ./target/release/spec-runner --quiet --format tagger spec-state.toml > /dev/null
+          ./target/release/spec-runner --quiet --format yaml spec-state.toml > /dev/null
+        working-directory: "spec-runner"

--- a/.github/workflows/crash.yaml
+++ b/.github/workflows/crash.yaml
@@ -46,6 +46,8 @@ jobs:
           ./target/debug/spec-runner --quiet --format tagger all-core-specs.toml > /dev/null
           ./target/debug/spec-runner --quiet --format yaml all-core-specs.toml > /dev/null
         working-directory: "spec-runner"
+        env:
+          PERNOSCO_ENABLE: 1
 
       - name: Run specs
         run: |
@@ -54,6 +56,8 @@ jobs:
           ./target/debug/spec-runner --quiet --format tagger spec-state.toml > /dev/null
           ./target/debug/spec-runner --quiet --format yaml spec-state.toml > /dev/null
         working-directory: "spec-runner"
+        env:
+          PERNOSCO_ENABLE: 1
 
       - name: Run specs
         run: |
@@ -62,6 +66,8 @@ jobs:
           ./target/release/spec-runner --quiet --format tagger all-core-specs.toml > /dev/null
           ./target/release/spec-runner --quiet --format yaml all-core-specs.toml > /dev/null
         working-directory: "spec-runner"
+        env:
+          PERNOSCO_ENABLE: 1
 
       - name: Run specs
         run: |
@@ -70,3 +76,5 @@ jobs:
           ./target/release/spec-runner --quiet --format tagger spec-state.toml > /dev/null
           ./target/release/spec-runner --quiet --format yaml spec-state.toml > /dev/null
         working-directory: "spec-runner"
+        env:
+          PERNOSCO_ENABLE: 1

--- a/artichoke-backend/build.rs
+++ b/artichoke-backend/build.rs
@@ -280,7 +280,6 @@ mod libmruby {
             .define("MRB_NO_STDIO", None)
             .define("MRB_ARY_NO_EMBED", None)
             .define("MRB_INT64", None)
-            .define("MRB_GC_TURN_OFF_GENERATIONAL", None)
             .define("MRB_UTF8_STRING", None)
             .define("DISABLE_GEMS", None)
             .define("ARTICHOKE", None);
@@ -383,7 +382,6 @@ mod libmruby {
             .arg("-DMRB_NO_STDIO")
             .arg("-DMRB_ARY_NO_EMBED")
             .arg("-DMRB_INT64")
-            .arg("-DMRB_GC_TURN_OFF_GENERATIONAL")
             .arg("-DMRB_UTF8_STRING");
         if let Architecture::Wasm32 = target.architecture {
             for include_dir in wasm_include_dirs() {

--- a/artichoke-backend/vendor/mruby/src/class.c
+++ b/artichoke-backend/vendor/mruby/src/class.c
@@ -2210,6 +2210,7 @@ mrb_alias_method(mrb_state *mrb, struct RClass *c, mrb_sym a, mrb_sym b)
       }
       p->e.env = e;
       p->flags |= MRB_PROC_ENVSET;
+      mrb_field_write_barrier(mrb, (struct RBasic*)p, (struct RBasic*)e);
     }
   }
   mrb_define_method_raw(mrb, c, a, m);


### PR DESCRIPTION
This PR branches from 4321b467860419e0718bdac25e8683a9fdc8cf50 which was known to cause a core dump in #1327.

This PR includes an improved version of the `crash.yaml` workflow which splits apart the invocations of the spec runner to one per job step and enables recording execution with Pernosco.

cc @rocallahan @khuey

Opening this PR will kick off a run of the crash workflow which I expect to produce a core dump. Once I confirm the Pernosco GitHub Actions integration is working correctly, I'll rebase to the latest trunk and merge this PR.