### PR TITLE
Impl `Deref` and `DerefMut` with deref coercion

### DIFF
--- a/spinoso-array/src/array/smallvec/impls.rs
+++ b/spinoso-array/src/array/smallvec/impls.rs
@@ -54,14 +54,14 @@ impl<T> Deref for SmallArray<T> {
 
     #[inline]
     fn deref(&self) -> &Self::Target {
-        self.0.as_slice()
+        &*self.0
     }
 }
 
 impl<T> DerefMut for SmallArray<T> {
     #[inline]
     fn deref_mut(&mut self) -> &mut Self::Target {
-        self.0.as_mut_slice()
+        &mut *self.0
     }
 }
 

--- a/spinoso-array/src/array/tinyvec/impls.rs
+++ b/spinoso-array/src/array/tinyvec/impls.rs
@@ -75,7 +75,7 @@ where
 
     #[inline]
     fn deref(&self) -> &Self::Target {
-        self.0.as_slice()
+        &*self.0
     }
 }
 
@@ -85,7 +85,7 @@ where
 {
     #[inline]
     fn deref_mut(&mut self) -> &mut Self::Target {
-        self.0.as_mut_slice()
+        &mut *self.0
     }
 }
 

--- a/spinoso-array/src/array/vec/impls.rs
+++ b/spinoso-array/src/array/vec/impls.rs
@@ -52,14 +52,14 @@ impl<T> Deref for Array<T> {
 
     #[inline]
     fn deref(&self) -> &Self::Target {
-        self.0.as_slice()
+        &*self.0
     }
 }
 
 impl<T> DerefMut for Array<T> {
     #[inline]
     fn deref_mut(&mut self) -> &mut Self::Target {
-        self.0.as_mut_slice()
+        &mut *self.0
     }
 }
 

--- a/spinoso-string/src/enc/ascii/impls.rs
+++ b/spinoso-string/src/enc/ascii/impls.rs
@@ -108,13 +108,13 @@ impl Deref for AsciiString {
 
     #[inline]
     fn deref(&self) -> &[u8] {
-        self.as_slice()
+        &*self.inner
     }
 }
 
 impl DerefMut for AsciiString {
     #[inline]
     fn deref_mut(&mut self) -> &mut [u8] {
-        self.as_mut_slice()
+        &mut *self.inner
     }
 }

--- a/spinoso-string/src/enc/binary/impls.rs
+++ b/spinoso-string/src/enc/binary/impls.rs
@@ -108,13 +108,13 @@ impl Deref for BinaryString {
 
     #[inline]
     fn deref(&self) -> &[u8] {
-        self.as_slice()
+        &*self.inner
     }
 }
 
 impl DerefMut for BinaryString {
     #[inline]
     fn deref_mut(&mut self) -> &mut [u8] {
-        self.as_mut_slice()
+        &mut *self.inner
     }
 }

--- a/spinoso-string/src/enc/impls.rs
+++ b/spinoso-string/src/enc/impls.rs
@@ -83,25 +83,23 @@ impl AsMut<Vec<u8>> for EncodedString {
 impl Deref for EncodedString {
     type Target = [u8];
 
-    #[allow(clippy::explicit_deref_methods)]
     #[inline]
     fn deref(&self) -> &[u8] {
         match self {
-            EncodedString::Ascii(inner) => inner.deref(),
-            EncodedString::Binary(inner) => inner.deref(),
-            EncodedString::Utf8(inner) => inner.deref(),
+            EncodedString::Ascii(inner) => &*inner,
+            EncodedString::Binary(inner) => &*inner,
+            EncodedString::Utf8(inner) => &*inner,
         }
     }
 }
 
 impl DerefMut for EncodedString {
-    #[allow(clippy::explicit_deref_methods)]
     #[inline]
     fn deref_mut(&mut self) -> &mut [u8] {
         match self {
-            EncodedString::Ascii(inner) => inner.deref_mut(),
-            EncodedString::Binary(inner) => inner.deref_mut(),
-            EncodedString::Utf8(inner) => inner.deref_mut(),
+            EncodedString::Ascii(inner) => &mut *inner,
+            EncodedString::Binary(inner) => &mut *inner,
+            EncodedString::Utf8(inner) => &mut *inner,
         }
     }
 }

--- a/spinoso-string/src/enc/utf8/impls.rs
+++ b/spinoso-string/src/enc/utf8/impls.rs
@@ -108,13 +108,13 @@ impl Deref for Utf8String {
 
     #[inline]
     fn deref(&self) -> &[u8] {
-        self.as_slice()
+        &*self.inner
     }
 }
 
 impl DerefMut for Utf8String {
     #[inline]
     fn deref_mut(&mut self) -> &mut [u8] {
-        self.as_mut_slice()
+        &mut *self.inner
     }
 }

--- a/spinoso-string/src/impls.rs
+++ b/spinoso-string/src/impls.rs
@@ -207,18 +207,16 @@ impl AsMut<Vec<u8>> for String {
 impl Deref for String {
     type Target = [u8];
 
-    #[allow(clippy::explicit_deref_methods)]
     #[inline]
     fn deref(&self) -> &[u8] {
-        self.inner.deref()
+        &*self.inner
     }
 }
 
 impl DerefMut for String {
-    #[allow(clippy::explicit_deref_methods)]
     #[inline]
     fn deref_mut(&mut self) -> &mut [u8] {
-        self.inner.deref_mut()
+        &mut *self.inner
     }
 }
 


### PR DESCRIPTION
Remove instances of explicit `deref()` and `deref_mut()` and the
corresponding lint `allow`s.