### PR TITLE
Make `Value::inner` `pub(crate)` in artichoke-backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,7 +26,7 @@ dependencies = [
 
 [[package]]
 name = "artichoke-backend"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "artichoke-core",
  "artichoke-load-path",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ rustyline = { version = "9.1.2", optional = true, default-features = false }
 termcolor = { version = "1.1.0", optional = true }
 
 [dependencies.artichoke-backend]
-version = "0.8.0"
+version = "0.9.0"
 path = "artichoke-backend"
 default-features = false
 

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "artichoke-backend"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2021"
 rust-version = "1.58.1"

--- a/artichoke-backend/src/value.rs
+++ b/artichoke-backend/src/value.rs
@@ -80,11 +80,10 @@ impl Value {
         Self::default()
     }
 
-    /// The [`sys::mrb_value`] that this [`Value`] wraps.
-    // TODO(GH-251): make `Value::inner` pub(crate).
+    /// Retrieve the inner [`sys::mrb_value`] that this [`Value`] wraps.
     #[inline]
     #[must_use]
-    pub const fn inner(&self) -> sys::mrb_value {
+    pub(crate) const fn inner(&self) -> sys::mrb_value {
         self.0
     }
 

--- a/artichoke-backend/tests/integration/extension.rs
+++ b/artichoke-backend/tests/integration/extension.rs
@@ -15,7 +15,7 @@ unsafe extern "C" fn container_initialize(mrb: *mut sys::mrb_state, slf: sys::mr
     let inner = inner.try_convert_into::<i64>(&guard).unwrap_or_default();
     let container = Box::new(Container(inner));
     let result = Box::<Container>::box_into_value(container, slf, &mut guard).unwrap_or_default();
-    result.inner()
+    result.into()
 }
 
 unsafe extern "C" fn container_value(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
@@ -26,7 +26,7 @@ unsafe extern "C" fn container_value(mrb: *mut sys::mrb_state, slf: sys::mrb_val
     } else {
         Value::nil()
     };
-    result.inner()
+    result.into()
 }
 
 impl File for Container {

--- a/artichoke-backend/tests/integration/leak/boxing.rs
+++ b/artichoke-backend/tests/integration/leak/boxing.rs
@@ -30,7 +30,7 @@ unsafe extern "C" fn container_initialize(mrb: *mut sys::mrb_state, slf: sys::mr
     let container = Container(inner);
     let result = Container::box_into_value(container, slf, &mut guard);
     match result {
-        Ok(value) => value.inner(),
+        Ok(value) => value.into(),
         Err(exception) => error::raise(guard, exception),
     }
 }

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "artichoke-backend"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "artichoke-core",
  "artichoke-load-path",

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -23,7 +23,7 @@ dependencies = [
 
 [[package]]
 name = "artichoke-backend"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "artichoke-core",
  "artichoke-load-path",


### PR DESCRIPTION
I think this was fixed in the great de-rc/refcell event in #670 and was
never cleaned up in the issue tracker.

For crates external to `artichoke-backend` that define methods on the
mruby VM, like the `artichoke-backend` integration tests, `Value::into`
is available to get at the inner `sys::mrb_value` because `mrb_value`
impls `From<Value>`.

Fixes #234.
Fixes #251.