### PR TITLE
Move `std::io` trait impls to their own modules in `spinoso-string`

### DIFF
--- a/spinoso-string/src/enc/ascii/impls.rs
+++ b/spinoso-string/src/enc/ascii/impls.rs
@@ -2,41 +2,9 @@ use alloc::borrow::Cow;
 use alloc::string::String;
 use alloc::vec::Vec;
 use core::borrow::{Borrow, BorrowMut};
-#[cfg(feature = "std")]
-use core::fmt;
 use core::ops::{Deref, DerefMut};
-#[cfg(feature = "std")]
-use std::io::{IoSlice, Result, Write};
 
 use super::AsciiString;
-
-#[cfg(feature = "std")]
-impl Write for AsciiString {
-    #[inline]
-    fn write(&mut self, buf: &[u8]) -> Result<usize> {
-        self.inner.write(buf)
-    }
-
-    #[inline]
-    fn write_all(&mut self, buf: &[u8]) -> Result<()> {
-        self.inner.write_all(buf)
-    }
-
-    #[inline]
-    fn write_fmt(&mut self, fmt: fmt::Arguments<'_>) -> Result<()> {
-        self.inner.write_fmt(fmt)
-    }
-
-    #[inline]
-    fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> Result<usize> {
-        self.inner.write_vectored(bufs)
-    }
-
-    #[inline]
-    fn flush(&mut self) -> Result<()> {
-        self.inner.flush()
-    }
-}
 
 impl Extend<u8> for AsciiString {
     #[inline]

--- a/spinoso-string/src/enc/ascii/io.rs
+++ b/spinoso-string/src/enc/ascii/io.rs
@@ -1,0 +1,31 @@
+use core::fmt;
+use std::io::{self, IoSlice, Write};
+
+use super::AsciiString;
+
+impl Write for AsciiString {
+    #[inline]
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.inner.write(buf)
+    }
+
+    #[inline]
+    fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
+        self.inner.write_all(buf)
+    }
+
+    #[inline]
+    fn write_fmt(&mut self, fmt: fmt::Arguments<'_>) -> io::Result<()> {
+        self.inner.write_fmt(fmt)
+    }
+
+    #[inline]
+    fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
+        self.inner.write_vectored(bufs)
+    }
+
+    #[inline]
+    fn flush(&mut self) -> io::Result<()> {
+        self.inner.flush()
+    }
+}

--- a/spinoso-string/src/enc/ascii/mod.rs
+++ b/spinoso-string/src/enc/ascii/mod.rs
@@ -1,6 +1,3 @@
-mod eq;
-mod impls;
-
 use alloc::collections::TryReserveError;
 use alloc::vec::Vec;
 use core::fmt;
@@ -12,6 +9,11 @@ use bstr::{ByteSlice, ByteVec};
 use crate::codepoints::InvalidCodepointError;
 use crate::iter::{Bytes, IntoIter, Iter, IterMut};
 use crate::ord::OrdError;
+
+mod eq;
+mod impls;
+#[cfg(feature = "std")]
+mod io;
 
 #[allow(clippy::module_name_repetitions)]
 #[derive(Default, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]

--- a/spinoso-string/src/enc/binary/impls.rs
+++ b/spinoso-string/src/enc/binary/impls.rs
@@ -2,41 +2,9 @@ use alloc::borrow::Cow;
 use alloc::string::String;
 use alloc::vec::Vec;
 use core::borrow::{Borrow, BorrowMut};
-#[cfg(feature = "std")]
-use core::fmt;
 use core::ops::{Deref, DerefMut};
-#[cfg(feature = "std")]
-use std::io::{IoSlice, Result, Write};
 
 use super::BinaryString;
-
-#[cfg(feature = "std")]
-impl Write for BinaryString {
-    #[inline]
-    fn write(&mut self, buf: &[u8]) -> Result<usize> {
-        self.inner.write(buf)
-    }
-
-    #[inline]
-    fn write_all(&mut self, buf: &[u8]) -> Result<()> {
-        self.inner.write_all(buf)
-    }
-
-    #[inline]
-    fn write_fmt(&mut self, fmt: fmt::Arguments<'_>) -> Result<()> {
-        self.inner.write_fmt(fmt)
-    }
-
-    #[inline]
-    fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> Result<usize> {
-        self.inner.write_vectored(bufs)
-    }
-
-    #[inline]
-    fn flush(&mut self) -> Result<()> {
-        self.inner.flush()
-    }
-}
 
 impl Extend<u8> for BinaryString {
     #[inline]

--- a/spinoso-string/src/enc/binary/io.rs
+++ b/spinoso-string/src/enc/binary/io.rs
@@ -1,0 +1,31 @@
+use core::fmt;
+use std::io::{self, IoSlice, Write};
+
+use super::BinaryString;
+
+impl Write for BinaryString {
+    #[inline]
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.inner.write(buf)
+    }
+
+    #[inline]
+    fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
+        self.inner.write_all(buf)
+    }
+
+    #[inline]
+    fn write_fmt(&mut self, fmt: fmt::Arguments<'_>) -> io::Result<()> {
+        self.inner.write_fmt(fmt)
+    }
+
+    #[inline]
+    fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
+        self.inner.write_vectored(bufs)
+    }
+
+    #[inline]
+    fn flush(&mut self) -> io::Result<()> {
+        self.inner.flush()
+    }
+}

--- a/spinoso-string/src/enc/binary/mod.rs
+++ b/spinoso-string/src/enc/binary/mod.rs
@@ -1,6 +1,3 @@
-mod eq;
-mod impls;
-
 use alloc::collections::TryReserveError;
 use alloc::vec::Vec;
 use core::fmt;
@@ -12,6 +9,11 @@ use bstr::{ByteSlice, ByteVec};
 use crate::codepoints::InvalidCodepointError;
 use crate::iter::{Bytes, IntoIter, Iter, IterMut};
 use crate::ord::OrdError;
+
+mod eq;
+mod impls;
+#[cfg(feature = "std")]
+mod io;
 
 #[allow(clippy::module_name_repetitions)]
 #[derive(Default, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]

--- a/spinoso-string/src/enc/impls.rs
+++ b/spinoso-string/src/enc/impls.rs
@@ -1,61 +1,9 @@
 //use alloc::borrow::Cow;
 use alloc::vec::Vec;
 use core::borrow::{Borrow, BorrowMut};
-#[cfg(feature = "std")]
-use core::fmt;
 use core::ops::{Deref, DerefMut};
-#[cfg(feature = "std")]
-use std::io::{IoSlice, Result, Write};
 
 use super::EncodedString;
-
-#[cfg(feature = "std")]
-impl Write for EncodedString {
-    #[inline]
-    fn write(&mut self, buf: &[u8]) -> Result<usize> {
-        match self {
-            EncodedString::Ascii(inner) => inner.write(buf),
-            EncodedString::Binary(inner) => inner.write(buf),
-            EncodedString::Utf8(inner) => inner.write(buf),
-        }
-    }
-
-    #[inline]
-    fn write_all(&mut self, buf: &[u8]) -> Result<()> {
-        match self {
-            EncodedString::Ascii(inner) => inner.write_all(buf),
-            EncodedString::Binary(inner) => inner.write_all(buf),
-            EncodedString::Utf8(inner) => inner.write_all(buf),
-        }
-    }
-
-    #[inline]
-    fn write_fmt(&mut self, fmt: fmt::Arguments<'_>) -> Result<()> {
-        match self {
-            EncodedString::Ascii(inner) => inner.write_fmt(fmt),
-            EncodedString::Binary(inner) => inner.write_fmt(fmt),
-            EncodedString::Utf8(inner) => inner.write_fmt(fmt),
-        }
-    }
-
-    #[inline]
-    fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> Result<usize> {
-        match self {
-            EncodedString::Ascii(inner) => inner.write_vectored(bufs),
-            EncodedString::Binary(inner) => inner.write_vectored(bufs),
-            EncodedString::Utf8(inner) => inner.write_vectored(bufs),
-        }
-    }
-
-    #[inline]
-    fn flush(&mut self) -> Result<()> {
-        match self {
-            EncodedString::Ascii(inner) => inner.flush(),
-            EncodedString::Binary(inner) => inner.flush(),
-            EncodedString::Utf8(inner) => inner.flush(),
-        }
-    }
-}
 
 impl Extend<u8> for EncodedString {
     #[inline]

--- a/spinoso-string/src/enc/io.rs
+++ b/spinoso-string/src/enc/io.rs
@@ -1,0 +1,51 @@
+use core::fmt;
+use std::io::{self, IoSlice, Write};
+
+use super::EncodedString;
+
+impl Write for EncodedString {
+    #[inline]
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        match self {
+            EncodedString::Ascii(inner) => inner.write(buf),
+            EncodedString::Binary(inner) => inner.write(buf),
+            EncodedString::Utf8(inner) => inner.write(buf),
+        }
+    }
+
+    #[inline]
+    fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
+        match self {
+            EncodedString::Ascii(inner) => inner.write_all(buf),
+            EncodedString::Binary(inner) => inner.write_all(buf),
+            EncodedString::Utf8(inner) => inner.write_all(buf),
+        }
+    }
+
+    #[inline]
+    fn write_fmt(&mut self, fmt: fmt::Arguments<'_>) -> io::Result<()> {
+        match self {
+            EncodedString::Ascii(inner) => inner.write_fmt(fmt),
+            EncodedString::Binary(inner) => inner.write_fmt(fmt),
+            EncodedString::Utf8(inner) => inner.write_fmt(fmt),
+        }
+    }
+
+    #[inline]
+    fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
+        match self {
+            EncodedString::Ascii(inner) => inner.write_vectored(bufs),
+            EncodedString::Binary(inner) => inner.write_vectored(bufs),
+            EncodedString::Utf8(inner) => inner.write_vectored(bufs),
+        }
+    }
+
+    #[inline]
+    fn flush(&mut self) -> io::Result<()> {
+        match self {
+            EncodedString::Ascii(inner) => inner.flush(),
+            EncodedString::Binary(inner) => inner.flush(),
+            EncodedString::Utf8(inner) => inner.flush(),
+        }
+    }
+}

--- a/spinoso-string/src/enc/mod.rs
+++ b/spinoso-string/src/enc/mod.rs
@@ -1,8 +1,3 @@
-mod ascii;
-mod binary;
-mod impls;
-mod utf8;
-
 use alloc::collections::TryReserveError;
 use alloc::vec::Vec;
 use core::cmp::Ordering;
@@ -18,6 +13,13 @@ use crate::codepoints::InvalidCodepointError;
 use crate::encoding::Encoding;
 use crate::iter::{Bytes, IntoIter, Iter, IterMut};
 use crate::ord::OrdError;
+
+mod ascii;
+mod binary;
+mod impls;
+#[cfg(feature = "std")]
+mod io;
+mod utf8;
 
 #[derive(Clone)]
 pub enum EncodedString {

--- a/spinoso-string/src/enc/utf8/impls.rs
+++ b/spinoso-string/src/enc/utf8/impls.rs
@@ -2,41 +2,9 @@ use alloc::borrow::Cow;
 use alloc::string::String;
 use alloc::vec::Vec;
 use core::borrow::{Borrow, BorrowMut};
-#[cfg(feature = "std")]
-use core::fmt;
 use core::ops::{Deref, DerefMut};
-#[cfg(feature = "std")]
-use std::io::{IoSlice, Result, Write};
 
 use super::Utf8String;
-
-#[cfg(feature = "std")]
-impl Write for Utf8String {
-    #[inline]
-    fn write(&mut self, buf: &[u8]) -> Result<usize> {
-        self.inner.write(buf)
-    }
-
-    #[inline]
-    fn write_all(&mut self, buf: &[u8]) -> Result<()> {
-        self.inner.write_all(buf)
-    }
-
-    #[inline]
-    fn write_fmt(&mut self, fmt: fmt::Arguments<'_>) -> Result<()> {
-        self.inner.write_fmt(fmt)
-    }
-
-    #[inline]
-    fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> Result<usize> {
-        self.inner.write_vectored(bufs)
-    }
-
-    #[inline]
-    fn flush(&mut self) -> Result<()> {
-        self.inner.flush()
-    }
-}
 
 impl Extend<u8> for Utf8String {
     #[inline]

--- a/spinoso-string/src/enc/utf8/io.rs
+++ b/spinoso-string/src/enc/utf8/io.rs
@@ -1,0 +1,31 @@
+use core::fmt;
+use std::io::{self, IoSlice, Write};
+
+use super::Utf8String;
+
+impl Write for Utf8String {
+    #[inline]
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.inner.write(buf)
+    }
+
+    #[inline]
+    fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
+        self.inner.write_all(buf)
+    }
+
+    #[inline]
+    fn write_fmt(&mut self, fmt: fmt::Arguments<'_>) -> io::Result<()> {
+        self.inner.write_fmt(fmt)
+    }
+
+    #[inline]
+    fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
+        self.inner.write_vectored(bufs)
+    }
+
+    #[inline]
+    fn flush(&mut self) -> io::Result<()> {
+        self.inner.flush()
+    }
+}

--- a/spinoso-string/src/enc/utf8/mod.rs
+++ b/spinoso-string/src/enc/utf8/mod.rs
@@ -1,6 +1,3 @@
-mod eq;
-mod impls;
-
 use alloc::collections::TryReserveError;
 use alloc::vec::Vec;
 use core::fmt;
@@ -12,6 +9,11 @@ use bstr::{ByteSlice, ByteVec};
 use crate::codepoints::InvalidCodepointError;
 use crate::iter::{Bytes, IntoIter, Iter, IterMut};
 use crate::ord::OrdError;
+
+mod eq;
+mod impls;
+#[cfg(feature = "std")]
+mod io;
 
 #[allow(clippy::module_name_repetitions)]
 #[derive(Default, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]


### PR DESCRIPTION
Each string type has an impl of `std::io::Write`. All such impls have
been moved to an `io` module local to each type:

- `crate::enc::ascii::io`
- `crate::enc::binary::io`
- `crate::enc::utf8::io`
- `crate::enc::io`

This helps with code symmetry, makes the imports easier to read, moves
some logic out of the monolithic `impls` modules, and limits `io::Write`
code to a single `#[cfg(feature = "std")]` attribute.

Fixes #1724.