### PR TITLE
Use `EncodedString::utf8` constructor in `Default` impl

### DIFF
--- a/spinoso-string/src/enc/mod.rs
+++ b/spinoso-string/src/enc/mod.rs
@@ -30,7 +30,7 @@ pub enum EncodedString {
 
 impl Default for EncodedString {
     fn default() -> Self {
-        Self::Utf8(Utf8String::new(Vec::new()))
+        Self::utf8(Vec::new())
     }
 }
 


### PR DESCRIPTION
Missed cleanup from #1734.