### PR TITLE
Implement a full wrapper around spinoso-array in artichoke-backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "artichoke-backend"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "artichoke-core",
  "artichoke-load-path",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ rustyline = { version = "9", optional = true, default-features = false }
 termcolor = { version = "1.1", optional = true }
 
 [dependencies.artichoke-backend]
-version = "0.2"
+version = "0.3"
 path = "artichoke-backend"
 default-features = false
 

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "artichoke-backend"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2021"
 description = "Embeddable VM implementation for Artichoke Ruby"

--- a/artichoke-backend/src/extn/core/array/ffi.rs
+++ b/artichoke-backend/src/extn/core/array/ffi.rs
@@ -294,7 +294,7 @@ unsafe extern "C" fn mrb_ary_unshift(
         // The array is repacked before any intervening uses of `interp`.
         // The array is repacked before any intervening mruby allocations.
         let array_mut = array.as_inner_mut();
-        array_mut.0.unshift(value);
+        array_mut.unshift(value.into());
 
         let inner = array.take();
         Array::box_into_value(inner, ary.into(), &mut guard).expect("Array reboxing should not fail");

--- a/artichoke-backend/src/extn/core/array/mod.rs
+++ b/artichoke-backend/src/extn/core/array/mod.rs
@@ -1,496 +1,236 @@
 use std::ffi::c_void;
 use std::fmt::Write;
 use std::ops::Deref;
-use std::slice;
-
-use spinoso_array::Array as SpinosoArray;
 
 use crate::convert::{implicitly_convert_to_int, implicitly_convert_to_string, UnboxedValueGuard};
 use crate::extn::prelude::*;
 use crate::io::IoError;
 
-pub use spinoso_array::RawParts;
-
 pub mod args;
 mod ffi;
 pub mod mruby;
 pub mod trampoline;
+mod wrapper;
 
-/// Contiguous growable vector that implement the [Ruby `Array`] API for
-/// [`sys::mrb_value`] elements.
-///
-/// `Array` is a growable vector with potentially heap-allocated contents.
-/// `Array` implements the small vector optimization using
-/// [`spinoso_array::SmallArray`]. This type can be passed by pointer over FFI
-/// to the underlying mruby VM (this is why it stores `sys::mrb_value` rather
-/// than [`Value`].
-///
-/// `Array` implements [`BoxUnboxVmValue`] which enables it to be serialized to
-/// a mruby value and unboxed to the Rust `Array` type.
-#[derive(Default, Debug, Clone)]
-pub struct Array(SpinosoArray<sys::mrb_value>);
+#[doc(inline)]
+pub use wrapper::{Array, RawParts};
 
-impl From<SpinosoArray<sys::mrb_value>> for Array {
-    fn from(buffer: SpinosoArray<sys::mrb_value>) -> Self {
-        Self(buffer)
-    }
-}
-
-impl From<Vec<sys::mrb_value>> for Array {
-    fn from(values: Vec<sys::mrb_value>) -> Self {
-        Self(values.into())
-    }
-}
-
-impl From<Vec<Value>> for Array {
-    fn from(values: Vec<Value>) -> Self {
-        Self(values.iter().map(Value::inner).collect())
-    }
-}
-
-impl<'a> From<&'a [sys::mrb_value]> for Array {
-    fn from(values: &'a [sys::mrb_value]) -> Self {
-        Self(values.into())
-    }
-}
-
-impl<'a> From<&'a [Value]> for Array {
-    fn from(values: &'a [Value]) -> Self {
-        Self(values.iter().map(Value::inner).collect())
-    }
-}
-
-impl FromIterator<sys::mrb_value> for Array {
-    fn from_iter<I>(iter: I) -> Self
-    where
-        I: IntoIterator<Item = sys::mrb_value>,
-    {
-        Self(iter.into_iter().collect())
-    }
-}
-
-impl FromIterator<Value> for Array {
-    fn from_iter<I>(iter: I) -> Self
-    where
-        I: IntoIterator<Item = Value>,
-    {
-        Self(iter.into_iter().map(|value| value.inner()).collect())
-    }
-}
-
-impl FromIterator<Option<Value>> for Array {
-    fn from_iter<I>(iter: I) -> Self
-    where
-        I: IntoIterator<Item = Option<Value>>,
-    {
-        let array = iter
-            .into_iter()
-            .map(|value| value.unwrap_or_default().inner())
-            .collect();
-        Self(array)
-    }
-}
-
-impl<'a> FromIterator<&'a Option<Value>> for Array {
-    fn from_iter<I>(iter: I) -> Self
-    where
-        I: IntoIterator<Item = &'a Option<Value>>,
-    {
-        let array = iter
-            .into_iter()
-            .map(|value| value.unwrap_or_default().inner())
-            .collect();
-        Self(array)
-    }
-}
-
-#[derive(Debug)]
-pub struct Iter<'a>(slice::Iter<'a, sys::mrb_value>);
-
-impl<'a> Iterator for Iter<'a> {
-    type Item = Value;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.0.next().copied().map(Value::from)
-    }
-}
-
-impl<'a> IntoIterator for &'a Array {
-    type Item = Value;
-    type IntoIter = Iter<'a>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        Iter(self.0.iter())
-    }
-}
-
-impl Extend<sys::mrb_value> for Array {
-    fn extend<T>(&mut self, iter: T)
-    where
-        T: IntoIterator<Item = sys::mrb_value>,
-    {
-        self.0.extend(iter.into_iter());
-    }
-}
-
-impl Extend<Value> for Array {
-    fn extend<T>(&mut self, iter: T)
-    where
-        T: IntoIterator<Item = Value>,
-    {
-        self.0.extend(iter.into_iter().map(|value| value.inner()));
-    }
-}
-
-impl Array {
-    #[must_use]
-    pub fn new() -> Self {
-        Self(SpinosoArray::new())
-    }
-
-    #[must_use]
-    pub fn with_capacity(capacity: usize) -> Self {
-        Self(SpinosoArray::with_capacity(capacity))
-    }
-
-    #[must_use]
-    pub fn assoc(one: Value, two: Value) -> Self {
-        Self(SpinosoArray::assoc(one.inner(), two.inner()))
-    }
-
-    #[must_use]
-    pub fn iter(&self) -> Iter<'_> {
-        self.into_iter()
-    }
-
-    #[must_use]
-    pub fn len(&self) -> usize {
-        self.0.len()
-    }
-
-    #[must_use]
-    pub fn capacity(&self) -> usize {
-        self.0.capacity()
-    }
-
-    #[must_use]
-    pub fn as_mut_ptr(&mut self) -> *mut sys::mrb_value {
-        self.0.as_mut_ptr()
-    }
-
-    #[must_use]
-    pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
-
-    pub fn clear(&mut self) {
-        self.0.clear();
-    }
-
-    pub fn initialize(
-        interp: &mut Artichoke,
-        first: Option<Value>,
-        second: Option<Value>,
-        block: Option<Block>,
-    ) -> Result<Self, Error> {
-        let vector = match (first, second, block) {
-            (Some(mut array_or_len), default, None) => {
-                if let Ok(len) = array_or_len.try_convert_into::<i64>(interp) {
+pub fn initialize(
+    interp: &mut Artichoke,
+    first: Option<Value>,
+    second: Option<Value>,
+    block: Option<Block>,
+) -> Result<Array, Error> {
+    let ary = match (first, second, block) {
+        (Some(mut array_or_len), default, None) => {
+            if let Ok(len) = array_or_len.try_convert_into::<i64>(interp) {
+                let len = usize::try_from(len).map_err(|_| ArgumentError::with_message("negative array size"))?;
+                let default = default.unwrap_or_else(Value::nil);
+                Array::with_len_and_default(len, default)
+            } else {
+                let unboxed = unsafe { Array::unbox_from_value(&mut array_or_len, interp) };
+                if let Ok(ary) = unboxed {
+                    ary.clone()
+                } else if array_or_len.respond_to(interp, "to_ary")? {
+                    let mut other = array_or_len.funcall(interp, "to_ary", &[], None)?;
+                    let unboxed = unsafe { Array::unbox_from_value(&mut other, interp) };
+                    if let Ok(other) = unboxed {
+                        other.clone()
+                    } else {
+                        let mut message = String::from("can't convert ");
+                        let name = interp.inspect_type_name_for_value(array_or_len);
+                        message.push_str(name);
+                        message.push_str(" to Array (");
+                        message.push_str(name);
+                        message.push_str("#to_ary gives ");
+                        message.push_str(interp.inspect_type_name_for_value(other));
+                        return Err(TypeError::from(message).into());
+                    }
+                } else {
+                    let len = implicitly_convert_to_int(interp, array_or_len)?;
                     let len = usize::try_from(len).map_err(|_| ArgumentError::with_message("negative array size"))?;
                     let default = default.unwrap_or_else(Value::nil);
-                    SpinosoArray::with_len_and_default(len, default.inner())
-                } else {
-                    let unboxed = unsafe { Self::unbox_from_value(&mut array_or_len, interp) };
-                    if let Ok(ary) = unboxed {
-                        ary.0.clone()
-                    } else if array_or_len.respond_to(interp, "to_ary")? {
-                        let mut other = array_or_len.funcall(interp, "to_ary", &[], None)?;
-                        let unboxed = unsafe { Self::unbox_from_value(&mut other, interp) };
-                        if let Ok(other) = unboxed {
-                            other.0.clone()
-                        } else {
-                            let mut message = String::from("can't convert ");
-                            let name = interp.inspect_type_name_for_value(array_or_len);
-                            message.push_str(name);
-                            message.push_str(" to Array (");
-                            message.push_str(name);
-                            message.push_str("#to_ary gives ");
-                            message.push_str(interp.inspect_type_name_for_value(other));
-                            return Err(TypeError::from(message).into());
-                        }
-                    } else {
-                        let len = implicitly_convert_to_int(interp, array_or_len)?;
-                        let len =
-                            usize::try_from(len).map_err(|_| ArgumentError::with_message("negative array size"))?;
-                        let default = default.unwrap_or_else(Value::nil);
-                        SpinosoArray::with_len_and_default(len, default.inner())
-                    }
+                    Array::with_len_and_default(len, default)
                 }
             }
-            (Some(mut array_or_len), default, Some(block)) => {
-                if let Ok(len) = array_or_len.try_convert_into::<i64>(interp) {
+        }
+        (Some(mut array_or_len), default, Some(block)) => {
+            if let Ok(len) = array_or_len.try_convert_into::<i64>(interp) {
+                let len = usize::try_from(len).map_err(|_| ArgumentError::with_message("negative array size"))?;
+                if default.is_some() {
+                    interp.warn(b"warning: block supersedes default value argument")?;
+                }
+                let mut buffer = Array::with_capacity(len);
+                for idx in 0..len {
+                    let idx = i64::try_from(idx)
+                        .map_err(|_| RangeError::with_message("bignum too big to convert into `long'"))?;
+                    let idx = interp.convert(idx);
+                    let elem = block.yield_arg(interp, &idx)?;
+                    buffer.push(elem);
+                }
+                buffer
+            } else {
+                let unboxed = unsafe { Array::unbox_from_value(&mut array_or_len, interp) };
+                if let Ok(ary) = unboxed {
+                    ary.clone()
+                } else if array_or_len.respond_to(interp, "to_ary")? {
+                    let mut other = array_or_len.funcall(interp, "to_ary", &[], None)?;
+                    let unboxed = unsafe { Array::unbox_from_value(&mut other, interp) };
+                    if let Ok(other) = unboxed {
+                        other.clone()
+                    } else {
+                        let mut message = String::from("can't convert ");
+                        let name = interp.inspect_type_name_for_value(array_or_len);
+                        message.push_str(name);
+                        message.push_str(" to Array (");
+                        message.push_str(name);
+                        message.push_str("#to_ary gives ");
+                        message.push_str(interp.inspect_type_name_for_value(other));
+                        return Err(TypeError::from(message).into());
+                    }
+                } else {
+                    let len = implicitly_convert_to_int(interp, array_or_len)?;
                     let len = usize::try_from(len).map_err(|_| ArgumentError::with_message("negative array size"))?;
                     if default.is_some() {
                         interp.warn(b"warning: block supersedes default value argument")?;
                     }
-                    let mut buffer = SpinosoArray::with_capacity(len);
+                    let mut buffer = Array::with_capacity(len);
                     for idx in 0..len {
                         let idx = i64::try_from(idx)
                             .map_err(|_| RangeError::with_message("bignum too big to convert into `long'"))?;
                         let idx = interp.convert(idx);
                         let elem = block.yield_arg(interp, &idx)?;
-                        buffer.push(elem.inner());
+                        buffer.push(elem);
                     }
                     buffer
+                }
+            }
+        }
+        (None, None, _) => Array::new(),
+        (None, Some(_), _) => {
+            let err_msg = "default cannot be set if first arg is missing in Array#initialize";
+            return Err(Fatal::from(err_msg).into());
+        }
+    };
+    Ok(ary)
+}
+
+pub fn repeat(ary: &Array, n: usize) -> Result<Array, ArgumentError> {
+    ary.repeat(n)
+        .ok_or_else(|| ArgumentError::with_message("argument too big"))
+}
+
+pub fn join(interp: &mut Artichoke, ary: &Array, sep: &[u8]) -> Result<Vec<u8>, Error> {
+    fn flatten(interp: &mut Artichoke, mut value: Value, out: &mut Vec<Vec<u8>>) -> Result<(), Error> {
+        match value.ruby_type() {
+            Ruby::Array => {
+                let ary = unsafe { Array::unbox_from_value(&mut value, interp)? };
+                out.reserve(ary.len());
+                for elem in ary.iter() {
+                    flatten(interp, elem, out)?;
+                }
+            }
+            Ruby::Fixnum => {
+                let mut buf = Vec::new();
+                let int = unsafe { sys::mrb_sys_fixnum_to_cint(value.inner()) };
+                itoa::write(&mut buf, int).map_err(IoError::from)?;
+                out.push(buf);
+            }
+            Ruby::Float => {
+                let float = unsafe { sys::mrb_sys_float_to_cdouble(value.inner()) };
+                let mut buf = String::new();
+                write!(&mut buf, "{}", float).map_err(WriteError::from)?;
+                out.push(buf.into_bytes());
+            }
+            _ => {
+                // Safety:
+                //
+                // `s` is converted to an owned byte vec immediately before
+                // any intervening operations on the VM which may cause a
+                // garbage collection of the `RString` that backs `value`.
+                if let Ok(s) = unsafe { implicitly_convert_to_string(interp, &mut value) } {
+                    out.push(s.to_vec());
                 } else {
-                    let unboxed = unsafe { Self::unbox_from_value(&mut array_or_len, interp) };
-                    if let Ok(ary) = unboxed {
-                        ary.0.clone()
-                    } else if array_or_len.respond_to(interp, "to_ary")? {
-                        let mut other = array_or_len.funcall(interp, "to_ary", &[], None)?;
-                        let unboxed = unsafe { Self::unbox_from_value(&mut other, interp) };
-                        if let Ok(other) = unboxed {
-                            other.0.clone()
-                        } else {
-                            let mut message = String::from("can't convert ");
-                            let name = interp.inspect_type_name_for_value(array_or_len);
-                            message.push_str(name);
-                            message.push_str(" to Array (");
-                            message.push_str(name);
-                            message.push_str("#to_ary gives ");
-                            message.push_str(interp.inspect_type_name_for_value(other));
-                            return Err(TypeError::from(message).into());
-                        }
-                    } else {
-                        let len = implicitly_convert_to_int(interp, array_or_len)?;
-                        let len =
-                            usize::try_from(len).map_err(|_| ArgumentError::with_message("negative array size"))?;
-                        if default.is_some() {
-                            interp.warn(b"warning: block supersedes default value argument")?;
-                        }
-                        let mut buffer = SpinosoArray::with_capacity(len);
-                        for idx in 0..len {
-                            let idx = i64::try_from(idx)
-                                .map_err(|_| RangeError::with_message("bignum too big to convert into `long'"))?;
-                            let idx = interp.convert(idx);
-                            let elem = block.yield_arg(interp, &idx)?;
-                            buffer.push(elem.inner());
-                        }
-                        buffer
-                    }
+                    out.push(value.to_s(interp));
                 }
             }
-            (None, None, _) => SpinosoArray::new(),
-            (None, Some(_), _) => {
-                let err_msg = "default cannot be set if first arg is missing in Array#initialize";
-                return Err(Fatal::from(err_msg).into());
-            }
-        };
-        Ok(Self(vector))
+        }
+        Ok(())
     }
 
-    pub fn repeat(&self, n: usize) -> Result<Self, ArgumentError> {
-        if let Some(repeated) = self.0.repeat(n) {
-            Ok(Array::from(repeated))
-        } else {
-            Err(ArgumentError::with_message("argument too big"))
-        }
+    let mut vec = Vec::with_capacity(ary.len());
+    for elem in ary {
+        flatten(interp, elem, &mut vec)?;
     }
 
-    pub fn join(&self, interp: &mut Artichoke, sep: &[u8]) -> Result<Vec<u8>, Error> {
-        fn flatten(interp: &mut Artichoke, mut value: Value, out: &mut Vec<Vec<u8>>) -> Result<(), Error> {
-            match value.ruby_type() {
-                Ruby::Array => {
-                    let ary = unsafe { Array::unbox_from_value(&mut value, interp)? };
-                    out.reserve(ary.len());
-                    for elem in ary.iter() {
-                        flatten(interp, elem, out)?;
-                    }
-                }
-                Ruby::Fixnum => {
-                    let mut buf = Vec::new();
-                    let int = unsafe { sys::mrb_sys_fixnum_to_cint(value.inner()) };
-                    itoa::write(&mut buf, int).map_err(IoError::from)?;
-                    out.push(buf);
-                }
-                Ruby::Float => {
-                    let float = unsafe { sys::mrb_sys_float_to_cdouble(value.inner()) };
-                    let mut buf = String::new();
-                    write!(&mut buf, "{}", float).map_err(WriteError::from)?;
-                    out.push(buf.into_bytes());
-                }
-                _ => {
-                    // Safety:
-                    //
-                    // `s` is converted to an owned byte vec immediately before
-                    // any intervening operations on the VM which may cause a
-                    // garbage collection of the `RString` that backs `value`.
-                    if let Ok(s) = unsafe { implicitly_convert_to_string(interp, &mut value) } {
-                        out.push(s.to_vec());
-                    } else {
-                        out.push(value.to_s(interp));
-                    }
-                }
-            }
-            Ok(())
-        }
+    Ok(bstr::join(sep, vec))
+}
 
-        let mut vec = Vec::with_capacity(self.len());
-        for elem in self {
-            flatten(interp, elem, &mut vec)?;
-        }
-
-        Ok(bstr::join(sep, vec))
-    }
-
-    fn element_reference(
-        &self,
-        interp: &mut Artichoke,
-        index: Value,
-        len: Option<Value>,
-    ) -> Result<Option<Value>, Error> {
-        let (index, len) = match args::element_reference(interp, index, len, self.0.len())? {
-            args::ElementReference::Empty => return Ok(None),
-            args::ElementReference::Index(index) => (index, None),
-            args::ElementReference::StartLen(index, len) => (index, Some(len)),
-        };
-        let start = if let Ok(start) = usize::try_from(index) {
+fn aref(interp: &mut Artichoke, ary: &Array, index: Value, len: Option<Value>) -> Result<Option<Value>, Error> {
+    let (index, len) = match args::element_reference(interp, index, len, ary.len())? {
+        args::ElementReference::Empty => return Ok(None),
+        args::ElementReference::Index(index) => (index, None),
+        args::ElementReference::StartLen(index, len) => (index, Some(len)),
+    };
+    let start = if let Ok(start) = usize::try_from(index) {
+        start
+    } else {
+        let idx = index
+            .checked_neg()
+            .and_then(|index| usize::try_from(index).ok())
+            .and_then(|index| ary.len().checked_sub(index));
+        if let Some(start) = idx {
             start
         } else {
-            let idx = index
-                .checked_neg()
-                .and_then(|index| usize::try_from(index).ok())
-                .and_then(|index| self.0.len().checked_sub(index));
-            if let Some(start) = idx {
-                start
-            } else {
-                return Ok(None);
-            }
-        };
-        if start > self.0.len() {
             return Ok(None);
         }
-        if let Some(len) = len {
-            let result = self.0.slice(start, len);
-            let result = Self(result.into());
-            let result = Self::alloc_value(result, interp)?;
-            Ok(Some(result))
-        } else {
-            Ok(self.0.get(start).copied().map(Value::from))
-        }
+    };
+    if start > ary.len() {
+        return Ok(None);
     }
+    if let Some(len) = len {
+        let result = ary.slice(start, len);
+        let result = Array::alloc_value(result.into(), interp)?;
+        Ok(Some(result))
+    } else {
+        Ok(ary.get(start))
+    }
+}
 
-    fn element_assignment(
-        &mut self,
-        interp: &mut Artichoke,
-        first: Value,
-        second: Value,
-        third: Option<Value>,
-    ) -> Result<Value, Error> {
-        let (start, drain, mut elem) = args::element_assignment(interp, first, second, third, self.0.len())?;
+fn aset(
+    interp: &mut Artichoke,
+    ary: &mut Array,
+    first: Value,
+    second: Value,
+    third: Option<Value>,
+) -> Result<Value, Error> {
+    let (start, drain, mut elem) = args::element_assignment(interp, first, second, third, ary.len())?;
 
-        if let Some(drain) = drain {
-            if let Ok(other) = unsafe { Self::unbox_from_value(&mut elem, interp) } {
-                self.0.set_slice(start, drain, other.0.as_slice());
-            } else if elem.respond_to(interp, "to_ary")? {
-                let mut other = elem.funcall(interp, "to_ary", &[], None)?;
-                if let Ok(other) = unsafe { Self::unbox_from_value(&mut other, interp) } {
-                    self.0.set_slice(start, drain, other.0.as_slice());
-                } else {
-                    let mut message = String::from("can't convert ");
-                    let name = interp.inspect_type_name_for_value(elem);
-                    message.push_str(name);
-                    message.push_str(" to Array (");
-                    message.push_str(name);
-                    message.push_str("#to_ary gives ");
-                    message.push_str(interp.inspect_type_name_for_value(other));
-                    return Err(TypeError::from(message).into());
-                }
+    if let Some(drain) = drain {
+        if let Ok(other) = unsafe { Array::unbox_from_value(&mut elem, interp) } {
+            ary.set_slice(start, drain, other.as_slice());
+        } else if elem.respond_to(interp, "to_ary")? {
+            let mut other = elem.funcall(interp, "to_ary", &[], None)?;
+            if let Ok(other) = unsafe { Array::unbox_from_value(&mut other, interp) } {
+                ary.set_slice(start, drain, other.as_slice());
             } else {
-                self.0.set_with_drain(start, drain, elem.inner());
+                let mut message = String::from("can't convert ");
+                let name = interp.inspect_type_name_for_value(elem);
+                message.push_str(name);
+                message.push_str(" to Array (");
+                message.push_str(name);
+                message.push_str("#to_ary gives ");
+                message.push_str(interp.inspect_type_name_for_value(other));
+                return Err(TypeError::from(message).into());
             }
         } else {
-            self.0.set(start, elem.inner());
+            ary.set_with_drain(start, drain, elem);
         }
-
-        Ok(elem)
+    } else {
+        ary.set(start, elem);
     }
 
-    #[must_use]
-    pub fn get(&self, index: usize) -> Option<Value> {
-        self.0.get(index).copied().map(Value::from)
-    }
-
-    pub fn set(&mut self, index: usize, elem: Value) {
-        self.0.set(index, elem.inner());
-    }
-
-    pub fn pop(&mut self) -> Option<Value> {
-        self.0.pop().map(Value::from)
-    }
-
-    pub fn push(&mut self, elem: Value) {
-        self.0.push(elem.inner());
-    }
-
-    pub fn reverse(&mut self) {
-        self.0.reverse();
-    }
-
-    pub fn shift(&mut self) -> Option<Value> {
-        self.0.shift().map(Value::from)
-    }
-
-    pub fn shift_n(&mut self, count: usize) -> Self {
-        Self(self.0.shift_n(count))
-    }
-
-    /// Creates an `Array<T>` directly from the raw components of another array.
-    ///
-    /// # Safety
-    ///
-    /// This is highly unsafe, due to the number of invariants that aren't
-    /// checked:
-    ///
-    /// - `ptr` needs to have been previously allocated via `Array<T>` (at
-    ///   least, it's highly likely to be incorrect if it wasn't).
-    /// - `T` needs to have the same size and alignment as what `ptr` was
-    ///   allocated with. (`T` having a less strict alignment is not sufficient,
-    ///   the alignment really needs to be equal to satisfy the `dealloc`
-    ///   requirement that memory must be allocated and deallocated with the
-    ///   same layout.)
-    /// - `length` needs to be less than or equal to `capacity`.
-    /// - `capacity` needs to be the `capacity` that the pointer was allocated
-    ///   with.
-    ///
-    /// Violating these may cause problems like corrupting the allocator's
-    /// internal data structures.
-    ///
-    /// The ownership of `ptr` is effectively transferred to the `Array<T>`
-    /// which may then deallocate, reallocate or change the contents of memory
-    /// pointed to by the pointer at will. Ensure that nothing else uses the
-    /// pointer after calling this function.
-    #[must_use]
-    pub unsafe fn from_raw_parts(raw_parts: RawParts<sys::mrb_value>) -> Self {
-        Self(SpinosoArray::from_raw_parts(raw_parts))
-    }
-
-    /// Decomposes an `Array<T>` into its raw components.
-    ///
-    /// Returns the raw pointer to the underlying data, the length of the array
-    /// (in elements), and the allocated capacity of the data (in elements).
-    ///
-    /// After calling this function, the caller is responsible for the memory
-    /// previously managed by the `Array`. The only way to do this is to convert
-    /// the raw pointer, length, and capacity back into a `Array` with the
-    /// [`from_raw_parts`] function, allowing the destructor to perform the
-    /// cleanup.
-    ///
-    /// [`from_raw_parts`]: Array::from_raw_parts
-    #[must_use]
-    pub fn into_raw_parts(self) -> RawParts<sys::mrb_value> {
-        self.0.into_raw_parts()
-    }
+    Ok(elem)
 }
 
 impl BoxUnboxVmValue for Array {
@@ -561,7 +301,7 @@ impl BoxUnboxVmValue for Array {
         //
         // This check is critical to the memory safety of future runs of the
         // garbage collector.
-        if into.ruby_type() != Ruby::Array {
+        if !matches!(into.ruby_type(), Ruby::Array) {
             panic!("Tried to box Array into {:?} value", into.ruby_type());
         }
 

--- a/artichoke-backend/src/extn/core/array/wrapper.rs
+++ b/artichoke-backend/src/extn/core/array/wrapper.rs
@@ -31,6 +31,7 @@ use crate::value::Value;
 /// [`pop_n`]: Array::pop_n
 /// [`first_n`]: Array::first_n
 /// [`last_n`]: Array::last_n
+/// [`BoxUnboxVmValue`]: crate::convert::BoxUnboxVmValue
 #[derive(Debug, Clone)]
 pub struct Array(spinoso_array::Array<sys::mrb_value>);
 
@@ -322,10 +323,9 @@ impl Array {
 
     /// Consume the array and return its elements as a [`Vec<T>`].
     ///
-    /// For `Array`, this is a cheap operation that unwraps the inner `Vec` and
-    /// is an alias for [`into_inner`](Self::into_inner).
+    /// For `Array`, this is a cheap operation that unwraps the inner `Vec`.
     ///
-    /// [`Vec<T>`]: alloc::vec::Vec
+    /// [`Vec<T>`]: std::vec::Vec
     #[inline]
     #[must_use]
     pub fn into_vec(self) -> Vec<sys::mrb_value> {

--- a/artichoke-backend/src/extn/core/array/wrapper.rs
+++ b/artichoke-backend/src/extn/core/array/wrapper.rs
@@ -1,0 +1,687 @@
+use core::slice;
+
+#[doc(inline)]
+pub use spinoso_array::RawParts;
+
+use crate::sys;
+use crate::value::Value;
+
+/// A contiguous growable array type based on [`Vec<sys::mrb_value>`](Vec) that
+/// implements the [Ruby `Array`][ruby-array] API for `artichoke-backend` and
+/// `mruby`.
+///
+/// `Array` implements indexing and mutating APIs that make an ideal backend for
+/// the [Ruby `Array` core class][ruby-array]. In practice, this results in less
+/// generic, more single-use APIs. For example, instead of [`Vec::drain`],
+/// `Array` implements [`shift`], [`shift_n`], [`pop`], and [`pop_n`].
+///
+/// Similarly, slicing APIs are more specialized, such as [`first_n`] and
+/// [`last_n`]. Slicing APIs do not return [`Option`], instead preferring to
+/// return an empty slice.
+///
+///
+/// `Array` implements [`BoxUnboxVmValue`] which enables it to be serialized to
+/// a mruby value and unboxed to the Rust `Array` type.
+///
+/// [ruby-array]: https://ruby-doc.org/core-2.6.3/Array.html
+/// [`shift`]: Array::shift
+/// [`shift_n`]: Array::shift_n
+/// [`drop_n`]: Array::drop_n
+/// [`pop`]: Array::pop
+/// [`pop_n`]: Array::pop_n
+/// [`first_n`]: Array::first_n
+/// [`last_n`]: Array::last_n
+#[derive(Debug, Clone)]
+pub struct Array(spinoso_array::Array<sys::mrb_value>);
+
+impl Default for Array {
+    #[inline]
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl From<spinoso_array::Array<sys::mrb_value>> for Array {
+    fn from(buffer: spinoso_array::Array<sys::mrb_value>) -> Self {
+        Self(buffer)
+    }
+}
+
+impl From<Vec<sys::mrb_value>> for Array {
+    fn from(values: Vec<sys::mrb_value>) -> Self {
+        Self(values.into())
+    }
+}
+
+impl From<Vec<Value>> for Array {
+    fn from(values: Vec<Value>) -> Self {
+        Self(values.iter().map(Value::inner).collect())
+    }
+}
+
+impl<'a> From<&'a [sys::mrb_value]> for Array {
+    fn from(values: &'a [sys::mrb_value]) -> Self {
+        Self(values.into())
+    }
+}
+
+impl<'a> From<&'a [Value]> for Array {
+    fn from(values: &'a [Value]) -> Self {
+        Self(values.iter().map(Value::inner).collect())
+    }
+}
+
+impl FromIterator<sys::mrb_value> for Array {
+    fn from_iter<I>(iter: I) -> Self
+    where
+        I: IntoIterator<Item = sys::mrb_value>,
+    {
+        Self(iter.into_iter().collect())
+    }
+}
+
+impl FromIterator<Value> for Array {
+    fn from_iter<I>(iter: I) -> Self
+    where
+        I: IntoIterator<Item = Value>,
+    {
+        Self(iter.into_iter().map(|value| value.inner()).collect())
+    }
+}
+
+impl FromIterator<Option<Value>> for Array {
+    fn from_iter<I>(iter: I) -> Self
+    where
+        I: IntoIterator<Item = Option<Value>>,
+    {
+        let array = iter
+            .into_iter()
+            .map(|value| value.unwrap_or_default().inner())
+            .collect();
+        Self(array)
+    }
+}
+
+impl<'a> FromIterator<&'a Option<Value>> for Array {
+    fn from_iter<I>(iter: I) -> Self
+    where
+        I: IntoIterator<Item = &'a Option<Value>>,
+    {
+        let array = iter
+            .into_iter()
+            .map(|value| value.unwrap_or_default().inner())
+            .collect();
+        Self(array)
+    }
+}
+
+#[derive(Debug)]
+pub struct Iter<'a>(slice::Iter<'a, sys::mrb_value>);
+
+impl<'a> Iterator for Iter<'a> {
+    type Item = Value;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().copied().map(Value::from)
+    }
+}
+
+impl<'a> IntoIterator for &'a Array {
+    type Item = Value;
+    type IntoIter = Iter<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        Iter(self.0.iter())
+    }
+}
+
+impl Extend<sys::mrb_value> for Array {
+    fn extend<T>(&mut self, iter: T)
+    where
+        T: IntoIterator<Item = sys::mrb_value>,
+    {
+        self.0.extend(iter.into_iter());
+    }
+}
+
+impl Extend<Value> for Array {
+    fn extend<T>(&mut self, iter: T)
+    where
+        T: IntoIterator<Item = Value>,
+    {
+        self.0.extend(iter.into_iter().map(|value| value.inner()));
+    }
+}
+
+impl Array {
+    /// Construct a new, empty `Array`.
+    ///
+    /// The vector will not allocate until elements are pushed into it.
+    #[inline]
+    #[must_use]
+    pub const fn new() -> Self {
+        Self(spinoso_array::Array::new())
+    }
+
+    /// Construct a new, empty `Array` with the specified capacity.
+    ///
+    /// The vector will be able to hold exactly `capacity` elements without
+    /// reallocating. If `capacity` is 0, the vector will not allocate.
+    ///
+    /// It is important to note that although the returned vector has the
+    /// _capacity_ specified, the vector will have a zero _length_.
+    #[inline]
+    #[must_use]
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self(spinoso_array::Array::with_capacity(capacity))
+    }
+
+    /// Construct a new two-element `Array` from the given arguments.
+    ///
+    /// The vector is constructed with `capacity` of 2.
+    #[inline]
+    #[must_use]
+    pub fn assoc(first: Value, second: Value) -> Self {
+        Self(spinoso_array::Array::assoc(first.inner(), second.inner()))
+    }
+
+    /// Returns an iterator over the slice.
+    #[inline]
+    #[must_use]
+    pub fn iter(&self) -> Iter<'_> {
+        self.into_iter()
+    }
+
+    /// Extracts a slice containing the entire vector.
+    ///
+    /// Equivalent to `&ary[..]`.
+    #[inline]
+    #[must_use]
+    pub fn as_slice(&self) -> &[sys::mrb_value] {
+        self.0.as_slice()
+    }
+
+    /// Extracts a mutable slice containing the entire vector.
+    ///
+    /// Equivalent to `&mut ary[..]`.
+    #[inline]
+    #[must_use]
+    pub fn as_mut_slice(&mut self) -> &mut [sys::mrb_value] {
+        self.0.as_mut_slice()
+    }
+
+    /// Returns a raw pointer to the vector's buffer.
+    ///
+    /// The caller must ensure that the vector outlives the pointer this
+    /// function returns, or else it will end up pointing to garbage. Modifying
+    /// the vector may cause its buffer to be reallocated, which would also make
+    /// any pointers to it invalid.
+    ///
+    /// The caller must also ensure that the memory the pointer
+    /// (non-transitively) points to is never written to (except inside an
+    /// `UnsafeCell`) using this pointer or any pointer derived from it. If you
+    /// need to mutate the contents of the slice, use
+    /// [`as_mut_ptr`](Self::as_mut_ptr).
+    #[inline]
+    #[must_use]
+    pub fn as_ptr(&self) -> *const sys::mrb_value {
+        self.0.as_ptr()
+    }
+
+    /// Returns an unsafe mutable pointer to the vector's buffer.
+    ///
+    /// The caller must ensure that the vector outlives the pointer this
+    /// function returns, or else it will end up pointing to garbage.
+    /// Modifying the vector may cause its buffer to be reallocated, which would
+    /// also make any pointers to it invalid.
+    ///
+    /// # Examples
+    ///
+    /// This method is primarily used when mutating a `Array` via a raw pointer
+    /// passed over FFI.
+    ///
+    /// See the [`ARY_PTR`] macro in mruby.
+    ///
+    /// [`ARY_PTR`]: https://github.com/artichoke/mruby/blob/d66440864d08f1c3ac5820d45f11df031b7d43c6/include/mruby/array.h#L52
+    #[inline]
+    #[must_use]
+    pub fn as_mut_ptr(&mut self) -> *mut sys::mrb_value {
+        self.0.as_mut_ptr()
+    }
+
+    /// Set the vector's length without dropping or moving out elements
+    ///
+    /// This method is unsafe because it changes the notion of the number of
+    /// "valid" elements in the vector. Use with care.
+    ///
+    /// # Safety
+    ///
+    /// - `new_len` must be less than or equal to capacity().
+    /// - The elements at `old_len..new_len` must be initialized.
+    ///
+    /// # Examples
+    ///
+    /// This method is primarily used when mutating a `Array` via a raw pointer
+    /// passed over FFI.
+    ///
+    /// See the [`ARY_PTR`] macro in mruby.
+    ///
+    /// [`ARY_PTR`]: https://github.com/artichoke/mruby/blob/d66440864d08f1c3ac5820d45f11df031b7d43c6/include/mruby/array.h#L52
+    #[inline]
+    pub unsafe fn set_len(&mut self, new_len: usize) {
+        self.0.set_len(new_len);
+    }
+
+    /// Creates an `Array` directly from the raw components of another array.
+    ///
+    /// # Safety
+    ///
+    /// This is highly unsafe, due to the number of invariants that aren't
+    /// checked:
+    ///
+    /// - `ptr` needs to have been previously allocated via `Array<T>` (at
+    ///   least, it's highly likely to be incorrect if it wasn't).
+    /// - `T` needs to have the same size and alignment as what `ptr` was
+    ///   allocated with. (`T` having a less strict alignment is not sufficient,
+    ///   the alignment really needs to be equal to satisfy the `dealloc`
+    ///   requirement that memory must be allocated and deallocated with the
+    ///   same layout.)
+    /// - `length` needs to be less than or equal to `capacity`.
+    /// - `capacity` needs to be the `capacity` that the pointer was allocated
+    ///   with.
+    ///
+    /// Violating these may cause problems like corrupting the allocator's
+    /// internal data structures.
+    ///
+    /// The ownership of `ptr` is effectively transferred to the `Array<T>`
+    /// which may then deallocate, reallocate or change the contents of memory
+    /// pointed to by the pointer at will. Ensure that nothing else uses the
+    /// pointer after calling this function.
+    #[must_use]
+    pub unsafe fn from_raw_parts(raw_parts: RawParts<sys::mrb_value>) -> Self {
+        let array = spinoso_array::Array::from_raw_parts(raw_parts);
+        Self(array)
+    }
+
+    /// Decomposes an `Array<T>` into its raw components.
+    ///
+    /// Returns the raw pointer to the underlying data, the length of the array
+    /// (in elements), and the allocated capacity of the data (in elements).
+    ///
+    /// After calling this function, the caller is responsible for the memory
+    /// previously managed by the `Array`. The only way to do this is to convert
+    /// the raw pointer, length, and capacity back into a `Array` with the
+    /// [`from_raw_parts`] function, allowing the destructor to perform the
+    /// cleanup.
+    ///
+    /// [`from_raw_parts`]: Array::from_raw_parts
+    #[must_use]
+    pub fn into_raw_parts(self) -> RawParts<sys::mrb_value> {
+        self.0.into_raw_parts()
+    }
+
+    /// Consume the array and return its elements as a [`Vec<T>`].
+    ///
+    /// For `Array`, this is a cheap operation that unwraps the inner `Vec` and
+    /// is an alias for [`into_inner`](Self::into_inner).
+    ///
+    /// [`Vec<T>`]: alloc::vec::Vec
+    #[inline]
+    #[must_use]
+    pub fn into_vec(self) -> Vec<sys::mrb_value> {
+        self.0.into_vec()
+    }
+
+    /// Converts the vector into [`Box<[T]>`](Box).
+    ///
+    /// This will drop any excess capacity.
+    #[inline]
+    #[must_use]
+    pub fn into_boxed_slice(self) -> Box<[sys::mrb_value]> {
+        self.0.into_boxed_slice()
+    }
+
+    /// Returns the number of elements the vector can hold without reallocating.
+    #[inline]
+    #[must_use]
+    pub fn capacity(&self) -> usize {
+        self.0.capacity()
+    }
+
+    /// Reserves capacity for at least `additional` more elements to be inserted
+    /// in the given `Array<T>`. The collection may reserve more space to avoid
+    /// frequent reallocations. After calling reserve, capacity will be greater
+    /// than or equal to `self.len() + additional`. Does nothing if capacity is
+    /// already sufficient.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the new capacity overflows `usize`.
+    #[inline]
+    pub fn reserve(&mut self, additional: usize) {
+        self.0.reserve(additional);
+    }
+
+    /// Shrinks the capacity of the vector as much as possible.
+    ///
+    /// It will drop down as close as possible to the length but the allocator
+    /// may still inform the vector that there is space for a few more elements.
+    #[inline]
+    pub fn shrink_to_fit(&mut self) {
+        self.0.shrink_to_fit();
+    }
+
+    /// Clears the vector, removing all values.
+    ///
+    /// Note that this method has no effect on the allocated capacity of the
+    /// vector.
+    #[inline]
+    pub fn clear(&mut self) {
+        self.0.clear();
+    }
+
+    /// Returns the number of elements in the vector, also referred to as its
+    /// "length".
+    #[inline]
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Returns `true` if the vector contains no elements.
+    #[inline]
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Returns a reference to an element at the index.
+    ///
+    /// Unlike [`Vec`], this method does not support indexing with a range.  See
+    /// the [`slice`](Self::slice) method for retrieving a sub-slice from the
+    /// array.
+    #[inline]
+    #[must_use]
+    pub fn get(&self, index: usize) -> Option<Value> {
+        self.0.get(index).copied().map(Value::from)
+    }
+
+    /// Deletes the element at the specified `index`, returning that element, or
+    /// [`None`] if the `index` is out of range.
+    #[inline]
+    #[must_use]
+    pub fn delete_at(&mut self, index: usize) -> Option<Value> {
+        self.0.delete_at(index).map(Value::from)
+    }
+
+    /// Returns the first element from the vector, or [`None`] if the vector is
+    /// empty.
+    ///
+    /// To retrieve a slice of the first elements in the vector, use
+    /// [`first_n`](Self::first_n).
+    #[inline]
+    #[must_use]
+    pub fn first(&self) -> Option<Value> {
+        self.0.first().copied().map(Value::from)
+    }
+
+    /// Returns up to `n` of the first elements from the vector, or `&[]` if the
+    /// vector is empty.
+    ///
+    /// To retrieve only the first element in the vector, use
+    /// [`first`](Self::first).
+    #[inline]
+    #[must_use]
+    pub fn first_n(&self, n: usize) -> &[sys::mrb_value] {
+        self.0.first_n(n)
+    }
+
+    /// Returns the last element from the vector, or [`None`] if the vector is
+    /// empty.
+    ///
+    /// To retrieve a slice of the last elements in the vector, use
+    /// [`last_n`](Self::last_n).
+    #[inline]
+    #[must_use]
+    pub fn last(&self) -> Option<Value> {
+        self.0.last().copied().map(Value::from)
+    }
+
+    /// Returns up to `n` of the last elements from the vector, or `&[]` if the
+    /// vector is empty.
+    ///
+    /// To retrieve only the last element in the vector, use
+    /// [`last`](Self::last).
+    #[inline]
+    #[must_use]
+    pub fn last_n(&self, n: usize) -> &[sys::mrb_value] {
+        self.0.last_n(n)
+    }
+
+    /// Returns a slice of the underlying vector that includes only the first
+    /// `n` elements.
+    ///
+    /// If `n` is greater than or equal to the length of the vector, `&self[..]`
+    /// is returned.
+    ///
+    /// The inverse of this operation is [`drop_n`](Self::drop_n).
+    #[inline]
+    #[must_use]
+    pub fn take_n(&self, n: usize) -> &[sys::mrb_value] {
+        self.0.take_n(n)
+    }
+
+    /// Returns a slice of the underlying vector that excludes the first `n`
+    /// elements.
+    ///
+    /// If `n` is greater than or equal to the length of the vector, `&[]` is
+    /// returned.
+    ///
+    /// The inverse of this operation is [`take_n`](Self::take_n).
+    #[inline]
+    #[must_use]
+    pub fn drop_n(&self, n: usize) -> &[sys::mrb_value] {
+        self.0.drop_n(n)
+    }
+
+    /// Removes the last element from the vector and returns it, or [`None`] if
+    /// the vector is empty.
+    ///
+    /// To pop more than one element from the end of the vector, use
+    /// [`pop_n`](Self::pop_n).
+    #[inline]
+    #[must_use]
+    pub fn pop(&mut self) -> Option<Value> {
+        self.0.pop().map(Value::from)
+    }
+
+    /// Removes the last `n` elements from the vector.
+    ///
+    /// To pop a single element from the end of the vector, use
+    /// [`pop`](Self::pop).
+    #[inline]
+    #[must_use]
+    pub fn pop_n(&mut self, n: usize) -> Self {
+        Self(self.0.pop_n(n))
+    }
+
+    /// Appends an element to the back of the vector.
+    ///
+    /// To push more than one element to the end of the vector, use
+    /// [`concat`](Self::concat) or `extend`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the number of elements in the vector overflows a `usize`.
+    #[inline]
+    pub fn push(&mut self, elem: Value) {
+        self.0.push(elem.inner());
+    }
+
+    /// Reverses the order of elements of the vector, in place.
+    #[inline]
+    pub fn reverse(&mut self) {
+        self.0.reverse();
+    }
+
+    /// Removes the first element of the vector and returns it (shifting all
+    /// other elements down by one). Returns [`None`] if the vector is empty.
+    ///
+    /// This operation is also known as "pop front".
+    ///
+    /// To remove more than one element from the front of the vector, use
+    /// [`shift_n`](Self::shift_n).
+    #[inline]
+    #[must_use]
+    pub fn shift(&mut self) -> Option<Value> {
+        self.0.shift().map(Value::from)
+    }
+
+    /// Removes the first `n` elements from the vector.
+    ///
+    /// To shift a single element from the front of the vector, use
+    /// [`shift`](Self::shift).
+    #[inline]
+    #[must_use]
+    pub fn shift_n(&mut self, n: usize) -> Self {
+        Self(self.0.shift_n(n))
+    }
+
+    /// Inserts an element to the front of the vector.
+    ///
+    /// To insert more than one element to the front of the vector, use
+    /// [`unshift_n`](Self::unshift_n).
+    ///
+    /// This operation is also known as "prepend".
+    ///
+    /// # Panics
+    ///
+    /// Panics if the number of elements in the vector overflows a `usize`.
+    #[inline]
+    pub fn unshift(&mut self, elem: Value) {
+        self.0.unshift(elem.inner());
+    }
+
+    /// Return a reference to a subslice of the vector.
+    ///
+    /// This function always returns a slice. If the range specified by `start`
+    /// and `end` overlaps the vector (even if only partially), the overlapping
+    /// slice is returned. If the range does not overlap the vector, an empty
+    /// slice is returned.
+    #[inline]
+    #[must_use]
+    pub fn slice(&self, start: usize, len: usize) -> &[sys::mrb_value] {
+        self.0.slice(start, len)
+    }
+}
+
+impl Array
+where
+    sys::mrb_value: Clone,
+{
+    /// Construct a new `Array` with length `len` and all elements set to
+    /// `default`. The `Array` will have capacity `len`.
+    #[inline]
+    #[must_use]
+    pub fn with_len_and_default(len: usize, default: Value) -> Self {
+        Self(spinoso_array::Array::with_len_and_default(len, default.inner()))
+    }
+
+    /// Appends the elements of `other` to self.
+    ///
+    /// Slice version of `extend`. This operation is analogous to "push n".
+    #[inline]
+    pub fn concat(&mut self, other: &[sys::mrb_value]) {
+        self.0.concat(other);
+    }
+
+    /// Prepends the elements of `other` to self.
+    ///
+    /// To insert one element to the front of the vector, use
+    /// [`unshift`](Self::unshift).
+    ///
+    /// This operation is also known as "prepend".
+    ///
+    /// # Panics
+    ///
+    /// Panics if the number of elements in the vector overflows a `usize`.
+    #[inline]
+    pub fn unshift_n(&mut self, other: &[sys::mrb_value]) {
+        self.0.unshift_n(other);
+    }
+}
+
+impl Array
+where
+    sys::mrb_value: Copy,
+{
+    /// Creates a new array by repeating this array `n` times.
+    ///
+    /// This function will not panic. If the resulting `Array`'s capacity would
+    /// overflow, [`None`] is returned.
+    #[must_use]
+    pub fn repeat(&self, n: usize) -> Option<Self> {
+        self.0.repeat(n).map(Self)
+    }
+}
+
+impl Array
+where
+    sys::mrb_value: Default,
+{
+    /// Set element at position `index` within the vector, extending the vector
+    /// with `nil` if `index` is out of bounds.
+    #[inline]
+    pub fn set(&mut self, index: usize, elem: Value) {
+        self.0.set(index, elem.inner());
+    }
+
+    /// Insert element at position `start` within the vector and remove the
+    /// following `drain` elements. If `start` is out of bounds, the vector will
+    /// be extended with `nil`.
+    ///
+    /// This method sets a slice of the `Array` to a single element, including
+    /// the zero-length slice. It is similar in intent to calling
+    /// [`Vec::splice`] with a one-element iterator.
+    ///
+    /// `set_with_drain` will only drain up to the end of the vector.
+    ///
+    /// To set a single element without draining, use [`set`](Self::set).
+    #[inline]
+    pub fn set_with_drain(&mut self, start: usize, drain: usize, elem: Value) -> usize {
+        self.0.set_with_drain(start, drain, elem.inner())
+    }
+}
+
+impl Array
+where
+    sys::mrb_value: Default + Clone,
+{
+    /// Insert the elements from a slice at a position `index` in the vector,
+    /// extending the vector with `nil` if `index` is out of bounds.
+    ///
+    /// This method is similar to [`Vec::splice`] when called with a zero-length
+    /// range.
+    #[inline]
+    pub fn insert_slice(&mut self, index: usize, values: &[sys::mrb_value]) {
+        self.0.insert_slice(index, values);
+    }
+
+    /// Insert the elements from a slice at a position `index` in the vector and
+    /// remove the following `drain` elements. The vector is extended with
+    /// `nil` if `index` is out of bounds.
+    ///
+    /// This method is similar to [`Vec::splice`] when called with a
+    /// nonzero-length range.
+    ///
+    /// When called with `drain == 0`, this method is equivalent to
+    /// [`insert_slice`](Self::insert_slice).
+    ///
+    /// If `drain >= src.len()` or the tail of the vector is replaced, this
+    /// method is efficient. Otherwise, a temporary buffer is used to move the
+    /// elements.
+    #[inline]
+    pub fn set_slice(&mut self, index: usize, drain: usize, values: &[sys::mrb_value]) -> usize {
+        self.0.set_slice(index, drain, values)
+    }
+}

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "artichoke-backend"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "artichoke-core",
  "artichoke-load-path",

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -32,7 +32,7 @@ dependencies = [
 
 [[package]]
 name = "artichoke-backend"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "artichoke-core",
  "artichoke-load-path",

--- a/spinoso-array/src/array/vec/mod.rs
+++ b/spinoso-array/src/array/vec/mod.rs
@@ -1016,8 +1016,6 @@ where
             None
         }
     }
-    
-
 }
 
 impl<T> Array<T>

--- a/spinoso-array/src/array/vec/mod.rs
+++ b/spinoso-array/src/array/vec/mod.rs
@@ -1016,6 +1016,8 @@ where
             None
         }
     }
+    
+
 }
 
 impl<T> Array<T>


### PR DESCRIPTION
Implement a full wrapper of all APIs in `spinoso_array::Array` in `artichoke-backend` that concretizes `Array<T>` to `Array<sys::mrb_value>`.

As many APIs as feasible (such that no allocations are required) are modified to take `Value` or return `Value`.

Helpers for `Array#initialize`, `Array#[]`, `Array#[]=`, `Array#join`, and `Array#repeat` are converted to free functions that take `Array` as defined in `artichoke-backend`.

This PR removes all accesses to the inner spinoso array. All VM-adjacent code only calls methods on `artichoke_backend::extn::core::Array`.

This PR bumps `artichoke-backend` to 0.3.0 due to breaking changes in `extn::core::array::Array`.