### PR TITLE
Improve the `spinoso-regexp` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -576,7 +576,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-regexp"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "bitflags",
  "bstr",

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -27,7 +27,7 @@ spinoso-env = { version = "0.1", path = "../spinoso-env", optional = true, defau
 spinoso-exception = { version = "0.1", path = "../spinoso-exception" }
 spinoso-math = { version = "0.2", path = "../spinoso-math", optional = true, default-features = false }
 spinoso-random = { version = "0.1", path = "../spinoso-random", optional = true }
-spinoso-regexp = { version = "0.1", path = "../spinoso-regexp", optional = true, default-features = false }
+spinoso-regexp = { version = "0.2", path = "../spinoso-regexp", optional = true, default-features = false }
 spinoso-securerandom = { version = "0.1", path = "../spinoso-securerandom", optional = true }
 spinoso-symbol = { version = "0.1", path = "../spinoso-symbol" }
 spinoso-time = { version = "0.2", path = "../spinoso-time", optional = true }

--- a/artichoke-backend/src/extn/core/regexp/backend/lazy.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/lazy.rs
@@ -85,7 +85,7 @@ impl RegexpType for Lazy {
         debug.push_str(pattern.replace("/", r"\/").as_str());
         debug.push('/');
         debug.push_str(self.config.options().as_display_modifier());
-        debug.push_str(self.encoding.modifier_string());
+        debug.push_str(self.encoding.as_modifier_str());
         debug
     }
 

--- a/artichoke-backend/src/extn/core/regexp/backend/onig.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/onig.rs
@@ -133,7 +133,7 @@ impl RegexpType for Onig {
         debug.push_str(pattern.replace("/", r"\/").as_str());
         debug.push('/');
         debug.push_str(self.source.options().as_display_modifier());
-        debug.push_str(self.encoding.modifier_string());
+        debug.push_str(self.encoding.as_modifier_str());
         debug
     }
 
@@ -160,7 +160,7 @@ impl RegexpType for Onig {
         }
         inspect.push(b'/');
         inspect.extend_from_slice(self.source.options().as_display_modifier().as_bytes());
-        inspect.extend_from_slice(self.encoding.modifier_string().as_bytes());
+        inspect.extend_from_slice(self.encoding.as_modifier_str().as_bytes());
         inspect
     }
 

--- a/artichoke-backend/src/extn/core/regexp/backend/regex/utf8.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/regex/utf8.rs
@@ -134,7 +134,7 @@ impl RegexpType for Utf8 {
         debug.push_str(pattern.replace("/", r"\/").as_str());
         debug.push('/');
         debug.push_str(self.source.options().as_display_modifier());
-        debug.push_str(self.encoding.modifier_string());
+        debug.push_str(self.encoding.as_modifier_str());
         debug
     }
 
@@ -161,7 +161,7 @@ impl RegexpType for Utf8 {
         }
         inspect.push(b'/');
         inspect.extend_from_slice(self.source.options().as_display_modifier().as_bytes());
-        inspect.extend_from_slice(self.encoding.modifier_string().as_bytes());
+        inspect.extend_from_slice(self.encoding.as_modifier_str().as_bytes());
         inspect
     }
 

--- a/artichoke-backend/src/extn/core/regexp/mod.rs
+++ b/artichoke-backend/src/extn/core/regexp/mod.rs
@@ -19,8 +19,9 @@ use crate::extn::prelude::*;
 
 #[doc(inline)]
 pub use spinoso_regexp::{
-    nth_match_group, Config, Encoding, Flags, InvalidEncodingError, Options, RegexpError, RegexpOption, Source,
-    HIGHEST_MATCH_GROUP, LAST_MATCH, LAST_MATCHED_STRING, STRING_LEFT_OF_MATCH, STRING_RIGHT_OF_MATCH,
+    nth_match_group_bytes as nth_match_group, Config, Encoding, Flags, InvalidEncodingError, Options, RegexpError,
+    RegexpOption, Source, HIGHEST_MATCH_GROUP, LAST_MATCH, LAST_MATCHED_STRING, STRING_LEFT_OF_MATCH,
+    STRING_RIGHT_OF_MATCH,
 };
 
 pub mod backend;

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -418,7 +418,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-regexp"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "bitflags",
  "bstr",

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -560,7 +560,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-regexp"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "bitflags",
  "bstr",

--- a/spinoso-array/README.md
+++ b/spinoso-array/README.md
@@ -30,7 +30,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-spinoso-array = "0.3"
+spinoso-array = "0.5"
 ```
 
 Then construct and manipulate an `Array` like this:

--- a/spinoso-regexp/Cargo.toml
+++ b/spinoso-regexp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spinoso-regexp"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2018"
 description = """

--- a/spinoso-regexp/README.md
+++ b/spinoso-regexp/README.md
@@ -31,7 +31,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-spinoso-regexp = "0.1"
+spinoso-regexp = "0.2"
 ```
 
 ## Crate features

--- a/spinoso-regexp/src/debug.rs
+++ b/spinoso-regexp/src/debug.rs
@@ -43,6 +43,34 @@ impl Delimiters {
     }
 }
 
+/// An iterator that yields a debug representation of a `Regexp` as a sequence
+/// of `char`s.
+///
+/// This struct is created by the `debug` method on the regexp implementations
+/// in this crate. See these functions' documentation for more.
+///
+/// # Examples
+///
+/// UTF-8 regexp patterns and options are formatted in a debug
+/// representation:
+///
+/// ```
+/// use spinoso_regexp::Debug;
+///
+/// let debug = Debug::new("crab 🦀 for Rust".as_bytes(), "mix", "");
+/// let s = debug.collect::<String>();
+/// assert_eq!(s, "/crab 🦀 for Rust/mix");
+/// ```
+///
+/// Binary content is hex escaped:
+///
+/// ```
+/// use spinoso_regexp::Debug;
+///
+/// let debug = Debug::new(b"\xFF\xFE", "", "");
+/// let s = debug.collect::<String>();
+/// assert_eq!(s, r"/\xFF\xFE/");
+/// ```
 #[derive(Default, Debug, Clone)]
 #[must_use = "this `Debug` is an `Iterator`, which should be consumed if constructed"]
 pub struct Debug<'a> {
@@ -63,7 +91,34 @@ pub struct Debug<'a> {
 }
 
 impl<'a> Debug<'a> {
-    // TODO: make `Debug::new` pub(crate) once it is used internally.
+    /// Construct a new `Debug` iterator with a regexp source, [options
+    /// modifiers], and [encoding modifiers].
+    ///
+    /// # Examples
+    ///
+    /// UTF-8 regexp patterns and options are formatted in a debug
+    /// representation:
+    ///
+    /// ```
+    /// use spinoso_regexp::Debug;
+    ///
+    /// let debug = Debug::new("crab 🦀 for Rust".as_bytes(), "mix", "");
+    /// let s = debug.collect::<String>();
+    /// assert_eq!(s, "/crab 🦀 for Rust/mix");
+    /// ```
+    ///
+    /// Binary content is hex escaped:
+    ///
+    /// ```
+    /// use spinoso_regexp::Debug;
+    ///
+    /// let debug = Debug::new(b"\xFF\xFE", "", "");
+    /// let s = debug.collect::<String>();
+    /// assert_eq!(s, r"/\xFF\xFE/");
+    /// ```
+    ///
+    /// [options modifiers]: crate::Options::as_display_modifier
+    /// [encoding modifiers]: crate::Encoding::as_modifier_str
     pub fn new(source: &'a [u8], options: &'static str, encoding: &'static str) -> Self {
         Self {
             delimiters: Delimiters::DEFAULT,

--- a/spinoso-regexp/src/debug.rs
+++ b/spinoso-regexp/src/debug.rs
@@ -1,13 +1,54 @@
 use core::convert::TryFrom;
 use core::iter::FusedIterator;
+
 use scolapasta_string_escape::InvalidUtf8ByteSequence;
 
 #[derive(Debug, Clone)]
+struct Delimiters {
+    bits: u8,
+}
+
+impl Default for Delimiters {
+    fn default() -> Self {
+        Self::DEFAULT
+    }
+}
+
+impl Delimiters {
+    const EMIT_LEFT_DELIMITER: Self = Self { bits: 0b0000_0001 };
+    const EMIT_RIGHT_DELIMITER: Self = Self { bits: 0b0000_0010 };
+
+    const DEFAULT: Self = Self {
+        bits: Self::EMIT_LEFT_DELIMITER.bits | Self::EMIT_RIGHT_DELIMITER.bits,
+    };
+
+    #[inline]
+    fn emit_left_delimiter(&mut self) -> Option<char> {
+        if (self.bits & Self::EMIT_LEFT_DELIMITER.bits) == Self::EMIT_LEFT_DELIMITER.bits {
+            self.bits &= !Self::EMIT_LEFT_DELIMITER.bits;
+            Some('/')
+        } else {
+            None
+        }
+    }
+
+    #[inline]
+    fn emit_right_delimiter(&mut self) -> Option<char> {
+        if (self.bits & Self::EMIT_RIGHT_DELIMITER.bits) == Self::EMIT_RIGHT_DELIMITER.bits {
+            self.bits &= !Self::EMIT_RIGHT_DELIMITER.bits;
+            Some('/')
+        } else {
+            None
+        }
+    }
+}
+
+#[derive(Default, Debug, Clone)]
 #[must_use = "this `Debug` is an `Iterator`, which should be consumed if constructed"]
 pub struct Debug<'a> {
-    prefix: Option<char>,
+    delimiters: Delimiters,
     // When `Regexp`s are constructed with a `/.../` literal, `Regexp#source`
-    // refers to the literal characters contained within the `/` delimeters.
+    // refers to the literal characters contained within the `/` delimiters.
     // For example, `/\t/.source.bytes` has byte sequence `[92, 116]`.
     //
     // When `Regexp`s are constructed with `Regexp::compile`, `Regexp#source`
@@ -17,7 +58,6 @@ pub struct Debug<'a> {
     // `Regexp#inspect` prints `"/#{source}/"`.
     source: &'a [u8],
     literal: InvalidUtf8ByteSequence,
-    suffix: Option<char>,
     options: &'static str,
     encoding: &'static str,
 }
@@ -26,10 +66,9 @@ impl<'a> Debug<'a> {
     // TODO: make `Debug::new` pub(crate) once it is used internally.
     pub fn new(source: &'a [u8], options: &'static str, encoding: &'static str) -> Self {
         Self {
-            prefix: Some('/'),
+            delimiters: Delimiters::DEFAULT,
             source,
             literal: InvalidUtf8ByteSequence::new(),
-            suffix: Some('/'),
             options,
             encoding,
         }
@@ -40,7 +79,7 @@ impl<'a> Iterator for Debug<'a> {
     type Item = char;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if let Some(prefix) = self.prefix.take() {
+        if let Some(prefix) = self.delimiters.emit_left_delimiter() {
             return Some(prefix);
         }
         if let Some(literal) = self.literal.next() {
@@ -73,7 +112,7 @@ impl<'a> Iterator for Debug<'a> {
             self.source = &self.source[size..];
             return next;
         }
-        if let Some(suffix) = self.suffix.take() {
+        if let Some(suffix) = self.delimiters.emit_right_delimiter() {
             return Some(suffix);
         }
         if let (Some(ch), size) = bstr::decode_utf8(self.options) {

--- a/spinoso-regexp/src/encoding.rs
+++ b/spinoso-regexp/src/encoding.rs
@@ -1,11 +1,12 @@
 //! Parse encoding parameter to `Regexp#initialize` and `Regexp::compile`.
 
-use bstr::ByteSlice;
 use core::convert::TryFrom;
 use core::fmt;
 use core::hash::{Hash, Hasher};
 use core::mem;
 use std::error;
+
+use bstr::ByteSlice;
 
 use crate::Flags;
 

--- a/spinoso-regexp/src/encoding.rs
+++ b/spinoso-regexp/src/encoding.rs
@@ -203,7 +203,7 @@ impl From<&Encoding> for i64 {
 
 impl fmt::Display for Encoding {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(self.modifier_string())
+        f.write_str(self.as_modifier_str())
     }
 }
 
@@ -243,7 +243,7 @@ impl Encoding {
     ///
     /// [regexp-inspect]: https://ruby-doc.org/core-2.6.3/Regexp.html#method-i-inspect
     #[must_use]
-    pub const fn modifier_string(self) -> &'static str {
+    pub const fn as_modifier_str(self) -> &'static str {
         match self {
             Self::Fixed | Self::None => "",
             Self::No => "n",

--- a/spinoso-regexp/src/encoding.rs
+++ b/spinoso-regexp/src/encoding.rs
@@ -223,9 +223,9 @@ impl Encoding {
     #[must_use]
     pub const fn flags(self) -> Flags {
         match self {
-            Encoding::Fixed => Flags::FIXEDENCODING,
-            Encoding::No => Flags::NOENCODING,
-            Encoding::None => Flags::empty(),
+            Self::Fixed => Flags::FIXEDENCODING,
+            Self::No => Flags::NOENCODING,
+            Self::None => Flags::empty(),
         }
     }
 

--- a/spinoso-regexp/src/error.rs
+++ b/spinoso-regexp/src/error.rs
@@ -3,7 +3,6 @@ use std::borrow::Cow;
 use std::error;
 
 /// Sum type of all errors possibly returned from `Regexp` APIs.
-///
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Error {
     /// Error that indicates an argument parsing or value logic error occurred.

--- a/spinoso-regexp/src/lib.rs
+++ b/spinoso-regexp/src/lib.rs
@@ -227,6 +227,12 @@ impl Source {
     }
 }
 
+/// A `Config` represents the parsed, expanded, and normalized pattern and
+/// options used to initialize a `Regexp`.
+///
+/// A `Config` is derived from a [`Source`].
+///
+/// When a `Regexp` is cloned, it is cloned from its compiled `Config`.
 #[derive(Default, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Config {
     pattern: Vec<u8>,
@@ -256,6 +262,16 @@ impl From<&Source> for Config {
 
 impl Config {
     /// Construct a new, empty `Config`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use spinoso_regexp::Config;
+    ///
+    /// const CONFIG: Config = Config::new();
+    /// assert!(CONFIG.pattern().is_empty());
+    /// assert!(CONFIG.options().as_display_modifier().is_empty());
+    /// ```
     #[must_use]
     pub const fn new() -> Self {
         Self {
@@ -265,18 +281,55 @@ impl Config {
     }
 
     /// Construct a new `Config` with the given pattern and [`Options`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use spinoso_regexp::{Config, Options};
+    ///
+    /// let config = Config::with_pattern_and_options(
+    ///     b"Artichoke( Ruby)?".to_vec(),
+    ///     Options::with_ignore_case(),
+    /// );
+    /// assert_eq!(config.pattern(), b"Artichoke( Ruby)?");
+    /// assert_eq!(config.options().as_display_modifier(), "i");
+    /// ```
     #[must_use]
     pub const fn with_pattern_and_options(pattern: Vec<u8>, options: Options) -> Self {
         Self { pattern, options }
     }
 
     /// Extracts a slice containing the entire pattern.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use spinoso_regexp::{Config, Options};
+    ///
+    /// let config = Config::with_pattern_and_options(
+    ///     b"Artichoke( Ruby)?".to_vec(),
+    ///     Options::with_ignore_case(),
+    /// );
+    /// assert_eq!(config.pattern(), b"Artichoke( Ruby)?");
+    /// ```
     #[must_use]
     pub fn pattern(&self) -> &[u8] {
         self.pattern.as_slice()
     }
 
     /// Return a copy of the underlying [`Options`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use spinoso_regexp::{Config, Options};
+    ///
+    /// let config = Config::with_pattern_and_options(
+    ///     b"Artichoke( Ruby)?".to_vec(),
+    ///     Options::with_ignore_case(),
+    /// );
+    /// assert_eq!(config.options().as_display_modifier(), "i");
+    /// ```
     #[must_use]
     pub const fn options(&self) -> Options {
         self.options

--- a/spinoso-regexp/src/lib.rs
+++ b/spinoso-regexp/src/lib.rs
@@ -26,9 +26,6 @@
 #[doc = include_str!("../README.md")]
 mod readme {}
 
-#[macro_use]
-extern crate bitflags;
-
 use core::fmt;
 use core::num::NonZeroUsize;
 use std::borrow::Cow;
@@ -46,7 +43,7 @@ pub use encoding::{Encoding, InvalidEncodingError};
 pub use error::{ArgumentError, Error, RegexpError, SyntaxError};
 pub use options::{Options, RegexpOption};
 
-bitflags! {
+bitflags::bitflags! {
     #[derive(Default)]
     pub struct Flags: u8 {
         const IGNORECASE      = 0b0000_0001;

--- a/spinoso-regexp/src/lib.rs
+++ b/spinoso-regexp/src/lib.rs
@@ -74,6 +74,23 @@ pub const HIGHEST_MATCH_GROUP: &[u8] = b"$+";
 /// The information about the last match in the current scope.
 pub const LAST_MATCH: &[u8] = b"$~";
 
+/// A `Source` represents the literal contents used to construct a given
+/// `Regexp`.
+///
+/// When [`Regexp`]s are constructed with a `/.../` literal, [`Regexp#source`]
+/// refers to the literal characters contained within the `/` delimeters.
+/// For example, `/\t/.source.bytes` has byte sequence `[92, 116]`.
+///
+/// When `Regexp`s are constructed with [`Regexp::compile`], [`Regexp#source`]
+/// refers to the argument passed to `compile`. For example,
+/// `Regexp.compile("\t").source.bytes` has byte sequence `[9]`.
+///
+/// [`Regexp#inspect`] prints `"/#{source}/"`.
+///
+/// [`Regexp`]: https://ruby-doc.org/core-2.6.3/Regexp.html
+/// [`Regexp#source`]: https://ruby-doc.org/core-2.6.3/Regexp.html#method-i-source
+/// [`Regexp::compile`]: https://ruby-doc.org/core-2.6.3/Regexp.html#method-c-compile
+/// [`Regexp#inspect`]: https://ruby-doc.org/core-2.6.3/Regexp.html#method-i-inspect
 #[derive(Default, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Source {
     pattern: Vec<u8>,
@@ -103,6 +120,16 @@ impl From<&Config> for Source {
 
 impl Source {
     /// Construct a new, empty `Source`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use spinoso_regexp::Source;
+    ///
+    /// const SOURCE: Source = Source::new();
+    /// assert!(SOURCE.pattern().is_empty());
+    /// assert!(SOURCE.options().as_display_modifier().is_empty());
+    /// ```
     #[must_use]
     pub const fn new() -> Self {
         Self {
@@ -112,12 +139,40 @@ impl Source {
     }
 
     /// Construct a new `Source` with the given pattern and [`Options`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use spinoso_regexp::{Options, Source};
+    ///
+    /// let source = Source::with_pattern_and_options(
+    ///     b"Artichoke( Ruby)?".to_vec(),
+    ///     Options::with_ignore_case(),
+    /// );
+    /// assert_eq!(source.pattern(), b"Artichoke( Ruby)?");
+    /// assert_eq!(source.options().as_display_modifier(), "i");
+    /// ```
     #[must_use]
     pub const fn with_pattern_and_options(pattern: Vec<u8>, options: Options) -> Self {
         Self { pattern, options }
     }
 
     /// Whether this source was parsed with ignore case enabled.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use spinoso_regexp::{Options, Source};
+    ///
+    /// let source = Source::new();
+    /// assert!(!source.is_casefold());
+    ///
+    /// let source = Source::with_pattern_and_options(
+    ///     b"Artichoke( Ruby)?".to_vec(),
+    ///     Options::with_ignore_case(),
+    /// );
+    /// assert!(source.is_casefold());
+    /// ```
     #[must_use]
     pub const fn is_casefold(&self) -> bool {
         self.options.ignore_case().is_enabled()
@@ -128,18 +183,44 @@ impl Source {
     /// This enables Ruby parsers to inject whether a Regexp is a literal to the
     /// core library. Literal Regexps have some special behavior regrding
     /// capturing groups and report parse failures differently.
+    ///
+    /// A source's literal flag can only be set using [`Options::try_from_int`].
     #[must_use]
     pub const fn is_literal(&self) -> bool {
         self.options.is_literal()
     }
 
     /// Extracts a slice containing the entire pattern.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use spinoso_regexp::{Options, Source};
+    ///
+    /// let source = Source::with_pattern_and_options(
+    ///     b"Artichoke( Ruby)?".to_vec(),
+    ///     Options::with_ignore_case(),
+    /// );
+    /// assert_eq!(source.pattern(), b"Artichoke( Ruby)?");
+    /// ```
     #[must_use]
     pub fn pattern(&self) -> &[u8] {
         self.pattern.as_slice()
     }
 
     /// Return a copy of the underlying [`Options`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use spinoso_regexp::{Options, Source};
+    ///
+    /// let source = Source::with_pattern_and_options(
+    ///     b"Artichoke( Ruby)?".to_vec(),
+    ///     Options::with_ignore_case(),
+    /// );
+    /// assert_eq!(source.options().as_display_modifier(), "i");
+    /// ```
     #[must_use]
     pub const fn options(&self) -> Options {
         self.options

--- a/spinoso-regexp/src/lib.rs
+++ b/spinoso-regexp/src/lib.rs
@@ -29,10 +29,11 @@ mod readme {}
 #[macro_use]
 extern crate bitflags;
 
-use bstr::ByteSlice;
 use core::fmt;
 use core::num::NonZeroUsize;
 use std::borrow::Cow;
+
+use bstr::ByteSlice;
 
 mod debug;
 mod encoding;

--- a/spinoso-regexp/src/options.rs
+++ b/spinoso-regexp/src/options.rs
@@ -1,8 +1,9 @@
 //! Parse options parameter to `Regexp#initialize` and `Regexp::compile`.
 
-use bstr::ByteSlice;
 use core::convert::TryFrom;
 use core::fmt;
+
+use bstr::ByteSlice;
 
 use crate::Flags;
 

--- a/spinoso-symbol/README.md
+++ b/spinoso-symbol/README.md
@@ -48,7 +48,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-spinoso-symbol = "0.3"
+spinoso-symbol = "0.1"
 ```
 
 Most of the functionality in this crate depends on a Ruby interpreter that

--- a/spinoso-time/README.md
+++ b/spinoso-time/README.md
@@ -36,7 +36,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-spinoso-time = "0.1"
+spinoso-time = "0.2"
 ```
 
 ## Examples


### PR DESCRIPTION
A smattering of refactorings and quality improvements for `spinoso-regexp`. `spinoso-regexp` is version bumped to 0.2.0.

- Reduce the size of `spinoso_regexp::Debug` by replacing two `Option<char>` with a set of `u8` bitflags. This is the same approach used for outputting `:` and bracketing `"` in `spinoso_symbol::Inspect`.
- Rename `Encoding::modifier_string` to `Encoding::as_modifier_str` to reflect that this is a cheap conversion and it returns a borrowed `&'static str`.
- Sort `bstr` imports in `spinoso-regexp` to match `core` + `std`, then 3p, then crate import groupings.
- Use `Self` type in more places in `Encoding` method implementations.
- Remove `#[macro_use]` for `bitflags`.
- Strengthen the return type of `nth_match_group` to return `Cow<'static, str>` and add a `nth_match_group_bytes` function to transform to `Cow<'static, [u8]>`.
- Add docs for `spinoso_regexp::Debug`.
- Add docs for `spinoso_regexp::Source`.
- Add docs for `spinoso_regexp::Config`.

While I was bumping `spinoso-regexp` to 0.2.0, I noticed that some crates had mismatched versions between `README.md` and `Cargo.toml`. Other crates in the Artichoke organization that are released to crates.io have tests that enforce these match. See https://github.com/artichoke/intaglio/blob/3162eece3b76d928b3d6493ea2e06af33020abc8/tests/version_numbers.rs. Artichoke used to have a dependency and tests with `version-sync`, but it was removed in https://github.com/artichoke/artichoke/pull/704.