### PR TITLE
Ensure `core-regexp` feature is activated when onig is active

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "artichoke-backend"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "artichoke-core",
  "artichoke-load-path",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ rustyline = { version = "9", optional = true, default-features = false }
 termcolor = { version = "1.1", optional = true }
 
 [dependencies.artichoke-backend]
-version = "0.3"
+version = "0.4"
 path = "artichoke-backend"
 default-features = false
 
@@ -115,7 +115,7 @@ core-regexp = ["artichoke-backend/core-regexp"]
 # feature, Regexp patterns must be parsable by oniguruma regardless of the
 # backend they execute on. The `regex` crate backend remains the default as long
 # as it can parse the given pattern.
-core-regexp-oniguruma = ["artichoke-backend/core-regexp-oniguruma"]
+core-regexp-oniguruma = ["core-regexp", "artichoke-backend/core-regexp-oniguruma"]
 # Implement the `Time` core class. This feature adds dependencies on `chrono`
 # and `chrono-tz`.
 core-time = ["artichoke-backend/core-time"]

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "artichoke-backend"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2021"
 description = "Embeddable VM implementation for Artichoke Ruby"
@@ -60,7 +60,7 @@ core-math = ["spinoso-math"]
 core-math-full = ["core-math", "spinoso-math/full"]
 core-random = ["spinoso-random"]
 core-regexp = ["spinoso-regexp"]
-core-regexp-oniguruma = ["spinoso-regexp/oniguruma", "onig"]
+core-regexp-oniguruma = ["core-regexp", "spinoso-regexp/oniguruma", "onig"]
 core-time = ["spinoso-time"]
 
 load-path-native-file-system-loader = ["artichoke-load-path/native-file-system-loader"]

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "artichoke-backend"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "artichoke-core",
  "artichoke-load-path",

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -32,7 +32,7 @@ dependencies = [
 
 [[package]]
 name = "artichoke-backend"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "artichoke-core",
  "artichoke-load-path",


### PR DESCRIPTION
`core-regexp-oniguruma` is intended to be a derived feature that enables `core-regexp` + a dep on `rust-onig`.