### PR TITLE
Use fallible `TryConvertMut` API for converting `Vec<u8>` and `String`

### DIFF
--- a/artichoke-backend/src/block.rs
+++ b/artichoke-backend/src/block.rs
@@ -4,7 +4,7 @@ use std::error;
 use std::fmt;
 
 use crate::class_registry::ClassRegistry;
-use crate::core::{ConvertMut, Value as _};
+use crate::core::{TryConvertMut, Value as _};
 use crate::error::{Error, RubyException};
 use crate::exception_handler;
 use crate::extn::core::exception::{Fatal, TypeError};
@@ -39,7 +39,7 @@ impl RubyException for NoBlockGiven {
     }
 
     fn as_mrb_value(&self, interp: &mut Artichoke) -> Option<sys::mrb_value> {
-        let message = interp.convert_mut(self.message());
+        let message = interp.try_convert_mut(self.message()).ok()?;
         let value = interp.new_instance::<TypeError>(&[message]).ok().flatten()?;
         Some(value.inner())
     }

--- a/artichoke-backend/src/convert.rs
+++ b/artichoke-backend/src/convert.rs
@@ -102,7 +102,7 @@ impl RubyException for UnboxRubyError {
     }
 
     fn as_mrb_value(&self, interp: &mut Artichoke) -> Option<sys::mrb_value> {
-        let message = interp.convert_mut(self.to_string());
+        let message = interp.try_convert_mut(self.to_string()).ok()?;
         let value = interp.new_instance::<TypeError>(&[message]).ok().flatten()?;
         Some(value.inner())
     }
@@ -170,7 +170,7 @@ impl RubyException for BoxIntoRubyError {
     }
 
     fn as_mrb_value(&self, interp: &mut Artichoke) -> Option<sys::mrb_value> {
-        let message = interp.convert_mut(self.to_string());
+        let message = interp.try_convert_mut(self.to_string()).ok()?;
         let value = interp.new_instance::<TypeError>(&[message]).ok().flatten()?;
         Some(value.inner())
     }

--- a/artichoke-backend/src/convert/array.rs
+++ b/artichoke-backend/src/convert/array.rs
@@ -1,5 +1,5 @@
 use crate::convert::{BoxUnboxVmValue, UnboxRubyError};
-use crate::core::{Convert, ConvertMut, TryConvert, TryConvertMut, Value as _};
+use crate::core::{Convert, TryConvert, TryConvertMut, Value as _};
 use crate::error::Error;
 use crate::extn::core::array::Array;
 use crate::types::{Ruby, Rust};
@@ -40,8 +40,10 @@ impl TryConvertMut<Vec<Vec<u8>>, Value> for Artichoke {
     type Error = Error;
 
     fn try_convert_mut(&mut self, value: Vec<Vec<u8>>) -> Result<Value, Self::Error> {
-        let iter = value.into_iter().map(|item| self.convert_mut(item));
-        let ary = iter.collect();
+        let ary = value
+            .into_iter()
+            .map(|item| self.try_convert_mut(item))
+            .collect::<Result<Array, _>>()?;
         let value = Array::alloc_value(ary, self)?;
         Ok(self.protect(value))
     }
@@ -51,8 +53,10 @@ impl TryConvertMut<Vec<&[u8]>, Value> for Artichoke {
     type Error = Error;
 
     fn try_convert_mut(&mut self, value: Vec<&[u8]>) -> Result<Value, Self::Error> {
-        let iter = value.into_iter().map(|item| self.convert_mut(item));
-        let ary = iter.collect();
+        let ary = value
+            .into_iter()
+            .map(|item| self.try_convert_mut(item))
+            .collect::<Result<Array, _>>()?;
         let value = Array::alloc_value(ary, self)?;
         Ok(self.protect(value))
     }
@@ -62,8 +66,10 @@ impl TryConvertMut<&[Vec<u8>], Value> for Artichoke {
     type Error = Error;
 
     fn try_convert_mut(&mut self, value: &[Vec<u8>]) -> Result<Value, Self::Error> {
-        let iter = value.iter().map(|item| self.convert_mut(item.as_slice()));
-        let ary = iter.collect();
+        let ary = value
+            .iter()
+            .map(|item| self.try_convert_mut(item.as_slice()))
+            .collect::<Result<Array, _>>()?;
         let value = Array::alloc_value(ary, self)?;
         Ok(self.protect(value))
     }
@@ -73,8 +79,11 @@ impl TryConvertMut<&[&[u8]], Value> for Artichoke {
     type Error = Error;
 
     fn try_convert_mut(&mut self, value: &[&[u8]]) -> Result<Value, Self::Error> {
-        let iter = value.iter().copied().map(|item| self.convert_mut(item));
-        let ary = iter.collect();
+        let ary = value
+            .iter()
+            .copied()
+            .map(|item| self.try_convert_mut(item))
+            .collect::<Result<Array, _>>()?;
         let value = Array::alloc_value(ary, self)?;
         Ok(self.protect(value))
     }
@@ -84,8 +93,10 @@ impl TryConvertMut<Vec<String>, Value> for Artichoke {
     type Error = Error;
 
     fn try_convert_mut(&mut self, value: Vec<String>) -> Result<Value, Self::Error> {
-        let iter = value.into_iter().map(|item| self.convert_mut(item));
-        let ary = iter.collect();
+        let ary = value
+            .into_iter()
+            .map(|item| self.try_convert_mut(item))
+            .collect::<Result<Array, _>>()?;
         let value = Array::alloc_value(ary, self)?;
         Ok(self.protect(value))
     }
@@ -95,8 +106,10 @@ impl TryConvertMut<Vec<&str>, Value> for Artichoke {
     type Error = Error;
 
     fn try_convert_mut(&mut self, value: Vec<&str>) -> Result<Value, Self::Error> {
-        let iter = value.into_iter().map(|item| self.convert_mut(item));
-        let ary = iter.collect();
+        let ary = value
+            .into_iter()
+            .map(|item| self.try_convert_mut(item))
+            .collect::<Result<Array, _>>()?;
         let value = Array::alloc_value(ary, self)?;
         Ok(self.protect(value))
     }
@@ -106,8 +119,10 @@ impl TryConvertMut<&[String], Value> for Artichoke {
     type Error = Error;
 
     fn try_convert_mut(&mut self, value: &[String]) -> Result<Value, Self::Error> {
-        let iter = value.iter().map(|item| self.convert_mut(item.as_str()));
-        let ary = iter.collect();
+        let ary = value
+            .iter()
+            .map(|item| self.try_convert_mut(item.as_str()))
+            .collect::<Result<Array, _>>()?;
         let value = Array::alloc_value(ary, self)?;
         Ok(self.protect(value))
     }
@@ -117,8 +132,11 @@ impl TryConvertMut<&[&str], Value> for Artichoke {
     type Error = Error;
 
     fn try_convert_mut(&mut self, value: &[&str]) -> Result<Value, Self::Error> {
-        let iter = value.iter().copied().map(|item| self.convert_mut(item));
-        let ary = iter.collect();
+        let ary = value
+            .iter()
+            .copied()
+            .map(|item| self.try_convert_mut(item))
+            .collect::<Result<Array, _>>()?;
         let value = Array::alloc_value(ary, self)?;
         Ok(self.protect(value))
     }
@@ -150,8 +168,10 @@ impl TryConvertMut<&[Option<Vec<u8>>], Value> for Artichoke {
     type Error = Error;
 
     fn try_convert_mut(&mut self, value: &[Option<Vec<u8>>]) -> Result<Value, Self::Error> {
-        let iter = value.iter().map(|item| self.convert_mut(item.as_deref()));
-        let ary = iter.collect();
+        let ary = value
+            .iter()
+            .map(|item| self.try_convert_mut(item.as_deref()))
+            .collect::<Result<Array, _>>()?;
         let value = Array::alloc_value(ary, self)?;
         Ok(self.protect(value))
     }
@@ -161,8 +181,10 @@ impl TryConvertMut<Vec<Option<Vec<u8>>>, Value> for Artichoke {
     type Error = Error;
 
     fn try_convert_mut(&mut self, value: Vec<Option<Vec<u8>>>) -> Result<Value, Self::Error> {
-        let iter = value.into_iter().map(|item| self.convert_mut(item));
-        let ary = iter.collect();
+        let ary = value
+            .into_iter()
+            .map(|item| self.try_convert_mut(item))
+            .collect::<Result<Array, _>>()?;
         let value = Array::alloc_value(ary, self)?;
         Ok(self.protect(value))
     }
@@ -172,8 +194,11 @@ impl TryConvertMut<&[Option<&[u8]>], Value> for Artichoke {
     type Error = Error;
 
     fn try_convert_mut(&mut self, value: &[Option<&[u8]>]) -> Result<Value, Self::Error> {
-        let iter = value.iter().copied().map(|item| self.convert_mut(item));
-        let ary = iter.collect();
+        let ary = value
+            .iter()
+            .copied()
+            .map(|item| self.try_convert_mut(item))
+            .collect::<Result<Array, _>>()?;
         let value = Array::alloc_value(ary, self)?;
         Ok(self.protect(value))
     }
@@ -183,8 +208,10 @@ impl TryConvertMut<Vec<Option<&[u8]>>, Value> for Artichoke {
     type Error = Error;
 
     fn try_convert_mut(&mut self, value: Vec<Option<&[u8]>>) -> Result<Value, Self::Error> {
-        let iter = value.into_iter().map(|item| self.convert_mut(item));
-        let ary = iter.collect();
+        let ary = value
+            .into_iter()
+            .map(|item| self.try_convert_mut(item))
+            .collect::<Result<Array, _>>()?;
         let value = Array::alloc_value(ary, self)?;
         Ok(self.protect(value))
     }
@@ -220,8 +247,11 @@ impl TryConvertMut<&[Option<&str>], Value> for Artichoke {
     type Error = Error;
 
     fn try_convert_mut(&mut self, value: &[Option<&str>]) -> Result<Value, Self::Error> {
-        let iter = value.iter().copied().map(|item| self.convert_mut(item));
-        let ary = iter.collect();
+        let ary = value
+            .iter()
+            .copied()
+            .map(|item| self.try_convert_mut(item))
+            .collect::<Result<Array, _>>()?;
         let value = Array::alloc_value(ary, self)?;
         Ok(self.protect(value))
     }
@@ -231,8 +261,10 @@ impl TryConvertMut<Vec<Option<&str>>, Value> for Artichoke {
     type Error = Error;
 
     fn try_convert_mut(&mut self, value: Vec<Option<&str>>) -> Result<Value, Self::Error> {
-        let iter = value.into_iter().map(|item| self.convert_mut(item));
-        let ary = iter.collect();
+        let ary = value
+            .into_iter()
+            .map(|item| self.try_convert_mut(item))
+            .collect::<Result<Array, _>>()?;
         let value = Array::alloc_value(ary, self)?;
         Ok(self.protect(value))
     }

--- a/artichoke-backend/src/convert/boxing.rs
+++ b/artichoke-backend/src/convert/boxing.rs
@@ -323,7 +323,7 @@ mod tests {
 
         let mut value = Value::from(slf);
         let result = if let Ok(container) = Container::unbox_from_value(&mut value, &mut guard) {
-            guard.convert_mut(container.0.as_bytes())
+            guard.try_convert_mut(container.0.as_bytes()).unwrap_or_default()
         } else {
             Value::nil()
         };
@@ -409,7 +409,7 @@ mod tests {
             .unwrap();
         interp.def_class::<Box<Flag>>(spec).unwrap();
 
-        let mut value = interp.convert_mut("string");
+        let mut value = interp.try_convert_mut("string").unwrap();
         let class = value.funcall(&mut interp, "class", &[], None).unwrap();
         let class_display = class.to_s(&mut interp);
         assert_eq!(class_display.as_bstr(), b"String".as_bstr());

--- a/artichoke-backend/src/convert/bytes.rs
+++ b/artichoke-backend/src/convert/bytes.rs
@@ -4,7 +4,7 @@ use std::ffi::{OsStr, OsString};
 use std::slice;
 
 use crate::convert::UnboxRubyError;
-use crate::core::{ConvertMut, TryConvertMut, Value as _};
+use crate::core::{TryConvertMut, Value as _};
 use crate::error::Error;
 use crate::platform_string::{os_str_to_bytes, os_string_to_bytes};
 use crate::sys;
@@ -12,30 +12,36 @@ use crate::types::{Ruby, Rust};
 use crate::value::Value;
 use crate::Artichoke;
 
-impl ConvertMut<Vec<u8>, Value> for Artichoke {
-    fn convert_mut(&mut self, value: Vec<u8>) -> Value {
-        self.convert_mut(value.as_slice())
+impl TryConvertMut<Vec<u8>, Value> for Artichoke {
+    type Error = Error;
+
+    fn try_convert_mut(&mut self, value: Vec<u8>) -> Result<Value, Self::Error> {
+        self.try_convert_mut(value.as_slice())
     }
 }
 
-impl ConvertMut<&[u8], Value> for Artichoke {
-    fn convert_mut(&mut self, value: &[u8]) -> Value {
+impl TryConvertMut<&[u8], Value> for Artichoke {
+    type Error = Error;
+
+    fn try_convert_mut(&mut self, value: &[u8]) -> Result<Value, Self::Error> {
         // Ruby strings contain raw bytes, so we can convert from a &[u8] to a
         // `char *` and `size_t`.
         let raw = value.as_ptr().cast::<i8>();
         let len = value.len();
         // `mrb_str_new` copies the `char *` to the mruby heap so we do not have
         // to worry about the lifetime of the slice passed into this converter.
-        let string = unsafe { self.with_ffi_boundary(|mrb| sys::mrb_str_new(mrb, raw, len)) };
-        self.protect(Value::from(string.unwrap()))
+        let string = unsafe { self.with_ffi_boundary(|mrb| sys::mrb_str_new(mrb, raw, len))? };
+        Ok(string.into())
     }
 }
 
-impl<'a> ConvertMut<Cow<'a, [u8]>, Value> for Artichoke {
-    fn convert_mut(&mut self, value: Cow<'a, [u8]>) -> Value {
+impl<'a> TryConvertMut<Cow<'a, [u8]>, Value> for Artichoke {
+    type Error = Error;
+
+    fn try_convert_mut(&mut self, value: Cow<'a, [u8]>) -> Result<Value, Self::Error> {
         match value {
-            Cow::Borrowed(bytes) => self.convert_mut(bytes),
-            Cow::Owned(bytes) => self.convert_mut(bytes),
+            Cow::Borrowed(bytes) => self.try_convert_mut(bytes),
+            Cow::Owned(bytes) => self.try_convert_mut(bytes),
         }
     }
 }
@@ -45,7 +51,7 @@ impl TryConvertMut<OsString, Value> for Artichoke {
 
     fn try_convert_mut(&mut self, value: OsString) -> Result<Value, Self::Error> {
         let bytes = os_string_to_bytes(value)?;
-        Ok(self.convert_mut(bytes))
+        self.try_convert_mut(bytes)
     }
 }
 
@@ -54,7 +60,7 @@ impl TryConvertMut<&OsStr, Value> for Artichoke {
 
     fn try_convert_mut(&mut self, value: &OsStr) -> Result<Value, Self::Error> {
         let bytes = os_str_to_bytes(value)?;
-        Ok(self.convert_mut(bytes))
+        self.try_convert_mut(bytes)
     }
 }
 
@@ -65,11 +71,11 @@ impl<'a> TryConvertMut<Cow<'a, OsStr>, Value> for Artichoke {
         match value {
             Cow::Borrowed(value) => {
                 let bytes = os_str_to_bytes(value)?;
-                Ok(self.convert_mut(bytes))
+                self.try_convert_mut(bytes)
             }
             Cow::Owned(value) => {
                 let bytes = os_string_to_bytes(value)?;
-                Ok(self.convert_mut(bytes))
+                self.try_convert_mut(bytes)
             }
         }
     }

--- a/artichoke-backend/src/convert/bytes.rs
+++ b/artichoke-backend/src/convert/bytes.rs
@@ -129,7 +129,7 @@ mod tests {
     fn convert_with_trailing_nul() {
         let mut interp = interpreter().unwrap();
         let bytes: &[u8] = &[0];
-        let value = interp.convert_mut(bytes);
+        let value = interp.try_convert_mut(bytes).unwrap();
         let retrieved_bytes = value.try_into_mut::<&[u8]>(&mut interp).unwrap();
         assert_eq!(bytes.as_bstr(), retrieved_bytes.as_bstr());
 
@@ -158,7 +158,7 @@ mod tests {
     quickcheck! {
         fn convert_to_vec(bytes: Vec<u8>) -> bool {
             let mut interp = interpreter().unwrap();
-            let value = interp.convert_mut(bytes);
+            let value = interp.try_convert_mut(bytes).unwrap();
             value.ruby_type() == Ruby::String
         }
 
@@ -166,7 +166,7 @@ mod tests {
         fn bytestring_borrowed(bytes: Vec<u8>) -> bool {
             let mut interp = interpreter().unwrap();
             // Borrowed converter
-            let value = interp.convert_mut(bytes.as_slice());
+            let value = interp.try_convert_mut(bytes.as_slice()).unwrap();
             let len = value.funcall(&mut interp, "bytesize", &[], None).unwrap();
             let len = len.try_into::<usize>(&interp).unwrap();
             if len != bytes.len() {
@@ -206,7 +206,7 @@ mod tests {
         fn bytestring_owned(bytes: Vec<u8>) -> bool {
             let mut interp = interpreter().unwrap();
             // Owned converter
-            let value = interp.convert_mut(bytes.clone());
+            let value = interp.try_convert_mut(bytes.clone()).unwrap();
             let len = value.funcall(&mut interp, "bytesize", &[], None).unwrap();
             let len = len.try_into::<usize>(&interp).unwrap();
             if len != bytes.len() {
@@ -245,7 +245,7 @@ mod tests {
         #[allow(clippy::needless_pass_by_value)]
         fn roundtrip(bytes: Vec<u8>) -> bool {
             let mut interp = interpreter().unwrap();
-            let value = interp.convert_mut(bytes.as_slice());
+            let value = interp.try_convert_mut(bytes.as_slice()).unwrap();
             let value = value.try_into_mut::<Vec<u8>>(&mut interp).unwrap();
             value == bytes
         }

--- a/artichoke-backend/src/convert/hash.rs
+++ b/artichoke-backend/src/convert/hash.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::convert::TryFrom;
 
 use crate::convert::{BoxUnboxVmValue, UnboxRubyError};
-use crate::core::{ConvertMut, TryConvertMut, Value as _};
+use crate::core::{TryConvertMut, Value as _};
 use crate::error::Error;
 use crate::extn::core::array::Array;
 use crate::sys;
@@ -60,8 +60,8 @@ impl TryConvertMut<HashMap<Vec<u8>, Vec<u8>>, Value> for Artichoke {
         let hash = self.protect(Value::from(hash));
 
         for (key, val) in value {
-            let key = self.convert_mut(key);
-            let val = self.convert_mut(val);
+            let key = self.try_convert_mut(key)?;
+            let val = self.try_convert_mut(val)?;
             unsafe {
                 self.with_ffi_boundary(|mrb| sys::mrb_hash_set(mrb, hash.inner(), key.inner(), val.inner()))?;
             }
@@ -81,8 +81,8 @@ impl TryConvertMut<Option<HashMap<Vec<u8>, Option<Vec<u8>>>>, Value> for Articho
             let hash = self.protect(Value::from(hash));
 
             for (key, val) in value {
-                let key = self.convert_mut(key);
-                let val = self.convert_mut(val);
+                let key = self.try_convert_mut(key)?;
+                let val = self.try_convert_mut(val)?;
                 unsafe {
                     self.with_ffi_boundary(|mrb| sys::mrb_hash_set(mrb, hash.inner(), key.inner(), val.inner()))?;
                 }

--- a/artichoke-backend/src/convert/implicit.rs
+++ b/artichoke-backend/src/convert/implicit.rs
@@ -220,7 +220,7 @@ pub fn implicitly_convert_to_int(interp: &mut Artichoke, value: Value) -> Result
 /// # fn example() -> Result<(), Error> {
 /// let mut interp = artichoke_backend::interpreter()?;
 /// // successful conversions
-/// let mut string = interp.convert_mut("artichoke");
+/// let mut string = interp.try_convert_mut("artichoke")?;
 /// let mut a = interp.eval(b"class A; def to_str; 'spinoso'; end; end; A.new")?;
 ///
 /// # unsafe {
@@ -427,7 +427,7 @@ pub unsafe fn implicitly_convert_to_string<'a>(
 /// # fn example() -> Result<(), Error> {
 /// let mut interp = artichoke_backend::interpreter()?;
 /// // successful conversions
-/// let mut string = interp.convert_mut("artichoke");
+/// let mut string = interp.try_convert_mut("artichoke")?;
 /// let mut nil = Value::nil();
 /// let mut a = interp.eval(b"class A; def to_str; 'spinoso'; end; end; A.new")?;
 ///

--- a/artichoke-backend/src/convert/nilable.rs
+++ b/artichoke-backend/src/convert/nilable.rs
@@ -2,7 +2,7 @@
 //!
 //! Excludes collection types Array and Hash.
 
-use crate::core::{Convert, ConvertMut, TryConvert, TryConvertMut, Value as _};
+use crate::core::{Convert, TryConvert, TryConvertMut, Value as _};
 use crate::error::Error;
 use crate::value::Value;
 use crate::Artichoke;
@@ -23,34 +23,42 @@ impl Convert<Option<i64>, Value> for Artichoke {
     }
 }
 
-impl ConvertMut<Option<Vec<u8>>, Value> for Artichoke {
-    fn convert_mut(&mut self, value: Option<Vec<u8>>) -> Value {
-        self.convert_mut(value.as_deref())
+impl TryConvertMut<Option<Vec<u8>>, Value> for Artichoke {
+    type Error = Error;
+
+    fn try_convert_mut(&mut self, value: Option<Vec<u8>>) -> Result<Value, Self::Error> {
+        self.try_convert_mut(value.as_deref())
     }
 }
 
-impl ConvertMut<Option<&[u8]>, Value> for Artichoke {
-    fn convert_mut(&mut self, value: Option<&[u8]>) -> Value {
+impl TryConvertMut<Option<&[u8]>, Value> for Artichoke {
+    type Error = Error;
+
+    fn try_convert_mut(&mut self, value: Option<&[u8]>) -> Result<Value, Self::Error> {
         if let Some(value) = value {
-            self.convert_mut(value)
+            self.try_convert_mut(value)
         } else {
-            Value::nil()
+            Ok(Value::nil())
         }
     }
 }
 
-impl ConvertMut<Option<String>, Value> for Artichoke {
-    fn convert_mut(&mut self, value: Option<String>) -> Value {
-        self.convert_mut(value.as_deref())
+impl TryConvertMut<Option<String>, Value> for Artichoke {
+    type Error = Error;
+
+    fn try_convert_mut(&mut self, value: Option<String>) -> Result<Value, Self::Error> {
+        self.try_convert_mut(value.as_deref())
     }
 }
 
-impl ConvertMut<Option<&str>, Value> for Artichoke {
-    fn convert_mut(&mut self, value: Option<&str>) -> Value {
+impl TryConvertMut<Option<&str>, Value> for Artichoke {
+    type Error = Error;
+
+    fn try_convert_mut(&mut self, value: Option<&str>) -> Result<Value, Self::Error> {
         if let Some(value) = value {
-            self.convert_mut(value)
+            self.try_convert_mut(value)
         } else {
-            Value::nil()
+            Ok(Value::nil())
         }
     }
 }

--- a/artichoke-backend/src/convert/string.rs
+++ b/artichoke-backend/src/convert/string.rs
@@ -2,33 +2,39 @@ use std::borrow::Cow;
 use std::str;
 
 use crate::convert::UnboxRubyError;
-use crate::core::{ConvertMut, TryConvertMut};
+use crate::core::TryConvertMut;
 use crate::error::Error;
 use crate::types::Rust;
 use crate::value::Value;
 use crate::Artichoke;
 
-impl ConvertMut<String, Value> for Artichoke {
-    fn convert_mut(&mut self, value: String) -> Value {
+impl TryConvertMut<String, Value> for Artichoke {
+    type Error = Error;
+
+    fn try_convert_mut(&mut self, value: String) -> Result<Value, Self::Error> {
         // Ruby `String`s are just bytes, so get a pointer to the underlying
         // `&[u8]` infallibly and convert that to a `Value`.
-        self.convert_mut(value.as_bytes())
+        self.try_convert_mut(value.into_bytes())
     }
 }
 
-impl ConvertMut<&str, Value> for Artichoke {
-    fn convert_mut(&mut self, value: &str) -> Value {
+impl TryConvertMut<&str, Value> for Artichoke {
+    type Error = Error;
+
+    fn try_convert_mut(&mut self, value: &str) -> Result<Value, Self::Error> {
         // Ruby `String`s are just bytes, so get a pointer to the underlying
         // `&[u8]` infallibly and convert that to a `Value`.
-        self.convert_mut(value.as_bytes())
+        self.try_convert_mut(value.as_bytes())
     }
 }
 
-impl<'a> ConvertMut<Cow<'a, str>, Value> for Artichoke {
-    fn convert_mut(&mut self, value: Cow<'a, str>) -> Value {
+impl<'a> TryConvertMut<Cow<'a, str>, Value> for Artichoke {
+    type Error = Error;
+
+    fn try_convert_mut(&mut self, value: Cow<'a, str>) -> Result<Value, Self::Error> {
         match value {
-            Cow::Borrowed(string) => self.convert_mut(string),
-            Cow::Owned(string) => self.convert_mut(string),
+            Cow::Borrowed(string) => self.try_convert_mut(string),
+            Cow::Owned(string) => self.try_convert_mut(string),
         }
     }
 }

--- a/artichoke-backend/src/convert/string.rs
+++ b/artichoke-backend/src/convert/string.rs
@@ -74,7 +74,7 @@ mod tests {
         #[allow(clippy::needless_pass_by_value)]
         fn convert_to_string(s: String) -> bool {
             let mut interp = interpreter().unwrap();
-            let value = interp.convert_mut(s.clone());
+            let value = interp.try_convert_mut(s.clone()).unwrap();
             let string = unsafe {
                 interp
                     .with_ffi_boundary(|mrb| {
@@ -91,7 +91,7 @@ mod tests {
         #[allow(clippy::needless_pass_by_value)]
         fn string_with_value(s: String) -> bool {
             let mut interp = interpreter().unwrap();
-            let value = interp.convert_mut(s.clone());
+            let value = interp.try_convert_mut(s.clone()).unwrap();
             value.to_s(&mut interp) == s.as_bytes()
         }
 
@@ -100,7 +100,7 @@ mod tests {
         fn utf8string_borrowed(string: String) -> bool {
             let mut interp = interpreter().unwrap();
             // Borrowed converter
-            let value = interp.convert_mut(string.as_str());
+            let value = interp.try_convert_mut(string.as_str()).unwrap();
             let len = value
                 .funcall(&mut interp, "length", &[], None)
                 .and_then(|value| value.try_into::<usize>(&interp))
@@ -133,7 +133,7 @@ mod tests {
         fn utf8string_owned(string: String) -> bool {
             let mut interp = interpreter().unwrap();
             // Owned converter
-            let value = interp.convert_mut(string.clone());
+            let value = interp.try_convert_mut(string.clone()).unwrap();
             let len = value
                 .funcall(&mut interp, "length", &[], None)
                 .and_then(|value| value.try_into::<usize>(&interp))
@@ -164,7 +164,7 @@ mod tests {
         #[allow(clippy::needless_pass_by_value)]
         fn roundtrip(s: String) -> bool {
             let mut interp = interpreter().unwrap();
-            let value = interp.convert_mut(s.clone());
+            let value = interp.try_convert_mut(s.clone()).unwrap();
             let value = value.try_into_mut::<String>(&mut interp).unwrap();
             value == s
         }

--- a/artichoke-backend/src/def.rs
+++ b/artichoke-backend/src/def.rs
@@ -7,7 +7,7 @@ use std::ptr::NonNull;
 use crate::class;
 use crate::class_registry::ClassRegistry;
 use crate::convert::BoxUnboxVmValue;
-use crate::core::ConvertMut;
+use crate::core::TryConvertMut;
 use crate::error::{Error, RubyException};
 use crate::extn::core::exception::{NameError, ScriptError};
 use crate::module;
@@ -257,7 +257,7 @@ impl RubyException for ConstantNameError {
     }
 
     fn as_mrb_value(&self, interp: &mut Artichoke) -> Option<sys::mrb_value> {
-        let message = interp.convert_mut(self.message());
+        let message = interp.try_convert_mut(self.message()).ok()?;
         let value = interp.new_instance::<NameError>(&[message]).ok().flatten()?;
         Some(value.inner())
     }
@@ -416,7 +416,7 @@ impl RubyException for NotDefinedError {
     }
 
     fn as_mrb_value(&self, interp: &mut Artichoke) -> Option<sys::mrb_value> {
-        let message = interp.convert_mut(self.message());
+        let message = interp.try_convert_mut(self.message()).ok()?;
         let value = interp.new_instance::<ScriptError>(&[message]).ok().flatten()?;
         Some(value.inner())
     }

--- a/artichoke-backend/src/extn/core/array/trampoline.rs
+++ b/artichoke-backend/src/extn/core/array/trampoline.rs
@@ -46,7 +46,7 @@ pub fn mul(interp: &mut Artichoke, mut ary: Value, mut joiner: Value) -> Result<
     if let Ok(separator) = unsafe { implicitly_convert_to_string(interp, &mut joiner) } {
         let separator = separator.to_vec();
         let s = array.join(interp, &separator)?;
-        Ok(interp.convert_mut(s))
+        interp.try_convert_mut(s)
     } else {
         let n = implicitly_convert_to_int(interp, joiner)?;
         if let Ok(n) = usize::try_from(n) {

--- a/artichoke-backend/src/extn/core/env/trampoline.rs
+++ b/artichoke-backend/src/extn/core/env/trampoline.rs
@@ -16,7 +16,7 @@ pub fn element_reference(interp: &mut Artichoke, mut environ: Value, mut name: V
     let environ = unsafe { Environ::unbox_from_value(&mut environ, interp) }?;
     let name = unsafe { implicitly_convert_to_string(interp, &mut name)? };
     let result = environ.get(name)?;
-    let mut result = interp.convert_mut(result.as_ref().map(Cow::as_ref));
+    let mut result = interp.try_convert_mut(result.as_ref().map(Cow::as_ref))?;
     result.freeze(interp)?;
     Ok(result)
 }

--- a/artichoke-backend/src/extn/core/exception/mod.rs
+++ b/artichoke-backend/src/extn/core/exception/mod.rs
@@ -79,7 +79,7 @@ macro_rules! ruby_exception_impl {
             }
 
             fn as_mrb_value(&self, interp: &mut Artichoke) -> Option<sys::mrb_value> {
-                let message = interp.convert_mut(self.message());
+                let message = interp.try_convert_mut(self.message()).ok()?;
                 let value = interp.new_instance::<Self>(&[message]).ok().flatten()?;
                 Some(value.inner())
             }

--- a/artichoke-backend/src/extn/core/integer/trampoline.rs
+++ b/artichoke-backend/src/extn/core/integer/trampoline.rs
@@ -5,7 +5,7 @@ use crate::extn::prelude::*;
 pub fn chr(interp: &mut Artichoke, value: Value, encoding: Option<Value>) -> Result<Value, Error> {
     let value = value.try_into::<Integer>(interp)?;
     let s = value.chr(interp, encoding)?;
-    Ok(interp.convert_mut(s))
+    interp.try_convert_mut(s)
 }
 
 pub fn element_reference(interp: &mut Artichoke, value: Value, bit: Value) -> Result<Value, Error> {

--- a/artichoke-backend/src/extn/core/matchdata/trampoline.rs
+++ b/artichoke-backend/src/extn/core/matchdata/trampoline.rs
@@ -125,13 +125,13 @@ pub fn offset(interp: &mut Artichoke, mut value: Value, mut at: Value) -> Result
 pub fn post_match(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
     let data = unsafe { MatchData::unbox_from_value(&mut value, interp)? };
     let post = data.post();
-    Ok(interp.convert_mut(post))
+    interp.try_convert_mut(post)
 }
 
 pub fn pre_match(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
     let data = unsafe { MatchData::unbox_from_value(&mut value, interp)? };
     let pre = data.pre();
-    Ok(interp.convert_mut(pre))
+    interp.try_convert_mut(pre)
 }
 
 pub fn regexp(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
@@ -150,7 +150,7 @@ pub fn regexp(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> 
 
 pub fn string(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
     let data = unsafe { MatchData::unbox_from_value(&mut value, interp)? };
-    let mut string = interp.convert_mut(data.string());
+    let mut string = interp.try_convert_mut(data.string())?;
     string.freeze(interp)?;
     Ok(string)
 }
@@ -167,5 +167,5 @@ pub fn to_a(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
 pub fn to_s(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
     let data = unsafe { MatchData::unbox_from_value(&mut value, interp)? };
     let display = data.to_s()?;
-    Ok(interp.convert_mut(display))
+    interp.try_convert_mut(display)
 }

--- a/artichoke-backend/src/extn/core/math/mod.rs
+++ b/artichoke-backend/src/extn/core/math/mod.rs
@@ -45,7 +45,7 @@ impl RubyException for DomainError {
     }
 
     fn as_mrb_value(&self, interp: &mut Artichoke) -> Option<sys::mrb_value> {
-        let message = interp.convert_mut(self.message());
+        let message = interp.try_convert_mut(self.message()).ok()?;
         let value = interp.new_instance::<Self>(&[message]).ok().flatten()?;
         Some(value.inner())
     }

--- a/artichoke-backend/src/extn/core/random/trampoline.rs
+++ b/artichoke-backend/src/extn/core/random/trampoline.rs
@@ -26,7 +26,7 @@ pub fn bytes(interp: &mut Artichoke, mut rand: Value, size: Value) -> Result<Val
         Rng::Global => interp.prng_mut()?.bytes(size)?,
         Rng::Value(random) => random.bytes(size)?,
     };
-    Ok(interp.convert_mut(buf))
+    interp.try_convert_mut(buf)
 }
 
 pub fn rand(interp: &mut Artichoke, mut rand: Value, max: Option<Value>) -> Result<Value, Error> {
@@ -62,5 +62,5 @@ pub fn srand(interp: &mut Artichoke, seed: Option<Value>) -> Result<Value, Error
 pub fn urandom(interp: &mut Artichoke, size: Value) -> Result<Value, Error> {
     let size = implicitly_convert_to_int(interp, size)?;
     let buf = super::urandom(size)?;
-    Ok(interp.convert_mut(buf))
+    interp.try_convert_mut(buf)
 }

--- a/artichoke-backend/src/extn/core/regexp/backend/regex/utf8.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/regex/utf8.rs
@@ -184,18 +184,18 @@ impl RegexpType for Utf8 {
             interp.set_active_regexp_globals(captures.len().checked_sub(1).unwrap_or_default())?;
 
             let fullmatch = captures.get(0).as_ref().map(Match::as_str).map(str::as_bytes);
-            let value = interp.convert_mut(fullmatch);
+            let value = interp.try_convert_mut(fullmatch)?;
             interp.set_global_variable(regexp::LAST_MATCHED_STRING, &value)?;
             for group in 1..captures.len() {
                 let capture = captures.get(group).as_ref().map(Match::as_str).map(str::as_bytes);
-                let value = interp.convert_mut(capture);
+                let value = interp.try_convert_mut(capture)?;
                 let group = unsafe { NonZeroUsize::new_unchecked(group) };
                 interp.set_global_variable(regexp::nth_match_group(group), &value)?;
             }
 
             if let Some(match_pos) = captures.get(0) {
-                let pre_match = interp.convert_mut(&haystack[..match_pos.start()]);
-                let post_match = interp.convert_mut(&haystack[match_pos.end()..]);
+                let pre_match = interp.try_convert_mut(&haystack[..match_pos.start()])?;
+                let post_match = interp.try_convert_mut(&haystack[match_pos.end()..])?;
                 interp.set_global_variable(regexp::STRING_LEFT_OF_MATCH, &pre_match)?;
                 interp.set_global_variable(regexp::STRING_RIGHT_OF_MATCH, &post_match)?;
             }
@@ -282,19 +282,19 @@ impl RegexpType for Utf8 {
             interp.set_active_regexp_globals(captures.len().checked_sub(1).unwrap_or_default())?;
 
             let fullmatch = captures.get(0).as_ref().map(Match::as_str).map(str::as_bytes);
-            let value = interp.convert_mut(fullmatch);
+            let value = interp.try_convert_mut(fullmatch)?;
             interp.set_global_variable(regexp::LAST_MATCHED_STRING, &value)?;
             for group in 1..captures.len() {
                 let capture = captures.get(group).as_ref().map(Match::as_str).map(str::as_bytes);
-                let value = interp.convert_mut(capture);
+                let value = interp.try_convert_mut(capture)?;
                 let group = unsafe { NonZeroUsize::new_unchecked(group) };
                 interp.set_global_variable(regexp::nth_match_group(group), &value)?;
             }
 
             let mut matchdata = MatchData::new(haystack.into(), Regexp::from(self.box_clone()), ..);
             if let Some(match_pos) = captures.get(0) {
-                let pre_match = interp.convert_mut(&target[..match_pos.start()]);
-                let post_match = interp.convert_mut(&target[match_pos.end()..]);
+                let pre_match = interp.try_convert_mut(&target[..match_pos.start()])?;
+                let post_match = interp.try_convert_mut(&target[match_pos.end()..])?;
                 interp.set_global_variable(regexp::STRING_LEFT_OF_MATCH, &pre_match)?;
                 interp.set_global_variable(regexp::STRING_RIGHT_OF_MATCH, &post_match)?;
                 matchdata.set_region(offset + match_pos.start()..offset + match_pos.end());
@@ -330,11 +330,11 @@ impl RegexpType for Utf8 {
             interp.set_active_regexp_globals(captures.len().checked_sub(1).unwrap_or_default())?;
 
             let fullmatch = captures.get(0).as_ref().map(Match::as_str).map(str::as_bytes);
-            let value = interp.convert_mut(fullmatch);
+            let value = interp.try_convert_mut(fullmatch)?;
             interp.set_global_variable(regexp::LAST_MATCHED_STRING, &value)?;
             for group in 1..captures.len() {
                 let capture = captures.get(group).as_ref().map(Match::as_str).map(str::as_bytes);
-                let value = interp.convert_mut(capture);
+                let value = interp.try_convert_mut(capture)?;
                 let group = unsafe { NonZeroUsize::new_unchecked(group) };
                 interp.set_global_variable(regexp::nth_match_group(group), &value)?;
             }
@@ -343,8 +343,8 @@ impl RegexpType for Utf8 {
             let data = MatchData::alloc_value(matchdata, interp)?;
             interp.set_global_variable(regexp::LAST_MATCH, &data)?;
             if let Some(match_pos) = captures.get(0) {
-                let pre_match = interp.convert_mut(&haystack[..match_pos.start()]);
-                let post_match = interp.convert_mut(&haystack[match_pos.end()..]);
+                let pre_match = interp.try_convert_mut(&haystack[..match_pos.start()])?;
+                let post_match = interp.try_convert_mut(&haystack[match_pos.end()..])?;
                 interp.set_global_variable(regexp::STRING_LEFT_OF_MATCH, &pre_match)?;
                 interp.set_global_variable(regexp::STRING_RIGHT_OF_MATCH, &post_match)?;
                 let pos = match_pos.start();
@@ -444,13 +444,13 @@ impl RegexpType for Utf8 {
                 }
                 for captures in iter {
                     let matched = captures.get(0).as_ref().map(Match::as_str).map(str::as_bytes);
-                    let capture = interp.convert_mut(matched);
+                    let capture = interp.try_convert_mut(matched)?;
                     interp.set_global_variable(regexp::LAST_MATCHED_STRING, &capture)?;
 
                     let mut groups = Vec::with_capacity(len.get() - 1);
                     for group in 1..=len.get() {
                         let matched = captures.get(group).as_ref().map(Match::as_str).map(str::as_bytes);
-                        let capture = interp.convert_mut(matched);
+                        let capture = interp.try_convert_mut(matched)?;
                         let group = unsafe { NonZeroUsize::new_unchecked(group) };
                         interp.set_global_variable(regexp::nth_match_group(group), &capture)?;
                         groups.push(matched);
@@ -473,7 +473,7 @@ impl RegexpType for Utf8 {
                 }
                 for pos in iter {
                     let scanned = &haystack[pos.start()..pos.end()];
-                    let matched = interp.convert_mut(scanned);
+                    let matched = interp.try_convert_mut(scanned)?;
                     matchdata.set_region(pos.start()..pos.end());
                     let data = MatchData::alloc_value(matchdata.clone(), interp)?;
                     interp.set_global_variable(regexp::LAST_MATCH, &data)?;
@@ -538,7 +538,7 @@ impl RegexpType for Utf8 {
                 let data = MatchData::alloc_value(matchdata, interp)?;
                 interp.set_global_variable(regexp::LAST_MATCH, &data)?;
                 let last_matched = collected.last().map(Vec::as_slice);
-                let last_matched = interp.convert_mut(last_matched);
+                let last_matched = interp.try_convert_mut(last_matched)?;
                 interp.set_global_variable(regexp::LAST_MATCHED_STRING, &last_matched)?;
                 Ok(Scan::Patterns(collected))
             }

--- a/artichoke-backend/src/extn/core/regexp/trampoline.rs
+++ b/artichoke-backend/src/extn/core/regexp/trampoline.rs
@@ -38,7 +38,7 @@ pub fn escape(interp: &mut Artichoke, mut pattern: Value) -> Result<Value, Error
         pattern_vec = unsafe { implicitly_convert_to_string(interp, &mut pattern)?.to_vec() };
     }
     let pattern = Regexp::escape(&pattern_vec)?;
-    Ok(interp.convert_mut(pattern))
+    interp.try_convert_mut(pattern)
 }
 
 pub fn union<T>(interp: &mut Artichoke, patterns: T) -> Result<Value, Error>
@@ -142,7 +142,7 @@ pub fn hash(interp: &mut Artichoke, mut regexp: Value) -> Result<Value, Error> {
 pub fn inspect(interp: &mut Artichoke, mut regexp: Value) -> Result<Value, Error> {
     let regexp = unsafe { Regexp::unbox_from_value(&mut regexp, interp)? };
     let inspect = regexp.inspect();
-    Ok(interp.convert_mut(inspect))
+    interp.try_convert_mut(inspect)
 }
 
 pub fn named_captures(interp: &mut Artichoke, mut regexp: Value) -> Result<Value, Error> {
@@ -166,11 +166,11 @@ pub fn options(interp: &mut Artichoke, mut regexp: Value) -> Result<Value, Error
 pub fn source(interp: &mut Artichoke, mut regexp: Value) -> Result<Value, Error> {
     let regexp = unsafe { Regexp::unbox_from_value(&mut regexp, interp)? };
     let source = regexp.source();
-    Ok(interp.convert_mut(source))
+    interp.try_convert_mut(source)
 }
 
 pub fn to_s(interp: &mut Artichoke, mut regexp: Value) -> Result<Value, Error> {
     let regexp = unsafe { Regexp::unbox_from_value(&mut regexp, interp)? };
     let s = regexp.string();
-    Ok(interp.convert_mut(s))
+    interp.try_convert_mut(s)
 }

--- a/artichoke-backend/src/extn/core/string/trampoline.rs
+++ b/artichoke-backend/src/extn/core/string/trampoline.rs
@@ -55,7 +55,7 @@ pub fn scan(interp: &mut Artichoke, value: Value, mut pattern: Value, block: Opt
                 let data = MatchData::alloc_value(data, interp)?;
                 interp.set_global_variable(regexp::LAST_MATCH, &data)?;
 
-                let block_arg = interp.convert_mut(pattern_bytes.as_slice());
+                let block_arg = interp.try_convert_mut(pattern_bytes.as_slice())?;
                 block.yield_arg(interp, &block_arg)?;
 
                 interp.set_global_variable(regexp::LAST_MATCH, &data)?;
@@ -68,7 +68,7 @@ pub fn scan(interp: &mut Artichoke, value: Value, mut pattern: Value, block: Opt
                     let data = MatchData::alloc_value(data, interp)?;
                     interp.set_global_variable(regexp::LAST_MATCH, &data)?;
 
-                    let block_arg = interp.convert_mut(pattern_bytes.as_slice());
+                    let block_arg = interp.try_convert_mut(pattern_bytes.as_slice())?;
                     block.yield_arg(interp, &block_arg)?;
 
                     interp.set_global_variable(regexp::LAST_MATCH, &data)?;
@@ -86,7 +86,7 @@ pub fn scan(interp: &mut Artichoke, value: Value, mut pattern: Value, block: Opt
             .unwrap_or_default();
         let mut result = Vec::with_capacity(matches);
         for _ in 0..matches {
-            result.push(interp.convert_mut(pattern_bytes.as_slice()));
+            result.push(interp.try_convert_mut(pattern_bytes.as_slice())?);
         }
         if matches > 0 {
             let regex = Regexp::lazy(pattern_bytes.clone());
@@ -110,13 +110,13 @@ pub fn scan(interp: &mut Artichoke, value: Value, mut pattern: Value, block: Opt
         if let Some(ref block) = block {
             let patlen = pattern_bytes.len();
             if let Some(pos) = string.find(&pattern_bytes) {
-                let block_arg = interp.convert_mut(pattern_bytes.as_slice());
+                let block_arg = interp.try_convert_mut(pattern_bytes.as_slice())?;
                 block.yield_arg(interp, &block_arg)?;
 
                 let offset = pos + patlen;
                 let string = string.get(offset..).unwrap_or_default();
                 for _ in string.find_iter(&pattern_bytes) {
-                    let block_arg = interp.convert_mut(pattern_bytes.as_slice());
+                    let block_arg = interp.try_convert_mut(pattern_bytes.as_slice())?;
                     block.yield_arg(interp, &block_arg)?;
                 }
             }
@@ -130,7 +130,7 @@ pub fn scan(interp: &mut Artichoke, value: Value, mut pattern: Value, block: Opt
             .unwrap_or_default();
         let mut result = Vec::with_capacity(matches);
         for _ in 0..matches {
-            result.push(interp.convert_mut(pattern_bytes.as_slice()));
+            result.push(interp.try_convert_mut(pattern_bytes.as_slice())?);
         }
         return interp.try_convert_mut(result);
     }

--- a/artichoke-backend/src/extn/core/symbol/trampoline.rs
+++ b/artichoke-backend/src/extn/core/symbol/trampoline.rs
@@ -58,12 +58,12 @@ pub fn bytes(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
     let symbol = unsafe { Symbol::unbox_from_value(&mut value, interp)? };
     // These bytes must be cloned because they are owned by the interpreter.
     let bytes = symbol.bytes(interp).to_vec();
-    Ok(interp.convert_mut(bytes))
+    interp.try_convert_mut(bytes)
 }
 
 pub fn inspect(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
     let symbol = unsafe { Symbol::unbox_from_value(&mut value, interp)? };
     let inspect = symbol.inspect(interp);
     let debug = inspect.collect::<String>();
-    Ok(interp.convert_mut(debug))
+    interp.try_convert_mut(debug)
 }

--- a/artichoke-backend/src/extn/core/time/trampoline.rs
+++ b/artichoke-backend/src/extn/core/time/trampoline.rs
@@ -167,7 +167,7 @@ pub fn to_string(interp: &mut Artichoke, time: Value) -> Result<Value, Error> {
     // ```rust
     // Err(NotImplementedError::new().into())
     // ```
-    Ok(interp.convert_mut("Time<Time#inspect is not implemented>"))
+    interp.try_convert_mut("Time<Time#inspect is not implemented>")
 }
 
 pub fn to_array(interp: &mut Artichoke, time: Value) -> Result<Value, Error> {

--- a/artichoke-backend/src/extn/mod.rs
+++ b/artichoke-backend/src/extn/mod.rs
@@ -11,19 +11,19 @@ use prelude::*;
 pub const INPUT_RECORD_SEPARATOR: &str = "\n";
 
 pub fn init(interp: &mut Artichoke, config: ReleaseMetadata<'_>) -> InitializeResult<()> {
-    let mut copyright = interp.convert_mut(config.ruby_copyright());
+    let mut copyright = interp.try_convert_mut(config.ruby_copyright())?;
     copyright.freeze(interp)?;
     interp.define_global_constant("RUBY_COPYRIGHT", copyright)?;
 
-    let mut description = interp.convert_mut(config.ruby_description());
+    let mut description = interp.try_convert_mut(config.ruby_description())?;
     description.freeze(interp)?;
     interp.define_global_constant("RUBY_DESCRIPTION", description)?;
 
-    let mut engine = interp.convert_mut(config.ruby_engine());
+    let mut engine = interp.try_convert_mut(config.ruby_engine())?;
     engine.freeze(interp)?;
     interp.define_global_constant("RUBY_ENGINE", engine)?;
 
-    let mut engine_version = interp.convert_mut(config.ruby_engine_version());
+    let mut engine_version = interp.try_convert_mut(config.ruby_engine_version())?;
     engine_version.freeze(interp)?;
     interp.define_global_constant("RUBY_ENGINE_VERSION", engine_version)?;
 
@@ -34,11 +34,11 @@ pub fn init(interp: &mut Artichoke, config: ReleaseMetadata<'_>) -> InitializeRe
     let patchlevel = interp.convert(patchlevel);
     interp.define_global_constant("RUBY_PATCHLEVEL", patchlevel)?;
 
-    let mut platform = interp.convert_mut(config.ruby_platform());
+    let mut platform = interp.try_convert_mut(config.ruby_platform())?;
     platform.freeze(interp)?;
     interp.define_global_constant("RUBY_PLATFORM", platform)?;
 
-    let mut release_date = interp.convert_mut(config.ruby_release_date());
+    let mut release_date = interp.try_convert_mut(config.ruby_release_date())?;
     release_date.freeze(interp)?;
     interp.define_global_constant("RUBY_RELEASE_DATE", release_date)?;
 
@@ -49,11 +49,11 @@ pub fn init(interp: &mut Artichoke, config: ReleaseMetadata<'_>) -> InitializeRe
     let revision = interp.convert(revision);
     interp.define_global_constant("RUBY_REVISION", revision)?;
 
-    let mut version = interp.convert_mut(config.ruby_version());
+    let mut version = interp.try_convert_mut(config.ruby_version())?;
     version.freeze(interp)?;
     interp.define_global_constant("RUBY_VERSION", version)?;
 
-    let mut compiler_version = interp.convert_mut(config.artichoke_compiler_version());
+    let mut compiler_version = interp.try_convert_mut(config.artichoke_compiler_version())?;
     compiler_version.freeze(interp)?;
     interp.define_global_constant("ARTICHOKE_COMPILER_VERSION", compiler_version)?;
 

--- a/artichoke-backend/src/extn/stdlib/securerandom/trampoline.rs
+++ b/artichoke-backend/src/extn/stdlib/securerandom/trampoline.rs
@@ -12,7 +12,7 @@ pub fn alphanumeric(interp: &mut Artichoke, len: Option<Value>) -> Result<Value,
     } else {
         securerandom::alphanumeric(None)?
     };
-    Ok(interp.convert_mut(alpha))
+    interp.try_convert_mut(alpha)
 }
 
 #[inline]
@@ -23,7 +23,7 @@ pub fn base64(interp: &mut Artichoke, len: Option<Value>) -> Result<Value, Error
     } else {
         securerandom::base64(None)?
     };
-    Ok(interp.convert_mut(base64))
+    interp.try_convert_mut(base64)
 }
 
 #[inline]
@@ -44,7 +44,7 @@ pub fn urlsafe_base64(interp: &mut Artichoke, len: Option<Value>, padding: Optio
     } else {
         securerandom::urlsafe_base64(None, padding)?
     };
-    Ok(interp.convert_mut(base64))
+    interp.try_convert_mut(base64)
 }
 
 #[inline]
@@ -55,7 +55,7 @@ pub fn hex(interp: &mut Artichoke, len: Option<Value>) -> Result<Value, Error> {
     } else {
         securerandom::hex(None)?
     };
-    Ok(interp.convert_mut(hex))
+    interp.try_convert_mut(hex)
 }
 
 #[inline]
@@ -70,7 +70,7 @@ pub fn random_bytes(interp: &mut Artichoke, len: Option<Value>) -> Result<Value,
     } else {
         securerandom::random_bytes(None)?
     };
-    Ok(interp.convert_mut(bytes))
+    interp.try_convert_mut(bytes)
 }
 
 #[inline]
@@ -83,5 +83,5 @@ pub fn random_number(interp: &mut Artichoke, max: Option<Value>) -> Result<Value
 #[inline]
 pub fn uuid(interp: &mut Artichoke) -> Result<Value, Error> {
     let uuid = securerandom::uuid()?;
-    Ok(interp.convert_mut(uuid))
+    interp.try_convert_mut(uuid)
 }

--- a/artichoke-backend/src/ffi.rs
+++ b/artichoke-backend/src/ffi.rs
@@ -11,7 +11,7 @@ use std::ptr::{self, NonNull};
 use spinoso_exception::Fatal;
 
 use crate::class_registry::ClassRegistry;
-use crate::core::ConvertMut;
+use crate::core::TryConvertMut;
 use crate::error::{Error, RubyException};
 use crate::state::State;
 use crate::sys;
@@ -96,7 +96,7 @@ impl RubyException for InterpreterExtractError {
     }
 
     fn as_mrb_value(&self, interp: &mut Artichoke) -> Option<sys::mrb_value> {
-        let message = interp.convert_mut(self.message());
+        let message = interp.try_convert_mut(self.message()).ok()?;
         let value = interp.new_instance::<Fatal>(&[message]).ok().flatten()?;
         Some(value.inner())
     }

--- a/artichoke-backend/src/gc/arena.rs
+++ b/artichoke-backend/src/gc/arena.rs
@@ -6,7 +6,7 @@ use std::fmt;
 use std::ops::{Deref, DerefMut};
 
 use crate::class_registry::ClassRegistry;
-use crate::core::ConvertMut;
+use crate::core::TryConvertMut;
 use crate::error::{Error, RubyException};
 use crate::extn::core::exception::Fatal;
 use crate::sys;
@@ -52,7 +52,7 @@ impl RubyException for ArenaSavepointError {
     }
 
     fn as_mrb_value(&self, interp: &mut Artichoke) -> Option<sys::mrb_value> {
-        let message = interp.convert_mut(self.message());
+        let message = interp.try_convert_mut(self.message()).ok()?;
         let value = interp.new_instance::<Fatal>(&[message]).ok().flatten()?;
         Some(value.inner())
     }

--- a/artichoke-backend/src/intern.rs
+++ b/artichoke-backend/src/intern.rs
@@ -2,8 +2,8 @@ use intaglio::SymbolOverflowError;
 use std::borrow::Cow;
 
 use crate::class_registry::ClassRegistry;
-use crate::core::ConvertMut;
 use crate::core::Intern;
+use crate::core::TryConvertMut;
 use crate::error::{Error, RubyException};
 use crate::extn::core::exception::Fatal;
 use crate::ffi::InterpreterExtractError;
@@ -139,7 +139,7 @@ impl RubyException for SymbolOverflowError {
     }
 
     fn as_mrb_value(&self, interp: &mut Artichoke) -> Option<sys::mrb_value> {
-        let message = interp.convert_mut(self.message());
+        let message = interp.try_convert_mut(self.message()).ok()?;
         let value = interp.new_instance::<Fatal>(&[message]).ok().flatten()?;
         Some(value.inner())
     }

--- a/artichoke-backend/src/interpreter.rs
+++ b/artichoke-backend/src/interpreter.rs
@@ -4,7 +4,7 @@ use std::ffi::c_void;
 use std::fmt;
 
 use crate::class_registry::ClassRegistry;
-use crate::core::{ConvertMut, Eval};
+use crate::core::{Eval, TryConvertMut};
 use crate::error::{Error, RubyException};
 use crate::extn;
 use crate::extn::core::exception::Fatal;
@@ -121,7 +121,7 @@ impl RubyException for InterpreterAllocError {
     }
 
     fn as_mrb_value(&self, interp: &mut Artichoke) -> Option<sys::mrb_value> {
-        let message = interp.convert_mut(self.message());
+        let message = interp.try_convert_mut(self.message()).ok()?;
         let value = interp.new_instance::<Fatal>(&[message]).ok().flatten()?;
         Some(value.inner())
     }

--- a/artichoke-backend/src/io.rs
+++ b/artichoke-backend/src/io.rs
@@ -4,7 +4,7 @@ use std::fmt;
 use std::io;
 
 use crate::class_registry::ClassRegistry;
-use crate::core::{ConvertMut, Io};
+use crate::core::{Io, TryConvertMut};
 use crate::error::{Error, RubyException};
 use crate::extn::core::exception;
 use crate::ffi::InterpreterExtractError;
@@ -87,7 +87,7 @@ impl RubyException for IoError {
     }
 
     fn as_mrb_value(&self, interp: &mut Artichoke) -> Option<sys::mrb_value> {
-        let message = interp.convert_mut(self.message());
+        let message = interp.try_convert_mut(self.message()).ok()?;
         let value = interp.new_instance::<exception::IOError>(&[message]).ok().flatten()?;
         Some(value.inner())
     }

--- a/artichoke-backend/src/parser.rs
+++ b/artichoke-backend/src/parser.rs
@@ -4,7 +4,7 @@
 use std::borrow::Cow;
 
 use crate::class_registry::ClassRegistry;
-use crate::core::{ConvertMut, IncrementLinenoError, Parser};
+use crate::core::{IncrementLinenoError, Parser, TryConvertMut};
 use crate::error::{Error, RubyException};
 use crate::extn::core::exception::ScriptError;
 use crate::ffi::InterpreterExtractError;
@@ -77,7 +77,7 @@ impl RubyException for IncrementLinenoError {
     }
 
     fn as_mrb_value(&self, interp: &mut Artichoke) -> Option<sys::mrb_value> {
-        let message = interp.convert_mut(self.message());
+        let message = interp.try_convert_mut(self.message()).ok()?;
         let value = interp.new_instance::<ScriptError>(&[message]).ok().flatten()?;
         Some(value.inner())
     }

--- a/artichoke-backend/src/platform_string/impls.rs
+++ b/artichoke-backend/src/platform_string/impls.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use artichoke_core::convert::ConvertMut;
+use artichoke_core::convert::TryConvertMut;
 use spinoso_exception::ArgumentError;
 
 use crate::class_registry::ClassRegistry;
@@ -25,7 +25,7 @@ impl RubyException for ConvertBytesError {
     }
 
     fn as_mrb_value(&self, interp: &mut Artichoke) -> Option<sys::mrb_value> {
-        let message = interp.convert_mut(self.message());
+        let message = interp.try_convert_mut(self.message()).ok()?;
         let value = interp.new_instance::<ArgumentError>(&[message]).ok().flatten()?;
         Some(value.inner())
     }

--- a/artichoke-backend/src/string.rs
+++ b/artichoke-backend/src/string.rs
@@ -12,7 +12,7 @@ use std::error;
 use std::fmt;
 
 use crate::class_registry::ClassRegistry;
-use crate::core::ConvertMut;
+use crate::core::TryConvertMut;
 use crate::error::{Error, RubyException};
 use crate::extn::core::exception::Fatal;
 use crate::sys;
@@ -135,7 +135,7 @@ impl RubyException for WriteError {
     }
 
     fn as_mrb_value(&self, interp: &mut Artichoke) -> Option<sys::mrb_value> {
-        let message = interp.convert_mut(self.message());
+        let message = interp.try_convert_mut(self.message()).ok()?;
         let value = interp.new_instance::<Fatal>(&[message]).ok().flatten()?;
         Some(value.inner())
     }

--- a/artichoke-backend/src/types.rs
+++ b/artichoke-backend/src/types.rs
@@ -204,11 +204,11 @@ mod tests {
     #[test]
     fn parse_string_ruby_type() {
         let mut interp = interpreter().unwrap();
-        let empty = interp.convert_mut("");
+        let empty = interp.try_convert_mut("").unwrap();
         assert_eq!(Ruby::String, types::ruby_from_mrb_value(empty.inner()));
-        let utf8 = interp.convert_mut("Artichoke");
+        let utf8 = interp.try_convert_mut("Artichoke").unwrap();
         assert_eq!(Ruby::String, types::ruby_from_mrb_value(utf8.inner()));
-        let binary = interp.convert_mut(vec![0xFF_u8, 0x00, 0xFE]);
+        let binary = interp.try_convert_mut(vec![0xFF_u8, 0x00, 0xFE]).unwrap();
         assert_eq!(Ruby::String, types::ruby_from_mrb_value(binary.inner()));
     }
 

--- a/artichoke-backend/src/warn.rs
+++ b/artichoke-backend/src/warn.rs
@@ -1,6 +1,6 @@
 use std::fmt::Write;
 
-use crate::core::{ConvertMut, Value as _, Warn};
+use crate::core::{TryConvertMut, Value as _, Warn};
 use crate::def::NotDefinedError;
 use crate::error::Error;
 use crate::extn::core::exception::IOError;
@@ -34,7 +34,7 @@ impl Warn for Artichoke {
         let warning = self
             .module_of::<Warning>()?
             .ok_or_else(|| NotDefinedError::module("Warning"))?;
-        let message = self.convert_mut(message);
+        let message = self.try_convert_mut(message)?;
         warning.funcall(self, "warn", &[message], None)?;
         Ok(())
     }

--- a/artichoke-backend/tests/integration/leak/funcall.rs
+++ b/artichoke-backend/tests/integration/leak/funcall.rs
@@ -14,7 +14,7 @@ const ITERATIONS: usize = 100;
 #[test]
 fn arena() {
     let mut interp = artichoke_backend::interpreter().unwrap();
-    let s = interp.convert_mut("a".repeat(1024 * 1024));
+    let s = interp.try_convert_mut("a".repeat(1024 * 1024)).unwrap();
 
     let mut expected = String::from('"');
     expected.push_str(&"a".repeat(1024 * 1024));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@
 //!
 //! # fn example() -> Result<(), Error> {
 //! let mut interp = artichoke::interpreter()?;
-//! let s = interp.convert_mut("💎");
+//! let s = interp.try_convert_mut("💎")?;
 //! let codepoint = s.funcall(&mut interp, "ord", &[] /* args */, None /* block */)?;
 //! let codepoint = codepoint.try_into::<u32>(&interp)?;
 //! assert_eq!(128142, codepoint);

--- a/src/ruby.rs
+++ b/src/ruby.rs
@@ -224,7 +224,7 @@ fn setup_fixture_hack<P: AsRef<Path>>(interp: &mut Artichoke, fixture: P) -> Res
     } else {
         return Err(LoadError::from(load_error(fixture.as_ref(), "No such file or directory")?).into());
     };
-    let value = interp.convert_mut(data);
+    let value = interp.try_convert_mut(data)?;
     interp.set_global_variable(&b"$fixture"[..], &value)?;
     Ok(())
 }


### PR DESCRIPTION
Use the fallible converter API to convert UTF-8 strings and bytestrings
to Ruby `Value`s. These trait implementations invoke fallible code
pathways but currently suppress errors. Make the trait implementation use
the fallible version and propagate errors.

This change prepares for #1222 which will transition `String` to a Rust
data structure which must be fallibly allocated and fallibly packed into
a `Value`.

This changeset was extracted from https://github.com/artichoke/artichoke/pull/1222.