### PR TITLE
Hide the internals of `spinoso-string` iterators

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -697,7 +697,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-string"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "bstr",
  "bytecount",

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -32,7 +32,7 @@ spinoso-math = { version = "0.2.0", path = "../spinoso-math", optional = true, d
 spinoso-random = { version = "0.2.0", path = "../spinoso-random", optional = true }
 spinoso-regexp = { version = "0.2.0", path = "../spinoso-regexp", optional = true, default-features = false }
 spinoso-securerandom = { version = "0.2.0", path = "../spinoso-securerandom", optional = true }
-spinoso-string = { version = "0.13.0", path = "../spinoso-string" }
+spinoso-string = { version = "0.14.0", path = "../spinoso-string" }
 spinoso-symbol = { version = "0.1.0", path = "../spinoso-symbol" }
 spinoso-time = { version = "0.2.0", path = "../spinoso-time", optional = true }
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -496,7 +496,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-string"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "bstr",
  "bytecount",

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -627,7 +627,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-string"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "bstr",
  "bytecount",

--- a/spinoso-string/Cargo.toml
+++ b/spinoso-string/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spinoso-string"
-version = "0.13.0"
+version = "0.14.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2021"
 rust-version = "1.58.1"

--- a/spinoso-string/README.md
+++ b/spinoso-string/README.md
@@ -27,7 +27,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-spinoso-string = "0.13.0"
+spinoso-string = "0.14.0"
 ```
 
 ## `no_std`

--- a/spinoso-string/src/iter.rs
+++ b/spinoso-string/src/iter.rs
@@ -23,7 +23,7 @@ use core::slice;
 /// [`String`]: crate::String
 /// [`iter`]: crate::String::iter
 #[derive(Debug, Clone)]
-pub struct Iter<'a>(pub slice::Iter<'a, u8>);
+pub struct Iter<'a>(pub(crate) slice::Iter<'a, u8>);
 
 impl<'a> Iter<'a> {
     /// Views the underlying data as a subslice of the original data.
@@ -55,7 +55,7 @@ impl<'a> Iter<'a> {
 
 impl<'a> AsRef<[u8]> for Iter<'a> {
     fn as_ref(&self) -> &[u8] {
-        self.0.as_slice()
+        self.as_slice()
     }
 }
 
@@ -125,7 +125,7 @@ impl<'a> ExactSizeIterator for Iter<'a> {}
 /// [`iter_mut`]: crate::String::iter_mut
 #[derive(Debug)]
 #[allow(clippy::module_name_repetitions)]
-pub struct IterMut<'a>(pub slice::IterMut<'a, u8>);
+pub struct IterMut<'a>(pub(crate) slice::IterMut<'a, u8>);
 
 impl<'a> IterMut<'a> {
     /// Views the underlying data as a subslice of the original data.
@@ -217,7 +217,7 @@ impl<'a> ExactSizeIterator for IterMut<'a> {}
 /// ```
 #[derive(Debug)]
 #[allow(clippy::module_name_repetitions)]
-pub struct IntoIter(pub vec::IntoIter<u8>);
+pub struct IntoIter(pub(crate) vec::IntoIter<u8>);
 
 impl IntoIter {
     /// Returns the remaining bytes of this iterator as a slice.
@@ -265,7 +265,7 @@ impl IntoIter {
 impl AsRef<[u8]> for IntoIter {
     #[inline]
     fn as_ref(&self) -> &[u8] {
-        self.0.as_slice()
+        self.as_slice()
     }
 }
 
@@ -335,7 +335,7 @@ impl ExactSizeIterator for IntoIter {}
 /// [`String`]: crate::String
 /// [`bytes`]: crate::String::bytes
 #[derive(Debug, Clone)]
-pub struct Bytes<'a>(pub slice::Iter<'a, u8>);
+pub struct Bytes<'a>(pub(crate) slice::Iter<'a, u8>);
 
 impl<'a> From<&'a [u8]> for Bytes<'a> {
     #[inline]


### PR DESCRIPTION
Make the inner iterators in the following structs `pub(crate)` instead of `pub`:

- `Iter`
- `IterMut`
- `IntoIter`
- `Bytes`

This is a breaking change, bump `spinoso-string` to 0.14.0.