### PR TITLE
Remove references to webpack from ARCHITECTURE.md

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -393,12 +393,11 @@ Playground][playground-repo] runs a [WebAssembly] build of
 The Artichoke project hosts a project website at
 <https://www.artichokeruby.org>.
 
-The website is a [Webpack]-generated static site which is deployed on [GitHub
-Pages]. The source code can be found in the [artichoke/www.artichokeruby.org]
-repository and is [deployed automatically][github-actions-www-deploy] when PRs
-are merged.
+The website is a static site built with a custom static site generator which is
+deployed on [GitHub Pages]. The source code can be found in the
+[artichoke/www.artichokeruby.org] repository and is [deployed
+automatically][github-actions-www-deploy] when PRs are merged.
 
-[webpack]: https://webpack.js.org/
 [github pages]: https://pages.github.com/
 [artichoke/www.artichokeruby.org]:
   https://github.com/artichoke/www.artichokeruby.org


### PR DESCRIPTION
All Artichoke properties have discontinued using webpack as part of
their build pipeline.

See:

- https://github.com/artichoke/artichoke.github.io/pull/91
- https://github.com/artichoke/playground/pull/697
- https://github.com/artichoke/rubyconf/pull/367
- https://github.com/artichoke/www.artichokeruby.org/pull/431