### PR TITLE
Remove `AsRef` generics from `mezzaluna-feature-loader` and `artichoke-load-path` APIs

### DIFF
--- a/artichoke-load-path/src/rubylib.rs
+++ b/artichoke-load-path/src/rubylib.rs
@@ -33,6 +33,8 @@ use same_file::Handle;
 /// have higher priority.
 ///
 /// ```no_run
+/// # use std::ffi::OsStr;
+/// # use std::path::Path;
 /// # use artichoke_load_path::Rubylib;
 /// # fn example() -> Option<()> {
 /// // Grab the load paths from the `RUBYLIB` environment variable. If the
@@ -48,8 +50,8 @@ use same_file::Handle;
 /// // The relative path `./_lib` is resolved relative to the given working
 /// // directory.
 /// let fixed_loader = Rubylib::with_rubylib_and_cwd(
-///     "/home/artichoke/src:/usr/share/artichoke:./_lib",
-///     "/home/artichoke"
+///     OsStr::new("/home/artichoke/src:/usr/share/artichoke:./_lib"),
+///     Path::new("/home/artichoke")
 /// )?;
 /// # Some(())
 /// # }
@@ -115,10 +117,7 @@ impl Rubylib {
     /// [current working directory]: env::current_dir
     #[inline]
     #[must_use]
-    pub fn with_rubylib<T>(rubylib: T) -> Option<Self>
-    where
-        T: AsRef<OsStr>,
-    {
+    pub fn with_rubylib(rubylib: &OsStr) -> Option<Self> {
         let cwd = env::current_dir().ok()?;
         Self::with_rubylib_and_cwd(rubylib, &cwd)
     }
@@ -141,13 +140,8 @@ impl Rubylib {
     /// paths.
     #[inline]
     #[must_use]
-    pub fn with_rubylib_and_cwd<T, U>(rubylib: T, cwd: U) -> Option<Self>
-    where
-        T: AsRef<OsStr>,
-        U: AsRef<OsStr>,
-    {
-        let cwd = Path::new(&cwd);
-        let load_paths = env::split_paths(&rubylib)
+    pub fn with_rubylib_and_cwd(rubylib: &OsStr, cwd: &Path) -> Option<Self> {
+        let load_paths = env::split_paths(rubylib)
             .map(|load_path| cwd.join(&load_path))
             .collect::<Vec<_>>();
 

--- a/mezzaluna-feature-loader/src/loader/mod.rs
+++ b/mezzaluna-feature-loader/src/loader/mod.rs
@@ -1,5 +1,6 @@
 use std::ffi::OsStr;
 use std::io;
+use std::path::Path;
 
 #[cfg(feature = "rubylib")]
 mod rubylib;
@@ -31,10 +32,7 @@ impl Loader {
 
     #[must_use]
     #[cfg(feature = "rubylib")]
-    pub fn with_rubylib<T>(rubylib: T) -> Option<Self>
-    where
-        T: AsRef<OsStr>,
-    {
+    pub fn with_rubylib(rubylib: &OsStr) -> Option<Self> {
         let rubylib = Rubylib::with_rubylib(rubylib)?;
         let loaded_features = LoadedFeatures::new();
         Some(Self {
@@ -45,11 +43,7 @@ impl Loader {
 
     #[must_use]
     #[cfg(feature = "rubylib")]
-    pub fn with_rubylib_and_cwd<T, U>(rubylib: T, cwd: U) -> Option<Self>
-    where
-        T: AsRef<OsStr>,
-        U: AsRef<OsStr>,
-    {
+    pub fn with_rubylib_and_cwd(rubylib: &OsStr, cwd: &Path) -> Option<Self> {
         #[cfg(feature = "rubylib")]
         let rubylib = Rubylib::with_rubylib_and_cwd(rubylib, cwd)?;
         let loaded_features = LoadedFeatures::new();
@@ -61,16 +55,12 @@ impl Loader {
 
     #[allow(clippy::missing_errors_doc)]
     #[allow(clippy::missing_panics_doc)]
-    pub fn read<T>(&self, path: T) -> io::Result<Vec<u8>>
-    where
-        T: AsRef<OsStr>,
-    {
+    pub fn read<T>(&self, path: &Path) -> io::Result<Vec<u8>> {
         #[cfg(feature = "rubylib")]
         {
             use std::io::Read;
-            use std::path::Path;
 
-            if let Some(handle) = self.rubylib.resolve_file(Path::new(&path)) {
+            if let Some(handle) = self.rubylib.resolve_file(path) {
                 let file = handle.as_file();
                 // Allocate one extra byte so the buffer doesn't need to grow before the
                 // final `read` call at the end of the file.  Don't worry about `usize`

--- a/mezzaluna-feature-loader/src/loader/mod.rs
+++ b/mezzaluna-feature-loader/src/loader/mod.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "rubylib")]
 use std::ffi::OsStr;
 use std::io;
 use std::path::Path;

--- a/mezzaluna-feature-loader/src/loader/rubylib.rs
+++ b/mezzaluna-feature-loader/src/loader/rubylib.rs
@@ -30,6 +30,8 @@ use same_file::Handle;
 /// have higher priority.
 ///
 /// ```no_run
+/// # use std::ffi::OsStr;
+/// # use std::path::Path;
 /// # use mezzaluna_feature_loader::Rubylib;
 /// # fn example() -> Option<()> {
 /// // Grab the load paths from the `RUBYLIB` environment variable. If the
@@ -45,8 +47,8 @@ use same_file::Handle;
 /// // The relative path `./_lib` is resolved relative to the given working
 /// // directory.
 /// let fixed_loader = Rubylib::with_rubylib_and_cwd(
-///     "/home/artichoke/src:/usr/share/artichoke:./_lib",
-///     "/home/artichoke"
+///     OsStr::new("/home/artichoke/src:/usr/share/artichoke:./_lib"),
+///     Path::new("/home/artichoke")
 /// )?;
 /// # Some(())
 /// # }
@@ -88,7 +90,7 @@ impl Rubylib {
     pub fn new() -> Option<Self> {
         let rubylib = env::var_os("RUBYLIB")?;
         let cwd = env::current_dir().ok()?;
-        Self::with_rubylib_and_cwd(rubylib, cwd)
+        Self::with_rubylib_and_cwd(&rubylib, &cwd)
     }
 
     /// Create a new native filesystem loader that searches the filesystem for
@@ -111,12 +113,9 @@ impl Rubylib {
     /// [current working directory]: env::current_dir
     #[inline]
     #[must_use]
-    pub fn with_rubylib<T>(rubylib: T) -> Option<Self>
-    where
-        T: AsRef<OsStr>,
-    {
+    pub fn with_rubylib(rubylib: &OsStr) -> Option<Self> {
         let cwd = env::current_dir().ok()?;
-        Self::with_rubylib_and_cwd(rubylib, cwd)
+        Self::with_rubylib_and_cwd(rubylib, &cwd)
     }
 
     /// Create a new native filesystem loader that searches the filesystem for
@@ -137,12 +136,7 @@ impl Rubylib {
     /// paths.
     #[inline]
     #[must_use]
-    pub fn with_rubylib_and_cwd<T, U>(rubylib: T, cwd: U) -> Option<Self>
-    where
-        T: AsRef<OsStr>,
-        U: AsRef<OsStr>,
-    {
-        let cwd = Path::new(&cwd);
+    pub fn with_rubylib_and_cwd(rubylib: &OsStr, cwd: &Path) -> Option<Self> {
         let load_paths = env::split_paths(&rubylib)
             .map(|load_path| cwd.join(&load_path))
             .collect::<Vec<_>>();


### PR DESCRIPTION
These APIs, which are for internal-to-artichoke consumption, are unnecessarily generic. This commit removes the `AsRef<OsStr>` generics and replaces them with either `&OsStr` or `&Path`.

This cleans up the parameters to make it clear that `cwd` is meant to be a filesystem path.

Inspired by: https://matklad.github.io/2021/09/04/fast-rust-builds.html#keeping-instantiations-in-check