### PR TITLE
Use `std::os::raw::c_char` for APIs that take "char *"

### DIFF
--- a/artichoke-backend/src/extn/core/string/mod.rs
+++ b/artichoke-backend/src/extn/core/string/mod.rs
@@ -1,5 +1,6 @@
 use core::ops::Deref;
 use std::ffi::c_void;
+use std::os::raw::c_char;
 
 use artichoke_core::value::Value as _;
 use spinoso_exception::TypeError;
@@ -74,7 +75,12 @@ impl BoxUnboxVmValue for String {
         let RawParts { ptr, length, capacity } = String::into_raw_parts(value);
         let value = unsafe {
             interp.with_ffi_boundary(|mrb| {
-                sys::mrb_sys_alloc_rstring(mrb, ptr.cast::<i8>(), length as sys::mrb_int, capacity as sys::mrb_int)
+                sys::mrb_sys_alloc_rstring(
+                    mrb,
+                    ptr.cast::<c_char>(),
+                    length as sys::mrb_int,
+                    capacity as sys::mrb_int,
+                )
             })?
         };
         let string = unsafe { sys::mrb_sys_basic_ptr(value).cast::<sys::RString>() };
@@ -101,7 +107,7 @@ impl BoxUnboxVmValue for String {
         let RawParts { ptr, length, capacity } = String::into_raw_parts(value);
         let string = unsafe {
             sys::mrb_sys_repack_into_rstring(
-                ptr.cast::<i8>(),
+                ptr.cast::<c_char>(),
                 length as sys::mrb_int,
                 capacity as sys::mrb_int,
                 into.inner(),

--- a/artichoke-backend/src/sys/protect.rs
+++ b/artichoke-backend/src/sys/protect.rs
@@ -1,5 +1,6 @@
 use std::ffi::c_void;
 use std::mem;
+use std::os::raw::c_char;
 use std::ptr::{self, NonNull};
 
 use crate::sys;
@@ -111,7 +112,7 @@ impl<'a> Protect for Eval<'a> {
         // `mrb_load_nstring_ctx` sets the "stack keep" field on the context
         // which means the most recent value returned by eval will always be
         // considered live by the GC.
-        sys::mrb_load_nstring_cxt(mrb, code.as_ptr().cast::<i8>(), code.len(), context)
+        sys::mrb_load_nstring_cxt(mrb, code.as_ptr().cast::<c_char>(), code.len(), context)
     }
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -4,6 +4,7 @@
 //! enter multiline editing mode.
 
 use std::ffi::CStr;
+use std::os::raw::c_char;
 use std::ptr::NonNull;
 
 use crate::backend::sys;
@@ -133,7 +134,7 @@ impl<'a> Parser<'a> {
         let parser = unsafe { self.parser.as_mut() };
         let context = unsafe { self.context.as_mut() };
 
-        let ptr = code.as_ptr().cast::<i8>();
+        let ptr = code.as_ptr().cast::<c_char>();
         parser.s = ptr;
         parser.send = unsafe { ptr.offset(len) };
         parser.lineno = context.lineno;


### PR DESCRIPTION
Fixes #1631.

Compilation fails on aarch64 linux where c_char is aliased to u8.

This bug is caused by a misuse of APIs that take `c_char`, which is a platform-dependent typedef, mostly `CStr::from_ptr`, but also some native mruby and mruby-sys APIs:

- https://doc.rust-lang.org/stable/std/ffi/struct.CStr.html#method.from_ptr
- https://doc.rust-lang.org/stable/std/os/raw/type.c_char.html