### PR TITLE
Implements `shrink_to` on `spinoso_string::String`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -673,7 +673,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-string"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "bstr",
  "bytecount",

--- a/spinoso-string/Cargo.toml
+++ b/spinoso-string/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spinoso-string"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2021"
 description = """

--- a/spinoso-string/README.md
+++ b/spinoso-string/README.md
@@ -27,7 +27,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-spinoso-string = "0.4"
+spinoso-string = "0.5"
 ```
 
 ## `no_std`

--- a/spinoso-string/src/lib.rs
+++ b/spinoso-string/src/lib.rs
@@ -1249,6 +1249,29 @@ impl String {
     pub fn shrink_to_fit(&mut self) {
         self.buf.shrink_to_fit();
     }
+
+    /// Shrinks the capacity of the vector with a lower bound.
+    ///
+    /// The capacity will remain at least as large as both the length and the
+    /// supplied value.
+    ///
+    /// If the current capacity is less than the lower limit, this is a no-op.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use spinoso_string::String;
+    ///
+    /// let mut s = String::with_capacity(10);
+    /// s.extend_from_slice(b"abc");
+    /// assert_eq!(s.capacity(), 10);
+    /// s.shrink_to(5);
+    /// assert!(s.capacity() >= 5);
+    /// ```
+    #[inline]
+    pub fn shrink_to(&mut self, min_capacity: usize) {
+        self.buf.shrink_to(min_capacity);
+    }
 }
 
 // Indexing


### PR DESCRIPTION
This API on the underlying Vec and HashMap was stabilized in Rust 1.56.0.

This closes #1500.