### PR TITLE
Improve docs in `artichoke-core`, make a few small breaking changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "artichoke-core"
-version = "0.10.0"
+version = "0.11.0"
 
 [[package]]
 name = "artichoke-load-path"

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["artichoke", "artichoke-ruby", "mruby", "ruby"]
 categories = ["api-bindings"]
 
 [dependencies]
-artichoke-core = { version = "0.10.0", path = "../artichoke-core" }
+artichoke-core = { version = "0.11.0", path = "../artichoke-core" }
 artichoke-load-path = { version = "0.1.0", path = "../artichoke-load-path", default-features = false }
 bstr = { version = "0.2.9", default-features = false, features = ["std"] }
 cstr = "0.2.4, < 0.2.10"

--- a/artichoke-backend/src/extn/core/kernel/trampoline.rs
+++ b/artichoke-backend/src/extn/core/kernel/trampoline.rs
@@ -25,7 +25,7 @@ where
 {
     for value in args {
         let display = value.to_s(interp);
-        interp.print(display)?;
+        interp.print(&display)?;
     }
     Ok(Value::nil())
 }
@@ -44,7 +44,7 @@ where
             }
         } else {
             let display = value.to_s(interp);
-            interp.puts(display)?;
+            interp.puts(&display)?;
         }
         Ok(())
     }
@@ -68,14 +68,14 @@ where
     let mut args = args.into_iter().peekable();
     if let Some(first) = args.next() {
         let display = first.inspect(interp);
-        interp.puts(display)?;
+        interp.puts(&display)?;
         if args.peek().is_none() {
             return Ok(first);
         }
         let mut result = vec![first];
         for value in args {
             let display = value.inspect(interp);
-            interp.puts(display)?;
+            interp.puts(&display)?;
             result.push(value);
         }
         interp.try_convert_mut(result)

--- a/artichoke-backend/src/extn/core/string/ffi.rs
+++ b/artichoke-backend/src/extn/core/string/ffi.rs
@@ -539,8 +539,8 @@ unsafe extern "C" fn mrb_str_cat(
 unsafe extern "C" fn mrb_str_hash(mrb: *mut sys::mrb_state, s: sys::mrb_value) -> u32 {
     unwrap_interpreter!(mrb, to => guard, or_else = 0);
     let mut s = Value::from(s);
-    let mut hasher = if let Ok(build_hasher) = guard.build_hasher() {
-        build_hasher.build_hasher()
+    let mut hasher = if let Ok(global_build_hasher) = guard.global_build_hasher() {
+        global_build_hasher.build_hasher()
     } else {
         return 0;
     };

--- a/artichoke-backend/src/extn/core/string/trampoline.rs
+++ b/artichoke-backend/src/extn/core/string/trampoline.rs
@@ -819,7 +819,7 @@ pub fn getbyte(interp: &mut Artichoke, mut value: Value, index: Value) -> Result
 
 pub fn hash(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
     let s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
-    let mut hasher = interp.build_hasher()?.build_hasher();
+    let mut hasher = interp.global_build_hasher()?.build_hasher();
     s.as_slice().hash(&mut hasher);
     #[allow(clippy::cast_possible_wrap)]
     let hash = hasher.finish() as i64;

--- a/artichoke-backend/src/hash.rs
+++ b/artichoke-backend/src/hash.rs
@@ -7,9 +7,9 @@ use crate::Artichoke;
 
 impl Hash for Artichoke {
     type Error = Error;
-    type BuildHasher = RandomState;
+    type GlobalBuildHasher = RandomState;
 
-    fn build_hasher(&mut self) -> Result<&Self::BuildHasher, Self::Error> {
+    fn global_build_hasher(&mut self) -> Result<&Self::GlobalBuildHasher, Self::Error> {
         let state = self.state.as_deref_mut().ok_or_else(InterpreterExtractError::new)?;
         Ok(&state.hash_builder)
     }

--- a/artichoke-backend/src/io.rs
+++ b/artichoke-backend/src/io.rs
@@ -21,9 +21,9 @@ impl Io for Artichoke {
     /// # Errors
     ///
     /// If the output stream encounters an error, an error is returned.
-    fn print<T: AsRef<[u8]>>(&mut self, message: T) -> Result<(), Self::Error> {
+    fn print(&mut self, message: &[u8]) -> Result<(), Self::Error> {
         let state = self.state.as_deref_mut().ok_or_else(InterpreterExtractError::new)?;
-        state.output.write_stdout(message.as_ref())?;
+        state.output.write_stdout(message)?;
         Ok(())
     }
 
@@ -35,9 +35,9 @@ impl Io for Artichoke {
     /// # Errors
     ///
     /// If the output stream encounters an error, an error is returned.
-    fn puts<T: AsRef<[u8]>>(&mut self, message: T) -> Result<(), Self::Error> {
+    fn puts(&mut self, message: &[u8]) -> Result<(), Self::Error> {
         let state = self.state.as_deref_mut().ok_or_else(InterpreterExtractError::new)?;
-        state.output.write_stdout(message.as_ref())?;
+        state.output.write_stdout(message)?;
         state.output.write_stdout(b"\n")?;
         Ok(())
     }

--- a/artichoke-core/Cargo.toml
+++ b/artichoke-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "artichoke-core"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2021"
 rust-version = "1.58.1"

--- a/artichoke-core/README.md
+++ b/artichoke-core/README.md
@@ -20,6 +20,11 @@ interpreter agnostic implementations of Ruby Core and Standard Library.
 
 Artichoke Core defines traits for the following interpreter capabilities:
 
+- [`ClassRegistry`][core-class-registry]: Define and store class specs for Ruby
+  `Class`es.
+- [`CoerceToNumeric`][core-coerce-numeric]: Coerce Ruby values to native
+  numerics (floats and integers).
+- [`Debug`][core-debug]: Provide debugging and `Exception` message support.
 - [`DefineConstant`][core-define-constant]: Define global, class, and module
   constants to be arbitrary Ruby [`Value`][core-value]s.
 - [`Eval`][core-eval]: Execute Ruby source code on an interpreter from various
@@ -33,6 +38,8 @@ Artichoke Core defines traits for the following interpreter capabilities:
   the current process.
 - [`LoadSources`][core-load-sources]: [Require][kernel#require] source code from
   interpreter disk or [`File`][core-file] gems.
+- [`ModuleRegistry`][core-module-registry]: Define and store module spec for
+  Ruby `Module`s.
 - [`Parser`][core-parser]: Manipulate the parser state, e.g. setting the current
   filename.
 - [`Prng`][core-prng]: An interpreter-level pseudorandom number generator that
@@ -74,8 +81,14 @@ All features are enabled by default:
 [`random::default`]: https://ruby-doc.org/core-2.6.3/Random.html#DEFAULT
 [regexp-globals]:
   https://ruby-doc.org/core-2.6.3/Regexp.html#class-Regexp-label-Special+global+variables
+[core-class-registry]:
+  https://artichoke.github.io/artichoke/artichoke_core/class_registry/trait.ClassRegistry.html
+[core-coerce-numeric]:
+  https://artichoke.github.io/artichoke/artichoke_core/coerce_to_numeric/trait.CoerceToNumeric.html
 [core-convert-module]:
   https://artichoke.github.io/artichoke/artichoke_core/convert/index.html
+[core-debug]:
+  https://artichoke.github.io/artichoke/artichoke_core/debug/trait.Debug.html
 [core-define-constant]:
   https://artichoke.github.io/artichoke/artichoke_core/constant/trait.DefineConstant.html
 [core-value]:
@@ -93,6 +106,8 @@ All features are enabled by default:
   https://artichoke.github.io/artichoke/artichoke_core/load/trait.LoadSources.html
 [core-file]:
   https://artichoke.github.io/artichoke/artichoke_core/file/trait.File.html
+[core-module-registry]:
+  https://artichoke.github.io/artichoke/artichoke_core/module_registry/trait.ModuleRegistry.html
 [core-parser]:
   https://artichoke.github.io/artichoke/artichoke_core/parser/trait.Parser.html
 [core-prng]:

--- a/artichoke-core/src/eval.rs
+++ b/artichoke-core/src/eval.rs
@@ -15,18 +15,15 @@ pub trait Eval {
     /// Concrete error type for eval functions.
     type Error;
 
-    /// Eval code on the Artichoke interpreter using the current `Context`.
+    /// Eval code on the Artichoke interpreter using the current parser context.
     ///
     /// # Errors
     ///
     /// If an exception is raised on the interpreter, then an error is returned.
     fn eval(&mut self, code: &[u8]) -> Result<Self::Value, Self::Error>;
 
-    /// Eval code on the Artichoke interpreter using the current `Context` when
-    /// given code as an [`OsStr`].
-    ///
-    /// This trait method requires activating the `std` feature in
-    /// `artichoke-core`.
+    /// Eval code on the Artichoke interpreter using the current parser context
+    /// when given code as an [`OsStr`].
     ///
     /// # Errors
     ///
@@ -35,13 +32,11 @@ pub trait Eval {
     /// If `code` cannot be converted to a `&[u8]` on the current platform, then
     /// an error is returned.
     #[cfg(feature = "std")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     fn eval_os_str(&mut self, code: &OsStr) -> Result<Self::Value, Self::Error>;
 
     /// Eval code on the Artichoke interpreter using a new file `Context` given
     /// a file path.
-    ///
-    /// This trait method requires activating the `std` feature in
-    /// `artichoke-core`.
     ///
     /// # Errors
     ///
@@ -49,5 +44,6 @@ pub trait Eval {
     ///
     /// If `path` does not exist or code cannot be read, an error is returned.
     #[cfg(feature = "std")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     fn eval_file(&mut self, file: &Path) -> Result<Self::Value, Self::Error>;
 }

--- a/artichoke-core/src/globals.rs
+++ b/artichoke-core/src/globals.rs
@@ -46,8 +46,12 @@ pub trait Globals {
 
     /// Get the Ruby value stored in the global variable pointed to by `name`.
     ///
-    /// Getting a global that is currently unset returns `Ok(None)` even through
-    /// a non-existent global resolves to `nil` in the Ruby VM.
+    /// # Compatibility Notes
+    ///
+    /// Getting a global that is currently may return `Ok(None)` even through
+    /// a non-existent global resolves to `nil` in the Ruby VM. Consult the
+    /// documentation on implementations of this trait for implementation-defined
+    /// behavior.
     ///
     /// # Errors
     ///

--- a/artichoke-core/src/hash.rs
+++ b/artichoke-core/src/hash.rs
@@ -1,17 +1,31 @@
-//! Build hashers and hash values
+//! Build hashers and hash values.
 
-/// Hashing functions such as building hashers
+use core::hash::BuildHasher;
+
+/// A trait for retrieving an interpreter-global [`BuildHasher`].
+///
+/// The [`BuildHasher`] associated with the interpreter is for creating instances
+/// of [`Hasher`]. A `BuildHasher` is typically used (e.g., by `HashMap`) to
+/// create [`Hasher`]s for each key such that they are hashed independently of
+/// one another, since [`Hasher`]s contain state.
+///
+/// By associating one [`BuildHasher`] with the interpreter, identical Ruby
+/// objects should hash identically, even if the interpreter's [`BuildHasher`]
+/// includes randomness.
+///
+/// [`Hasher`]: core::hash::Hasher
 pub trait Hash {
-    /// Concrete error type for errors encountered when outputting hash errors.
+    /// Concrete error type for errors encountered when retrieving the
+    /// interpreter's global [`BuildHasher`].
     type Error;
 
-    /// Concrete build hasher type.
-    type BuildHasher: core::hash::BuildHasher;
+    /// Concrete [`BuildHasher`] type which is global to the interpreter.
+    type GlobalBuildHasher: BuildHasher;
 
-    /// Build a Hasher
+    /// Retrieve the interpreter's global [`BuildHasher`].
     ///
     /// # Errors
     ///
-    /// If the build hasher is inaccessible, an error is returned.
-    fn build_hasher(&mut self) -> Result<&Self::BuildHasher, Self::Error>;
+    /// If the [`BuildHasher`] is inaccessible, an error is returned.
+    fn global_build_hasher(&mut self) -> Result<&Self::GlobalBuildHasher, Self::Error>;
 }

--- a/artichoke-core/src/intern.rs
+++ b/artichoke-core/src/intern.rs
@@ -57,13 +57,15 @@ pub trait Intern {
     /// Returns an identifier that enables retrieving the original bytes.
     ///
     /// By default, this method is implemented by delegating to
-    /// [`Intern::intern_bytes`].
+    /// [`intern_bytes`].
     ///
     /// # Errors
     ///
     /// If the symbol store cannot be accessed, an error is returned.
     ///
     /// If the symbol table overflows, an error is returned.
+    ///
+    /// [`intern_bytes`]: Self::intern_bytes
     fn intern_string<T>(&mut self, symbol: T) -> Result<Self::Symbol, Self::Error>
     where
         T: Into<Cow<'static, str>>,
@@ -80,11 +82,13 @@ pub trait Intern {
     /// Returns an identifier that enables retrieving the original bytes.
     ///
     /// By default, this method is implemented by delegating to
-    /// [`Intern::check_interned_bytes`].
+    /// [`check_interned_bytes`].
     ///
     /// # Errors
     ///
     /// If the symbol store cannot be accessed, an error is returned.
+    ///
+    /// [`check_interned_bytes`]: Self::check_interned_bytes
     fn check_interned_string(&self, symbol: &str) -> Result<Option<Self::Symbol>, Self::Error> {
         self.check_interned_bytes(symbol.as_bytes())
     }

--- a/artichoke-core/src/io.rs
+++ b/artichoke-core/src/io.rs
@@ -1,6 +1,6 @@
 //! I/O read and write APIs.
 
-/// Make I/O external to the interpreter.
+/// Perform I/O external to the interpreter.
 pub trait Io {
     /// Concrete error type for errors encountered when reading and writing.
     type Error;
@@ -10,19 +10,21 @@ pub trait Io {
     /// # Errors
     ///
     /// If the output stream encounters an error, an error is returned.
-    fn print<T: AsRef<[u8]>>(&mut self, message: T) -> Result<(), Self::Error>;
+    fn print(&mut self, message: &[u8]) -> Result<(), Self::Error>;
 
     /// Writes the given bytes to the interpreter stdout stream followed by a
     /// newline.
     ///
-    /// This default implementation uses two calls to [`Io::print`].
+    /// The default implementation uses two calls to [`print`].
     ///
     /// # Errors
     ///
     /// If the output stream encounters an error, an error is returned.
-    fn puts<T: AsRef<[u8]>>(&mut self, message: T) -> Result<(), Self::Error> {
-        self.print(message.as_ref())?;
-        self.print("\n")?;
+    ///
+    /// [`print`]: Self::print
+    fn puts(&mut self, message: &[u8]) -> Result<(), Self::Error> {
+        self.print(message)?;
+        self.print(b"\n")?;
         Ok(())
     }
 }

--- a/artichoke-core/src/lib.rs
+++ b/artichoke-core/src/lib.rs
@@ -11,6 +11,12 @@
 #![warn(unused_qualifications)]
 #![warn(variant_size_differences)]
 #![forbid(unsafe_code)]
+// Enable feature callouts in generated documentation:
+// https://doc.rust-lang.org/beta/unstable-book/language-features/doc-cfg.html
+//
+// This approach is borrowed from tokio.
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_alias))]
 
 //! This crate provides a set of traits that, when implemented, comprise a
 //! complete Ruby interpreter.

--- a/artichoke-core/src/lib.rs
+++ b/artichoke-core/src/lib.rs
@@ -32,28 +32,57 @@
 //!
 //! Artichoke Core defines traits for the following interpreter capabilities:
 //!
-//! - [`DefineConstant`](constant::DefineConstant): Define global, class, and
-//!   module constants to be arbitrary Ruby [`Value`](value::Value)s.
-//! - [`Eval`](eval::Eval): Execute Ruby source code on an interpreter from
+//! - [`ClassRegistry`][core-class-registry]: Define and store class specs for
+//!   Ruby `Class`es.
+//! - [`CoerceToNumeric`][core-coerce-numeric]: Coerce Ruby values to native
+//!   numerics (floats and integers).
+//! - [`Debug`][core-debug]: Provide debugging and `Exception` message support.
+//! - [`DefineConstant`][core-define-constant]: Define global, class, and module
+//!   constants to be arbitrary Ruby [`Value`][core-value]s.
+//! - [`Eval`][core-eval]: Execute Ruby source code on an interpreter from
 //!   various sources.
-//! - [`Globals`](globals::Globals): Get, set, and unset interpreter-level
-//!   global variables.
-//! - [`Hash`](hash::Hash): Hashing functions such as building hashers.
-//! - [`Intern`](intern::Intern): Intern byte strings to a cheap to copy and
-//!   compare symbol type.
-//! - [`Io`](io::Io): External I/O APIs, such as writing to the standard output
+//! - [`Globals`][core-globals]: Get, set, and unset interpreter-level global
+//!   variables.
+//! - [`Hash`][core-hash]: Hashing functions such as building hashers.
+//! - [`Intern`][core-intern]: Intern byte strings to a cheap to copy and compare
+//!   symbol type.
+//! - [`Io`][core-io]: External I/O APIs, such as writing to the standard output
 //!   of the current process.
-//! - [`LoadSources`](load::LoadSources): [Require][Kernel#require] source code
-//!   from interpreter disk or [`File`](file::File) gems.
-//! - [`Parser`](parser::Parser): Manipulate the parser state, e.g. setting the
+//! - [`LoadSources`][core-load-sources]: [Require][kernel#require] source code
+//!   from interpreter disk or [`File`][core-file] gems.
+//! - [`ModuleRegistry`][core-module-registry]: Define and store module spec for
+//!   Ruby `Module`s.
+//! - [`Parser`][core-parser]: Manipulate the parser state, e.g. setting the
 //!   current filename.
-//! - [`Prng`](prng::Prng): An interpreter-level pseudorandom number generator
+//! - [`Prng`][core-prng]: An interpreter-level pseudorandom number generator
 //!   that is the backend for [`Random::DEFAULT`].
-//! - [`Regexp`](regexp::Regexp): Manipulate [`Regexp`] global state.
-//! - [`ReleaseMetadata`](release_metadata::ReleaseMetadata): Enable
-//!   interpreters to describe themselves.
-//! - [`TopSelf`](top_self::TopSelf): Access to the root execution context.
-//! - [`Warn`](warn::Warn): Emit warnings.
+//! - [`Regexp`][core-regexp]: Manipulate [`Regexp`][regexp-globals] global
+//!   state.
+//! - [`ReleaseMetadata`][core-releasemetadata]: Enable interpreters to describe
+//!   themselves.
+//! - [`TopSelf`][core-topself]: Access to the root execution context.
+//! - [`Warn`][core-warn]: Emit warnings.
+//!
+//! [core-class-registry]: class_registry::ClassRegistry
+//! [core-coerce-numeric]: coerce_to_numeric::CoerceToNumeric
+//! [core-convert-module]: convert
+//! [core-debug]: debug::Debug
+//! [core-define-constant]: constant::DefineConstant
+//! [core-value]: value::Value
+//! [core-eval]: eval::Eval
+//! [core-globals]: globals::Globals
+//! [core-hash]: hash::Hash
+//! [core-intern]: intern::Intern
+//! [core-io]: io::Io
+//! [core-load-sources]: load::LoadSources
+//! [core-file]: file::File
+//! [core-module-registry]: module_registry::ModuleRegistry
+//! [core-parser]: parser::Parser
+//! [core-prng]: prng::Prng
+//! [core-regexp]: regexp::Regexp
+//! [core-releasemetadata]: release_metadata::ReleaseMetadata
+//! [core-topself]: top_self::TopSelf
+//! [core-warn]: warn::Warn
 //!
 //! Artichoke Core also describes what capabilities a Ruby
 //! [`Value`](value::Value) must have and how to [convert] between Ruby VM and

--- a/artichoke-core/src/prng.rs
+++ b/artichoke-core/src/prng.rs
@@ -1,10 +1,18 @@
 //! Interpreter global pseudorandom number generator.
 
-/// Interpreter global pseudorandom number generator.
+/// Interpreter global pseudorandom number generator (PRNG).
 ///
-/// Implementors of this trait back the `Random::DEFAULT` PRNG.
+/// Implementations of this trait may be used as the backing pseudorandom number
+/// generator for [`Random::DEFAULT`].
+///
+/// The PRNG used to implement this trait is **not** required to be
+/// cryptographically secure. For example, MRI's PRNG is a variant of Mersenne
+/// Twister.
+///
+/// [`Random::DEFAULT`]: https://ruby-doc.org/core-2.6.3/Random.html#DEFAULT
 pub trait Prng {
-    /// Concrete type for PRNG errors.
+    /// Concrete type for errors when retrieving the pseudorandom number
+    /// generator.
     type Error;
 
     /// Concrete type for the interpreter pseudorandom number generator.

--- a/artichoke-core/src/regexp.rs
+++ b/artichoke-core/src/regexp.rs
@@ -1,6 +1,10 @@
 //! Track `Regexp` global state.
 
-/// Track the state of `Regexp` globals and global interpreter state.
+/// Track the state of [`Regexp`] special [global variables] and global
+/// interpreter state.
+///
+/// [`Regexp`]: https://ruby-doc.org/core-2.6.3/Regexp.html
+/// [global variables]: https://ruby-doc.org/core-2.6.3/Regexp.html#class-Regexp-label-Special+global+variables
 pub trait Regexp {
     /// Concrete error type for errors encountered when manipulating `Regexp`
     /// state.
@@ -12,6 +16,11 @@ pub trait Regexp {
     /// `Regexp` matching methods for each capturing group in the regular
     /// expression.
     ///
+    /// Per the Ruby documentation:
+    ///
+    /// > `$1`, `$2` and so on contain text matching first, second, etc capture
+    /// > group.
+    ///
     /// # Errors
     ///
     /// If the `Regexp` state is inaccessible, an error is returned.
@@ -22,6 +31,11 @@ pub trait Regexp {
     /// `Regexp` global variables like `$1` and `$7` are defined after certain
     /// `Regexp` matching methods for each capturing group in the regular
     /// expression.
+    ///
+    /// Per the Ruby documentation:
+    ///
+    /// > `$1`, `$2` and so on contain text matching first, second, etc capture
+    /// > group.
     ///
     /// # Errors
     ///

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -54,7 +54,7 @@ dependencies = [
 
 [[package]]
 name = "artichoke-core"
-version = "0.10.0"
+version = "0.11.0"
 
 [[package]]
 name = "artichoke-fuzz"

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -49,7 +49,7 @@ dependencies = [
 
 [[package]]
 name = "artichoke-core"
-version = "0.10.0"
+version = "0.11.0"
 
 [[package]]
 name = "artichoke-load-path"

--- a/spinoso-symbol/Cargo.toml
+++ b/spinoso-symbol/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["ident", "intern", "no_std", "spinoso", "symbol"]
 categories = ["data-structures", "no-std", "parser-implementations"]
 
 [dependencies]
-artichoke-core = { version = "0.10.0", path = "../artichoke-core", optional = true, default-features = false }
+artichoke-core = { version = "0.11.0", path = "../artichoke-core", optional = true, default-features = false }
 bstr = { version = "0.2.9", optional = true, default-features = false }
 focaccia = { version = "1.1.0", optional = true, default-features = false }
 scolapasta-string-escape = { version = "0.2.0", path = "../scolapasta-string-escape", optional = true, default-features = false }


### PR DESCRIPTION
Improve documentation in `artichoke-core`. This PR includes the following breaking changes and corresponding version bumps:

- Remove `AsRef<[u8]>` generics in method signatures for `Io` trait.
- Rename associated type in `Hash` trait: `Hash::BuildHasher` to `Hash::GlobalBuildHasher`.
- Rename `Hash::build_hasher` to `Hash::global_build_hasher`.

The `Hash` changes make this previously awkward code read a bit nicer:

```rust
interp.build_hasher()?.build_hasher().hasher();
```