### PR TITLE
Add encoding-specific constructors to `EncodedString`

### DIFF
--- a/spinoso-string/src/enc/mod.rs
+++ b/spinoso-string/src/enc/mod.rs
@@ -85,10 +85,28 @@ impl EncodedString {
     #[must_use]
     pub const fn new(buf: Vec<u8>, encoding: Encoding) -> Self {
         match encoding {
-            Encoding::Ascii => Self::Ascii(AsciiString::new(buf)),
-            Encoding::Binary => Self::Binary(BinaryString::new(buf)),
-            Encoding::Utf8 => Self::Utf8(Utf8String::new(buf)),
+            Encoding::Ascii => Self::ascii(buf),
+            Encoding::Binary => Self::binary(buf),
+            Encoding::Utf8 => Self::utf8(buf),
         }
+    }
+
+    #[inline]
+    #[must_use]
+    pub const fn ascii(buf: Vec<u8>) -> Self {
+        Self::Ascii(AsciiString::new(buf))
+    }
+
+    #[inline]
+    #[must_use]
+    pub const fn binary(buf: Vec<u8>) -> Self {
+        Self::Binary(BinaryString::new(buf))
+    }
+
+    #[inline]
+    #[must_use]
+    pub const fn utf8(buf: Vec<u8>) -> Self {
+        Self::Utf8(Utf8String::new(buf))
     }
 }
 

--- a/spinoso-string/src/lib.rs
+++ b/spinoso-string/src/lib.rs
@@ -106,9 +106,8 @@ impl String {
     #[must_use]
     pub const fn new() -> Self {
         let buf = Vec::new();
-        Self {
-            inner: EncodedString::new(buf, Encoding::Utf8),
-        }
+        let inner = EncodedString::utf8(buf);
+        Self { inner }
     }
 
     /// Constructs a new, empty `String` with the specified capacity.
@@ -157,9 +156,8 @@ impl String {
     #[must_use]
     pub fn with_capacity(capacity: usize) -> Self {
         let buf = Vec::with_capacity(capacity);
-        Self {
-            inner: EncodedString::new(buf, Encoding::Utf8),
-        }
+        let inner = EncodedString::utf8(buf);
+        Self { inner }
     }
 
     /// Constructs a new, empty `String` with the specified capacity and
@@ -207,35 +205,36 @@ impl String {
     #[must_use]
     pub fn with_capacity_and_encoding(capacity: usize, encoding: Encoding) -> Self {
         let buf = Vec::with_capacity(capacity);
-        Self {
-            inner: EncodedString::new(buf, encoding),
-        }
+        let inner = EncodedString::new(buf, encoding);
+        Self { inner }
     }
 
     #[inline]
     #[must_use]
     pub fn with_bytes_and_encoding(buf: Vec<u8>, encoding: Encoding) -> Self {
-        Self {
-            inner: EncodedString::new(buf, encoding),
-        }
+        let inner = EncodedString::new(buf, encoding);
+        Self { inner }
     }
 
     #[inline]
     #[must_use]
     pub fn utf8(buf: Vec<u8>) -> Self {
-        Self::with_bytes_and_encoding(buf, Encoding::Utf8)
+        let inner = EncodedString::utf8(buf);
+        Self { inner }
     }
 
     #[inline]
     #[must_use]
     pub fn ascii(buf: Vec<u8>) -> Self {
-        Self::with_bytes_and_encoding(buf, Encoding::Ascii)
+        let inner = EncodedString::ascii(buf);
+        Self { inner }
     }
 
     #[inline]
     #[must_use]
     pub fn binary(buf: Vec<u8>) -> Self {
-        Self::with_bytes_and_encoding(buf, Encoding::Binary)
+        let inner = EncodedString::binary(buf);
+        Self { inner }
     }
 }
 


### PR DESCRIPTION
Add the following APIs to avoid branching when we know the encoding:

- `EncodedString::ascii`
- `EncodedString::binary`
- `EncodedString::utf8`

Make use of these APIs in:

- `String::ascii`
- `String::binary`
- `String::utf8`
- `String::new`
- `String::with_capacity`
- `EncodedString::new`

Fixes #1725.