### PR TITLE
Reorder match arms in `is_explicit_relative`

### DIFF
--- a/mezzaluna-feature-loader/src/loader/mod.rs
+++ b/mezzaluna-feature-loader/src/loader/mod.rs
@@ -74,8 +74,8 @@ pub fn is_explicit_relative(path: &Path) -> bool {
     //
     // https://github.com/artichoke/artichoke/blob/7c845ddfe709658ad6f66be00b2514af05b2619a/artichoke-backend/vendor/ruby/file.c#L6005-L6011
     match bytes {
-        [b'.', x, ..] if path::is_separator((*x).into()) => true,
         [b'.', b'.', x, ..] if path::is_separator((*x).into()) => true,
+        [b'.', x, ..] if path::is_separator((*x).into()) => true,
         _ => false,
     }
 }


### PR DESCRIPTION
Reorder arms so the more specific match arm comes first.