### PR TITLE
Upgrade to clap 3.1.x, address deprecations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,9 +143,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.0.14"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b63edc3f163b3c71ec8aa23f9bd6070f77edbf3d1d198b164afa90ff00e4ec62"
+checksum = "5177fac1ab67102d8989464efd043c6ff44191b1557ec1ddd489b4f7e1447e77"
 dependencies = [
  "bitflags",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ keywords = ["artichoke", "artichoke-ruby", "mri", "cruby", "ruby"]
 categories = ["command-line-utilities"]
 
 [dependencies]
-clap = { version = "3.0.14", optional = true, default-features = false, features = ["std", "suggestions"] }
+clap = { version = "3.1.2", optional = true, default-features = false, features = ["std", "suggestions"] }
 # XXX: load-bearing unused dependency.
 #
 # `rustyline` improperly declares its minimum version on `log` as `0.4` despite

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -148,9 +148,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.0.14"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b63edc3f163b3c71ec8aa23f9bd6070f77edbf3d1d198b164afa90ff00e4ec62"
+checksum = "5177fac1ab67102d8989464efd043c6ff44191b1557ec1ddd489b4f7e1447e77"
 dependencies = [
  "bitflags",
  "indexmap",

--- a/spec-runner/Cargo.toml
+++ b/spec-runner/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["development-tools::testing"]
 
 [dependencies]
 artichoke = { version = "0.1.0-pre.0", path = "..", default-features = false, features = ["backtrace", "kitchen-sink"] }
-clap = { version = "3.0.14", default-features = false, features = ["std", "suggestions"] }
+clap = { version = "3.1.2", default-features = false, features = ["std", "suggestions"] }
 rust-embed = "6.3.0"
 serde = { version = "1.0.136", features = ["derive"] }
 termcolor = "1.1.0"

--- a/spec-runner/src/main.rs
+++ b/spec-runner/src/main.rs
@@ -82,7 +82,7 @@ use std::str;
 
 use artichoke::backtrace;
 use artichoke::prelude::*;
-use clap::{App, Arg};
+use clap::{Arg, Command};
 use termcolor::{ColorChoice, StandardStream, WriteColor};
 
 mod model;
@@ -105,9 +105,9 @@ struct Args {
 pub fn main() {
     let mut stderr = StandardStream::stderr(ColorChoice::Auto);
 
-    let app = App::new("spec-runner");
-    let app = app.about("ruby/spec runner for Artichoke.");
-    let app = app.arg(
+    let command = Command::new("spec-runner");
+    let command = command.about("ruby/spec runner for Artichoke.");
+    let command = command.arg(
         Arg::new("formatter")
             .long("format")
             .short('f')
@@ -118,23 +118,23 @@ pub fn main() {
             .required(false)
             .help("Choose an output formatter"),
     );
-    let app = app.arg(
+    let command = command.arg(
         Arg::new("quiet")
             .long("quiet")
             .short('q')
             .required(false)
             .help("Suppress spec failures when exiting"),
     );
-    let app = app.arg(
+    let command = command.arg(
         Arg::new("config")
             .allow_invalid_utf8(true)
             .takes_value(true)
             .required(true)
             .help("Path to TOML config file"),
     );
-    let app = app.version(env!("CARGO_PKG_VERSION"));
+    let command = command.version(env!("CARGO_PKG_VERSION"));
 
-    let matches = app.get_matches();
+    let matches = command.get_matches();
 
     let formatter = matches
         .value_of_os("formatter")

--- a/src/bin/artichoke.rs
+++ b/src/bin/artichoke.rs
@@ -48,7 +48,7 @@ use std::path::PathBuf;
 use std::process;
 
 use artichoke::ruby::{self, Args};
-use clap::{App, AppSettings, Arg, ArgMatches};
+use clap::{Arg, ArgMatches, Command};
 use termcolor::{ColorChoice, StandardStream, WriteColor};
 
 type Result<T> = ::std::result::Result<T, Box<dyn error::Error>>;
@@ -135,16 +135,16 @@ fn parse_args() -> Result<Args> {
     Ok(args)
 }
 
-fn app() -> App<'static> {
-    let app = App::new("artichoke");
-    let app = app.about("Artichoke is a Ruby made with Rust.");
-    let app = app.arg(
+fn command() -> Command<'static> {
+    let command = Command::new("artichoke");
+    let command = command.about("Artichoke is a Ruby made with Rust.");
+    let command = command.arg(
         Arg::new("copyright")
             .long("copyright")
             .takes_value(false)
             .help("print the copyright"),
     );
-    let app = app.arg(
+    let command = command.arg(
         Arg::new("commands")
             .short('e')
             .allow_invalid_utf8(true)
@@ -152,17 +152,17 @@ fn app() -> App<'static> {
             .multiple_occurrences(true)
             .help(r"one line of script. Several -e's allowed. Omit [programfile]"),
     );
-    let app = app.arg(
+    let command = command.arg(
         Arg::new("fixture")
             .long("with-fixture")
             .allow_invalid_utf8(true)
             .takes_value(true)
             .help("file whose contents will be read into the `$fixture` global"),
     );
-    let app = app.arg(Arg::new("programfile").allow_invalid_utf8(true));
-    let app = app.arg(Arg::new("arguments").multiple_values(true).allow_invalid_utf8(true));
-    let app = app.version(env!("CARGO_PKG_VERSION"));
-    app.setting(AppSettings::TrailingVarArg)
+    let command = command.arg(Arg::new("programfile").allow_invalid_utf8(true));
+    let command = command.arg(Arg::new("arguments").multiple_values(true).allow_invalid_utf8(true));
+    let command = command.version(env!("CARGO_PKG_VERSION"));
+    command.trailing_var_arg(true)
 }
 
 // NOTE: This routine is plucked from `ripgrep` as of
@@ -185,7 +185,7 @@ where
     I: IntoIterator<Item = T>,
     T: Into<OsString> + Clone,
 {
-    let err = match app().try_get_matches_from(args) {
+    let err = match command().try_get_matches_from(args) {
         Ok(matches) => return Ok(matches),
         Err(err) => err,
     };


### PR DESCRIPTION
https://epage.github.io/blog/2022/02/clap-31-a-step-towards-40/

https://github.com/clap-rs/clap/blob/master/CHANGELOG.md#310---2022-02-16