### PR TITLE
repl fix: check for open code block first

### DIFF
--- a/src/repl.rs
+++ b/src/repl.rs
@@ -237,12 +237,13 @@ where
             Ok(line) => {
                 buf.push_str(line.as_str());
                 parser_state = parser.parse(buf.as_bytes());
-                if parser_state.is_fatal() {
-                    return Err(Box::new(ParserInternalError::new()));
-                }
+
                 if parser_state.is_code_block_open() {
                     buf.push('\n');
                     continue;
+                }
+                if parser_state.is_fatal() {
+                    return Err(Box::new(ParserInternalError::new()));
                 }
                 if parser_state.is_recoverable_error() {
                     writeln!(error, "Could not parse input")?;


### PR DESCRIPTION
Reorders checks in the repl to look at whether a code block is open _before_ checking whether it has fatal parsing errors

Tracks behavior in https://github.com/artichoke/artichoke/blob/858b686ed93fa3b23b4e65d0dc64d1ea6e591cb6/artichoke-backend/vendor/mruby/mrbgems/mruby-bin-mirb/tools/mirb/mirb.c#L634-L648

Fixes https://github.com/artichoke/artichoke/issues/1358