### PR TITLE
Fix incorrect version in `scolapasta-string-escape` README

### DIFF
--- a/scolapasta-string-escape/README.md
+++ b/scolapasta-string-escape/README.md
@@ -40,7 +40,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-scolapasta-string-escape = "0.1"
+scolapasta-string-escape = "0.2"
 ```
 
 To debug escape a conventionally UTF-8 byte string:


### PR DESCRIPTION
https://github.com/artichoke/artichoke/blob/0ac710ef01e6aeff88c1258aae0953649947ddd4/scolapasta-string-escape/Cargo.toml#L1-L3