### PR TITLE
Refactor trait impls in `spinoso-array`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -635,7 +635,7 @@ checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
 
 [[package]]
 name = "spinoso-array"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "raw-parts",
  "smallvec",

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -25,7 +25,7 @@ onig = { version = "6.3.0", optional = true, default-features = false }
 # https://github.com/artichoke/artichoke/pull/1729
 regex = "1.5.5"
 scolapasta-string-escape = { version = "0.2.0", path = "../scolapasta-string-escape", default-features = false }
-spinoso-array = { version = "0.7.0", path = "../spinoso-array", default-features = false }
+spinoso-array = { version = "0.8.0", path = "../spinoso-array", default-features = false }
 spinoso-env = { version = "0.1.1", path = "../spinoso-env", optional = true, default-features = false }
 spinoso-exception = { version = "0.1.0", path = "../spinoso-exception" }
 spinoso-math = { version = "0.2.0", path = "../spinoso-math", optional = true, default-features = false }

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -436,7 +436,7 @@ checksum = "a86232ab60fa71287d7f2ddae4a7073f6b7aac33631c3015abb556f08c6d0a3e"
 
 [[package]]
 name = "spinoso-array"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "raw-parts",
 ]

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -567,7 +567,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-array"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "raw-parts",
 ]

--- a/spinoso-array/Cargo.toml
+++ b/spinoso-array/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spinoso-array"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2021"
 rust-version = "1.58.1"

--- a/spinoso-array/README.md
+++ b/spinoso-array/README.md
@@ -30,7 +30,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-spinoso-array = "0.6"
+spinoso-array = "0.8.0"
 ```
 
 Then construct and manipulate an `Array` like this:

--- a/spinoso-array/src/array/smallvec/impls.rs
+++ b/spinoso-array/src/array/smallvec/impls.rs
@@ -1,30 +1,13 @@
 use core::borrow::{Borrow, BorrowMut};
 use core::ops::{Deref, DerefMut, Index, IndexMut};
-use core::slice::{Iter, IterMut, SliceIndex};
+use core::slice::SliceIndex;
 
-use smallvec::SmallVec;
-
-use crate::array::smallvec::SmallArray;
-use crate::array::INLINE_CAPACITY;
-
-impl<T> AsRef<SmallVec<[T; INLINE_CAPACITY]>> for SmallArray<T> {
-    #[inline]
-    fn as_ref(&self) -> &SmallVec<[T; INLINE_CAPACITY]> {
-        &self.0
-    }
-}
+use super::SmallArray;
 
 impl<T> AsRef<[T]> for SmallArray<T> {
     #[inline]
     fn as_ref(&self) -> &[T] {
         self.0.as_ref()
-    }
-}
-
-impl<T> AsMut<SmallVec<[T; INLINE_CAPACITY]>> for SmallArray<T> {
-    #[inline]
-    fn as_mut(&mut self) -> &mut SmallVec<[T; INLINE_CAPACITY]> {
-        &mut self.0
     }
 }
 
@@ -101,25 +84,5 @@ where
     #[inline]
     fn index_mut(&mut self, index: I) -> &mut I::Output {
         &mut self.0[index]
-    }
-}
-
-impl<'a, T> IntoIterator for &'a SmallArray<T> {
-    type Item = &'a T;
-    type IntoIter = Iter<'a, T>;
-
-    #[inline]
-    fn into_iter(self) -> Self::IntoIter {
-        self.0.iter()
-    }
-}
-
-impl<'a, T> IntoIterator for &'a mut SmallArray<T> {
-    type Item = &'a mut T;
-    type IntoIter = IterMut<'a, T>;
-
-    #[inline]
-    fn into_iter(self) -> Self::IntoIter {
-        self.0.iter_mut()
     }
 }

--- a/spinoso-array/src/array/smallvec/iter.rs
+++ b/spinoso-array/src/array/smallvec/iter.rs
@@ -1,0 +1,23 @@
+use core::slice::{Iter, IterMut};
+
+use super::SmallArray;
+
+impl<'a, T> IntoIterator for &'a SmallArray<T> {
+    type Item = &'a T;
+    type IntoIter = Iter<'a, T>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter()
+    }
+}
+
+impl<'a, T> IntoIterator for &'a mut SmallArray<T> {
+    type Item = &'a mut T;
+    type IntoIter = IterMut<'a, T>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter_mut()
+    }
+}

--- a/spinoso-array/src/array/smallvec/mod.rs
+++ b/spinoso-array/src/array/smallvec/mod.rs
@@ -12,6 +12,7 @@ use crate::array::INLINE_CAPACITY;
 mod convert;
 mod eq;
 mod impls;
+mod iter;
 
 /// A contiguous growable array type based on
 /// [`SmallVec<[T; INLINE_CAPACITY]>`](SmallVec) that implements the small vector

--- a/spinoso-array/src/array/tinyvec/impls.rs
+++ b/spinoso-array/src/array/tinyvec/impls.rs
@@ -1,21 +1,8 @@
 use core::borrow::{Borrow, BorrowMut};
 use core::ops::{Deref, DerefMut, Index, IndexMut};
-use core::slice::{Iter, IterMut, SliceIndex};
+use core::slice::SliceIndex;
 
-use tinyvec::TinyVec;
-
-use crate::array::tinyvec::TinyArray;
-use crate::array::INLINE_CAPACITY;
-
-impl<T> AsRef<TinyVec<[T; INLINE_CAPACITY]>> for TinyArray<T>
-where
-    T: Default,
-{
-    #[inline]
-    fn as_ref(&self) -> &TinyVec<[T; INLINE_CAPACITY]> {
-        &self.0
-    }
-}
+use super::TinyArray;
 
 impl<T> AsRef<[T]> for TinyArray<T>
 where
@@ -24,16 +11,6 @@ where
     #[inline]
     fn as_ref(&self) -> &[T] {
         self.0.as_ref()
-    }
-}
-
-impl<T> AsMut<TinyVec<[T; INLINE_CAPACITY]>> for TinyArray<T>
-where
-    T: Default,
-{
-    #[inline]
-    fn as_mut(&mut self) -> &mut TinyVec<[T; INLINE_CAPACITY]> {
-        &mut self.0
     }
 }
 
@@ -130,31 +107,5 @@ where
     #[inline]
     fn index_mut(&mut self, index: I) -> &mut I::Output {
         &mut self.0[index]
-    }
-}
-
-impl<'a, T> IntoIterator for &'a TinyArray<T>
-where
-    T: Default,
-{
-    type Item = &'a T;
-    type IntoIter = Iter<'a, T>;
-
-    #[inline]
-    fn into_iter(self) -> Self::IntoIter {
-        self.0.iter()
-    }
-}
-
-impl<'a, T> IntoIterator for &'a mut TinyArray<T>
-where
-    T: Default,
-{
-    type Item = &'a mut T;
-    type IntoIter = IterMut<'a, T>;
-
-    #[inline]
-    fn into_iter(self) -> Self::IntoIter {
-        self.0.iter_mut()
     }
 }

--- a/spinoso-array/src/array/tinyvec/iter.rs
+++ b/spinoso-array/src/array/tinyvec/iter.rs
@@ -1,0 +1,29 @@
+use core::slice::{Iter, IterMut};
+
+use super::TinyArray;
+
+impl<'a, T> IntoIterator for &'a TinyArray<T>
+where
+    T: Default,
+{
+    type Item = &'a T;
+    type IntoIter = Iter<'a, T>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter()
+    }
+}
+
+impl<'a, T> IntoIterator for &'a mut TinyArray<T>
+where
+    T: Default,
+{
+    type Item = &'a mut T;
+    type IntoIter = IterMut<'a, T>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter_mut()
+    }
+}

--- a/spinoso-array/src/array/tinyvec/mod.rs
+++ b/spinoso-array/src/array/tinyvec/mod.rs
@@ -5,7 +5,6 @@
 use alloc::boxed::Box;
 use alloc::vec::Vec;
 use core::cmp;
-use core::iter;
 use core::slice::{Iter, IterMut};
 
 use tinyvec::TinyVec;
@@ -15,6 +14,7 @@ use crate::array::INLINE_CAPACITY;
 mod convert;
 mod eq;
 mod impls;
+mod iter;
 
 /// A contiguous growable array type based on
 /// [`TinyVec<[T; INLINE_CAPACITY]>`](TinyVec) that implements the small vector
@@ -899,7 +899,9 @@ where
     #[inline]
     #[must_use]
     pub fn with_len_and_default(len: usize, default: T) -> Self {
-        Self(iter::repeat(default).take(len).collect())
+        let mut buf = TinyVec::new();
+        buf.resize(len, default);
+        Self(buf)
     }
 
     /// Appends the elements of `other` to self.

--- a/spinoso-array/src/array/vec/impls.rs
+++ b/spinoso-array/src/array/vec/impls.rs
@@ -1,28 +1,13 @@
-use alloc::vec::Vec;
 use core::borrow::{Borrow, BorrowMut};
 use core::ops::{Deref, DerefMut, Index, IndexMut};
-use core::slice::{Iter, IterMut, SliceIndex};
+use core::slice::SliceIndex;
 
-use crate::array::vec::Array;
-
-impl<T> AsRef<Vec<T>> for Array<T> {
-    #[inline]
-    fn as_ref(&self) -> &Vec<T> {
-        &self.0
-    }
-}
+use super::Array;
 
 impl<T> AsRef<[T]> for Array<T> {
     #[inline]
     fn as_ref(&self) -> &[T] {
         self.0.as_ref()
-    }
-}
-
-impl<T> AsMut<Vec<T>> for Array<T> {
-    #[inline]
-    fn as_mut(&mut self) -> &mut Vec<T> {
-        &mut self.0
     }
 }
 
@@ -99,25 +84,5 @@ where
     #[inline]
     fn index_mut(&mut self, index: I) -> &mut I::Output {
         &mut self.0[index]
-    }
-}
-
-impl<'a, T> IntoIterator for &'a Array<T> {
-    type Item = &'a T;
-    type IntoIter = Iter<'a, T>;
-
-    #[inline]
-    fn into_iter(self) -> Self::IntoIter {
-        self.0.iter()
-    }
-}
-
-impl<'a, T> IntoIterator for &'a mut Array<T> {
-    type Item = &'a mut T;
-    type IntoIter = IterMut<'a, T>;
-
-    #[inline]
-    fn into_iter(self) -> Self::IntoIter {
-        self.0.iter_mut()
     }
 }

--- a/spinoso-array/src/array/vec/iter.rs
+++ b/spinoso-array/src/array/vec/iter.rs
@@ -1,0 +1,23 @@
+use core::slice::{Iter, IterMut};
+
+use super::Array;
+
+impl<'a, T> IntoIterator for &'a Array<T> {
+    type Item = &'a T;
+    type IntoIter = Iter<'a, T>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter()
+    }
+}
+
+impl<'a, T> IntoIterator for &'a mut Array<T> {
+    type Item = &'a mut T;
+    type IntoIter = IterMut<'a, T>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter_mut()
+    }
+}

--- a/spinoso-array/src/array/vec/mod.rs
+++ b/spinoso-array/src/array/vec/mod.rs
@@ -12,6 +12,7 @@ pub use raw_parts::RawParts;
 mod convert;
 mod eq;
 mod impls;
+mod iter;
 
 /// A contiguous growable array type based on [`Vec<T>`](Vec).
 ///


### PR DESCRIPTION
Remove some trait impls and move `IntoIterator` impls to an `iter`
module in each array subtype.

This commit removes the following impls:

- `AsRef<Vec<T>> for Array`
- `AsMut<Vec<T>> for Array`
- `AsRef<SmallVec<[T; N]>> for SmallArray`
- `AsMut<SmallVec<[T; N]>> for SmallArray`
- `AsRef<TinyVec<[T; N]>> for TinyArray`
- `AsMut<TinyVec<[T; N]>> for TinyArray`

This commit addresses a namespace conflict with `core::iter` by
reimplementing `TinyArray::with_len_and_default` using `TinyVec::new`
and `TinyVec::resize`.

Removing trait impls is a breaking change, even though they are unused
in `artichoke-backend`. Bump `spinoso-array` to 0.8.0 and update README.