### PR TITLE
Remove hack that works around a segfault in the spec-runner

### DIFF
--- a/spec-runner/src/spec_runner.rb
+++ b/spec-runner/src/spec_runner.rb
@@ -246,11 +246,6 @@ module Artichoke
           formatter = YamlFormatter.new
           formatter.register
 
-          # HACK: tickle the GC so a full spec run passes without segfaulting.
-          200.times do
-            'a' * 200
-          end
-
           MSpec.process
 
           return false unless formatter.tally.counter.failures.zero?
@@ -281,11 +276,6 @@ module Artichoke
             raise ArgumentError, 'No recognized tagger action given'
           end
           tag_action.register
-
-          # HACK: tickle the GC so a full spec run passes without segfaulting.
-          200.times do
-            'a' * 200
-          end
 
           MSpec.process
 


### PR DESCRIPTION
Revert ee531eff3061ac334150a1b0765757e7c5ece840 and remove a work around that sprays garbage to the mruby heap.

The segfault that the work around prevents was fixed in #1323.