### PR TITLE
Improve error messages in artichoke-backend and spec-runner functional tests

### DIFF
--- a/artichoke-backend/src/extn/core/array/mod.rs
+++ b/artichoke-backend/src/extn/core/array/mod.rs
@@ -338,8 +338,6 @@ impl<'a> Deref for UnboxedValueGuard<'a, Array> {
 
 #[cfg(test)]
 mod tests {
-    use bstr::ByteSlice;
-
     use crate::test::prelude::*;
 
     const SUBJECT: &str = "Array";
@@ -348,17 +346,9 @@ mod tests {
     #[test]
     fn functional() {
         let mut interp = interpreter().unwrap();
-        interp.eval(FUNCTIONAL_TEST).unwrap();
+        let result = interp.eval(FUNCTIONAL_TEST);
+        unwrap_or_panic_with_backtrace(&mut interp, SUBJECT, result);
         let result = interp.eval(b"spec");
-        if let Err(exc) = result {
-            let backtrace = exc.vm_backtrace(&mut interp);
-            let backtrace = bstr::join("\n", backtrace.unwrap_or_default());
-            panic!(
-                "{} tests failed with message: {:?} and backtrace:\n{:?}",
-                SUBJECT,
-                exc.message().as_bstr(),
-                backtrace.as_bstr()
-            );
-        }
+        unwrap_or_panic_with_backtrace(&mut interp, SUBJECT, result);
     }
 }

--- a/artichoke-backend/src/extn/core/kernel/mod.rs
+++ b/artichoke-backend/src/extn/core/kernel/mod.rs
@@ -8,8 +8,6 @@ pub struct Kernel;
 
 #[cfg(test)]
 mod tests {
-    use bstr::ByteSlice;
-
     use crate::test::prelude::*;
 
     const SUBJECT: &str = "Kernel";
@@ -18,17 +16,9 @@ mod tests {
     #[test]
     fn functional() {
         let mut interp = interpreter().unwrap();
-        interp.eval(FUNCTIONAL_TEST).unwrap();
+        let result = interp.eval(FUNCTIONAL_TEST);
+        unwrap_or_panic_with_backtrace(&mut interp, SUBJECT, result);
         let result = interp.eval(b"spec");
-        if let Err(exc) = result {
-            let backtrace = exc.vm_backtrace(&mut interp);
-            let backtrace = bstr::join("\n", backtrace.unwrap_or_default());
-            panic!(
-                "{} tests failed with message: {:?} and backtrace:\n{:?}",
-                SUBJECT,
-                exc.message().as_bstr(),
-                backtrace.as_bstr()
-            );
-        }
+        unwrap_or_panic_with_backtrace(&mut interp, SUBJECT, result);
     }
 }

--- a/artichoke-backend/src/extn/core/string/mod.rs
+++ b/artichoke-backend/src/extn/core/string/mod.rs
@@ -5,29 +5,19 @@ pub mod trampoline;
 pub struct String;
 
 #[cfg(test)]
-#[cfg(feature = "core-regexp")]
 mod tests {
-    use bstr::ByteSlice;
-
     use crate::test::prelude::*;
 
     const SUBJECT: &str = "String";
     const FUNCTIONAL_TEST: &[u8] = include_bytes!("string_test.rb");
 
     #[test]
+    #[cfg(feature = "core-regexp")]
     fn functional() {
         let mut interp = interpreter().unwrap();
-        interp.eval(FUNCTIONAL_TEST).unwrap();
+        let result = interp.eval(FUNCTIONAL_TEST);
+        unwrap_or_panic_with_backtrace(&mut interp, SUBJECT, result);
         let result = interp.eval(b"spec");
-        if let Err(exc) = result {
-            let backtrace = exc.vm_backtrace(&mut interp);
-            let backtrace = bstr::join("\n", backtrace.unwrap_or_default());
-            panic!(
-                "{} tests failed with message: {:?} and backtrace:\n{:?}",
-                SUBJECT,
-                exc.message().as_bstr(),
-                backtrace.as_bstr()
-            );
-        }
+        unwrap_or_panic_with_backtrace(&mut interp, SUBJECT, result);
     }
 }

--- a/artichoke-backend/src/extn/core/thread/mod.rs
+++ b/artichoke-backend/src/extn/core/thread/mod.rs
@@ -35,8 +35,6 @@ pub struct Mutex;
 
 #[cfg(test)]
 mod tests {
-    use bstr::ByteSlice;
-
     use crate::test::prelude::*;
 
     const SUBJECT: &str = "Thread";
@@ -45,17 +43,9 @@ mod tests {
     #[test]
     fn functional() {
         let mut interp = interpreter().unwrap();
-        interp.eval(FUNCTIONAL_TEST).unwrap();
+        let result = interp.eval(FUNCTIONAL_TEST);
+        unwrap_or_panic_with_backtrace(&mut interp, SUBJECT, result);
         let result = interp.eval(b"spec");
-        if let Err(exc) = result {
-            let backtrace = exc.vm_backtrace(&mut interp);
-            let backtrace = bstr::join("\n", backtrace.unwrap_or_default());
-            panic!(
-                "{} tests failed with message: {:?} and backtrace:\n{:?}",
-                SUBJECT,
-                exc.message().as_bstr(),
-                backtrace.as_bstr()
-            );
-        }
+        unwrap_or_panic_with_backtrace(&mut interp, SUBJECT, result);
     }
 }

--- a/artichoke-backend/src/extn/stdlib/abbrev/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/abbrev/mod.rs
@@ -16,8 +16,6 @@ pub struct Abbrev;
 
 #[cfg(test)]
 mod tests {
-    use bstr::ByteSlice;
-
     use crate::test::prelude::*;
 
     const SUBJECT: &str = "Abbrev";
@@ -26,17 +24,9 @@ mod tests {
     #[test]
     fn functional() {
         let mut interp = interpreter().unwrap();
-        interp.eval(FUNCTIONAL_TEST).unwrap();
+        let result = interp.eval(FUNCTIONAL_TEST);
+        unwrap_or_panic_with_backtrace(&mut interp, SUBJECT, result);
         let result = interp.eval(b"spec");
-        if let Err(exc) = result {
-            let backtrace = exc.vm_backtrace(&mut interp);
-            let backtrace = bstr::join("\n", backtrace.unwrap_or_default());
-            panic!(
-                "{} tests failed with message: {:?} and backtrace:\n{:?}",
-                SUBJECT,
-                exc.message().as_bstr(),
-                backtrace.as_bstr()
-            );
-        }
+        unwrap_or_panic_with_backtrace(&mut interp, SUBJECT, result);
     }
 }

--- a/artichoke-backend/src/extn/stdlib/forwardable/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/forwardable/mod.rs
@@ -17,8 +17,6 @@ pub struct Forwardable;
 
 #[cfg(test)]
 mod tests {
-    use bstr::ByteSlice;
-
     use crate::test::prelude::*;
 
     const SUBJECT: &str = "Forwardable";
@@ -27,17 +25,9 @@ mod tests {
     #[test]
     fn functional() {
         let mut interp = interpreter().unwrap();
-        interp.eval(FUNCTIONAL_TEST).unwrap();
+        let result = interp.eval(FUNCTIONAL_TEST);
+        unwrap_or_panic_with_backtrace(&mut interp, SUBJECT, result);
         let result = interp.eval(b"spec");
-        if let Err(exc) = result {
-            let backtrace = exc.vm_backtrace(&mut interp);
-            let backtrace = bstr::join("\n", backtrace.unwrap_or_default());
-            panic!(
-                "{} tests failed with message: {:?} and backtrace:\n{:?}",
-                SUBJECT,
-                exc.message().as_bstr(),
-                backtrace.as_bstr()
-            );
-        }
+        unwrap_or_panic_with_backtrace(&mut interp, SUBJECT, result);
     }
 }

--- a/artichoke-backend/src/extn/stdlib/json/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/json/mod.rs
@@ -31,8 +31,6 @@ pub struct Json;
 
 #[cfg(test)]
 mod tests {
-    use bstr::ByteSlice;
-
     use crate::test::prelude::*;
 
     const SUBJECT: &str = "JSON";
@@ -41,17 +39,9 @@ mod tests {
     #[test]
     fn functional() {
         let mut interp = interpreter().unwrap();
-        interp.eval(FUNCTIONAL_TEST).unwrap();
+        let result = interp.eval(FUNCTIONAL_TEST);
+        unwrap_or_panic_with_backtrace(&mut interp, SUBJECT, result);
         let result = interp.eval(b"spec");
-        if let Err(exc) = result {
-            let backtrace = exc.vm_backtrace(&mut interp);
-            let backtrace = bstr::join("\n", backtrace.unwrap_or_default());
-            panic!(
-                "{} tests failed with message: {:?} and backtrace:\n{:?}",
-                SUBJECT,
-                exc.message().as_bstr(),
-                backtrace.as_bstr()
-            );
-        }
+        unwrap_or_panic_with_backtrace(&mut interp, SUBJECT, result);
     }
 }

--- a/artichoke-backend/src/extn/stdlib/monitor/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/monitor/mod.rs
@@ -16,8 +16,6 @@ pub struct Monitor;
 
 #[cfg(test)]
 mod tests {
-    use bstr::ByteSlice;
-
     use crate::test::prelude::*;
 
     const SUBJECT: &str = "Monitor";
@@ -26,17 +24,9 @@ mod tests {
     #[test]
     fn functional() {
         let mut interp = interpreter().unwrap();
-        interp.eval(FUNCTIONAL_TEST).unwrap();
+        let result = interp.eval(FUNCTIONAL_TEST);
+        unwrap_or_panic_with_backtrace(&mut interp, SUBJECT, result);
         let result = interp.eval(b"spec");
-        if let Err(exc) = result {
-            let backtrace = exc.vm_backtrace(&mut interp);
-            let backtrace = bstr::join("\n", backtrace.unwrap_or_default());
-            panic!(
-                "{} tests failed with message: {:?} and backtrace:\n{:?}",
-                SUBJECT,
-                exc.message().as_bstr(),
-                backtrace.as_bstr()
-            );
-        }
+        unwrap_or_panic_with_backtrace(&mut interp, SUBJECT, result);
     }
 }

--- a/artichoke-backend/src/extn/stdlib/strscan/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/strscan/mod.rs
@@ -16,8 +16,6 @@ pub struct StringScanner;
 
 #[cfg(test)]
 mod tests {
-    use bstr::ByteSlice;
-
     use crate::test::prelude::*;
 
     const SUBJECT: &str = "StringScanner";
@@ -26,17 +24,9 @@ mod tests {
     #[test]
     fn functional() {
         let mut interp = interpreter().unwrap();
-        interp.eval(FUNCTIONAL_TEST).unwrap();
+        let result = interp.eval(FUNCTIONAL_TEST);
+        unwrap_or_panic_with_backtrace(&mut interp, SUBJECT, result);
         let result = interp.eval(b"spec");
-        if let Err(exc) = result {
-            let backtrace = exc.vm_backtrace(&mut interp);
-            let backtrace = bstr::join("\n", backtrace.unwrap_or_default());
-            panic!(
-                "{} tests failed with message: {:?} and backtrace:\n{:?}",
-                SUBJECT,
-                exc.message().as_bstr(),
-                backtrace.as_bstr()
-            );
-        }
+        unwrap_or_panic_with_backtrace(&mut interp, SUBJECT, result);
     }
 }

--- a/artichoke-backend/src/extn/stdlib/uri/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/uri/mod.rs
@@ -49,8 +49,6 @@ pub struct Uri;
 
 #[cfg(test)]
 mod tests {
-    use bstr::ByteSlice;
-
     use crate::test::prelude::*;
 
     const SUBJECT: &str = "URI";
@@ -59,17 +57,9 @@ mod tests {
     #[test]
     fn functional() {
         let mut interp = interpreter().unwrap();
-        interp.eval(FUNCTIONAL_TEST).unwrap();
+        let result = interp.eval(FUNCTIONAL_TEST);
+        unwrap_or_panic_with_backtrace(&mut interp, SUBJECT, result);
         let result = interp.eval(b"spec");
-        if let Err(exc) = result {
-            let backtrace = exc.vm_backtrace(&mut interp);
-            let backtrace = bstr::join("\n", backtrace.unwrap_or_default());
-            panic!(
-                "{} tests failed with message: {:?} and backtrace:\n{:?}",
-                SUBJECT,
-                exc.message().as_bstr(),
-                backtrace.as_bstr()
-            );
-        }
+        unwrap_or_panic_with_backtrace(&mut interp, SUBJECT, result);
     }
 }

--- a/artichoke-backend/src/test/prelude.rs
+++ b/artichoke-backend/src/test/prelude.rs
@@ -10,6 +10,8 @@
 //!
 //! The prelude may grow over time as additional items see ubiquitous use.
 
+use bstr::ByteSlice;
+
 pub use crate::block::Block;
 pub use crate::class;
 pub use crate::convert::{BoxUnboxVmValue, HeapAllocatedData};
@@ -62,4 +64,36 @@ impl Drop for AutoDropArtichoke {
 pub fn interpreter() -> Result<AutoDropArtichoke, Error> {
     let interp = crate::interpreter()?;
     Ok(AutoDropArtichoke(Some(interp)))
+}
+
+/// Unwrap a result returned from the VM or panic.
+///
+/// # Panics
+///
+/// This function panics if the given result is an error.
+#[track_caller]
+pub fn unwrap_or_panic_with_backtrace<T>(interp: &mut Artichoke, subject: &str, result: Result<T, Error>) -> T {
+    match result {
+        Ok(result) => result,
+        Err(exc) => {
+            let backtrace = exc.vm_backtrace(interp);
+            let name = exc.name();
+            let backtrace = backtrace
+                .unwrap_or_default()
+                .into_iter()
+                .map(|line| {
+                    let frame = format!("{:?}", line.as_bstr());
+                    format!("        {}", &frame[1..frame.len() - 1])
+                })
+                .collect::<Vec<_>>();
+            let backtrace = backtrace.join("\n");
+            panic!(
+                "\n{} tests failed with {} exception\n    message: {:?}\n    backtrace:\n{}\n",
+                subject,
+                name,
+                exc.message().as_bstr(),
+                backtrace
+            );
+        }
+    }
 }

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -584,6 +584,7 @@ name = "spec-runner"
 version = "0.6.0"
 dependencies = [
  "artichoke",
+ "bstr",
  "clap",
  "rust-embed",
  "serde",

--- a/spec-runner/Cargo.toml
+++ b/spec-runner/Cargo.toml
@@ -18,6 +18,9 @@ serde = { version = "1.0", features = ["derive"] }
 termcolor = "1.1"
 toml = { version = "0.5", default-features = false }
 
+[dev-dependencies]
+bstr = { version = "0.2, >= 0.2.4", default-features = false }
+
 # `spec-runner` is a regression testing tool
 # Remove it from the main artichoke workspace.
 [workspace]

--- a/spec-runner/src/mspec.rs
+++ b/spec-runner/src/mspec.rs
@@ -95,50 +95,65 @@ where
 
 #[cfg(test)]
 mod tests {
+    use artichoke::prelude::*;
+    use bstr::ByteSlice;
+
     use super::{init, run, Formatter};
+
+    fn load_mspec_with_formatter(formatter: Formatter) {
+        let mut interp = artichoke::interpreter().unwrap();
+        init(&mut interp).unwrap();
+        match run(&mut interp, formatter, vec![]) {
+            Ok(true) => {}
+            Ok(false) => {
+                panic!("mspec::run with {:?} formatter failed", formatter);
+            }
+            Err(exc) => {
+                let backtrace = exc.vm_backtrace(&mut interp);
+                let backtrace = backtrace
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(|line| format!("{:?}", line.as_bstr()))
+                    .collect::<Vec<_>>();
+                let backtrace = backtrace.join("\n");
+                panic!(
+                    "mspec::run tests with {:?} formatter failed with message: {:?} and backtrace:\n{}",
+                    formatter,
+                    exc.message().as_bstr(),
+                    backtrace
+                );
+            }
+        }
+        interp.close();
+    }
 
     #[test]
     fn mspec_framework_loads() {
-        let mut interp = artichoke::interpreter().unwrap();
-        init(&mut interp).unwrap();
         // should not panic
-        assert!(run(&mut interp, Formatter::default(), vec![]).unwrap());
-        interp.close();
+        load_mspec_with_formatter(Formatter::default());
     }
 
     #[test]
     fn artichoke_formatter_succeeds() {
-        let mut interp = artichoke::interpreter().unwrap();
-        init(&mut interp).unwrap();
         // should not panic
-        assert!(run(&mut interp, Formatter::Artichoke, vec![]).unwrap());
-        interp.close();
+        load_mspec_with_formatter(Formatter::Artichoke);
     }
 
     #[test]
     fn summary_formatter_succeeds() {
-        let mut interp = artichoke::interpreter().unwrap();
-        init(&mut interp).unwrap();
         // should not panic
-        assert!(run(&mut interp, Formatter::Summary, vec![]).unwrap());
-        interp.close();
+        load_mspec_with_formatter(Formatter::Summary);
     }
 
     #[test]
     fn tagger_formatter_succeeds() {
-        let mut interp = artichoke::interpreter().unwrap();
-        init(&mut interp).unwrap();
         // should not panic
-        assert!(run(&mut interp, Formatter::Tagger, vec![]).unwrap());
-        interp.close();
+        load_mspec_with_formatter(Formatter::Tagger);
     }
 
     #[test]
     fn yaml_formatter_succeeds() {
-        let mut interp = artichoke::interpreter().unwrap();
-        init(&mut interp).unwrap();
         // should not panic
-        assert!(run(&mut interp, Formatter::Yaml, vec![]).unwrap());
-        interp.close();
+        load_mspec_with_formatter(Formatter::Yaml);
     }
 }


### PR DESCRIPTION
Modify functional tests to panic on exception such that backtraces have
one frame per line of panic message.

Modify functional tests so that errors eval'ing the functional test
source (and e.g. requiring packages from stdlib) print the same
prettified exception message and backtrace.

These panics look like this:

```console
$ cargo test -q -p artichoke-backend array::tests::functional

running 1 test
F
failures:

---- extn::core::array::tests::functional stdout ----
thread 'extn::core::array::tests::functional' panicked at '
Array tests failed with RuntimeError exception
    message: ""
    backtrace:
        (eval):43:in inline_get
        (eval):5:in spec
        (eval):1
', artichoke-backend/src/extn/core/array/mod.rs:352:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

failures:
    extn::core::array::tests::functional

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 227 filtered out; finished in 0.05s

error: test failed, to rerun pass '-p artichoke-backend --lib'
```

This commit was extracted from #1222.

https://github.com/artichoke/artichoke/pull/1511 was pulled out of this branch.