### PR TITLE
Implement `strscan` in Ruby with byte-wise `String` operations

### DIFF
--- a/artichoke-backend/src/extn/stdlib/strscan/strscan.rb
+++ b/artichoke-backend/src/extn/stdlib/strscan/strscan.rb
@@ -7,7 +7,7 @@ class StringScanner
     self
   end
 
-  attr_reader :string
+  attr_reader :string, :pos
 
   def string=(str)
     @string = String.try_convert(str)
@@ -188,10 +188,6 @@ class StringScanner
     warn 'peep is obsolete use peek instead' if $VERBOSE
     peek(len)
   end
-
-  def pos
-    @pos
-  end
   alias pointer pos
 
   # rubocop:disable Lint/Void
@@ -273,7 +269,7 @@ class StringScanner
       return nil
     end
 
-    match_end_byte_pos = haystack[0, match.end(0)].bytesize 
+    match_end_byte_pos = haystack[0, match.end(0)].bytesize
     @pos += match_end_byte_pos if advance_pointer_p
     @previous_pos = previous_pos
     @last_match = match
@@ -294,7 +290,7 @@ class StringScanner
     match = pattern.match(haystack)
     return nil if match.nil?
 
-    match_end_byte_pos = haystack[0, match.end(0)].bytesize 
+    match_end_byte_pos = haystack[0, match.end(0)].bytesize
     @pos += match_end_byte_pos
     @previous_pos = previous_pos
     @last_match = match
@@ -309,7 +305,7 @@ class StringScanner
     match = pattern.match(haystack)
     return nil if match.nil?
 
-    match_end_byte_pos = haystack[0, match.end(0)].bytesize 
+    match_end_byte_pos = haystack[0, match.end(0)].bytesize
     @pos += match_end_byte_pos if advance_pointer_p
     @previous_pos = previous_pos
     if return_string_p
@@ -334,7 +330,7 @@ class StringScanner
       return nil
     end
 
-    match_end_byte_pos = haystack[0, match.end(0)].bytesize 
+    match_end_byte_pos = haystack[0, match.end(0)].bytesize
     @pos += match_end_byte_pos
     @previous_pos = previous_pos
     @last_match = match
@@ -353,7 +349,7 @@ class StringScanner
       return nil
     end
 
-    match_end_byte_pos = haystack[0, match.end(0)].bytesize 
+    match_end_byte_pos = haystack[0, match.end(0)].bytesize
     @pos += match_end_byte_pos
     @previous_pos = previous_pos
     @last_match = match

--- a/artichoke-backend/src/extn/stdlib/strscan/strscan.rb
+++ b/artichoke-backend/src/extn/stdlib/strscan/strscan.rb
@@ -7,7 +7,7 @@ class StringScanner
     self
   end
 
-  attr_reader :charpos, :string
+  attr_reader :string
 
   def string=(str)
     @string = String.try_convert(str)
@@ -15,10 +15,10 @@ class StringScanner
 
   def initialize(string)
     @string = String.try_convert(string)
-    @charpos = 0
-    @previous_charpos = nil
+    @pos = 0
+    @previous_pos = nil
     @last_match = nil
-    @last_match_charpos = nil
+    @last_match_pos = nil
   end
 
   def <<(str)
@@ -49,9 +49,9 @@ class StringScanner
   end
 
   def beginning_of_line?
-    return true if @charpos.zero?
+    return true if @pos.zero?
 
-    @string[@charpos - 1] == "\n"
+    @string.byteslice(@pos - 1) == "\n"
   end
   alias bol? beginning_of_line?
 
@@ -59,15 +59,20 @@ class StringScanner
     @last_match&.captures
   end
 
+  def charpos
+    @string.byteslice(0, @pos).length
+  end
+
   def charpos=(pointer)
     raise RangeError unless pointer.abs < @string.length
 
-    @charpos =
+    charpos =
       if pointer.negative?
         @string.length + pointer
       else
         pointer
       end
+    @pos = @string[0, charpos].bytesize
   end
 
   def check(pattern)
@@ -75,14 +80,14 @@ class StringScanner
   end
 
   def check_until(pattern)
-    old = @charpos
+    old = @pos
     result = scan_until(pattern)
-    @charpos = old
+    @pos = old
     result
   end
 
   def eos?
-    @charpos == @string.length
+    @pos == @string.bytesize
   end
 
   def empty?
@@ -92,7 +97,7 @@ class StringScanner
   end
 
   def exist?(pattern)
-    match = @string[@charpos..-1].match(pattern)
+    match = @string.byteslice(@pos, @string.bytesize - @pos).match(pattern)
     return nil if match.nil?
 
     match.end(0)
@@ -101,10 +106,10 @@ class StringScanner
   def get_byte # rubocop:disable Naming/AccessorMethodName
     return nil if eos?
 
-    byte, *_bytes = @string[@charpos..-1].bytes
-    @charpos += 1
-    @last_match_charpos = @charpos
-    @last_match = [byte].pack('c*')
+    byte = @string.byteslice(@pos)
+    @pos += 1
+    @last_match_pos = @pos
+    @last_match = byte
   end
 
   def getbyte
@@ -120,28 +125,39 @@ class StringScanner
   def inspect
     return "#<#{self.class.name} fin>" if eos?
 
-    before = @string.reverse[@string.length - @charpos, 5].reverse
+    charpos = @string.byteslice(0, @pos).length
+
+    before = @string.byteslice(0, @pos)
+    prior = before.length - 5
+    prior = 0 if prior.negative?
+
+    before = before[prior, 5]
     if before.length.positive? && before.length < 5
-      before = " \"#{before}\""
+      before = " #{before.inspect}"
     elsif !before.empty?
-      before = " \"...#{before}\""
+      before = " \"...#{before.inspect[1..-1]}"
     end
-    after = @string[@charpos, 5]
-    after = "\"#{after}...\"" unless after&.empty?
+
+    after = @string.byteslice(@pos, 5)
+    after = "#{after.inspect[0..-2]}...\"" unless after&.empty?
+
     "#<#{self.class.name} #{charpos}/#{@string.length}#{before} @ #{after}>"
   end
 
   def match?(pattern)
-    match = pattern.match(@string[@charpos..-1])
+    haystack = @string.byteslice(@pos, @string.bytesize - @pos)
+    match = pattern.match(haystack)
     if match.nil? || match.begin(0).positive?
       @last_match = nil
-      @last_match_charpos = nil
+      @last_match_pos = nil
       return nil
     end
 
     @last_match = match
-    @last_match_charpos ||= 0
-    @last_match_charpos += match.end(0)
+    @last_match_pos ||= 0
+
+    @last_match_pos += haystack[0, match.end(0)].bytesize
+
     match.end(0) - match.begin(0)
   end
 
@@ -165,7 +181,7 @@ class StringScanner
     raise RangeError unless len.is_a?(Integer)
     raise ArgumentError if len.negative?
 
-    @string.bytes[pos, len].pack('c*')
+    @string.byteslice(pos, len)
   end
 
   def peep(len)
@@ -174,7 +190,7 @@ class StringScanner
   end
 
   def pos
-    @string[0...@charpos].bytes.length
+    @pos
   end
   alias pointer pos
 
@@ -182,11 +198,12 @@ class StringScanner
   def pos=(pointer)
     raise RangeError unless pointer.abs < @string.bytesize
 
-    @charpos =
+    @pos =
       if pointer.negative?
-        @string.bytes[0..pointer - 1].pack('c*').length
+        pointer = @string.bytesize + pointer
+        @string.byteslice(0, pointer).bytesize
       else
-        @string.bytes[0, pointer].pack('c*').length
+        @string.byteslice(0, pointer).bytesize
       end
     pointer
   end
@@ -196,7 +213,7 @@ class StringScanner
   def post_match
     return nil if @last_match.nil?
 
-    ret = @string[@last_match_charpos..-1]
+    ret = @string.byteslice(@last_match_pos, @string.bytesize - @last_match_pos) || ''
     ret = String.new(ret) unless ret.instance_of?(String)
     ret
   end
@@ -204,26 +221,27 @@ class StringScanner
   def pre_match
     return nil if @last_match.nil?
 
-    match_len =
+    match_byte_offset =
       if @last_match.is_a?(MatchData)
-        @last_match.end(0) - @last_match.begin(0)
+        match_char_len = @last_match.end(0) - @last_match.begin(0)
+        @last_match.string[@last_match.begin(0), match_char_len].bytesize
       else
-        @last_match.length
+        @last_match.bytesize
       end
-    ret = @string[0...@last_match_charpos - match_len]
+    ret = @string.byteslice(0, @last_match_pos - match_byte_offset) || ''
     ret = String.new(ret) unless ret.instance_of?(String)
     ret
   end
 
   def reset
-    @charpos = 0
-    @previous_charpos = nil
+    @pos = 0
+    @previous_pos = nil
     @last_match = nil
-    @last_match_charpos = nil
+    @last_match_pos = nil
   end
 
   def rest
-    ret = @string[@charpos..-1]
+    ret = @string.byteslice(@pos, @string.bytesize - @pos)
     ret = String.new(ret) unless ret.instance_of?(String)
     ret
   end
@@ -249,22 +267,25 @@ class StringScanner
   def scan_full(pattern, advance_pointer_p, return_string_p)
     raise TypeError, "wrong argument type #{pattern.class} (expected Regexp)" unless pattern.is_a?(Regexp)
 
-    previous_charpos = @charpos
-    match = pattern.match(@string[@charpos..-1])
+    previous_pos = @pos
+    haystack = @string.byteslice(@pos, @string.bytesize - @pos)
+    match = pattern.match(haystack)
+
     if match.nil? || match.begin(0).positive?
       @last_match = nil
-      @last_match_charpos = nil
-      @previous_charpos = nil
+      @last_match_pos = nil
+      @previous_pos = nil
       return nil
     end
 
-    @charpos += match.end(0) if advance_pointer_p
-    @previous_charpos = previous_charpos
+    match_end_byte_pos = haystack[0, match.end(0)].bytesize 
+    @pos += match_end_byte_pos if advance_pointer_p
+    @previous_pos = previous_pos
     @last_match = match
-    @last_match_charpos = @charpos
+    @last_match_pos = @pos
 
     if return_string_p
-      ret = @string[previous_charpos, match.end(0)]
+      ret = @string.byteslice(previous_pos, match_end_byte_pos)
       ret = String.new(ret) unless ret.instance_of?(String)
       ret
     else
@@ -273,27 +294,31 @@ class StringScanner
   end
 
   def scan_until(pattern)
-    previous_charpos = @charpos
-    match = pattern.match(@string[@charpos..-1])
+    previous_pos = @pos
+    haystack = @string.byteslice(@pos, @string.bytesize - @pos)
+    match = pattern.match(haystack)
     return nil if match.nil?
 
-    @charpos += match.end(0)
-    @previous_charpos = previous_charpos
+    match_end_byte_pos = haystack[0, match.end(0)].bytesize 
+    @pos += match_end_byte_pos
+    @previous_pos = previous_pos
     @last_match = match
-    @last_match_charpos = @charpos
+    @last_match_pos = @pos
 
-    @string[previous_charpos, match.end(0)]
+    @string.byteslice(previous_pos, match_end_byte_pos)
   end
 
   def search_full(pattern, advance_pointer_p, return_string_p)
-    previous_charpos = @charpos
-    match = pattern.match(@string[@charpos..-1])
+    previous_pos = @pos
+    haystack = @string.byteslice(@pos, @string.bytesize - @pos)
+    match = pattern.match(haystack)
     return nil if match.nil?
 
-    @charpos += match.end(0) if advance_pointer_p
-    @previous_charpos = previous_charpos
+    match_end_byte_pos = haystack[0, match.end(0)].bytesize 
+    @pos += match_end_byte_pos if advance_pointer_p
+    @previous_pos = previous_pos
     if return_string_p
-      @string[previous_charpos, match.end(0)]
+      @string.byteslice(previous_pos, match_end_byte_pos)
     else
       match.end(0)
     end
@@ -304,53 +329,57 @@ class StringScanner
   end
 
   def skip(pattern)
-    previous_charpos = @charpos
-    match = pattern.match(@string[@charpos..-1])
+    previous_pos = @pos
+    haystack = @string.byteslice(@pos, @string.bytesize - @pos)
+    match = pattern.match(haystack)
     if match.nil? || match.begin(0).positive?
       @last_match = nil
-      @last_match_charpos = nil
-      @previous_charpos = nil
+      @last_match_pos = nil
+      @previous_pos = nil
       return nil
     end
 
-    @charpos += match.end(0)
-    @previous_charpos = previous_charpos
+    match_end_byte_pos = haystack[0, match.end(0)].bytesize 
+    @pos += match_end_byte_pos
+    @previous_pos = previous_pos
     @last_match = match
-    @last_match_charpos = @charpos
+    @last_match_pos = @pos
     match.end(0)
   end
 
   def skip_until(pattern)
-    previous_charpos = @charpos
-    match = pattern.match(@string[@charpos..-1])
+    previous_pos = @pos
+    haystack = @string.byteslice(@pos, @string.bytesize - @pos)
+    match = pattern.match(haystack)
     if match.nil?
       @last_match = nil
-      @last_match_charpos = nil
-      @previous_charpos = nil
+      @last_match_pos = nil
+      @previous_pos = nil
       return nil
     end
 
-    @charpos += match.end(0)
-    @previous_charpos = previous_charpos
+    match_end_byte_pos = haystack[0, match.end(0)].bytesize 
+    @pos += match_end_byte_pos
+    @previous_pos = previous_pos
     @last_match = match
-    @last_match_charpos = @charpos
+    @last_match_pos = @pos
     match.end(0)
   end
 
   def unscan
-    raise ScanError, 'unscan failed: previous match record not exist' if @previous_charpos.nil?
+    raise ScanError, 'unscan failed: previous match record not exist' if @previous_pos.nil?
 
-    @charpos = @previous_charpos
-    @previous_charpos = nil
+    @pos = @previous_pos
+    @previous_pos = nil
     @last_match = nil
-    @last_match_charpos = nil
+    @last_match_pos = nil
     nil
   end
 
   def terminate
-    @charpos = @string.length
+    @pos = @string.bytesize
     @last_match = nil
-    @last_match_charpos = nil
+    @last_match_pos = nil
     self
   end
 

--- a/artichoke-backend/src/extn/stdlib/strscan/strscan.rb
+++ b/artichoke-backend/src/extn/stdlib/strscan/strscan.rb
@@ -115,7 +115,7 @@ class StringScanner
 
     result = +"#<#{self.class.name}"
     result << " #{@pos}/#{@string.bytesize}"
-    result << " "
+    result << ' '
 
     slice_begin = @pos - 5
     slice_begin = 0 if slice_begin.negative?
@@ -124,10 +124,10 @@ class StringScanner
       previous = @string.byteslice(slice_begin, len)
       previous = "...#{previous}" if @pos > 5
       result << previous.b.inspect
-      result << " "
+      result << ' '
     end
 
-    result << "@ "
+    result << '@ '
 
     slice_end = @pos + 5
     slice_end = @string.bytesize if slice_end > @string.bytesize
@@ -138,7 +138,7 @@ class StringScanner
       result << following.b.inspect
     end
 
-    result << ">"
+    result << '>'
 
     result
   end

--- a/artichoke-backend/src/extn/stdlib/strscan/strscan.rb
+++ b/artichoke-backend/src/extn/stdlib/strscan/strscan.rb
@@ -113,23 +113,34 @@ class StringScanner
   def inspect
     return "#<#{self.class.name} fin>" if eos?
 
-    charpos = @string.byteslice(0, @pos).length
+    result = +"#<#{self.class.name}"
+    result << " #{@pos}/#{@string.bytesize}"
+    result << " "
 
-    before = @string.byteslice(0, @pos)
-    prior = before.length - 5
-    prior = 0 if prior.negative?
-
-    before = before[prior, 5]
-    if before.length.positive? && before.length < 5
-      before = " #{before.inspect}"
-    elsif !before.empty?
-      before = " \"...#{before.inspect[1..-1]}"
+    slice_begin = @pos - 5
+    slice_begin = 0 if slice_begin.negative?
+    if slice_begin < @pos
+      len = @pos - slice_begin
+      previous = @string.byteslice(slice_begin, len)
+      previous = "...#{previous}" if @pos > 5
+      result << previous.b.inspect
+      result << " "
     end
 
-    after = @string.byteslice(@pos, 5)
-    after = "#{after.inspect[0..-2]}...\"" unless after&.empty?
+    result << "@ "
 
-    "#<#{self.class.name} #{charpos}/#{@string.length}#{before} @ #{after}>"
+    slice_end = @pos + 5
+    slice_end = @string.bytesize if slice_end > @string.bytesize
+    if @pos < slice_end
+      len = slice_end - @pos
+      following = @string.byteslice(@pos, len)
+      following = "#{following}..." if @string.bytesize - @pos > 5
+      result << following.b.inspect
+    end
+
+    result << ">"
+
+    result
   end
 
   def match?(pattern)

--- a/artichoke-backend/src/extn/stdlib/strscan/strscan.rb
+++ b/artichoke-backend/src/extn/stdlib/strscan/strscan.rb
@@ -198,13 +198,8 @@ class StringScanner
   def pos=(pointer)
     raise RangeError unless pointer.abs < @string.bytesize
 
-    @pos =
-      if pointer.negative?
-        pointer = @string.bytesize + pointer
-        @string.byteslice(0, pointer).bytesize
-      else
-        @string.byteslice(0, pointer).bytesize
-      end
+    pointer = @string.bytesize + pointer if pointer.negative?
+    @pos = @string.byteslice(0, pointer).bytesize
     pointer
   end
   alias pointer= pos=

--- a/artichoke-backend/src/extn/stdlib/strscan/strscan.rb
+++ b/artichoke-backend/src/extn/stdlib/strscan/strscan.rb
@@ -88,7 +88,7 @@ class StringScanner
   end
 
   def fixed_anchor?
-    raise NotImplementedError, "StringScanner#fixed_anchor? is not yet implemented"
+    raise NotImplementedError, 'StringScanner#fixed_anchor? is not yet implemented'
   end
 
   def get_byte # rubocop:disable Naming/AccessorMethodName
@@ -177,7 +177,7 @@ class StringScanner
     peek(len)
   end
 
-  attr_reader :pos
+  attr_reader :pos # rubocop:disable Style/AccessorGrouping
   alias pointer pos
 
   # rubocop:disable Lint/Void
@@ -347,8 +347,9 @@ class StringScanner
     match.end(0)
   end
 
-  attr_reader :string
+  attr_reader :string # rubocop:disable Style/AccessorGrouping
 
+  # rubocop:disable Lint/Void
   def string=(str)
     s = str
     s = String.try_convert(str) unless str.is_a?(String)
@@ -358,6 +359,7 @@ class StringScanner
 
     str
   end
+  # rubocop:enable Lint/Void
 
   def terminate
     @pos = @string.bytesize

--- a/artichoke-backend/src/extn/stdlib/strscan/strscan.rb
+++ b/artichoke-backend/src/extn/stdlib/strscan/strscan.rb
@@ -7,7 +7,7 @@ class StringScanner
     self
   end
 
-  attr_reader :string, :pos
+  attr_reader :pos, :string
 
   def string=(str)
     @string = String.try_convert(str)

--- a/artichoke-backend/src/extn/stdlib/strscan/strscan_test.rb
+++ b/artichoke-backend/src/extn/stdlib/strscan/strscan_test.rb
@@ -60,7 +60,7 @@ def test_strscan
 end
 
 def test_shift
-  s = StringScanner.new('Fri Dec 12 1975 14:39')
+  s = StringScanner.new(+'Fri Dec 12 1975 14:39')
   s.scan(/Fri /)
   s << ' +1000 GMT'
   raise unless s.string == 'Fri Dec 12 1975 14:39 +1000 GMT'

--- a/artichoke-backend/src/extn/stdlib/strscan/strscan_test.rb
+++ b/artichoke-backend/src/extn/stdlib/strscan/strscan_test.rb
@@ -362,26 +362,37 @@ end
 def test_inspect_emoji_partial
   s = StringScanner.new('abc💎xyz')
   raise unless s.inspect == '#<StringScanner 0/10 @ "abc\xF0\x9F...">'
+
   s.get_byte
   raise unless s.inspect == '#<StringScanner 1/10 "a" @ "bc\xF0\x9F\x92...">'
+
   s.get_byte
   raise unless s.inspect == '#<StringScanner 2/10 "ab" @ "c\xF0\x9F\x92\x8E...">'
+
   s.get_byte
   raise unless s.inspect == '#<StringScanner 3/10 "abc" @ "\xF0\x9F\x92\x8Ex...">'
+
   s.get_byte
   raise unless s.inspect == '#<StringScanner 4/10 "abc\xF0" @ "\x9F\x92\x8Exy...">'
+
   s.get_byte
   raise unless s.inspect == '#<StringScanner 5/10 "abc\xF0\x9F" @ "\x92\x8Exyz">'
+
   s.get_byte
   raise unless s.inspect == '#<StringScanner 6/10 "...bc\xF0\x9F\x92" @ "\x8Exyz">'
+
   s.get_byte
   raise unless s.inspect == '#<StringScanner 7/10 "...c\xF0\x9F\x92\x8E" @ "xyz">'
+
   s.get_byte
   raise unless s.inspect == '#<StringScanner 8/10 "...\xF0\x9F\x92\x8Ex" @ "yz">'
+
   s.get_byte
   raise unless s.inspect == '#<StringScanner 9/10 "...\x9F\x92\x8Exy" @ "z">'
+
   s.get_byte
   raise unless s.inspect == '#<StringScanner fin>'
+
   s.get_byte
   raise unless s.inspect == '#<StringScanner fin>'
 end


### PR DESCRIPTION
These changes are enabled by the spinoso-string implementation of String in Ruby Core.

Obsoletes:

- https://github.com/artichoke/artichoke/pull/1414

Fixes #135.