### PR TITLE
Run more specs as part of the `spec-state` workflow

### DIFF
--- a/.github/workflows/spec-state.yaml
+++ b/.github/workflows/spec-state.yaml
@@ -40,7 +40,7 @@ jobs:
           working-directory: "artichoke/spec-runner"
 
       - name: Compile spec-runner
-        run: cargo build --verbose --bin spec-runner
+        run: cargo build --release --verbose --bin spec-runner
         working-directory: "artichoke/spec-runner"
 
       - name: Set commit metadata
@@ -97,7 +97,7 @@ jobs:
 
       - name: Generate spec tags
         run: |
-          ./artichoke/spec-runner/target/debug/spec-runner --quiet --format tagger artichoke/spec-runner/all-core-specs.toml | tee "${{ steps.tagged.outputs.yaml }}"
+          ./artichoke/spec-runner/target/release/spec-runner --quiet --format tagger artichoke/spec-runner/all-core-specs.toml | tee "${{ steps.tagged.outputs.yaml }}"
           ./artichoke/spec-runner/scripts/spec-yaml-to-json.rb "${{ steps.tagged.outputs.yaml }}" > "${{ steps.tagged.outputs.json }}"
           mkdir -p "spec-state/reports/tagged/${{ steps.commit.outputs.year }}/${{ steps.commit.outputs.month }}"
           cp "${{ steps.tagged.outputs.json }}" "spec-state/reports/tagged/${{ steps.commit.outputs.year }}/${{ steps.commit.outputs.month }}/${{ steps.tagged.outputs.json }}"
@@ -107,7 +107,7 @@ jobs:
 
       - name: Generate spec exceptions
         run: |
-          ./artichoke/spec-runner/target/debug/spec-runner --quiet --format yaml artichoke/spec-runner/all-core-specs.toml | tee "${{ steps.exceptions.outputs.yaml }}"
+          ./artichoke/spec-runner/target/release/spec-runner --quiet --format yaml artichoke/spec-runner/all-core-specs.toml | tee "${{ steps.exceptions.outputs.yaml }}"
           ./artichoke/spec-runner/scripts/spec-yaml-to-json.rb "${{ steps.exceptions.outputs.yaml }}" > "${{ steps.exceptions.outputs.json }}"
           mkdir -p "spec-state/reports/exceptions/${{ steps.commit.outputs.year }}/${{ steps.commit.outputs.month }}"
           cp "${{ steps.exceptions.outputs.json }}" "spec-state/reports/exceptions/${{ steps.commit.outputs.year }}/${{ steps.commit.outputs.month }}/${{ steps.exceptions.outputs.json }}"

--- a/.github/workflows/spec-state.yaml
+++ b/.github/workflows/spec-state.yaml
@@ -88,6 +88,16 @@ jobs:
           echo "::set-output name=json::${json}"
         working-directory: "artichoke"
 
+      - name: Generate spec tags
+        run: |
+          ./artichoke/spec-runner/target/release/spec-runner --quiet --format tagger artichoke/spec-runner/all-core-specs.toml | tee "${{ steps.tagged.outputs.yaml }}"
+          ./artichoke/spec-runner/scripts/spec-yaml-to-json.rb "${{ steps.tagged.outputs.yaml }}" > "${{ steps.tagged.outputs.json }}"
+
+      - name: Generate spec exceptions
+        run: |
+          ./artichoke/spec-runner/target/release/spec-runner --quiet --format yaml artichoke/spec-runner/all-core-specs.toml | tee "${{ steps.exceptions.outputs.yaml }}"
+          ./artichoke/spec-runner/scripts/spec-yaml-to-json.rb "${{ steps.exceptions.outputs.yaml }}" > "${{ steps.exceptions.outputs.json }}"
+
       - name: Checkout spec state repository
         uses: actions/checkout@v2
         with:
@@ -95,20 +105,15 @@ jobs:
           path: spec-state
           ssh-key: ${{ secrets.SPEC_STATE_SSH_DEPLOY_PRIVATE_KEY }}
 
-      - name: Generate spec tags
+      - name: Copy spec-state reports
         run: |
-          ./artichoke/spec-runner/target/release/spec-runner --quiet --format tagger artichoke/spec-runner/all-core-specs.toml | tee "${{ steps.tagged.outputs.yaml }}"
-          ./artichoke/spec-runner/scripts/spec-yaml-to-json.rb "${{ steps.tagged.outputs.yaml }}" > "${{ steps.tagged.outputs.json }}"
+          # tags
           mkdir -p "spec-state/reports/tagged/${{ steps.commit.outputs.year }}/${{ steps.commit.outputs.month }}"
           cp "${{ steps.tagged.outputs.json }}" "spec-state/reports/tagged/${{ steps.commit.outputs.year }}/${{ steps.commit.outputs.month }}/${{ steps.tagged.outputs.json }}"
           cp "${{ steps.tagged.outputs.json }}" "spec-state/reports/tagged/${{ steps.commit.outputs.year }}/${{ steps.commit.outputs.month }}/latest.json"
           cp "${{ steps.tagged.outputs.json }}" "spec-state/reports/tagged/${{ steps.commit.outputs.year }}/latest.json"
           cp "${{ steps.tagged.outputs.json }}" "spec-state/reports/tagged/latest.json"
-
-      - name: Generate spec exceptions
-        run: |
-          ./artichoke/spec-runner/target/release/spec-runner --quiet --format yaml artichoke/spec-runner/all-core-specs.toml | tee "${{ steps.exceptions.outputs.yaml }}"
-          ./artichoke/spec-runner/scripts/spec-yaml-to-json.rb "${{ steps.exceptions.outputs.yaml }}" > "${{ steps.exceptions.outputs.json }}"
+          # exceptions
           mkdir -p "spec-state/reports/exceptions/${{ steps.commit.outputs.year }}/${{ steps.commit.outputs.month }}"
           cp "${{ steps.exceptions.outputs.json }}" "spec-state/reports/exceptions/${{ steps.commit.outputs.year }}/${{ steps.commit.outputs.month }}/${{ steps.exceptions.outputs.json }}"
           cp "${{ steps.exceptions.outputs.json }}" "spec-state/reports/exceptions/${{ steps.commit.outputs.year }}/${{ steps.commit.outputs.month }}/latest.json"

--- a/.github/workflows/spec-state.yaml
+++ b/.github/workflows/spec-state.yaml
@@ -90,12 +90,12 @@ jobs:
 
       - name: Generate spec tags
         run: |
-          ./artichoke/spec-runner/target/release/spec-runner --quiet --format tagger artichoke/spec-runner/all-core-specs.toml | tee "${{ steps.tagged.outputs.yaml }}"
+          ./artichoke/spec-runner/target/release/spec-runner --quiet --format tagger artichoke/spec-runner/spec-state.toml | tee "${{ steps.tagged.outputs.yaml }}"
           ./artichoke/spec-runner/scripts/spec-yaml-to-json.rb "${{ steps.tagged.outputs.yaml }}" > "${{ steps.tagged.outputs.json }}"
 
       - name: Generate spec exceptions
         run: |
-          ./artichoke/spec-runner/target/release/spec-runner --quiet --format yaml artichoke/spec-runner/all-core-specs.toml | tee "${{ steps.exceptions.outputs.yaml }}"
+          ./artichoke/spec-runner/target/release/spec-runner --quiet --format yaml artichoke/spec-runner/spec-state.toml | tee "${{ steps.exceptions.outputs.yaml }}"
           ./artichoke/spec-runner/scripts/spec-yaml-to-json.rb "${{ steps.exceptions.outputs.yaml }}" > "${{ steps.exceptions.outputs.json }}"
 
       - name: Checkout spec state repository

--- a/.github/workflows/spec-state.yaml
+++ b/.github/workflows/spec-state.yaml
@@ -97,7 +97,7 @@ jobs:
 
       - name: Generate spec tags
         run: |
-          ( ./artichoke/spec-runner/target/debug/spec-runner --format tagger artichoke/spec-runner/all-core-specs.toml || : ) | tee "${{ steps.tagged.outputs.yaml }}"
+          ./artichoke/spec-runner/target/debug/spec-runner --quiet --format tagger artichoke/spec-runner/all-core-specs.toml | tee "${{ steps.tagged.outputs.yaml }}"
           ./artichoke/spec-runner/scripts/spec-yaml-to-json.rb "${{ steps.tagged.outputs.yaml }}" > "${{ steps.tagged.outputs.json }}"
           mkdir -p "spec-state/reports/tagged/${{ steps.commit.outputs.year }}/${{ steps.commit.outputs.month }}"
           cp "${{ steps.tagged.outputs.json }}" "spec-state/reports/tagged/${{ steps.commit.outputs.year }}/${{ steps.commit.outputs.month }}/${{ steps.tagged.outputs.json }}"
@@ -107,7 +107,7 @@ jobs:
 
       - name: Generate spec exceptions
         run: |
-          ( ./artichoke/spec-runner/target/debug/spec-runner --format yaml artichoke/spec-runner/all-core-specs.toml || : ) | tee "${{ steps.exceptions.outputs.yaml }}"
+          ./artichoke/spec-runner/target/debug/spec-runner --quiet --format yaml artichoke/spec-runner/all-core-specs.toml | tee "${{ steps.exceptions.outputs.yaml }}"
           ./artichoke/spec-runner/scripts/spec-yaml-to-json.rb "${{ steps.exceptions.outputs.yaml }}" > "${{ steps.exceptions.outputs.json }}"
           mkdir -p "spec-state/reports/exceptions/${{ steps.commit.outputs.year }}/${{ steps.commit.outputs.month }}"
           cp "${{ steps.exceptions.outputs.json }}" "spec-state/reports/exceptions/${{ steps.commit.outputs.year }}/${{ steps.commit.outputs.month }}/${{ steps.exceptions.outputs.json }}"

--- a/spec-runner/all-core-specs.toml
+++ b/spec-runner/all-core-specs.toml
@@ -1,4 +1,5 @@
-# This config file lists the ruby/specs that should pass for Artichoke Ruby.
+# This config file lists the largest set of ruby/specs from the `core` group
+# that will let Artichoke Ruby run the spec-runner harness to completion.
 #
 # Valid values for `include` are:
 #

--- a/spec-runner/all-core-specs.toml
+++ b/spec-runner/all-core-specs.toml
@@ -118,7 +118,11 @@ include = "all"
 [specs.core.hash]
 include = "all"
 skip = [
+  # This generates a `SystemStackError` on recursive hashes that takes an
+  # eternity to print out when running with the `artichok` or `yaml` formatter.
   "eql",
+  # This generates a `SystemStackError` on recursive hashes that takes an
+  # eternity to print out when running with the `artichok` or `yaml` formatter.
   "equal_value",
 ]
 

--- a/spec-runner/all-library-specs.toml
+++ b/spec-runner/all-library-specs.toml
@@ -50,4 +50,3 @@ include = "none"
 [specs.library.uri]
 include = "all"
 skip = ["parse"]
-

--- a/spec-runner/spec-state.toml
+++ b/spec-runner/spec-state.toml
@@ -1,4 +1,8 @@
-# This config file lists the ruby/specs that should pass for Artichoke Ruby.
+# This config file lists all ruby/specs that are run as part of the `spec-state`
+# GitHub Actions workflow. Historical results for these specs are published to
+# the artichoke/spec-state repository:
+#
+# https://github.com/artichoke/spec-state
 #
 # Valid values for `include` are:
 #

--- a/spec-runner/spec-state.toml
+++ b/spec-runner/spec-state.toml
@@ -118,7 +118,11 @@ include = "all"
 [specs.core.hash]
 include = "all"
 skip = [
+  # This generates a `SystemStackError` on recursive hashes that takes an
+  # eternity to print out when running with the `artichok` or `yaml` formatter.
   "eql",
+  # This generates a `SystemStackError` on recursive hashes that takes an
+  # eternity to print out when running with the `artichok` or `yaml` formatter.
   "equal_value",
 ]
 

--- a/spec-runner/spec-state.toml
+++ b/spec-runner/spec-state.toml
@@ -1,0 +1,263 @@
+# This config file lists the ruby/specs that should pass for Artichoke Ruby.
+#
+# Valid values for `include` are:
+#
+# - all - run all specs. When `include` is set to `all`, the optional `skip`
+#   field may list specs to skip.
+# - none - run no specs, equivalent to the section not being present in this
+#   config file.
+# - `set` - run an enumerated set of specs. When `include` is set to `set`, the
+#   set of specs must be listed in the required `specs` field, which is a list
+#   of strings.
+
+## Ruby Core
+
+[specs.core.argf]
+include = "all"
+
+[specs.core.array]
+include = "set"
+specs = [
+  "any",
+  "append",
+  "array",
+  "assoc",
+  "at",
+  "clear",
+  "collect",
+  "combination",
+  "compact",
+  "concat",
+  "constructor",
+  "count",
+  "cycle",
+  "delete",
+  "delete_at",
+  "delete_if",
+  "drop",
+  "drop_while",
+  "each",
+  "each_index",
+  "empty",
+  "first",
+  "frozen",
+  "include",
+  "last",
+  "length",
+  "map",
+  "multiply",
+  "plus",
+  "prepend",
+  "push",
+  "rassoc",
+  "replace",
+  "reverse",
+  "reverse_each",
+  "shift",
+  "size",
+  "sort_by",
+  "to_ary",
+  "try_convert",
+  "unshift",
+]
+
+[specs.core.basicobject]
+include = "all"
+
+[specs.core.binding]
+include = "all"
+
+[specs.core.builtin_constants]
+include = "all"
+
+[specs.core.class]
+include = "all"
+
+[specs.core.comparable]
+include = "all"
+
+[specs.core.complex]
+include = "all"
+
+[specs.core.dir]
+include = "all"
+
+[specs.core.encoding]
+include = "all"
+
+[specs.core.enumerable]
+include = "all"
+
+[specs.core.enumerator]
+include = "all"
+
+[specs.core.env]
+include = "all"
+
+[specs.core.exception]
+include = "all"
+
+[specs.core.false]
+include = "all"
+
+[specs.core.fiber]
+include = "all"
+
+[specs.core.file]
+include = "all"
+
+[specs.core.filetest]
+include = "all"
+
+[specs.core.float]
+include = "all"
+
+[specs.core.gc]
+include = "all"
+
+[specs.core.hash]
+include = "all"
+skip = [
+  "eql",
+  "equal_value",
+]
+
+[specs.core.integer]
+include = "all"
+
+[specs.core.io]
+include = "none"
+
+[specs.core.kernel]
+include = "none"
+
+[specs.core.main]
+include = "all"
+
+[specs.core.marshal]
+include = "all"
+
+[specs.core.matchdata]
+include = "all"
+
+[specs.core.math]
+include = "all"
+
+[specs.core.method]
+include = "all"
+
+[specs.core.module]
+include = "all"
+
+[specs.core.mutex]
+include = "none"
+
+[specs.core.nil]
+include = "all"
+
+[specs.core.numeric]
+include = "all"
+
+[specs.core.objectspace]
+include = "none"
+
+[specs.core.proc]
+include = "all"
+
+[specs.core.process]
+include = "none"
+
+[specs.core.queue]
+include = "all"
+
+[specs.core.random]
+include = "all"
+
+[specs.core.range]
+include = "all"
+
+[specs.core.rational]
+include = "all"
+
+[specs.core.regexp]
+include = "all"
+
+[specs.core.signal]
+include = "all"
+
+[specs.core.sizedqueue]
+include = "all"
+
+[specs.core.string]
+include = "all"
+
+[specs.core.struct]
+include = "all"
+
+[specs.core.symbol]
+include = "all"
+
+[specs.core.systemexit]
+include = "all"
+
+[specs.core.thread]
+include = "none"
+
+[specs.core.threadgroup]
+include = "none"
+
+[specs.core.time]
+include = "all"
+
+[specs.core.tracepoint]
+include = "none"
+
+[specs.core.true]
+include = "all"
+
+[specs.core.unboundmethod]
+include = "all"
+
+[specs.core.warning]
+include = "all"
+
+## Ruby Standard Library
+
+[specs.library.abbrev]
+include = "all"
+
+[specs.library.base64]
+include = "all"
+
+[specs.library.delegate]
+include = "none"
+
+[specs.library.monitor]
+include = "all"
+
+[specs.library.securerandom]
+include = "all"
+skip = [
+  # specs require ASCII-8BIT / BINARY encoding for `String`s
+  "random_bytes",
+  # missing support for Bignum and Range arguments
+  "random_number",
+]
+
+[specs.library.shellwords]
+include = "all"
+skip = [
+  # missing `String#gsub` support for back references
+  "shellwords",
+]
+
+[specs.library.stringscanner]
+include = "all"
+
+[specs.library.time]
+# missing `date` package
+include = "none"
+
+[specs.library.uri]
+include = "all"
+skip = ["parse"]


### PR DESCRIPTION
Now that https://github.com/artichoke/artichoke/pull/1343 is fixed, run a larger set of specs in the `spec-state` workflow. This PR creates a new `spec-state` ruby/spec configuration for the spec-runner which includes the maximum set of core specs that Artichoke can handle, as well as some stdlib specs known to pass.

This PR also tweaks the workflow to:

- Reduce the likelihood of a race on `git push` to the `spec-state` repository.
- Build the `spec-runner` in release mode.
- Use the `--quiet` flag introduced in #1342.