### PR TITLE
Sync rust versions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,6 +79,7 @@ rake lint:clippy                  # Lint Rust sources with Clippy
 rake lint:clippy:restriction      # Lint Rust sources with Clippy restriction pass (unenforced lints)
 rake lint:rubocop                 # Run RuboCop
 rake lint:rubocop:auto_correct    # Auto-correct RuboCop offenses
+rake pkg:rust_version:sync        # Sync the root rust-toolchain version to all crates
 rake release:markdown_link_check  # Check for broken links in markdown files
 rake sanitizer:leak               # Run Artichoke with LeakSanitizer
 rake spec                         # Run enforced ruby/spec suite

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0-pre.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 license = "MIT"
 edition = "2021"
+rust-version = "1.57.0"
 readme = "README.md"
 repository = "https://github.com/artichoke/artichoke"
 documentation = "https://artichoke.github.io/artichoke/artichoke/"

--- a/Rakefile
+++ b/Rakefile
@@ -164,7 +164,7 @@ namespace :pkg do
     next_rust_version = "rust-version = \"#{rust_version}\""
 
     failures = Dir.glob("#{__dir__}/{,*/}Cargo.toml").map do |file|
-      contents = File.open(file).read
+      contents = File.read(file)
 
       if (existing_version = contents.match(regexp))
         File.write(file, contents.gsub(regexp, next_rust_version)) if existing_version != rust_version

--- a/Rakefile
+++ b/Rakefile
@@ -159,7 +159,7 @@ end
 namespace :pkg do
   desc 'Sync the root rust-toolchain version to all crates'
   task :'rust_version:sync' do
-    rust_version = File.open('rust-toolchain').read.chomp
+    rust_version = File.read('rust-toolchain').chomp
     regexp = /^rust-version = "(.*)"$/
     next_rust_version = "rust-version = \"#{rust_version}\""
 

--- a/Rakefile
+++ b/Rakefile
@@ -163,7 +163,9 @@ namespace :pkg do
     regexp = /^rust-version = "(.*)"$/
     next_rust_version = "rust-version = \"#{rust_version}\""
 
-    failures = Dir.glob("#{__dir__}/{,*/}Cargo.toml").map do |file|
+    pkg_files = FileList.new('*/Cargo.toml').include('Cargo.toml')
+
+    failures = pkg_files.map do |file|
       contents = File.read(file)
 
       if (existing_version = contents.match(regexp))

--- a/Rakefile
+++ b/Rakefile
@@ -155,3 +155,26 @@ namespace :release do
     end
   end
 end
+
+namespace :pkg do
+  desc 'Sync the root rust-toolchain version to all crates'
+  task :'rust_version:sync' do
+    rust_version = File.open('rust-toolchain').read.chomp
+    regexp = /^rust-version = "(.*)"$/
+    next_rust_version = "rust-version = \"#{rust_version}\""
+
+    failures = Dir.glob("#{__dir__}/{,*/}Cargo.toml").map do |file|
+      contents = File.open(file).read
+
+      if (existing_version = contents.match(regexp))
+        File.write(file, contents.gsub(regexp, next_rust_version)) if existing_version != rust_version
+        next
+      end
+
+      puts "Failed to update #{file}, ensure there is a rust-version specified" if Rake.verbose
+      file
+    end.compact
+
+    raise 'Failed to update some rust-versions' if failures.any?
+  end
+end

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -3,6 +3,7 @@ name = "artichoke-backend"
 version = "0.6.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2021"
+rust-version = "1.57.0"
 description = "Embeddable VM implementation for Artichoke Ruby"
 repository = "https://github.com/artichoke/artichoke"
 readme = "README.md"

--- a/artichoke-core/Cargo.toml
+++ b/artichoke-core/Cargo.toml
@@ -3,6 +3,7 @@ name = "artichoke-core"
 version = "0.10.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2021"
+rust-version = "1.57.0"
 description = "Core traits for implementing an Artichoke Ruby interpreter"
 repository = "https://github.com/artichoke/artichoke"
 readme = "README.md"

--- a/artichoke-load-path/Cargo.toml
+++ b/artichoke-load-path/Cargo.toml
@@ -3,6 +3,7 @@ name = "artichoke-load-path"
 version = "0.1.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2021"
+rust-version = "1.57.0"
 description = "Source and extension loaders for a managing a Ruby $LOAD_PATH"
 repository = "https://github.com/artichoke/artichoke"
 readme = "README.md"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 authors = ["Automatically generated"]
 publish = false
 edition = "2021"
+rust-version = "1.57.0"
 license = "MIT"
 
 [package.metadata]

--- a/mezzaluna-feature-loader/Cargo.toml
+++ b/mezzaluna-feature-loader/Cargo.toml
@@ -3,6 +3,7 @@ name = "mezzaluna-feature-loader"
 version = "0.1.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2021"
+rust-version = "1.57.0"
 description = "Source and extension loaders for a managing a Ruby $LOAD_PATH"
 repository = "https://github.com/artichoke/artichoke"
 readme = "README.md"

--- a/scolapasta-hex/Cargo.toml
+++ b/scolapasta-hex/Cargo.toml
@@ -3,6 +3,7 @@ name = "scolapasta-hex"
 version = "0.1.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2021"
+rust-version = "1.57.0"
 description = """
 no_std hexadecimal encoding utility package for Artichoke Ruby.
 """

--- a/scolapasta-string-escape/Cargo.toml
+++ b/scolapasta-string-escape/Cargo.toml
@@ -3,6 +3,7 @@ name = "scolapasta-string-escape"
 version = "0.2.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2021"
+rust-version = "1.57.0"
 description = """
 String escape code and debug formatting utility package for Artichoke Ruby.
 """

--- a/spec-runner/Cargo.toml
+++ b/spec-runner/Cargo.toml
@@ -3,6 +3,7 @@ name = "spec-runner"
 version = "0.6.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2021"
+rust-version = "1.57.0"
 description = "Binary for running Ruby Specs with Artichoke Ruby"
 repository = "https://github.com/artichoke/artichoke"
 readme = "README.md"

--- a/spinoso-array/Cargo.toml
+++ b/spinoso-array/Cargo.toml
@@ -3,6 +3,7 @@ name = "spinoso-array"
 version = "0.7.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2021"
+rust-version = "1.57.0"
 description = """
 Growable vector backends for the Ruby Array core type in Artichoke Ruby
 """

--- a/spinoso-env/Cargo.toml
+++ b/spinoso-env/Cargo.toml
@@ -3,6 +3,7 @@ name = "spinoso-env"
 version = "0.1.1"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2021"
+rust-version = "1.57.0"
 description = """
 Access to environment variables, system or virtualized, for Artichoke Ruby
 """

--- a/spinoso-exception/Cargo.toml
+++ b/spinoso-exception/Cargo.toml
@@ -3,6 +3,7 @@ name = "spinoso-exception"
 version = "0.1.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2021"
+rust-version = "1.57.0"
 description = """
 Ruby Exception error structs
 """

--- a/spinoso-math/Cargo.toml
+++ b/spinoso-math/Cargo.toml
@@ -3,6 +3,7 @@ name = "spinoso-math"
 version = "0.2.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2021"
+rust-version = "1.57.0"
 description = """
 Implementation of the Ruby Math module
 """

--- a/spinoso-random/Cargo.toml
+++ b/spinoso-random/Cargo.toml
@@ -3,6 +3,7 @@ name = "spinoso-random"
 version = "0.2.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2021"
+rust-version = "1.57.0"
 description = """
 Implementation of Ruby Random Core class.
 """

--- a/spinoso-regexp/Cargo.toml
+++ b/spinoso-regexp/Cargo.toml
@@ -3,6 +3,7 @@ name = "spinoso-regexp"
 version = "0.2.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2021"
+rust-version = "1.57.0"
 description = """
 Regex implementation for Ruby Regexp core type in Artichoke Ruby
 """

--- a/spinoso-securerandom/Cargo.toml
+++ b/spinoso-securerandom/Cargo.toml
@@ -3,6 +3,7 @@ name = "spinoso-securerandom"
 version = "0.1.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2021"
+rust-version = "1.57.0"
 description = """
 Secure PRNG backend for Artichoke Ruby, implements 'securerandom' package
 """

--- a/spinoso-string/Cargo.toml
+++ b/spinoso-string/Cargo.toml
@@ -3,6 +3,7 @@ name = "spinoso-string"
 version = "0.11.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2021"
+rust-version = "1.57.0"
 description = """
 Encoding-aware string implementation for Ruby String core type in Artichoke Ruby
 """

--- a/spinoso-symbol/Cargo.toml
+++ b/spinoso-symbol/Cargo.toml
@@ -3,6 +3,7 @@ name = "spinoso-symbol"
 version = "0.1.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2021"
+rust-version = "1.57.0"
 description = """
 Symbol implementation for Ruby Symbol core type in Artichoke Ruby
 """

--- a/spinoso-time/Cargo.toml
+++ b/spinoso-time/Cargo.toml
@@ -3,6 +3,7 @@ name = "spinoso-time"
 version = "0.2.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2021"
+rust-version = "1.57.0"
 description = """
 Datetime handling for Artichoke Ruby
 """


### PR DESCRIPTION
Something to try and help with #1581 

I tried looking for some TOML parsers, but there's nothing that looks like it can easily edit in place - so regex is our best friend I guess. It should be stable, and/or error if there are ever new crates created that don't have the `rust-version` attribute in their `Cargo.toml`.

I'll have a quick think about how to add an action for this. I'm thinking a nightly action that creates a PR (think dependabot?) with the newest version. It should be doable, just need to find a way of programmatically getting the current stable version number (I have some ideas)

Fixes #1581.