### PR TITLE
Remove `log` dependency from artichoke-backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,7 +42,6 @@ dependencies = [
  "cc",
  "cstr",
  "intaglio",
- "log",
  "onig",
  "quickcheck",
  "regex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,7 @@ dependencies = [
  "artichoke-backend",
  "chrono",
  "clap",
+ "log",
  "rustyline",
  "target-lexicon",
  "termcolor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,17 @@ categories = ["command-line-utilities"]
 
 [dependencies]
 clap = { version = "2.34", optional = true }
+# XXX: load-bearing unused dependency.
+#
+# `rustyline` improperly declares its minimum version on `log` as `0.4` despite
+# requiring `>=0.4.5` to compile. Link in at least the minimum version here so
+# cargo pulls in at least 0.4.5, e.g. when using `-Zminimal-versions`.
+#
+# Upstream has not been willing to merge a patch to fix this, so hack around it
+# here.
+#
+# See: https://github.com/kkawakam/rustyline/pull/583
+log = { version = "0.4.5", optional = true }
 rustyline = { version = "9", optional = true, default-features = false }
 termcolor = { version = "1.1", optional = true }
 
@@ -73,7 +84,7 @@ default = [
 ]
 # Enable a CLI frontend for Artichoke, including a `ruby`-equivalent CLI and
 # REPL.
-cli = ["backtrace", "clap", "rustyline"]
+cli = ["backtrace", "clap", "log", "rustyline"]
 # Enable a module for formtting backtraces from Ruby exceptions.
 backtrace = ["termcolor"]
 # Enable all features of Ruby Core, Standard Library, and the underlying VM.

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -16,7 +16,6 @@ artichoke-load-path = { version = "0.1", path = "../artichoke-load-path", defaul
 bstr = { version = "0.2, >= 0.2.2", default-features = false, features = ["std"] }
 cstr = "0.2, >= 0.2.4"
 intaglio = "1.4"
-log = "0.4, >= 0.4.5"
 onig = { version = "6.3", optional = true, default-features = false }
 regex = "1"
 scolapasta-string-escape = { version = "0.2", path = "../scolapasta-string-escape", default-features = false }

--- a/artichoke-backend/src/artichoke.rs
+++ b/artichoke-backend/src/artichoke.rs
@@ -252,7 +252,6 @@ impl<'a> Drop for Guard<'a> {
         let state = state.unwrap_or_else(|| panic!("Dropping Guard with no State"));
 
         unsafe {
-            trace!("Serializing Artichoke State into mrb to prepare for FFI boundary");
             let mrb = self.0.mrb.as_ptr();
             (*mrb).ud = Box::into_raw(state).cast::<c_void>();
         }

--- a/artichoke-backend/src/exception_handler.rs
+++ b/artichoke-backend/src/exception_handler.rs
@@ -169,7 +169,6 @@ pub fn last_error(interp: &mut Artichoke, exception: Value) -> Result<Error, Err
         .with_name(classname.into())
         .with_message(message.to_vec())
         .finish();
-    debug!("Extracted exception from interpreter: {}", exc);
     Ok(Error::from(exc))
 }
 

--- a/artichoke-backend/src/ffi.rs
+++ b/artichoke-backend/src/ffi.rs
@@ -28,8 +28,6 @@ use crate::Artichoke;
 /// [`Box::into_raw`] and that the pointer is to a non-free'd
 /// [`Box`]`<`[`State`]`>`.
 pub unsafe fn from_user_data(mrb: *mut sys::mrb_state) -> Result<Artichoke, InterpreterExtractError> {
-    trace!("Extracting Artichoke State from FFI boundary");
-
     let mut mrb = if let Some(mrb) = NonNull::new(mrb) {
         mrb
     } else {
@@ -51,10 +49,6 @@ pub unsafe fn from_user_data(mrb: *mut sys::mrb_state) -> Result<Artichoke, Inte
     };
 
     let state = Box::from_raw(state.as_ptr());
-    trace!(
-        "Extracted Artichoke from user data pointer on {}",
-        sys::mrb_sys_state_debug(mrb.as_mut())
-    );
     Ok(Artichoke::new(mrb, state))
 }
 

--- a/artichoke-backend/src/lib.rs
+++ b/artichoke-backend/src/lib.rs
@@ -105,9 +105,6 @@
 mod readme {}
 
 #[macro_use]
-extern crate log;
-
-#[macro_use]
 #[doc(hidden)]
 pub mod macros;
 

--- a/artichoke-backend/src/load.rs
+++ b/artichoke-backend/src/load.rs
@@ -22,7 +22,6 @@ impl LoadSources for Artichoke {
         let state = self.state.as_deref_mut().ok_or_else(InterpreterExtractError::new)?;
         let path = path.as_ref();
         state.load_path_vfs.register_extension(path, T::require)?;
-        trace!("Added Rust extension to interpreter file system -- {}", path.display());
         Ok(())
     }
 
@@ -34,7 +33,6 @@ impl LoadSources for Artichoke {
         let state = self.state.as_deref_mut().ok_or_else(InterpreterExtractError::new)?;
         let path = path.as_ref();
         state.load_path_vfs.write_file(path, contents.into())?;
-        trace!("Added Ruby source to interpreter file system -- {}", path.display());
         Ok(())
     }
 
@@ -123,7 +121,6 @@ impl LoadSources for Artichoke {
         };
         let contents = self.read_source_file_contents(path)?.into_owned();
         self.eval(contents.as_ref())?;
-        trace!("Successful load of {}", path.display());
         Ok(true)
     }
 
@@ -167,7 +164,6 @@ impl LoadSources for Artichoke {
                             self.eval(&contents)?;
                             let state = self.state.as_deref_mut().ok_or_else(InterpreterExtractError::new)?;
                             state.load_path_vfs.mark_required(path)?;
-                            trace!("Successful require of {}", path.display());
                             return Ok(true);
                         }
                         // else proceed with the alternate path
@@ -182,7 +178,6 @@ impl LoadSources for Artichoke {
         self.eval(contents.as_ref())?;
         let state = self.state.as_deref_mut().ok_or_else(InterpreterExtractError::new)?;
         state.load_path_vfs.mark_required(path)?;
-        trace!("Successful require of {}", path.display());
         Ok(true)
     }
 

--- a/artichoke-backend/src/value.rs
+++ b/artichoke-backend/src/value.rs
@@ -151,13 +151,6 @@ impl ValueCore for Value {
             return Err(arg_count_error.into());
         }
         let args = args.iter().map(Self::inner).collect::<Vec<_>>();
-        trace!(
-            "Calling {}#{} with {} args{}",
-            self.ruby_type(),
-            func,
-            args.len(),
-            if block.is_some() { " and block" } else { "" }
-        );
         let func = interp.intern_string(func.to_string())?;
         let result = unsafe {
             interp.with_ffi_boundary(|mrb| {

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -36,7 +36,6 @@ dependencies = [
  "cc",
  "cstr",
  "intaglio",
- "log",
  "onig",
  "regex",
  "scolapasta-string-escape",
@@ -212,15 +211,6 @@ name = "libm"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
-
-[[package]]
-name = "log"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
-dependencies = [
- "cfg-if",
-]
 
 [[package]]
 name = "memchr"

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -40,7 +40,6 @@ dependencies = [
  "cc",
  "cstr",
  "intaglio",
- "log",
  "onig",
  "regex",
  "scolapasta-string-escape",
@@ -269,15 +268,6 @@ name = "libm"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
-
-[[package]]
-name = "log"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
-dependencies = [
- "cfg-if",
-]
 
 [[package]]
 name = "memchr"


### PR DESCRIPTION
Prior work that enabled this change:

- https://github.com/artichoke/artichoke/pull/1568
- https://github.com/artichoke/artichoke/pull/1569
- https://github.com/artichoke/artichoke/pull/1573
- https://github.com/artichoke/artichoke/pull/1574

Closes https://github.com/artichoke/artichoke/issues/1043. The direction is to remove logging rather than adding tracing.