### PR TITLE
Remove potential for stack overflow when booting interpreter

### DIFF
--- a/artichoke-backend/src/extn/core/array/mruby.rs
+++ b/artichoke-backend/src/extn/core/array/mruby.rs
@@ -4,11 +4,13 @@ use crate::extn::core::array::{trampoline, Array};
 use crate::extn::prelude::*;
 
 const ARRAY_CSTR: &CStr = cstr::cstr!("Array");
+static ARRAY_RUBY_SOURCE: &[u8] = include_bytes!("array.rb");
 
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     if interp.is_class_defined::<Array>() {
         return Ok(());
     }
+
     let spec = class::Spec::new("Array", ARRAY_CSTR, None, Some(def::box_unbox_free::<Array>))?;
     class::Builder::for_spec(interp, &spec)
         .add_self_method("[]", ary_cls_constructor, sys::mrb_args_rest())?
@@ -34,8 +36,8 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
         .add_method("size", ary_len, sys::mrb_args_none())?
         .define()?;
     interp.def_class::<Array>(spec)?;
-    interp.eval(&include_bytes!("array.rb")[..])?;
-    trace!("Patched Array onto interpreter");
+    interp.eval(ARRAY_RUBY_SOURCE)?;
+
     Ok(())
 }
 

--- a/artichoke-backend/src/extn/core/artichoke/mod.rs
+++ b/artichoke-backend/src/extn/core/artichoke/mod.rs
@@ -8,10 +8,11 @@ pub fn init(interp: &mut crate::Artichoke) -> InitializeResult<()> {
     if interp.is_module_defined::<Artichoke>() {
         return Ok(());
     }
+
     let spec = module::Spec::new(interp, "Artichoke", ARTICHOKE_CSTR, None)?;
     module::Builder::for_spec(interp, &spec).define()?;
     interp.def_module::<Artichoke>(spec)?;
-    trace!("Patched Artichoke onto interpreter");
+
     Ok(())
 }
 

--- a/artichoke-backend/src/extn/core/basicobject/mod.rs
+++ b/artichoke-backend/src/extn/core/basicobject/mod.rs
@@ -3,15 +3,17 @@ use std::ffi::CStr;
 use crate::extn::prelude::*;
 
 const BASIC_OBJECT_CSTR: &CStr = cstr::cstr!("BasicObject");
+static BASIC_OBJECT_RUBY_SOURCE: &[u8] = include_bytes!("basicobject.rb");
 
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     if interp.is_class_defined::<BasicObject>() {
         return Ok(());
     }
+
     let spec = class::Spec::new("BasicObject", BASIC_OBJECT_CSTR, None, None)?;
     interp.def_class::<BasicObject>(spec)?;
-    interp.eval(&include_bytes!("basicobject.rb")[..])?;
-    trace!("Patched BasicObject onto interpreter");
+    interp.eval(BASIC_OBJECT_RUBY_SOURCE)?;
+
     Ok(())
 }
 

--- a/artichoke-backend/src/extn/core/comparable/mod.rs
+++ b/artichoke-backend/src/extn/core/comparable/mod.rs
@@ -3,16 +3,18 @@ use std::ffi::CStr;
 use crate::extn::prelude::*;
 
 const COMPARABLE_CSTR: &CStr = cstr::cstr!("Comparable");
+static COMPARABLE_RUBY_SOURCE: &[u8] = include_bytes!("comparable.rb");
 
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     if interp.is_module_defined::<Comparable>() {
         return Ok(());
     }
+
     let spec = module::Spec::new(interp, "Comparable", COMPARABLE_CSTR, None)?;
     module::Builder::for_spec(interp, &spec).define()?;
     interp.def_module::<Comparable>(spec)?;
-    interp.eval(&include_bytes!("comparable.rb")[..])?;
-    trace!("Patched Comparable onto interpreter");
+    interp.eval(COMPARABLE_RUBY_SOURCE)?;
+
     Ok(())
 }
 

--- a/artichoke-backend/src/extn/core/enumerable/mod.rs
+++ b/artichoke-backend/src/extn/core/enumerable/mod.rs
@@ -3,16 +3,18 @@ use std::ffi::CStr;
 use crate::extn::prelude::*;
 
 const ENUMERABLE_CSTR: &CStr = cstr::cstr!("Enumerable");
+static ENUMERABLE_RUBY_SOURCE: &[u8] = include_bytes!("enumerable.rb");
 
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     if interp.is_module_defined::<Enumerable>() {
         return Ok(());
     }
+
     let spec = module::Spec::new(interp, "Enumerable", ENUMERABLE_CSTR, None)?;
     module::Builder::for_spec(interp, &spec).define()?;
     interp.def_module::<Enumerable>(spec)?;
-    interp.eval(&include_bytes!("enumerable.rb")[..])?;
-    trace!("Patched Enumerable onto interpreter");
+    interp.eval(ENUMERABLE_RUBY_SOURCE)?;
+
     Ok(())
 }
 

--- a/artichoke-backend/src/extn/core/enumerator/mod.rs
+++ b/artichoke-backend/src/extn/core/enumerator/mod.rs
@@ -3,17 +3,19 @@ use std::ffi::CStr;
 use crate::extn::prelude::*;
 
 const ENUMERATOR_CSTR: &CStr = cstr::cstr!("Enumerator");
+static ENUMERATOR_RUBY_SOURCE: &[u8] = include_bytes!("enumerator.rb");
+static ENUMERATOR_LAZY_RUBY_SOURCE: &[u8] = include_bytes!("lazy.rb");
 
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     if interp.is_class_defined::<Enumerator>() {
         return Ok(());
     }
+
     let spec = class::Spec::new("Enumerator", ENUMERATOR_CSTR, None, None)?;
     interp.def_class::<Enumerator>(spec)?;
-    interp.eval(&include_bytes!("enumerator.rb")[..])?;
-    interp.eval(&include_bytes!("lazy.rb")[..])?;
-    trace!("Patched Enumerator onto interpreter");
-    trace!("Patched Enumerator::Lazy onto interpreter");
+    interp.eval(ENUMERATOR_RUBY_SOURCE)?;
+    interp.eval(ENUMERATOR_LAZY_RUBY_SOURCE)?;
+
     Ok(())
 }
 

--- a/artichoke-backend/src/extn/core/env/mruby.rs
+++ b/artichoke-backend/src/extn/core/env/mruby.rs
@@ -2,18 +2,18 @@
 
 use std::ffi::CStr;
 
-use spinoso_env::RUBY_API_POLYFILLS;
-
 use crate::extn::core::artichoke;
 use crate::extn::core::env::{self, trampoline};
 use crate::extn::prelude::*;
 
 const ENVIRON_CSTR: &CStr = cstr::cstr!("Environ");
+static ENV_RUBY_SOURCE: &[u8] = spinoso_env::RUBY_API_POLYFILLS.as_bytes();
 
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     if interp.is_class_defined::<env::Environ>() {
         return Ok(());
     }
+
     let scope = interp
         .module_spec::<artichoke::Artichoke>()?
         .map(EnclosingRubyScope::module)
@@ -32,9 +32,8 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
         .add_method("to_h", env_to_h, sys::mrb_args_none())?
         .define()?;
     interp.def_class::<env::Environ>(spec)?;
-    interp.eval(RUBY_API_POLYFILLS.as_bytes())?;
-    trace!("Patched ENV onto interpreter");
-    trace!("Patched Artichoke::Environ onto interpreter");
+    interp.eval(ENV_RUBY_SOURCE)?;
+
     Ok(())
 }
 

--- a/artichoke-backend/src/extn/core/exception/mruby.rs
+++ b/artichoke-backend/src/extn/core/exception/mruby.rs
@@ -39,6 +39,8 @@ const SYSTEM_EXIT_CSTR: &CStr = cstr::cstr!("SystemExit");
 const SYSTEM_STACK_CSTR: &CStr = cstr::cstr!("SystemStackError");
 const FATAL_CSTR: &CStr = cstr::cstr!("fatal");
 
+static EXCEPTION_RUBY_SOURCE: &[u8] = include_bytes!("exception.rb");
+
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     let exception_spec = class::Spec::new("Exception", EXCEPTION_CSTR, None, None)?;
     class::Builder::for_spec(interp, &exception_spec).define()?;
@@ -244,8 +246,7 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
         .define()?;
     interp.def_class::<Fatal>(fatal_spec)?;
 
-    interp.eval(&include_bytes!("exception.rb")[..])?;
-    trace!("Patched Exception onto interpreter");
-    trace!("Patched core exception hierarchy onto interpreter");
+    interp.eval(EXCEPTION_RUBY_SOURCE)?;
+
     Ok(())
 }

--- a/artichoke-backend/src/extn/core/falseclass/mod.rs
+++ b/artichoke-backend/src/extn/core/falseclass/mod.rs
@@ -3,15 +3,17 @@ use std::ffi::CStr;
 use crate::extn::prelude::*;
 
 const FALSE_CLASS_CSTR: &CStr = cstr::cstr!("FalseClass");
+static FALSE_CLASS_RUBY_SOURCE: &[u8] = include_bytes!("falseclass.rb");
 
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     if interp.is_class_defined::<FalseClass>() {
         return Ok(());
     }
+
     let spec = class::Spec::new("FalseClass", FALSE_CLASS_CSTR, None, None)?;
     interp.def_class::<FalseClass>(spec)?;
-    interp.eval(&include_bytes!("falseclass.rb")[..])?;
-    trace!("Patched FalseClass onto interpreter");
+    interp.eval(FALSE_CLASS_RUBY_SOURCE)?;
+
     Ok(())
 }
 

--- a/artichoke-backend/src/extn/core/float/mruby.rs
+++ b/artichoke-backend/src/extn/core/float/mruby.rs
@@ -4,14 +4,16 @@ use crate::extn::core::float::Float;
 use crate::extn::prelude::*;
 
 const FLOAT_CSTR: &CStr = cstr::cstr!("Float");
+static FLOAT_RUBY_SOURCE: &[u8] = include_bytes!("float.rb");
 
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     if interp.is_class_defined::<Float>() {
         return Ok(());
     }
+
     let spec = class::Spec::new("Float", FLOAT_CSTR, None, None)?;
     interp.def_class::<Float>(spec)?;
-    interp.eval(&include_bytes!("float.rb")[..])?;
+    interp.eval(FLOAT_RUBY_SOURCE)?;
 
     let dig = interp.convert(Float::DIG);
     interp.define_class_constant::<Float>("DIG", dig)?;
@@ -40,6 +42,5 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     let rounds = interp.convert(Float::ROUNDS);
     interp.define_class_constant::<Float>("ROUNDS", rounds)?;
 
-    trace!("Patched Float onto interpreter");
     Ok(())
 }

--- a/artichoke-backend/src/extn/core/hash/mod.rs
+++ b/artichoke-backend/src/extn/core/hash/mod.rs
@@ -3,15 +3,17 @@ use std::ffi::CStr;
 use crate::extn::prelude::*;
 
 const HASH_CSTR: &CStr = cstr::cstr!("Hash");
+static HASH_RUBY_SOURCE: &[u8] = include_bytes!("hash.rb");
 
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     if interp.is_class_defined::<Hash>() {
         return Ok(());
     }
+
     let spec = class::Spec::new("Hash", HASH_CSTR, None, None)?;
     interp.def_class::<Hash>(spec)?;
-    interp.eval(&include_bytes!("hash.rb")[..])?;
-    trace!("Patched Hash onto interpreter");
+    interp.eval(HASH_RUBY_SOURCE)?;
+
     Ok(())
 }
 

--- a/artichoke-backend/src/extn/core/integer/mruby.rs
+++ b/artichoke-backend/src/extn/core/integer/mruby.rs
@@ -5,11 +5,13 @@ use crate::extn::core::integer::Integer;
 use crate::extn::prelude::*;
 
 const INTEGER_CSTR: &CStr = cstr::cstr!("Integer");
+static INTEGER_RUBY_SOURCE: &[u8] = include_bytes!("integer.rb");
 
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     if interp.is_class_defined::<Integer>() {
         return Ok(());
     }
+
     let spec = class::Spec::new("Integer", INTEGER_CSTR, None, None)?;
     class::Builder::for_spec(interp, &spec)
         .add_method("chr", integer_chr, sys::mrb_args_opt(1))?
@@ -21,8 +23,8 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
         .add_method("size", integer_size, sys::mrb_args_none())?
         .define()?;
     interp.def_class::<Integer>(spec)?;
-    interp.eval(&include_bytes!("integer.rb")[..])?;
-    trace!("Patched Integer onto interpreter");
+    interp.eval(INTEGER_RUBY_SOURCE)?;
+
     Ok(())
 }
 

--- a/artichoke-backend/src/extn/core/matchdata/mruby.rs
+++ b/artichoke-backend/src/extn/core/matchdata/mruby.rs
@@ -4,11 +4,13 @@ use crate::extn::core::matchdata::{self, trampoline};
 use crate::extn::prelude::*;
 
 const MATCH_DATA_CSTR: &CStr = cstr::cstr!("MatchData");
+static MATCH_DATA_RUBY_SOURCE: &[u8] = include_bytes!("matchdata.rb");
 
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     if interp.is_class_defined::<matchdata::MatchData>() {
         return Ok(());
     }
+
     let spec = class::Spec::new(
         "MatchData",
         MATCH_DATA_CSTR,
@@ -34,8 +36,8 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
         .add_method("end", matchdata_end, sys::mrb_args_req(1))?
         .define()?;
     interp.def_class::<matchdata::MatchData>(spec)?;
-    interp.eval(&include_bytes!("matchdata.rb")[..])?;
-    trace!("Patched MatchData onto interpreter");
+    interp.eval(MATCH_DATA_RUBY_SOURCE)?;
+
     Ok(())
 }
 

--- a/artichoke-backend/src/extn/core/math/mruby.rs
+++ b/artichoke-backend/src/extn/core/math/mruby.rs
@@ -13,6 +13,7 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     if interp.is_module_defined::<Math>() {
         return Ok(());
     }
+
     let spec = module::Spec::new(interp, "Math", MATH_CSTR, None)?;
     module::Builder::for_spec(interp, &spec)
         .add_module_method("acos", math_acos, sys::mrb_args_req(1))?
@@ -59,6 +60,7 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     interp.define_module_constant::<Math>("E", e)?;
     let pi = interp.convert_mut(math::PI);
     interp.define_module_constant::<Math>("PI", pi)?;
+
     Ok(())
 }
 

--- a/artichoke-backend/src/extn/core/method/mod.rs
+++ b/artichoke-backend/src/extn/core/method/mod.rs
@@ -3,15 +3,17 @@ use std::ffi::CStr;
 use crate::extn::prelude::*;
 
 const METHOD_CSTR: &CStr = cstr::cstr!("Method");
+static METHOD_RUBY_SOURCE: &[u8] = include_bytes!("method.rb");
 
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     if interp.is_class_defined::<Method>() {
         return Ok(());
     }
+
     let spec = class::Spec::new("Method", METHOD_CSTR, None, None)?;
     interp.def_class::<Method>(spec)?;
-    interp.eval(&include_bytes!("method.rb")[..])?;
-    trace!("Patched Method onto interpreter");
+    interp.eval(METHOD_RUBY_SOURCE)?;
+
     Ok(())
 }
 

--- a/artichoke-backend/src/extn/core/mod.rs
+++ b/artichoke-backend/src/extn/core/mod.rs
@@ -55,7 +55,7 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     #[cfg(feature = "core-env")]
     env::mruby::init(interp)?;
     hash::init(interp)?;
-    numeric::init(interp)?;
+    numeric::mruby::init(interp)?;
     integer::mruby::init(interp)?;
     float::mruby::init(interp)?;
     kernel::mruby::init(interp)?;

--- a/artichoke-backend/src/extn/core/module/mod.rs
+++ b/artichoke-backend/src/extn/core/module/mod.rs
@@ -3,15 +3,17 @@ use std::ffi::CStr;
 use crate::extn::prelude::*;
 
 const MODULE_CSTR: &CStr = cstr::cstr!("Module");
+static MODULE_RUBY_SOURCE: &[u8] = include_bytes!("module.rb");
 
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     if interp.is_class_defined::<Module>() {
         return Ok(());
     }
+
     let spec = class::Spec::new("Module", MODULE_CSTR, None, None)?;
     interp.def_class::<Module>(spec)?;
-    interp.eval(&include_bytes!("module.rb")[..])?;
-    trace!("Patched Module onto interpreter");
+    interp.eval(MODULE_RUBY_SOURCE)?;
+
     Ok(())
 }
 

--- a/artichoke-backend/src/extn/core/nilclass/mod.rs
+++ b/artichoke-backend/src/extn/core/nilclass/mod.rs
@@ -3,15 +3,17 @@ use std::ffi::CStr;
 use crate::extn::prelude::*;
 
 const NIL_CLASS_CSTR: &CStr = cstr::cstr!("NilClass");
+static NIL_CLASS_RUBY_SOURCE: &[u8] = include_bytes!("nilclass.rb");
 
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     if interp.is_class_defined::<NilClass>() {
         return Ok(());
     }
+
     let spec = class::Spec::new("NilClass", NIL_CLASS_CSTR, None, None)?;
     interp.def_class::<NilClass>(spec)?;
-    interp.eval(&include_bytes!("nilclass.rb")[..])?;
-    trace!("Patched NilClass onto interpreter");
+    interp.eval(NIL_CLASS_RUBY_SOURCE)?;
+
     Ok(())
 }
 

--- a/artichoke-backend/src/extn/core/numeric/mod.rs
+++ b/artichoke-backend/src/extn/core/numeric/mod.rs
@@ -1,22 +1,8 @@
-use std::ffi::CStr;
-
 use crate::extn::core::integer::Integer;
 use crate::extn::prelude::*;
 
 mod ffi;
-
-const NUMERIC_CSTR: &CStr = cstr::cstr!("Numeric");
-
-pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
-    if interp.is_class_defined::<Numeric>() {
-        return Ok(());
-    }
-    let spec = class::Spec::new("Numeric", NUMERIC_CSTR, None, None)?;
-    interp.def_class::<Numeric>(spec)?;
-    interp.eval(&include_bytes!("numeric.rb")[..])?;
-    trace!("Patched Numeric onto interpreter");
-    Ok(())
-}
+pub mod mruby;
 
 #[derive(Debug, Clone, Copy)]
 pub struct Numeric;

--- a/artichoke-backend/src/extn/core/numeric/mruby.rs
+++ b/artichoke-backend/src/extn/core/numeric/mruby.rs
@@ -1,0 +1,17 @@
+use std::ffi::CStr;
+
+use crate::extn::core::numeric::Numeric;
+use crate::extn::prelude::*;
+
+const NUMERIC_CSTR: &CStr = cstr::cstr!("Numeric");
+static NUMERIC_RUBY_SOURCE: &[u8] = include_bytes!("numeric.rb");
+
+pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
+    if interp.is_class_defined::<Numeric>() {
+        return Ok(());
+    }
+    let spec = class::Spec::new("Numeric", NUMERIC_CSTR, None, None)?;
+    interp.def_class::<Numeric>(spec)?;
+    interp.eval(NUMERIC_RUBY_SOURCE)?;
+    Ok(())
+}

--- a/artichoke-backend/src/extn/core/object/mod.rs
+++ b/artichoke-backend/src/extn/core/object/mod.rs
@@ -3,15 +3,17 @@ use std::ffi::CStr;
 use crate::extn::prelude::*;
 
 const OBJECT_CSTR: &CStr = cstr::cstr!("Object");
+static OBJECT_RUBY_SOURCE: &[u8] = include_bytes!("object.rb");
 
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     if interp.is_class_defined::<Object>() {
         return Ok(());
     }
+
     let spec = class::Spec::new("Object", OBJECT_CSTR, None, None)?;
     interp.def_class::<Object>(spec)?;
-    interp.eval(&include_bytes!("object.rb")[..])?;
-    trace!("Patched Object onto interpreter");
+    interp.eval(OBJECT_RUBY_SOURCE)?;
+
     Ok(())
 }
 

--- a/artichoke-backend/src/extn/core/proc/mod.rs
+++ b/artichoke-backend/src/extn/core/proc/mod.rs
@@ -3,15 +3,17 @@ use std::ffi::CStr;
 use crate::extn::prelude::*;
 
 const PROC_CSTR: &CStr = cstr::cstr!("Proc");
+static PROC_RUBY_SOURCE: &[u8] = include_bytes!("proc.rb");
 
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     if interp.is_class_defined::<Proc>() {
         return Ok(());
     }
+
     let spec = class::Spec::new("Proc", PROC_CSTR, None, None)?;
     interp.def_class::<Proc>(spec)?;
-    interp.eval(&include_bytes!("proc.rb")[..])?;
-    trace!("Patched Proc onto interpreter");
+    interp.eval(PROC_RUBY_SOURCE)?;
+
     Ok(())
 }
 

--- a/artichoke-backend/src/extn/core/random/mruby.rs
+++ b/artichoke-backend/src/extn/core/random/mruby.rs
@@ -6,11 +6,13 @@ use super::{trampoline, Rng};
 use crate::extn::prelude::*;
 
 const RANDOM_CSTR: &CStr = cstr::cstr!("Random");
+static RANDOM_RUBY_SOURCE: &[u8] = include_bytes!("random.rb");
 
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     if interp.is_class_defined::<Rng>() {
         return Ok(());
     }
+
     let spec = class::Spec::new("Random", RANDOM_CSTR, None, Some(def::box_unbox_free::<Rng>))?;
     class::Builder::for_spec(interp, &spec)
         .value_is_rust_object()
@@ -28,8 +30,8 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     let default = Rng::Global;
     let default = Rng::alloc_value(default, interp).map_err(|_| NotDefinedError::class_constant("Random::DEFAULT"))?;
     interp.define_class_constant::<Rng>("DEFAULT", default)?;
-    interp.eval(&include_bytes!("random.rb")[..])?;
-    trace!("Patched Random onto interpreter");
+    interp.eval(RANDOM_RUBY_SOURCE)?;
+
     Ok(())
 }
 

--- a/artichoke-backend/src/extn/core/range/mod.rs
+++ b/artichoke-backend/src/extn/core/range/mod.rs
@@ -3,15 +3,17 @@ use std::ffi::CStr;
 use crate::extn::prelude::*;
 
 const RANGE_CSTR: &CStr = cstr::cstr!("Range");
+static RANGE_RUBY_SOURCE: &[u8] = include_bytes!("range.rb");
 
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     if interp.is_class_defined::<Range>() {
         return Ok(());
     }
+
     let spec = class::Spec::new("Range", RANGE_CSTR, None, None)?;
     interp.def_class::<Range>(spec)?;
-    interp.eval(&include_bytes!("range.rb")[..])?;
-    trace!("Patched Range onto interpreter");
+    interp.eval(RANGE_RUBY_SOURCE)?;
+
     Ok(())
 }
 

--- a/artichoke-backend/src/extn/core/regexp/mruby.rs
+++ b/artichoke-backend/src/extn/core/regexp/mruby.rs
@@ -4,11 +4,13 @@ use super::{trampoline, Flags, Regexp};
 use crate::extn::prelude::*;
 
 const REGEXP_CSTR: &CStr = cstr::cstr!("Regexp");
+static REGEXP_RUBY_SOURCE: &[u8] = include_bytes!("regexp.rb");
 
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     if interp.is_class_defined::<Regexp>() {
         return Ok(());
     }
+
     let spec = class::Spec::new("Regexp", REGEXP_CSTR, None, Some(def::box_unbox_free::<Regexp>))?;
     class::Builder::for_spec(interp, &spec)
         .value_is_rust_object()
@@ -35,7 +37,7 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
         .define()?;
     interp.def_class::<Regexp>(spec)?;
 
-    interp.eval(&include_bytes!("regexp.rb")[..])?;
+    interp.eval(REGEXP_RUBY_SOURCE)?;
 
     // Declare class constants
     let ignorecase = interp.convert(Flags::IGNORECASE.bits());
@@ -49,7 +51,6 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     let no_encoding = interp.convert(Flags::NOENCODING.bits());
     interp.define_class_constant::<Regexp>("NOENCODING", no_encoding)?;
 
-    trace!("Patched Regexp onto interpreter");
     Ok(())
 }
 

--- a/artichoke-backend/src/extn/core/string/mruby.rs
+++ b/artichoke-backend/src/extn/core/string/mruby.rs
@@ -4,11 +4,13 @@ use crate::extn::core::string::{self, trampoline};
 use crate::extn::prelude::*;
 
 const STRING_CSTR: &CStr = cstr::cstr!("String");
+static STRING_RUBY_SOURCE: &[u8] = include_bytes!("string.rb");
 
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     if interp.is_class_defined::<string::String>() {
         return Ok(());
     }
+
     let spec = class::Spec::new("String", STRING_CSTR, None, None)?;
     class::Builder::for_spec(interp, &spec)
         .add_method("*", string_mul, sys::mrb_args_req(1))?
@@ -70,8 +72,8 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
         .add_method("valid_encoding?", string_valid_encoding, sys::mrb_args_none())?
         .define()?;
     interp.def_class::<string::String>(spec)?;
-    interp.eval(&include_bytes!("string.rb")[..])?;
-    trace!("Patched String onto interpreter");
+    interp.eval(STRING_RUBY_SOURCE)?;
+
     Ok(())
 }
 

--- a/artichoke-backend/src/extn/core/symbol/mruby.rs
+++ b/artichoke-backend/src/extn/core/symbol/mruby.rs
@@ -4,11 +4,13 @@ use crate::extn::core::symbol::{self, trampoline};
 use crate::extn::prelude::*;
 
 const SYMBOL_CSTR: &CStr = cstr::cstr!("Symbol");
+static SYMBOL_RUBY_SOURCE: &[u8] = include_bytes!("symbol.rb");
 
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     if interp.is_class_defined::<symbol::Symbol>() {
         return Ok(());
     }
+
     let spec = class::Spec::new("Symbol", SYMBOL_CSTR, None, None)?;
     class::Builder::for_spec(interp, &spec)
         .add_self_method("all_symbols", symbol_all_symbols, sys::mrb_args_none())?
@@ -21,8 +23,8 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
         .add_method("to_s", symbol_to_s, sys::mrb_args_none())?
         .define()?;
     interp.def_class::<symbol::Symbol>(spec)?;
-    interp.eval(&include_bytes!("symbol.rb")[..])?;
-    trace!("Patched Symbol onto interpreter");
+    interp.eval(SYMBOL_RUBY_SOURCE)?;
+
     Ok(())
 }
 

--- a/artichoke-backend/src/extn/core/thread/mod.rs
+++ b/artichoke-backend/src/extn/core/thread/mod.rs
@@ -4,6 +4,7 @@ use crate::extn::prelude::*;
 
 const THREAD_CSTR: &CStr = cstr::cstr!("Thread");
 const MUTEX_CSTR: &CStr = cstr::cstr!("Mutex");
+static THREAD_RUBY_SOURCE: &[u8] = include_bytes!("thread.rb");
 
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     if interp.is_class_defined::<Thread>() {
@@ -12,18 +13,18 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     if interp.is_class_defined::<Mutex>() {
         return Ok(());
     }
+
     let spec = class::Spec::new("Thread", THREAD_CSTR, None, None)?;
     interp.def_class::<Thread>(spec)?;
     let spec = class::Spec::new("Mutex", MUTEX_CSTR, None, None)?;
     interp.def_class::<Mutex>(spec)?;
     // TODO: Don't add a source file and don't add an explicit require below.
     // Instead, have thread be a default loaded feature in `mezzaluna-feature-loader`.
-    interp.def_rb_source_file("thread.rb", &include_bytes!("thread.rb")[..])?;
+    interp.def_rb_source_file("thread.rb", THREAD_RUBY_SOURCE)?;
     // Thread is loaded by default, so eval it on interpreter initialization
     // https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/UnneededRequireStatement
     interp.eval(&b"require 'thread'"[..])?;
-    trace!("Patched Thread onto interpreter");
-    trace!("Patched Mutex onto interpreter");
+
     Ok(())
 }
 

--- a/artichoke-backend/src/extn/core/time/mruby.rs
+++ b/artichoke-backend/src/extn/core/time/mruby.rs
@@ -11,6 +11,7 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     if interp.is_class_defined::<time::Time>() {
         return Ok(());
     }
+
     let spec = class::Spec::new("Time", TIME_CSTR, None, Some(def::box_unbox_free::<time::Time>))?;
     // NOTE: The ordering of method declarations in the builder below is the
     // same as in `Init_Time` in MRI `time.c`.
@@ -95,7 +96,6 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
         .define()?;
     interp.def_class::<time::Time>(spec)?;
 
-    trace!("Patched Time onto interpreter");
     Ok(())
 }
 

--- a/artichoke-backend/src/extn/core/trueclass/mod.rs
+++ b/artichoke-backend/src/extn/core/trueclass/mod.rs
@@ -3,15 +3,17 @@ use std::ffi::CStr;
 use crate::extn::prelude::*;
 
 const TRUE_CLASS_CSTR: &CStr = cstr::cstr!("TrueClass");
+static TRUE_CLASS_RUBY_SOURCE: &[u8] = include_bytes!("trueclass.rb");
 
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     if interp.is_class_defined::<TrueClass>() {
         return Ok(());
     }
+
     let spec = class::Spec::new("TrueClass", TRUE_CLASS_CSTR, None, None)?;
     interp.def_class::<TrueClass>(spec)?;
-    interp.eval(&include_bytes!("trueclass.rb")[..])?;
-    trace!("Patched TrueClass onto interpreter");
+    interp.eval(TRUE_CLASS_RUBY_SOURCE)?;
+
     Ok(())
 }
 

--- a/artichoke-backend/src/extn/core/warning/mod.rs
+++ b/artichoke-backend/src/extn/core/warning/mod.rs
@@ -3,16 +3,18 @@ use std::ffi::CStr;
 use crate::extn::prelude::*;
 
 const WARNING_CSTR: &CStr = cstr::cstr!("Warning");
+static WARNING_RUBY_SOURCE: &[u8] = include_bytes!("warning.rb");
 
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     if interp.is_module_defined::<Warning>() {
         return Ok(());
     }
+
     let spec = module::Spec::new(interp, "Warning", WARNING_CSTR, None)?;
     module::Builder::for_spec(interp, &spec).define()?;
     interp.def_module::<Warning>(spec)?;
-    interp.eval(&include_bytes!("warning.rb")[..])?;
-    trace!("Patched Warning onto interpreter");
+    interp.eval(WARNING_RUBY_SOURCE)?;
+
     Ok(())
 }
 

--- a/artichoke-backend/src/extn/stdlib/abbrev/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/abbrev/mod.rs
@@ -3,11 +3,13 @@ use std::ffi::CStr;
 use crate::extn::prelude::*;
 
 const ABBREV_CSTR: &CStr = cstr::cstr!("Abbrev");
+static ABBREV_RUBY_SOURCE: &[u8] = include_bytes!("vendor/abbrev.rb");
 
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     let spec = module::Spec::new(interp, "Abbrev", ABBREV_CSTR, None)?;
     interp.def_module::<Abbrev>(spec)?;
-    interp.def_rb_source_file("abbrev.rb", &include_bytes!("vendor/abbrev.rb")[..])?;
+    interp.def_rb_source_file("abbrev.rb", ABBREV_RUBY_SOURCE)?;
+
     Ok(())
 }
 

--- a/artichoke-backend/src/extn/stdlib/base64/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/base64/mod.rs
@@ -3,11 +3,12 @@ use std::ffi::CStr;
 use crate::extn::prelude::*;
 
 const BASE64_CSTR: &CStr = cstr::cstr!("Base64");
+static BASE64_RUBY_SOURCE: &[u8] = include_bytes!("vendor/base64.rb");
 
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     let spec = crate::module::Spec::new(interp, "Base64", BASE64_CSTR, None)?;
     interp.def_module::<Base64>(spec)?;
-    interp.def_rb_source_file("base64.rb", &include_bytes!("vendor/base64.rb")[..])?;
+    interp.def_rb_source_file("base64.rb", BASE64_RUBY_SOURCE)?;
 
     Ok(())
 }

--- a/artichoke-backend/src/extn/stdlib/cmath/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/cmath/mod.rs
@@ -3,11 +3,13 @@ use std::ffi::CStr;
 use crate::extn::prelude::*;
 
 const CMATH_CSTR: &CStr = cstr::cstr!("CMath");
+static CMATH_RUBY_SOURCE: &[u8] = include_bytes!("vendor/cmath.rb");
 
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     let spec = module::Spec::new(interp, "CMath", CMATH_CSTR, None)?;
     interp.def_module::<CMath>(spec)?;
-    interp.def_rb_source_file("cmath.rb", &include_bytes!("vendor/cmath.rb")[..])?;
+    interp.def_rb_source_file("cmath.rb", CMATH_RUBY_SOURCE)?;
+
     Ok(())
 }
 

--- a/artichoke-backend/src/extn/stdlib/delegate/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/delegate/mod.rs
@@ -4,13 +4,15 @@ use crate::extn::prelude::*;
 
 const DELEGATOR_CSTR: &CStr = cstr::cstr!("Delegator");
 const SIMPLE_DELEGATOR_CSTR: &CStr = cstr::cstr!("SimpleDelegator");
+static DELEGATE_RUBY_SOURCE: &[u8] = include_bytes!("vendor/delegate.rb");
 
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     let spec = class::Spec::new("Delegator", DELEGATOR_CSTR, None, None)?;
     interp.def_class::<Delegator>(spec)?;
     let spec = class::Spec::new("SimpleDelegator", SIMPLE_DELEGATOR_CSTR, None, None)?;
     interp.def_class::<SimpleDelegator>(spec)?;
-    interp.def_rb_source_file("delegate.rb", &include_bytes!("vendor/delegate.rb")[..])?;
+    interp.def_rb_source_file("delegate.rb", DELEGATE_RUBY_SOURCE)?;
+
     Ok(())
 }
 

--- a/artichoke-backend/src/extn/stdlib/forwardable/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/forwardable/mod.rs
@@ -3,12 +3,15 @@ use std::ffi::CStr;
 use crate::extn::prelude::*;
 
 const FORWARDABLE_CSTR: &CStr = cstr::cstr!("Forwardable");
+static FORWARDABLE_RUBY_SOURCE: &[u8] = include_bytes!("vendor/forwardable.rb");
+static FORWARDABLE_IMPL_RUBY_SOURCE: &[u8] = include_bytes!("vendor/forwardable/impl.rb");
 
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     let spec = module::Spec::new(interp, "Forwardable", FORWARDABLE_CSTR, None)?;
     interp.def_module::<Forwardable>(spec)?;
-    interp.def_rb_source_file("forwardable.rb", &include_bytes!("vendor/forwardable.rb")[..])?;
-    interp.def_rb_source_file("forwardable/impl.rb", &include_bytes!("vendor/forwardable/impl.rb")[..])?;
+    interp.def_rb_source_file("forwardable.rb", FORWARDABLE_RUBY_SOURCE)?;
+    interp.def_rb_source_file("forwardable/impl.rb", FORWARDABLE_IMPL_RUBY_SOURCE)?;
+
     Ok(())
 }
 

--- a/artichoke-backend/src/extn/stdlib/json/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/json/mod.rs
@@ -3,6 +3,13 @@ use std::ffi::CStr;
 use crate::extn::prelude::*;
 
 const JSON_CSTR: &CStr = cstr::cstr!("JSON");
+static JSON_RUBY_SOURCE: &[u8] = include_bytes!("vendor/json.rb");
+static JSON_COMMON_RUBY_SOURCE: &[u8] = include_bytes!("vendor/json/common.rb");
+static JSON_GENERIC_OBJECT_RUBY_SOURCE: &[u8] = include_bytes!("vendor/json/generic_object.rb");
+static JSON_VERSION_RUBY_SOURCE: &[u8] = include_bytes!("vendor/json/version.rb");
+static JSON_PURE_RUBY_SOURCE: &[u8] = include_bytes!("vendor/json/pure.rb");
+static JSON_PURE_GENERATOR_RUBY_SOURCE: &[u8] = include_bytes!("vendor/json/pure/generator.rb");
+static JSON_PURE_PARSER_RUBY_SOURCE: &[u8] = include_bytes!("vendor/json/pure/parser.rb");
 
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     let spec = module::Spec::new(interp, "JSON", JSON_CSTR, None)?;
@@ -10,19 +17,14 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     // NOTE(lopopolo): This setup of the JSON gem in the virtual file system does not include
     // any of the `json/add` sources for serializing "extra" types like `Time`
     // and `BigDecimal`, not all of which Artichoke supports.
-    interp.def_rb_source_file("json.rb", &include_bytes!("vendor/json.rb")[..])?;
-    interp.def_rb_source_file("json/common.rb", &include_bytes!("vendor/json/common.rb")[..])?;
-    interp.def_rb_source_file(
-        "json/generic_object.rb",
-        &include_bytes!("vendor/json/generic_object.rb")[..],
-    )?;
-    interp.def_rb_source_file("json/version.rb", &include_bytes!("vendor/json/version.rb")[..])?;
-    interp.def_rb_source_file("json/pure.rb", &include_bytes!("vendor/json/pure.rb")[..])?;
-    interp.def_rb_source_file(
-        "json/pure/generator.rb",
-        &include_bytes!("vendor/json/pure/generator.rb")[..],
-    )?;
-    interp.def_rb_source_file("json/pure/parser.rb", &include_bytes!("vendor/json/pure/parser.rb")[..])?;
+    interp.def_rb_source_file("json.rb", JSON_RUBY_SOURCE)?;
+    interp.def_rb_source_file("json/common.rb", JSON_COMMON_RUBY_SOURCE)?;
+    interp.def_rb_source_file("json/generic_object.rb", JSON_GENERIC_OBJECT_RUBY_SOURCE)?;
+    interp.def_rb_source_file("json/version.rb", JSON_VERSION_RUBY_SOURCE)?;
+    interp.def_rb_source_file("json/pure.rb", JSON_PURE_RUBY_SOURCE)?;
+    interp.def_rb_source_file("json/pure/generator.rb", JSON_PURE_GENERATOR_RUBY_SOURCE)?;
+    interp.def_rb_source_file("json/pure/parser.rb", JSON_PURE_PARSER_RUBY_SOURCE)?;
+
     Ok(())
 }
 

--- a/artichoke-backend/src/extn/stdlib/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/mod.rs
@@ -60,6 +60,5 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     #[cfg(feature = "stdlib-uri")]
     uri::init(interp)?;
 
-    trace!("Patched Ruby standard library onto interpreter");
     Ok(())
 }

--- a/artichoke-backend/src/extn/stdlib/monitor/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/monitor/mod.rs
@@ -3,11 +3,13 @@ use std::ffi::CStr;
 use crate::extn::prelude::*;
 
 const MONITOR_CSTR: &CStr = cstr::cstr!("Monitor");
+static MONITOR_RUBY_SOURCE: &[u8] = include_bytes!("vendor/monitor.rb");
 
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     let spec = class::Spec::new("Monitor", MONITOR_CSTR, None, None)?;
     interp.def_class::<Monitor>(spec)?;
-    interp.def_rb_source_file("monitor.rb", &include_bytes!("vendor/monitor.rb")[..])?;
+    interp.def_rb_source_file("monitor.rb", MONITOR_RUBY_SOURCE)?;
+
     Ok(())
 }
 

--- a/artichoke-backend/src/extn/stdlib/ostruct/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/ostruct/mod.rs
@@ -3,11 +3,13 @@ use std::ffi::CStr;
 use crate::extn::prelude::*;
 
 const OPEN_STRUCT_CSTR: &CStr = cstr::cstr!("OpenStruct");
+static OPEN_STRUCT_RUBY_SOURCE: &[u8] = include_bytes!("vendor/ostruct.rb");
 
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     let spec = class::Spec::new("OpenStruct", OPEN_STRUCT_CSTR, None, None)?;
     interp.def_class::<OpenStruct>(spec)?;
-    interp.def_rb_source_file("ostruct.rb", &include_bytes!("vendor/ostruct.rb")[..])?;
+    interp.def_rb_source_file("ostruct.rb", OPEN_STRUCT_RUBY_SOURCE)?;
+
     Ok(())
 }
 

--- a/artichoke-backend/src/extn/stdlib/securerandom/mruby.rs
+++ b/artichoke-backend/src/extn/stdlib/securerandom/mruby.rs
@@ -26,6 +26,7 @@ impl File for SecureRandomFile {
         if interp.is_module_defined::<securerandom::SecureRandom>() {
             return Ok(());
         }
+
         let spec = module::Spec::new(interp, "SecureRandom", SECURE_RANDOM_CSTR, None)?;
         module::Builder::for_spec(interp, &spec)
             .add_self_method("alphanumeric", securerandom_alphanumeric, sys::mrb_args_opt(1))?
@@ -38,7 +39,6 @@ impl File for SecureRandomFile {
             .define()?;
         interp.def_module::<securerandom::SecureRandom>(spec)?;
 
-        trace!("Patched SecureRandom onto interpreter");
         Ok(())
     }
 }

--- a/artichoke-backend/src/extn/stdlib/set/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/set/mod.rs
@@ -4,13 +4,15 @@ use crate::extn::prelude::*;
 
 const SET_CSTR: &CStr = cstr::cstr!("Set");
 const SORTED_SET_CSTR: &CStr = cstr::cstr!("SortedSet");
+static SET_RUBY_SOURCE: &[u8] = include_bytes!("vendor/set.rb");
 
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     let spec = class::Spec::new("Set", SET_CSTR, None, None)?;
     interp.def_class::<Set>(spec)?;
     let spec = class::Spec::new("SortedSet", SORTED_SET_CSTR, None, None)?;
     interp.def_class::<SortedSet>(spec)?;
-    interp.def_rb_source_file("set.rb", &include_bytes!("vendor/set.rb")[..])?;
+    interp.def_rb_source_file("set.rb", SET_RUBY_SOURCE)?;
+
     Ok(())
 }
 

--- a/artichoke-backend/src/extn/stdlib/shellwords/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/shellwords/mod.rs
@@ -3,11 +3,13 @@ use std::ffi::CStr;
 use crate::extn::prelude::*;
 
 const SHELLWORDS_CSTR: &CStr = cstr::cstr!("Shellwords");
+static SHELLWORDS_RUBY_SOURCE: &[u8] = include_bytes!("vendor/shellwords.rb");
 
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     let spec = module::Spec::new(interp, "Shellwords", SHELLWORDS_CSTR, None)?;
     interp.def_module::<Shellwords>(spec)?;
-    interp.def_rb_source_file("shellwords.rb", &include_bytes!("vendor/shellwords.rb")[..])?;
+    interp.def_rb_source_file("shellwords.rb", SHELLWORDS_RUBY_SOURCE)?;
+
     Ok(())
 }
 

--- a/artichoke-backend/src/extn/stdlib/strscan/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/strscan/mod.rs
@@ -3,11 +3,13 @@ use std::ffi::CStr;
 use crate::extn::prelude::*;
 
 const STRING_SCANNER_CSTR: &CStr = cstr::cstr!("StringScanner");
+static STRING_SCANNER_RUBY_SOURCE: &[u8] = include_bytes!("strscan.rb");
 
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     let spec = class::Spec::new("StringScanner", STRING_SCANNER_CSTR, None, None)?;
     interp.def_class::<StringScanner>(spec)?;
-    interp.def_rb_source_file("strscan.rb", &include_bytes!("strscan.rb")[..])?;
+    interp.def_rb_source_file("strscan.rb", STRING_SCANNER_RUBY_SOURCE)?;
+
     Ok(())
 }
 

--- a/artichoke-backend/src/extn/stdlib/time/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/time/mod.rs
@@ -1,8 +1,11 @@
 use crate::extn::prelude::*;
 
+static TIME_RUBY_SOURCE: &[u8] = include_bytes!("vendor/time.rb");
+
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     // time package does not define any additional types; it provides extension
     // methods on the `Time` core class.
-    interp.def_rb_source_file("time.rb", &include_bytes!("vendor/time.rb")[..])?;
+    interp.def_rb_source_file("time.rb", TIME_RUBY_SOURCE)?;
+
     Ok(())
 }

--- a/artichoke-backend/src/extn/stdlib/uri/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/uri/mod.rs
@@ -6,6 +6,19 @@ const IP_SOCKET_CSTR: &CStr = cstr::cstr!("IPSocket");
 const IP_ADDR_CSTR: &CStr = cstr::cstr!("IPAddr");
 const URI_CSTR: &CStr = cstr::cstr!("URI");
 
+static URI_RUBY_SOURCE: &[u8] = include_bytes!("vendor/uri.rb");
+static URI_COMMON_RUBY_SOURCE: &[u8] = include_bytes!("vendor/uri/common.rb");
+static URI_FILE_RUBY_SOURCE: &[u8] = include_bytes!("vendor/uri/file.rb");
+static URI_FTP_RUBY_SOURCE: &[u8] = include_bytes!("vendor/uri/ftp.rb");
+static URI_GENERIC_RUBY_SOURCE: &[u8] = include_bytes!("vendor/uri/generic.rb");
+static URI_HTTP_RUBY_SOURCE: &[u8] = include_bytes!("vendor/uri/http.rb");
+static URI_HTTPS_RUBY_SOURCE: &[u8] = include_bytes!("vendor/uri/https.rb");
+static URI_LDAP_RUBY_SOURCE: &[u8] = include_bytes!("vendor/uri/ldap.rb");
+static URI_LDAPS_RUBY_SOURCE: &[u8] = include_bytes!("vendor/uri/ldaps.rb");
+static URI_MAILTO_RUBY_SOURCE: &[u8] = include_bytes!("vendor/uri/mailto.rb");
+static URI_RFC2396_PARSER_RUBY_SOURCE: &[u8] = include_bytes!("vendor/uri/rfc2396_parser.rb");
+static URI_RFC3986_PARSER_RUBY_SOURCE: &[u8] = include_bytes!("vendor/uri/rfc3986_parser.rb");
+
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     let spec = class::Spec::new("IPSocket", IP_SOCKET_CSTR, None, None)?;
     interp.def_class::<IpSocket>(spec)?;
@@ -16,24 +29,18 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     let spec = module::Spec::new(interp, "URI", URI_CSTR, None)?;
     interp.def_module::<Uri>(spec)?;
 
-    interp.def_rb_source_file("uri.rb", &include_bytes!("vendor/uri.rb")[..])?;
-    interp.def_rb_source_file("uri/common.rb", &include_bytes!("vendor/uri/common.rb")[..])?;
-    interp.def_rb_source_file("uri/file.rb", &include_bytes!("vendor/uri/file.rb")[..])?;
-    interp.def_rb_source_file("uri/ftp.rb", &include_bytes!("vendor/uri/ftp.rb")[..])?;
-    interp.def_rb_source_file("uri/generic.rb", &include_bytes!("vendor/uri/generic.rb")[..])?;
-    interp.def_rb_source_file("uri/http.rb", &include_bytes!("vendor/uri/http.rb")[..])?;
-    interp.def_rb_source_file("uri/https.rb", &include_bytes!("vendor/uri/https.rb")[..])?;
-    interp.def_rb_source_file("uri/ldap.rb", &include_bytes!("vendor/uri/ldap.rb")[..])?;
-    interp.def_rb_source_file("uri/ldaps.rb", &include_bytes!("vendor/uri/ldaps.rb")[..])?;
-    interp.def_rb_source_file("uri/mailto.rb", &include_bytes!("vendor/uri/mailto.rb")[..])?;
-    interp.def_rb_source_file(
-        "uri/rfc2396_parser.rb",
-        &include_bytes!("vendor/uri/rfc2396_parser.rb")[..],
-    )?;
-    interp.def_rb_source_file(
-        "uri/rfc3986_parser.rb",
-        &include_bytes!("vendor/uri/rfc3986_parser.rb")[..],
-    )?;
+    interp.def_rb_source_file("uri.rb", URI_RUBY_SOURCE)?;
+    interp.def_rb_source_file("uri/common.rb", URI_COMMON_RUBY_SOURCE)?;
+    interp.def_rb_source_file("uri/file.rb", URI_FILE_RUBY_SOURCE)?;
+    interp.def_rb_source_file("uri/ftp.rb", URI_FTP_RUBY_SOURCE)?;
+    interp.def_rb_source_file("uri/generic.rb", URI_GENERIC_RUBY_SOURCE)?;
+    interp.def_rb_source_file("uri/http.rb", URI_HTTP_RUBY_SOURCE)?;
+    interp.def_rb_source_file("uri/https.rb", URI_HTTPS_RUBY_SOURCE)?;
+    interp.def_rb_source_file("uri/ldap.rb", URI_LDAP_RUBY_SOURCE)?;
+    interp.def_rb_source_file("uri/ldaps.rb", URI_LDAPS_RUBY_SOURCE)?;
+    interp.def_rb_source_file("uri/mailto.rb", URI_MAILTO_RUBY_SOURCE)?;
+    interp.def_rb_source_file("uri/rfc2396_parser.rb", URI_RFC2396_PARSER_RUBY_SOURCE)?;
+    interp.def_rb_source_file("uri/rfc3986_parser.rb", URI_RFC3986_PARSER_RUBY_SOURCE)?;
 
     Ok(())
 }


### PR DESCRIPTION
Prior to this commit, all core and stdlib modules in `extn` that loaded
Ruby sources into the interpreter did so with `include_bytes!` macro
invocations. These calls were done inline in the various `init`
functions.

`include_bytes!` returns a fixed-sized array, so all of the Ruby source
contents were on the stack. For modules like `JSON` and `URI`, this is a
lot of data on the stack.

Artichoke intends to be embeddable and makes no assumptions about how
deep the stack is in the application when the interpreter is booted.

Instead of calling `include_bytes!` inline, move the `include_bytes!`
calls to store the byte contents in a `static` binding. `static`s are
stored at a fixed location in memory and the program binary. These
statics are coerced to `&[u8]` which means when they are used in `init`,
the only stack space used is for a fat pointer.

This commit also removes largely useless calls to `trace!` and `debug!`
macros when bootstrapping the interpreter with individual classes and
modules.

`numeric::init` is moved to `numeric::mruby::init`.