### PR TITLE
Clean up clippy overrides

### DIFF
--- a/artichoke-backend/build.rs
+++ b/artichoke-backend/build.rs
@@ -1,6 +1,5 @@
 #![warn(clippy::all)]
 #![warn(clippy::pedantic)]
-#![allow(clippy::let_underscore_drop)]
 #![allow(clippy::restriction)]
 
 use std::env;
@@ -411,7 +410,7 @@ mod build {
     use super::{buildpath, libmruby};
 
     pub fn clean() {
-        let _ = fs::remove_dir_all(buildpath::build_root());
+        let _ignored = fs::remove_dir_all(buildpath::build_root());
     }
 
     pub fn setup_build_root() {
@@ -423,7 +422,7 @@ mod build {
         )
         .unwrap();
 
-        let _ = fs::remove_file(libmruby::mruby_build_config());
+        let _ignored = fs::remove_file(libmruby::mruby_build_config());
         fs::create_dir_all(libmruby::mruby_build_dir()).unwrap();
         fs::copy(buildpath::source::mruby_build_config(), libmruby::mruby_build_config()).unwrap();
         fs::copy(
@@ -456,7 +455,7 @@ mod build {
         while let Some(from) = stack.pop() {
             let dest = from.components().skip(input_root_depth);
             let dest = dest_root.join(dest.collect::<PathBuf>());
-            let _ = fs::create_dir_all(&dest);
+            let _ignored = fs::create_dir_all(&dest);
 
             for entry in fs::read_dir(from)? {
                 let entry = entry?;

--- a/artichoke-backend/src/extn/core/time/trampoline.rs
+++ b/artichoke-backend/src/extn/core/time/trampoline.rs
@@ -36,7 +36,7 @@ where
     T: IntoIterator<Item = Value>,
 {
     let _ = interp;
-    let _ = args;
+    let _ignored_while_unimplemented = args;
     Err(NotImplementedError::new().into())
 }
 
@@ -45,7 +45,7 @@ where
     T: IntoIterator<Item = Value>,
 {
     let _ = interp;
-    let _ = args;
+    let _ignored_while_unimplemented = args;
     Err(NotImplementedError::new().into())
 }
 
@@ -105,7 +105,7 @@ where
 {
     let _ = interp;
     let _ = time;
-    let _ = args;
+    let _ignored_while_unimplemented = args;
     Err(NotImplementedError::new().into())
 }
 

--- a/artichoke-backend/src/extn/mod.rs
+++ b/artichoke-backend/src/extn/mod.rs
@@ -1,3 +1,5 @@
+// This pragma is needed to allow passing `Value` by value in all of the mruby
+// and Rust trampolines.
 #![allow(clippy::needless_pass_by_value)]
 
 use crate::release_metadata::ReleaseMetadata;

--- a/artichoke-backend/src/lib.rs
+++ b/artichoke-backend/src/lib.rs
@@ -1,7 +1,6 @@
 #![warn(clippy::all)]
 #![warn(clippy::pedantic)]
 #![warn(clippy::cargo)]
-#![warn(clippy::needless_borrow)]
 #![allow(clippy::let_underscore_drop)]
 #![allow(clippy::missing_errors_doc)]
 #![allow(clippy::non_ascii_literal)]

--- a/artichoke-backend/src/lib.rs
+++ b/artichoke-backend/src/lib.rs
@@ -3,8 +3,6 @@
 #![warn(clippy::cargo)]
 #![warn(clippy::needless_borrow)]
 #![allow(clippy::let_underscore_drop)]
-// https://github.com/rust-lang/rust-clippy/pull/5998#issuecomment-731855891
-#![allow(clippy::map_err_ignore)]
 #![allow(clippy::missing_errors_doc)]
 #![allow(clippy::non_ascii_literal)]
 #![allow(clippy::option_if_let_else)]

--- a/artichoke-backend/src/lib.rs
+++ b/artichoke-backend/src/lib.rs
@@ -1,7 +1,6 @@
 #![warn(clippy::all)]
 #![warn(clippy::pedantic)]
 #![warn(clippy::cargo)]
-#![allow(clippy::let_underscore_drop)]
 #![allow(clippy::missing_errors_doc)]
 #![allow(clippy::non_ascii_literal)]
 #![allow(clippy::option_if_let_else)]

--- a/artichoke-backend/src/lib.rs
+++ b/artichoke-backend/src/lib.rs
@@ -2,7 +2,7 @@
 #![warn(clippy::pedantic)]
 #![warn(clippy::cargo)]
 #![allow(clippy::missing_errors_doc)]
-#![allow(clippy::non_ascii_literal)]
+#![cfg_attr(test, allow(clippy::non_ascii_literal))]
 #![allow(clippy::option_if_let_else)]
 #![allow(unknown_lints)]
 // #![warn(missing_docs)]

--- a/artichoke-backend/src/parser.rs
+++ b/artichoke-backend/src/parser.rs
@@ -1,4 +1,9 @@
-// https://github.com/rust-lang/rust-clippy/issues/6137
+// This `allow` pragma suppresses false positives.
+//
+// See:
+//
+// - https://github.com/rust-lang/rust-clippy/issues/6141
+// - https://github.com/rust-lang/rust-clippy/issues/6563
 #![allow(clippy::shadow_unrelated)]
 
 use std::borrow::Cow;

--- a/artichoke-backend/src/platform_string.rs
+++ b/artichoke-backend/src/platform_string.rs
@@ -152,7 +152,7 @@ impl From<Utf8Error> for ConvertBytesError {
 impl From<OsString> for ConvertBytesError {
     #[inline]
     fn from(err: OsString) -> Self {
-        let _ = err;
+        drop(err);
         Self { _private: () }
     }
 }

--- a/artichoke-backend/src/state/output.rs
+++ b/artichoke-backend/src/state/output.rs
@@ -119,12 +119,12 @@ impl Null {
 
 impl Output for Null {
     fn write_stdout<T: AsRef<[u8]>>(&mut self, bytes: T) -> io::Result<()> {
-        let _ = bytes;
+        drop(bytes);
         Ok(())
     }
 
     fn write_stderr<T: AsRef<[u8]>>(&mut self, bytes: T) -> io::Result<()> {
-        let _ = bytes;
+        drop(bytes);
         Ok(())
     }
 }

--- a/artichoke-backend/src/state/parser.rs
+++ b/artichoke-backend/src/state/parser.rs
@@ -1,4 +1,9 @@
-// https://github.com/rust-lang/rust-clippy/issues/6137
+// This `allow` pragma suppresses false positives.
+//
+// See:
+//
+// - https://github.com/rust-lang/rust-clippy/issues/6141
+// - https://github.com/rust-lang/rust-clippy/issues/6563
 #![allow(clippy::shadow_unrelated)]
 
 use std::borrow::Cow;

--- a/artichoke-backend/tests/integration/main.rs
+++ b/artichoke-backend/tests/integration/main.rs
@@ -1,7 +1,6 @@
 #![warn(clippy::all)]
 #![warn(clippy::pedantic)]
 #![warn(clippy::cargo)]
-#![warn(clippy::needless_borrow)]
 #![allow(clippy::let_underscore_drop)]
 #![allow(clippy::missing_errors_doc)]
 #![allow(clippy::non_ascii_literal)]

--- a/artichoke-backend/tests/integration/main.rs
+++ b/artichoke-backend/tests/integration/main.rs
@@ -3,8 +3,6 @@
 #![warn(clippy::cargo)]
 #![warn(clippy::needless_borrow)]
 #![allow(clippy::let_underscore_drop)]
-// https://github.com/rust-lang/rust-clippy/pull/5998#issuecomment-731855891
-#![allow(clippy::map_err_ignore)]
 #![allow(clippy::missing_errors_doc)]
 #![allow(clippy::non_ascii_literal)]
 #![allow(clippy::option_if_let_else)]

--- a/artichoke-backend/tests/integration/main.rs
+++ b/artichoke-backend/tests/integration/main.rs
@@ -1,7 +1,6 @@
 #![warn(clippy::all)]
 #![warn(clippy::pedantic)]
 #![warn(clippy::cargo)]
-#![allow(clippy::let_underscore_drop)]
 #![allow(clippy::missing_errors_doc)]
 #![allow(clippy::non_ascii_literal)]
 #![allow(clippy::option_if_let_else)]

--- a/artichoke-core/src/lib.rs
+++ b/artichoke-core/src/lib.rs
@@ -1,7 +1,6 @@
 #![warn(clippy::all)]
 #![warn(clippy::pedantic)]
 #![warn(clippy::cargo)]
-#![allow(clippy::let_underscore_drop)]
 #![allow(clippy::option_if_let_else)]
 #![allow(unknown_lints)]
 #![warn(missing_docs)]

--- a/artichoke-core/src/lib.rs
+++ b/artichoke-core/src/lib.rs
@@ -1,7 +1,6 @@
 #![warn(clippy::all)]
 #![warn(clippy::pedantic)]
 #![warn(clippy::cargo)]
-#![warn(clippy::needless_borrow)]
 #![allow(clippy::let_underscore_drop)]
 #![allow(clippy::option_if_let_else)]
 #![allow(unknown_lints)]

--- a/artichoke-core/src/lib.rs
+++ b/artichoke-core/src/lib.rs
@@ -3,8 +3,6 @@
 #![warn(clippy::cargo)]
 #![warn(clippy::needless_borrow)]
 #![allow(clippy::let_underscore_drop)]
-// https://github.com/rust-lang/rust-clippy/pull/5998#issuecomment-731855891
-#![allow(clippy::map_err_ignore)]
 #![allow(clippy::option_if_let_else)]
 #![allow(unknown_lints)]
 #![warn(missing_docs)]

--- a/artichoke-load-path/src/lib.rs
+++ b/artichoke-load-path/src/lib.rs
@@ -2,8 +2,6 @@
 #![warn(clippy::pedantic)]
 #![warn(clippy::cargo)]
 #![warn(clippy::needless_borrow)]
-// https://github.com/rust-lang/rust-clippy/pull/5998#issuecomment-731855891
-#![allow(clippy::map_err_ignore)]
 #![allow(clippy::option_if_let_else)]
 #![allow(unknown_lints)]
 #![warn(missing_docs)]

--- a/artichoke-load-path/src/lib.rs
+++ b/artichoke-load-path/src/lib.rs
@@ -1,7 +1,6 @@
 #![warn(clippy::all)]
 #![warn(clippy::pedantic)]
 #![warn(clippy::cargo)]
-#![warn(clippy::needless_borrow)]
 #![allow(clippy::option_if_let_else)]
 #![allow(unknown_lints)]
 #![warn(missing_docs)]

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,5 @@
 #![warn(clippy::all)]
 #![warn(clippy::pedantic)]
-#![warn(clippy::needless_borrow)]
 #![allow(clippy::let_underscore_drop)]
 #![allow(clippy::option_if_let_else)]
 

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,6 @@
 #![warn(clippy::all)]
 #![warn(clippy::pedantic)]
+#![allow(clippy::restriction)]
 #![allow(clippy::option_if_let_else)]
 
 use chrono::prelude::*;

--- a/build.rs
+++ b/build.rs
@@ -2,8 +2,6 @@
 #![warn(clippy::pedantic)]
 #![warn(clippy::needless_borrow)]
 #![allow(clippy::let_underscore_drop)]
-// https://github.com/rust-lang/rust-clippy/pull/5998#issuecomment-731855891
-#![allow(clippy::map_err_ignore)]
 #![allow(clippy::option_if_let_else)]
 
 use chrono::prelude::*;

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,5 @@
 #![warn(clippy::all)]
 #![warn(clippy::pedantic)]
-#![allow(clippy::let_underscore_drop)]
 #![allow(clippy::option_if_let_else)]
 
 use chrono::prelude::*;

--- a/mezzaluna-feature-loader/src/lib.rs
+++ b/mezzaluna-feature-loader/src/lib.rs
@@ -2,8 +2,6 @@
 #![warn(clippy::pedantic)]
 #![warn(clippy::cargo)]
 #![warn(clippy::needless_borrow)]
-// https://github.com/rust-lang/rust-clippy/pull/5998#issuecomment-731855891
-#![allow(clippy::map_err_ignore)]
 #![allow(clippy::option_if_let_else)]
 #![allow(unknown_lints)]
 // #![warn(missing_docs)]

--- a/mezzaluna-feature-loader/src/lib.rs
+++ b/mezzaluna-feature-loader/src/lib.rs
@@ -1,7 +1,6 @@
 #![warn(clippy::all)]
 #![warn(clippy::pedantic)]
 #![warn(clippy::cargo)]
-#![warn(clippy::needless_borrow)]
 #![allow(clippy::option_if_let_else)]
 #![allow(unknown_lints)]
 // #![warn(missing_docs)]

--- a/scolapasta-hex/src/lib.rs
+++ b/scolapasta-hex/src/lib.rs
@@ -1,7 +1,6 @@
 #![warn(clippy::all)]
 #![warn(clippy::pedantic)]
 #![warn(clippy::cargo)]
-#![allow(clippy::let_underscore_drop)]
 #![allow(clippy::option_if_let_else)]
 #![cfg_attr(test, allow(clippy::non_ascii_literal))]
 #![allow(unknown_lints)]

--- a/scolapasta-hex/src/lib.rs
+++ b/scolapasta-hex/src/lib.rs
@@ -1,7 +1,6 @@
 #![warn(clippy::all)]
 #![warn(clippy::pedantic)]
 #![warn(clippy::cargo)]
-#![warn(clippy::needless_borrow)]
 #![allow(clippy::let_underscore_drop)]
 #![allow(clippy::option_if_let_else)]
 #![cfg_attr(test, allow(clippy::non_ascii_literal))]

--- a/scolapasta-hex/src/lib.rs
+++ b/scolapasta-hex/src/lib.rs
@@ -3,8 +3,6 @@
 #![warn(clippy::cargo)]
 #![warn(clippy::needless_borrow)]
 #![allow(clippy::let_underscore_drop)]
-// https://github.com/rust-lang/rust-clippy/pull/5998#issuecomment-731855891
-#![allow(clippy::map_err_ignore)]
 #![allow(clippy::option_if_let_else)]
 #![cfg_attr(test, allow(clippy::non_ascii_literal))]
 #![allow(unknown_lints)]

--- a/scolapasta-string-escape/src/lib.rs
+++ b/scolapasta-string-escape/src/lib.rs
@@ -1,7 +1,6 @@
 #![warn(clippy::all)]
 #![warn(clippy::pedantic)]
 #![warn(clippy::cargo)]
-#![allow(clippy::let_underscore_drop)]
 #![allow(clippy::option_if_let_else)]
 #![cfg_attr(test, allow(clippy::non_ascii_literal))]
 #![allow(unknown_lints)]

--- a/scolapasta-string-escape/src/lib.rs
+++ b/scolapasta-string-escape/src/lib.rs
@@ -1,7 +1,6 @@
 #![warn(clippy::all)]
 #![warn(clippy::pedantic)]
 #![warn(clippy::cargo)]
-#![warn(clippy::needless_borrow)]
 #![allow(clippy::let_underscore_drop)]
 #![allow(clippy::option_if_let_else)]
 #![cfg_attr(test, allow(clippy::non_ascii_literal))]

--- a/scolapasta-string-escape/src/lib.rs
+++ b/scolapasta-string-escape/src/lib.rs
@@ -3,8 +3,6 @@
 #![warn(clippy::cargo)]
 #![warn(clippy::needless_borrow)]
 #![allow(clippy::let_underscore_drop)]
-// https://github.com/rust-lang/rust-clippy/pull/5998#issuecomment-731855891
-#![allow(clippy::map_err_ignore)]
 #![allow(clippy::option_if_let_else)]
 #![cfg_attr(test, allow(clippy::non_ascii_literal))]
 #![allow(unknown_lints)]

--- a/spec-runner/src/main.rs
+++ b/spec-runner/src/main.rs
@@ -1,7 +1,6 @@
 #![warn(clippy::all)]
 #![warn(clippy::pedantic)]
 #![warn(clippy::cargo)]
-#![warn(clippy::needless_borrow)]
 #![allow(clippy::let_underscore_drop)]
 #![allow(clippy::option_if_let_else)]
 #![allow(unknown_lints)]

--- a/spec-runner/src/main.rs
+++ b/spec-runner/src/main.rs
@@ -1,7 +1,6 @@
 #![warn(clippy::all)]
 #![warn(clippy::pedantic)]
 #![warn(clippy::cargo)]
-#![allow(clippy::let_underscore_drop)]
 #![allow(clippy::option_if_let_else)]
 #![allow(unknown_lints)]
 #![warn(missing_docs)]
@@ -151,7 +150,7 @@ pub fn main() {
         Err(err) => {
             // Suppress all errors at this point (e.g. from a broken pipe) since
             // we're exiting with an error code anyway.
-            let _ = writeln!(&mut stderr, "{}", err);
+            let _ignored = writeln!(&mut stderr, "{}", err);
             process::exit(1);
         }
     };
@@ -165,7 +164,7 @@ pub fn main() {
     } else {
         // Suppress all errors at this point (e.g. from a broken pipe) since
         // we're exiting with an error code anyway.
-        let _ = writeln!(&mut stderr, "Missing required spec configuration");
+        let _ignored = writeln!(&mut stderr, "Missing required spec configuration");
         process::exit(1);
     };
 
@@ -175,7 +174,7 @@ pub fn main() {
         Err(err) => {
             // Suppress all errors at this point (e.g. from a broken pipe) since
             // we're exiting with an error code anyway.
-            let _ = writeln!(&mut stderr, "{}", err);
+            let _ignored = writeln!(&mut stderr, "{}", err);
             process::exit(1);
         }
     }

--- a/spinoso-array/src/lib.rs
+++ b/spinoso-array/src/lib.rs
@@ -1,7 +1,6 @@
 #![warn(clippy::all)]
 #![warn(clippy::pedantic)]
 #![warn(clippy::cargo)]
-#![allow(clippy::let_underscore_drop)]
 #![allow(clippy::option_if_let_else)]
 #![allow(unknown_lints)]
 #![warn(missing_docs)]

--- a/spinoso-array/src/lib.rs
+++ b/spinoso-array/src/lib.rs
@@ -1,7 +1,6 @@
 #![warn(clippy::all)]
 #![warn(clippy::pedantic)]
 #![warn(clippy::cargo)]
-#![warn(clippy::needless_borrow)]
 #![allow(clippy::let_underscore_drop)]
 #![allow(clippy::option_if_let_else)]
 #![allow(unknown_lints)]

--- a/spinoso-array/src/lib.rs
+++ b/spinoso-array/src/lib.rs
@@ -3,8 +3,6 @@
 #![warn(clippy::cargo)]
 #![warn(clippy::needless_borrow)]
 #![allow(clippy::let_underscore_drop)]
-// https://github.com/rust-lang/rust-clippy/pull/5998#issuecomment-731855891
-#![allow(clippy::map_err_ignore)]
 #![allow(clippy::option_if_let_else)]
 #![allow(unknown_lints)]
 #![warn(missing_docs)]

--- a/spinoso-env/src/lib.rs
+++ b/spinoso-env/src/lib.rs
@@ -1,7 +1,6 @@
 #![warn(clippy::all)]
 #![warn(clippy::pedantic)]
 #![warn(clippy::cargo)]
-#![allow(clippy::let_underscore_drop)]
 #![allow(clippy::option_if_let_else)]
 #![allow(unknown_lints)]
 #![warn(missing_docs)]

--- a/spinoso-env/src/lib.rs
+++ b/spinoso-env/src/lib.rs
@@ -1,7 +1,6 @@
 #![warn(clippy::all)]
 #![warn(clippy::pedantic)]
 #![warn(clippy::cargo)]
-#![warn(clippy::needless_borrow)]
 #![allow(clippy::let_underscore_drop)]
 #![allow(clippy::option_if_let_else)]
 #![allow(unknown_lints)]

--- a/spinoso-env/src/lib.rs
+++ b/spinoso-env/src/lib.rs
@@ -3,8 +3,6 @@
 #![warn(clippy::cargo)]
 #![warn(clippy::needless_borrow)]
 #![allow(clippy::let_underscore_drop)]
-// https://github.com/rust-lang/rust-clippy/pull/5998#issuecomment-731855891
-#![allow(clippy::map_err_ignore)]
 #![allow(clippy::option_if_let_else)]
 #![allow(unknown_lints)]
 #![warn(missing_docs)]

--- a/spinoso-exception/src/lib.rs
+++ b/spinoso-exception/src/lib.rs
@@ -1,7 +1,6 @@
 #![warn(clippy::all)]
 #![warn(clippy::pedantic)]
 #![warn(clippy::cargo)]
-#![allow(clippy::let_underscore_drop)]
 #![allow(clippy::option_if_let_else)]
 #![allow(unknown_lints)]
 #![warn(missing_docs)]

--- a/spinoso-exception/src/lib.rs
+++ b/spinoso-exception/src/lib.rs
@@ -1,7 +1,6 @@
 #![warn(clippy::all)]
 #![warn(clippy::pedantic)]
 #![warn(clippy::cargo)]
-#![warn(clippy::needless_borrow)]
 #![allow(clippy::let_underscore_drop)]
 #![allow(clippy::option_if_let_else)]
 #![allow(unknown_lints)]

--- a/spinoso-exception/src/lib.rs
+++ b/spinoso-exception/src/lib.rs
@@ -3,8 +3,6 @@
 #![warn(clippy::cargo)]
 #![warn(clippy::needless_borrow)]
 #![allow(clippy::let_underscore_drop)]
-// https://github.com/rust-lang/rust-clippy/pull/5998#issuecomment-731855891
-#![allow(clippy::map_err_ignore)]
 #![allow(clippy::option_if_let_else)]
 #![allow(unknown_lints)]
 #![warn(missing_docs)]

--- a/spinoso-math/src/lib.rs
+++ b/spinoso-math/src/lib.rs
@@ -1,7 +1,6 @@
 #![warn(clippy::all)]
 #![warn(clippy::pedantic)]
 #![warn(clippy::cargo)]
-#![allow(clippy::let_underscore_drop)]
 #![allow(clippy::option_if_let_else)]
 #![allow(unknown_lints)]
 #![warn(missing_docs)]

--- a/spinoso-math/src/lib.rs
+++ b/spinoso-math/src/lib.rs
@@ -1,7 +1,6 @@
 #![warn(clippy::all)]
 #![warn(clippy::pedantic)]
 #![warn(clippy::cargo)]
-#![warn(clippy::needless_borrow)]
 #![allow(clippy::let_underscore_drop)]
 #![allow(clippy::option_if_let_else)]
 #![allow(unknown_lints)]

--- a/spinoso-math/src/lib.rs
+++ b/spinoso-math/src/lib.rs
@@ -3,8 +3,6 @@
 #![warn(clippy::cargo)]
 #![warn(clippy::needless_borrow)]
 #![allow(clippy::let_underscore_drop)]
-// https://github.com/rust-lang/rust-clippy/pull/5998#issuecomment-731855891
-#![allow(clippy::map_err_ignore)]
 #![allow(clippy::option_if_let_else)]
 #![allow(unknown_lints)]
 #![warn(missing_docs)]

--- a/spinoso-random/src/lib.rs
+++ b/spinoso-random/src/lib.rs
@@ -1,7 +1,6 @@
 #![warn(clippy::all)]
 #![warn(clippy::pedantic)]
 #![warn(clippy::cargo)]
-#![allow(clippy::let_underscore_drop)]
 #![allow(clippy::option_if_let_else)]
 #![allow(unknown_lints)]
 #![warn(missing_docs)]

--- a/spinoso-random/src/lib.rs
+++ b/spinoso-random/src/lib.rs
@@ -1,7 +1,6 @@
 #![warn(clippy::all)]
 #![warn(clippy::pedantic)]
 #![warn(clippy::cargo)]
-#![warn(clippy::needless_borrow)]
 #![allow(clippy::let_underscore_drop)]
 #![allow(clippy::option_if_let_else)]
 #![allow(unknown_lints)]

--- a/spinoso-random/src/lib.rs
+++ b/spinoso-random/src/lib.rs
@@ -3,8 +3,6 @@
 #![warn(clippy::cargo)]
 #![warn(clippy::needless_borrow)]
 #![allow(clippy::let_underscore_drop)]
-// https://github.com/rust-lang/rust-clippy/pull/5998#issuecomment-731855891
-#![allow(clippy::map_err_ignore)]
 #![allow(clippy::option_if_let_else)]
 #![allow(unknown_lints)]
 #![warn(missing_docs)]

--- a/spinoso-random/src/random/ruby/mod.rs
+++ b/spinoso-random/src/random/ruby/mod.rs
@@ -122,6 +122,9 @@ impl Mt {
     #[inline]
     #[must_use]
     pub fn next_int32(&mut self) -> u32 {
+        // Failing this check indicates that, somehow, the structure
+        // was not initialized.
+        debug_assert!(self.idx != 0);
         if self.idx >= N {
             next_state(self);
         }

--- a/spinoso-securerandom/src/lib.rs
+++ b/spinoso-securerandom/src/lib.rs
@@ -1,7 +1,6 @@
 #![warn(clippy::all)]
 #![warn(clippy::pedantic)]
 #![warn(clippy::cargo)]
-#![allow(clippy::let_underscore_drop)]
 #![allow(clippy::option_if_let_else)]
 #![allow(unknown_lints)]
 #![warn(missing_docs)]

--- a/spinoso-securerandom/src/lib.rs
+++ b/spinoso-securerandom/src/lib.rs
@@ -1,7 +1,6 @@
 #![warn(clippy::all)]
 #![warn(clippy::pedantic)]
 #![warn(clippy::cargo)]
-#![warn(clippy::needless_borrow)]
 #![allow(clippy::let_underscore_drop)]
 #![allow(clippy::option_if_let_else)]
 #![allow(unknown_lints)]

--- a/spinoso-securerandom/src/lib.rs
+++ b/spinoso-securerandom/src/lib.rs
@@ -3,8 +3,6 @@
 #![warn(clippy::cargo)]
 #![warn(clippy::needless_borrow)]
 #![allow(clippy::let_underscore_drop)]
-// https://github.com/rust-lang/rust-clippy/pull/5998#issuecomment-731855891
-#![allow(clippy::map_err_ignore)]
 #![allow(clippy::option_if_let_else)]
 #![allow(unknown_lints)]
 #![warn(missing_docs)]

--- a/spinoso-string/src/lib.rs
+++ b/spinoso-string/src/lib.rs
@@ -1,7 +1,6 @@
 #![warn(clippy::all)]
 #![warn(clippy::pedantic)]
 #![warn(clippy::cargo)]
-#![allow(clippy::let_underscore_drop)]
 #![allow(clippy::option_if_let_else)]
 #![cfg_attr(test, allow(clippy::non_ascii_literal))]
 #![allow(unknown_lints)]

--- a/spinoso-string/src/lib.rs
+++ b/spinoso-string/src/lib.rs
@@ -1,7 +1,6 @@
 #![warn(clippy::all)]
 #![warn(clippy::pedantic)]
 #![warn(clippy::cargo)]
-#![warn(clippy::needless_borrow)]
 #![allow(clippy::let_underscore_drop)]
 #![allow(clippy::option_if_let_else)]
 #![cfg_attr(test, allow(clippy::non_ascii_literal))]

--- a/spinoso-symbol/src/all_symbols.rs
+++ b/spinoso-symbol/src/all_symbols.rs
@@ -223,7 +223,7 @@ mod tests {
         where
             T: Into<Cow<'static, [u8]>>,
         {
-            let _ = symbol;
+            drop(symbol.into());
             Err("not implemented")
         }
 
@@ -254,7 +254,7 @@ mod tests {
         where
             T: Into<Cow<'static, [u8]>>,
         {
-            let _ = symbol;
+            drop(symbol.into());
             Err("not implemented")
         }
 
@@ -285,7 +285,7 @@ mod tests {
         where
             T: Into<Cow<'static, [u8]>>,
         {
-            let _ = symbol;
+            drop(symbol.into());
             Err("not implemented")
         }
 

--- a/spinoso-symbol/src/lib.rs
+++ b/spinoso-symbol/src/lib.rs
@@ -1,7 +1,6 @@
 #![warn(clippy::all)]
 #![warn(clippy::pedantic)]
 #![warn(clippy::cargo)]
-#![allow(clippy::let_underscore_drop)]
 #![allow(clippy::option_if_let_else)]
 #![cfg_attr(test, allow(clippy::non_ascii_literal))]
 #![allow(unknown_lints)]

--- a/spinoso-symbol/src/lib.rs
+++ b/spinoso-symbol/src/lib.rs
@@ -1,7 +1,6 @@
 #![warn(clippy::all)]
 #![warn(clippy::pedantic)]
 #![warn(clippy::cargo)]
-#![warn(clippy::needless_borrow)]
 #![allow(clippy::let_underscore_drop)]
 #![allow(clippy::option_if_let_else)]
 #![cfg_attr(test, allow(clippy::non_ascii_literal))]

--- a/spinoso-symbol/src/lib.rs
+++ b/spinoso-symbol/src/lib.rs
@@ -3,8 +3,6 @@
 #![warn(clippy::cargo)]
 #![warn(clippy::needless_borrow)]
 #![allow(clippy::let_underscore_drop)]
-// https://github.com/rust-lang/rust-clippy/pull/5998#issuecomment-731855891
-#![allow(clippy::map_err_ignore)]
 #![allow(clippy::option_if_let_else)]
 #![cfg_attr(test, allow(clippy::non_ascii_literal))]
 #![allow(unknown_lints)]

--- a/spinoso-time/src/lib.rs
+++ b/spinoso-time/src/lib.rs
@@ -1,7 +1,6 @@
 #![warn(clippy::all)]
 #![warn(clippy::pedantic)]
 #![warn(clippy::cargo)]
-#![allow(clippy::let_underscore_drop)]
 #![allow(clippy::option_if_let_else)]
 #![allow(unknown_lints)]
 #![warn(missing_docs)]

--- a/spinoso-time/src/lib.rs
+++ b/spinoso-time/src/lib.rs
@@ -1,7 +1,6 @@
 #![warn(clippy::all)]
 #![warn(clippy::pedantic)]
 #![warn(clippy::cargo)]
-#![warn(clippy::needless_borrow)]
 #![allow(clippy::let_underscore_drop)]
 #![allow(clippy::option_if_let_else)]
 #![allow(unknown_lints)]

--- a/spinoso-time/src/lib.rs
+++ b/spinoso-time/src/lib.rs
@@ -3,8 +3,6 @@
 #![warn(clippy::cargo)]
 #![warn(clippy::needless_borrow)]
 #![allow(clippy::let_underscore_drop)]
-// https://github.com/rust-lang/rust-clippy/pull/5998#issuecomment-731855891
-#![allow(clippy::map_err_ignore)]
 #![allow(clippy::option_if_let_else)]
 #![allow(unknown_lints)]
 #![warn(missing_docs)]

--- a/src/bin/airb.rs
+++ b/src/bin/airb.rs
@@ -1,6 +1,5 @@
 #![warn(clippy::all)]
 #![warn(clippy::pedantic)]
-#![allow(clippy::let_underscore_drop)]
 #![warn(clippy::cargo)]
 #![allow(unknown_lints)]
 #![warn(missing_docs)]
@@ -40,8 +39,8 @@ fn main() {
         //
         // Suppress all errors at this point (e.g. from a broken pipe) since
         // we're exiting with an error code anyway.
-        let _ = stderr.reset();
-        let _ = writeln!(stderr, "{}", err);
+        let _ignored = stderr.reset();
+        let _ignored = writeln!(stderr, "{}", err);
         process::exit(1);
     }
 }

--- a/src/bin/artichoke.rs
+++ b/src/bin/artichoke.rs
@@ -1,6 +1,5 @@
 #![warn(clippy::all)]
 #![warn(clippy::pedantic)]
-#![allow(clippy::let_underscore_drop)]
 #![warn(clippy::cargo)]
 #![allow(unknown_lints)]
 #![warn(missing_docs)]
@@ -60,7 +59,7 @@ fn main() {
         Err(err) => {
             // Suppress all errors at this point (e.g. from a broken pipe) since
             // we're exiting with an error code anyway.
-            let _ = writeln!(io::stderr(), "{}", err);
+            let _ignored = writeln!(io::stderr(), "{}", err);
             process::exit(2);
         }
     };
@@ -74,8 +73,8 @@ fn main() {
             //
             // Suppress all errors at this point (e.g. from a broken pipe) since
             // we're exiting with an error code anyway.
-            let _ = stderr.reset();
-            let _ = writeln!(stderr, "{}", err);
+            let _ignored = stderr.reset();
+            let _ignored = writeln!(stderr, "{}", err);
             process::exit(1);
         }
     }
@@ -168,6 +167,6 @@ where
     //
     // (This is the point of this helper function. clap's functionality for
     // doing this will panic on a broken pipe error.)
-    let _ = write!(io::stdout(), "{}", err);
+    let _ignored = write!(io::stdout(), "{}", err);
     process::exit(0);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,8 +3,6 @@
 // #![warn(clippy::cargo)]
 #![warn(clippy::needless_borrow)]
 #![allow(clippy::let_underscore_drop)]
-// https://github.com/rust-lang/rust-clippy/pull/5998#issuecomment-731855891
-#![allow(clippy::map_err_ignore)]
 #![allow(unknown_lints)]
 #![warn(missing_docs)]
 #![warn(missing_debug_implementations)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 #![warn(clippy::all)]
 #![warn(clippy::pedantic)]
 // #![warn(clippy::cargo)]
-#![warn(clippy::needless_borrow)]
 #![allow(clippy::let_underscore_drop)]
 #![allow(unknown_lints)]
 #![warn(missing_docs)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #![warn(clippy::all)]
 #![warn(clippy::pedantic)]
-// #![warn(clippy::cargo)]
+#![warn(clippy::cargo)]
 #![allow(clippy::let_underscore_drop)]
 #![allow(unknown_lints)]
 #![warn(missing_docs)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 #![warn(clippy::all)]
 #![warn(clippy::pedantic)]
 #![warn(clippy::cargo)]
-#![allow(clippy::let_underscore_drop)]
 #![allow(unknown_lints)]
 #![warn(missing_docs)]
 #![warn(missing_debug_implementations)]


### PR DESCRIPTION
Some allowed clippy lints have been downgraded to the nursery or had false positives fixed since they were disabled. Some explicitly warn'd lints have been moved to either `all` or `pedantic` groups.

For allow pragmas that remain, document why with links to upstream bug reports.