### PR TITLE
Fix comment for `shrink_to` function implementation

### DIFF
--- a/artichoke-backend/src/class/registry.rs
+++ b/artichoke-backend/src/class/registry.rs
@@ -226,7 +226,7 @@ where
         self.0.shrink_to_fit();
     }
 
-    /// Shrinks the capacity of the symbol table with a lower bound.
+    /// Shrinks the capacity of the registry with a lower bound.
     /// The capacity will remain at least as large as both the length and the
     /// supplied value.
     ///

--- a/artichoke-backend/src/module/registry.rs
+++ b/artichoke-backend/src/module/registry.rs
@@ -226,7 +226,7 @@ where
         self.0.shrink_to_fit();
     }
 
-    /// Shrinks the capacity of the symbol table with a lower bound.
+    /// Shrinks the capacity of the registry with a lower bound.
     /// The capacity will remain at least as large as both the length and the
     /// supplied value.
     ///


### PR DESCRIPTION
These changes are based on the comments here: https://github.com/artichoke/artichoke/pull/1520#discussion_r757960871 in #1520 