### PR TITLE
Push a GitHub Actions workflow to trigger crashers with Pernosco

### DIFF
--- a/.github/workflows/crash.yaml
+++ b/.github/workflows/crash.yaml
@@ -1,0 +1,80 @@
+---
+name: Crash
+"on":
+  pull_request:
+    branches:
+      - trunk
+jobs:
+  crash:
+    name: Crash
+    runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: -D warnings
+      RUST_BACKTRACE: 1
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+
+      - name: Install Ruby toolchain
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ".ruby-version"
+          bundler-cache: true
+
+      - uses: Swatinem/rust-cache@v1
+        with:
+          key: v3
+          working-directory: "spec-runner"
+
+      - name: Compile debug
+        run: cargo build --verbose --bin spec-runner
+        working-directory: "spec-runner"
+
+      - name: Compile release
+        run: cargo build --verbose --bin spec-runner --release
+        working-directory: "spec-runner"
+
+      - name: Run specs
+        run: |
+          ./target/debug/spec-runner --quiet --format artichoke all-core-specs.toml > /dev/null
+          ./target/debug/spec-runner --quiet --format summary all-core-specs.toml > /dev/null
+          ./target/debug/spec-runner --quiet --format tagger all-core-specs.toml > /dev/null
+          ./target/debug/spec-runner --quiet --format yaml all-core-specs.toml > /dev/null
+        working-directory: "spec-runner"
+        env:
+          PERNOSCO_ENABLE: 1
+
+      - name: Run specs
+        run: |
+          ./target/debug/spec-runner --quiet --format artichoke spec-state.toml > /dev/null
+          ./target/debug/spec-runner --quiet --format summary spec-state.toml > /dev/null
+          ./target/debug/spec-runner --quiet --format tagger spec-state.toml > /dev/null
+          ./target/debug/spec-runner --quiet --format yaml spec-state.toml > /dev/null
+        working-directory: "spec-runner"
+        env:
+          PERNOSCO_ENABLE: 1
+
+      - name: Run specs
+        run: |
+          ./target/release/spec-runner --quiet --format artichoke all-core-specs.toml > /dev/null
+          ./target/release/spec-runner --quiet --format summary all-core-specs.toml > /dev/null
+          ./target/release/spec-runner --quiet --format tagger all-core-specs.toml > /dev/null
+          ./target/release/spec-runner --quiet --format yaml all-core-specs.toml > /dev/null
+        working-directory: "spec-runner"
+        env:
+          PERNOSCO_ENABLE: 1
+
+      - name: Run specs
+        run: |
+          ./target/release/spec-runner --quiet --format artichoke spec-state.toml > /dev/null
+          ./target/release/spec-runner --quiet --format summary spec-state.toml > /dev/null
+          ./target/release/spec-runner --quiet --format tagger spec-state.toml > /dev/null
+          ./target/release/spec-runner --quiet --format yaml spec-state.toml > /dev/null
+        working-directory: "spec-runner"
+        env:
+          PERNOSCO_ENABLE: 1


### PR DESCRIPTION
Now that the Pernosco integration is known to be working as tested in the PR #1346, merge the workflow so we can generate reproduction environments for future crashes.

Pernosco is enabled via environment variable on the runs of the `spec-runner`.

This commit cherry-picks and squashes a couple of commits from #1346:

- e1eea7148076e8a9329a076bb8d0a39b4332dc93
- 91bc825269530a37fff960d448127f0a843f1cee

Closes #1346.