### PR TITLE
Improve perf of `String::char_len` and `String::is_valid_encoding`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,6 +111,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytecount"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72feb31ffc86498dacdbd0fcebb56138e7177a8cc5cea4516031d15ae85a742e"
+
+[[package]]
 name = "cc"
 version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -580,6 +586,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
+name = "simdutf8"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c970da16e7c682fa90a261cf0724dee241c9f7831635ecc4e988ae8f3b505559"
+
+[[package]]
 name = "siphasher"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -654,12 +666,14 @@ dependencies = [
 
 [[package]]
 name = "spinoso-string"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "bstr",
+ "bytecount",
  "focaccia",
  "quickcheck",
  "scolapasta-string-escape",
+ "simdutf8",
 ]
 
 [[package]]

--- a/spinoso-string/Cargo.toml
+++ b/spinoso-string/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spinoso-string"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2021"
 description = """
@@ -14,8 +14,10 @@ categories = ["data-structures", "encoding", "no-std"]
 
 [dependencies]
 bstr = { version = "0.2", default-features = false, features = ["std"] }
+bytecount = "0.6, >= 0.6.2"
 focaccia = { version = "1.0", optional = true, default-features = false }
 scolapasta-string-escape = { version = "0.2", path = "../scolapasta-string-escape", default-features = false }
+simdutf8 = { version = "0.1, >= 0.1.3", default-features = false }
 
 [dev-dependencies]
 quickcheck = { version = "1.0", default-features = false }
@@ -26,4 +28,6 @@ casecmp = ["focaccia"]
 # Helpers for implementing Ruby and mruby FFI routines.
 ffi = []
 # Enable implementations of traits in `std` like `Error` and `io::Write`.
-std = []
+#
+# Enable runtime SIMD dispatch in `bytecount` and `simdutf8` dependencies.
+std = ["bytecount/runtime-dispatch-simd", "simdutf8/std"]

--- a/spinoso-string/README.md
+++ b/spinoso-string/README.md
@@ -27,7 +27,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-spinoso-string = "0.2"
+spinoso-string = "0.4"
 ```
 
 ## `no_std`


### PR DESCRIPTION
Introduce `bytecount` and `simdutf8` for SIMD-accelerated UTF-8 validation and character counting.

## Performance

I've tested this PR out on the tip of the WIP PR to add `String` to the VM #1222. These numbers compare with and without this PR as well as against MRI 3.0.2.

This PR speeds up the existing implementation of `String::length` by a factor of 10 and brings `String#length` performance to the same order of magnitude as MRI in all cases except pure ASCII strings. MRI caches which valid encodings a `String` has. For ASCII `String`s this fast path is very fast: it returns the length embedded in the `RString`.

### Benchmark script `string_length.rb`

```ruby
# frozen_string_literal: true

def bench(s, name:)
  s = s * 100_000
  before = Time.now
  result = s.length
  after = Time.now

  puts "#{name}; length: #{result}; time: #{after - before}"
end

s = "a" * 10_000
bench(s, name: 'UTF-8 only ascii')

t = s + '💎' * 10_000 + s
bench(t, name: 'UTF-8 with emojis')

u = 'a💎' * 10_000
bench(u, name: 'ascii + emoji interspersed')

v = 'a' * 10_000
v << '\xFF'
bench(v, name: 'invalid UTF-8 at tail')

w = s + '💎' * 10_000 + s
w << '\xFF'
bench(w, name: 'invalid UTF-8 at tail with emojis')
```

### MRI 3.0.2

```console
$ /usr/local/var/rbenv/versions/3.0.2/bin/ruby ../string_length.rb
UTF-8 only ascii; length: 1000000000; time: 2.0e-06
UTF-8 with emojis; length: 3000000000; time: 0.768025
ascii + emoji interspersed; length: 2000000000; time: 0.614303
invalid UTF-8 at tail; length: 1000400000; time: 1.0e-06
invalid UTF-8 at tail with emojis; length: 3000400000; time: 0.746079
```

```console
$ /usr/local/var/rbenv/versions/3.0.2/bin/ruby ../string_length.rb
UTF-8 only ascii; length: 1000000000; time: 1.0e-06
UTF-8 with emojis; length: 3000000000; time: 0.739436
ascii + emoji interspersed; length: 2000000000; time: 0.624905
invalid UTF-8 at tail; length: 1000400000; time: 2.0e-06
invalid UTF-8 at tail with emojis; length: 3000400000; time: 0.75076
```

### Without this PR

```console
$ cargo run --bin artichoke --release -q -- ../string_length.rb
UTF-8 only ascii; length: 1000000000; time: 0.729179
UTF-8 with emojis; length: 3000000000; time: 7.913318
ascii + emoji interspersed; length: 2000000000; time: 7.228271
invalid UTF-8 at tail; length: 1000400000; time: 0.719593
invalid UTF-8 at tail with emojis; length: 3000400000; time: 7.944082
```

```console
$ cargo run --bin artichoke --release -q -- ../string_length.rb
UTF-8 only ascii; length: 1000000000; time: 0.731228
UTF-8 with emojis; length: 3000000000; time: 7.867516
ascii + emoji interspersed; length: 2000000000; time: 7.173596
invalid UTF-8 at tail; length: 1000400000; time: 0.712632
invalid UTF-8 at tail with emojis; length: 3000400000; time: 7.86214
```

### With this PR

```console
$ cargo run --bin artichoke --release -q -- ../string_length.rb
UTF-8 only ascii; length: 1000000000; time: 0.06711499999999999
UTF-8 with emojis; length: 3000000000; time: 0.899454
ascii + emoji interspersed; length: 2000000000; time: 0.763296
invalid UTF-8 at tail; length: 1000400000; time: 0.064452
invalid UTF-8 at tail with emojis; length: 3000400000; time: 0.929182
```