### PR TITLE
Improve artichoke-backend test ergonomics: `crate::test::interpreter` now unwraps internally

### DIFF
--- a/artichoke-backend/src/block.rs
+++ b/artichoke-backend/src/block.rs
@@ -193,7 +193,7 @@ mod tests {
     #[test]
     fn yield_arg_is_dead() {
         // construct a dead value
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         let mut arena = interp.create_arena_savepoint().unwrap();
 
         let dead = arena.eval(b"'dead'").unwrap();

--- a/artichoke-backend/src/class.rs
+++ b/artichoke-backend/src/class.rs
@@ -308,7 +308,7 @@ mod tests {
 
     #[test]
     fn super_class() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         let spec = class::Spec::new("RustError", cstr::cstr!("RustError"), None, None).unwrap();
         class::Builder::for_spec(&mut interp, &spec)
             .with_super_class::<StandardError, _>("StandardError")
@@ -328,7 +328,7 @@ mod tests {
 
     #[test]
     fn rclass_for_undef_root_class() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         let spec = class::Spec::new("Foo", cstr::cstr!("Foo"), None, None).unwrap();
         let rclass = unsafe { interp.with_ffi_boundary(|mrb| spec.rclass().resolve(mrb)) }.unwrap();
         assert!(rclass.is_none());
@@ -336,7 +336,7 @@ mod tests {
 
     #[test]
     fn rclass_for_undef_nested_class() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         let scope = interp.module_spec::<Kernel>().unwrap().unwrap();
         let spec = class::Spec::new("Foo", cstr::cstr!("Foo"), Some(EnclosingRubyScope::module(scope)), None).unwrap();
         let rclass = unsafe { interp.with_ffi_boundary(|mrb| spec.rclass().resolve(mrb)) }.unwrap();
@@ -345,7 +345,7 @@ mod tests {
 
     #[test]
     fn rclass_for_nested_class() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         interp.eval(b"module Foo; class Bar; end; end").unwrap();
         let spec = module::Spec::new(&mut interp, "Foo", cstr::cstr!("Foo"), None).unwrap();
         let spec = class::Spec::new("Bar", cstr::cstr!("Bar"), Some(EnclosingRubyScope::module(&spec)), None).unwrap();
@@ -355,7 +355,7 @@ mod tests {
 
     #[test]
     fn rclass_for_nested_class_under_class() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         interp.eval(b"class Foo; class Bar; end; end").unwrap();
         let spec = class::Spec::new("Foo", cstr::cstr!("Foo"), None, None).unwrap();
         let spec = class::Spec::new("Bar", cstr::cstr!("Bar"), Some(EnclosingRubyScope::class(&spec)), None).unwrap();

--- a/artichoke-backend/src/convert/array.rs
+++ b/artichoke-backend/src/convert/array.rs
@@ -421,7 +421,7 @@ mod tests {
 
     #[test]
     fn fail_convert() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         // get a Ruby value that can't be converted to a primitive type.
         let value = interp.eval(b"Object.new").unwrap();
         let result = value.try_convert_into_mut::<Vec<Value>>(&mut interp);
@@ -431,7 +431,7 @@ mod tests {
     quickcheck! {
         #[allow(clippy::needless_pass_by_value)]
         fn arr_int_borrowed(arr: Vec<i64>) -> bool {
-            let mut interp = interpreter().unwrap();
+            let mut interp = interpreter();
             // Borrowed converter
             let value = interp.try_convert_mut(arr.as_slice()).unwrap();
             let len = value.funcall(&mut interp, "length", &[], None).unwrap();
@@ -453,7 +453,7 @@ mod tests {
 
         #[allow(clippy::needless_pass_by_value)]
         fn arr_int_owned(arr: Vec<i64>) -> bool {
-            let mut interp = interpreter().unwrap();
+            let mut interp = interpreter();
             // Owned converter
             let value = interp.try_convert_mut(arr.clone()).unwrap();
             let len = value.funcall(&mut interp, "length", &[], None).unwrap();
@@ -475,7 +475,7 @@ mod tests {
 
         #[allow(clippy::needless_pass_by_value)]
         fn arr_utf8_borrowed(arr: Vec<String>) -> bool {
-            let mut interp = interpreter().unwrap();
+            let mut interp = interpreter();
             // Borrowed converter
             let value = interp.try_convert_mut(arr.as_slice()).unwrap();
             let len = value.funcall(&mut interp, "length", &[], None).unwrap();
@@ -497,7 +497,7 @@ mod tests {
 
         #[allow(clippy::needless_pass_by_value)]
         fn arr_utf8_owned(arr: Vec<String>) -> bool {
-            let mut interp = interpreter().unwrap();
+            let mut interp = interpreter();
             // Owned converter
             let value = interp.try_convert_mut(arr.clone()).unwrap();
             let len = value.funcall(&mut interp, "length", &[], None).unwrap();
@@ -519,7 +519,7 @@ mod tests {
 
         #[allow(clippy::needless_pass_by_value)]
         fn arr_nilable_bstr_borrowed(arr: Vec<Option<Vec<u8>>>) -> bool {
-            let mut interp = interpreter().unwrap();
+            let mut interp = interpreter();
             // Borrowed converter
             let value = interp.try_convert_mut(arr.as_slice()).unwrap();
             let len = value.funcall(&mut interp, "length", &[], None).unwrap();
@@ -541,7 +541,7 @@ mod tests {
 
         #[allow(clippy::needless_pass_by_value)]
         fn arr_nilable_bstr_owned(arr: Vec<Option<Vec<u8>>>) -> bool {
-            let mut interp = interpreter().unwrap();
+            let mut interp = interpreter();
             // Owned converter
             let value = interp.try_convert_mut(arr.clone()).unwrap();
             let len = value.funcall(&mut interp, "length", &[], None).unwrap();
@@ -562,7 +562,7 @@ mod tests {
         }
 
         fn roundtrip_err(i: i64) -> bool {
-            let mut interp = interpreter().unwrap();
+            let mut interp = interpreter();
             let value = interp.convert(i);
             let value = value.try_convert_into_mut::<Vec<Value>>(&mut interp);
             value.is_err()

--- a/artichoke-backend/src/convert/boolean.rs
+++ b/artichoke-backend/src/convert/boolean.rs
@@ -71,7 +71,7 @@ mod tests {
 
     #[test]
     fn fail_convert() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         // get a Ruby value that can't be converted to a primitive type.
         let value = interp.eval(b"Object.new").unwrap();
         let result = value.try_convert_into::<bool>(&interp);
@@ -80,13 +80,13 @@ mod tests {
 
     quickcheck! {
         fn convert_to_bool(b: bool) -> bool {
-            let interp = interpreter().unwrap();
+            let interp = interpreter();
             let value = interp.convert(b);
             value.ruby_type() == Ruby::Bool
         }
 
         fn convert_to_nilable_bool(b: Option<bool>) -> bool {
-            let interp = interpreter().unwrap();
+            let interp = interpreter();
             let value = interp.convert(b);
             if b.is_some() {
                 value.ruby_type() == Ruby::Bool
@@ -96,7 +96,7 @@ mod tests {
         }
 
         fn bool_with_value(b: bool) -> bool {
-            let interp = interpreter().unwrap();
+            let interp = interpreter();
             let value = interp.convert(b);
             let value = value.inner();
             if b {
@@ -121,7 +121,7 @@ mod tests {
         }
 
         fn nilable_bool_with_value(b: Option<bool>) -> bool {
-            let interp = interpreter().unwrap();
+            let interp = interpreter();
             let value = interp.convert(b);
             let value = value.inner();
             match b {
@@ -163,21 +163,21 @@ mod tests {
         }
 
         fn roundtrip(b: bool) -> bool {
-            let interp = interpreter().unwrap();
+            let interp = interpreter();
             let value = interp.convert(b);
             let value = value.try_convert_into::<bool>(&interp).unwrap();
             value == b
         }
 
         fn nilable_roundtrip(b: Option<bool>) -> bool {
-            let interp = interpreter().unwrap();
+            let interp = interpreter();
             let value = interp.convert(b);
             let value = value.try_convert_into::<Option<bool>>(&interp).unwrap();
             value == b
         }
 
         fn roundtrip_err(i: i64) -> bool {
-            let interp = interpreter().unwrap();
+            let interp = interpreter();
             let value = interp.convert(i);
             let value = value.try_convert_into::<bool>(&interp);
             value.is_err()

--- a/artichoke-backend/src/convert/boxing.rs
+++ b/artichoke-backend/src/convert/boxing.rs
@@ -344,7 +344,7 @@ mod tests {
 
     #[test]
     fn convert_obj_roundtrip() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         let spec = class::Spec::new(
             "Container",
             cstr::cstr!("Container"),
@@ -379,7 +379,7 @@ mod tests {
 
     #[test]
     fn convert_obj_not_data() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
 
         let spec = class::Spec::new(
             "Container",

--- a/artichoke-backend/src/convert/bytes.rs
+++ b/artichoke-backend/src/convert/bytes.rs
@@ -110,7 +110,7 @@ mod tests {
 
     #[test]
     fn fail_convert() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         // get a Ruby value that can't be converted to a primitive type.
         let value = interp.eval(b"Object.new").unwrap();
         let result = value.try_convert_into_mut::<Vec<u8>>(&mut interp);
@@ -119,7 +119,7 @@ mod tests {
 
     #[test]
     fn convert_with_trailing_nul() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         let bytes: &[u8] = &[0];
         let value = interp.try_convert_mut(bytes).unwrap();
         let retrieved_bytes = value.try_convert_into_mut::<&[u8]>(&mut interp).unwrap();
@@ -149,14 +149,14 @@ mod tests {
 
     quickcheck! {
         fn convert_to_vec(bytes: Vec<u8>) -> bool {
-            let mut interp = interpreter().unwrap();
+            let mut interp = interpreter();
             let value = interp.try_convert_mut(bytes).unwrap();
             value.ruby_type() == Ruby::String
         }
 
         #[allow(clippy::needless_pass_by_value)]
         fn byte_string_borrowed(bytes: Vec<u8>) -> bool {
-            let mut interp = interpreter().unwrap();
+            let mut interp = interpreter();
             // Borrowed converter
             let value = interp.try_convert_mut(bytes.as_slice()).unwrap();
             let len = value.funcall(&mut interp, "bytesize", &[], None).unwrap();
@@ -196,7 +196,7 @@ mod tests {
 
         #[allow(clippy::needless_pass_by_value)]
         fn byte_string_owned(bytes: Vec<u8>) -> bool {
-            let mut interp = interpreter().unwrap();
+            let mut interp = interpreter();
             // Owned converter
             let value = interp.try_convert_mut(bytes.clone()).unwrap();
             let len = value.funcall(&mut interp, "bytesize", &[], None).unwrap();
@@ -236,14 +236,14 @@ mod tests {
 
         #[allow(clippy::needless_pass_by_value)]
         fn roundtrip(bytes: Vec<u8>) -> bool {
-            let mut interp = interpreter().unwrap();
+            let mut interp = interpreter();
             let value = interp.try_convert_mut(bytes.as_slice()).unwrap();
             let value = value.try_convert_into_mut::<Vec<u8>>(&mut interp).unwrap();
             value == bytes
         }
 
         fn roundtrip_err(b: bool) -> bool {
-            let mut interp = interpreter().unwrap();
+            let mut interp = interpreter();
             let value = interp.convert(b);
             let value = value.try_convert_into_mut::<Vec<u8>>(&mut interp);
             value.is_err()

--- a/artichoke-backend/src/convert/fixnum.rs
+++ b/artichoke-backend/src/convert/fixnum.rs
@@ -162,7 +162,7 @@ mod tests {
 
     #[test]
     fn fail_convert() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         // get a Ruby value that can't be converted to a primitive type.
         let value = interp.eval(b"Object.new").unwrap();
         let result = value.try_convert_into::<i64>(&interp);
@@ -171,13 +171,13 @@ mod tests {
 
     quickcheck! {
         fn convert_to_fixnum(i: i64) -> bool {
-            let interp = interpreter().unwrap();
+            let interp = interpreter();
             let value = interp.convert(i);
             value.ruby_type() == Ruby::Fixnum
         }
 
         fn fixnum_with_value(i: i64) -> bool {
-            let interp = interpreter().unwrap();
+            let interp = interpreter();
             let value = interp.convert(i);
             let inner = value.inner();
             let cint = unsafe { sys::mrb_sys_fixnum_to_cint(inner) };
@@ -185,14 +185,14 @@ mod tests {
         }
 
         fn roundtrip(i: i64) -> bool {
-            let interp = interpreter().unwrap();
+            let interp = interpreter();
             let value = interp.convert(i);
             let value = value.try_convert_into::<i64>(&interp).unwrap();
             value == i
         }
 
         fn roundtrip_err(b: bool) -> bool {
-            let interp = interpreter().unwrap();
+            let interp = interpreter();
             let value = interp.convert(b);
             let value = value.try_convert_into::<i64>(&interp);
             value.is_err()
@@ -201,7 +201,7 @@ mod tests {
 
     #[test]
     fn fixnum_to_usize() {
-        let interp = interpreter().unwrap();
+        let interp = interpreter();
         let value = Convert::<_, Value>::convert(&*interp, 100);
         let value = value.try_convert_into::<usize>(&interp).unwrap();
         assert_eq!(100, value);

--- a/artichoke-backend/src/convert/float.rs
+++ b/artichoke-backend/src/convert/float.rs
@@ -35,7 +35,7 @@ mod tests {
 
     #[test]
     fn fail_convert() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         // get a Ruby Value that can't be converted to a primitive type.
         let value = interp.eval(b"Object.new").unwrap();
         let result = value.try_convert_into::<f64>(&interp);
@@ -44,13 +44,13 @@ mod tests {
 
     quickcheck! {
         fn convert_to_float(f: f64) -> bool {
-            let mut interp = interpreter().unwrap();
+            let mut interp = interpreter();
             let value = interp.convert_mut(f);
             value.ruby_type() == Ruby::Float
         }
 
         fn float_with_value(f: f64) -> bool {
-            let mut interp = interpreter().unwrap();
+            let mut interp = interpreter();
             let value = interp.convert_mut(f);
             let inner = value.inner();
             let cdouble = unsafe { sys::mrb_sys_float_to_cdouble(inner) };
@@ -70,7 +70,7 @@ mod tests {
         }
 
         fn roundtrip(f: f64) -> bool {
-            let mut interp = interpreter().unwrap();
+            let mut interp = interpreter();
             let value = interp.convert_mut(f);
             let value = value.try_convert_into::<f64>(&interp).unwrap();
             if f.is_nan() {
@@ -89,7 +89,7 @@ mod tests {
         }
 
         fn roundtrip_err(b: bool) -> bool {
-            let interp = interpreter().unwrap();
+            let interp = interpreter();
             let value = interp.convert(b);
             let value = value.try_convert_into::<f64>(&interp);
             value.is_err()

--- a/artichoke-backend/src/convert/hash.rs
+++ b/artichoke-backend/src/convert/hash.rs
@@ -127,7 +127,7 @@ mod tests {
     quickcheck! {
         #[allow(clippy::needless_pass_by_value)]
         fn roundtrip_kv(hash: HashMap<Vec<u8>, Vec<u8>>) -> bool {
-            let mut interp = interpreter().unwrap();
+            let mut interp = interpreter();
             let value = interp.try_convert_mut(hash.clone()).unwrap();
             let len = value.funcall(&mut interp, "length", &[], None).unwrap();
             let len = len.try_convert_into::<usize>(&interp).unwrap();

--- a/artichoke-backend/src/convert/string.rs
+++ b/artichoke-backend/src/convert/string.rs
@@ -67,7 +67,7 @@ mod tests {
 
     #[test]
     fn fail_convert() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         // get a mrb_value that can't be converted to a primitive type.
         let value = interp.eval(b"Object.new").unwrap();
         let result = value.try_convert_into_mut::<String>(&mut interp);
@@ -77,7 +77,7 @@ mod tests {
     quickcheck! {
         #[allow(clippy::needless_pass_by_value)]
         fn convert_to_string(s: String) -> bool {
-            let mut interp = interpreter().unwrap();
+            let mut interp = interpreter();
             let value = interp.try_convert_mut(s.clone()).unwrap();
             let string: Vec<u8> = interp.try_convert_mut(value).unwrap();
             s.as_bytes() == string
@@ -85,7 +85,7 @@ mod tests {
 
         #[allow(clippy::needless_pass_by_value)]
         fn string_with_value(s: String) -> bool {
-            let mut interp = interpreter().unwrap();
+            let mut interp = interpreter();
             let value = interp.try_convert_mut(s.clone()).unwrap();
             value.to_s(&mut interp) == s.as_bytes()
         }
@@ -93,7 +93,7 @@ mod tests {
         #[allow(clippy::needless_pass_by_value)]
         #[cfg(feature = "core-regexp")]
         fn utf8string_borrowed(string: String) -> bool {
-            let mut interp = interpreter().unwrap();
+            let mut interp = interpreter();
             // Borrowed converter
             let value = interp.try_convert_mut(string.as_str()).unwrap();
             let len = value
@@ -126,7 +126,7 @@ mod tests {
         #[allow(clippy::needless_pass_by_value)]
         #[cfg(feature = "core-regexp")]
         fn utf8string_owned(string: String) -> bool {
-            let mut interp = interpreter().unwrap();
+            let mut interp = interpreter();
             // Owned converter
             let value = interp.try_convert_mut(string.clone()).unwrap();
             let len = value
@@ -158,14 +158,14 @@ mod tests {
 
         #[allow(clippy::needless_pass_by_value)]
         fn roundtrip(s: String) -> bool {
-            let mut interp = interpreter().unwrap();
+            let mut interp = interpreter();
             let value = interp.try_convert_mut(s.clone()).unwrap();
             let value = value.try_convert_into_mut::<String>(&mut interp).unwrap();
             value == s
         }
 
         fn roundtrip_err(b: bool) -> bool {
-            let mut interp = interpreter().unwrap();
+            let mut interp = interpreter();
             let value = interp.convert(b);
             let result = value.try_convert_into_mut::<String>(&mut interp);
             result.is_err()

--- a/artichoke-backend/src/debug.rs
+++ b/artichoke-backend/src/debug.rs
@@ -36,42 +36,42 @@ mod tests {
 
     #[test]
     fn debug_true_value_as_classlike() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         let value = interp.convert(true);
         assert_eq!(interp.inspect_type_name_for_value(value), "true");
     }
 
     #[test]
     fn debug_false_value_as_classlike() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         let value = interp.convert(false);
         assert_eq!(interp.inspect_type_name_for_value(value), "false");
     }
 
     #[test]
     fn debug_nil_value_as_classlike() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         let value = interp.convert(None::<Value>);
         assert_eq!(interp.inspect_type_name_for_value(value), "nil");
     }
 
     #[test]
     fn debug_fixnum_value_as_classlike() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         let value = interp.convert(1_i64);
         assert_eq!(interp.inspect_type_name_for_value(value), "Integer");
     }
 
     #[test]
     fn debug_hash_value_as_classlike() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         let value = interp.try_convert_mut(vec![(b"foo".to_vec(), vec![1, 2, 3])]).unwrap();
         assert_eq!(interp.inspect_type_name_for_value(value), "Hash");
     }
 
     #[test]
     fn debug_array_value_as_classlike() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         let value = interp.try_convert_mut(vec![1_i64]).unwrap();
         assert_eq!(interp.inspect_type_name_for_value(value), "Array");
     }

--- a/artichoke-backend/src/def.rs
+++ b/artichoke-backend/src/def.rs
@@ -500,7 +500,7 @@ mod tests {
         #[test]
         fn integration_test() {
             // Setup: define module and class hierarchy
-            let mut interp = interpreter().unwrap();
+            let mut interp = interpreter();
             let root = module::Spec::new(&mut interp, "A", cstr::cstr!("A"), None).unwrap();
             let mod_under_root = module::Spec::new(
                 &mut interp,
@@ -584,7 +584,7 @@ mod tests {
 
         #[test]
         fn define_method() {
-            let mut interp = interpreter().unwrap();
+            let mut interp = interpreter();
             let class = class::Spec::new(
                 "DefineMethodTestClass",
                 cstr::cstr!("DefineMethodTestClass"),

--- a/artichoke-backend/src/eval.rs
+++ b/artichoke-backend/src/eval.rs
@@ -70,7 +70,7 @@ mod tests {
 
     #[test]
     fn root_eval_context() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         let result = interp.eval(b"__FILE__").unwrap();
         let result = result.try_convert_into_mut::<&str>(&mut interp).unwrap();
         assert_eq!(result, "(eval)");
@@ -78,7 +78,7 @@ mod tests {
 
     #[test]
     fn context_is_restored_after_eval() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         let context = Context::new(&b"context.rb"[..]).unwrap();
         interp.push_context(context).unwrap();
         interp.eval(b"15").unwrap();
@@ -89,7 +89,7 @@ mod tests {
 
     #[test]
     fn root_context_is_not_pushed_after_eval() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         interp.eval(b"15").unwrap();
         let context = interp.peek_context().unwrap();
         assert!(context.is_none());
@@ -130,7 +130,7 @@ mod tests {
         #[should_panic]
         // this test is known broken
         fn eval_context_is_a_stack() {
-            let mut interp = interpreter().unwrap();
+            let mut interp = interpreter();
             interp.def_file_for_type::<_, NestedEval>("nested_eval.rb").unwrap();
             let code = br#"require 'nested_eval'; NestedEval.file"#;
             let result = interp.eval(code).unwrap();
@@ -141,7 +141,7 @@ mod tests {
 
     #[test]
     fn eval_with_context() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
 
         let context = Context::new(b"source.rb".as_ref()).unwrap();
         interp.push_context(context).unwrap();
@@ -167,14 +167,14 @@ mod tests {
 
     #[test]
     fn unparseable_code_returns_err_syntax_error() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         let err = interp.eval(b"'a").unwrap_err();
         assert_eq!("SyntaxError", err.name().as_ref());
     }
 
     #[test]
     fn interpreter_is_usable_after_syntax_error() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         let err = interp.eval(b"'a").unwrap_err();
         assert_eq!("SyntaxError", err.name().as_ref());
         // Ensure interpreter is usable after evaling unparseable code
@@ -190,7 +190,7 @@ mod tests {
         } else {
             "/artichoke/virtual_root/src/lib/source.rb"
         };
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         interp
             .def_rb_source_file("source.rb", &b"def file; __FILE__; end"[..])
             .unwrap();
@@ -201,7 +201,7 @@ mod tests {
 
     #[test]
     fn file_not_persistent() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         interp
             .def_rb_source_file("source.rb", &b"def file; __FILE__; end"[..])
             .unwrap();
@@ -212,7 +212,7 @@ mod tests {
 
     #[test]
     fn return_syntax_error() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         interp
             .def_rb_source_file("fail.rb", &b"def bad; 'as'.scan(; end"[..])
             .unwrap();

--- a/artichoke-backend/src/exception_handler.rs
+++ b/artichoke-backend/src/exception_handler.rs
@@ -180,7 +180,7 @@ mod tests {
 
     #[test]
     fn return_exception() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         let err = interp.eval(b"raise ArgumentError.new('waffles')").unwrap_err();
         assert_eq!("ArgumentError", err.name().as_ref());
         assert_eq!(b"waffles".as_bstr(), err.message().as_ref().as_bstr());
@@ -191,7 +191,7 @@ mod tests {
 
     #[test]
     fn return_exception_with_no_backtrace() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         let err = interp.eval(b"def bad; (; end").unwrap_err();
         assert_eq!("SyntaxError", err.name().as_ref());
         assert_eq!(b"syntax error".as_bstr(), err.message().as_ref().as_bstr());
@@ -200,7 +200,7 @@ mod tests {
 
     #[test]
     fn raise_does_not_panic_or_segfault() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         interp.eval(br#"raise 'foo'"#).unwrap_err();
         interp.eval(br#"raise 'foo'"#).unwrap_err();
         interp.eval(br#"eval("raise 'foo'")"#).unwrap_err();

--- a/artichoke-backend/src/extn/core/array/mod.rs
+++ b/artichoke-backend/src/extn/core/array/mod.rs
@@ -347,7 +347,7 @@ mod tests {
 
     #[test]
     fn functional() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         let result = interp.eval(FUNCTIONAL_TEST);
         unwrap_or_panic_with_backtrace(&mut interp, SUBJECT, result);
         let result = interp.eval(b"spec");

--- a/artichoke-backend/src/extn/core/exception/mod.rs
+++ b/artichoke-backend/src/extn/core/exception/mod.rs
@@ -157,7 +157,7 @@ mod tests {
 
     #[test]
     fn raise() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         Run::require(&mut interp).unwrap();
         let err = interp.eval(b"Run.run").unwrap_err();
         assert_eq!("RuntimeError", err.name().as_ref());

--- a/artichoke-backend/src/extn/core/hash/mod.rs
+++ b/artichoke-backend/src/extn/core/hash/mod.rs
@@ -26,7 +26,7 @@ mod tests {
 
     #[test]
     fn regression_github_1099() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         let inspect = interp.eval(b"{ a: 'GH-1099' }.inspect").unwrap();
         let inspect = inspect.try_convert_into_mut::<&str>(&mut interp).unwrap();
         assert_eq!(inspect, r#"{:a=>"GH-1099"}"#);

--- a/artichoke-backend/src/extn/core/integer/mod.rs
+++ b/artichoke-backend/src/extn/core/integer/mod.rs
@@ -219,7 +219,7 @@ mod tests {
 
     quickcheck! {
         fn positive_integer_division_vm_opcode(x: u8, y: u8) -> bool {
-            let mut interp = interpreter().unwrap();
+            let mut interp = interpreter();
             match (x, y) {
                 (0, 0) => interp.eval(b"0 / 0").is_err(),
                 (x, 0) | (0, x) => {
@@ -241,7 +241,7 @@ mod tests {
         }
 
         fn positive_integer_division_send(x: u8, y: u8) -> bool {
-            let mut interp = interpreter().unwrap();
+            let mut interp = interpreter();
             match (x, y) {
                 (0, 0) => interp.eval(b"0.send('/', 0)").is_err(),
                 (x, 0) | (0, x) => {
@@ -263,7 +263,7 @@ mod tests {
         }
 
         fn negative_integer_division_vm_opcode(x: u8, y: u8) -> bool {
-            let mut interp = interpreter().unwrap();
+            let mut interp = interpreter();
             match (x, y) {
                 (0, 0) => interp.eval(b"-0 / 0").is_err(),
                 (x, 0) | (0, x) => {
@@ -291,7 +291,7 @@ mod tests {
         }
 
         fn negative_integer_division_send(x: u8, y: u8) -> bool {
-            let mut interp = interpreter().unwrap();
+            let mut interp = interpreter();
             match (x, y) {
                 (0, 0) => interp.eval(b"-0.send('/', 0)").is_err(),
                 (x, 0) | (0, x) => {

--- a/artichoke-backend/src/extn/core/kernel/integer.rs
+++ b/artichoke-backend/src/extn/core/kernel/integer.rs
@@ -485,7 +485,7 @@ mod tests {
 
     #[test]
     fn nil_radix_parses_to_none() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         let result: Result<Option<Radix>, _> = interp.try_convert_mut(None);
         let result = result.unwrap();
         assert!(result.is_none());
@@ -493,7 +493,7 @@ mod tests {
 
     #[test]
     fn zero_radix_parses_to_none() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         let radix = interp.convert(0);
         let result: Result<Option<Radix>, _> = interp.try_convert_mut(Some(radix));
         let result = result.unwrap();
@@ -505,7 +505,7 @@ mod tests {
 
     #[test]
     fn negative_one_radix_parses_to_none() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         let expected = Radix::new(10).unwrap();
         let radix = interp.convert(-1);
         let result: Result<Option<Radix>, _> = interp.try_convert_mut(Some(radix));
@@ -515,7 +515,7 @@ mod tests {
 
     #[test]
     fn one_radix_has_parse_failure() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         let radix = interp.convert(1);
         let result: Result<Option<Radix>, _> = interp.try_convert_mut(Some(radix));
         assert!(result.is_err());
@@ -528,7 +528,7 @@ mod tests {
 
     #[test]
     fn invalid_radix_has_parse_failure() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         let radix = interp.convert(12000);
         let result: Result<Option<Radix>, _> = interp.try_convert_mut(Some(radix));
         assert!(result.is_err());
@@ -541,7 +541,7 @@ mod tests {
 
     #[test]
     fn invalid_negative_radix_has_parse_failure() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         let radix = interp.convert(-12000);
         let result: Result<Option<Radix>, _> = interp.try_convert_mut(Some(radix));
         assert!(result.is_err());
@@ -562,7 +562,7 @@ mod tests {
 
     #[test]
     fn positive_radix_in_valid_range_is_parsed() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         for r in 2_i32..=36_i32 {
             let radix = interp.convert(r);
             let expected = Radix::new(r.try_into().unwrap()).unwrap();
@@ -574,7 +574,7 @@ mod tests {
 
     #[test]
     fn negative_radix_in_valid_range_is_parsed() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         for r in 2_i32..=36_i32 {
             let radix = interp.convert(-r);
             let expected = Radix::new(r.try_into().unwrap()).unwrap();
@@ -586,7 +586,7 @@ mod tests {
 
     #[test]
     fn int_max_min_do_not_panic() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         let radix = interp.convert(i64::MAX);
         let result: Result<Option<Radix>, _> = interp.try_convert_mut(Some(radix));
         assert!(result.is_err());

--- a/artichoke-backend/src/extn/core/kernel/mod.rs
+++ b/artichoke-backend/src/extn/core/kernel/mod.rs
@@ -15,7 +15,7 @@ mod tests {
 
     #[test]
     fn functional() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         let result = interp.eval(FUNCTIONAL_TEST);
         unwrap_or_panic_with_backtrace(&mut interp, SUBJECT, result);
         let result = interp.eval(b"spec");

--- a/artichoke-backend/src/extn/core/kernel/require.rs
+++ b/artichoke-backend/src/extn/core/kernel/require.rs
@@ -199,7 +199,7 @@ mod test {
     // - Require non-existing file raises and returns `nil`.
     #[test]
     fn functional() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         interp.def_file_for_type::<_, MockSourceFile>("file.rb").unwrap();
         let result = interp.eval(b"require 'file'").unwrap();
         let require_result = result.try_convert_into::<bool>(&interp).unwrap();
@@ -225,7 +225,7 @@ mod test {
 
     #[test]
     fn absolute_path() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         let (path, require_code) = if cfg!(windows) {
             (
                 "c:/artichoke/virtual_root/src/lib/foo/bar/source.rb",
@@ -247,7 +247,7 @@ mod test {
 
     #[test]
     fn relative_with_dotted_path() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         if cfg!(windows) {
             interp
                 .def_rb_source_file(
@@ -289,7 +289,7 @@ mod test {
 
     #[test]
     fn directory_err() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         let err = interp.eval(b"require '/src'").unwrap_err();
         assert_eq!(
             b"cannot load such file -- /src".as_bstr(),
@@ -302,7 +302,7 @@ mod test {
 
     #[test]
     fn path_defined_as_source_then_extension_file() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         interp
             .def_rb_source_file("foo.rb", &b"module Foo; RUBY = 3; end"[..])
             .unwrap();
@@ -319,7 +319,7 @@ mod test {
 
     #[test]
     fn path_defined_as_extension_file_then_source() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         interp
             .def_file_for_type::<_, MockExtensionAndSourceFile>("foo.rb")
             .unwrap();

--- a/artichoke-backend/src/extn/core/string/mod.rs
+++ b/artichoke-backend/src/extn/core/string/mod.rs
@@ -163,7 +163,7 @@ mod tests {
     #[test]
     #[cfg(feature = "core-regexp")]
     fn functional() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         let result = interp.eval(FUNCTIONAL_TEST);
         unwrap_or_panic_with_backtrace(&mut interp, SUBJECT, result);
         let result = interp.eval(b"spec");

--- a/artichoke-backend/src/extn/core/thread/mod.rs
+++ b/artichoke-backend/src/extn/core/thread/mod.rs
@@ -43,7 +43,7 @@ mod tests {
 
     #[test]
     fn functional() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         let result = interp.eval(FUNCTIONAL_TEST);
         unwrap_or_panic_with_backtrace(&mut interp, SUBJECT, result);
         let result = interp.eval(b"spec");

--- a/artichoke-backend/src/extn/stdlib/abbrev/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/abbrev/mod.rs
@@ -25,7 +25,7 @@ mod tests {
 
     #[test]
     fn functional() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         let result = interp.eval(FUNCTIONAL_TEST);
         unwrap_or_panic_with_backtrace(&mut interp, SUBJECT, result);
         let result = interp.eval(b"spec");

--- a/artichoke-backend/src/extn/stdlib/forwardable/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/forwardable/mod.rs
@@ -27,7 +27,7 @@ mod tests {
 
     #[test]
     fn functional() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         let result = interp.eval(FUNCTIONAL_TEST);
         unwrap_or_panic_with_backtrace(&mut interp, SUBJECT, result);
         let result = interp.eval(b"spec");

--- a/artichoke-backend/src/extn/stdlib/json/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/json/mod.rs
@@ -40,7 +40,7 @@ mod tests {
 
     #[test]
     fn functional() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         let result = interp.eval(FUNCTIONAL_TEST);
         unwrap_or_panic_with_backtrace(&mut interp, SUBJECT, result);
         let result = interp.eval(b"spec");

--- a/artichoke-backend/src/extn/stdlib/monitor/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/monitor/mod.rs
@@ -25,7 +25,7 @@ mod tests {
 
     #[test]
     fn functional() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         let result = interp.eval(FUNCTIONAL_TEST);
         unwrap_or_panic_with_backtrace(&mut interp, SUBJECT, result);
         let result = interp.eval(b"spec");

--- a/artichoke-backend/src/extn/stdlib/strscan/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/strscan/mod.rs
@@ -25,7 +25,7 @@ mod tests {
 
     #[test]
     fn functional() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         let result = interp.eval(FUNCTIONAL_TEST);
         unwrap_or_panic_with_backtrace(&mut interp, SUBJECT, result);
         let result = interp.eval(b"spec");

--- a/artichoke-backend/src/extn/stdlib/uri/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/uri/mod.rs
@@ -63,7 +63,7 @@ mod tests {
 
     #[test]
     fn functional() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         let result = interp.eval(FUNCTIONAL_TEST);
         unwrap_or_panic_with_backtrace(&mut interp, SUBJECT, result);
         let result = interp.eval(b"spec");

--- a/artichoke-backend/src/gc.rs
+++ b/artichoke-backend/src/gc.rs
@@ -129,7 +129,7 @@ mod tests {
 
     #[test]
     fn arena_restore_on_explicit_restore() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         let baseline_object_count = interp.live_object_count();
         let mut arena = interp.create_arena_savepoint().unwrap();
         for _ in 0..2000 {
@@ -149,7 +149,7 @@ mod tests {
 
     #[test]
     fn arena_restore_on_drop() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         let baseline_object_count = interp.live_object_count();
         {
             let mut arena = interp.create_arena_savepoint().unwrap();
@@ -170,7 +170,7 @@ mod tests {
 
     #[test]
     fn enable_disable_gc() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         interp.disable_gc().unwrap();
         let mut arena = interp.create_arena_savepoint().unwrap();
         arena
@@ -211,7 +211,7 @@ mod tests {
 
     #[test]
     fn gc_after_empty_eval() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         let mut arena = interp.create_arena_savepoint().unwrap();
         let baseline_object_count = arena.live_object_count();
         arena.eval(b"").unwrap();
@@ -222,7 +222,7 @@ mod tests {
 
     #[test]
     fn gc_functional_test() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         let baseline_object_count = interp.live_object_count();
         let mut initial_arena = interp.create_arena_savepoint().unwrap();
         for _ in 0..2000 {

--- a/artichoke-backend/src/load.rs
+++ b/artichoke-backend/src/load.rs
@@ -209,7 +209,7 @@ LoadSources::Counter.instance.inc!
 
     #[test]
     fn load_has_no_memory() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         interp.def_rb_source_file("counter.rb", NON_IDEMPOTENT_LOAD).unwrap();
 
         let result = interp.load_source("./counter.rb").unwrap();
@@ -234,7 +234,7 @@ LoadSources::Counter.instance.inc!
 
     #[test]
     fn load_has_no_memory_and_ignores_loaded_features() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         interp.def_rb_source_file("counter.rb", NON_IDEMPOTENT_LOAD).unwrap();
 
         let result = interp.require_source("./counter.rb").unwrap();
@@ -271,7 +271,7 @@ LoadSources::Counter.instance.inc!
 
     #[test]
     fn load_does_not_discover_paths_from_loaded_features() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         interp.def_rb_source_file("counter.rb", NON_IDEMPOTENT_LOAD).unwrap();
 
         let result = interp.require_source("./counter").unwrap();

--- a/artichoke-backend/src/module.rs
+++ b/artichoke-backend/src/module.rs
@@ -258,7 +258,7 @@ mod tests {
 
     #[test]
     fn rclass_for_undef_root_module() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         let spec = Spec::new(&mut interp, "Foo", cstr::cstr!("Foo"), None).unwrap();
         let rclass = unsafe { interp.with_ffi_boundary(|mrb| spec.rclass().resolve(mrb)) }.unwrap();
         assert!(rclass.is_none());
@@ -266,7 +266,7 @@ mod tests {
 
     #[test]
     fn rclass_for_undef_nested_module() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         let scope = Spec::new(&mut interp, "Kernel", cstr::cstr!("Kernel"), None).unwrap();
         let scope = EnclosingRubyScope::module(&scope);
         let spec = Spec::new(&mut interp, "Foo", cstr::cstr!("Foo"), Some(scope)).unwrap();
@@ -276,7 +276,7 @@ mod tests {
 
     #[test]
     fn rclass_for_root_module() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         let spec = Spec::new(&mut interp, "Kernel", cstr::cstr!("Kernel"), None).unwrap();
         let rclass = unsafe { interp.with_ffi_boundary(|mrb| spec.rclass().resolve(mrb)) }.unwrap();
         assert!(rclass.is_some());
@@ -284,7 +284,7 @@ mod tests {
 
     #[test]
     fn rclass_for_nested_module() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         interp.eval(b"module Foo; module Bar; end; end").unwrap();
         let scope = Spec::new(&mut interp, "Foo", cstr::cstr!("Foo"), None).unwrap();
         let scope = EnclosingRubyScope::module(&scope);
@@ -295,7 +295,7 @@ mod tests {
 
     #[test]
     fn rclass_for_nested_module_under_class() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         interp.eval(b"class Foo; module Bar; end; end").unwrap();
         let scope = class::Spec::new("Foo", cstr::cstr!("Foo"), None, None).unwrap();
         let scope = EnclosingRubyScope::class(&scope);

--- a/artichoke-backend/src/sys/mod.rs
+++ b/artichoke-backend/src/sys/mod.rs
@@ -115,7 +115,7 @@ mod tests {
     fn interpreter_debug() {
         // Since the introduction of Rust symbol table, `mrb_open` cannot be
         // called without an Artichoke `State`.
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         unsafe {
             let mrb = interp.mrb.as_mut();
             let debug = sys::mrb_sys_state_debug(mrb);

--- a/artichoke-backend/src/test/prelude.rs
+++ b/artichoke-backend/src/test/prelude.rs
@@ -61,9 +61,13 @@ impl Drop for AutoDropArtichoke {
 //
 // See https://github.com/artichoke/artichoke/issues/930 for rationale of this
 // constructor.
-pub fn interpreter() -> Result<AutoDropArtichoke, Error> {
-    let interp = crate::interpreter()?;
-    Ok(AutoDropArtichoke(Some(interp)))
+//
+// This function unwraps internally and does not return error since every test
+// that uses this function must unwrap. Unwrapping internally makes grep code
+// analysis that looks for `unwrap` and `expect` a bit easier.
+pub fn interpreter() -> AutoDropArtichoke {
+    let interp = crate::interpreter().unwrap_or_else(|err| panic!("Artichoke failed to initialize in tests: {err}"));
+    AutoDropArtichoke(Some(interp))
 }
 
 /// Unwrap a result returned from the VM or panic.

--- a/artichoke-backend/src/types.rs
+++ b/artichoke-backend/src/types.rs
@@ -111,7 +111,7 @@ mod tests {
 
     #[test]
     fn parse_bool_ruby_type() {
-        let interp = interpreter().unwrap();
+        let interp = interpreter();
         let yes = interp.convert(true);
         assert_eq!(Ruby::Bool, types::ruby_from_mrb_value(yes.inner()));
         let no = interp.convert(false);
@@ -120,7 +120,7 @@ mod tests {
 
     #[test]
     fn parse_fixnum_ruby_type() {
-        let interp = interpreter().unwrap();
+        let interp = interpreter();
         let zero = interp.convert(0_i64);
         assert_eq!(Ruby::Fixnum, types::ruby_from_mrb_value(zero.inner()));
         let thousand = interp.convert(1000_i64);
@@ -129,7 +129,7 @@ mod tests {
 
     #[test]
     fn parse_symbol_ruby_type() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         let empty = interp.eval(b":''").unwrap();
         assert_eq!(Ruby::Symbol, types::ruby_from_mrb_value(empty.inner()));
         let utf8 = interp.eval(b":Artichoke").unwrap();
@@ -140,7 +140,7 @@ mod tests {
 
     #[test]
     fn parse_float_ruby_type() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         let zero = interp.convert_mut(0.0_f64);
         assert_eq!(Ruby::Float, types::ruby_from_mrb_value(zero.inner()));
         let float = interp.convert_mut(1.5_f64);
@@ -149,7 +149,7 @@ mod tests {
 
     #[test]
     fn parse_object_ruby_type() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         let object = interp.eval(b"Object.new").unwrap();
         assert_eq!(Ruby::Object, types::ruby_from_mrb_value(object.inner()));
         #[cfg(feature = "core-env")]
@@ -161,7 +161,7 @@ mod tests {
 
     #[test]
     fn parse_class_ruby_type() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         let builtin = interp.eval(b"Object").unwrap();
         assert_eq!(Ruby::Class, types::ruby_from_mrb_value(builtin.inner()));
         let data = interp.eval(b"Array").unwrap();
@@ -175,7 +175,7 @@ mod tests {
 
     #[test]
     fn parse_module_ruby_type() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         let builtin = interp.eval(b"Comparable").unwrap();
         assert_eq!(Ruby::Module, types::ruby_from_mrb_value(builtin.inner()));
         #[cfg(feature = "core-math")]
@@ -189,7 +189,7 @@ mod tests {
 
     #[test]
     fn parse_proc_ruby_type() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         let literal = interp.eval(b"proc {}").unwrap();
         assert_eq!(Ruby::Proc, types::ruby_from_mrb_value(literal.inner()));
         let proc = interp.eval(b"Proc.new {}").unwrap();
@@ -202,7 +202,7 @@ mod tests {
 
     #[test]
     fn parse_string_ruby_type() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         let empty = interp.try_convert_mut("").unwrap();
         assert_eq!(Ruby::String, types::ruby_from_mrb_value(empty.inner()));
         let utf8 = interp.try_convert_mut("Artichoke").unwrap();
@@ -213,7 +213,7 @@ mod tests {
 
     #[test]
     fn parse_array_ruby_type() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         let empty = interp.eval(b"[]").unwrap();
         assert_eq!(Ruby::Array, types::ruby_from_mrb_value(empty.inner()));
         #[cfg(feature = "core-regexp")]
@@ -228,7 +228,7 @@ mod tests {
 
     #[test]
     fn parse_hash_ruby_type() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         let empty = interp.eval(b"{}").unwrap();
         assert_eq!(Ruby::Hash, types::ruby_from_mrb_value(empty.inner()));
         #[cfg(feature = "core-regexp")]
@@ -245,7 +245,7 @@ mod tests {
 
     #[test]
     fn parse_range_ruby_type() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         let dot2 = interp.eval(b"0..0").unwrap();
         assert_eq!(Ruby::Range, types::ruby_from_mrb_value(dot2.inner()));
         let dot3 = interp.eval(b"0...0").unwrap();
@@ -254,7 +254,7 @@ mod tests {
 
     #[test]
     fn parse_exception_ruby_type() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         let root = interp.eval(b"Exception.new").unwrap();
         assert_eq!(Ruby::Exception, types::ruby_from_mrb_value(root.inner()));
         let stderror = interp.eval(b"StandardError.new").unwrap();

--- a/artichoke-backend/src/value.rs
+++ b/artichoke-backend/src/value.rs
@@ -387,7 +387,7 @@ mod tests {
 
     #[test]
     fn to_s_true() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
 
         let value = interp.convert(true);
         let string = value.to_s(&mut interp);
@@ -396,7 +396,7 @@ mod tests {
 
     #[test]
     fn inspect_true() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
 
         let value = interp.convert(true);
         let debug = value.inspect(&mut interp);
@@ -405,7 +405,7 @@ mod tests {
 
     #[test]
     fn to_s_false() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
 
         let value = interp.convert(false);
         let string = value.to_s(&mut interp);
@@ -414,7 +414,7 @@ mod tests {
 
     #[test]
     fn inspect_false() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
 
         let value = interp.convert(false);
         let debug = value.inspect(&mut interp);
@@ -423,7 +423,7 @@ mod tests {
 
     #[test]
     fn to_s_nil() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
 
         let value = Value::nil();
         let string = value.to_s(&mut interp);
@@ -432,7 +432,7 @@ mod tests {
 
     #[test]
     fn inspect_nil() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
 
         let value = Value::nil();
         let debug = value.inspect(&mut interp);
@@ -441,7 +441,7 @@ mod tests {
 
     #[test]
     fn to_s_fixnum() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
 
         let value = Convert::<_, Value>::convert(&*interp, 255);
         let string = value.to_s(&mut interp);
@@ -450,7 +450,7 @@ mod tests {
 
     #[test]
     fn inspect_fixnum() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
 
         let value = Convert::<_, Value>::convert(&*interp, 255);
         let debug = value.inspect(&mut interp);
@@ -459,7 +459,7 @@ mod tests {
 
     #[test]
     fn to_s_string() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
 
         let value = interp.try_convert_mut("interstate").unwrap();
         let string = value.to_s(&mut interp);
@@ -468,7 +468,7 @@ mod tests {
 
     #[test]
     fn inspect_string() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
 
         let value = interp.try_convert_mut("interstate").unwrap();
         let debug = value.inspect(&mut interp);
@@ -477,7 +477,7 @@ mod tests {
 
     #[test]
     fn to_s_empty_string() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
 
         let value = interp.try_convert_mut("").unwrap();
         let string = value.to_s(&mut interp);
@@ -486,7 +486,7 @@ mod tests {
 
     #[test]
     fn inspect_empty_string() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
 
         let value = interp.try_convert_mut("").unwrap();
         let debug = value.inspect(&mut interp);
@@ -495,7 +495,7 @@ mod tests {
 
     #[test]
     fn is_dead() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         let mut arena = interp.create_arena_savepoint().unwrap();
         let live = arena.eval(b"'dead'").unwrap();
         assert!(!live.is_dead(&mut arena));
@@ -514,7 +514,7 @@ mod tests {
 
     #[test]
     fn funcall_is_dead() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         let mut arena = interp.create_arena_savepoint().unwrap();
 
         let dead = arena.eval(b"'dead'").unwrap();
@@ -530,7 +530,7 @@ mod tests {
 
     #[test]
     fn immediate_is_dead() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         let mut arena = interp.create_arena_savepoint().unwrap();
         let live = arena.eval(b"27").unwrap();
         assert!(!live.is_dead(&mut arena));
@@ -554,7 +554,7 @@ mod tests {
 
     #[test]
     fn funcall_nil_nil() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
 
         let nil = Value::nil();
         let result = nil
@@ -566,7 +566,7 @@ mod tests {
 
     #[test]
     fn funcall_string_nil() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
 
         let s = interp.try_convert_mut("foo").unwrap();
         let result = s
@@ -578,7 +578,7 @@ mod tests {
 
     #[test]
     fn funcall_string_split_regexp() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
 
         let s = interp.try_convert_mut("foo").unwrap();
         let delim = interp.try_convert_mut("").unwrap();
@@ -591,7 +591,7 @@ mod tests {
 
     #[test]
     fn funcall_different_types() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         let nil = Value::nil();
         let s = interp.try_convert_mut("foo").unwrap();
         let result = nil
@@ -603,7 +603,7 @@ mod tests {
 
     #[test]
     fn funcall_type_error() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         let nil = Value::nil();
         let s = interp.try_convert_mut("foo").unwrap();
         let err = s
@@ -619,7 +619,7 @@ mod tests {
 
     #[test]
     fn funcall_method_not_exists() {
-        let mut interp = interpreter().unwrap();
+        let mut interp = interpreter();
         let nil = Value::nil();
         let s = interp.try_convert_mut("foo").unwrap();
         let err = nil.funcall(&mut interp, "garbage_method_name", &[s], None).unwrap_err();


### PR DESCRIPTION
This makes static analysis of grepping for `unwrap` a bit easier by removing a bunch of them. `interpreter()` must succeed for all tests anyway, so this removes some linenoise from the code.