### PR TITLE
Add lint pragmas to `spinoso-regexp` crate

### DIFF
--- a/spinoso-regexp/src/encoding.rs
+++ b/spinoso-regexp/src/encoding.rs
@@ -61,10 +61,8 @@ impl Hash for Encoding {
 impl PartialEq for Encoding {
     fn eq(&self, other: &Self) -> bool {
         use Encoding::{Fixed, No, None};
-        matches!(
-            (self, other),
-            (No, No) | (No, None) | (None, No) | (None, None) | (Fixed, Fixed)
-        )
+
+        matches!((self, other), (No | None, No | None) | (Fixed, Fixed))
     }
 }
 

--- a/spinoso-regexp/src/error.rs
+++ b/spinoso-regexp/src/error.rs
@@ -79,6 +79,7 @@ impl error::Error for Error {
 ///
 /// [Ruby `ArgumentError` Exception class]: https://ruby-doc.org/core-2.6.3/ArgumentError.html
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[allow(clippy::module_name_repetitions)]
 pub struct ArgumentError(Cow<'static, str>);
 
 impl From<&'static str> for ArgumentError {
@@ -180,6 +181,7 @@ impl ArgumentError {
 /// [`Regexp::compile`]: https://ruby-doc.org/core-2.6.3/Regexp.html#method-c-compile
 /// [Ruby `RegexpError` Exception class]: https://ruby-doc.org/core-2.6.3/RegexpError.html
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[allow(clippy::module_name_repetitions)]
 pub struct RegexpError(Cow<'static, str>);
 
 impl From<&'static str> for RegexpError {
@@ -275,6 +277,7 @@ impl RegexpError {
 ///
 /// [Ruby `SyntaxError` Exception class]: https://ruby-doc.org/core-2.6.3/SyntaxError.html
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[allow(clippy::module_name_repetitions)]
 pub struct SyntaxError(Cow<'static, str>);
 
 impl From<&'static str> for SyntaxError {

--- a/spinoso-regexp/src/lib.rs
+++ b/spinoso-regexp/src/lib.rs
@@ -2,6 +2,7 @@
 #![warn(clippy::pedantic)]
 #![warn(clippy::cargo)]
 #![allow(clippy::option_if_let_else)]
+#![cfg_attr(test, allow(clippy::non_ascii_literal))]
 #![allow(unknown_lints)]
 // TODO: warn on missing docs once crate is API-complete.
 // #![warn(missing_docs)]
@@ -47,15 +48,15 @@ pub use options::{Options, RegexpOption};
 bitflags! {
     #[derive(Default)]
     pub struct Flags: u8 {
-        const IGNORECASE      = 0b00000001;
-        const EXTENDED        = 0b00000010;
-        const MULTILINE       = 0b00000100;
+        const IGNORECASE      = 0b0000_0001;
+        const EXTENDED        = 0b0000_0010;
+        const MULTILINE       = 0b0000_0100;
         const ALL_REGEXP_OPTS = Self::IGNORECASE.bits | Self::EXTENDED.bits | Self::MULTILINE.bits;
 
-        const FIXEDENCODING   = 0b00010000;
-        const NOENCODING      = 0b00100000;
+        const FIXEDENCODING   = 0b0001_0000;
+        const NOENCODING      = 0b0010_0000;
 
-        const LITERAL         = 0b10000000;
+        const LITERAL         = 0b1000_0000;
     }
 }
 
@@ -104,6 +105,7 @@ impl From<&Config> for Source {
 
 impl Source {
     /// Construct a new, empty `Source`.
+    #[must_use]
     pub const fn new() -> Self {
         Self {
             pattern: Vec::new(),
@@ -112,11 +114,13 @@ impl Source {
     }
 
     /// Construct a new `Source` with the given pattern and [`Options`].
+    #[must_use]
     pub const fn with_pattern_and_options(pattern: Vec<u8>, options: Options) -> Self {
         Self { pattern, options }
     }
 
     /// Whether this source was parsed with ignore case enabled.
+    #[must_use]
     pub const fn is_casefold(&self) -> bool {
         self.options.ignore_case().is_enabled()
     }
@@ -126,16 +130,19 @@ impl Source {
     /// This enables Ruby parsers to inject whether a Regexp is a literal to the
     /// core library. Literal Regexps have some special behavior regrding
     /// capturing groups and report parse failures differently.
+    #[must_use]
     pub const fn is_literal(&self) -> bool {
         self.options.is_literal()
     }
 
     /// Extracts a slice containing the entire pattern.
+    #[must_use]
     pub fn pattern(&self) -> &[u8] {
         self.pattern.as_slice()
     }
 
     /// Return a copy of the underlying [`Options`].
+    #[must_use]
     pub const fn options(&self) -> Options {
         self.options
     }
@@ -170,6 +177,7 @@ impl From<&Source> for Config {
 
 impl Config {
     /// Construct a new, empty `Config`.
+    #[must_use]
     pub const fn new() -> Self {
         Self {
             pattern: Vec::new(),
@@ -178,16 +186,19 @@ impl Config {
     }
 
     /// Construct a new `Config` with the given pattern and [`Options`].
+    #[must_use]
     pub const fn with_pattern_and_options(pattern: Vec<u8>, options: Options) -> Self {
         Self { pattern, options }
     }
 
     /// Extracts a slice containing the entire pattern.
+    #[must_use]
     pub fn pattern(&self) -> &[u8] {
         self.pattern.as_slice()
     }
 
     /// Return a copy of the underlying [`Options`].
+    #[must_use]
     pub const fn options(&self) -> Options {
         self.options
     }

--- a/spinoso-regexp/src/lib.rs
+++ b/spinoso-regexp/src/lib.rs
@@ -1,4 +1,24 @@
+#![warn(clippy::all)]
+#![warn(clippy::pedantic)]
+#![warn(clippy::cargo)]
+#![allow(clippy::option_if_let_else)]
+#![allow(unknown_lints)]
+// TODO: warn on missing docs once crate is API-complete.
+// #![warn(missing_docs)]
+#![warn(missing_debug_implementations)]
+#![warn(missing_copy_implementations)]
+#![warn(rust_2018_idioms)]
 #![warn(rust_2021_compatibility)]
+#![warn(trivial_casts, trivial_numeric_casts)]
+#![warn(unused_qualifications)]
+#![warn(variant_size_differences)]
+#![forbid(unsafe_code)]
+// Enable feature callouts in generated documentation:
+// https://doc.rust-lang.org/beta/unstable-book/language-features/doc-cfg.html
+//
+// This approach is borrowed from tokio.
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_alias))]
 
 // Ensure code blocks in README.md compile
 #[cfg(doctest)]

--- a/spinoso-regexp/src/options.rs
+++ b/spinoso-regexp/src/options.rs
@@ -43,7 +43,7 @@ impl Default for RegexpOption {
 impl From<bool> for RegexpOption {
     /// Convert from `bool` to its `RegexpOption` representation.
     ///
-    /// `true` creates a [RegexpOption::Enabled`]. `false` creates a
+    /// `true` creates a [`RegexpOption::Enabled`]. `false` creates a
     /// [`RegexpOption::Disabled`].
     fn from(value: bool) -> Self {
         if value {
@@ -214,6 +214,7 @@ impl Options {
     }
 
     /// Whether these `Options` are configured for multiline mode.
+    #[must_use]
     pub const fn multiline(self) -> RegexpOption {
         if self.flags.intersects(Flags::MULTILINE) {
             RegexpOption::Enabled
@@ -223,6 +224,7 @@ impl Options {
     }
 
     /// Whether these `Options` are configured for case-insensitive mode.
+    #[must_use]
     pub const fn ignore_case(self) -> RegexpOption {
         if self.flags.intersects(Flags::IGNORECASE) {
             RegexpOption::Enabled
@@ -233,6 +235,7 @@ impl Options {
 
     /// Whether these `Options` are configured for extended mode with
     /// insignificant whitespace.
+    #[must_use]
     pub const fn extended(self) -> RegexpOption {
         if self.flags.intersects(Flags::EXTENDED) {
             RegexpOption::Enabled
@@ -246,6 +249,7 @@ impl Options {
     /// This enables Ruby parsers to inject whether a Regexp is a literal to the
     /// core library. Literal Regexps have some special behavior regrding
     /// capturing groups and report parse failures differently.
+    #[must_use]
     pub const fn is_literal(self) -> bool {
         self.flags.intersects(Flags::LITERAL)
     }
@@ -292,7 +296,7 @@ impl Options {
 
     /// Inserts or removes the specified flags depending on the passed value.
     pub fn set(&mut self, other: Flags, value: bool) {
-        self.flags.set(other, value)
+        self.flags.set(other, value);
     }
 }
 
@@ -316,6 +320,7 @@ mod tests {
     // together. Otherwise, if options is not `nil` or `false`, the regexp will
     // be case insensitive.
     #[test]
+    #[allow(clippy::too_many_lines)]
     fn parse_options() {
         assert_eq!(Options::from(None), Options::new());
         assert_eq!(Options::from(Some(false)), Options::new());


### PR DESCRIPTION
Address clippy lint violations in `spinoso-regexp`.