### PR TITLE
Add macro for emitting fatal error logs

### DIFF
--- a/artichoke-backend/src/error.rs
+++ b/artichoke-backend/src/error.rs
@@ -3,7 +3,6 @@ use std::error;
 use std::ffi::CStr;
 use std::fmt;
 use std::hint;
-use std::io::{self, Write as _};
 
 use crate::sys;
 use crate::{Artichoke, Guard};
@@ -90,15 +89,10 @@ where
 
     // Being unable to turn the given exception into an `mrb_value` is a bug, so
     // log loudly to stderr and attempt to fallback to a runtime error.
-
-    // Suppress errors from logging to stderr because this function is called
-    // when there are foreign C frames in the stack and panics are either UB or
-    // will result in an abort.
-    let ignored_err = write!(io::stderr(), "Unable to raise exception: {:?}", exception);
+    emit_fatal_warning!("Unable to raise exception: {:?}", exception);
 
     // Any non-`Copy` objects that we haven't cleaned up at this point will
     // leak, so drop everything.
-    drop(ignored_err);
     drop(exception);
 
     // `mrb_sys_raise` will call longjmp which will unwind the stack.

--- a/artichoke-backend/src/eval.rs
+++ b/artichoke-backend/src/eval.rs
@@ -35,7 +35,7 @@ impl Eval for Artichoke {
                 // result in a segfault.
                 //
                 // See: https://github.com/mruby/mruby/issues/4460
-                emit_fatal_warning!("fatal: eval returned an unreachable Ruby value");
+                emit_fatal_warning!("eval returned an unreachable Ruby value");
                 Err(Fatal::from("eval returned an unreachable Ruby value").into())
             }
             Ok(value) => Ok(self.protect(value)),

--- a/artichoke-backend/src/eval.rs
+++ b/artichoke-backend/src/eval.rs
@@ -1,5 +1,4 @@
 use std::ffi::OsStr;
-use std::io::{self, Write as _};
 use std::path::Path;
 
 use crate::core::{Eval, LoadSources, Parser};
@@ -36,7 +35,7 @@ impl Eval for Artichoke {
                 // result in a segfault.
                 //
                 // See: https://github.com/mruby/mruby/issues/4460
-                let _ignored = write!(io::stderr(), "fatal: eval returned an unreachable Ruby value");
+                emit_fatal_warning!("fatal: eval returned an unreachable Ruby value");
                 Err(Fatal::from("eval returned an unreachable Ruby value").into())
             }
             Ok(value) => Ok(self.protect(value)),

--- a/artichoke-backend/src/extn/core/array/ffi.rs
+++ b/artichoke-backend/src/extn/core/array/ffi.rs
@@ -124,8 +124,9 @@ unsafe extern "C" fn mrb_ary_concat(mrb: *mut sys::mrb_state, ary: sys::mrb_valu
             let inner = array.take();
             Array::box_into_value(inner, ary.into(), &mut guard).expect("Array reboxing should not fail");
         } else {
-            warn!(
-                "Attempted to call mrb_ary_concat with a {:?} argument",
+            emit_fatal_warning!(
+                "ffi: mrb_ary_concat: Expected {:?} argument but got {:?} argument",
+                Ruby::Array,
                 other.ruby_type()
             );
         }

--- a/artichoke-backend/src/ffi.rs
+++ b/artichoke-backend/src/ffi.rs
@@ -33,7 +33,7 @@ pub unsafe fn from_user_data(mrb: *mut sys::mrb_state) -> Result<Artichoke, Inte
     let mut mrb = if let Some(mrb) = NonNull::new(mrb) {
         mrb
     } else {
-        emit_fatal_warning!("fatal: ffi: Attempted to extract Artichoke from null `mrb_state`");
+        emit_fatal_warning!("ffi: Attempted to extract Artichoke from null `mrb_state`");
         return Err(InterpreterExtractError::new());
     };
 
@@ -45,7 +45,7 @@ pub unsafe fn from_user_data(mrb: *mut sys::mrb_state) -> Result<Artichoke, Inte
         if let Some(state) = NonNull::new(alloc_ud) {
             state.cast::<State>()
         } else {
-            emit_fatal_warning!("fatal: ffi: Attempted to extract Artichoke from null `mrb_state->ud` pointer");
+            emit_fatal_warning!("ffi: Attempted to extract Artichoke from null `mrb_state->ud` pointer");
             return Err(InterpreterExtractError::new());
         }
     };

--- a/artichoke-backend/src/ffi.rs
+++ b/artichoke-backend/src/ffi.rs
@@ -33,7 +33,7 @@ pub unsafe fn from_user_data(mrb: *mut sys::mrb_state) -> Result<Artichoke, Inte
     let mut mrb = if let Some(mrb) = NonNull::new(mrb) {
         mrb
     } else {
-        error!("Attempted to extract Artichoke from null mrb_state");
+        emit_fatal_warning!("fatal: fi: Attempted to extract Artichoke from null `mrb_state`");
         return Err(InterpreterExtractError::new());
     };
 
@@ -45,7 +45,7 @@ pub unsafe fn from_user_data(mrb: *mut sys::mrb_state) -> Result<Artichoke, Inte
         if let Some(state) = NonNull::new(alloc_ud) {
             state.cast::<State>()
         } else {
-            warn!("Attempted to extract Artichoke from null mrb_state->ud pointer");
+            emit_fatal_warning!("fatal: ffi: Attempted to extract Artichoke from null `mrb_state->ud` pointer");
             return Err(InterpreterExtractError::new());
         }
     };

--- a/artichoke-backend/src/ffi.rs
+++ b/artichoke-backend/src/ffi.rs
@@ -33,7 +33,7 @@ pub unsafe fn from_user_data(mrb: *mut sys::mrb_state) -> Result<Artichoke, Inte
     let mut mrb = if let Some(mrb) = NonNull::new(mrb) {
         mrb
     } else {
-        emit_fatal_warning!("fatal: fi: Attempted to extract Artichoke from null `mrb_state`");
+        emit_fatal_warning!("fatal: ffi: Attempted to extract Artichoke from null `mrb_state`");
         return Err(InterpreterExtractError::new());
     };
 

--- a/artichoke-backend/src/macros.rs
+++ b/artichoke-backend/src/macros.rs
@@ -3,6 +3,24 @@
 // available to all modules within the artichoke-backend crate in addition to
 // being exported.
 
+#[macro_export]
+macro_rules! emit_fatal_warning {
+    ($($arg:tt)+) => {{
+        use ::std::io::Write;
+
+        // Something bad, terrible, and unexpected has happened.
+        //
+        // Suppress errors from logging to stderr because this function may being
+        // called when there are foreign C frames in the stack and panics are
+        // either UB or will result in an abort.
+        //
+        // Ensure the returned error is dropped so we don't leave anything on
+        // the stack in the event of a foreign unwind.
+        let maybe_err = ::std::write!(::std::io::stderr(), $($arg)+);
+        drop(maybe_err);
+    }};
+}
+
 /// Extract an [`Artichoke`] instance from the userdata on a [`sys::mrb_state`].
 ///
 /// If there is an error when extracting the Rust wrapper around the

--- a/artichoke-backend/src/macros.rs
+++ b/artichoke-backend/src/macros.rs
@@ -16,6 +16,8 @@ macro_rules! emit_fatal_warning {
         //
         // Ensure the returned error is dropped so we don't leave anything on
         // the stack in the event of a foreign unwind.
+        let maybe_err = ::std::write!(::std::io::stderr(), "fatal[artichoke-backend]: ");
+        drop(maybe_err);
         let maybe_err = ::std::writeln!(::std::io::stderr(), $($arg)+);
         drop(maybe_err);
     }};

--- a/artichoke-backend/src/macros.rs
+++ b/artichoke-backend/src/macros.rs
@@ -16,7 +16,7 @@ macro_rules! emit_fatal_warning {
         //
         // Ensure the returned error is dropped so we don't leave anything on
         // the stack in the event of a foreign unwind.
-        let maybe_err = ::std::write!(::std::io::stderr(), $($arg)+);
+        let maybe_err = ::std::writeln!(::std::io::stderr(), $($arg)+);
         drop(maybe_err);
     }};
 }

--- a/artichoke-backend/src/value.rs
+++ b/artichoke-backend/src/value.rs
@@ -147,7 +147,7 @@ impl ValueCore for Value {
             return Err(Fatal::from("Value receiver for function call is dead. This indicates a bug in the mruby garbage collector. Please leave a comment at https://github.com/artichoke/artichoke/issues/1336.").into());
         }
         if let Ok(arg_count_error) = ArgCountError::try_from(args) {
-            warn!("{}", arg_count_error);
+            emit_fatal_warning!("Value::funcall invoked with too many arguments: {}", arg_count_error);
             return Err(arg_count_error.into());
         }
         let args = args.iter().map(Self::inner).collect::<Vec<_>>();


### PR DESCRIPTION
`emit_fatal_warning!` takes a format string and format args and logs them to stderr while suppressing all panics and errors.

`emit_fatal_warning!` is intended to replace `log::error!` and `log::warn!`. `emit_fatal_warning!` will always log to stderr.

Replace existing log to stderr codes with `emit_fatal_warning!` and fixup code that was migrated away from `log::error!` in:

- #1568
- #1569

Replace existing uses of `log::warn!` and `log::error!` with `emit_fatal_warning!`.