### PR TITLE
Implement `String::clear` in `spinoso-string`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -654,7 +654,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-string"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bstr",
  "focaccia",

--- a/spinoso-string/Cargo.toml
+++ b/spinoso-string/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spinoso-string"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2021"
 description = """

--- a/spinoso-string/README.md
+++ b/spinoso-string/README.md
@@ -27,7 +27,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-spinoso-string = "0.1"
+spinoso-string = "0.2"
 ```
 
 ## `no_std`

--- a/spinoso-string/README.md
+++ b/spinoso-string/README.md
@@ -34,6 +34,8 @@ spinoso-string = "0.2"
 
 This crate is `no_std` compatible with a required dependency on [`alloc`].
 
+[`alloc`]: https://doc.rust-lang.org/alloc/
+
 ## Crate features
 
 All features are enabled by default.

--- a/spinoso-string/README.md
+++ b/spinoso-string/README.md
@@ -14,8 +14,8 @@ A String object holds and manipulates an arbitrary sequence of bytes, typically
 representing characters. String objects may be created using `::new` or as
 literals.
 
-`spinoso-string` is encoding-aware and implements support for Unicode, ASCII,
-and binary encodings.
+`spinoso-string` is encoding-aware and implements support for UTF-8, ASCII, and
+binary encodings.
 
 _Spinoso_ refers to _Carciofo spinoso di Sardegna_, the thorny artichoke of
 Sardinia. The data structures defined in the `spinoso` family of crates form the

--- a/spinoso-string/src/lib.rs
+++ b/spinoso-string/src/lib.rs
@@ -882,6 +882,25 @@ impl String {
         self.buf.capacity()
     }
 
+    /// Clears the string, removing all bytes.
+    ///
+    /// Note that this method has no effect on the allocated capacity or the
+    /// encoding of the string.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use spinoso_string::String;
+    ///
+    /// let mut s = String::from("abc");
+    /// s.clear();
+    /// assert!(s.is_empty());
+    /// ```
+    #[inline]
+    pub fn clear(&mut self) {
+        self.buf.clear();
+    }
+
     /// Returns true if the vector contains no bytes.
     ///
     /// # Examples


### PR DESCRIPTION
This method is needed to implement the Ruby method `String#clear`: https://ruby-doc.org/core-2.6.3/String.html#method-i-clear.

This PR was pulled out of:

- https://github.com/artichoke/artichoke/pull/1222