### PR TITLE
Add missing `Default` impls to some error types in SecureRandom

### DIFF
--- a/spinoso-securerandom/src/lib.rs
+++ b/spinoso-securerandom/src/lib.rs
@@ -275,7 +275,7 @@ impl ArgumentError {
 /// the requested random bytes.
 ///
 /// This error is typically returned by the operating system.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct RandomBytesError {
     _private: (),
 }
@@ -332,7 +332,7 @@ impl From<rand::Error> for RandomBytesError {
 /// used to bound a domain for generating random numbers.
 ///
 /// This error is returned by [`random_number`].
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct DomainError {
     _private: (),
 }


### PR DESCRIPTION
`ArgumentError` has an explicit `Default` impl because `new` does not give an empty struct. I am guessing the derivable `Default` impls on `RandomBytesError` and `DomainError` were unintentionally omitted.

I put more eyes here after this Twitter thread:

https://twitter.com/_lopopolo/status/1506855772700831746