### PR TITLE
Implement `ENV#merge!`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -626,7 +626,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-env"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bstr",
  "scolapasta-string-escape",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -458,7 +458,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-env"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bstr",
  "scolapasta-string-escape",

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -601,7 +601,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-env"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bstr",
  "scolapasta-string-escape",

--- a/spinoso-env/Cargo.toml
+++ b/spinoso-env/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spinoso-env"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2021"
 description = """

--- a/spinoso-env/env.rb
+++ b/spinoso-env/env.rb
@@ -172,6 +172,16 @@ class << ENV
     !self[name].nil?
   end
 
+  def merge!(hash)
+    hash.each do |key, value|
+      value = yield(key, self[key], value) if block_given? && key?(key)
+      self[key] = value
+    end
+
+    to_h
+  end
+  alias update merge!
+
   def rassoc(value)
     value = value.to_str unless value.is_a?(String)
     to_h.each do |k, v|
@@ -292,15 +302,6 @@ class << ENV
 
   def to_s
     'ENV'
-  end
-
-  def update(hash)
-    hash.each do |key, value|
-      value = yield(key, self[key], value) if block_given? && key?(key)
-      self[key] = value
-    end
-
-    to_h
   end
 
   def value?(name)


### PR DESCRIPTION
Per the docs, `ENV#update` is an alias for `ENV#merge!`.

https://ruby-doc.org/core-3.0.2/ENV.html#method-c-merge-21

Update the source so that `merge!` is implemented by renaming the `def update` block and add `update` as an alias to `merge!`.

Bump `spinoso-env` to v0.1.1.

This PR was extracted from #1222 and is required to get the `enforces-specs.toml` set of specs back into compliance.