### PR TITLE
Delegate to `std` for path join behavior

### DIFF
--- a/artichoke-load-path/src/rubylib.rs
+++ b/artichoke-load-path/src/rubylib.rs
@@ -148,13 +148,7 @@ impl Rubylib {
     {
         let cwd = Path::new(&cwd);
         let load_paths = env::split_paths(&rubylib)
-            .map(|load_path| {
-                if load_path.is_absolute() {
-                    load_path
-                } else {
-                    cwd.join(&load_path)
-                }
-            })
+            .map(|load_path| cwd.join(&load_path))
             .collect::<Vec<_>>();
 
         // If the `RUBYLIB` env variable is empty or otherwise results in no

--- a/mezzaluna-feature-loader/src/loader/rubylib.rs
+++ b/mezzaluna-feature-loader/src/loader/rubylib.rs
@@ -144,13 +144,7 @@ impl Rubylib {
     {
         let cwd = Path::new(&cwd);
         let load_paths = env::split_paths(&rubylib)
-            .map(|load_path| {
-                if load_path.is_absolute() {
-                    load_path
-                } else {
-                    cwd.join(&load_path)
-                }
-            })
+            .map(|load_path| cwd.join(&load_path))
             .collect::<Vec<_>>();
 
         // If the `RUBYLIB` env variable is empty or otherwise results in no


### PR DESCRIPTION
`PathBuf` in `std` documents that calling `Path::join` with an absolute
path replaces the receiver. This means the check for `is_absolute` in
the closure is redundant.

This commit removes these checks in several `RUBYLIB` feature loader
implementations.