### PR TITLE
Upgrade spinsoso-string raw parts APIs to use raw_parts crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -514,9 +514,9 @@ checksum = "88015c62ee73400068c6b1ba3e6fa7215c3f88fe882d208ab82d2e36d95c7aad"
 
 [[package]]
 name = "raw-parts"
-version = "1.0.2"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b86f9598ad5ee2abfdbfb67653a356ed2f50cfbb32915e672261a93853a3dc84"
+checksum = "4d684eb692d561551750a408e516759f550d51033179e7d2f676efc4495b3d4e"
 
 [[package]]
 name = "regex"
@@ -666,12 +666,13 @@ dependencies = [
 
 [[package]]
 name = "spinoso-string"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "bstr",
  "bytecount",
  "focaccia",
  "quickcheck",
+ "raw-parts",
  "scolapasta-string-escape",
  "simdutf8",
 ]

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -27,7 +27,7 @@ spinoso-math = { version = "0.2", path = "../spinoso-math", optional = true, def
 spinoso-random = { version = "0.2", path = "../spinoso-random", optional = true }
 spinoso-regexp = { version = "0.2", path = "../spinoso-regexp", optional = true, default-features = false }
 spinoso-securerandom = { version = "0.1", path = "../spinoso-securerandom", optional = true }
-spinoso-string = { version = "0.10", path = "../spinoso-string" }
+spinoso-string = { version = "0.11", path = "../spinoso-string" }
 spinoso-symbol = { version = "0.1", path = "../spinoso-symbol" }
 spinoso-time = { version = "0.2", path = "../spinoso-time", optional = true }
 

--- a/artichoke-backend/src/extn/core/string/ffi.rs
+++ b/artichoke-backend/src/extn/core/string/ffi.rs
@@ -12,7 +12,7 @@ use artichoke_core::convert::Convert;
 use artichoke_core::hash::Hash as _;
 use bstr::ByteSlice;
 use spinoso_exception::ArgumentError;
-use spinoso_string::String;
+use spinoso_string::{RawParts, String};
 
 use crate::convert::BoxUnboxVmValue;
 use crate::error;
@@ -563,11 +563,16 @@ unsafe extern "C" fn mrb_gc_free_str(mrb: *mut sys::mrb_state, string: *mut sys:
     let _ = mrb;
 
     let ptr = (*string).as_.heap.ptr;
-    let len = (*string).as_.heap.len as usize;
+    let length = (*string).as_.heap.len as usize;
     let capacity = (*string).as_.heap.aux.capa as usize;
 
     // we don't need to free the encoding since `Encoding` is `Copy` and we pack
     // it into the `RString` flags as a `u32`.
 
-    drop(String::from_raw_parts(ptr.cast::<u8>(), len, capacity));
+    let raw_parts = RawParts {
+        ptr: ptr.cast::<u8>(),
+        length,
+        capacity,
+    };
+    drop(String::from_raw_parts(raw_parts));
 }

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -401,9 +401,9 @@ checksum = "88015c62ee73400068c6b1ba3e6fa7215c3f88fe882d208ab82d2e36d95c7aad"
 
 [[package]]
 name = "raw-parts"
-version = "1.0.2"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b86f9598ad5ee2abfdbfb67653a356ed2f50cfbb32915e672261a93853a3dc84"
+checksum = "4d684eb692d561551750a408e516759f550d51033179e7d2f676efc4495b3d4e"
 
 [[package]]
 name = "regex"
@@ -516,11 +516,12 @@ dependencies = [
 
 [[package]]
 name = "spinoso-string"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "bstr",
  "bytecount",
  "focaccia",
+ "raw-parts",
  "scolapasta-string-escape",
  "simdutf8",
 ]

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -458,9 +458,9 @@ checksum = "88015c62ee73400068c6b1ba3e6fa7215c3f88fe882d208ab82d2e36d95c7aad"
 
 [[package]]
 name = "raw-parts"
-version = "1.0.2"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b86f9598ad5ee2abfdbfb67653a356ed2f50cfbb32915e672261a93853a3dc84"
+checksum = "4d684eb692d561551750a408e516759f550d51033179e7d2f676efc4495b3d4e"
 
 [[package]]
 name = "regex"
@@ -653,11 +653,12 @@ dependencies = [
 
 [[package]]
 name = "spinoso-string"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "bstr",
  "bytecount",
  "focaccia",
+ "raw-parts",
  "scolapasta-string-escape",
  "simdutf8",
 ]

--- a/spinoso-array/Cargo.toml
+++ b/spinoso-array/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["array", "no_std", "spinoso", "vec", "vector"]
 categories = ["data-structures", "no-std"]
 
 [dependencies]
-raw-parts = "1.0"
+raw-parts = "1.1"
 # 1.4.1 fixed UB when allocating zero-bytes for ZST element types.
 # https://github.com/servo/rust-smallvec/releases/tag/v1.4.1
 # 1.6.1 fixed a buffer overflow when calling `SmallVec::insert_many`.

--- a/spinoso-string/Cargo.toml
+++ b/spinoso-string/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spinoso-string"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2021"
 description = """
@@ -16,6 +16,7 @@ categories = ["data-structures", "encoding", "no-std"]
 bstr = { version = "0.2, >= 0.2.9", default-features = false, features = ["std"] }
 bytecount = "0.6, >= 0.6.2"
 focaccia = { version = "1.1", optional = true, default-features = false }
+raw-parts = "1.1"
 scolapasta-string-escape = { version = "0.2", path = "../scolapasta-string-escape", default-features = false }
 simdutf8 = { version = "0.1, >= 0.1.3", default-features = false }
 


### PR DESCRIPTION
This API change aligns spinoso-string with spinoso-array and reduces the likelihood of errors. Bump spinoso-string to 0.11.0 and raw-parts to 1.1.1.