### PR TITLE
Add `Disk` loader to `mezzaluna-feature-loader`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,6 +34,7 @@ dependencies = [
  "cc",
  "cstr",
  "intaglio",
+ "mezzaluna-feature-loader",
  "onig",
  "quickcheck",
  "regex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -318,7 +318,7 @@ dependencies = [
 
 [[package]]
 name = "mezzaluna-feature-loader"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "bstr",
  "same-file",

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -17,6 +17,7 @@ artichoke-load-path = { version = "0.1.0", path = "../artichoke-load-path", defa
 bstr = { version = "0.2.9", default-features = false, features = ["std"] }
 cstr = "0.2.4, < 0.2.10"
 intaglio = "1.4.0"
+mezzaluna-feature-loader = { version = "0.2.0", path = "../mezzaluna-feature-loader", default-features = false }
 onig = { version = "6.3.0", optional = true, default-features = false }
 # Ensure the `regex` minimum version is at least 1.5.5 to pull in a fix for a
 # DoS vulnerability.

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -36,6 +36,7 @@ dependencies = [
  "cc",
  "cstr",
  "intaglio",
+ "mezzaluna-feature-loader",
  "onig",
  "regex",
  "scolapasta-string-escape",
@@ -217,6 +218,13 @@ name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+
+[[package]]
+name = "mezzaluna-feature-loader"
+version = "0.2.0"
+dependencies = [
+ "bstr",
+]
 
 [[package]]
 name = "num-integer"

--- a/mezzaluna-feature-loader/Cargo.toml
+++ b/mezzaluna-feature-loader/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mezzaluna-feature-loader"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2021"
 rust-version = "1.58.1"
@@ -12,11 +12,11 @@ keywords = ["artichoke", "artichoke-ruby", "load-path", "ruby"]
 categories = ["filesystem"]
 
 [dependencies]
-bstr = { version = "0.2.9", optional = true, default-features = false }
+bstr = { version = "0.2.9", default-features = false, features = ["std"] }
 same-file = { version = "1.0.6", optional = true }
 
 [features]
-default = ["rubylib"]
+default = ["disk", "rubylib"]
 disk = ["same-file"]
 rubylib = ["disk"]
 

--- a/mezzaluna-feature-loader/src/lib.rs
+++ b/mezzaluna-feature-loader/src/lib.rs
@@ -33,9 +33,13 @@ mod loader;
 
 #[doc(inline)]
 pub use loaded_features::LoadedFeatures;
+#[cfg(feature = "disk")]
+pub use loader::Disk;
 pub use loader::Loader;
 #[cfg(feature = "rubylib")]
 pub use loader::Rubylib;
+pub use loader::{is_explicit_relative, memory_loader_ruby_load_path};
 #[doc(inline)]
 #[cfg(feature = "disk")]
+#[cfg_attr(docsrs, doc(cfg(feature = "disk")))]
 pub use same_file::Handle;

--- a/mezzaluna-feature-loader/src/loaded_features.rs
+++ b/mezzaluna-feature-loader/src/loaded_features.rs
@@ -276,7 +276,7 @@ impl<S> LoadedFeatures<S> {
     ///
     /// let s = RandomState::new();
     /// let mut set = LoadedFeatures::with_hasher(s);
-    /// set.insert_in_memory_feature(PathBuf::from("set.rb"));
+    /// set.insert_in_memory_feature(PathBuf::from("/src/set.rb"));
     /// ```
     #[must_use]
     pub fn with_hasher(hasher: S) -> Self {

--- a/mezzaluna-feature-loader/src/loader/disk.rs
+++ b/mezzaluna-feature-loader/src/loader/disk.rs
@@ -1,0 +1,260 @@
+//! A Ruby source loader that resolves sources from the host file system.
+
+use core::mem;
+use std::env;
+use std::path::{Path, PathBuf};
+
+use same_file::Handle;
+
+use super::is_explicit_relative;
+
+/// A Ruby source code loader that loads sources directly from disk and resolves
+/// relative paths with the Ruby `$LOAD_PATH`.
+///
+/// MRI Ruby allows manipulating the [require] search path by modifying the
+/// `$LOAD_PATH` global, or its alias `$:`, at runtime.
+///
+/// MRI Ruby allows requiring sources with relative, [explicit relative] or
+/// absolute paths.
+///
+/// Relative paths are paths of the form `json/pure` which do not begin with
+/// either a file system root like `/` or `C:\` or an explicit relative
+/// directory marker like `..` or `.`. These relative paths are resolved
+/// relative to the Ruby load path.
+///
+/// `$LOAD_PATH` contains a list of directory paths to search for Ruby sources
+/// and behaves similarly to the `RUBYLIB` environment variable in the
+/// [`Rubylib`] loader.
+///
+/// ```no_run
+/// # use std::ffi::OsStr;
+/// # use std::path::{Path, PathBuf};
+/// # use mezzaluna_feature_loader::Disk;
+/// # fn example() -> Option<()> {
+/// // Search `/home/artichoke/src` first, only attempting to search
+/// // `/usr/share/artichoke` if no file is found in `/home/artichoke/src`.
+/// //
+/// // The relative path `./_lib` is resolved relative to the given working
+/// // directory.
+/// let fixed_loader = Disk::with_load_path_and_cwd(
+///     vec![PathBuf::from("/home/artichoke/src"), PathBuf::from("/usr/share/artichoke"), PathBuf::from("_lib")],
+///     Path::new("/home/artichoke")
+/// )?;
+/// # Some(())
+/// # }
+/// # example().unwrap();
+/// ```
+///
+/// [require]: https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-require
+/// [explicit relative]: is_explicit_relative
+/// [resolves to the same file]: same_file
+/// [`Rubylib`]: super::Rubylib
+#[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(docsrs, doc(cfg(feature = "disk")))]
+pub struct Disk {
+    load_path: Vec<PathBuf>,
+}
+
+impl Disk {
+    /// Create a new native file system loader that searches the file system for
+    /// Ruby sources with an empty `$LOAD_PATH`.
+    ///
+    /// A `Disk` loader with an empty `$LOAD_PATH` can only load sources by
+    /// absolute paths or relatice to the process's [current working directory]
+    /// if an [explicit relative path] is given.
+    ///
+    /// The resolved load paths are mutable; `$LOAD_PATH` can be modified at
+    /// runtime by Ruby code as the VM executes. See [`load_path`] and
+    /// [`set_load_path`] for reading and modifying a `Disk` loader's load path.
+    ///
+    /// This source loader grants access to the host file system. The `Disk`
+    /// loader does not support native extensions.
+    ///
+    /// [`load_path`]: Self::load_path
+    /// [`set_load_path`]: Self::set_load_path
+    /// [current working directory]: env::current_dir
+    /// [explicit relative path]: is_explicit_relative
+    #[inline]
+    #[must_use]
+    pub const fn new() -> Self {
+        Self { load_path: Vec::new() }
+    }
+
+    /// Create a new native file system loader that searches the file system for
+    /// Ruby sources at the paths specified by the given `$LOAD_PATH` from the
+    /// Ruby global variable.
+    ///
+    /// The resolved load paths are mutable; `$LOAD_PATH` can be modified at
+    /// runtime by Ruby code as the VM executes. See [`load_path`] and
+    /// [`set_load_path`] for reading and modifying a `Disk` loader's load path.
+    ///
+    /// If any of the paths in the `$LOAD_PATH` global variable are not absolute
+    /// paths, they are absolutized relative to the current process's [current
+    /// working directory] at the time the load path is set or modified.
+    ///
+    /// This source loader grants access to the host file system. The `Disk`
+    /// loader does not support native extensions.
+    ///
+    /// This method returns [`None`] if the current working directory cannot be
+    /// retrieved, or if the `$LOAD_PATH` global variable does not contain any
+    /// paths.
+    ///
+    /// [`load_path`]: Self::load_path
+    /// [`set_load_path`]: Self::set_load_path
+    /// [current working directory]: env::current_dir
+    #[inline]
+    #[must_use]
+    pub fn with_load_path(load_path: Vec<PathBuf>) -> Option<Self> {
+        let cwd = env::current_dir().ok()?;
+        Self::with_load_path_and_cwd(load_path, &cwd)
+    }
+
+    /// Create a new native file system loader that searches the file system for
+    /// Ruby sources at the paths specified by the given `load_path` platform
+    /// string.
+    ///
+    /// The resolved load paths are mutable; `$LOAD_PATH` can be modified at
+    /// runtime by Ruby code as the VM executes. See [`load_path`] and
+    /// [`set_load_path`] for reading and modifying a `Disk` loader's load path.
+    ///
+    /// If any of the paths in the `$LOAD_PATH` global variable are not absolute
+    /// paths, they are absolutized relative to the current process's [current
+    /// working directory] at the time the load path is set or modified.
+    ///
+    /// This source loader grants access to the host file system. The `Disk`
+    /// loader does not support native extensions.
+    ///
+    /// This method returns [`None`] if the given `load_path` does not contain any
+    /// paths.
+    ///
+    /// [`load_path`]: Self::load_path
+    /// [`set_load_path`]: Self::set_load_path
+    /// [current working directory]: env::current_dir
+    #[inline]
+    #[must_use]
+    pub fn with_load_path_and_cwd(load_path: Vec<PathBuf>, cwd: &Path) -> Option<Self> {
+        // If the given load paths vec is empty, return `None` so the `Rubylib`
+        // loader is not used.
+        if load_path.is_empty() {
+            return None;
+        }
+
+        let load_path = load_path
+            .into_iter()
+            .map(|load_path| cwd.join(&load_path))
+            .collect::<Vec<_>>();
+
+        Some(Self { load_path })
+    }
+
+    /// Check whether `path` points to a file in the backing file system and
+    /// return a file [`Handle`] if it exists.
+    ///
+    /// Returns [`Some`] if the file system object pointed to by `path` exists.
+    /// If `path` is relative, it is joined to each path in the `$LOAD_PATH`
+    /// environment variable at the time this loader was initialized. If `path`
+    /// is an [explicit relative path], it is joined with the [current working
+    /// directory].
+    ///
+    /// This method is infallible and will return [`None`] for non-existent
+    /// paths or if the current working directory cannot be resolved when given
+    /// an explicit relative path.
+    ///
+    /// [explicit relative path]: is_explicit_relative
+    /// [current working directory]: env::current_dir
+    #[inline]
+    #[must_use]
+    pub fn resolve_file(&self, path: &Path) -> Option<Handle> {
+        // Absolute paths do not need to be resolved against the load paths.
+        if path.is_absolute() {
+            if let Ok(handle) = Handle::from_path(&path) {
+                return Some(handle);
+            }
+            return None;
+        }
+
+        // Explicit relative paths are loaded from the current directory only.
+        if is_explicit_relative(path) {
+            let cwd = env::current_dir().ok()?;
+            let path = cwd.join(path);
+            if let Ok(handle) = Handle::from_path(&path) {
+                return Some(handle);
+            }
+            return None;
+        }
+
+        for load_path in &*self.load_path {
+            let path = load_path.join(path);
+            if let Ok(handle) = Handle::from_path(&path) {
+                return Some(handle);
+            }
+        }
+        None
+    }
+
+    /// Return a reference to the loader's current `$LOAD_PATH`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::ffi::OsStr;
+    /// # use std::path::{Path, PathBuf};
+    /// # use mezzaluna_feature_loader::Disk;
+    /// # fn example() -> Option<()> {
+    /// let loader = Disk::with_load_path_and_cwd(
+    ///     vec![PathBuf::from("/home/artichoke/src"), PathBuf::from("/usr/share/artichoke"), PathBuf::from("_lib")],
+    ///     Path::new("/home/artichoke"),
+    /// )?;
+    /// assert_eq!(
+    ///     loader.load_path(),
+    ///     &[Path::new("/home/artichoke/src"), Path::new("/usr/share/artichoke"), Path::new("/home/artichoke/_lib")]
+    /// );
+    /// # Some(())
+    /// # }
+    /// # example().unwrap();
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn load_path(&self) -> &[PathBuf] {
+        &self.load_path
+    }
+
+    /// Replace the loader's current `$LOAD_PATH`.
+    ///
+    /// This method returns the loader's previous `$LOAD_PATH`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::ffi::OsStr;
+    /// # use std::path::{Path, PathBuf};
+    /// # use mezzaluna_feature_loader::Disk;
+    /// # fn example() -> Option<()> {
+    /// let mut loader = Disk::with_load_path_and_cwd(
+    ///     vec![PathBuf::from("/home/artichoke/src"), PathBuf::from("/usr/share/artichoke"), PathBuf::from("_lib")],
+    ///     Path::new("/home/artichoke"),
+    /// )?;
+    /// assert_eq!(
+    ///     loader.load_path(),
+    ///     &[Path::new("/home/artichoke/src"), Path::new("/usr/share/artichoke"), Path::new("/home/artichoke/_lib")]
+    /// );
+    ///
+    /// let old_load_path = loader.set_load_path(
+    ///     vec![PathBuf::from("libpath")],
+    ///     Path::new("/home/app"),
+    /// );
+    /// assert_eq!(
+    ///     old_load_path,
+    ///     &[Path::new("/home/artichoke/src"), Path::new("/usr/share/artichoke"), Path::new("/home/artichoke/_lib")]
+    /// );
+    /// assert_eq!(loader.load_path(), [Path::new("/home/app/libpath")]);
+    /// # Some(())
+    /// # }
+    /// # example().unwrap();
+    /// ```
+    #[inline]
+    pub fn set_load_path(&mut self, load_path: Vec<PathBuf>, cwd: &Path) -> Vec<PathBuf> {
+        let load_path = load_path.into_iter().map(|load_path| cwd.join(&load_path)).collect();
+        mem::replace(&mut self.load_path, load_path)
+    }
+}

--- a/mezzaluna-feature-loader/src/loader/mod.rs
+++ b/mezzaluna-feature-loader/src/loader/mod.rs
@@ -1,7 +1,14 @@
-#[cfg(feature = "rubylib")]
 use std::ffi::OsStr;
 use std::io;
-use std::path::Path;
+use std::path::{self, Path};
+
+use bstr::ByteSlice;
+
+#[cfg(feature = "disk")]
+mod disk;
+
+#[cfg(feature = "disk")]
+pub use disk::Disk;
 
 #[cfg(feature = "rubylib")]
 mod rubylib;
@@ -10,6 +17,67 @@ mod rubylib;
 pub use rubylib::Rubylib;
 
 use crate::loaded_features::LoadedFeatures;
+
+/// Directory at which Ruby sources and extensions are stored in the virtual
+/// file system.
+pub fn memory_loader_ruby_load_path() -> &'static OsStr {
+    if cfg!(windows) {
+        OsStr::new("c:/artichoke/virtual_root/src/lib")
+    } else {
+        OsStr::new("/artichoke/virtual_root/src/lib")
+    }
+}
+
+/// Return whether the given path starts with an explicit relative path.
+///
+/// Explicit relative paths start with `.` or `..` followed immediately by a
+/// directory separator.
+///
+/// [`Disk`] loaders have special handling for explicit relative paths: they are
+/// resolved relative to the process's [current working directory] rather than
+/// the load path.
+///
+/// # Examples
+///
+/// ```
+/// # use std::path::Path;
+/// # use mezzaluna_feature_loader::is_explicit_relative;
+/// assert!(is_explicit_relative(Path::new("./test/loader")));
+/// assert!(is_explicit_relative(Path::new("../rake/test_task")));
+///
+/// assert!(!is_explicit_relative(Path::new("json/pure")));
+/// assert!(!is_explicit_relative(Path::new("/artichoke/src/json/pure")));
+/// ```
+///
+/// # MRI C Declaration
+///
+/// ```c
+/// static int
+/// is_explicit_relative(const char *path)
+/// {
+///     if (*path++ != '.') return 0;
+///     if (*path == '.') path++;
+///     return isdirsep(*path);
+/// }
+/// ```
+///
+/// [current working directory]: std::env::current_dir
+#[allow(clippy::match_same_arms)]
+pub fn is_explicit_relative(path: &Path) -> bool {
+    let bytes = if let Some(bytes) = <[u8]>::from_path(path) {
+        bytes
+    } else {
+        return false;
+    };
+    // Implementation based on MRI:
+    //
+    // https://github.com/artichoke/artichoke/blob/7c845ddfe709658ad6f66be00b2514af05b2619a/artichoke-backend/vendor/ruby/file.c#L6005-L6011
+    match bytes {
+        [b'.', x, ..] if path::is_separator((*x).into()) => true,
+        [b'.', b'.', x, ..] if path::is_separator((*x).into()) => true,
+        _ => false,
+    }
+}
 
 #[derive(Debug)]
 pub struct Loader {
@@ -76,5 +144,131 @@ impl Loader {
         }
         let _ = path;
         unimplemented!("implement Loader::read");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use super::is_explicit_relative;
+
+    #[test]
+    #[cfg(windows)]
+    fn windows_explicit_relative() {
+        let absolute: &[&Path] = &[
+            Path::new(r"c:\windows"),
+            Path::new(r"c:/windows"),
+            Path::new(r"\\.\COM1"),
+            Path::new(r"\\?\C:\windows"),
+        ];
+        for &path in absolute {
+            assert!(
+                !is_explicit_relative(path),
+                "expected absolute path '{}' to NOT be explicit relative path",
+                path.display()
+            );
+        }
+
+        let relative: &[&Path] = &[
+            Path::new(r"c:temp"),
+            Path::new(r"temp"),
+            Path::new(r"\temp"),
+            Path::new(r"/temp"),
+        ];
+        for &path in relative {
+            assert!(
+                !is_explicit_relative(path),
+                "expected relative path '{}' to NOT be explicit relative path",
+                path.display()
+            );
+        }
+
+        let explicit_relative: &[&Path] = &[
+            Path::new(r".\windows"),
+            Path::new(r"./windows"),
+            Path::new(r"..\windows"),
+            Path::new(r"../windows"),
+            Path::new(r".\.git"),
+            Path::new(r"./.git"),
+            Path::new(r"..\.git"),
+            Path::new(r"../.git"),
+        ];
+        for &path in explicit_relative {
+            assert!(is_explicit_relative(path));
+            assert!(
+                is_explicit_relative(path),
+                "expected relative path '{}' to be explicit relative path",
+                path.display()
+            );
+        }
+
+        let not_explicit_relative: &[&Path] = &[
+            Path::new(r"...\windows"),
+            Path::new(r".../windows"),
+            Path::new(r"\windows"),
+            Path::new(r"/windows"),
+        ];
+        for &path in not_explicit_relative {
+            assert!(
+                !is_explicit_relative(path),
+                "expected relative path '{}' to NOT be explicit relative path",
+                path.display()
+            );
+        }
+    }
+
+    #[test]
+    #[cfg(not(windows))]
+    fn explicit_relative() {
+        let absolute: &[&Path] = &[Path::new(r"/bin"), Path::new(r"/home/artichoke")];
+        for &path in absolute {
+            assert!(
+                !is_explicit_relative(path),
+                "expected absolute path '{}' to NOT be explicit relative path",
+                path.display()
+            );
+        }
+
+        let relative: &[&Path] = &[Path::new(r"temp"), Path::new(r"temp/../var")];
+        for &path in relative {
+            assert!(
+                !is_explicit_relative(path),
+                "expected relative path '{}' to NOT be explicit relative path",
+                path.display()
+            );
+        }
+
+        let explicit_relative: &[&Path] = &[
+            Path::new(r"./cache"),
+            Path::new(r"../cache"),
+            Path::new(r"./.git"),
+            Path::new(r"../.git"),
+        ];
+        for &path in explicit_relative {
+            assert!(
+                is_explicit_relative(path),
+                "expected relative path '{}' to be explicit relative path",
+                path.display()
+            );
+        }
+
+        let not_explicit_relative: &[&Path] = &[
+            Path::new(r".\cache"),
+            Path::new(r"..\cache"),
+            Path::new(r".\.git"),
+            Path::new(r"..\.git"),
+            Path::new(r"...\var"),
+            Path::new(r".../var"),
+            Path::new(r"\var"),
+            Path::new(r"/var"),
+        ];
+        for &path in not_explicit_relative {
+            assert!(
+                !is_explicit_relative(path),
+                "expected relative path '{}' to NOT be explicit relative path",
+                path.display()
+            );
+        }
     }
 }

--- a/mezzaluna-feature-loader/src/loader/mod.rs
+++ b/mezzaluna-feature-loader/src/loader/mod.rs
@@ -20,6 +20,7 @@ use crate::loaded_features::LoadedFeatures;
 
 /// Directory at which Ruby sources and extensions are stored in the virtual
 /// file system.
+#[must_use]
 pub fn memory_loader_ruby_load_path() -> &'static OsStr {
     if cfg!(windows) {
         OsStr::new("c:/artichoke/virtual_root/src/lib")
@@ -62,7 +63,7 @@ pub fn memory_loader_ruby_load_path() -> &'static OsStr {
 /// ```
 ///
 /// [current working directory]: std::env::current_dir
-#[allow(clippy::match_same_arms)]
+#[must_use]
 pub fn is_explicit_relative(path: &Path) -> bool {
     let bytes = if let Some(bytes) = <[u8]>::from_path(path) {
         bytes

--- a/mezzaluna-feature-loader/src/loader/rubylib.rs
+++ b/mezzaluna-feature-loader/src/loader/rubylib.rs
@@ -151,12 +151,14 @@ impl Rubylib {
         Some(Self { load_paths })
     }
 
-    /// Check whether `path` points to a file in the virtual file system and
-    /// return the absolute path if it exists.
+    /// Check whether `path` points to a file in the backing file system and
+    /// return a file [`Handle`] if it exists.
     ///
     /// Returns [`Some`] if the file system object pointed to by `path` exists.
-    /// If `path` is relative, it is joined to each path in the `RUBYLIB`
-    /// environment variable at the time this loader was initialized.
+    /// This method refuses to resolve absolute paths and will always return
+    /// [`None`] for absolute paths. If `path` is relative, it is joined to each
+    /// path in the `RUBYLIB` environment variable at the time this loader was
+    /// initialized.
     ///
     /// This method is infallible and will return [`None`] for non-existent
     /// paths.

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -31,6 +31,7 @@ dependencies = [
  "cc",
  "cstr",
  "intaglio",
+ "mezzaluna-feature-loader",
  "onig",
  "regex",
  "scolapasta-string-escape",
@@ -259,6 +260,13 @@ name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+
+[[package]]
+name = "mezzaluna-feature-loader"
+version = "0.2.0"
+dependencies = [
+ "bstr",
+]
 
 [[package]]
 name = "num-integer"


### PR DESCRIPTION
Slowly chipping away at mezzaluna-feature-loader API gaps to work toward
purging artichoke-load-path crate.

`Disk` loader is similar to `Rubylib` loader except it semantically
pulls its load paths from the `$LOAD_PATH` global. The `Disk` loader
allows retrieving and replacing its load path.

`Disk` differs from `Rubylib` in how it resolves paths:

- `Disk` can load absolute paths.
- `Disk` can load "explicit relative paths" based on the current
  directory.

With this new loader and several functions that support it, bump
mezzaluna-feature-loader to 0.2.0.

This PR replaces some functionality in `artichoke-backend` with `mezzaluna-feature-loader`, which adds the dependency to Artichoke.