### PR TITLE
Remove `artichoke_` prefix from native `Kernel`, `MatchData`, `Math`, and `String` mruby trampolines 

### DIFF
--- a/artichoke-backend/src/extn/core/matchdata/mruby.rs
+++ b/artichoke-backend/src/extn/core/matchdata/mruby.rs
@@ -17,29 +17,21 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     )?;
     class::Builder::for_spec(interp, &spec)
         .value_is_rust_object()
-        .add_method("begin", artichoke_matchdata_begin, sys::mrb_args_req(1))?
-        .add_method("captures", artichoke_matchdata_captures, sys::mrb_args_none())?
-        .add_method(
-            "[]",
-            artichoke_matchdata_element_reference,
-            sys::mrb_args_req_and_opt(1, 1),
-        )?
-        .add_method("length", artichoke_matchdata_length, sys::mrb_args_none())?
-        .add_method(
-            "named_captures",
-            artichoke_matchdata_named_captures,
-            sys::mrb_args_none(),
-        )?
-        .add_method("names", artichoke_matchdata_names, sys::mrb_args_none())?
-        .add_method("offset", artichoke_matchdata_offset, sys::mrb_args_req(1))?
-        .add_method("post_match", artichoke_matchdata_post_match, sys::mrb_args_none())?
-        .add_method("pre_match", artichoke_matchdata_pre_match, sys::mrb_args_none())?
-        .add_method("regexp", artichoke_matchdata_regexp, sys::mrb_args_none())?
-        .add_method("size", artichoke_matchdata_length, sys::mrb_args_none())?
-        .add_method("string", artichoke_matchdata_string, sys::mrb_args_none())?
-        .add_method("to_a", artichoke_matchdata_to_a, sys::mrb_args_none())?
-        .add_method("to_s", artichoke_matchdata_to_s, sys::mrb_args_none())?
-        .add_method("end", artichoke_matchdata_end, sys::mrb_args_req(1))?
+        .add_method("begin", matchdata_begin, sys::mrb_args_req(1))?
+        .add_method("captures", matchdata_captures, sys::mrb_args_none())?
+        .add_method("[]", matchdata_element_reference, sys::mrb_args_req_and_opt(1, 1))?
+        .add_method("length", matchdata_length, sys::mrb_args_none())?
+        .add_method("named_captures", matchdata_named_captures, sys::mrb_args_none())?
+        .add_method("names", matchdata_names, sys::mrb_args_none())?
+        .add_method("offset", matchdata_offset, sys::mrb_args_req(1))?
+        .add_method("post_match", matchdata_post_match, sys::mrb_args_none())?
+        .add_method("pre_match", matchdata_pre_match, sys::mrb_args_none())?
+        .add_method("regexp", matchdata_regexp, sys::mrb_args_none())?
+        .add_method("size", matchdata_length, sys::mrb_args_none())?
+        .add_method("string", matchdata_string, sys::mrb_args_none())?
+        .add_method("to_a", matchdata_to_a, sys::mrb_args_none())?
+        .add_method("to_s", matchdata_to_s, sys::mrb_args_none())?
+        .add_method("end", matchdata_end, sys::mrb_args_req(1))?
         .define()?;
     interp.def_class::<matchdata::MatchData>(spec)?;
     interp.eval(&include_bytes!("matchdata.rb")[..])?;
@@ -47,7 +39,7 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     Ok(())
 }
 
-unsafe extern "C" fn artichoke_matchdata_begin(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
+unsafe extern "C" fn matchdata_begin(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
     let begin = mrb_get_args!(mrb, required = 1);
     unwrap_interpreter!(mrb, to => guard);
     let value = Value::from(slf);
@@ -59,7 +51,7 @@ unsafe extern "C" fn artichoke_matchdata_begin(mrb: *mut sys::mrb_state, slf: sy
     }
 }
 
-unsafe extern "C" fn artichoke_matchdata_captures(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
+unsafe extern "C" fn matchdata_captures(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
     mrb_get_args!(mrb, none);
     unwrap_interpreter!(mrb, to => guard);
     let value = Value::from(slf);
@@ -70,10 +62,7 @@ unsafe extern "C" fn artichoke_matchdata_captures(mrb: *mut sys::mrb_state, slf:
     }
 }
 
-unsafe extern "C" fn artichoke_matchdata_element_reference(
-    mrb: *mut sys::mrb_state,
-    slf: sys::mrb_value,
-) -> sys::mrb_value {
+unsafe extern "C" fn matchdata_element_reference(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
     let (elem, len) = mrb_get_args!(mrb, required = 1, optional = 1);
     unwrap_interpreter!(mrb, to => guard);
     let value = Value::from(slf);
@@ -86,7 +75,7 @@ unsafe extern "C" fn artichoke_matchdata_element_reference(
     }
 }
 
-unsafe extern "C" fn artichoke_matchdata_end(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
+unsafe extern "C" fn matchdata_end(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
     let end = mrb_get_args!(mrb, required = 1);
     unwrap_interpreter!(mrb, to => guard);
     let value = Value::from(slf);
@@ -98,7 +87,7 @@ unsafe extern "C" fn artichoke_matchdata_end(mrb: *mut sys::mrb_state, slf: sys:
     }
 }
 
-unsafe extern "C" fn artichoke_matchdata_length(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
+unsafe extern "C" fn matchdata_length(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
     mrb_get_args!(mrb, none);
     unwrap_interpreter!(mrb, to => guard);
     let value = Value::from(slf);
@@ -109,10 +98,7 @@ unsafe extern "C" fn artichoke_matchdata_length(mrb: *mut sys::mrb_state, slf: s
     }
 }
 
-unsafe extern "C" fn artichoke_matchdata_named_captures(
-    mrb: *mut sys::mrb_state,
-    slf: sys::mrb_value,
-) -> sys::mrb_value {
+unsafe extern "C" fn matchdata_named_captures(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
     mrb_get_args!(mrb, none);
     unwrap_interpreter!(mrb, to => guard);
     let value = Value::from(slf);
@@ -123,7 +109,7 @@ unsafe extern "C" fn artichoke_matchdata_named_captures(
     }
 }
 
-unsafe extern "C" fn artichoke_matchdata_names(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
+unsafe extern "C" fn matchdata_names(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
     mrb_get_args!(mrb, none);
     unwrap_interpreter!(mrb, to => guard);
     let value = Value::from(slf);
@@ -134,7 +120,7 @@ unsafe extern "C" fn artichoke_matchdata_names(mrb: *mut sys::mrb_state, slf: sy
     }
 }
 
-unsafe extern "C" fn artichoke_matchdata_offset(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
+unsafe extern "C" fn matchdata_offset(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
     let offset = mrb_get_args!(mrb, required = 1);
     unwrap_interpreter!(mrb, to => guard);
     let value = Value::from(slf);
@@ -146,7 +132,7 @@ unsafe extern "C" fn artichoke_matchdata_offset(mrb: *mut sys::mrb_state, slf: s
     }
 }
 
-unsafe extern "C" fn artichoke_matchdata_post_match(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
+unsafe extern "C" fn matchdata_post_match(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
     mrb_get_args!(mrb, none);
     unwrap_interpreter!(mrb, to => guard);
     let value = Value::from(slf);
@@ -157,7 +143,7 @@ unsafe extern "C" fn artichoke_matchdata_post_match(mrb: *mut sys::mrb_state, sl
     }
 }
 
-unsafe extern "C" fn artichoke_matchdata_pre_match(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
+unsafe extern "C" fn matchdata_pre_match(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
     mrb_get_args!(mrb, none);
     unwrap_interpreter!(mrb, to => guard);
     let value = Value::from(slf);
@@ -168,7 +154,7 @@ unsafe extern "C" fn artichoke_matchdata_pre_match(mrb: *mut sys::mrb_state, slf
     }
 }
 
-unsafe extern "C" fn artichoke_matchdata_regexp(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
+unsafe extern "C" fn matchdata_regexp(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
     mrb_get_args!(mrb, none);
     unwrap_interpreter!(mrb, to => guard);
     let value = Value::from(slf);
@@ -179,7 +165,7 @@ unsafe extern "C" fn artichoke_matchdata_regexp(mrb: *mut sys::mrb_state, slf: s
     }
 }
 
-unsafe extern "C" fn artichoke_matchdata_string(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
+unsafe extern "C" fn matchdata_string(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
     mrb_get_args!(mrb, none);
     unwrap_interpreter!(mrb, to => guard);
     let value = Value::from(slf);
@@ -190,7 +176,7 @@ unsafe extern "C" fn artichoke_matchdata_string(mrb: *mut sys::mrb_state, slf: s
     }
 }
 
-unsafe extern "C" fn artichoke_matchdata_to_a(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
+unsafe extern "C" fn matchdata_to_a(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
     mrb_get_args!(mrb, none);
     unwrap_interpreter!(mrb, to => guard);
     let value = Value::from(slf);
@@ -201,7 +187,7 @@ unsafe extern "C" fn artichoke_matchdata_to_a(mrb: *mut sys::mrb_state, slf: sys
     }
 }
 
-unsafe extern "C" fn artichoke_matchdata_to_s(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
+unsafe extern "C" fn matchdata_to_s(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
     mrb_get_args!(mrb, none);
     unwrap_interpreter!(mrb, to => guard);
     let value = Value::from(slf);

--- a/artichoke-backend/src/extn/core/math/mruby.rs
+++ b/artichoke-backend/src/extn/core/math/mruby.rs
@@ -15,32 +15,32 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     }
     let spec = module::Spec::new(interp, "Math", MATH_CSTR, None)?;
     module::Builder::for_spec(interp, &spec)
-        .add_module_method("acos", artichoke_math_acos, sys::mrb_args_req(1))?
-        .add_module_method("acosh", artichoke_math_acosh, sys::mrb_args_req(1))?
-        .add_module_method("asin", artichoke_math_asin, sys::mrb_args_req(1))?
-        .add_module_method("asinh", artichoke_math_asinh, sys::mrb_args_req(1))?
-        .add_module_method("atan", artichoke_math_atan, sys::mrb_args_req(1))?
-        .add_module_method("atan2", artichoke_math_atan2, sys::mrb_args_req(2))?
-        .add_module_method("atanh", artichoke_math_atanh, sys::mrb_args_req(1))?
-        .add_module_method("cbrt", artichoke_math_cbrt, sys::mrb_args_req(1))?
-        .add_module_method("cos", artichoke_math_cos, sys::mrb_args_req(1))?
-        .add_module_method("cosh", artichoke_math_cosh, sys::mrb_args_req(1))?
-        .add_module_method("erf", artichoke_math_erf, sys::mrb_args_req(1))?
-        .add_module_method("erfc", artichoke_math_erfc, sys::mrb_args_req(1))?
-        .add_module_method("exp", artichoke_math_exp, sys::mrb_args_req(1))?
-        .add_module_method("frexp", artichoke_math_frexp, sys::mrb_args_req(1))?
-        .add_module_method("gamma", artichoke_math_gamma, sys::mrb_args_req(1))?
-        .add_module_method("hypot", artichoke_math_hypot, sys::mrb_args_req(2))?
-        .add_module_method("ldexp", artichoke_math_ldexp, sys::mrb_args_req(2))?
-        .add_module_method("lgamma", artichoke_math_lgamma, sys::mrb_args_req(1))?
-        .add_module_method("log", artichoke_math_log, sys::mrb_args_req_and_opt(1, 1))?
-        .add_module_method("log10", artichoke_math_log10, sys::mrb_args_req(1))?
-        .add_module_method("log2", artichoke_math_log2, sys::mrb_args_req(1))?
-        .add_module_method("sin", artichoke_math_sin, sys::mrb_args_req(1))?
-        .add_module_method("sinh", artichoke_math_sinh, sys::mrb_args_req(1))?
-        .add_module_method("sqrt", artichoke_math_sqrt, sys::mrb_args_req(1))?
-        .add_module_method("tan", artichoke_math_tan, sys::mrb_args_req(1))?
-        .add_module_method("tanh", artichoke_math_tanh, sys::mrb_args_req(1))?
+        .add_module_method("acos", math_acos, sys::mrb_args_req(1))?
+        .add_module_method("acosh", math_acosh, sys::mrb_args_req(1))?
+        .add_module_method("asin", math_asin, sys::mrb_args_req(1))?
+        .add_module_method("asinh", math_asinh, sys::mrb_args_req(1))?
+        .add_module_method("atan", math_atan, sys::mrb_args_req(1))?
+        .add_module_method("atan2", math_atan2, sys::mrb_args_req(2))?
+        .add_module_method("atanh", math_atanh, sys::mrb_args_req(1))?
+        .add_module_method("cbrt", math_cbrt, sys::mrb_args_req(1))?
+        .add_module_method("cos", math_cos, sys::mrb_args_req(1))?
+        .add_module_method("cosh", math_cosh, sys::mrb_args_req(1))?
+        .add_module_method("erf", math_erf, sys::mrb_args_req(1))?
+        .add_module_method("erfc", math_erfc, sys::mrb_args_req(1))?
+        .add_module_method("exp", math_exp, sys::mrb_args_req(1))?
+        .add_module_method("frexp", math_frexp, sys::mrb_args_req(1))?
+        .add_module_method("gamma", math_gamma, sys::mrb_args_req(1))?
+        .add_module_method("hypot", math_hypot, sys::mrb_args_req(2))?
+        .add_module_method("ldexp", math_ldexp, sys::mrb_args_req(2))?
+        .add_module_method("lgamma", math_lgamma, sys::mrb_args_req(1))?
+        .add_module_method("log", math_log, sys::mrb_args_req_and_opt(1, 1))?
+        .add_module_method("log10", math_log10, sys::mrb_args_req(1))?
+        .add_module_method("log2", math_log2, sys::mrb_args_req(1))?
+        .add_module_method("sin", math_sin, sys::mrb_args_req(1))?
+        .add_module_method("sinh", math_sinh, sys::mrb_args_req(1))?
+        .add_module_method("sqrt", math_sqrt, sys::mrb_args_req(1))?
+        .add_module_method("tan", math_tan, sys::mrb_args_req(1))?
+        .add_module_method("tanh", math_tanh, sys::mrb_args_req(1))?
         .define()?;
 
     let domainerror = class::Spec::new(
@@ -62,7 +62,7 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     Ok(())
 }
 
-unsafe extern "C" fn artichoke_math_acos(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {
+unsafe extern "C" fn math_acos(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {
     let value = mrb_get_args!(mrb, required = 1);
     unwrap_interpreter!(mrb, to => guard);
     let value = Value::from(value);
@@ -73,7 +73,7 @@ unsafe extern "C" fn artichoke_math_acos(mrb: *mut sys::mrb_state, _slf: sys::mr
     }
 }
 
-unsafe extern "C" fn artichoke_math_acosh(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {
+unsafe extern "C" fn math_acosh(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {
     let value = mrb_get_args!(mrb, required = 1);
     unwrap_interpreter!(mrb, to => guard);
     let value = Value::from(value);
@@ -84,7 +84,7 @@ unsafe extern "C" fn artichoke_math_acosh(mrb: *mut sys::mrb_state, _slf: sys::m
     }
 }
 
-unsafe extern "C" fn artichoke_math_asin(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {
+unsafe extern "C" fn math_asin(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {
     let value = mrb_get_args!(mrb, required = 1);
     unwrap_interpreter!(mrb, to => guard);
     let value = Value::from(value);
@@ -95,7 +95,7 @@ unsafe extern "C" fn artichoke_math_asin(mrb: *mut sys::mrb_state, _slf: sys::mr
     }
 }
 
-unsafe extern "C" fn artichoke_math_asinh(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {
+unsafe extern "C" fn math_asinh(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {
     let value = mrb_get_args!(mrb, required = 1);
     unwrap_interpreter!(mrb, to => guard);
     let value = Value::from(value);
@@ -106,7 +106,7 @@ unsafe extern "C" fn artichoke_math_asinh(mrb: *mut sys::mrb_state, _slf: sys::m
     }
 }
 
-unsafe extern "C" fn artichoke_math_atan(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {
+unsafe extern "C" fn math_atan(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {
     let value = mrb_get_args!(mrb, required = 1);
     unwrap_interpreter!(mrb, to => guard);
     let value = Value::from(value);
@@ -117,7 +117,7 @@ unsafe extern "C" fn artichoke_math_atan(mrb: *mut sys::mrb_state, _slf: sys::mr
     }
 }
 
-unsafe extern "C" fn artichoke_math_atan2(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {
+unsafe extern "C" fn math_atan2(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {
     let (value, other) = mrb_get_args!(mrb, required = 2);
     unwrap_interpreter!(mrb, to => guard);
     let value = Value::from(value);
@@ -129,7 +129,7 @@ unsafe extern "C" fn artichoke_math_atan2(mrb: *mut sys::mrb_state, _slf: sys::m
     }
 }
 
-unsafe extern "C" fn artichoke_math_atanh(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {
+unsafe extern "C" fn math_atanh(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {
     let value = mrb_get_args!(mrb, required = 1);
     unwrap_interpreter!(mrb, to => guard);
     let value = Value::from(value);
@@ -140,7 +140,7 @@ unsafe extern "C" fn artichoke_math_atanh(mrb: *mut sys::mrb_state, _slf: sys::m
     }
 }
 
-unsafe extern "C" fn artichoke_math_cbrt(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {
+unsafe extern "C" fn math_cbrt(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {
     let value = mrb_get_args!(mrb, required = 1);
     unwrap_interpreter!(mrb, to => guard);
     let value = Value::from(value);
@@ -151,7 +151,7 @@ unsafe extern "C" fn artichoke_math_cbrt(mrb: *mut sys::mrb_state, _slf: sys::mr
     }
 }
 
-unsafe extern "C" fn artichoke_math_cos(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {
+unsafe extern "C" fn math_cos(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {
     let value = mrb_get_args!(mrb, required = 1);
     unwrap_interpreter!(mrb, to => guard);
     let value = Value::from(value);
@@ -162,7 +162,7 @@ unsafe extern "C" fn artichoke_math_cos(mrb: *mut sys::mrb_state, _slf: sys::mrb
     }
 }
 
-unsafe extern "C" fn artichoke_math_cosh(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {
+unsafe extern "C" fn math_cosh(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {
     let value = mrb_get_args!(mrb, required = 1);
     unwrap_interpreter!(mrb, to => guard);
     let value = Value::from(value);
@@ -173,7 +173,7 @@ unsafe extern "C" fn artichoke_math_cosh(mrb: *mut sys::mrb_state, _slf: sys::mr
     }
 }
 
-unsafe extern "C" fn artichoke_math_erf(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {
+unsafe extern "C" fn math_erf(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {
     let value = mrb_get_args!(mrb, required = 1);
     unwrap_interpreter!(mrb, to => guard);
     let value = Value::from(value);
@@ -184,7 +184,7 @@ unsafe extern "C" fn artichoke_math_erf(mrb: *mut sys::mrb_state, _slf: sys::mrb
     }
 }
 
-unsafe extern "C" fn artichoke_math_erfc(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {
+unsafe extern "C" fn math_erfc(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {
     let value = mrb_get_args!(mrb, required = 1);
     unwrap_interpreter!(mrb, to => guard);
     let value = Value::from(value);
@@ -195,7 +195,7 @@ unsafe extern "C" fn artichoke_math_erfc(mrb: *mut sys::mrb_state, _slf: sys::mr
     }
 }
 
-unsafe extern "C" fn artichoke_math_exp(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {
+unsafe extern "C" fn math_exp(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {
     let value = mrb_get_args!(mrb, required = 1);
     unwrap_interpreter!(mrb, to => guard);
     let value = Value::from(value);
@@ -206,7 +206,7 @@ unsafe extern "C" fn artichoke_math_exp(mrb: *mut sys::mrb_state, _slf: sys::mrb
     }
 }
 
-unsafe extern "C" fn artichoke_math_frexp(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {
+unsafe extern "C" fn math_frexp(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {
     let value = mrb_get_args!(mrb, required = 1);
     unwrap_interpreter!(mrb, to => guard);
     let value = Value::from(value);
@@ -221,7 +221,7 @@ unsafe extern "C" fn artichoke_math_frexp(mrb: *mut sys::mrb_state, _slf: sys::m
     }
 }
 
-unsafe extern "C" fn artichoke_math_gamma(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {
+unsafe extern "C" fn math_gamma(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {
     let value = mrb_get_args!(mrb, required = 1);
     unwrap_interpreter!(mrb, to => guard);
     let value = Value::from(value);
@@ -232,7 +232,7 @@ unsafe extern "C" fn artichoke_math_gamma(mrb: *mut sys::mrb_state, _slf: sys::m
     }
 }
 
-unsafe extern "C" fn artichoke_math_hypot(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {
+unsafe extern "C" fn math_hypot(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {
     let (value, other) = mrb_get_args!(mrb, required = 2);
     unwrap_interpreter!(mrb, to => guard);
     let value = Value::from(value);
@@ -244,7 +244,7 @@ unsafe extern "C" fn artichoke_math_hypot(mrb: *mut sys::mrb_state, _slf: sys::m
     }
 }
 
-unsafe extern "C" fn artichoke_math_ldexp(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {
+unsafe extern "C" fn math_ldexp(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {
     let (fraction, exponent) = mrb_get_args!(mrb, required = 2);
     unwrap_interpreter!(mrb, to => guard);
     let fraction = Value::from(fraction);
@@ -256,7 +256,7 @@ unsafe extern "C" fn artichoke_math_ldexp(mrb: *mut sys::mrb_state, _slf: sys::m
     }
 }
 
-unsafe extern "C" fn artichoke_math_lgamma(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {
+unsafe extern "C" fn math_lgamma(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {
     let value = mrb_get_args!(mrb, required = 1);
     unwrap_interpreter!(mrb, to => guard);
     let value = Value::from(value);
@@ -271,7 +271,7 @@ unsafe extern "C" fn artichoke_math_lgamma(mrb: *mut sys::mrb_state, _slf: sys::
     }
 }
 
-unsafe extern "C" fn artichoke_math_log(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {
+unsafe extern "C" fn math_log(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {
     let (value, base) = mrb_get_args!(mrb, required = 1, optional = 1);
     unwrap_interpreter!(mrb, to => guard);
     let value = Value::from(value);
@@ -283,7 +283,7 @@ unsafe extern "C" fn artichoke_math_log(mrb: *mut sys::mrb_state, _slf: sys::mrb
     }
 }
 
-unsafe extern "C" fn artichoke_math_log10(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {
+unsafe extern "C" fn math_log10(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {
     let value = mrb_get_args!(mrb, required = 1);
     unwrap_interpreter!(mrb, to => guard);
     let value = Value::from(value);
@@ -294,7 +294,7 @@ unsafe extern "C" fn artichoke_math_log10(mrb: *mut sys::mrb_state, _slf: sys::m
     }
 }
 
-unsafe extern "C" fn artichoke_math_log2(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {
+unsafe extern "C" fn math_log2(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {
     let value = mrb_get_args!(mrb, required = 1);
     unwrap_interpreter!(mrb, to => guard);
     let value = Value::from(value);
@@ -305,7 +305,7 @@ unsafe extern "C" fn artichoke_math_log2(mrb: *mut sys::mrb_state, _slf: sys::mr
     }
 }
 
-unsafe extern "C" fn artichoke_math_sin(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {
+unsafe extern "C" fn math_sin(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {
     let value = mrb_get_args!(mrb, required = 1);
     unwrap_interpreter!(mrb, to => guard);
     let value = Value::from(value);
@@ -316,7 +316,7 @@ unsafe extern "C" fn artichoke_math_sin(mrb: *mut sys::mrb_state, _slf: sys::mrb
     }
 }
 
-unsafe extern "C" fn artichoke_math_sinh(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {
+unsafe extern "C" fn math_sinh(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {
     let value = mrb_get_args!(mrb, required = 1);
     unwrap_interpreter!(mrb, to => guard);
     let value = Value::from(value);
@@ -327,7 +327,7 @@ unsafe extern "C" fn artichoke_math_sinh(mrb: *mut sys::mrb_state, _slf: sys::mr
     }
 }
 
-unsafe extern "C" fn artichoke_math_sqrt(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {
+unsafe extern "C" fn math_sqrt(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {
     let value = mrb_get_args!(mrb, required = 1);
     unwrap_interpreter!(mrb, to => guard);
     let value = Value::from(value);
@@ -338,7 +338,7 @@ unsafe extern "C" fn artichoke_math_sqrt(mrb: *mut sys::mrb_state, _slf: sys::mr
     }
 }
 
-unsafe extern "C" fn artichoke_math_tan(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {
+unsafe extern "C" fn math_tan(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {
     let value = mrb_get_args!(mrb, required = 1);
     unwrap_interpreter!(mrb, to => guard);
     let value = Value::from(value);
@@ -349,7 +349,7 @@ unsafe extern "C" fn artichoke_math_tan(mrb: *mut sys::mrb_state, _slf: sys::mrb
     }
 }
 
-unsafe extern "C" fn artichoke_math_tanh(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {
+unsafe extern "C" fn math_tanh(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {
     let value = mrb_get_args!(mrb, required = 1);
     unwrap_interpreter!(mrb, to => guard);
     let value = Value::from(value);

--- a/artichoke-backend/src/extn/core/string/mruby.rs
+++ b/artichoke-backend/src/extn/core/string/mruby.rs
@@ -11,8 +11,8 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     }
     let spec = class::Spec::new("String", STRING_CSTR, None, None)?;
     class::Builder::for_spec(interp, &spec)
-        .add_method("ord", artichoke_string_ord, sys::mrb_args_none())?
-        .add_method("scan", artichoke_string_scan, sys::mrb_args_req(1))?
+        .add_method("ord", string_ord, sys::mrb_args_none())?
+        .add_method("scan", string_scan, sys::mrb_args_req(1))?
         .define()?;
     interp.def_class::<string::String>(spec)?;
     interp.eval(&include_bytes!("string.rb")[..])?;
@@ -20,7 +20,7 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     Ok(())
 }
 
-unsafe extern "C" fn artichoke_string_ord(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
+unsafe extern "C" fn string_ord(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
     unwrap_interpreter!(mrb, to => guard);
     let value = Value::from(slf);
     let result = trampoline::ord(&mut guard, value);
@@ -30,7 +30,7 @@ unsafe extern "C" fn artichoke_string_ord(mrb: *mut sys::mrb_state, slf: sys::mr
     }
 }
 
-unsafe extern "C" fn artichoke_string_scan(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
+unsafe extern "C" fn string_scan(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
     let (pattern, block) = mrb_get_args!(mrb, required = 1, &block);
     unwrap_interpreter!(mrb, to => guard);
     let value = Value::from(slf);


### PR DESCRIPTION
This makes the style consistent with `Array` and most other mruby trampolines.

This PR was ripped out of #1222 and expanded to cover all core classes with divergent trampoline naming conventions.