### PR TITLE
Use fallible allocation in `scolapasta-hex` and `spinoso-securerandom`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -600,7 +600,7 @@ dependencies = [
 
 [[package]]
 name = "scolapasta-hex"
-version = "0.1.0"
+version = "0.2.0"
 
 [[package]]
 name = "scolapasta-string-escape"
@@ -688,7 +688,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-securerandom"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "base64",
  "rand",

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -31,7 +31,7 @@ spinoso-exception = { version = "0.1.0", path = "../spinoso-exception" }
 spinoso-math = { version = "0.2.0", path = "../spinoso-math", optional = true, default-features = false }
 spinoso-random = { version = "0.2.0", path = "../spinoso-random", optional = true }
 spinoso-regexp = { version = "0.2.0", path = "../spinoso-regexp", optional = true, default-features = false }
-spinoso-securerandom = { version = "0.1.0", path = "../spinoso-securerandom", optional = true }
+spinoso-securerandom = { version = "0.2.0", path = "../spinoso-securerandom", optional = true }
 spinoso-string = { version = "0.12.0", path = "../spinoso-string" }
 spinoso-symbol = { version = "0.1.0", path = "../spinoso-symbol" }
 spinoso-time = { version = "0.2.0", path = "../spinoso-time", optional = true }

--- a/artichoke-backend/src/class/registry.rs
+++ b/artichoke-backend/src/class/registry.rs
@@ -21,8 +21,8 @@
 //! name, are not invalidated as the underlying storage reallocates.
 
 use std::any::{self, Any, TypeId};
-use std::collections::hash_map::{RandomState, Values};
-use std::collections::HashMap;
+use std::collections::hash_map::{HashMap, RandomState, Values};
+use std::collections::TryReserveError;
 use std::hash::BuildHasher;
 use std::iter::FusedIterator;
 
@@ -222,7 +222,7 @@ where
     /// Tries to reserve capacity for at least additional more elements to be
     /// inserted in the `Registry`. The collection may reserve more space to
     /// avoid frequent reallocations.
-    pub fn try_reserve(&mut self, additional: usize) -> Result<(), std::collections::TryReserveError> {
+    pub fn try_reserve(&mut self, additional: usize) -> Result<(), TryReserveError> {
         self.0.try_reserve(additional)
     }
 

--- a/artichoke-backend/src/extn/stdlib/securerandom/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/securerandom/mod.rs
@@ -34,6 +34,8 @@ impl From<SecureRandomError> for Error {
         match err {
             SecureRandomError::Argument(err) => err.into(),
             SecureRandomError::RandomBytes(err) => err.into(),
+            // FIXME: this branch allocates when we might be out of memory.
+            SecureRandomError::Memory(_) => NoMemoryError::with_message("out of memory").into(),
         }
     }
 }

--- a/artichoke-backend/src/module/registry.rs
+++ b/artichoke-backend/src/module/registry.rs
@@ -21,8 +21,8 @@
 //! name, are not invalidated as the underlying storage reallocates.
 
 use std::any::{self, Any, TypeId};
-use std::collections::hash_map::{RandomState, Values};
-use std::collections::HashMap;
+use std::collections::hash_map::{HashMap, RandomState, Values};
+use std::collections::TryReserveError;
 use std::hash::BuildHasher;
 use std::iter::FusedIterator;
 
@@ -222,7 +222,7 @@ where
     /// Tries to reserve capacity for at least additional more elements to be
     /// inserted in the `Registry`. The collection may reserve more space to
     /// avoid frequent reallocations.
-    pub fn try_reserve(&mut self, additional: usize) -> Result<(), std::collections::TryReserveError> {
+    pub fn try_reserve(&mut self, additional: usize) -> Result<(), TryReserveError> {
         self.0.try_reserve(additional)
     }
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -413,7 +413,7 @@ dependencies = [
 
 [[package]]
 name = "scolapasta-hex"
-version = "0.1.0"
+version = "0.2.0"
 
 [[package]]
 name = "scolapasta-string-escape"
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-securerandom"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "base64",
  "rand",

--- a/mezzaluna-feature-loader/src/loaded_features.rs
+++ b/mezzaluna-feature-loader/src/loaded_features.rs
@@ -12,6 +12,7 @@
 
 use std::collections::hash_map::RandomState;
 use std::collections::hash_set::{self, HashSet};
+use std::collections::TryReserveError;
 use std::hash::{BuildHasher, Hash};
 use std::iter::FusedIterator;
 use std::path::{Path, PathBuf};
@@ -380,7 +381,7 @@ where
     /// features.try_reserve(10).expect("why is this OOMing on 10 bytes?");
     /// assert!(features.capacity() >= 10);
     /// ```
-    pub fn try_reserve(&mut self, additional: usize) -> Result<(), std::collections::TryReserveError> {
+    pub fn try_reserve(&mut self, additional: usize) -> Result<(), TryReserveError> {
         self.features.try_reserve(additional)?;
         self.paths.try_reserve(additional)?;
 

--- a/scolapasta-hex/Cargo.toml
+++ b/scolapasta-hex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scolapasta-hex"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2021"
 rust-version = "1.58.1"

--- a/scolapasta-hex/README.md
+++ b/scolapasta-hex/README.md
@@ -15,8 +15,8 @@ for encoding arbitrary octets.
 
 This crate offers encoders that:
 
-- Allocate and return a [`String`]: `encode`.
-- Encode into an already allocated [`String`]: `encode_into`.
+- Allocate and return a [`String`]: `try_encode`.
+- Encode into an already allocated [`String`]: `try_encode_into`.
 - Encode into a [`fmt::Write`]: `format_into`.
 - Encode into a [`io::Write`]: `write_into`.
 
@@ -30,7 +30,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-scolapasta-hex = "0.1"
+scolapasta-hex = "0.2.0"
 ```
 
 Hex encode data like:
@@ -38,7 +38,7 @@ Hex encode data like:
 ```rust
 let data = b"Artichoke Ruby";
 let mut buf = String::new();
-scolapasta_hex::encode_into(data, &mut buf);
+let _ignored = scolapasta_hex::try_encode_into(data, &mut buf);
 assert_eq!(buf, "4172746963686f6b652052756279");
 ```
 
@@ -56,6 +56,11 @@ assert_eq!(iter.collect::<String>(), "4172746963686f6b652052756279");
 
 This crate is `no_std` compatible when built without the `std` feature. This
 crate optionally depends on [`alloc`] when the `alloc` feature is enabled.
+
+When this crate depends on `alloc`, it exclusively uses fallible allocation
+APIs. The APIs in this crate will never abort due to allocation failure or
+capacity overflows. Note that writers given to `format_into` and `write_into`
+may have abort on allocation failure behavior.
 
 ## Crate features
 

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -498,7 +498,7 @@ dependencies = [
 
 [[package]]
 name = "scolapasta-hex"
-version = "0.1.0"
+version = "0.2.0"
 
 [[package]]
 name = "scolapasta-string-escape"
@@ -618,7 +618,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-securerandom"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "base64",
  "rand",

--- a/spinoso-securerandom/Cargo.toml
+++ b/spinoso-securerandom/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spinoso-securerandom"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2021"
 rust-version = "1.58.1"
@@ -16,7 +16,7 @@ categories = ["algorithms"]
 [dependencies]
 base64 = { version = "0.13.0", default-features = false, features = ["alloc"] }
 rand = "0.8.0"
-scolapasta-hex = { version = "0.1.0", path = "../scolapasta-hex", default-features = false, features = ["alloc"] }
+scolapasta-hex = { version = "0.2.0", path = "../scolapasta-hex", default-features = false, features = ["alloc"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/spinoso-securerandom/README.md
+++ b/spinoso-securerandom/README.md
@@ -27,7 +27,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-spinoso-securerandom = "0.1"
+spinoso-securerandom = "0.2.0"
 ```
 
 ## Examples

--- a/spinoso-securerandom/src/lib.rs
+++ b/spinoso-securerandom/src/lib.rs
@@ -455,9 +455,7 @@ pub fn random_bytes(len: Option<i64>) -> Result<Vec<u8>, Error> {
 
     let mut bytes = Vec::new();
     bytes.try_reserve(len)?;
-    for _ in 0..len {
-        bytes.push(0);
-    }
+    bytes.resize(len, 0);
     get_random_bytes(rand::thread_rng(), &mut bytes)?;
     Ok(bytes)
 }

--- a/spinoso-securerandom/src/lib.rs
+++ b/spinoso-securerandom/src/lib.rs
@@ -92,6 +92,7 @@
 mod readme {}
 
 use core::fmt;
+use std::collections::TryReserveError;
 use std::error;
 
 use rand::distributions::Alphanumeric;
@@ -109,7 +110,7 @@ const DEFAULT_REQUESTED_BYTES: usize = 16;
 /// - The given byte length is not a valid [`usize`].
 /// - The underlying source of randomness returns an error when generating the
 ///   requested random bytes.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Error {
     /// Error that indicates an argument parsing or value logic error occurred.
     ///
@@ -120,6 +121,15 @@ pub enum Error {
     ///
     /// See [`RandomBytesError`].
     RandomBytes(RandomBytesError),
+    /// Error that indicates an error was received from the memory allocator.
+    ///
+    /// This may mean that too many random bytes were requested or the system is
+    /// out of memory.
+    ///
+    /// See [`TryReserveError`] and [`TryReserveErrorKind`] for more information.
+    ///
+    /// [`TryReserveErrorKind`]: std::collections::TryReserveErrorKind
+    Memory(TryReserveError),
 }
 
 impl From<ArgumentError> for Error {
@@ -143,6 +153,12 @@ impl From<rand::Error> for Error {
     }
 }
 
+impl From<TryReserveError> for Error {
+    fn from(err: TryReserveError) -> Self {
+        Self::Memory(err)
+    }
+}
+
 impl fmt::Display for Error {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -156,6 +172,7 @@ impl error::Error for Error {
         match self {
             Self::Argument(ref err) => Some(err),
             Self::RandomBytes(ref err) => Some(err),
+            Self::Memory(ref err) => Some(err),
         }
     }
 }
@@ -417,6 +434,8 @@ impl SecureRandom {
 ///
 /// If the underlying source of randomness returns an error, return a
 /// [`RandomBytesError`].
+///
+/// If an allocation error occurs, an error is returned.
 #[inline]
 pub fn random_bytes(len: Option<i64>) -> Result<Vec<u8>, Error> {
     fn get_random_bytes<T: RngCore + CryptoRng>(mut rng: T, slice: &mut [u8]) -> Result<(), RandomBytesError> {
@@ -434,7 +453,11 @@ pub fn random_bytes(len: Option<i64>) -> Result<Vec<u8>, Error> {
         None => DEFAULT_REQUESTED_BYTES,
     };
 
-    let mut bytes = vec![0; len];
+    let mut bytes = Vec::new();
+    bytes.try_reserve(len)?;
+    for _ in 0..len {
+        bytes.push(0);
+    }
     get_random_bytes(rand::thread_rng(), &mut bytes)?;
     Ok(bytes)
 }
@@ -587,7 +610,8 @@ pub fn random_number(max: Max) -> Result<Rand, DomainError> {
 #[inline]
 pub fn hex(len: Option<i64>) -> Result<String, Error> {
     let bytes = random_bytes(len)?;
-    Ok(hex::encode(bytes))
+    let s = hex::try_encode(bytes)?;
+    Ok(s)
 }
 
 /// Generate a base64-encoded [`String`] of random bytes.
@@ -681,12 +705,16 @@ pub fn urlsafe_base64(len: Option<i64>, padding: bool) -> Result<String, Error> 
 ///
 /// If the given length is negative, return an [`ArgumentError`].
 ///
-/// If the underlying source of randomness returns an error, return a
-/// [`RandomBytesError`].
+/// If an allocation error occurs, an error is returned.
 #[inline]
-pub fn alphanumeric(len: Option<i64>) -> Result<Vec<u8>, ArgumentError> {
-    fn get_alphanumeric<T: RngCore + CryptoRng>(rng: T, len: usize) -> Vec<u8> {
-        rng.sample_iter(Alphanumeric).take(len).collect()
+pub fn alphanumeric(len: Option<i64>) -> Result<Vec<u8>, Error> {
+    fn get_alphanumeric<T: RngCore + CryptoRng>(rng: T, len: usize) -> Result<Vec<u8>, TryReserveError> {
+        let mut buf = Vec::new();
+        buf.try_reserve(len)?;
+        for ch in rng.sample_iter(Alphanumeric).take(len) {
+            buf.push(ch);
+        }
+        Ok(buf)
     }
 
     let len = match len.map(usize::try_from) {
@@ -694,12 +722,12 @@ pub fn alphanumeric(len: Option<i64>) -> Result<Vec<u8>, ArgumentError> {
         Some(Ok(len)) => len,
         Some(Err(_)) => {
             let err = ArgumentError::with_message("negative string size (or size too big)");
-            return Err(err);
+            return Err(err.into());
         }
         None => DEFAULT_REQUESTED_BYTES,
     };
 
-    let string = get_alphanumeric(rand::thread_rng(), len);
+    let string = get_alphanumeric(rand::thread_rng(), len)?;
     Ok(string)
 }
 
@@ -721,12 +749,14 @@ pub fn alphanumeric(len: Option<i64>) -> Result<Vec<u8>, ArgumentError> {
 ///
 /// # Errors
 ///
-/// If the underlying source of randomness returns an error, return a
-/// [`RandomBytesError`].
+/// If the underlying source of randomness returns an error, an error is
+/// returned.
+///
+/// If an allocation error occurs, an error is returned.
 ///
 /// [RFC 4122]: https://tools.ietf.org/html/rfc4122#section-4.4
 #[inline]
-pub fn uuid() -> Result<String, RandomBytesError> {
+pub fn uuid() -> Result<String, Error> {
     uuid::v4()
 }
 

--- a/spinoso-securerandom/src/uuid.rs
+++ b/spinoso-securerandom/src/uuid.rs
@@ -7,7 +7,7 @@
 use rand::{CryptoRng, RngCore};
 use scolapasta_hex as hex;
 
-use crate::RandomBytesError;
+use crate::{Error, RandomBytesError};
 
 /// The UUID format is 16 octets.
 ///
@@ -23,7 +23,7 @@ const OCTETS: usize = 16;
 const ENCODED_LENGTH: usize = 36;
 
 #[inline]
-pub fn v4() -> Result<String, RandomBytesError> {
+pub fn v4() -> Result<String, Error> {
     fn get_random_bytes<T: RngCore + CryptoRng>(mut rng: T, slice: &mut [u8]) -> Result<(), RandomBytesError> {
         rng.try_fill_bytes(slice)?;
         Ok(())
@@ -36,7 +36,9 @@ pub fn v4() -> Result<String, RandomBytesError> {
     bytes[6] = (bytes[6] & 0x0f) | 0x40;
     bytes[8] = (bytes[8] & 0x3f) | 0x80;
 
-    let mut buf = String::with_capacity(ENCODED_LENGTH);
+    let mut buf = String::new();
+    buf.try_reserve(ENCODED_LENGTH)?;
+
     let mut iter = bytes.iter().copied();
     for byte in iter.by_ref().take(4) {
         let escaped = hex::escape_byte(byte);

--- a/spinoso-string/src/enc/mod.rs
+++ b/spinoso-string/src/enc/mod.rs
@@ -3,6 +3,7 @@ mod binary;
 mod impls;
 mod utf8;
 
+use alloc::collections::TryReserveError;
 use alloc::vec::Vec;
 use core::cmp::Ordering;
 use core::hash::{Hash, Hasher};
@@ -291,7 +292,7 @@ impl EncodedString {
     }
 
     #[inline]
-    pub fn try_reserve(&mut self, additional: usize) -> Result<(), alloc::collections::TryReserveError> {
+    pub fn try_reserve(&mut self, additional: usize) -> Result<(), TryReserveError> {
         match self {
             EncodedString::Ascii(inner) => inner.try_reserve(additional),
             EncodedString::Binary(inner) => inner.try_reserve(additional),
@@ -309,7 +310,7 @@ impl EncodedString {
     }
 
     #[inline]
-    pub fn try_reserve_exact(&mut self, additional: usize) -> Result<(), alloc::collections::TryReserveError> {
+    pub fn try_reserve_exact(&mut self, additional: usize) -> Result<(), TryReserveError> {
         match self {
             EncodedString::Ascii(inner) => inner.try_reserve_exact(additional),
             EncodedString::Binary(inner) => inner.try_reserve_exact(additional),

--- a/spinoso-string/src/lib.rs
+++ b/spinoso-string/src/lib.rs
@@ -34,6 +34,7 @@ extern crate alloc;
 extern crate std;
 
 use alloc::boxed::Box;
+use alloc::collections::TryReserveError;
 use alloc::vec::Vec;
 #[cfg(feature = "casecmp")]
 use core::cmp::Ordering;
@@ -753,7 +754,7 @@ impl String {
     /// assert!(str.capacity() >= 11);
     /// ```
     #[inline]
-    pub fn try_reserve(&mut self, additional: usize) -> Result<(), alloc::collections::TryReserveError> {
+    pub fn try_reserve(&mut self, additional: usize) -> Result<(), TryReserveError> {
         self.inner.try_reserve(additional)
     }
 
@@ -809,7 +810,7 @@ impl String {
     /// assert!(str.capacity() >= 11);
     /// ```
     #[inline]
-    pub fn try_reserve_exact(&mut self, additional: usize) -> Result<(), alloc::collections::TryReserveError> {
+    pub fn try_reserve_exact(&mut self, additional: usize) -> Result<(), TryReserveError> {
         self.inner.try_reserve_exact(additional)
     }
 


### PR DESCRIPTION
These are breaking changes to many function signatures. Both crates are bumped to 0.2.0.

This PR also cleans up a bunch of function signatures so `TryReserveError` is imported at the top of files instead of embedding the full path to the type in a function signature.