### PR TITLE
Update `generate-third-party` for `cargo-about` v0.4.0

### DIFF
--- a/generate-third-party/lib/generate_third_party/all_targets/about.toml
+++ b/generate-third-party/lib/generate_third_party/all_targets/about.toml
@@ -4,7 +4,6 @@ accepted = [
   "Apache-2.0 WITH LLVM-exception",
   "BSL-1.0",
 ]
-
 targets = [
   "x86_64-unknown-linux-gnu",
   "x86_64-unknown-linux-musl",
@@ -12,48 +11,20 @@ targets = [
   "x86_64-apple-darwin",
   "aarch64-apple-darwin",
 ]
+workarounds = ["chrono", "clap"]
 
-[[artichoke.ignore]]
+[artichoke.clarify]
 license = "MIT"
-license-file = "spec-runner/vendor/mspec/LICENSE"
 
-[[artichoke.ignore]]
+[[artichoke.clarify.files]]
+path = "LICENSE"
 license = "MIT"
-license-file = "spec-runner/vendor/spec/LICENSE"
+checksum = "a7f7d7c7ab9585b1c5e43d592c648d6d3fff7debcf7cfbde301f63b02157444d"
 
-[[artichoke.ignore]]
+[artichoke-backend.clarify]
 license = "MIT"
-license-file = "artichoke-backend/vendor/mruby/LICENSE"
 
-[[artichoke.ignore]]
+[[artichoke-backend.clarify.files]]
+path = "LICENSE"
 license = "MIT"
-license-file = "artichoke-backend/vendor/ruby/LEGAL"
-
-[[artichoke.ignore]]
-license = "MIT"
-license-file = "artichoke-backend/vendor/ruby/spec/mspec/LICENSE"
-
-[[artichoke.ignore]]
-license = "MIT"
-license-file = "artichoke-backend/vendor/ruby/spec/ruby/LICENSE"
-
-[[artichoke-backend.ignore]]
-license = "MIT"
-license-file = "vendor/mruby/LICENSE"
-
-[[artichoke-backend.ignore]]
-license = "MIT"
-license-file = "vendor/ruby/LEGAL"
-
-[[artichoke-backend.ignore]]
-license = "MIT"
-license-file = "vendor/ruby/spec/mspec/LICENSE"
-
-[[artichoke-backend.ignore]]
-license = "MIT"
-license-file = "vendor/ruby/spec/ruby/LICENSE"
-
-[[artichoke-backend.additional]]
-root = "vendor/mruby"
-license = "MIT"
-license-file = "vendor/mruby/LICENSE"
+checksum = "a7f7d7c7ab9585b1c5e43d592c648d6d3fff7debcf7cfbde301f63b02157444d"

--- a/generate-third-party/lib/generate_third_party/cargo_about.rb
+++ b/generate-third-party/lib/generate_third_party/cargo_about.rb
@@ -26,22 +26,9 @@ module Artichoke
           File.expand_path(path)
         end
 
-        def root_config_path
-          path = File.join(__dir__, '..', '..', '..', 'about.toml')
-          File.expand_path(path)
-        end
-
         def invoke
-          # setup `about.toml`
-          config = File.read(@config)
-          File.open(root_config_path, 'w') do |f|
-            f.write config
-          end
-
-          command = ['cargo', 'about', '--manifest-path', manifest_path, 'generate', @template]
+          command = ['cargo', 'about', 'generate', @template, '--manifest-path', manifest_path, '--config', @config]
           out, err, status = Open3.capture3(command.shelljoin)
-
-          File.delete(root_config_path)
 
           unless status.success?
             warn 'Generate failed'

--- a/generate-third-party/lib/generate_third_party/cargo_about/about.hbs
+++ b/generate-third-party/lib/generate_third_party/cargo_about/about.hbs
@@ -1,7 +1,7 @@
 ---
 deps:
-{{~#each licenses}}
-{{~#each used_by}}
+{{#each licenses}}
+{{#each used_by}}
   - name: "{{{crate.name}}}"
     version: "{{{crate.version}}}"
     url: "{{#if crate.repository ~}} {{{crate.repository}}} {{~ else ~}} https://crates.io/crates/{{{crate.name}}} {{~ /if}}"
@@ -10,8 +10,8 @@ deps:
 @@@@text-start@@@@
 {{{../text}}}
 @@@@text-end@@@@
-{{~/each}}
-{{~/each}}
+{{/each}}
+{{/each}}
   - name: "mruby"
     version: "3.0.0"
     url: "https://github.com/mruby/mruby"

--- a/generate-third-party/lib/generate_third_party/one_target/aarch64-apple-darwin/about.toml
+++ b/generate-third-party/lib/generate_third_party/one_target/aarch64-apple-darwin/about.toml
@@ -4,52 +4,23 @@ accepted = [
   "Apache-2.0 WITH LLVM-exception",
   "BSL-1.0",
 ]
-
 targets = [
   "aarch64-apple-darwin",
 ]
+workarounds = ["chrono", "clap"]
 
-[[artichoke.ignore]]
+[artichoke.clarify]
 license = "MIT"
-license-file = "spec-runner/vendor/mspec/LICENSE"
 
-[[artichoke.ignore]]
+[[artichoke.clarify.files]]
+path = "LICENSE"
 license = "MIT"
-license-file = "spec-runner/vendor/spec/LICENSE"
+checksum = "a7f7d7c7ab9585b1c5e43d592c648d6d3fff7debcf7cfbde301f63b02157444d"
 
-[[artichoke.ignore]]
+[artichoke-backend.clarify]
 license = "MIT"
-license-file = "artichoke-backend/vendor/mruby/LICENSE"
 
-[[artichoke.ignore]]
+[[artichoke-backend.clarify.files]]
+path = "LICENSE"
 license = "MIT"
-license-file = "artichoke-backend/vendor/ruby/LEGAL"
-
-[[artichoke.ignore]]
-license = "MIT"
-license-file = "artichoke-backend/vendor/ruby/spec/mspec/LICENSE"
-
-[[artichoke.ignore]]
-license = "MIT"
-license-file = "artichoke-backend/vendor/ruby/spec/ruby/LICENSE"
-
-[[artichoke-backend.ignore]]
-license = "MIT"
-license-file = "vendor/mruby/LICENSE"
-
-[[artichoke-backend.ignore]]
-license = "MIT"
-license-file = "vendor/ruby/LEGAL"
-
-[[artichoke-backend.ignore]]
-license = "MIT"
-license-file = "vendor/ruby/spec/mspec/LICENSE"
-
-[[artichoke-backend.ignore]]
-license = "MIT"
-license-file = "vendor/ruby/spec/ruby/LICENSE"
-
-[[artichoke-backend.additional]]
-root = "vendor/mruby"
-license = "MIT"
-license-file = "vendor/mruby/LICENSE"
+checksum = "a7f7d7c7ab9585b1c5e43d592c648d6d3fff7debcf7cfbde301f63b02157444d"

--- a/generate-third-party/lib/generate_third_party/one_target/x86_64-apple-darwin/about.toml
+++ b/generate-third-party/lib/generate_third_party/one_target/x86_64-apple-darwin/about.toml
@@ -1,56 +1,26 @@
-
 accepted = [
   "MIT",
   "Apache-2.0",
   "Apache-2.0 WITH LLVM-exception",
   "BSL-1.0",
 ]
-
 targets = [
   "x86_64-apple-darwin",
 ]
+workarounds = ["chrono", "clap"]
 
-[[artichoke.ignore]]
+[artichoke.clarify]
 license = "MIT"
-license-file = "spec-runner/vendor/mspec/LICENSE"
 
-[[artichoke.ignore]]
+[[artichoke.clarify.files]]
+path = "LICENSE"
 license = "MIT"
-license-file = "spec-runner/vendor/spec/LICENSE"
+checksum = "a7f7d7c7ab9585b1c5e43d592c648d6d3fff7debcf7cfbde301f63b02157444d"
 
-[[artichoke.ignore]]
+[artichoke-backend.clarify]
 license = "MIT"
-license-file = "artichoke-backend/vendor/mruby/LICENSE"
 
-[[artichoke.ignore]]
+[[artichoke-backend.clarify.files]]
+path = "LICENSE"
 license = "MIT"
-license-file = "artichoke-backend/vendor/ruby/LEGAL"
-
-[[artichoke.ignore]]
-license = "MIT"
-license-file = "artichoke-backend/vendor/ruby/spec/mspec/LICENSE"
-
-[[artichoke.ignore]]
-license = "MIT"
-license-file = "artichoke-backend/vendor/ruby/spec/ruby/LICENSE"
-
-[[artichoke-backend.ignore]]
-license = "MIT"
-license-file = "vendor/mruby/LICENSE"
-
-[[artichoke-backend.ignore]]
-license = "MIT"
-license-file = "vendor/ruby/LEGAL"
-
-[[artichoke-backend.ignore]]
-license = "MIT"
-license-file = "vendor/ruby/spec/mspec/LICENSE"
-
-[[artichoke-backend.ignore]]
-license = "MIT"
-license-file = "vendor/ruby/spec/ruby/LICENSE"
-
-[[artichoke-backend.additional]]
-root = "vendor/mruby"
-license = "MIT"
-license-file = "vendor/mruby/LICENSE"
+checksum = "a7f7d7c7ab9585b1c5e43d592c648d6d3fff7debcf7cfbde301f63b02157444d"

--- a/generate-third-party/lib/generate_third_party/one_target/x86_64-pc-windows-msvc/about.toml
+++ b/generate-third-party/lib/generate_third_party/one_target/x86_64-pc-windows-msvc/about.toml
@@ -1,56 +1,26 @@
-
 accepted = [
   "MIT",
   "Apache-2.0",
   "Apache-2.0 WITH LLVM-exception",
   "BSL-1.0",
 ]
-
 targets = [
   "x86_64-pc-windows-msvc",
 ]
+workarounds = ["chrono", "clap"]
 
-[[artichoke.ignore]]
+[artichoke.clarify]
 license = "MIT"
-license-file = "spec-runner/vendor/mspec/LICENSE"
 
-[[artichoke.ignore]]
+[[artichoke.clarify.files]]
+path = "LICENSE"
 license = "MIT"
-license-file = "spec-runner/vendor/spec/LICENSE"
+checksum = "a7f7d7c7ab9585b1c5e43d592c648d6d3fff7debcf7cfbde301f63b02157444d"
 
-[[artichoke.ignore]]
+[artichoke-backend.clarify]
 license = "MIT"
-license-file = "artichoke-backend/vendor/mruby/LICENSE"
 
-[[artichoke.ignore]]
+[[artichoke-backend.clarify.files]]
+path = "LICENSE"
 license = "MIT"
-license-file = "artichoke-backend/vendor/ruby/LEGAL"
-
-[[artichoke.ignore]]
-license = "MIT"
-license-file = "artichoke-backend/vendor/ruby/spec/mspec/LICENSE"
-
-[[artichoke.ignore]]
-license = "MIT"
-license-file = "artichoke-backend/vendor/ruby/spec/ruby/LICENSE"
-
-[[artichoke-backend.ignore]]
-license = "MIT"
-license-file = "vendor/mruby/LICENSE"
-
-[[artichoke-backend.ignore]]
-license = "MIT"
-license-file = "vendor/ruby/LEGAL"
-
-[[artichoke-backend.ignore]]
-license = "MIT"
-license-file = "vendor/ruby/spec/mspec/LICENSE"
-
-[[artichoke-backend.ignore]]
-license = "MIT"
-license-file = "vendor/ruby/spec/ruby/LICENSE"
-
-[[artichoke-backend.additional]]
-root = "vendor/mruby"
-license = "MIT"
-license-file = "vendor/mruby/LICENSE"
+checksum = "a7f7d7c7ab9585b1c5e43d592c648d6d3fff7debcf7cfbde301f63b02157444d"

--- a/generate-third-party/lib/generate_third_party/one_target/x86_64-unknown-linux-gnu/about.toml
+++ b/generate-third-party/lib/generate_third_party/one_target/x86_64-unknown-linux-gnu/about.toml
@@ -4,52 +4,23 @@ accepted = [
   "Apache-2.0 WITH LLVM-exception",
   "BSL-1.0",
 ]
-
 targets = [
   "x86_64-unknown-linux-gnu",
 ]
+workarounds = ["chrono", "clap"]
 
-[[artichoke.ignore]]
+[artichoke.clarify]
 license = "MIT"
-license-file = "spec-runner/vendor/mspec/LICENSE"
 
-[[artichoke.ignore]]
+[[artichoke.clarify.files]]
+path = "LICENSE"
 license = "MIT"
-license-file = "spec-runner/vendor/spec/LICENSE"
+checksum = "a7f7d7c7ab9585b1c5e43d592c648d6d3fff7debcf7cfbde301f63b02157444d"
 
-[[artichoke.ignore]]
+[artichoke-backend.clarify]
 license = "MIT"
-license-file = "artichoke-backend/vendor/mruby/LICENSE"
 
-[[artichoke.ignore]]
+[[artichoke-backend.clarify.files]]
+path = "LICENSE"
 license = "MIT"
-license-file = "artichoke-backend/vendor/ruby/LEGAL"
-
-[[artichoke.ignore]]
-license = "MIT"
-license-file = "artichoke-backend/vendor/ruby/spec/mspec/LICENSE"
-
-[[artichoke.ignore]]
-license = "MIT"
-license-file = "artichoke-backend/vendor/ruby/spec/ruby/LICENSE"
-
-[[artichoke-backend.ignore]]
-license = "MIT"
-license-file = "vendor/mruby/LICENSE"
-
-[[artichoke-backend.ignore]]
-license = "MIT"
-license-file = "vendor/ruby/LEGAL"
-
-[[artichoke-backend.ignore]]
-license = "MIT"
-license-file = "vendor/ruby/spec/mspec/LICENSE"
-
-[[artichoke-backend.ignore]]
-license = "MIT"
-license-file = "vendor/ruby/spec/ruby/LICENSE"
-
-[[artichoke-backend.additional]]
-root = "vendor/mruby"
-license = "MIT"
-license-file = "vendor/mruby/LICENSE"
+checksum = "a7f7d7c7ab9585b1c5e43d592c648d6d3fff7debcf7cfbde301f63b02157444d"

--- a/generate-third-party/lib/generate_third_party/one_target/x86_64-unknown-linux-musl/about.toml
+++ b/generate-third-party/lib/generate_third_party/one_target/x86_64-unknown-linux-musl/about.toml
@@ -4,52 +4,23 @@ accepted = [
   "Apache-2.0 WITH LLVM-exception",
   "BSL-1.0",
 ]
-
 targets = [
   "x86_64-unknown-linux-musl",
 ]
+workarounds = ["chrono", "clap"]
 
-[[artichoke.ignore]]
+[artichoke.clarify]
 license = "MIT"
-license-file = "spec-runner/vendor/mspec/LICENSE"
 
-[[artichoke.ignore]]
+[[artichoke.clarify.files]]
+path = "LICENSE"
 license = "MIT"
-license-file = "spec-runner/vendor/spec/LICENSE"
+checksum = "a7f7d7c7ab9585b1c5e43d592c648d6d3fff7debcf7cfbde301f63b02157444d"
 
-[[artichoke.ignore]]
+[artichoke-backend.clarify]
 license = "MIT"
-license-file = "artichoke-backend/vendor/mruby/LICENSE"
 
-[[artichoke.ignore]]
+[[artichoke-backend.clarify.files]]
+path = "LICENSE"
 license = "MIT"
-license-file = "artichoke-backend/vendor/ruby/LEGAL"
-
-[[artichoke.ignore]]
-license = "MIT"
-license-file = "artichoke-backend/vendor/ruby/spec/mspec/LICENSE"
-
-[[artichoke.ignore]]
-license = "MIT"
-license-file = "artichoke-backend/vendor/ruby/spec/ruby/LICENSE"
-
-[[artichoke-backend.ignore]]
-license = "MIT"
-license-file = "vendor/mruby/LICENSE"
-
-[[artichoke-backend.ignore]]
-license = "MIT"
-license-file = "vendor/ruby/LEGAL"
-
-[[artichoke-backend.ignore]]
-license = "MIT"
-license-file = "vendor/ruby/spec/mspec/LICENSE"
-
-[[artichoke-backend.ignore]]
-license = "MIT"
-license-file = "vendor/ruby/spec/ruby/LICENSE"
-
-[[artichoke-backend.additional]]
-root = "vendor/mruby"
-license = "MIT"
-license-file = "vendor/mruby/LICENSE"
+checksum = "a7f7d7c7ab9585b1c5e43d592c648d6d3fff7debcf7cfbde301f63b02157444d"


### PR DESCRIPTION
- Use `clarify` sections instead of `ignore`s.
- Use the `--config` flag instead of copying `about.toml` to the repo root.

This PR fixes broken builds in the docker-artichoke-nightly repo:

https://github.com/artichoke/docker-artichoke-nightly/runs/4057649931?check_suite_focus=true