### PR TITLE
deps(security): Update `regex` crate to 1.5.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -537,9 +537,9 @@ checksum = "4d684eb692d561551750a408e516759f550d51033179e7d2f676efc4495b3d4e"
 
 [[package]]
 name = "regex"
-version = "1.5.4"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
 dependencies = [
  "aho-corasick",
  "memchr",

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -18,7 +18,12 @@ bstr = { version = "0.2.9", default-features = false, features = ["std"] }
 cstr = "0.2.4, < 0.2.10"
 intaglio = "1.4.0"
 onig = { version = "6.3.0", optional = true, default-features = false }
-regex = "1"
+# Ensure the `regex` minimum version is at least 1.5.5 to pull in a fix for a
+# DoS vulnerability.
+#
+# See: CVE-2022-24713
+# https://github.com/artichoke/artichoke/pull/1729
+regex = "1.5.5"
 scolapasta-string-escape = { version = "0.2.0", path = "../scolapasta-string-escape", default-features = false }
 spinoso-array = { version = "0.7.0", path = "../spinoso-array", default-features = false }
 spinoso-env = { version = "0.1.1", path = "../spinoso-env", optional = true, default-features = false }

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -387,9 +387,9 @@ checksum = "4d684eb692d561551750a408e516759f550d51033179e7d2f676efc4495b3d4e"
 
 [[package]]
 name = "regex"
-version = "1.5.4"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
 dependencies = [
  "aho-corasick",
  "memchr",

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -438,9 +438,9 @@ checksum = "4d684eb692d561551750a408e516759f550d51033179e7d2f676efc4495b3d4e"
 
 [[package]]
 name = "regex"
-version = "1.5.4"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
 dependencies = [
  "aho-corasick",
  "memchr",

--- a/spinoso-regexp/Cargo.toml
+++ b/spinoso-regexp/Cargo.toml
@@ -17,7 +17,12 @@ categories = ["data-structures", "parser-implementations"]
 bitflags = "1.3.0"
 bstr = { version = "0.2.9", default-features = false }
 onig = { version = "6.3.0", optional = true, default-features = false }
-regex = { version = "1.4.3", default-features = false, features = ["std", "unicode-perl"] }
+# Ensure the `regex` minimum version is at least 1.5.5 to pull in a fix for a
+# DoS vulnerability.
+#
+# See: CVE-2022-24713
+# https://github.com/artichoke/artichoke/pull/1729
+regex = { version = "1.5.5", default-features = false, features = ["std", "unicode-perl"] }
 scolapasta-string-escape = { version = "0.2.0", path = "../scolapasta-string-escape", default-features = false }
 
 [features]


### PR DESCRIPTION
The Rust `regex` crate is vulnerable to a denial of service
vulnerability similar to the billion laughs XML parsing vulnerability
when compiling empty patterns with repeat expressions.

Artichoke uses `regex` to parse untrusted Regexp patterns.

Artichoke is not believed to be vulnerable in its default configuration.
In its default feature configuration, Artichoke parses Regexp patterns
with `oniguruma` before delegating to `regex`. Oniguruma has mitigations
for large numbers of pattern repetitions.

For at least the test cases added to `regex`, Artichoke does not have
runtime blowup:

```
artichoke 0.1.0-pre.0 (2022-03-08 revision 5350) [x86_64-apple-darwin]
[rustc 1.58.1 (db9d1b20b 2022-01-20) on x86_64-apple-darwin]
>>> /(?:){294967295}/
Traceback (most recent call last):
        1: from (airb):1
RegexpError (too big number for repeat range)
>>> /(?:){64}{64}{64}{64}{64}{64}/
Traceback (most recent call last):
        1: from (airb):2
RegexpError (too big number for repeat range)
>>> /x{0}{4294967295}/
Traceback (most recent call last):
        1: from (airb):3
RegexpError (too big number for repeat range)
>>> /(?:|){4294967295}/
Traceback (most recent call last):
        1: from (airb):4
RegexpError (too big number for repeat range)
```

This commit also removes an overly loose `regex = "1"` version
specifier in `artichoke-backend` which was overlooked in #1688.

See:

- https://github.com/rust-lang/regex/security/advisories/GHSA-m5pq-gvj9-9vr8
- CVE-2022-24713
- https://github.com/rust-lang/regex/commit/ae70b41d4f46641dbc45c7a4f87954aea356283e
- https://groups.google.com/g/rustlang-security-announcements/c/NcNNL1Jq7Yw/m/jiZv_PAABQAJ