### PR TITLE
Implement methods in `spinoso-string` to enable packing and unpacking `String`s from Ruby values

### DIFF
--- a/spinoso-string/src/lib.rs
+++ b/spinoso-string/src/lib.rs
@@ -712,6 +712,23 @@ impl String {
         self.encoding
     }
 
+    /// Set the [`Encoding`] of this `String`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use spinoso_string::{Encoding, String};
+    ///
+    /// let mut s = String::utf8(b"xyz".to_vec());
+    /// assert_eq!(s.encoding(), Encoding::Utf8);
+    /// s.set_encoding(Encoding::Binary);
+    /// assert_eq!(s.encoding(), Encoding::Binary);
+    /// ```
+    #[inline]
+    pub fn set_encoding(&mut self, encoding: Encoding) {
+        self.encoding = encoding;
+    }
+
     /// Extracts a slice containing the entire byte string.
     ///
     /// Equivalent to `&s[..]`.


### PR DESCRIPTION
## Add "raw parts" APIs to spinoso-string

Add `String::into_raw_parts` and `String::from_raw_parts`. These APIs
enable deconstructing a `String` into a (pointer, length, capacity)
tuple so they can be packed into a `*mut sys::RString` when implementing
`BoxUnboxVmValue` in `artichoke-backend`.

## Add String::set_encoding method to spinoso-string

This method enables implementing `String#force_encoding` and friends.
This method also enables properly setting the encoding after
reconstructing a `String` from "raw parts".

## Notes

These commits were extracted from https://github.com/artichoke/artichoke/pull/1222.