### PR TITLE
Fix `String::chr` when string begins with an incomplete UTF-8 sequence

### DIFF
--- a/spinoso-string/src/lib.rs
+++ b/spinoso-string/src/lib.rs
@@ -1815,8 +1815,11 @@ impl String {
     #[must_use]
     pub fn chr(&self) -> &[u8] {
         if let Encoding::Utf8 = self.encoding {
-            let (_, size) = bstr::decode_utf8(self.buf.as_slice());
-            &self.buf[..size]
+            match bstr::decode_utf8(self.buf.as_slice()) {
+                (Some(_), size) => &self.buf[..size],
+                (None, 0) => &[],
+                (None, _) => &self.buf[..1],
+            }
         } else {
             self.buf.get(0..1).unwrap_or_default()
         }
@@ -2609,5 +2612,21 @@ mod tests {
 
         let center = s.center(5, Some(b""));
         assert!(matches!(center, Err(CenterError::ZeroWidthPadding)));
+    }
+
+    #[test]
+    fn chr_does_not_return_more_than_one_byte_for_invalid_utf8() {
+        // ```ruby
+        // [3.0.1] > "\xF0\x9F\x87".chr
+        // => "\xF0"
+        // ```
+        //
+        // Per `bstr`:
+        //
+        // The bytes \xF0\x9F\x87 could lead to a valid UTF-8 sequence, but 3 of them
+        // on their own are invalid. Only one replacement codepoint is substituted,
+        // which demonstrates the "substitution of maximal subparts" strategy.
+        let s = String::utf8(b"\xF0\x9F\x87".to_vec());
+        assert_eq!(s.chr(), b"\xF0");
     }
 }


### PR DESCRIPTION
When a `String` begins with a prefix that could be a well-formed UTF-8
code point, but isn't, `bstr` will return the full multi-byte sequence
when calling `bstr::decode_utf8` according to the substitution of
maximal subparts strategy.

MRI does not follow this strategy and will always return only the first
byte of an invalid UTF-8 prefix for conventionally UTF-8 strings.