### PR TITLE
Fix interpreter extract errors when parsing code in the airb REPL

### DIFF
--- a/src/repl.rs
+++ b/src/repl.rs
@@ -238,7 +238,7 @@ where
             Ok(line) if line.is_empty() && buf.is_empty() => (),
             Ok(line) => {
                 buf.push_str(line.as_str());
-                parser_state = parser.parse(buf.as_bytes());
+                parser_state = parser.parse(buf.as_bytes())?;
 
                 if parser_state.is_code_block_open() {
                     buf.push('\n');
@@ -252,6 +252,8 @@ where
                     buf.clear();
                     continue;
                 }
+
+                let interp = parser.interp();
                 match interp.eval(buf.as_bytes()) {
                     Ok(value) => {
                         let result = value.inspect(interp);


### PR DESCRIPTION
Noisy fatal error logging added in #1573 has shown some mruby interpreter state corruption when parsing code in the `airb` REPL.

```console
$ cargo run -q --bin airb
artichoke 0.1.0-pre.0 (2021-12-14 revision 5146) [x86_64-apple-darwin]
[rustc 1.57.0 (f1edd0429 2021-11-29) on x86_64-apple-darwin]
>>> s = "as"
fatal[artichoke-backend]: ffi: Attempted to extract Artichoke from null `mrb_state->ud` pointer
fatal[artichoke-backend]: ffi: Attempted to extract Artichoke from null `mrb_state->ud` pointer
=> "as"
```

Poking around in LLDB shows the following stack as the fatal error is emitted:

```
* thread #1, queue = 'com.apple.main-thread', stop reason = step over
  * frame #0: 0x00000001002294a4 airb`artichoke_backend::ffi::from_user_data::hd172ce8cd36595ff(mrb=0x0000000101809800) at ffi.rs:46:13
    frame #1: 0x00000001001880d5 airb`mrb_intern_cstr(mrb=0x0000000101809800, name="(airb)") at ffi.rs:40:5
    frame #2: 0x00000001002fcc80 airb`mrb_parser_set_filename(p=0x000000010180e220, f="(airb)") at parse.y:6670:9
    frame #3: 0x00000001002f3cc0 airb`parser_init_cxt(p=0x000000010180e220, cxt=0x00000001012095e0) at parse.y:6470:22
    frame #4: 0x00000001002f3b05 airb`mrb_parser_parse(p=0x000000010180e220, c=0x00000001012095e0) at parse.y:6525:5
    frame #5: 0x00000001000292e2 airb`artichoke::parser::Parser::parse::h5c79c4194e276746(self=0x00007ffeefbfea98, code=size=9) at parser.rs:130:13
    frame #6: 0x0000000100019706 airb`artichoke::repl::repl_loop::hbb9489ed20580c85(interp=0x00007ffeefbff1e8, output=Stdout @ 0x00007ffeefbfe8e8, error=0x00007ffeefbff338, config=0x00007ffeefbff238) at repl.rs:241:32
```

The mruby parser holds a pointer to the `mrb_state` and manipulates the interpreter state during parsing, such as in this case where the parser attempts to intern a C string.

The `Parser` struct in the `artichoke` frontend does not wrap calls to `mrb_parser_parse` in `Artichoke::with_ffi_boundary` which means the Artichoke `State` is moved out of the `mrb_state->ud` pointer. `mrb_intern_cstr` correctly logs a fatal error here. Interning will fail and return `0` which is likely causing a subtle bug in the REPL.

Making the fatal error logs noisy found a bug!

This patch fixes the bug by embedding a `&mut Artichoke` in the `Parser` struct and using `Artichoke::with_ffi_boundary` when invoking C functions on the parser internals. These changes make `Parser::parse` and `Parser::drop` fallible.

To simplify construction of the REPL and to avoid alloc/dealloc of the parser, add `Parser::interp` which allows the REPL loop to access the internal `Artichoke` from the `Parser`.