### PR TITLE
Remove incorrect trait impls on `WriteError` in `artichoke-backend`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,7 +26,7 @@ dependencies = [
 
 [[package]]
 name = "artichoke-backend"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "artichoke-core",
  "artichoke-load-path",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ rustyline = { version = "9.1.2", optional = true, default-features = false }
 termcolor = { version = "1.1.0", optional = true }
 
 [dependencies.artichoke-backend]
-version = "0.6"
+version = "0.7.0"
 path = "artichoke-backend"
 default-features = false
 

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "artichoke-backend"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2021"
 rust-version = "1.58.1"

--- a/artichoke-backend/src/string.rs
+++ b/artichoke-backend/src/string.rs
@@ -6,7 +6,7 @@
 //!
 //! Artichoke aims to support ASCII, UTF-8, maybe UTF-8, and binary encodings.
 
-use std::borrow::{Borrow, BorrowMut, Cow};
+use std::borrow::Cow;
 use std::error;
 use std::fmt;
 
@@ -78,30 +78,6 @@ impl WriteError {
     #[must_use]
     pub fn into_inner(self) -> fmt::Error {
         self.0
-    }
-}
-
-impl AsRef<fmt::Error> for WriteError {
-    fn as_ref(&self) -> &fmt::Error {
-        &self.0
-    }
-}
-
-impl AsMut<fmt::Error> for WriteError {
-    fn as_mut(&mut self) -> &mut fmt::Error {
-        &mut self.0
-    }
-}
-
-impl Borrow<fmt::Error> for WriteError {
-    fn borrow(&self) -> &fmt::Error {
-        &self.0
-    }
-}
-
-impl BorrowMut<fmt::Error> for WriteError {
-    fn borrow_mut(&mut self) -> &mut fmt::Error {
-        &mut self.0
     }
 }
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "artichoke-backend"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "artichoke-core",
  "artichoke-load-path",

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -23,7 +23,7 @@ dependencies = [
 
 [[package]]
 name = "artichoke-backend"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "artichoke-core",
  "artichoke-load-path",


### PR DESCRIPTION
Remove the following impls from `WriteError` since they do not meet the
contract and intent of the `Borrow` trait and are not useful.

- `AsRef<fmt::Error>`
- `AsMut<fmt::Error>`
- `Borrow<fmt::Error>`
- `BorrowMut<fmt::Error>`

This is technically a breaking change to `artichoke-backend` despite
these impls not being used. Bump the crate version to 0.7.0.