### PR TITLE
Remove `itoa` Rust dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,7 +42,6 @@ dependencies = [
  "cc",
  "cstr",
  "intaglio",
- "itoa",
  "log",
  "once_cell",
  "onig",
@@ -257,12 +256,6 @@ name = "intaglio"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1feb5417d69513d0a6755444a18a55b2ffff6e0521a2935087e595d6f7cb562d"
-
-[[package]]
-name = "itoa"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "lazy_static"
@@ -664,7 +657,6 @@ version = "0.2.0"
 dependencies = [
  "bitflags",
  "bstr",
- "itoa",
  "onig",
  "regex",
  "scolapasta-string-escape",

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -16,7 +16,6 @@ artichoke-load-path = { version = "0.1", path = "../artichoke-load-path", defaul
 bstr = { version = "0.2, >= 0.2.2", default-features = false, features = ["std"] }
 cstr = "0.2, >= 0.2.4"
 intaglio = "1.4"
-itoa = "0.4"
 log = "0.4, >= 0.4.5"
 once_cell = "1"
 onig = { version = "6.3", optional = true, default-features = false }

--- a/artichoke-backend/src/extn/core/array/args.rs
+++ b/artichoke-backend/src/extn/core/array/args.rs
@@ -61,10 +61,9 @@ pub fn element_assignment(
             if let Some(start) = pos {
                 start
             } else {
-                let mut message = String::from("index ");
-                write!(&mut message, "{}", start).map_err(WriteError::from)?;
-                message.push_str(" too small for array; minimum: -");
-                write!(&mut message, "{}", len).map_err(WriteError::from)?;
+                let mut message = String::new();
+                write!(&mut message, "index {} too small for array; minimum: -{}", start, len)
+                    .map_err(WriteError::from)?;
                 return Err(IndexError::from(message).into());
             }
         };
@@ -72,9 +71,8 @@ pub fn element_assignment(
         if let Ok(slice_len) = usize::try_from(slice_len) {
             Ok((start, Some(slice_len), elem))
         } else {
-            let mut message = String::from("negative length (");
-            write!(&mut message, "{}", slice_len).map_err(WriteError::from)?;
-            message.push(')');
+            let mut message = String::new();
+            write!(&mut message, "negative length ({})", slice_len).map_err(WriteError::from)?;
             Err(IndexError::from(message).into())
         }
     } else if let Ok(index) = implicitly_convert_to_int(interp, first) {
@@ -88,10 +86,9 @@ pub fn element_assignment(
             if let Some(idx) = idx {
                 Ok((idx, None, second))
             } else {
-                let mut message = String::from("index ");
-                write!(&mut message, "{}", index).map_err(WriteError::from)?;
-                message.push_str(" too small for array; minimum: -");
-                write!(&mut message, "{}", len).map_err(WriteError::from)?;
+                let mut message = String::new();
+                write!(&mut message, "index {} too small for array; minimum: -{}", index, len)
+                    .map_err(WriteError::from)?;
                 Err(IndexError::from(message).into())
             }
         }
@@ -110,10 +107,7 @@ pub fn element_assignment(
             // TODO: This conditional is probably not doing the right thing
             if start + (end - start) < 0 {
                 let mut message = String::new();
-                write!(&mut message, "{}", start).map_err(WriteError::from)?;
-                message.push_str("..");
-                write!(&mut message, "{}", end).map_err(WriteError::from)?;
-                message.push_str(" out of range");
+                write!(&mut message, "{}..{} out of range", start, end).map_err(WriteError::from)?;
                 return Err(RangeError::from(message).into());
             }
             match (usize::try_from(start), usize::try_from(end)) {
@@ -126,19 +120,17 @@ pub fn element_assignment(
                     if let Some(start) = pos {
                         Ok((start, end.checked_sub(start), second))
                     } else {
-                        let mut message = String::from("index ");
-                        write!(&mut message, "{}", start).map_err(WriteError::from)?;
-                        message.push_str(" too small for array; minimum: -");
-                        write!(&mut message, "{}", len).map_err(WriteError::from)?;
+                        let mut message = String::new();
+                        write!(&mut message, "index {} too small for array; minimum: -{}", start, len)
+                            .map_err(WriteError::from)?;
                         Err(IndexError::from(message).into())
                     }
                 }
                 (Ok(start), Err(_)) => Ok((start, None, second)),
                 (Err(_), Err(_)) => {
-                    let mut message = String::from("index ");
-                    write!(&mut message, "{}", start).map_err(WriteError::from)?;
-                    message.push_str(" too small for array; minimum: -");
-                    write!(&mut message, "{}", len).map_err(WriteError::from)?;
+                    let mut message = String::new();
+                    write!(&mut message, "index {} too small for array; minimum: -{}", start, len)
+                        .map_err(WriteError::from)?;
                     Err(IndexError::from(message).into())
                 }
             }

--- a/artichoke-backend/src/extn/core/array/args.rs
+++ b/artichoke-backend/src/extn/core/array/args.rs
@@ -1,3 +1,5 @@
+use std::fmt::Write as _;
+
 use crate::convert::implicitly_convert_to_int;
 use crate::extn::prelude::*;
 use crate::sys::protect;
@@ -60,9 +62,9 @@ pub fn element_assignment(
                 start
             } else {
                 let mut message = String::from("index ");
-                itoa::fmt(&mut message, start).map_err(WriteError::from)?;
+                write!(&mut message, "{}", start).map_err(WriteError::from)?;
                 message.push_str(" too small for array; minimum: -");
-                itoa::fmt(&mut message, len).map_err(WriteError::from)?;
+                write!(&mut message, "{}", len).map_err(WriteError::from)?;
                 return Err(IndexError::from(message).into());
             }
         };
@@ -71,7 +73,7 @@ pub fn element_assignment(
             Ok((start, Some(slice_len), elem))
         } else {
             let mut message = String::from("negative length (");
-            itoa::fmt(&mut message, slice_len).map_err(WriteError::from)?;
+            write!(&mut message, "{}", slice_len).map_err(WriteError::from)?;
             message.push(')');
             Err(IndexError::from(message).into())
         }
@@ -87,9 +89,9 @@ pub fn element_assignment(
                 Ok((idx, None, second))
             } else {
                 let mut message = String::from("index ");
-                itoa::fmt(&mut message, index).map_err(WriteError::from)?;
+                write!(&mut message, "{}", index).map_err(WriteError::from)?;
                 message.push_str(" too small for array; minimum: -");
-                itoa::fmt(&mut message, len).map_err(WriteError::from)?;
+                write!(&mut message, "{}", len).map_err(WriteError::from)?;
                 Err(IndexError::from(message).into())
             }
         }
@@ -108,9 +110,9 @@ pub fn element_assignment(
             // TODO: This conditional is probably not doing the right thing
             if start + (end - start) < 0 {
                 let mut message = String::new();
-                itoa::fmt(&mut message, start).map_err(WriteError::from)?;
+                write!(&mut message, "{}", start).map_err(WriteError::from)?;
                 message.push_str("..");
-                itoa::fmt(&mut message, end).map_err(WriteError::from)?;
+                write!(&mut message, "{}", end).map_err(WriteError::from)?;
                 message.push_str(" out of range");
                 return Err(RangeError::from(message).into());
             }
@@ -125,18 +127,18 @@ pub fn element_assignment(
                         Ok((start, end.checked_sub(start), second))
                     } else {
                         let mut message = String::from("index ");
-                        itoa::fmt(&mut message, start).map_err(WriteError::from)?;
+                        write!(&mut message, "{}", start).map_err(WriteError::from)?;
                         message.push_str(" too small for array; minimum: -");
-                        itoa::fmt(&mut message, len).map_err(WriteError::from)?;
+                        write!(&mut message, "{}", len).map_err(WriteError::from)?;
                         Err(IndexError::from(message).into())
                     }
                 }
                 (Ok(start), Err(_)) => Ok((start, None, second)),
                 (Err(_), Err(_)) => {
                     let mut message = String::from("index ");
-                    itoa::fmt(&mut message, start).map_err(WriteError::from)?;
+                    write!(&mut message, "{}", start).map_err(WriteError::from)?;
                     message.push_str(" too small for array; minimum: -");
-                    itoa::fmt(&mut message, len).map_err(WriteError::from)?;
+                    write!(&mut message, "{}", len).map_err(WriteError::from)?;
                     Err(IndexError::from(message).into())
                 }
             }

--- a/artichoke-backend/src/extn/core/array/mod.rs
+++ b/artichoke-backend/src/extn/core/array/mod.rs
@@ -1,10 +1,9 @@
 use std::ffi::c_void;
-use std::fmt::Write;
+use std::fmt::Write as _;
 use std::ops::Deref;
 
 use crate::convert::{implicitly_convert_to_int, implicitly_convert_to_string, UnboxedValueGuard};
 use crate::extn::prelude::*;
-use crate::io::IoError;
 
 pub mod args;
 mod ffi;
@@ -131,10 +130,10 @@ pub fn join(interp: &mut Artichoke, ary: &Array, sep: &[u8]) -> Result<Vec<u8>, 
                 }
             }
             Ruby::Fixnum => {
-                let mut buf = Vec::new();
+                let mut buf = String::new();
                 let int = unsafe { sys::mrb_sys_fixnum_to_cint(value.inner()) };
-                itoa::write(&mut buf, int).map_err(IoError::from)?;
-                out.push(buf);
+                write!(&mut buf, "{}", int).map_err(WriteError::from)?;
+                out.push(buf.into_bytes());
             }
             Ruby::Float => {
                 let float = unsafe { sys::mrb_sys_float_to_cdouble(value.inner()) };

--- a/artichoke-backend/src/extn/core/integer/mod.rs
+++ b/artichoke-backend/src/extn/core/integer/mod.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use std::fmt::{self, Write as _};
 use std::mem;
 
 use crate::extn::core::numeric::{self, Coercion, Outcome};
@@ -141,7 +141,7 @@ impl Integer {
                 }
                 _ => {
                     let mut message = String::new();
-                    itoa::fmt(&mut message, self.as_i64()).map_err(WriteError::from)?;
+                    write!(&mut message, "{}", self.as_i64()).map_err(WriteError::from)?;
                     message.push_str(" out of char range");
                     Err(RangeError::from(message).into())
                 }

--- a/artichoke-backend/src/extn/core/kernel/integer.rs
+++ b/artichoke-backend/src/extn/core/kernel/integer.rs
@@ -77,8 +77,8 @@ impl TryConvertMut<Option<Value>, Option<Radix>> for Artichoke {
                     Ok(1) => return Ok(Some(Radix::default())),
                     Ok(radix) => radix,
                     Err(_) => {
-                        let mut message = String::from("invalid radix ");
-                        write!(&mut message, "{}", num).map_err(WriteError::from)?;
+                        let mut message = String::new();
+                        write!(&mut message, "invalid radix {}", num).map_err(WriteError::from)?;
                         return Err(ArgumentError::from(message).into());
                     }
                 }
@@ -89,8 +89,8 @@ impl TryConvertMut<Option<Value>, Option<Radix>> for Artichoke {
                 // of numeric literal prefixes.
                 None if radix == 0 => Ok(None),
                 None => {
-                    let mut message = String::from("invalid radix ");
-                    write!(&mut message, "{}", radix).map_err(WriteError::from)?;
+                    let mut message = String::new();
+                    write!(&mut message, "invalid radix {}", radix).map_err(WriteError::from)?;
                     Err(ArgumentError::from(message).into())
                 }
             }

--- a/artichoke-backend/src/extn/core/kernel/integer.rs
+++ b/artichoke-backend/src/extn/core/kernel/integer.rs
@@ -1,5 +1,5 @@
 use std::error;
-use std::fmt;
+use std::fmt::{self, Write as _};
 use std::iter::Iterator;
 use std::num::NonZeroU32;
 use std::str::{self, FromStr};
@@ -78,7 +78,7 @@ impl TryConvertMut<Option<Value>, Option<Radix>> for Artichoke {
                     Ok(radix) => radix,
                     Err(_) => {
                         let mut message = String::from("invalid radix ");
-                        itoa::fmt(&mut message, num).map_err(WriteError::from)?;
+                        write!(&mut message, "{}", num).map_err(WriteError::from)?;
                         return Err(ArgumentError::from(message).into());
                     }
                 }
@@ -90,7 +90,7 @@ impl TryConvertMut<Option<Value>, Option<Radix>> for Artichoke {
                 None if radix == 0 => Ok(None),
                 None => {
                     let mut message = String::from("invalid radix ");
-                    itoa::fmt(&mut message, radix).map_err(WriteError::from)?;
+                    write!(&mut message, "{}", radix).map_err(WriteError::from)?;
                     Err(ArgumentError::from(message).into())
                 }
             }

--- a/artichoke-backend/src/extn/core/matchdata/mod.rs
+++ b/artichoke-backend/src/extn/core/matchdata/mod.rs
@@ -10,6 +10,7 @@
 //! [rubyspec]: https://github.com/ruby/spec
 
 use std::collections::HashMap;
+use std::fmt::Write as _;
 use std::ops::{Bound, RangeBounds};
 use std::str;
 
@@ -311,7 +312,7 @@ impl MatchData {
                     Ok(idx) if idx < captures_len => idx,
                     _ => {
                         let mut message = String::from("index ");
-                        itoa::fmt(&mut message, index).map_err(WriteError::from)?;
+                        write!(&mut message, "{}", index).map_err(WriteError::from)?;
                         message.push_str(" out of matches");
                         return Err(IndexError::from(message).into());
                     }

--- a/artichoke-backend/src/extn/core/matchdata/mod.rs
+++ b/artichoke-backend/src/extn/core/matchdata/mod.rs
@@ -311,9 +311,8 @@ impl MatchData {
                 match usize::try_from(index) {
                     Ok(idx) if idx < captures_len => idx,
                     _ => {
-                        let mut message = String::from("index ");
-                        write!(&mut message, "{}", index).map_err(WriteError::from)?;
-                        message.push_str(" out of matches");
+                        let mut message = String::new();
+                        write!(&mut message, "index {} out of matches", index).map_err(WriteError::from)?;
                         return Err(IndexError::from(message).into());
                     }
                 }

--- a/artichoke-backend/src/extn/core/math/trampoline.rs
+++ b/artichoke-backend/src/extn/core/math/trampoline.rs
@@ -125,15 +125,13 @@ pub fn ldexp(interp: &mut Artichoke, fraction: Value, exponent: Value) -> Result
             Ok(result)
         }
         Err(_) if exponent < 0 => {
-            let mut message = String::from("integer ");
-            write!(&mut message, "{}", exponent).map_err(WriteError::from)?;
-            message.push_str("too small to convert to `int'");
+            let mut message = String::new();
+            write!(&mut message, "integer {} too small to convert to `int'", exponent).map_err(WriteError::from)?;
             Err(RangeError::from(message).into())
         }
         Err(_) => {
-            let mut message = String::from("integer ");
-            write!(&mut message, "{}", exponent).map_err(WriteError::from)?;
-            message.push_str("too big to convert to `int'");
+            let mut message = String::new();
+            write!(&mut message, "integer {} too big to convert to `int'", exponent).map_err(WriteError::from)?;
             Err(RangeError::from(message).into())
         }
     }

--- a/artichoke-backend/src/extn/core/math/trampoline.rs
+++ b/artichoke-backend/src/extn/core/math/trampoline.rs
@@ -1,5 +1,7 @@
 //! Glue between mruby FFI and `ENV` Rust implementation.
 
+use std::fmt::Write as _;
+
 use crate::convert::implicitly_convert_to_int;
 use crate::extn::prelude::*;
 
@@ -124,13 +126,13 @@ pub fn ldexp(interp: &mut Artichoke, fraction: Value, exponent: Value) -> Result
         }
         Err(_) if exponent < 0 => {
             let mut message = String::from("integer ");
-            itoa::fmt(&mut message, exponent).map_err(WriteError::from)?;
+            write!(&mut message, "{}", exponent).map_err(WriteError::from)?;
             message.push_str("too small to convert to `int'");
             Err(RangeError::from(message).into())
         }
         Err(_) => {
             let mut message = String::from("integer ");
-            itoa::fmt(&mut message, exponent).map_err(WriteError::from)?;
+            write!(&mut message, "{}", exponent).map_err(WriteError::from)?;
             message.push_str("too big to convert to `int'");
             Err(RangeError::from(message).into())
         }

--- a/artichoke-backend/src/string.rs
+++ b/artichoke-backend/src/string.rs
@@ -53,7 +53,7 @@ where
 /// Error type for [`format_unicode_debug_into`].
 ///
 /// This error type can also be used to convert generic [`fmt::Error`] into an
-/// [`Error`], such as when formatting integers with [`itoa::fmt`].
+/// [`Error`], such as when formatting integers with [`write!`].
 ///
 /// This  error type wraps a [`fmt::Error`].
 ///

--- a/artichoke-backend/src/sys/mod.rs
+++ b/artichoke-backend/src/sys/mod.rs
@@ -45,7 +45,7 @@ impl fmt::Debug for mrb_value {
             Ruby::Bool => f.write_str("false"),
             Ruby::Fixnum => {
                 let fixnum = unsafe { mrb_sys_fixnum_to_cint(*self) };
-                itoa::fmt(f, fixnum)
+                write!(f, "{}", fixnum)
             }
             Ruby::Float => {
                 let float = unsafe { mrb_sys_float_to_cdouble(*self) };

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -36,7 +36,6 @@ dependencies = [
  "cc",
  "cstr",
  "intaglio",
- "itoa",
  "log",
  "once_cell",
  "onig",
@@ -185,12 +184,6 @@ name = "intaglio"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1feb5417d69513d0a6755444a18a55b2ffff6e0521a2935087e595d6f7cb562d"
-
-[[package]]
-name = "itoa"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "lazy_static"
@@ -508,7 +501,6 @@ version = "0.2.0"
 dependencies = [
  "bitflags",
  "bstr",
- "itoa",
  "onig",
  "regex",
  "scolapasta-string-escape",

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -40,7 +40,6 @@ dependencies = [
  "cc",
  "cstr",
  "intaglio",
- "itoa",
  "log",
  "once_cell",
  "onig",
@@ -253,12 +252,6 @@ name = "intaglio"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1feb5417d69513d0a6755444a18a55b2ffff6e0521a2935087e595d6f7cb562d"
-
-[[package]]
-name = "itoa"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "lazy_static"
@@ -651,7 +644,6 @@ version = "0.2.0"
 dependencies = [
  "bitflags",
  "bstr",
- "itoa",
  "onig",
  "regex",
  "scolapasta-string-escape",

--- a/spinoso-regexp/Cargo.toml
+++ b/spinoso-regexp/Cargo.toml
@@ -15,7 +15,6 @@ categories = ["data-structures", "parser-implementations"]
 [dependencies]
 bitflags = "1.2"
 bstr = { version = "0.2, >= 0.2.4", default-features = false }
-itoa = "0.4"
 onig = { version = "6.3", optional = true, default-features = false }
 regex = { version = "1, >= 1.4.3", default-features = false, features = ["std", "unicode-perl"] }
 scolapasta-string-escape = { version = "0.2", path = "../scolapasta-string-escape", default-features = false }

--- a/spinoso-regexp/src/lib.rs
+++ b/spinoso-regexp/src/lib.rs
@@ -25,7 +25,7 @@
 #[doc = include_str!("../README.md")]
 mod readme {}
 
-use core::fmt;
+use core::fmt::{self, Write as _};
 use core::num::NonZeroUsize;
 use std::borrow::Cow;
 
@@ -391,9 +391,9 @@ pub fn nth_match_group(group: NonZeroUsize) -> Cow<'static, str> {
             let mut buf = String::from("$");
             // Suppress formatting errors because this function is infallible.
             //
-            // In practice `itoa::fmt` will never error because the `fmt::Write`
+            // In practice `write!` will never error because the `fmt::Write`
             // impl for `String` never panics.
-            let _ = itoa::fmt(&mut buf, num);
+            let _ = write!(&mut buf, "{}", num);
             Cow::Owned(buf)
         }
     }

--- a/spinoso-regexp/src/lib.rs
+++ b/spinoso-regexp/src/lib.rs
@@ -388,12 +388,12 @@ pub fn nth_match_group(group: NonZeroUsize) -> Cow<'static, str> {
         19 => Cow::Borrowed("$19"),
         20 => Cow::Borrowed("$20"),
         num => {
-            let mut buf = String::from("$");
+            let mut buf = String::new();
             // Suppress formatting errors because this function is infallible.
             //
             // In practice `write!` will never error because the `fmt::Write`
             // impl for `String` never panics.
-            let _ = write!(&mut buf, "{}", num);
+            let _ = write!(&mut buf, "${}", num);
             Cow::Owned(buf)
         }
     }


### PR DESCRIPTION
Remove `itoa` from `spinoso-regexp` and `artichoke-backend`. Replace `itoa::fmt` and `itoa::write` calls with `fmt::Write` and `write!`.

Use ergonomic format strings to `write!` for old `itoa` uses

Now that calls to `itoa::fmt` don't need to be interspersed in `String` building, use an ergonomic call to `write!` that inlines the static content of the format string with the interpolated bits.