### PR TITLE
deny: ignore RUSTSEC-2020-0159

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -2,7 +2,11 @@
 vulnerability = "deny"
 unmaintained = "deny"
 notice = "warn"
-ignore = []
+ignore = [
+  # time/chrono problems, have not been a problem in practice
+  # see: https://github.com/chronotope/chrono/issues/499
+  "RUSTSEC-2020-0159",
+]
 
 [licenses]
 unlicensed = "deny"


### PR DESCRIPTION
https://rustsec.org/advisories/RUSTSEC-2020-0159

This advisory is not a problem in practice since Artichoke does notcall `getenv`/`setenv` from native code.