### PR TITLE
Add enum return types to `LoadSources` load and require APIs, fix #1730

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "artichoke-core"
-version = "0.11.0"
+version = "0.12.0"
 
 [[package]]
 name = "artichoke-load-path"

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["artichoke", "artichoke-ruby", "mruby", "ruby"]
 categories = ["api-bindings"]
 
 [dependencies]
-artichoke-core = { version = "0.11.0", path = "../artichoke-core" }
+artichoke-core = { version = "0.12.0", path = "../artichoke-core" }
 artichoke-load-path = { version = "0.1.0", path = "../artichoke-load-path", default-features = false }
 bstr = { version = "0.2.9", default-features = false, features = ["std"] }
 cstr = "0.2.4, < 0.2.10"

--- a/artichoke-backend/src/extn/core/kernel/require.rs
+++ b/artichoke-backend/src/extn/core/kernel/require.rs
@@ -2,6 +2,7 @@
 
 use std::path::{Path, PathBuf};
 
+use artichoke_core::load::{Loaded, Required};
 use bstr::ByteSlice;
 
 use crate::convert::implicitly_convert_to_string;
@@ -9,7 +10,7 @@ use crate::extn::prelude::*;
 use crate::platform_string::bytes_to_os_str;
 use crate::state::parser::Context;
 
-pub fn load(interp: &mut Artichoke, mut filename: Value) -> Result<bool, Error> {
+pub fn load(interp: &mut Artichoke, mut filename: Value) -> Result<Loaded, Error> {
     // Safety:
     //
     // Converting the extracted byte slice to an owned `Vec<u8>` is required to
@@ -42,7 +43,7 @@ pub fn load(interp: &mut Artichoke, mut filename: Value) -> Result<bool, Error> 
     Err(LoadError::from(message).into())
 }
 
-pub fn require(interp: &mut Artichoke, mut filename: Value) -> Result<bool, Error> {
+pub fn require(interp: &mut Artichoke, mut filename: Value) -> Result<Required, Error> {
     // Safety:
     //
     // Converting the extracted byte slice to an owned `Vec<u8>` is required to
@@ -76,7 +77,7 @@ pub fn require(interp: &mut Artichoke, mut filename: Value) -> Result<bool, Erro
 }
 
 #[allow(clippy::module_name_repetitions)]
-pub fn require_relative(interp: &mut Artichoke, mut filename: Value, base: RelativePath) -> Result<bool, Error> {
+pub fn require_relative(interp: &mut Artichoke, mut filename: Value, base: RelativePath) -> Result<Required, Error> {
     // Safety:
     //
     // Converting the extracted byte slice to an owned `Vec<u8>` is required to

--- a/artichoke-backend/src/extn/core/kernel/trampoline.rs
+++ b/artichoke-backend/src/extn/core/kernel/trampoline.rs
@@ -16,7 +16,7 @@ pub fn integer(interp: &mut Artichoke, mut arg: Value, base: Option<Value>) -> R
 
 pub fn load(interp: &mut Artichoke, path: Value) -> Result<Value, Error> {
     let success = kernel::require::load(interp, path)?;
-    Ok(interp.convert(success))
+    Ok(interp.convert(bool::from(success)))
 }
 
 pub fn print<T>(interp: &mut Artichoke, args: T) -> Result<Value, Error>
@@ -86,11 +86,11 @@ where
 
 pub fn require(interp: &mut Artichoke, path: Value) -> Result<Value, Error> {
     let success = kernel::require::require(interp, path)?;
-    Ok(interp.convert(success))
+    Ok(interp.convert(bool::from(success)))
 }
 
 pub fn require_relative(interp: &mut Artichoke, path: Value) -> Result<Value, Error> {
     let relative_base = RelativePath::try_from_interp(interp)?;
     let success = kernel::require::require_relative(interp, path, relative_base)?;
-    Ok(interp.convert(success))
+    Ok(interp.convert(bool::from(success)))
 }

--- a/artichoke-backend/src/load.rs
+++ b/artichoke-backend/src/load.rs
@@ -5,9 +5,11 @@ use std::path::Path;
 use artichoke_core::eval::Eval;
 use artichoke_core::file::File;
 use artichoke_core::load::{LoadSources, Loaded, Required};
+use spinoso_exception::LoadError;
 
 use crate::error::Error;
 use crate::ffi::InterpreterExtractError;
+use crate::platform_string::os_str_to_bytes;
 use crate::Artichoke;
 
 const RUBY_EXTENSION: &str = "rb";
@@ -84,37 +86,26 @@ impl LoadSources for Artichoke {
         P: AsRef<Path>,
     {
         let path = path.as_ref();
-        let mut alternate_path;
-        let path = {
-            let state = self.state.as_deref_mut().ok_or_else(InterpreterExtractError::new)?;
-            // Require Rust `File` first because an File may define classes and
-            // modules with `LoadSources` and Ruby files can require arbitrary
-            // other files, including some child sources that may depend on these
-            // module definitions.
-            match state.load_path_vfs.get_extension(path) {
-                Some(hook) => {
-                    // dynamic, Rust-backed `File` require
-                    hook(self)?;
-                    path
+        let state = self.state.as_deref_mut().ok_or_else(InterpreterExtractError::new)?;
+        // Require Rust `File` first because an File may define classes and
+        // modules with `LoadSources` and Ruby files can require arbitrary
+        // other files, including some child sources that may depend on these
+        // module definitions.
+        if let Some(hook) = state.load_path_vfs.get_extension(path) {
+            // dynamic, Rust-backed `File` require
+            hook(self)?;
+        }
+        let contents = self
+            .read_source_file_contents(path)
+            .map_err(|_| {
+                let mut message = b"cannot load such file".to_vec();
+                if let Ok(bytes) = os_str_to_bytes(path.as_os_str()) {
+                    message.extend_from_slice(b" -- ");
+                    message.extend_from_slice(bytes);
                 }
-                None if matches!(path.extension(), Some(ext) if *ext == *OsStr::new(RUBY_EXTENSION)) => path,
-                None => {
-                    alternate_path = path.to_owned();
-                    alternate_path.set_extension(RUBY_EXTENSION);
-                    if let Some(hook) = state.load_path_vfs.get_extension(&alternate_path) {
-                        // dynamic, Rust-backed `File` require
-                        hook(self)?;
-                        // This ensures that if we load the hook at an alternate
-                        // path, we use that alternate path to load the Ruby
-                        // source.
-                        &alternate_path
-                    } else {
-                        path
-                    }
-                }
-            }
-        };
-        let contents = self.read_source_file_contents(path)?.into_owned();
+                LoadError::from(message)
+            })?
+            .into_owned();
         self.eval(contents.as_ref())?;
         Ok(Loaded::Success)
     }
@@ -293,7 +284,7 @@ LoadSources::Counter.instance.inc!
         assert_eq!(count, 11);
 
         let exc = interp.load_source("./counter").unwrap_err();
-        assert_eq!(exc.message().as_bstr(), b"cannot load such file".as_bstr());
+        assert_eq!(exc.message().as_bstr(), b"cannot load such file -- ./counter".as_bstr());
         assert_eq!(exc.name(), "LoadError");
     }
 }

--- a/artichoke-core/Cargo.toml
+++ b/artichoke-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "artichoke-core"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2021"
 rust-version = "1.58.1"

--- a/artichoke-core/src/load.rs
+++ b/artichoke-core/src/load.rs
@@ -204,7 +204,7 @@ pub trait LoadSources {
     /// If `path` does not point to a source file, an error is returned.
     ///
     /// If the source file at `path` has no contents, an error is returned.
-    fn load_source<P>(&mut self, path: P) -> Result<bool, Self::Error>
+    fn load_source<P>(&mut self, path: P) -> Result<Loaded, Self::Error>
     where
         P: AsRef<Path>;
 
@@ -221,6 +221,11 @@ pub trait LoadSources {
     /// is loaded and added to `$LOADED_FEATURES`. This function is equivalent
     /// to `Kernel#require`.
     ///
+    /// Implementations should ensure that this method returns
+    /// [`Ok(Required::Success)`][success] at most once. Subsequent `Ok(_)`
+    /// return values should include [`Required::AlreadyRequired`]. See the
+    /// documentation of [`Required`] for more details.
+    ///
     /// # Errors
     ///
     /// If the underlying file system is inaccessible, an error is returned.
@@ -230,7 +235,9 @@ pub trait LoadSources {
     /// If `path` does not point to a source file, an error is returned.
     ///
     /// If the source file at `path` has no contents, an error is returned.
-    fn require_source<P>(&mut self, path: P) -> Result<bool, Self::Error>
+    ///
+    /// [success]: Required::Success
+    fn require_source<P>(&mut self, path: P) -> Result<Required, Self::Error>
     where
         P: AsRef<Path>;
 

--- a/artichoke-core/src/load.rs
+++ b/artichoke-core/src/load.rs
@@ -62,6 +62,10 @@ pub enum Required {
 }
 
 impl From<Required> for bool {
+    /// Convert a [`Required`] enum into a [`bool`] as returned by
+    /// [`Kernel#require`].
+    ///
+    /// [`Kernel#require`]: https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-require
     fn from(req: Required) -> Self {
         match req {
             Required::Success => true,
@@ -99,6 +103,10 @@ pub enum Loaded {
 }
 
 impl From<Loaded> for bool {
+    /// Convert a [`Loaded`] enum into a [`bool`] as returned by
+    /// [`Kernel#load`].
+    ///
+    /// [`Kernel#load`]: https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-load
     fn from(loaded: Loaded) -> Self {
         let Loaded::Success = loaded;
         true

--- a/artichoke-core/src/load.rs
+++ b/artichoke-core/src/load.rs
@@ -10,6 +10,100 @@ type Path = str;
 
 use crate::file::File;
 
+/// The side effect from a call to [`Kernel#require`].
+///
+/// In Ruby, `require` is stateful. All required sources are tracked in a global
+/// interpreter state accessible as `$"` and `$LOADED_FEATURES`.
+///
+/// The first time a file is required, it is parsed and executed by the
+/// interpreter. If the file executes without raising an error, the file is
+/// successfully required and Rust callers can expect a [`Required::Success`]
+/// variant. Files that are successfully required are added to the interpreter's
+/// set of loaded features.
+///
+/// If the file raises an exception as it is required, Rust callers can expect
+/// an `Err` variant. The file is not added to the set of loaded features.
+///
+/// If the file has previously been required such that [`Required::Success`] has
+/// been returned, all subsequent calls to require the file will return
+/// [`Required::AlreadyRequired`].
+///
+/// See the documentation of [`require_source`] for more details.
+///
+/// [`Kernel#require`]: https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-require
+/// [`require_source`]: LoadSources::require_source
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Required {
+    /// [`Kernel#require`] succeeded at requiring the file.
+    ///
+    /// If this variant is returned, this is the first time the given file has
+    /// been required in the interpreter.
+    ///
+    /// This variant has value `true` when converting to a Boolean as returned
+    /// by `Kernel#require`.
+    ///
+    /// [`Kernel#require`]: https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-require
+    Success,
+    /// [`Kernel#require`] did not require the file because it has already been
+    /// required.
+    ///
+    /// If this variant is returned, this is at least the second time the given
+    /// file has been required. Interpreters guarantee that files are only
+    /// required once. To load a source multiple times, see [`load_source`] and
+    /// [`Kernel#load`].
+    ///
+    /// This variant has value `false` when converting to a Boolean as returned
+    /// by `Kernel#require`.
+    ///
+    /// [`Kernel#require`]: https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-require
+    /// [`load_source`]: LoadSources::load_source
+    /// [`Kernel#load`]: https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-load
+    AlreadyRequired,
+}
+
+impl From<Required> for bool {
+    fn from(req: Required) -> Self {
+        match req {
+            Required::Success => true,
+            Required::AlreadyRequired => false,
+        }
+    }
+}
+
+/// The side effect from a call to [`Kernel#load`].
+///
+/// In Ruby, `load` is stateless. All sources passed to `load` are loaded for
+/// every method call.
+///
+/// Each time a file is loaded, it is parsed and executed by the
+/// interpreter. If the file executes without raising an error, the file is
+/// successfully loaded and Rust callers can expect a [`Loaded::Success`]
+/// variant.
+///
+/// If the file raises an exception as it is required, Rust callers can expect
+/// an `Err` variant. The file is not added to the set of loaded features.
+///
+/// See the documentation of [`load_source`] for more details.
+///
+/// [`Kernel#load`]: https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-load
+/// [`load_source`]: LoadSources::load_source
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Loaded {
+    /// [`Kernel#load`] succeeded at loading the file.
+    ///
+    /// This variant has value `true` when converting to a Boolean as returned
+    /// by `Kernel#load`.
+    /// [`Kernel#load`]: https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-load
+    Success,
+}
+
+impl From<Loaded> for bool {
+    fn from(loaded: Loaded) -> Self {
+        let Loaded::Success = loaded;
+        true
+    }
+}
+
 /// Load Ruby sources and Rust extensions into an interpreter.
 #[allow(clippy::module_name_repetitions)]
 pub trait LoadSources {

--- a/artichoke-core/src/load.rs
+++ b/artichoke-core/src/load.rs
@@ -93,6 +93,7 @@ pub enum Loaded {
     ///
     /// This variant has value `true` when converting to a Boolean as returned
     /// by `Kernel#load`.
+    ///
     /// [`Kernel#load`]: https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-load
     Success,
 }

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -54,7 +54,7 @@ dependencies = [
 
 [[package]]
 name = "artichoke-core"
-version = "0.11.0"
+version = "0.12.0"
 
 [[package]]
 name = "artichoke-fuzz"

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -49,7 +49,7 @@ dependencies = [
 
 [[package]]
 name = "artichoke-core"
-version = "0.11.0"
+version = "0.12.0"
 
 [[package]]
 name = "artichoke-load-path"

--- a/spinoso-symbol/Cargo.toml
+++ b/spinoso-symbol/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["ident", "intern", "no_std", "spinoso", "symbol"]
 categories = ["data-structures", "no-std", "parser-implementations"]
 
 [dependencies]
-artichoke-core = { version = "0.11.0", path = "../artichoke-core", optional = true, default-features = false }
+artichoke-core = { version = "0.12.0", path = "../artichoke-core", optional = true, default-features = false }
 bstr = { version = "0.2.9", optional = true, default-features = false }
 focaccia = { version = "1.1.0", optional = true, default-features = false }
 scolapasta-string-escape = { version = "0.2.0", path = "../scolapasta-string-escape", optional = true, default-features = false }


### PR DESCRIPTION
Add `Loaded` and `Required` enums to replace the `bool` return types from `LoadSources::load_source` and `LoadSources::require_source`.

This PR addresses both bugs in #1730.

Fixes #1730.