### PR TITLE
Add GitHub Actions workflow to run markdown-link-check

### DIFF
--- a/.github/markdown-link-check.json
+++ b/.github/markdown-link-check.json
@@ -2,6 +2,9 @@
   "ignorePatterns": [
     {
       "pattern": "img.shields.io"
+    },
+    {
+      "pattern": "^https://docs.rs/.*"
     }
   ],
   "replacementPatterns": [],

--- a/.github/workflows/markdown-link-check.yaml
+++ b/.github/workflows/markdown-link-check.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Purge vendored sources
         run: |
           shopt -s globstar
-          rm -rf **/vendor/*/
+          rm -rf **/vendor/*/*
       - uses: gaurav-nelson/github-action-markdown-link-check@v1
         # checks all markdown files from /docs including all subfolders
         with:

--- a/.github/workflows/markdown-link-check.yaml
+++ b/.github/workflows/markdown-link-check.yaml
@@ -22,7 +22,7 @@ jobs:
     name: Check links
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
       - name: Purge vendored sources
         run: |
           shopt -s globstar

--- a/.github/workflows/markdown-link-check.yaml
+++ b/.github/workflows/markdown-link-check.yaml
@@ -23,6 +23,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
+      - name: Purge vendored sources
+        run: |
+          shopt -s globstar
+          rm -rf **/vendor/*/
       - uses: gaurav-nelson/github-action-markdown-link-check@v1
         # checks all markdown files from /docs including all subfolders
         with:

--- a/.github/workflows/markdown-link-check.yaml
+++ b/.github/workflows/markdown-link-check.yaml
@@ -1,0 +1,32 @@
+---
+"on":
+  push:
+    branches:
+      - trunk
+    paths:
+      - .github/markdown-link-check.json
+      - .github/workflows/markdown-link-check.yaml
+      - "**/*.md"
+  pull_request:
+    branches:
+      - trunk
+    paths:
+      - .github/markdown-link-check.json
+      - .github/workflows/markdown-link-check.yaml
+      - "**/*.md"
+  schedule:
+    - cron: "0 0 * * TUE"
+name: Markdown Links Check
+jobs:
+  check-links:
+    name: Check links
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: gaurav-nelson/github-action-markdown-link-check@v1
+        # checks all markdown files from /docs including all subfolders
+        with:
+          use-quiet-mode: "yes"
+          use-verbose-mode: "yes"
+          config-file: ".github/markdown-link-check.json"
+          folder-path: "."

--- a/.github/workflows/markdown-link-check.yaml
+++ b/.github/workflows/markdown-link-check.yaml
@@ -22,15 +22,14 @@ jobs:
     name: Check links
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Purge vendored sources
-        run: |
-          shopt -s globstar
-          rm -rf **/vendor/*/*
-      - uses: gaurav-nelson/github-action-markdown-link-check@v1
-        # checks all markdown files from /docs including all subfolders
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Ruby toolchain
+        uses: ruby/setup-ruby@v1
         with:
-          use-quiet-mode: "yes"
-          use-verbose-mode: "yes"
-          config-file: ".github/markdown-link-check.json"
-          folder-path: "."
+          ruby-version: ".ruby-version"
+          bundler-cache: true
+
+      - name: Check for broken links in markdown files
+        run: bundle exec rake release:markdown_link_check

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -29,7 +29,7 @@ Artichoke is organized into several layers:
 ### Frontend
 
 The entry point to Artichoke for running Ruby code is the `artichoke` crate. The
-code for this crate is located in the [`src` directory](/src). All functionality
+code for this crate is located in the [`src` directory](src). All functionality
 of Artichoke Ruby is accessible through this crate. You'll likely want to create
 an interpreter with [`artichoke::interpreter()`] and import the
 [`artichoke::prelude::*`] items to bring the traits that define the interpreter
@@ -55,7 +55,7 @@ The frontend crate provides [two binary targets]:
 - `artichoke` is the Ruby CLI frontend.
 - `airb` is Artichoke's [`irb` shell].
 
-[two binary targets]: /README.md#Usage
+[two binary targets]: README.md#Usage
 [`irb` shell]: https://en.wikipedia.org/wiki/Interactive_Ruby_Shell
 
 The frontend implements command line argument parsing and a readline shell,
@@ -103,13 +103,13 @@ of the [Strangler Fig pattern].
 [artichoke-backend-docs]:
   https://artichoke.github.io/artichoke/artichoke_backend/
 [mruby vm]: https://github.com/mruby/mruby
-[artichoke-backend-src]: /artichoke-backend
-[mruby c sources]: /artichoke-backend/vendor/mruby
-[mruby-build]: /artichoke-backend/build.rs
+[artichoke-backend-src]: artichoke-backend
+[mruby c sources]: artichoke-backend/vendor/mruby
+[mruby-build]: artichoke-backend/build.rs
 [`bindgen`]: https://rust-lang.github.io/rust-bindgen/
 [`sys` module]:
   https://artichoke.github.io/artichoke/artichoke_backend/sys/index.html
-[mruby-globals]: /artichoke-backend/src/globals.rs
+[mruby-globals]: artichoke-backend/src/globals.rs
 [gh-562]: https://github.com/artichoke/artichoke/pull/562
 [artichoke-strangler]:
   https://twitter.com/artichokeruby/status/1339578582222266368
@@ -156,7 +156,7 @@ Artichoke Core also describes what capabilities a Ruby [`Value`][core-value]
 must have and how to [convert][core-convert-module] between Ruby VM and Rust
 types.
 
-[artichoke-core-src]: /artichoke-core
+[artichoke-core-src]: artichoke-core
 [kernel#require]: https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-require
 [`random::default`]: https://ruby-doc.org/core-2.6.3/Random.html#DEFAULT
 [regexp-globals]:
@@ -241,7 +241,7 @@ two implementations:
 out implementations by changing an import.
 
 [ruby `array`]: https://ruby-doc.org/core-2.6.3/Array.html
-[spinoso-array-src]: /spinoso-array
+[spinoso-array-src]: spinoso-array
 [rust-alloc-vec]: https://doc.rust-lang.org/alloc/vec/struct.Vec.html
 [`smallvec`]:
   https://artichoke.github.io/artichoke/smallvec/struct.SmallVec.html
@@ -271,7 +271,7 @@ where it may be undesirable for Ruby code to modify the host process's
 environment.
 
 [ruby-core-env]: https://ruby-doc.org/core-2.6.3/ENV.html
-[spinoso-env-src]: /spinoso-env
+[spinoso-env-src]: spinoso-env
 [rust-std-hashmap]:
   https://doc.rust-lang.org/nightly/std/collections/hash/map/struct.HashMap.html
 [rust-std-env]: https://doc.rust-lang.org/nightly/std/env/index.html

--- a/VISION.md
+++ b/VISION.md
@@ -116,7 +116,7 @@ Artichoke will include implementation-agnostic [C APIs][a-c-api] targeting:
 [file system backends]:
   https://github.com/artichoke/artichoke/labels/A-filesystem
 [virtual file system]:
-  https://artichoke.github.io/artichoke/artichoke_backend/fs/index.html
+  https://artichoke.github.io/artichoke/artichoke_backend/load_path/index.html
 [extn-env]: artichoke-backend/src/extn/core/env
 [a-optional-stdlib]:
   https://github.com/artichoke/artichoke/labels/A-optional-stdlib

--- a/spinoso-env/README.md
+++ b/spinoso-env/README.md
@@ -80,7 +80,7 @@ This crate requires [`std`], the Rust Standard Library.
 All features are enabled by default:
 
 - **system-env** - Enable an `ENV` backend that accesses the host system's
-  environment variables via the [`std::env`](module@std::env) module.
+  environment variables via the [`std::env`] module.
 
 ## License
 
@@ -90,3 +90,4 @@ All features are enabled by default:
 [`hashmap`]: std::collections::HashMap
 [rust standard library]: https://doc.rust-lang.org/std/
 [`std`]: https://doc.rust-lang.org/std/
+[`std::env`]: https://doc.rust-lang.org/std/env/index.html


### PR DESCRIPTION
Artichoke already incorporates this tool in the `Rakefile` as the
`release:markdown_link_check` task, but it is slow and doesn't get
regularly run.

Incorporate this into CI such that links are checked on every PR that
touches markdown files and on a weekly cron with the same cadence as the
audit workflow.

Ignore docs.rs links since none of the crates in this workspace are published yet.

Fixup all of the outstanding broken markdown links.