### PR TITLE
Add a 'perl hash' implementation to `spinoso-string`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -654,7 +654,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-string"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "bstr",
  "focaccia",

--- a/spinoso-string/Cargo.toml
+++ b/spinoso-string/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spinoso-string"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2018"
 description = """
@@ -21,6 +21,9 @@ scolapasta-string-escape = { version = "0.2", path = "../scolapasta-string-escap
 quickcheck = { version = "1.0", default-features = false }
 
 [features]
-default = ["casecmp", "std"]
+default = ["casecmp", "ffi", "std"]
 casecmp = ["focaccia"]
+# Helpers for implementing Ruby and mruby FFI routines.
+ffi = []
+# Enable implementations of traits in `std` like `Error` and `io::Write`.
 std = []

--- a/spinoso-string/src/ffi/mod.rs
+++ b/spinoso-string/src/ffi/mod.rs
@@ -1,0 +1,3 @@
+//! Helper routines for reimplementing functions in Ruby and mruby.
+
+pub mod mruby;

--- a/spinoso-string/src/ffi/mruby.rs
+++ b/spinoso-string/src/ffi/mruby.rs
@@ -1,0 +1,29 @@
+//! Helper routines for reimplementing functions in mruby.
+
+use core::num::Wrapping;
+
+/// Simple, non-cryptographic, non-collision-resistant bytestring hasher.
+///
+/// This hash routine is used in [mruby 3.0.0] and [MRI Ruby 1.8.7].
+///
+/// MRI Ruby 1.8.7 calls this hash routine "Perl hash".
+///
+/// [mruby 3.0.0]: https://github.com/artichoke/mruby/blob/3.0.0/src/string.c#L1751-L1769
+/// [MRI Ruby 1.8.7]: https://github.com/ruby/ruby/blob/v1_8_7/string.c#L869-L903
+pub fn mrb_str_hash<T: AsRef<[u8]>>(s: T) -> u32 {
+    fn inner(s: &[u8]) -> u32 {
+        let mut hash = Wrapping(0_u32);
+        for &b in s.iter() {
+            hash += Wrapping(u32::from(b));
+            hash += hash << 10;
+            hash ^= hash >> 6;
+        }
+        hash += hash << 3;
+        hash ^= hash >> 11;
+        hash += hash << 15;
+
+        hash.0
+    }
+
+    inner(s.as_ref())
+}

--- a/spinoso-string/src/lib.rs
+++ b/spinoso-string/src/lib.rs
@@ -53,6 +53,8 @@ pub use focaccia::CaseFold;
 mod chars;
 mod encoding;
 mod eq;
+#[cfg(feature = "ffi")]
+pub mod ffi;
 mod impls;
 mod inspect;
 


### PR DESCRIPTION
This hash routine is used in MRI Ruby 1.8.7 and mruby 3.0.0.

https://github.com/artichoke/mruby/blob/3.0.0/src/string.c#L1751-L1769
https://github.com/ruby/ruby/blob/v1_8_7/string.c#L869-L903

And the hash routine from Perl 5.8.0 on which the above are based: https://github.com/Perl/perl5/blob/perl-5.8.0/hv.h#L49-L73

This routine is not a cryptographic hash and is not collision-resistant.

This PR was extracted from https://github.com/artichoke/artichoke/pull/1222.