### PR TITLE
Fixup remaining errors from cargo-spellcheck

### DIFF
--- a/.config/artichoke.dic
+++ b/.config/artichoke.dic
@@ -122,6 +122,7 @@ manpage
 mantissa
 metadata
 millis
+missing_docs
 mojibake
 monomorphize
 monomorphizing

--- a/artichoke-backend/src/extn/core/exception/mod.rs
+++ b/artichoke-backend/src/extn/core/exception/mod.rs
@@ -117,7 +117,7 @@ ruby_exception_impl!(RegexpError);
 ruby_exception_impl!(RuntimeError);
 ruby_exception_impl!(FrozenError);
 ruby_exception_impl!(SystemCallError);
-// ruby_exception_impl!(Errno::*);
+// TODO: Implement `Errno` family of exceptions.
 ruby_exception_impl!(ThreadError);
 ruby_exception_impl!(TypeError);
 ruby_exception_impl!(ZeroDivisionError);

--- a/mezzaluna-feature-loader/src/paths/windows.rs
+++ b/mezzaluna-feature-loader/src/paths/windows.rs
@@ -179,9 +179,15 @@ mod tests {
 
     #[test]
     fn unpaired_surrogate_relative_bare() {
-        // Created a file named `<unpaired surrogate>.txt`
-        // ([]uint16=`[0xdcc0 0x2e 0x74 0x78 0x74]`) and attempt to read it by
-        // calling `ioutil.ReadDir` and reading all the files that come back.
+        // Created a file named:
+        //
+        // ```
+        // `<unpaired surrogate>.txt`
+        // ([]uint16=`[0xdcc0 0x2e 0x74 0x78 0x74]`)
+        // ```
+        //
+        // and attempt to read it by calling `ioutil.ReadDir` and reading all
+        // the files that come back.
         //
         // See: https://github.com/golang/go/issues/32334#issue-450436484
 

--- a/spinoso-string/src/encoding.rs
+++ b/spinoso-string/src/encoding.rs
@@ -279,14 +279,20 @@ impl Encoding {
     #[must_use]
     pub const fn name(self) -> &'static str {
         match self {
+            // ```
             // [2.6.3] > Encoding::UTF_8.name
             // => "UTF-8"
+            // ```
             Self::Utf8 => "UTF-8",
+            // ```
             // [2.6.3] > Encoding::ASCII.name
             // => "US-ASCII"
+            // ```
             Self::Ascii => "US-ASCII",
+            // ```
             // [2.6.3] > Encoding::BINARY.name
             // => "ASCII-8BIT"
+            // ```
             Self::Binary => "ASCII-8BIT",
         }
     }

--- a/spinoso-string/src/lib.rs
+++ b/spinoso-string/src/lib.rs
@@ -4,7 +4,7 @@
 #![cfg_attr(test, allow(clippy::non_ascii_literal))]
 #![allow(unknown_lints)]
 // TODO: warn on missing docs once crate is API-complete.
-// #![warn(missing_doc)]
+// #![warn(missing_docs)]
 #![warn(missing_debug_implementations)]
 #![warn(missing_copy_implementations)]
 #![warn(rust_2018_idioms)]

--- a/spinoso-time/src/time/chrono/convert.rs
+++ b/spinoso-time/src/time/chrono/convert.rs
@@ -100,7 +100,7 @@ mod tests {
     use crate::time::chrono::{Offset, Time};
 
     fn date() -> NaiveDateTime {
-        // Artichoke's birthday, 2019-04-07T01:30Z + .2s
+        // Artichoke's birthday, 2019-04-07T01:30Z + 0.2 seconds
         let time = NaiveDateTime::from_timestamp(1_554_600_621, 0);
         time.with_nanosecond(200_000_000).unwrap()
     }

--- a/spinoso-time/src/time/chrono/mod.rs
+++ b/spinoso-time/src/time/chrono/mod.rs
@@ -364,8 +364,11 @@ mod tests {
         assert_eq!(time.year_day(), 96);
         // TODO: Implement DST and timezone detection. This requires a new release of
         // `chrono-tz`.
+        //
+        // ```
         // assert!(time.is_dst());
         // assert_eq!(time.timezone(), Some("PDT"));
+        // ```
     }
 
     #[test]


### PR DESCRIPTION
Now that the false positives reported in drahnr/cargo-spellcheck#257 are resolved, fix the remaining spellcheck errors.

cargo spellcheck fix exits successful with no errors as of this commit.