### PR TITLE
Add APIs for encoding-aware character indexing and slicing to spinoso-string

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -680,7 +680,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-string"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "bstr",
  "bytecount",

--- a/spinoso-string/Cargo.toml
+++ b/spinoso-string/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spinoso-string"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2021"
 description = """

--- a/spinoso-string/README.md
+++ b/spinoso-string/README.md
@@ -27,7 +27,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-spinoso-string = "0.9"
+spinoso-string = "0.10"
 ```
 
 ## `no_std`

--- a/spinoso-string/src/lib.rs
+++ b/spinoso-string/src/lib.rs
@@ -2373,6 +2373,42 @@ impl String {
         }
     }
 
+    /// Returns the `index`'th character in the string.
+    ///
+    /// This function is encoding-aware. For `String`s with [UTF-8 encoding],
+    /// multi-byte Unicode characters are length 1 and invalid UTF-8 bytes are
+    /// length 1. For `String`s with [ASCII encoding] or [binary encoding],
+    /// this function is equivalent to [`get`] with a range of length 1.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use spinoso_string::String;
+    ///
+    /// let s = String::utf8(b"abc\xF0\x9F\x92\x8E\xFF".to_vec()); // "abc💎\xFF"
+    /// assert_eq!(s.get_char(0), Some(&b"a"[..]));
+    /// assert_eq!(s.get_char(1), Some(&b"b"[..]));
+    /// assert_eq!(s.get_char(2), Some(&b"c"[..]));
+    /// assert_eq!(s.get_char(3), Some("💎".as_bytes()));
+    /// assert_eq!(s.get_char(4), Some(&b"\xFF"[..]));
+    /// assert_eq!(s.get_char(5), None);
+    ///
+    /// let b = String::binary(b"abc\xF0\x9F\x92\x8E\xFF".to_vec()); // "abc💎\xFF"
+    /// assert_eq!(b.get_char(0), Some(&b"a"[..]));
+    /// assert_eq!(b.get_char(1), Some(&b"b"[..]));
+    /// assert_eq!(b.get_char(2), Some(&b"c"[..]));
+    /// assert_eq!(b.get_char(3), Some(&b"\xF0"[..]));
+    /// assert_eq!(b.get_char(4), Some(&b"\x9F"[..]));
+    /// assert_eq!(b.get_char(5), Some(&b"\x92"[..]));
+    /// assert_eq!(b.get_char(6), Some(&b"\x8E"[..]));
+    /// assert_eq!(b.get_char(7), Some(&b"\xFF"[..]));
+    /// assert_eq!(b.get_char(8), None);
+    /// ```
+    ///
+    /// [UTF-8 encoding]: crate::Encoding::Utf8
+    /// [ASCII encoding]: crate::Encoding::Ascii
+    /// [binary encoding]: crate::Encoding::Binary
+    /// [`get`]: Self::get
     #[inline]
     #[must_use]
     pub fn get_char(&self, index: usize) -> Option<&'_ [u8]> {
@@ -2413,6 +2449,36 @@ impl String {
         }
     }
 
+    /// Returns a substring of characters in the string.
+    ///
+    /// This function is encoding-aware. For `String`s with [UTF-8 encoding],
+    /// multi-byte Unicode characters are length 1 and invalid UTF-8 bytes are
+    /// length 1. For `String`s with [ASCII encoding] or [binary encoding],
+    /// this function is equivalent to [`get`] with a range.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use core::ops::Range;
+    /// use spinoso_string::String;
+    ///
+    /// let s = String::utf8(b"abc\xF0\x9F\x92\x8E\xFF".to_vec()); // "abc💎\xFF"
+    /// assert_eq!(s.get_char_slice(Range { start:  0, end:  1 }), Some(&b"a"[..]));
+    /// assert_eq!(s.get_char_slice(Range { start:  0, end:  3 }), Some(&b"abc"[..]));
+    /// assert_eq!(s.get_char_slice(Range { start:  0, end:  4 }), Some("abc💎".as_bytes()));
+    /// assert_eq!(s.get_char_slice(Range { start:  0, end:  5 }), Some(&b"abc\xF0\x9F\x92\x8E\xFF"[..]));
+    /// assert_eq!(s.get_char_slice(Range { start:  3, end: 10 }), Some(&b"\xF0\x9F\x92\x8E\xFF"[..]));
+    /// assert_eq!(s.get_char_slice(Range { start:  4, end: 10 }), Some(&b"\xFF"[..]));
+    /// assert_eq!(s.get_char_slice(Range { start: 10, end: 15 }), None);
+    /// assert_eq!(s.get_char_slice(Range { start: 15, end: 10 }), None);
+    /// assert_eq!(s.get_char_slice(Range { start: 15, end:  1 }), None);
+    /// assert_eq!(s.get_char_slice(Range { start:  4, end:  1 }), Some(&b""[..]));
+    /// ```
+    ///
+    /// [UTF-8 encoding]: crate::Encoding::Utf8
+    /// [ASCII encoding]: crate::Encoding::Ascii
+    /// [binary encoding]: crate::Encoding::Binary
+    /// [`get`]: Self::get
     #[inline]
     #[must_use]
     pub fn get_char_slice(&self, range: Range<usize>) -> Option<&'_ [u8]> {

--- a/spinoso-string/src/lib.rs
+++ b/spinoso-string/src/lib.rs
@@ -2542,9 +2542,23 @@ impl String {
         // => nil
         // [3.0.1] > "aaa"[3, 7]
         // => ""
+        // [3.0.1] > "🦀💎"[2, 0]
+        // => ""
+        // [3.0.1] > "🦀💎"[3, 1]
+        // => nil
+        // [3.0.1] > "🦀💎"[2, 1]
+        // => ""
         // ```
+        //
+        // Fast path rejection for indexes beyond bytesize, which is cheap to
+        // retrieve.
         if index > self.len() {
             return None;
+        }
+        match self.char_len() {
+            len if index > len => return None,
+            len if index == len => return Some(&[]),
+            _ => {}
         }
 
         // The span is guaranteed to at least partially overlap now.

--- a/spinoso-string/src/lib.rs
+++ b/spinoso-string/src/lib.rs
@@ -2412,38 +2412,87 @@ impl String {
     #[inline]
     #[must_use]
     pub fn get_char(&self, index: usize) -> Option<&'_ [u8]> {
+        // `Vec` has a max allocation size of `isize::MAX`. For a `Vec<u8>` like
+        // the one in `String` where the `size_of::<u8>() == 1`, the max length
+        // is `isize::MAX`. This checked add short circuits with `None` if we
+        // are given `usize::MAX` as an index, which we could never slice.
         let end = index.checked_add(1)?;
         match self.encoding {
+            // For ASCII and binary encodings, all character operations assume
+            // characters are exactly one byte, so we can fallback to byte
+            // slicing.
             Encoding::Ascii | Encoding::Binary => self.buf.get(index..end),
             Encoding::Utf8 => {
-                let last_ascii_byte_index = match self.buf.find_non_ascii_byte() {
+                // Fast path rejection for indexes beyond bytesize, which is
+                // cheap to retrieve.
+                if index >= self.len() {
+                    return None;
+                }
+                // Fast path for trying to treat the conventionally UTF-8 string
+                // as entirely ASCII.
+                //
+                // If the string is either all ASCII or all ASCII for a prefix
+                // of the string that contains the range we wish to slice,
+                // fallback to byte slicing as in the ASCII and binary fast path.
+                let consumed = match self.buf.find_non_ascii_byte() {
                     None => return self.buf.get(index..end),
                     Some(idx) if idx >= end => return self.buf.get(index..end),
                     Some(idx) => idx,
                 };
-                let mut slice = &self.buf[last_ascii_byte_index..];
-                let mut remaining = index - last_ascii_byte_index;
+                let mut slice = &self.buf[consumed..];
+                // Count of "characters" remaining until the `index`th character.
+                let mut remaining = index - consumed;
+                // This loop will terminate when either:
+                //
+                // - It counts `index` number of characters.
+                // - It consumes the entire slice when scanning for the
+                //   `index`th character.
+                //
+                // The loop will advance by at least one byte every iteration.
                 loop {
-                    if slice.is_empty() {
-                        return None;
-                    }
-                    let (ch, size) = bstr::decode_utf8(slice);
-                    if remaining == 0 {
-                        if ch.is_some() {
-                            return Some(&slice[..size]);
+                    match bstr::decode_utf8(slice) {
+                        // If we've run out of slice while trying to find the
+                        // `index`th character, the lookup fails and we return `nil`.
+                        (_, 0) => return None,
+
+                        // The next two arms mean we've reached the `index`th
+                        // character. Either return the next valid UTF-8
+                        // character byte slice or, if the next bytes are an
+                        // invalid UTF-8 sequence, the next byte.
+                        (Some(_), size) if remaining == 0 => return Some(&slice[..size]),
+                        // Size is guaranteed to be positive per the first arm
+                        // which means this slice operation will not panic.
+                        (None, _) if remaining == 0 => return Some(&slice[..1]),
+
+                        // We found a single UTF-8 encoded characterk keep track
+                        // of the count and advance the substring to continue
+                        // decoding.
+                        (Some(_), size) => {
+                            slice = &slice[size..];
+                            remaining -= 1;
                         }
-                        return Some(&slice[..1]);
+
+                        // The next two arms handle the case where we have
+                        // encountered an invalid UTF-8 byte sequence.
+                        //
+                        // In this case, `decode_utf8` will return slices whose
+                        // length is `1..=3`. The length of this slice is the
+                        // number of "characters" we can advance the loop by.
+                        //
+                        // If the invalid UTF-8 sequence contains more bytes
+                        // than we have remaining to get to the `index`th char,
+                        // then the target character is inside the invalid UTF-8
+                        // sequence.
+                        (None, size) if remaining < size => return Some(&slice[remaining..=remaining]),
+                        // If there are more characters remaining than the number
+                        // of bytes yielded in the invalid UTF-8 byte sequence,
+                        // count `size` bytes and advance the slice to continue
+                        // decoding.
+                        (None, size) => {
+                            slice = &slice[size..];
+                            remaining -= size;
+                        }
                     }
-                    if ch.is_some() {
-                        slice = &slice[size..];
-                        remaining -= 1;
-                        continue;
-                    }
-                    if remaining < size {
-                        return Some(&slice[remaining..=remaining]);
-                    }
-                    remaining -= size;
-                    slice = &slice[size..];
                 }
             }
         }

--- a/spinoso-string/src/lib.rs
+++ b/spinoso-string/src/lib.rs
@@ -1938,7 +1938,7 @@ impl String {
     /// from the end of str (if given).
     ///
     /// If `separator` is [`None`] (i.e. `separator` has not been changed from
-    /// the default Ruby record separator, then `chomp` also removes carriage
+    /// the default Ruby record separator), then `chomp` also removes carriage
     /// return characters (that is it will remove `\n`, `\r`, and `\r\n`). If
     /// `separator` is an empty string, it will remove all trailing newlines
     /// from the string.
@@ -1947,6 +1947,8 @@ impl String {
     /// separator. For `str.chomp nil`, MRI returns `str.dup`. For
     /// `str.chomp! nil`, MRI makes no changes to the receiver and returns
     /// `nil`.
+    ///
+    /// This function returns `true` if self is modified, `false` otherwise.
     ///
     /// # Examples
     ///

--- a/spinoso-string/src/lib.rs
+++ b/spinoso-string/src/lib.rs
@@ -2459,7 +2459,8 @@ impl String {
                 let last_ascii_byte_index = match self.buf.find_non_ascii_byte() {
                     None => return self.buf.get(index..end).or_else(|| self.buf.get(index..)),
                     Some(idx) if idx >= end => return self.buf.get(index..end).or_else(|| self.buf.get(index..)),
-                    Some(idx) => idx,
+                    Some(idx) if idx < index => idx,
+                    Some(_) => 0,
                 };
                 // Scan for the beginning of the slice
                 let mut slice = &self.buf[last_ascii_byte_index..];

--- a/spinoso-string/src/lib.rs
+++ b/spinoso-string/src/lib.rs
@@ -2406,6 +2406,7 @@ impl String {
                         return Some(&slice[remaining..=remaining]);
                     }
                     remaining -= size;
+                    slice = &slice[size..];
                 }
             }
         }


### PR DESCRIPTION
In Ruby, `String#[]` with either integer or range arguments performs substring slicing based on characters in the `String`s declared encoding.

```ruby
"🦀💎"[1]
=> "💎"
"🦀💎"[1, 10]
=> "💎"
```

Introduce `spinoso_string::String::get_char` for encoding-aware single character lookups. `get_char` returns `Option<&'_ [u8]>`.

Introduce `spinoso_string::String::get_char_slice` for encoding-aware character range lookups. `get_char_slice` returns `Option<&'_ [u8]>`. `get_char_slice` handles backwards ranges, ranges that start at `s.length`, and ranges that run beyond `s.length` in the same manner as MRI.

The algorithm for UTF-8 aware slicing is fairly complicated and extensively documented with inline comments and snippets from an MRI Ruby 3.0.2 REPL session. The algorithm is further complicated by a variety of fast paths and short circuiting in attempts to avoid an expensive byte-at-a-time UTF-8 decode.

Bump `spinoso-string` to v0.10.0.

This PR has made me realize that `spinoso-string` would be better structured if a `String`'s encoding were represented in the Rust type system. If `BinaryString` and `AsciiString` were their own types, the `Utf8String` type would be able to bump down the indentation level a lot and the fast pathing would be isolated to the cases that need it. See https://twitter.com/artichokeruby/status/1464117273862443010 for more context and thoughts along these lines. I'd like to defer work here until after #1222 is merged.

This PR was plucked out of #1222 from these commits:

- https://github.com/artichoke/artichoke/pull/1222/commits/e11c4d3e13fcae886bb76d10abd7395fc0d2d7aa
- https://github.com/artichoke/artichoke/pull/1222/commits/93241e0e80b99e7384a96d9be4caf335fa8ec36c
- https://github.com/artichoke/artichoke/pull/1222/commits/b324be1ff878de8fbfe985a1830eb2c354f3e84f