### PR TITLE
deps(cargo): Use precise dependency version specifiers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,9 +64,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "base64"
@@ -279,9 +279,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.116"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "565dbd88872dbe4cc8a46e527f26483c1d1f7afa6b884a3bd6cd893d4f98da74"
+checksum = "e74d72e0f9b65b5b4ca49a346af3976df0f9c61d550727f349ecd559f251a26c"
 
 [[package]]
 name = "libm"
@@ -798,9 +798,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
+checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -285,9 +285,9 @@ checksum = "565dbd88872dbe4cc8a46e527f26483c1d1f7afa6b884a3bd6cd893d4f98da74"
 
 [[package]]
 name = "libm"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
+checksum = "33a33a362ce288760ec6a508b94caaec573ae7d3bbbd91b87aa0bad4456839db"
 
 [[package]]
 name = "linux-raw-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ keywords = ["artichoke", "artichoke-ruby", "mri", "cruby", "ruby"]
 categories = ["command-line-utilities"]
 
 [dependencies]
-clap = { version = "3.0", optional = true, default-features = false, features = ["std", "suggestions"] }
+clap = { version = "3.0.14", optional = true, default-features = false, features = ["std", "suggestions"] }
 # XXX: load-bearing unused dependency.
 #
 # `rustyline` improperly declares its minimum version on `log` as `0.4` despite
@@ -31,8 +31,8 @@ clap = { version = "3.0", optional = true, default-features = false, features = 
 #
 # See: https://github.com/kkawakam/rustyline/pull/583
 log = { version = "0.4.5", optional = true }
-rustyline = { version = "9", optional = true, default-features = false }
-termcolor = { version = "1.1", optional = true }
+rustyline = { version = "9.1.2", optional = true, default-features = false }
+termcolor = { version = "1.1.0", optional = true }
 
 [dependencies.artichoke-backend]
 version = "0.6"
@@ -41,7 +41,7 @@ default-features = false
 
 [build-dependencies]
 chrono = { version = "0.4.19", default-features = false, features = ["clock"] }
-target-lexicon = "0.12"
+target-lexicon = "0.12.3"
 
 [[bin]]
 name = "airb"

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -12,31 +12,31 @@ keywords = ["artichoke", "artichoke-ruby", "mruby", "ruby"]
 categories = ["api-bindings"]
 
 [dependencies]
-artichoke-core = { version = "0.10", path = "../artichoke-core" }
-artichoke-load-path = { version = "0.1", path = "../artichoke-load-path", default-features = false }
-bstr = { version = "0.2, >= 0.2.2", default-features = false, features = ["std"] }
-cstr = "0.2, >= 0.2.4"
-intaglio = "1.4"
-onig = { version = "6.3", optional = true, default-features = false }
+artichoke-core = { version = "0.10.0", path = "../artichoke-core" }
+artichoke-load-path = { version = "0.1.0", path = "../artichoke-load-path", default-features = false }
+bstr = { version = "0.2.9", default-features = false, features = ["std"] }
+cstr = "0.2.4"
+intaglio = "1.4.0"
+onig = { version = "6.3.0", optional = true, default-features = false }
 regex = "1"
-scolapasta-string-escape = { version = "0.2", path = "../scolapasta-string-escape", default-features = false }
-spinoso-array = { version = "0.7", path = "../spinoso-array", default-features = false }
-spinoso-env = { version = "0.1", path = "../spinoso-env", optional = true, default-features = false }
-spinoso-exception = { version = "0.1", path = "../spinoso-exception" }
-spinoso-math = { version = "0.2", path = "../spinoso-math", optional = true, default-features = false }
-spinoso-random = { version = "0.2", path = "../spinoso-random", optional = true }
-spinoso-regexp = { version = "0.2", path = "../spinoso-regexp", optional = true, default-features = false }
-spinoso-securerandom = { version = "0.1", path = "../spinoso-securerandom", optional = true }
-spinoso-string = { version = "0.11", path = "../spinoso-string" }
-spinoso-symbol = { version = "0.1", path = "../spinoso-symbol" }
-spinoso-time = { version = "0.2", path = "../spinoso-time", optional = true }
+scolapasta-string-escape = { version = "0.2.0", path = "../scolapasta-string-escape", default-features = false }
+spinoso-array = { version = "0.7.0", path = "../spinoso-array", default-features = false }
+spinoso-env = { version = "0.1.1", path = "../spinoso-env", optional = true, default-features = false }
+spinoso-exception = { version = "0.1.0", path = "../spinoso-exception" }
+spinoso-math = { version = "0.2.0", path = "../spinoso-math", optional = true, default-features = false }
+spinoso-random = { version = "0.2.0", path = "../spinoso-random", optional = true }
+spinoso-regexp = { version = "0.2.0", path = "../spinoso-regexp", optional = true, default-features = false }
+spinoso-securerandom = { version = "0.1.0", path = "../spinoso-securerandom", optional = true }
+spinoso-string = { version = "0.11.0", path = "../spinoso-string" }
+spinoso-symbol = { version = "0.1.0", path = "../spinoso-symbol" }
+spinoso-time = { version = "0.2.0", path = "../spinoso-time", optional = true }
 
 [dev-dependencies]
-quickcheck = { version = "1.0", default-features = false }
+quickcheck = { version = "1.0.3", default-features = false }
 
 [build-dependencies]
-cc = "1.0"
-target-lexicon = "0.12"
+cc = "1.0.72"
+target-lexicon = "0.12.3"
 
 [features]
 default = [

--- a/artichoke-load-path/Cargo.toml
+++ b/artichoke-load-path/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["artichoke", "artichoke-ruby", "load-path", "ruby"]
 categories = ["filesystem"]
 
 [dependencies]
-same-file = { version = "1, >= 1.0.6", optional = true }
+same-file = { version = "1.0.6", optional = true }
 
 [features]
 default = ["native-file-system-loader", "rubylib-native-file-system-loader"]

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "arbitrary"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "510c76ecefdceada737ea728f4f9a84bd2e1ef29f1ba555e560940fe279954de"
+checksum = "c38b6b6b79f671c25e1a3e785b7b82d7562ffc9cd3efdc98627e5668a2472490"
 
 [[package]]
 name = "artichoke"
@@ -73,9 +73,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "base64"
@@ -191,9 +191,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.116"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "565dbd88872dbe4cc8a46e527f26483c1d1f7afa6b884a3bd6cd893d4f98da74"
+checksum = "e74d72e0f9b65b5b4ca49a346af3976df0f9c61d550727f349ecd559f251a26c"
 
 [[package]]
 name = "libfuzzer-sys"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -208,9 +208,9 @@ dependencies = [
 
 [[package]]
 name = "libm"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
+checksum = "33a33a362ce288760ec6a508b94caaec573ae7d3bbbd91b87aa0bad4456839db"
 
 [[package]]
 name = "memchr"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -12,7 +12,7 @@ cargo-fuzz = true
 
 [dependencies]
 artichoke = { version = "0.1.0-pre.0", path = "..", default-features = false, features = ["kitchen-sink"] }
-libfuzzer-sys = "0.4"
+libfuzzer-sys = "0.4.2"
 
 # Prevent this from interfering with workspaces
 [workspace]

--- a/mezzaluna-feature-loader/Cargo.toml
+++ b/mezzaluna-feature-loader/Cargo.toml
@@ -12,8 +12,8 @@ keywords = ["artichoke", "artichoke-ruby", "load-path", "ruby"]
 categories = ["filesystem"]
 
 [dependencies]
-bstr = { version = "0.2, >= 0.2.4", optional = true, default-features = false }
-same-file = { version = "1, >= 1.0.6", optional = true }
+bstr = { version = "0.2.9", optional = true, default-features = false }
+same-file = { version = "1.0.6", optional = true }
 
 [features]
 default = ["rubylib"]

--- a/scolapasta-string-escape/Cargo.toml
+++ b/scolapasta-string-escape/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["artichoke", "escape", "no_std", "ruby"]
 categories = ["encoding", "no-std", "parser-implementations"]
 
 [dependencies]
-bstr = { version = "0.2, >= 0.2.4", default-features = false }
+bstr = { version = "0.2.9", default-features = false }
 
 [features]
 default = ["std"]

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -250,9 +250,9 @@ checksum = "565dbd88872dbe4cc8a46e527f26483c1d1f7afa6b884a3bd6cd893d4f98da74"
 
 [[package]]
 name = "libm"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
+checksum = "33a33a362ce288760ec6a508b94caaec573ae7d3bbbd91b87aa0bad4456839db"
 
 [[package]]
 name = "memchr"

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -60,9 +60,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "base64"
@@ -244,9 +244,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.116"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "565dbd88872dbe4cc8a46e527f26483c1d1f7afa6b884a3bd6cd893d4f98da74"
+checksum = "e74d72e0f9b65b5b4ca49a346af3976df0f9c61d550727f349ecd559f251a26c"
 
 [[package]]
 name = "libm"

--- a/spec-runner/Cargo.toml
+++ b/spec-runner/Cargo.toml
@@ -13,14 +13,14 @@ categories = ["development-tools::testing"]
 
 [dependencies]
 artichoke = { version = "0.1.0-pre.0", path = "..", default-features = false, features = ["backtrace", "kitchen-sink"] }
-clap = { version = "3.0", default-features = false, features = ["std", "suggestions"] }
+clap = { version = "3.0.14", default-features = false, features = ["std", "suggestions"] }
 rust-embed = "6.3.0"
-serde = { version = "1.0", features = ["derive"] }
-termcolor = "1.1"
-toml = { version = "0.5", default-features = false }
+serde = { version = "1.0.136", features = ["derive"] }
+termcolor = "1.1.0"
+toml = { version = "0.5.8", default-features = false }
 
 [dev-dependencies]
-bstr = { version = "0.2, >= 0.2.4", default-features = false }
+bstr = { version = "0.2.9", default-features = false }
 
 # `spec-runner` is a regression testing tool
 # Remove it from the main artichoke workspace.

--- a/spinoso-array/Cargo.toml
+++ b/spinoso-array/Cargo.toml
@@ -14,13 +14,13 @@ keywords = ["array", "no_std", "spinoso", "vec", "vector"]
 categories = ["data-structures", "no-std"]
 
 [dependencies]
-raw-parts = "1.1"
+raw-parts = "1.1.1"
 # 1.4.1 fixed UB when allocating zero-bytes for ZST element types.
 # https://github.com/servo/rust-smallvec/releases/tag/v1.4.1
 # 1.6.1 fixed a buffer overflow when calling `SmallVec::insert_many`.
 # https://github.com/servo/rust-smallvec/issues/252
-smallvec = { version = "1, >= 1.6.1", optional = true }
-tinyvec = { version = "1.3", optional = true, default-features = false, features = ["alloc"] }
+smallvec = { version = "1.6.1", optional = true }
+tinyvec = { version = "1.3.0", optional = true, default-features = false, features = ["alloc"] }
 
 [features]
 default = ["small-array", "tiny-array"]

--- a/spinoso-env/Cargo.toml
+++ b/spinoso-env/Cargo.toml
@@ -14,8 +14,8 @@ keywords = ["artichoke", "env", "environ", "spinoso"]
 categories = ["os", "wasm"]
 
 [dependencies]
-bstr = { version = "0.2, >= 0.2.4", default-features = false }
-scolapasta-string-escape = { version = "0.2", path = "../scolapasta-string-escape", default-features = false }
+bstr = { version = "0.2.9", default-features = false }
+scolapasta-string-escape = { version = "0.2.0", path = "../scolapasta-string-escape", default-features = false }
 
 [features]
 default = ["system-env"]

--- a/spinoso-exception/Cargo.toml
+++ b/spinoso-exception/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["error", "exception", "no_std", "spinoso"]
 categories = ["rust-patterns"]
 
 [dependencies]
-scolapasta-string-escape = { version = "0.2", path = "../scolapasta-string-escape", default-features = false }
+scolapasta-string-escape = { version = "0.2.0", path = "../scolapasta-string-escape", default-features = false }
 
 [features]
 default = ["std"]

--- a/spinoso-math/Cargo.toml
+++ b/spinoso-math/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["libm", "math", "no_std", "spinoso"]
 categories = ["algorithms", "no-std"]
 
 [dependencies]
-libm = { version = "0.2", optional = true }
+libm = { version = "0.2.2", optional = true }
 
 [features]
 default = ["full"]

--- a/spinoso-random/Cargo.toml
+++ b/spinoso-random/Cargo.toml
@@ -14,14 +14,14 @@ keywords = ["random", "rand", "rng", "mt", "spinoso"]
 categories = ["algorithms", "no-std"]
 
 [dependencies]
-getrandom = { version = "0.2", default-features = false }
-libm = "0.2"
-rand = { version = "0.8", optional = true, default-features = false }
+getrandom = { version = "0.2.0", default-features = false }
+libm = "0.2.2"
+rand = { version = "0.8.0", optional = true, default-features = false }
 # 0.6.1 is vulnerable to underfilling a buffer.
 #
 # https://rustsec.org/advisories/RUSTSEC-2021-0023
-rand_core = { version = "0.6, >= 0.6.2", optional = true, default-features = false }
-rand_mt = { version = "4.1", default-features = false }
+rand_core = { version = "0.6.2", optional = true, default-features = false }
+rand_mt = { version = "4.1.0", default-features = false }
 
 [features]
 default = ["random-rand", "rand-traits", "std"]

--- a/spinoso-regexp/Cargo.toml
+++ b/spinoso-regexp/Cargo.toml
@@ -26,3 +26,7 @@ oniguruma = ["onig"]
 regex-full = ["regex-perf", "regex-unicode"]
 regex-perf = ["regex/perf"]
 regex-unicode = ["regex/unicode"]
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/spinoso-regexp/Cargo.toml
+++ b/spinoso-regexp/Cargo.toml
@@ -14,11 +14,11 @@ keywords = ["artichoke", "onig", "regex", "regexp", "ruby"]
 categories = ["data-structures", "parser-implementations"]
 
 [dependencies]
-bitflags = "1.3"
-bstr = { version = "0.2, >= 0.2.4", default-features = false }
-onig = { version = "6.3", optional = true, default-features = false }
-regex = { version = "1, >= 1.4.3", default-features = false, features = ["std", "unicode-perl"] }
-scolapasta-string-escape = { version = "0.2", path = "../scolapasta-string-escape", default-features = false }
+bitflags = "1.3.0"
+bstr = { version = "0.2.9", default-features = false }
+onig = { version = "6.3.0", optional = true, default-features = false }
+regex = { version = "1.4.3", default-features = false, features = ["std", "unicode-perl"] }
+scolapasta-string-escape = { version = "0.2.0", path = "../scolapasta-string-escape", default-features = false }
 
 [features]
 default = ["oniguruma", "regex-full"]

--- a/spinoso-securerandom/Cargo.toml
+++ b/spinoso-securerandom/Cargo.toml
@@ -14,14 +14,9 @@ keywords = ["artichoke", "rand", "random", "rng", "spinoso"]
 categories = ["algorithms"]
 
 [dependencies]
-base64 = { version = "0.13", default-features = false, features = ["alloc"] }
-rand = "0.8"
-
-[dependencies.scolapasta-hex]
-version = "0.1"
-path = "../scolapasta-hex"
-default-features = false
-features = ["alloc"]
+base64 = { version = "0.13.0", default-features = false, features = ["alloc"] }
+rand = "0.8.0"
+scolapasta-hex = { version = "0.1.0", path = "../scolapasta-hex", default-features = false, features = ["alloc"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/spinoso-string/Cargo.toml
+++ b/spinoso-string/Cargo.toml
@@ -31,3 +31,7 @@ casecmp = ["focaccia"]
 #
 # Enable runtime SIMD dispatch in `bytecount` and `simdutf8` dependencies.
 std = ["bytecount/runtime-dispatch-simd", "simdutf8/std"]
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/spinoso-string/Cargo.toml
+++ b/spinoso-string/Cargo.toml
@@ -14,15 +14,15 @@ keywords = ["encoding", "no_std", "spinoso", "string", "utf8"]
 categories = ["data-structures", "encoding", "no-std"]
 
 [dependencies]
-bstr = { version = "0.2, >= 0.2.9", default-features = false, features = ["std"] }
-bytecount = "0.6, >= 0.6.2"
-focaccia = { version = "1.1", optional = true, default-features = false }
-raw-parts = "1.1"
-scolapasta-string-escape = { version = "0.2", path = "../scolapasta-string-escape", default-features = false }
-simdutf8 = { version = "0.1, >= 0.1.3", default-features = false }
+bstr = { version = "0.2.9", default-features = false, features = ["std"] }
+bytecount = "0.6.2"
+focaccia = { version = "1.1.0", optional = true, default-features = false }
+raw-parts = "1.1.1"
+scolapasta-string-escape = { version = "0.2.0", path = "../scolapasta-string-escape", default-features = false }
+simdutf8 = { version = "0.1.3", default-features = false }
 
 [dev-dependencies]
-quickcheck = { version = "1.0", default-features = false }
+quickcheck = { version = "1.0.3", default-features = false }
 
 [features]
 default = ["casecmp", "std"]

--- a/spinoso-symbol/Cargo.toml
+++ b/spinoso-symbol/Cargo.toml
@@ -14,10 +14,10 @@ keywords = ["ident", "intern", "no_std", "spinoso", "symbol"]
 categories = ["data-structures", "no-std", "parser-implementations"]
 
 [dependencies]
-artichoke-core = { version = "0.10", path = "../artichoke-core", optional = true, default-features = false }
-bstr = { version = "0.2, >= 0.2.4", optional = true, default-features = false }
-focaccia = { version = "1.1", optional = true, default-features = false }
-scolapasta-string-escape = { version = "0.2", path = "../scolapasta-string-escape", optional = true, default-features = false }
+artichoke-core = { version = "0.10.0", path = "../artichoke-core", optional = true, default-features = false }
+bstr = { version = "0.2.9", optional = true, default-features = false }
+focaccia = { version = "1.1.0", optional = true, default-features = false }
+scolapasta-string-escape = { version = "0.2.0", path = "../scolapasta-string-escape", optional = true, default-features = false }
 
 [features]
 default = ["artichoke", "std"]

--- a/spinoso-time/Cargo.toml
+++ b/spinoso-time/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["date-and-time"]
 
 [dependencies]
 chrono = { version = "0.4.19", default-features = false, features = ["clock"] }
-chrono-tz = { version = "0.6", default-features = false }
+chrono-tz = { version = "0.6.0", default-features = false }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/ui-tests/Cargo.lock
+++ b/ui-tests/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "autocfg"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "bstr"
@@ -75,9 +75,9 @@ checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "libc"
-version = "0.2.116"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "565dbd88872dbe4cc8a46e527f26483c1d1f7afa6b884a3bd6cd893d4f98da74"
+checksum = "e74d72e0f9b65b5b4ca49a346af3976df0f9c61d550727f349ecd559f251a26c"
 
 [[package]]
 name = "linked-hash-map"


### PR DESCRIPTION
See: https://users.rust-lang.org/t/psa-please-specify-precise-dependency-versions-in-cargo-toml/71277

Artichoke haphazardly set precise minimal version bounds but did so inconsistently and used strange `0.x, >= 0.x.y` specifiers to work around @dependabot specific behavior. Moving to rollup PRs like #1677 removes the need for this strangeness.

When the same dependency is used in multiple workspace crates, this PR changes them all to use the same lower bound. When. compiling a workspace with `-Z minimal-version`, only the highest effective lower bound is tested, so modify the constraints to reflect that.

While touching a bunch of `Cargo.toml` manifests, I noticed some crates which were missing `package.metadata.docs.rs sections`, which have been added.

This PR also runs a `cargo update`, which should close out:

- #1679
- #1680
- #1681
- #1682
- #1683
- #1684
- #1685
- #1686
- #1687
