### PR TITLE
Remove most `Borrow` and `BorrowMut` impls from `spinoso-string`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -697,7 +697,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-string"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "bstr",
  "bytecount",

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -32,7 +32,7 @@ spinoso-math = { version = "0.2.0", path = "../spinoso-math", optional = true, d
 spinoso-random = { version = "0.2.0", path = "../spinoso-random", optional = true }
 spinoso-regexp = { version = "0.2.0", path = "../spinoso-regexp", optional = true, default-features = false }
 spinoso-securerandom = { version = "0.2.0", path = "../spinoso-securerandom", optional = true }
-spinoso-string = { version = "0.12.0", path = "../spinoso-string" }
+spinoso-string = { version = "0.13.0", path = "../spinoso-string" }
 spinoso-symbol = { version = "0.1.0", path = "../spinoso-symbol" }
 spinoso-time = { version = "0.2.0", path = "../spinoso-time", optional = true }
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -496,7 +496,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-string"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "bstr",
  "bytecount",

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -627,7 +627,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-string"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "bstr",
  "bytecount",

--- a/spinoso-string/Cargo.toml
+++ b/spinoso-string/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spinoso-string"
-version = "0.12.0"
+version = "0.13.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2021"
 rust-version = "1.58.1"

--- a/spinoso-string/README.md
+++ b/spinoso-string/README.md
@@ -27,7 +27,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-spinoso-string = "0.12"
+spinoso-string = "0.13.0"
 ```
 
 ## `no_std`

--- a/spinoso-string/src/enc/ascii/impls.rs
+++ b/spinoso-string/src/enc/ascii/impls.rs
@@ -1,7 +1,7 @@
 use alloc::borrow::Cow;
 use alloc::string::String;
 use alloc::vec::Vec;
-use core::borrow::{Borrow, BorrowMut};
+use core::borrow::Borrow;
 use core::ops::{Deref, DerefMut};
 
 use super::AsciiString;
@@ -124,26 +124,5 @@ impl Borrow<[u8]> for AsciiString {
     #[inline]
     fn borrow(&self) -> &[u8] {
         self.as_slice()
-    }
-}
-
-impl BorrowMut<[u8]> for AsciiString {
-    #[inline]
-    fn borrow_mut(&mut self) -> &mut [u8] {
-        self.as_mut_slice()
-    }
-}
-
-impl Borrow<Vec<u8>> for AsciiString {
-    #[inline]
-    fn borrow(&self) -> &Vec<u8> {
-        &self.inner
-    }
-}
-
-impl BorrowMut<Vec<u8>> for AsciiString {
-    #[inline]
-    fn borrow_mut(&mut self) -> &mut Vec<u8> {
-        &mut self.inner
     }
 }

--- a/spinoso-string/src/enc/ascii/impls.rs
+++ b/spinoso-string/src/enc/ascii/impls.rs
@@ -1,7 +1,6 @@
 use alloc::borrow::Cow;
 use alloc::string::String;
 use alloc::vec::Vec;
-use core::borrow::Borrow;
 use core::ops::{Deref, DerefMut};
 
 use super::AsciiString;
@@ -117,12 +116,5 @@ impl DerefMut for AsciiString {
     #[inline]
     fn deref_mut(&mut self) -> &mut [u8] {
         self.as_mut_slice()
-    }
-}
-
-impl Borrow<[u8]> for AsciiString {
-    #[inline]
-    fn borrow(&self) -> &[u8] {
-        self.as_slice()
     }
 }

--- a/spinoso-string/src/enc/binary/impls.rs
+++ b/spinoso-string/src/enc/binary/impls.rs
@@ -1,7 +1,6 @@
 use alloc::borrow::Cow;
 use alloc::string::String;
 use alloc::vec::Vec;
-use core::borrow::Borrow;
 use core::ops::{Deref, DerefMut};
 
 use super::BinaryString;
@@ -117,12 +116,5 @@ impl DerefMut for BinaryString {
     #[inline]
     fn deref_mut(&mut self) -> &mut [u8] {
         self.as_mut_slice()
-    }
-}
-
-impl Borrow<[u8]> for BinaryString {
-    #[inline]
-    fn borrow(&self) -> &[u8] {
-        self.as_slice()
     }
 }

--- a/spinoso-string/src/enc/binary/impls.rs
+++ b/spinoso-string/src/enc/binary/impls.rs
@@ -1,7 +1,7 @@
 use alloc::borrow::Cow;
 use alloc::string::String;
 use alloc::vec::Vec;
-use core::borrow::{Borrow, BorrowMut};
+use core::borrow::Borrow;
 use core::ops::{Deref, DerefMut};
 
 use super::BinaryString;
@@ -124,26 +124,5 @@ impl Borrow<[u8]> for BinaryString {
     #[inline]
     fn borrow(&self) -> &[u8] {
         self.as_slice()
-    }
-}
-
-impl BorrowMut<[u8]> for BinaryString {
-    #[inline]
-    fn borrow_mut(&mut self) -> &mut [u8] {
-        self.as_mut_slice()
-    }
-}
-
-impl Borrow<Vec<u8>> for BinaryString {
-    #[inline]
-    fn borrow(&self) -> &Vec<u8> {
-        &self.inner
-    }
-}
-
-impl BorrowMut<Vec<u8>> for BinaryString {
-    #[inline]
-    fn borrow_mut(&mut self) -> &mut Vec<u8> {
-        &mut self.inner
     }
 }

--- a/spinoso-string/src/enc/impls.rs
+++ b/spinoso-string/src/enc/impls.rs
@@ -1,6 +1,5 @@
-//use alloc::borrow::Cow;
 use alloc::vec::Vec;
-use core::borrow::{Borrow, BorrowMut};
+use core::borrow::Borrow;
 use core::ops::{Deref, DerefMut};
 
 use super::EncodedString;
@@ -115,39 +114,6 @@ impl Borrow<[u8]> for EncodedString {
             EncodedString::Ascii(inner) => inner.borrow(),
             EncodedString::Binary(inner) => inner.borrow(),
             EncodedString::Utf8(inner) => inner.borrow(),
-        }
-    }
-}
-
-impl BorrowMut<[u8]> for EncodedString {
-    #[inline]
-    fn borrow_mut(&mut self) -> &mut [u8] {
-        match self {
-            EncodedString::Ascii(inner) => inner.borrow_mut(),
-            EncodedString::Binary(inner) => inner.borrow_mut(),
-            EncodedString::Utf8(inner) => inner.borrow_mut(),
-        }
-    }
-}
-
-impl Borrow<Vec<u8>> for EncodedString {
-    #[inline]
-    fn borrow(&self) -> &Vec<u8> {
-        match self {
-            EncodedString::Ascii(inner) => inner.borrow(),
-            EncodedString::Binary(inner) => inner.borrow(),
-            EncodedString::Utf8(inner) => inner.borrow(),
-        }
-    }
-}
-
-impl BorrowMut<Vec<u8>> for EncodedString {
-    #[inline]
-    fn borrow_mut(&mut self) -> &mut Vec<u8> {
-        match self {
-            EncodedString::Ascii(inner) => inner.borrow_mut(),
-            EncodedString::Binary(inner) => inner.borrow_mut(),
-            EncodedString::Utf8(inner) => inner.borrow_mut(),
         }
     }
 }

--- a/spinoso-string/src/enc/impls.rs
+++ b/spinoso-string/src/enc/impls.rs
@@ -1,5 +1,4 @@
 use alloc::vec::Vec;
-use core::borrow::Borrow;
 use core::ops::{Deref, DerefMut};
 
 use super::EncodedString;
@@ -103,17 +102,6 @@ impl DerefMut for EncodedString {
             EncodedString::Ascii(inner) => inner.deref_mut(),
             EncodedString::Binary(inner) => inner.deref_mut(),
             EncodedString::Utf8(inner) => inner.deref_mut(),
-        }
-    }
-}
-
-impl Borrow<[u8]> for EncodedString {
-    #[inline]
-    fn borrow(&self) -> &[u8] {
-        match self {
-            EncodedString::Ascii(inner) => inner.borrow(),
-            EncodedString::Binary(inner) => inner.borrow(),
-            EncodedString::Utf8(inner) => inner.borrow(),
         }
     }
 }

--- a/spinoso-string/src/enc/mod.rs
+++ b/spinoso-string/src/enc/mod.rs
@@ -1,5 +1,6 @@
 use alloc::collections::TryReserveError;
 use alloc::vec::Vec;
+use core::borrow::Borrow;
 use core::cmp::Ordering;
 use core::hash::{Hash, Hasher};
 use core::ops::Range;
@@ -79,6 +80,26 @@ impl PartialOrd for EncodedString {
 impl Ord for EncodedString {
     fn cmp(&self, other: &Self) -> Ordering {
         self.as_slice().cmp(other.as_slice())
+    }
+}
+
+// This impl of `Borrow<[u8]>` is permissible due to the manual implementations
+// of `PartialEq`, `Hash`, and `Ord` above which only rely on the byte slice
+// contents in the underlying typed strings.
+//
+// Per the docs in `std`:
+//
+// > In particular `Eq`, `Ord` and `Hash` must be equivalent for borrowed and
+// > owned values: `x.borrow() == y.borrow()` should give the same result as
+// > `x == y`.
+impl Borrow<[u8]> for EncodedString {
+    #[inline]
+    fn borrow(&self) -> &[u8] {
+        match self {
+            EncodedString::Ascii(inner) => inner.borrow(),
+            EncodedString::Binary(inner) => inner.borrow(),
+            EncodedString::Utf8(inner) => inner.borrow(),
+        }
     }
 }
 

--- a/spinoso-string/src/enc/utf8/impls.rs
+++ b/spinoso-string/src/enc/utf8/impls.rs
@@ -1,7 +1,7 @@
 use alloc::borrow::Cow;
 use alloc::string::String;
 use alloc::vec::Vec;
-use core::borrow::{Borrow, BorrowMut};
+use core::borrow::Borrow;
 use core::ops::{Deref, DerefMut};
 
 use super::Utf8String;
@@ -124,26 +124,5 @@ impl Borrow<[u8]> for Utf8String {
     #[inline]
     fn borrow(&self) -> &[u8] {
         self.as_slice()
-    }
-}
-
-impl BorrowMut<[u8]> for Utf8String {
-    #[inline]
-    fn borrow_mut(&mut self) -> &mut [u8] {
-        self.as_mut_slice()
-    }
-}
-
-impl Borrow<Vec<u8>> for Utf8String {
-    #[inline]
-    fn borrow(&self) -> &Vec<u8> {
-        &self.inner
-    }
-}
-
-impl BorrowMut<Vec<u8>> for Utf8String {
-    #[inline]
-    fn borrow_mut(&mut self) -> &mut Vec<u8> {
-        &mut self.inner
     }
 }

--- a/spinoso-string/src/enc/utf8/impls.rs
+++ b/spinoso-string/src/enc/utf8/impls.rs
@@ -1,7 +1,6 @@
 use alloc::borrow::Cow;
 use alloc::string::String;
 use alloc::vec::Vec;
-use core::borrow::Borrow;
 use core::ops::{Deref, DerefMut};
 
 use super::Utf8String;
@@ -117,12 +116,5 @@ impl DerefMut for Utf8String {
     #[inline]
     fn deref_mut(&mut self) -> &mut [u8] {
         self.as_mut_slice()
-    }
-}
-
-impl Borrow<[u8]> for Utf8String {
-    #[inline]
-    fn borrow(&self) -> &[u8] {
-        self.as_slice()
     }
 }

--- a/spinoso-string/src/impls.rs
+++ b/spinoso-string/src/impls.rs
@@ -222,6 +222,15 @@ impl DerefMut for String {
     }
 }
 
+// This impl of `Borrow<[u8]>` is permissible due to the behavior of
+// `PartialEq`, `Hash`, and `Ord` impls on `String` which only rely on the byte
+// slice contents in the underlying encoded string.
+//
+// Per the docs in `std`:
+//
+// > In particular `Eq`, `Ord` and `Hash` must be equivalent for borrowed and
+// > owned values: `x.borrow() == y.borrow()` should give the same result as
+// > `x == y`.
 impl Borrow<[u8]> for String {
     #[inline]
     fn borrow(&self) -> &[u8] {

--- a/spinoso-string/src/impls.rs
+++ b/spinoso-string/src/impls.rs
@@ -1,6 +1,6 @@
 use alloc::borrow::Cow;
 use alloc::vec::Vec;
-use core::borrow::{Borrow, BorrowMut};
+use core::borrow::Borrow;
 use core::fmt;
 use core::ops::{Deref, DerefMut, Index, IndexMut};
 use core::slice::SliceIndex;
@@ -226,27 +226,6 @@ impl Borrow<[u8]> for String {
     #[inline]
     fn borrow(&self) -> &[u8] {
         self.inner.borrow()
-    }
-}
-
-impl BorrowMut<[u8]> for String {
-    #[inline]
-    fn borrow_mut(&mut self) -> &mut [u8] {
-        self.inner.borrow_mut()
-    }
-}
-
-impl Borrow<Vec<u8>> for String {
-    #[inline]
-    fn borrow(&self) -> &Vec<u8> {
-        self.inner.borrow()
-    }
-}
-
-impl BorrowMut<Vec<u8>> for String {
-    #[inline]
-    fn borrow_mut(&mut self) -> &mut Vec<u8> {
-        self.inner.borrow_mut()
     }
 }
 


### PR DESCRIPTION
Remove the following trait impls from all string types in `spinoso-string`:

- `Borrow<Vec<u8>>`
- `BorrowMut<[u8]>`
- `BorrowMut<Vec<u8>>`

Additionally, remove `Borrow<[u8]>` impls from all encoded string subtypes.

Per the docs in [`std`][0], for an impl of `Borrow<T>` to be correct:

> In particular `Eq`, `Ord` and `Hash` must be equivalent for borrowed and owned values: `x.borrow() == y.borrow()` should give the same result as `x == y`.

The encoded string subtypes are not guaranteed to uphold this invariant, so remove the impls. This invariant _is_ meant to be upheld by `EncodedString` and `String`; code has been moved and docs added to reflect this intended contract.

As removing these trait impls is a breaking change, bump `spinoso-string` to 0.13.0.

[0]: https://doc.rust-lang.org/std/borrow/trait.Borrow.html