### PR TITLE
Add uppercase and lowercase APIs to `spinoso-string`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -680,7 +680,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-string"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "bstr",
  "bytecount",

--- a/spinoso-string/Cargo.toml
+++ b/spinoso-string/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spinoso-string"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2021"
 description = """

--- a/spinoso-string/README.md
+++ b/spinoso-string/README.md
@@ -27,7 +27,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-spinoso-string = "0.5"
+spinoso-string = "0.7"
 ```
 
 ## `no_std`


### PR DESCRIPTION
Bump `spinoso-string` to 0.7.0.

Add `String::make_lowercase` and `String::make_uppercase` APIs to mirror `String::make_capitalized`.

These APIs are required to unblock:

- #1222