### PR TITLE
Ensure `spinoso-string` is exercised in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -357,12 +357,12 @@ jobs:
       - name: Check artichoke with minimal versions
         run: |
           cargo +nightly generate-lockfile -Z minimal-versions
-          cargo check --all-targets --profile=test
+          cargo check --workspace --all-targets --profile=test
 
       - name: Check spec-runner with minimal versions
         run: |
           cargo +nightly generate-lockfile -Z minimal-versions
-          cargo check --all-targets --profile=test
+          cargo check --workspace --all-targets --profile=test
         working-directory: "spec-runner"
 
   ruby:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -280,6 +280,14 @@ jobs:
         run: cargo check --verbose --all-features --all-targets --profile=test
         working-directory: "spinoso-securerandom"
 
+      - name: Check spinoso-string with no default features
+        run: cargo check --verbose --no-default-features --all-targets --profile=test
+        working-directory: "spinoso-string"
+
+      - name: Check spinoso-string with all features
+        run: cargo check --verbose --all-features --all-targets --profile=test
+        working-directory: "spinoso-string"
+
       - name: Check spinoso-symbol with no default features
         run: cargo check --verbose --no-default-features --all-targets --profile=test
         working-directory: "spinoso-symbol"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -680,7 +680,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-string"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "bstr",
  "bytecount",

--- a/spinoso-string/Cargo.toml
+++ b/spinoso-string/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spinoso-string"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2021"
 description = """

--- a/spinoso-string/Cargo.toml
+++ b/spinoso-string/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["encoding", "no_std", "spinoso", "string", "utf8"]
 categories = ["data-structures", "encoding", "no-std"]
 
 [dependencies]
-bstr = { version = "0.2", default-features = false, features = ["std"] }
+bstr = { version = "0.2, >= 0.2.9", default-features = false, features = ["std"] }
 bytecount = "0.6, >= 0.6.2"
 focaccia = { version = "1.0", optional = true, default-features = false }
 scolapasta-string-escape = { version = "0.2", path = "../scolapasta-string-escape", default-features = false }

--- a/spinoso-string/README.md
+++ b/spinoso-string/README.md
@@ -27,7 +27,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-spinoso-string = "0.8"
+spinoso-string = "0.9"
 ```
 
 ## `no_std`

--- a/spinoso-string/src/codepoints.rs
+++ b/spinoso-string/src/codepoints.rs
@@ -83,7 +83,7 @@ impl std::error::Error for CodepointsError {}
 ///
 /// ```
 /// use spinoso_string::{CodepointsError, String};
-/// # fn example() -> Result<(), Box<dyn std::error::Error>> {
+/// # fn example() -> Result<(), CodepointsError> {
 /// let s = String::from("hello");
 ///
 /// assert_eq!(s.codepoints()?.collect::<Vec<_>>(), [104, 101, 108, 108, 111]);
@@ -103,7 +103,7 @@ impl std::error::Error for CodepointsError {}
 ///
 /// ```
 /// use spinoso_string::String;
-/// # fn example() -> Result<(), Box<dyn std::error::Error>> {
+/// # fn example() -> Result<(), spinoso_string::CodepointsError> {
 /// let s = String::from("💎");
 ///
 /// assert_eq!(s.codepoints()?.collect::<Vec<_>>(), [u32::from('💎')]);

--- a/spinoso-string/src/inspect.rs
+++ b/spinoso-string/src/inspect.rs
@@ -351,7 +351,7 @@ impl<'a> FusedIterator for State<'a> {}
 
 #[cfg(test)]
 mod tests {
-    use std::string::String;
+    use alloc::string::String;
 
     use super::Inspect;
 

--- a/spinoso-string/src/lib.rs
+++ b/spinoso-string/src/lib.rs
@@ -356,7 +356,7 @@ impl std::error::Error for CenterError {}
 ///
 /// ```
 /// use spinoso_string::String;
-/// # fn example() -> Result<(), Box<dyn std::error::Error>> {
+/// # fn example() -> Result<(), spinoso_string::CenterError> {
 /// let s = String::from("hello");
 ///
 /// assert_eq!(s.center(4, None)?.collect::<Vec<_>>(), b"hello");
@@ -372,7 +372,7 @@ impl std::error::Error for CenterError {}
 ///
 /// ```
 /// use spinoso_string::String;
-/// # fn example() -> Result<(), Box<dyn std::error::Error>> {
+/// # fn example() -> Result<(), spinoso_string::CenterError> {
 /// let s = String::from("💎");
 ///
 /// assert_eq!(s.center(3, None)?.collect::<Vec<_>>(), " 💎 ".as_bytes());
@@ -1891,7 +1891,7 @@ impl String {
     ///
     /// ```
     /// use spinoso_string::String;
-    /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn example() -> Result<(), spinoso_string::CenterError> {
     /// let s = String::from("hello");
     ///
     /// assert_eq!(s.center(4, None)?.collect::<Vec<_>>(), b"hello");
@@ -1907,7 +1907,7 @@ impl String {
     ///
     /// ```
     /// use spinoso_string::String;
-    /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn example() -> Result<(), spinoso_string::CenterError> {
     /// let s = String::from("💎");
     ///
     /// assert_eq!(s.center(3, None)?.collect::<Vec<_>>(), " 💎 ".as_bytes());
@@ -2296,7 +2296,7 @@ impl String {
     /// ```
     /// use spinoso_string::{CodepointsError, String};
     ///
-    /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn example() -> Result<(), spinoso_string::CodepointsError> {
     /// let s = String::utf8(b"ab\xF0\x9F\x92\x8E\xFF".to_vec());
     /// assert!(matches!(s.codepoints(), Err(CodepointsError::InvalidUtf8Codepoint)));
     ///
@@ -2314,7 +2314,7 @@ impl String {
     /// ```
     /// use spinoso_string::String;
     ///
-    /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn example() -> Result<(), spinoso_string::CodepointsError> {
     /// let s = String::binary("💎".as_bytes().to_vec());
     /// let mut codepoints = s.codepoints()?;
     /// assert_eq!(codepoints.next(), Some(0xF0));


### PR DESCRIPTION
- Add `--workspace` flag to `cargo check` invocation for `rust-minimal-versions` CI job.
- Add `spinoso-string` to `check-sub-crates` CI job.

At least one of these jobs will fail since `spinoso-string` does not properly set its minimal version on `bstr`.

Bugs fixed:

- Fixup an import in inspect tests to pull `String` from `alloc`.
- Fixup doctests to not assume `Box` is in scope.
- Fixup doctests to not assume `std::error::Error` is available.
- Bump minimum required `bstr` version to 0.2.9 to ensure `ByteSlice::find_non_ascii_byte` and `ByteSlice::utf8_chunks` are available.

This PR was extracted from and blocks #1222.