### PR TITLE
Add more methods to `spinoso_string::String`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -654,7 +654,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-string"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "bstr",
  "focaccia",

--- a/spinoso-string/Cargo.toml
+++ b/spinoso-string/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spinoso-string"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2021"
 description = """

--- a/spinoso-string/src/lib.rs
+++ b/spinoso-string/src/lib.rs
@@ -734,6 +734,55 @@ impl String {
         self.encoding = encoding;
     }
 
+    /// Shortens the string, keeping the first `len` bytes and dropping the
+    /// rest.
+    ///
+    /// If `len` is greater than the string's current length, this has no
+    /// effect.
+    ///
+    /// Note that this method has no effect on the allocated capacity
+    /// of the string.
+    ///
+    /// # Examples
+    ///
+    /// Truncating a five byte to two elements:
+    ///
+    /// ```
+    /// use spinoso_string::String;
+    ///
+    /// let mut s = String::from("12345");
+    /// s.truncate(2);
+    /// assert_eq!(*s, *b"12");
+    /// ```
+    ///
+    /// No truncation occurs when `len` is greater than the string's current
+    /// length:
+    ///
+    /// ```
+    /// use spinoso_string::String;
+    ///
+    /// let mut s = String::from("12345");
+    /// s.truncate(10);
+    /// assert_eq!(*s, *b"12345");
+    /// ```
+    ///
+    /// Truncating when `len == 0` is equivalent to calling the [`clear`]
+    /// method.
+    ///
+    /// ```
+    /// use spinoso_string::String;
+    ///
+    /// let mut s = String::from("12345");
+    /// s.truncate(0);
+    /// assert_eq!(*s, *b"");
+    /// ```
+    ///
+    /// [`clear`]: Self::clear
+    #[inline]
+    pub fn truncate(&mut self, len: usize) {
+        self.buf.truncate(len);
+    }
+
     /// Extracts a slice containing the entire byte string.
     ///
     /// Equivalent to `&s[..]`.

--- a/spinoso-string/src/lib.rs
+++ b/spinoso-string/src/lib.rs
@@ -676,23 +676,26 @@ impl String {
 
     #[inline]
     #[must_use]
-    pub fn utf8(buf: Vec<u8>) -> Self {
-        let encoding = Encoding::Utf8;
+    pub fn with_bytes_and_encoding(buf: Vec<u8>, encoding: Encoding) -> Self {
         Self { buf, encoding }
+    }
+
+    #[inline]
+    #[must_use]
+    pub fn utf8(buf: Vec<u8>) -> Self {
+        Self::with_bytes_and_encoding(buf, Encoding::Utf8)
     }
 
     #[inline]
     #[must_use]
     pub fn ascii(buf: Vec<u8>) -> Self {
-        let encoding = Encoding::Ascii;
-        Self { buf, encoding }
+        Self::with_bytes_and_encoding(buf, Encoding::Ascii)
     }
 
     #[inline]
     #[must_use]
     pub fn binary(buf: Vec<u8>) -> Self {
-        let encoding = Encoding::Binary;
-        Self { buf, encoding }
+        Self::with_bytes_and_encoding(buf, Encoding::Binary)
     }
 }
 

--- a/spinoso-string/src/lib.rs
+++ b/spinoso-string/src/lib.rs
@@ -623,7 +623,7 @@ impl String {
     /// The `String` is [conventionally UTF-8].
     ///
     /// The string will be able to hold exactly `capacity` bytes without
-    /// reallocating. If `capacity` is 0, the vector will not allocate.
+    /// reallocating. If `capacity` is 0, the string will not allocate.
     ///
     /// It is important to note that although the returned string has the
     /// capacity specified, the string will have a zero length. For an
@@ -658,6 +658,7 @@ impl String {
     /// assert_eq!(s.len(), 10);
     /// ```
     ///
+    /// [conventionally UTF-8]: crate::Encoding::Utf8
     /// [Capacity and reallocation]: https://doc.rust-lang.org/std/vec/struct.Vec.html#capacity-and-reallocation
     #[inline]
     #[must_use]
@@ -667,6 +668,47 @@ impl String {
         Self { buf, encoding }
     }
 
+    /// Constructs a new, empty `String` with the specified capacity and
+    /// encoding.
+    ///
+    /// The string will be able to hold exactly `capacity` bytes without
+    /// reallocating. If `capacity` is 0, the string will not allocate.
+    ///
+    /// It is important to note that although the returned string has the
+    /// capacity specified, the string will have a zero length. For an
+    /// explanation of the difference between length and capacity, see
+    /// *[Capacity and reallocation]*.
+    ///
+    /// # Examples
+    ///
+    /// Encoding, capacity, and length:
+    ///
+    /// ```
+    /// use spinoso_string::{Encoding, String};
+    ///
+    /// let s = String::with_capacity(10);
+    /// assert_eq!(s.encoding(), Encoding::Utf8);
+    /// assert_eq!(s.capacity(), 10);
+    /// assert_eq!(s.len(), 0);
+    /// ```
+    ///
+    /// Allocation:
+    ///
+    /// ```
+    /// use spinoso_string::{Encoding, String};
+    ///
+    /// let mut s = String::with_capacity_and_encoding(10, Encoding::Binary);
+    /// assert_eq!(s.encoding(), Encoding::Binary);
+    ///
+    /// for ch in 'a'..='j' {
+    ///     s.push_byte(ch as u8);
+    /// }
+    /// // 10 elements have been inserted without reallocating.
+    /// assert_eq!(s.capacity(), 10);
+    /// assert_eq!(s.len(), 10);
+    /// ```
+    ///
+    /// [Capacity and reallocation]: https://doc.rust-lang.org/std/vec/struct.Vec.html#capacity-and-reallocation
     #[inline]
     #[must_use]
     pub fn with_capacity_and_encoding(capacity: usize, encoding: Encoding) -> Self {


### PR DESCRIPTION
- `String::with_bytes_and_encoding`
- `String::truncate`
- `String::set_len`

Add more docs, fix typos.

This PR was pulled out of:

- https://github.com/artichoke/artichoke/pull/1222