### PR TITLE
Add local `generate_third_party` gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,5 @@ gem 'bundler-audit', '~> 0.9', require: false
 gem 'rake', '>= 12.3.3', require: false
 gem 'rubocop', '~> 1.20', require: false
 gem 'rubocop-rake', '~> 0.6', require: false
+
+gem 'generate_third_party', path: './generate-third-party'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,8 @@
+PATH
+  remote: generate-third-party
+  specs:
+    generate_third_party (0.0.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -35,6 +40,7 @@ PLATFORMS
 
 DEPENDENCIES
   bundler-audit (~> 0.9)
+  generate_third_party!
   rake (>= 12.3.3)
   rubocop (~> 1.20)
   rubocop-rake (~> 0.6)

--- a/generate-third-party/README.md
+++ b/generate-third-party/README.md
@@ -1,0 +1,20 @@
+# generate_third_party
+
+Generate listings of third party dependencies and their licenses for copyright
+attribution in distributed Artichoke binaries.
+
+## Usage
+
+To generate a `THIRDPARTY` text file for all targets Artichoke supports:
+
+```sh
+bundle exec generate-third-party-text-file
+```
+
+To generate a `THIRDPARTY` text file for a single target triple:
+
+```sh
+bundle exec generate-third-party-text-file-single-target x86_64-unknown-linux-gnu
+```
+
+(or any other target)

--- a/generate-third-party/bin/generate-third-party-html
+++ b/generate-third-party/bin/generate-third-party-html
@@ -1,0 +1,22 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# avoid ugly stacks on permissible signals
+Signal.trap('INT', 'SYSTEM_DEFAULT') if Signal.list.include?('INT')
+Signal.trap('PIPE', 'SYSTEM_DEFAULT') if Signal.list.include?('PIPE')
+
+require 'generate_third_party'
+
+unless Artichoke::Generate::ThirdParty::CargoAbout.present?
+  warn <<~ERR
+    Error: `cargo-about` not found in PATH.
+
+    Try installing `cargo-about` with:
+
+        cargo install cargo-about
+
+  ERR
+  exit 1
+end
+
+puts Artichoke::Generate::ThirdParty::AllTargets.third_party_html

--- a/generate-third-party/bin/generate-third-party-text-file
+++ b/generate-third-party/bin/generate-third-party-text-file
@@ -1,0 +1,22 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# avoid ugly stacks on permissible signals
+Signal.trap('INT', 'SYSTEM_DEFAULT') if Signal.list.include?('INT')
+Signal.trap('PIPE', 'SYSTEM_DEFAULT') if Signal.list.include?('PIPE')
+
+require 'generate_third_party'
+
+unless Artichoke::Generate::ThirdParty::CargoAbout.present?
+  warn <<~ERR
+    Error: `cargo-about` not found in PATH.
+
+    Try installing `cargo-about` with:
+
+        cargo install cargo-about
+
+  ERR
+  exit 1
+end
+
+puts Artichoke::Generate::ThirdParty::AllTargets.third_party_flatfile

--- a/generate-third-party/bin/generate-third-party-text-file-single-target
+++ b/generate-third-party/bin/generate-third-party-text-file-single-target
@@ -1,0 +1,65 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# avoid ugly stacks on permissible signals
+Signal.trap('INT', 'SYSTEM_DEFAULT') if Signal.list.include?('INT')
+Signal.trap('PIPE', 'SYSTEM_DEFAULT') if Signal.list.include?('PIPE')
+
+require 'generate_third_party'
+
+KNOWN_TARGETS = %w[
+  x86_64-unknown-linux-gnu
+  x86_64-unknown-linux-musl
+  x86_64-pc-windows-msvc
+  x86_64-apple-darwin
+  aarch64-apple-darwin
+].freeze
+
+target = ARGV[0]
+if target.nil?
+  warn <<~ERR
+    Error: Missing required TARGET argument.
+
+    Usage: generate-third-party-text-file-single-target TARGET
+
+    Where TARGET is one of:
+
+    - x86_64-unknown-linux-gnu
+    - x86_64-unknown-linux-musl
+    - x86_64-pc-windows-msvc
+    - x86_64-apple-darwin
+    - aarch64-apple-darwin
+  ERR
+  exit 2
+end
+
+unless KNOWN_TARGETS.include?(target)
+  warn <<~ERR
+    Error: Unknown TARGET.
+
+    Usage: generate-third-party-text-file-single-target TARGET
+
+    Where TARGET is one of:
+
+    - x86_64-unknown-linux-gnu
+    - x86_64-unknown-linux-musl
+    - x86_64-pc-windows-msvc
+    - x86_64-apple-darwin
+    - aarch64-apple-darwin
+  ERR
+  exit 2
+end
+
+unless Artichoke::Generate::ThirdParty::CargoAbout.present?
+  warn <<~ERR
+    Error: `cargo-about` not found in PATH.
+
+    Try installing `cargo-about` with:
+
+        cargo install cargo-about
+
+  ERR
+  exit 1
+end
+
+puts Artichoke::Generate::ThirdParty::OneTarget.third_party_flatfile(target)

--- a/generate-third-party/generate_third_party.gemspec
+++ b/generate-third-party/generate_third_party.gemspec
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+Gem::Specification.new do |s|
+  s.name                  = 'generate_third_party'
+  s.version               = '0.0.0'
+  s.required_ruby_version = '>= 2.6.3'
+  s.summary               = "Generate Artichoke's third party dependencies"
+  s.description           = 'Generate lists of third party dependencies and their licenses'
+  s.authors               = ['Ryan Lopopolo']
+  s.email                 = 'rj@hyperbo.la'
+  s.files                 = Dir['lib/**/*'].keep_if { |file| File.file?(file) } + Dir['bin/*']
+  s.bindir                = 'bin'
+  s.homepage              = 'https://github.com/artichoke/artichoke'
+  s.license               = 'MIT'
+
+  s.executables << 'generate-third-party-html'
+  s.executables << 'generate-third-party-text-file'
+  s.executables << 'generate-third-party-text-file-single-target'
+end

--- a/generate-third-party/lib/generate_third_party.rb
+++ b/generate-third-party/lib/generate_third_party.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require_relative 'generate_third_party/cargo_about'
+require_relative 'generate_third_party/deps'
+
+require_relative 'generate_third_party/all_targets'
+require_relative 'generate_third_party/one_target'

--- a/generate-third-party/lib/generate_third_party/all_targets.rb
+++ b/generate-third-party/lib/generate_third_party/all_targets.rb
@@ -1,0 +1,172 @@
+# frozen_string_literal: true
+
+require 'stringio'
+
+module Artichoke
+  module Generate
+    module ThirdParty
+      module AllTargets
+        def self.third_party_flatfile
+          cmd = CargoAbout.new(
+            config: File.join(__dir__, 'all_targets', 'about.toml')
+          )
+
+          deps = cmd.invoke
+
+          s = StringIO.new
+          needs_separator = false
+          deps.each do |dep|
+            if needs_separator
+              s.puts
+              s.puts '---'
+              s.puts
+            end
+
+            s.puts "#{dep.name} #{dep.version}"
+            s.puts ''
+            s.puts dep.url
+            s.puts
+            s.puts dep.license_full_text
+
+            needs_separator = true
+          end
+
+          s.string
+        end
+
+        def self.third_party_html
+          cmd = CargoAbout.new(
+            config: File.join(__dir__, 'all_targets', 'about.toml')
+          )
+
+          deps = cmd.invoke
+
+          s = StringIO.new
+          s.write <<~HEADER
+            <!DOCTYPE html>
+            <html lang="en">
+              <head>
+                <meta charset="utf-8" />
+                <meta
+                  name="viewport"
+                  content="width=device-width, initial-scale=1, shrink-to-fit=no"
+                />
+                <meta
+                  name="description"
+                  content="Artichoke Ruby third party acknowledgements and copyright notices."
+                />
+                <meta name="author" content="Ryan Lopopolo" />
+
+                <title>Artichoke Ruby Third Party Licenses</title>
+
+                <link rel="canonical" href="https://www.artichokeruby.org/thirdparty/" />
+
+                <!-- Favicons -->
+                <%= require("./partials/favicons.html").default %>
+
+                <!-- Twitter -->
+                <meta name="twitter:card" content="summary_large_image" />
+                <meta name="twitter:site" content="@artichokeruby" />
+                <meta name="twitter:creator" content="@artichokeruby" />
+                <meta name="twitter:title" content="Artichoke Ruby Third Party Licenses" />
+                <meta
+                  name="twitter:description"
+                  content="Artichoke Ruby third party acknowledgements and copyright notices."
+                />
+                <meta
+                  name="twitter:image"
+                  content="https://www.artichokeruby.org/artichoke-social-logo.png"
+                />
+
+                <!-- Facebook Open Graph metadata -->
+                <meta
+                  property="og:url"
+                  content="https://www.artichokeruby.org/thirdparty/"
+                />
+                <meta property="og:site_name" content="artichokeruby.org" />
+                <meta property="og:title" content="Artichoke Ruby Third Party Licenses" />
+                <meta
+                  property="og:description"
+                  content="Artichoke Ruby third party acknowledgements and copyright notices."
+                />
+                <meta property="og:type" content="website" />
+                <meta
+                  property="og:image"
+                  content="https://www.artichokeruby.org/artichoke-social-logo.png"
+                />
+                <meta property="og:image:type" content="image/png" />
+                <meta property="og:image:width" content="1600" />
+                <meta property="og:image:height" content="800" />
+
+                <%= require("./partials/google-analytics.html").default %>
+              </head>
+              <body>
+                <%= require("./partials/google-analytics-noscript.html").default %>
+                <a class="visually-hidden visually-hidden-focusable" href="#content">
+                  Skip to main content
+                </a>
+                <%= require("./partials/nav/thirdparty.html").default %>
+
+                <main id="content">
+                  <div class="container mb-3 mb-md-5 mt-3 mt-md-5">
+                    <div class="row">
+                      <div class="thirdparty col-sm-12 col-md-8 offset-md-2">
+                        <div class="intro">
+                          <h1>Third Party Licenses</h1>
+                          <p class="lead">
+                            Artichoke is made possible by the Artichoke open source project
+                            and other open source software.
+                          </p>
+                        </div>
+
+                        <h2>Overview of Licenses</h2>
+                        <ul class="licenses-overview">
+          HEADER
+
+          counts = Hash.new(0)
+          deps.each do |dep|
+            counts[dep.license] += 1
+          end
+          counts.each_pair.to_a.sort_by { |_k, v| -v }.each do |license, count|
+            s.puts "              <li>#{license} (#{count})</li>"
+          end
+
+          s.puts '            </ul>'
+          s.puts '            <h2>All License Text</h2>'
+          deps.each do |dep|
+            section = <<~LICENSE
+              <section class="license" id="#{dep.name}-#{dep.version}-#{dep.license_id}">
+                <h3>
+                  <a href="#{dep.url}">#{dep.name} #{dep.version}</a>
+                  <small class="text-muted"
+                    >[<a href="##{dep.name}-#{dep.version}-#{dep.license_id}">&sect;</a>]</small
+                  >
+                </h3>
+                <pre class="license-text">
+                @@@
+                </pre>
+              </section>
+            LICENSE
+            section = section.lines.map do |line|
+              next dep.license_full_text.gsub('<', '&lt;').gsub('>', '&gt;') if line == "  @@@\n"
+
+              "            #{line}"
+            end
+            s.write section.join
+          end
+
+          s.puts '          </div>'
+          s.puts '        </div>'
+          s.puts '      </div>'
+          s.puts '    </main>'
+          s.puts
+          s.puts '    <%= require("./partials/footer.html").default %>'
+          s.puts '  </body>'
+          s.puts '</html>'
+
+          s.string
+        end
+      end
+    end
+  end
+end

--- a/generate-third-party/lib/generate_third_party/all_targets/about.toml
+++ b/generate-third-party/lib/generate_third_party/all_targets/about.toml
@@ -1,0 +1,59 @@
+accepted = [
+  "MIT",
+  "Apache-2.0",
+  "Apache-2.0 WITH LLVM-exception",
+  "BSL-1.0",
+]
+
+targets = [
+  "x86_64-unknown-linux-gnu",
+  "x86_64-unknown-linux-musl",
+  "x86_64-pc-windows-msvc",
+  "x86_64-apple-darwin",
+  "aarch64-apple-darwin",
+]
+
+[[artichoke.ignore]]
+license = "MIT"
+license-file = "spec-runner/vendor/mspec/LICENSE"
+
+[[artichoke.ignore]]
+license = "MIT"
+license-file = "spec-runner/vendor/spec/LICENSE"
+
+[[artichoke.ignore]]
+license = "MIT"
+license-file = "artichoke-backend/vendor/mruby/LICENSE"
+
+[[artichoke.ignore]]
+license = "MIT"
+license-file = "artichoke-backend/vendor/ruby/LEGAL"
+
+[[artichoke.ignore]]
+license = "MIT"
+license-file = "artichoke-backend/vendor/ruby/spec/mspec/LICENSE"
+
+[[artichoke.ignore]]
+license = "MIT"
+license-file = "artichoke-backend/vendor/ruby/spec/ruby/LICENSE"
+
+[[artichoke-backend.ignore]]
+license = "MIT"
+license-file = "vendor/mruby/LICENSE"
+
+[[artichoke-backend.ignore]]
+license = "MIT"
+license-file = "vendor/ruby/LEGAL"
+
+[[artichoke-backend.ignore]]
+license = "MIT"
+license-file = "vendor/ruby/spec/mspec/LICENSE"
+
+[[artichoke-backend.ignore]]
+license = "MIT"
+license-file = "vendor/ruby/spec/ruby/LICENSE"
+
+[[artichoke-backend.additional]]
+root = "vendor/mruby"
+license = "MIT"
+license-file = "vendor/mruby/LICENSE"

--- a/generate-third-party/lib/generate_third_party/cargo_about.rb
+++ b/generate-third-party/lib/generate_third_party/cargo_about.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require 'open3'
+require 'shellwords'
+require 'stringio'
+
+module Artichoke
+  module Generate
+    module ThirdParty
+      class CargoAbout
+        def self.present?
+          _out, status = Open3.capture2e('cargo about --version')
+
+          status.success?
+        end
+
+        def initialize(config:, template: nil)
+          template = File.join(__dir__, 'cargo_about', 'about.hbs') if template.nil?
+
+          @template = template
+          @config = config
+        end
+
+        def manifest_path
+          path = File.join(__dir__, '..', '..', '..', 'Cargo.toml')
+          File.expand_path(path)
+        end
+
+        def root_config_path
+          path = File.join(__dir__, '..', '..', '..', 'about.toml')
+          File.expand_path(path)
+        end
+
+        def invoke
+          # setup `about.toml`
+          config = File.read(@config)
+          File.open(root_config_path, 'w') do |f|
+            f.write config
+          end
+
+          command = ['cargo', 'about', '--manifest-path', manifest_path, 'generate', @template]
+          out, err, status = Open3.capture3(command.shelljoin)
+
+          File.delete(root_config_path)
+
+          unless status.success?
+            warn 'Generate failed'
+            warn err
+            exit 1
+          end
+
+          Deps.parse(out)
+        end
+
+        def self.third_party_flatfile
+          cmd = CargoAbout.new(
+            cwd: File.join(__dir__, 'all_targets')
+          )
+
+          deps = cmd.invoke
+          deps.sort_by!(&:name)
+
+          s = StringIO.new
+          first = true
+          deps.each do |dep|
+            s.puts unless first
+
+            s.puts "#{dep.name} #{dep.version}"
+            s.puts ''
+            s.puts dep.url
+            s.puts
+            s.puts dep.license_full_text
+
+            first = false
+          end
+        end
+      end
+    end
+  end
+end

--- a/generate-third-party/lib/generate_third_party/cargo_about/about.hbs
+++ b/generate-third-party/lib/generate_third_party/cargo_about/about.hbs
@@ -1,0 +1,71 @@
+---
+deps:
+{{~#each licenses}}
+{{~#each used_by}}
+  - name: "{{{crate.name}}}"
+    version: "{{{crate.version}}}"
+    url: "{{#if crate.repository ~}} {{{crate.repository}}} {{~ else ~}} https://crates.io/crates/{{{crate.name}}} {{~ /if}}"
+    license: "{{{../name}}}"
+    id: "{{{../id}}}"
+@@@@text-start@@@@
+{{{../text}}}
+@@@@text-end@@@@
+{{~/each}}
+{{~/each}}
+  - name: "mruby"
+    version: "3.0.0"
+    url: "https://github.com/mruby/mruby"
+    license: "MIT License"
+    id: "MIT"
+    text: |
+      Copyright (c) 2010-2021 mruby developers
+
+      Permission is hereby granted, free of charge, to any person obtaining a
+      copy of this software and associated documentation files (the "Software"),
+      to deal in the Software without restriction, including without limitation
+      the rights to use, copy, modify, merge, publish, distribute, sublicense,
+      and/or sell copies of the Software, and to permit persons to whom the
+      Software is furnished to do so, subject to the following conditions:
+
+      The above copyright notice and this permission notice shall be included in
+      all copies or substantial portions of the Software.
+
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+      IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+      FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+      AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+      LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+      FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+      DEALINGS IN THE SOFTWARE.
+  - name: "oniguruma"
+    version: "6.9.7"
+    url: "https://github.com/kkos/oniguruma/tree/3bbb3d65c65350bfd941129592cb390aadedb25a"
+    license: "2-Clause BSD License"
+    id: "BSD-2-Clause"
+    text: |
+      Oniguruma LICENSE
+      -----------------
+
+      Copyright (c) 2002-2021  K.Kosako  <kkosako0@gmail.com>
+      All rights reserved.
+
+      Redistribution and use in source and binary forms, with or without
+      modification, are permitted provided that the following conditions
+      are met:
+      1. Redistributions of source code must retain the above copyright
+         notice, this list of conditions and the following disclaimer.
+      2. Redistributions in binary form must reproduce the above copyright
+         notice, this list of conditions and the following disclaimer in the
+         documentation and/or other materials provided with the distribution.
+
+      THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+      ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+      IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+      ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+      FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+      DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+      OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+      HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+      LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+      OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+      SUCH DAMAGE.

--- a/generate-third-party/lib/generate_third_party/deps.rb
+++ b/generate-third-party/lib/generate_third_party/deps.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require 'stringio'
+require 'yaml'
+
+module Artichoke
+  module Generate
+    module ThirdParty
+      module Deps
+        # Parse the output of `cargo about` and return a list of `Dependency` objects
+        # alphabetized by dependency name.
+        def self.parse(cargo_about_output)
+          # Psych won't parse a document delimiter in a quoted string, so munge it
+          tx = cargo_about_output.gsub(
+            '--- LLVM Exceptions to the Apache 2.0 License ----',
+            'aaa LLVM Exceptions to the Apache 2.0 License zzzz'
+          )
+
+          # turn license text blocks into pipe-delimited literal multi-line strings
+          is_text = false
+          tx = tx.each_line.map do |line|
+            if is_text && line == "@@@@text-end@@@@\n"
+              is_text = false
+              next nil
+            end
+            next "      #{line}" if is_text
+
+            if line == "@@@@text-start@@@@\n"
+              is_text = true
+              # The `|2` indentation specifier is necessary because some licenses like
+              # Apache-2.0 have initial lines that begin with whitespace.
+              next "    text: |2\n"
+            end
+            line
+          end
+
+          yaml_output = tx.compact.join
+
+          deps = YAML.safe_load(yaml_output)
+          deps = deps['deps'].map do |hash|
+            Dependency.from_hash(hash)
+          end
+
+          deps.sort_by!(&:name)
+        end
+      end
+
+      class Dependency
+        attr_reader :name, :version, :url, :license, :license_id
+
+        def initialize(name, version, url, license, license_id, text)
+          @name = name
+          @version = version
+          @url = url
+          @license = license
+          @license_id = license_id
+          @text = text
+        end
+
+        def self.from_hash(hash)
+          new(
+            hash.fetch('name'),
+            hash.fetch('version'),
+            hash.fetch('url'),
+            hash.fetch('license'),
+            hash.fetch('id'),
+            hash.fetch('text')
+          )
+        end
+
+        def license_full_text
+          @text.gsub(
+            'aaa LLVM Exceptions to the Apache 2.0 License zzzz',
+            '--- LLVM Exceptions to the Apache 2.0 License ----'
+          )
+        end
+
+        def to_yaml
+          s = StringIO.new
+          s.puts <<~YAML
+            - name: #{name}
+              version: "#{version}"
+              url: "#{url}"
+              license: #{license}
+              license_id: #{license_id}
+          YAML
+
+          # The `|2` indentation specifier is necessary because some licenses like
+          # Apache-2.0 have initial lines that begin with whitespace.
+          s.puts '  text: |2'
+
+          license_full_text.each_line do |line|
+            s.print "    #{line}"
+          end
+          s.string
+        end
+      end
+    end
+  end
+end

--- a/generate-third-party/lib/generate_third_party/one_target.rb
+++ b/generate-third-party/lib/generate_third_party/one_target.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'stringio'
+
+module Artichoke
+  module Generate
+    module ThirdParty
+      module OneTarget
+        def self.third_party_flatfile(target)
+          raise ArgumentError if target.nil?
+          raise ArgumentError unless target.is_a?(String)
+
+          cmd = CargoAbout.new(
+            config: File.join(__dir__, 'one_target', target, 'about.toml')
+          )
+
+          deps = cmd.invoke
+
+          s = StringIO.new
+          needs_separator = false
+          deps.each do |dep|
+            if needs_separator
+              s.puts
+              s.puts '---'
+              s.puts
+            end
+
+            s.puts "#{dep.name} #{dep.version}"
+            s.puts ''
+            s.puts dep.url
+            s.puts
+            s.puts dep.license_full_text
+
+            needs_separator = true
+          end
+
+          s.string
+        end
+      end
+    end
+  end
+end

--- a/generate-third-party/lib/generate_third_party/one_target/aarch64-apple-darwin/about.toml
+++ b/generate-third-party/lib/generate_third_party/one_target/aarch64-apple-darwin/about.toml
@@ -1,0 +1,55 @@
+accepted = [
+  "MIT",
+  "Apache-2.0",
+  "Apache-2.0 WITH LLVM-exception",
+  "BSL-1.0",
+]
+
+targets = [
+  "aarch64-apple-darwin",
+]
+
+[[artichoke.ignore]]
+license = "MIT"
+license-file = "spec-runner/vendor/mspec/LICENSE"
+
+[[artichoke.ignore]]
+license = "MIT"
+license-file = "spec-runner/vendor/spec/LICENSE"
+
+[[artichoke.ignore]]
+license = "MIT"
+license-file = "artichoke-backend/vendor/mruby/LICENSE"
+
+[[artichoke.ignore]]
+license = "MIT"
+license-file = "artichoke-backend/vendor/ruby/LEGAL"
+
+[[artichoke.ignore]]
+license = "MIT"
+license-file = "artichoke-backend/vendor/ruby/spec/mspec/LICENSE"
+
+[[artichoke.ignore]]
+license = "MIT"
+license-file = "artichoke-backend/vendor/ruby/spec/ruby/LICENSE"
+
+[[artichoke-backend.ignore]]
+license = "MIT"
+license-file = "vendor/mruby/LICENSE"
+
+[[artichoke-backend.ignore]]
+license = "MIT"
+license-file = "vendor/ruby/LEGAL"
+
+[[artichoke-backend.ignore]]
+license = "MIT"
+license-file = "vendor/ruby/spec/mspec/LICENSE"
+
+[[artichoke-backend.ignore]]
+license = "MIT"
+license-file = "vendor/ruby/spec/ruby/LICENSE"
+
+[[artichoke-backend.additional]]
+root = "vendor/mruby"
+license = "MIT"
+license-file = "vendor/mruby/LICENSE"

--- a/generate-third-party/lib/generate_third_party/one_target/x86_64-apple-darwin/about.toml
+++ b/generate-third-party/lib/generate_third_party/one_target/x86_64-apple-darwin/about.toml
@@ -1,0 +1,56 @@
+
+accepted = [
+  "MIT",
+  "Apache-2.0",
+  "Apache-2.0 WITH LLVM-exception",
+  "BSL-1.0",
+]
+
+targets = [
+  "x86_64-apple-darwin",
+]
+
+[[artichoke.ignore]]
+license = "MIT"
+license-file = "spec-runner/vendor/mspec/LICENSE"
+
+[[artichoke.ignore]]
+license = "MIT"
+license-file = "spec-runner/vendor/spec/LICENSE"
+
+[[artichoke.ignore]]
+license = "MIT"
+license-file = "artichoke-backend/vendor/mruby/LICENSE"
+
+[[artichoke.ignore]]
+license = "MIT"
+license-file = "artichoke-backend/vendor/ruby/LEGAL"
+
+[[artichoke.ignore]]
+license = "MIT"
+license-file = "artichoke-backend/vendor/ruby/spec/mspec/LICENSE"
+
+[[artichoke.ignore]]
+license = "MIT"
+license-file = "artichoke-backend/vendor/ruby/spec/ruby/LICENSE"
+
+[[artichoke-backend.ignore]]
+license = "MIT"
+license-file = "vendor/mruby/LICENSE"
+
+[[artichoke-backend.ignore]]
+license = "MIT"
+license-file = "vendor/ruby/LEGAL"
+
+[[artichoke-backend.ignore]]
+license = "MIT"
+license-file = "vendor/ruby/spec/mspec/LICENSE"
+
+[[artichoke-backend.ignore]]
+license = "MIT"
+license-file = "vendor/ruby/spec/ruby/LICENSE"
+
+[[artichoke-backend.additional]]
+root = "vendor/mruby"
+license = "MIT"
+license-file = "vendor/mruby/LICENSE"

--- a/generate-third-party/lib/generate_third_party/one_target/x86_64-pc-windows-msvc/about.toml
+++ b/generate-third-party/lib/generate_third_party/one_target/x86_64-pc-windows-msvc/about.toml
@@ -1,0 +1,56 @@
+
+accepted = [
+  "MIT",
+  "Apache-2.0",
+  "Apache-2.0 WITH LLVM-exception",
+  "BSL-1.0",
+]
+
+targets = [
+  "x86_64-pc-windows-msvc",
+]
+
+[[artichoke.ignore]]
+license = "MIT"
+license-file = "spec-runner/vendor/mspec/LICENSE"
+
+[[artichoke.ignore]]
+license = "MIT"
+license-file = "spec-runner/vendor/spec/LICENSE"
+
+[[artichoke.ignore]]
+license = "MIT"
+license-file = "artichoke-backend/vendor/mruby/LICENSE"
+
+[[artichoke.ignore]]
+license = "MIT"
+license-file = "artichoke-backend/vendor/ruby/LEGAL"
+
+[[artichoke.ignore]]
+license = "MIT"
+license-file = "artichoke-backend/vendor/ruby/spec/mspec/LICENSE"
+
+[[artichoke.ignore]]
+license = "MIT"
+license-file = "artichoke-backend/vendor/ruby/spec/ruby/LICENSE"
+
+[[artichoke-backend.ignore]]
+license = "MIT"
+license-file = "vendor/mruby/LICENSE"
+
+[[artichoke-backend.ignore]]
+license = "MIT"
+license-file = "vendor/ruby/LEGAL"
+
+[[artichoke-backend.ignore]]
+license = "MIT"
+license-file = "vendor/ruby/spec/mspec/LICENSE"
+
+[[artichoke-backend.ignore]]
+license = "MIT"
+license-file = "vendor/ruby/spec/ruby/LICENSE"
+
+[[artichoke-backend.additional]]
+root = "vendor/mruby"
+license = "MIT"
+license-file = "vendor/mruby/LICENSE"

--- a/generate-third-party/lib/generate_third_party/one_target/x86_64-unknown-linux-gnu/about.toml
+++ b/generate-third-party/lib/generate_third_party/one_target/x86_64-unknown-linux-gnu/about.toml
@@ -1,0 +1,55 @@
+accepted = [
+  "MIT",
+  "Apache-2.0",
+  "Apache-2.0 WITH LLVM-exception",
+  "BSL-1.0",
+]
+
+targets = [
+  "x86_64-unknown-linux-gnu",
+]
+
+[[artichoke.ignore]]
+license = "MIT"
+license-file = "spec-runner/vendor/mspec/LICENSE"
+
+[[artichoke.ignore]]
+license = "MIT"
+license-file = "spec-runner/vendor/spec/LICENSE"
+
+[[artichoke.ignore]]
+license = "MIT"
+license-file = "artichoke-backend/vendor/mruby/LICENSE"
+
+[[artichoke.ignore]]
+license = "MIT"
+license-file = "artichoke-backend/vendor/ruby/LEGAL"
+
+[[artichoke.ignore]]
+license = "MIT"
+license-file = "artichoke-backend/vendor/ruby/spec/mspec/LICENSE"
+
+[[artichoke.ignore]]
+license = "MIT"
+license-file = "artichoke-backend/vendor/ruby/spec/ruby/LICENSE"
+
+[[artichoke-backend.ignore]]
+license = "MIT"
+license-file = "vendor/mruby/LICENSE"
+
+[[artichoke-backend.ignore]]
+license = "MIT"
+license-file = "vendor/ruby/LEGAL"
+
+[[artichoke-backend.ignore]]
+license = "MIT"
+license-file = "vendor/ruby/spec/mspec/LICENSE"
+
+[[artichoke-backend.ignore]]
+license = "MIT"
+license-file = "vendor/ruby/spec/ruby/LICENSE"
+
+[[artichoke-backend.additional]]
+root = "vendor/mruby"
+license = "MIT"
+license-file = "vendor/mruby/LICENSE"

--- a/generate-third-party/lib/generate_third_party/one_target/x86_64-unknown-linux-musl/about.toml
+++ b/generate-third-party/lib/generate_third_party/one_target/x86_64-unknown-linux-musl/about.toml
@@ -1,0 +1,55 @@
+accepted = [
+  "MIT",
+  "Apache-2.0",
+  "Apache-2.0 WITH LLVM-exception",
+  "BSL-1.0",
+]
+
+targets = [
+  "x86_64-unknown-linux-musl",
+]
+
+[[artichoke.ignore]]
+license = "MIT"
+license-file = "spec-runner/vendor/mspec/LICENSE"
+
+[[artichoke.ignore]]
+license = "MIT"
+license-file = "spec-runner/vendor/spec/LICENSE"
+
+[[artichoke.ignore]]
+license = "MIT"
+license-file = "artichoke-backend/vendor/mruby/LICENSE"
+
+[[artichoke.ignore]]
+license = "MIT"
+license-file = "artichoke-backend/vendor/ruby/LEGAL"
+
+[[artichoke.ignore]]
+license = "MIT"
+license-file = "artichoke-backend/vendor/ruby/spec/mspec/LICENSE"
+
+[[artichoke.ignore]]
+license = "MIT"
+license-file = "artichoke-backend/vendor/ruby/spec/ruby/LICENSE"
+
+[[artichoke-backend.ignore]]
+license = "MIT"
+license-file = "vendor/mruby/LICENSE"
+
+[[artichoke-backend.ignore]]
+license = "MIT"
+license-file = "vendor/ruby/LEGAL"
+
+[[artichoke-backend.ignore]]
+license = "MIT"
+license-file = "vendor/ruby/spec/mspec/LICENSE"
+
+[[artichoke-backend.ignore]]
+license = "MIT"
+license-file = "vendor/ruby/spec/ruby/LICENSE"
+
+[[artichoke-backend.additional]]
+root = "vendor/mruby"
+license = "MIT"
+license-file = "vendor/mruby/LICENSE"


### PR DESCRIPTION
Add a local RubyGem that installs executables used to generate
`THIRDPARTY` flat files for inclusion in nightly build artifacts.

This gem exposes three commands:

- `generate-third-party-text-file`: generate a `THIRDPARTY` text file
  that is a flat listing of all dependencies, versions, and their
  licesnes for all targets Artichoke supports.
- `generate-third-party-text-file-single-target`: generate a
  `THIRDPARTY` text file that is a flat listing of all dependencies,
  versions, and their licenses for a single target triple.
- `generate-third-party-html`: generate an HTML page that lists all
  dependencies, bersions, and their licesnes for all targets Artichoke
  supports. This output is meant to be embedded in
  www.artichokeruby.org.

Two additional licenses are included for C libraries Artichoke
transitively depends on through Rust crates:

- Oniguruma 6.9.7 (via `onig` -> `onig_sys`)
- mruby 3.0.0 (via `artichoke-backend`)