### PR TITLE
Rework clippy allow pragmas

### DIFF
--- a/artichoke-backend/src/convert/array.rs
+++ b/artichoke-backend/src/convert/array.rs
@@ -429,7 +429,6 @@ mod tests {
     }
 
     quickcheck! {
-        #[allow(clippy::needless_pass_by_value)]
         fn arr_int_borrowed(arr: Vec<i64>) -> bool {
             let mut interp = interpreter();
             // Borrowed converter
@@ -451,7 +450,6 @@ mod tests {
             true
         }
 
-        #[allow(clippy::needless_pass_by_value)]
         fn arr_int_owned(arr: Vec<i64>) -> bool {
             let mut interp = interpreter();
             // Owned converter
@@ -473,7 +471,6 @@ mod tests {
             true
         }
 
-        #[allow(clippy::needless_pass_by_value)]
         fn arr_utf8_borrowed(arr: Vec<String>) -> bool {
             let mut interp = interpreter();
             // Borrowed converter
@@ -495,7 +492,6 @@ mod tests {
             true
         }
 
-        #[allow(clippy::needless_pass_by_value)]
         fn arr_utf8_owned(arr: Vec<String>) -> bool {
             let mut interp = interpreter();
             // Owned converter
@@ -517,7 +513,6 @@ mod tests {
             true
         }
 
-        #[allow(clippy::needless_pass_by_value)]
         fn arr_nilable_bstr_borrowed(arr: Vec<Option<Vec<u8>>>) -> bool {
             let mut interp = interpreter();
             // Borrowed converter
@@ -539,7 +534,6 @@ mod tests {
             true
         }
 
-        #[allow(clippy::needless_pass_by_value)]
         fn arr_nilable_bstr_owned(arr: Vec<Option<Vec<u8>>>) -> bool {
             let mut interp = interpreter();
             // Owned converter

--- a/artichoke-backend/src/convert/bytes.rs
+++ b/artichoke-backend/src/convert/bytes.rs
@@ -154,7 +154,6 @@ mod tests {
             value.ruby_type() == Ruby::String
         }
 
-        #[allow(clippy::needless_pass_by_value)]
         fn byte_string_borrowed(bytes: Vec<u8>) -> bool {
             let mut interp = interpreter();
             // Borrowed converter
@@ -194,7 +193,6 @@ mod tests {
             true
         }
 
-        #[allow(clippy::needless_pass_by_value)]
         fn byte_string_owned(bytes: Vec<u8>) -> bool {
             let mut interp = interpreter();
             // Owned converter
@@ -234,7 +232,6 @@ mod tests {
             true
         }
 
-        #[allow(clippy::needless_pass_by_value)]
         fn roundtrip(bytes: Vec<u8>) -> bool {
             let mut interp = interpreter();
             let value = interp.try_convert_mut(bytes.as_slice()).unwrap();

--- a/artichoke-backend/src/convert/hash.rs
+++ b/artichoke-backend/src/convert/hash.rs
@@ -125,7 +125,6 @@ mod tests {
     use crate::test::prelude::*;
 
     quickcheck! {
-        #[allow(clippy::needless_pass_by_value)]
         fn roundtrip_kv(hash: HashMap<Vec<u8>, Vec<u8>>) -> bool {
             let mut interp = interpreter();
             let value = interp.try_convert_mut(hash.clone()).unwrap();

--- a/artichoke-backend/src/convert/string.rs
+++ b/artichoke-backend/src/convert/string.rs
@@ -75,7 +75,6 @@ mod tests {
     }
 
     quickcheck! {
-        #[allow(clippy::needless_pass_by_value)]
         fn convert_to_string(s: String) -> bool {
             let mut interp = interpreter();
             let value = interp.try_convert_mut(s.clone()).unwrap();
@@ -83,14 +82,12 @@ mod tests {
             s.as_bytes() == string
         }
 
-        #[allow(clippy::needless_pass_by_value)]
         fn string_with_value(s: String) -> bool {
             let mut interp = interpreter();
             let value = interp.try_convert_mut(s.clone()).unwrap();
             value.to_s(&mut interp) == s.as_bytes()
         }
 
-        #[allow(clippy::needless_pass_by_value)]
         #[cfg(feature = "core-regexp")]
         fn utf8string_borrowed(string: String) -> bool {
             let mut interp = interpreter();
@@ -123,7 +120,6 @@ mod tests {
             true
         }
 
-        #[allow(clippy::needless_pass_by_value)]
         #[cfg(feature = "core-regexp")]
         fn utf8string_owned(string: String) -> bool {
             let mut interp = interpreter();
@@ -156,7 +152,6 @@ mod tests {
             true
         }
 
-        #[allow(clippy::needless_pass_by_value)]
         fn roundtrip(s: String) -> bool {
             let mut interp = interpreter();
             let value = interp.try_convert_mut(s.clone()).unwrap();

--- a/artichoke-backend/src/extn/core/float/mod.rs
+++ b/artichoke-backend/src/extn/core/float/mod.rs
@@ -200,8 +200,8 @@ impl Float {
 
     #[inline]
     #[must_use]
-    #[allow(clippy::cast_possible_truncation)]
     #[allow(clippy::cast_precision_loss)]
+    #[allow(clippy::cast_possible_truncation)]
     pub fn try_into_fixnum(self) -> Option<i64> {
         const FIXABLE_MAX: f64 = 2_i64.pow(f64::MANTISSA_DIGITS) as f64;
         const FIXABLE_MIN: f64 = -(2_i64.pow(f64::MANTISSA_DIGITS)) as f64;

--- a/artichoke-backend/src/extn/core/integer/mod.rs
+++ b/artichoke-backend/src/extn/core/integer/mod.rs
@@ -89,9 +89,9 @@ impl Integer {
         self.0
     }
 
-    #[allow(clippy::cast_precision_loss)]
     #[inline]
     #[must_use]
+    #[allow(clippy::cast_precision_loss)]
     pub const fn as_f64(self) -> f64 {
         self.0 as f64
     }

--- a/artichoke-backend/src/extn/core/random/mod.rs
+++ b/artichoke-backend/src/extn/core/random/mod.rs
@@ -65,11 +65,9 @@ impl Seed {
     }
 
     #[must_use]
-    #[allow(clippy::cast_sign_loss)]
-    #[allow(clippy::cast_possible_wrap)]
     pub fn to_mt_seed(self) -> Option<[u32; 4]> {
         if let Self::New(seed) = self {
-            let seed = u128::from(seed as u64);
+            let seed = i128::from(seed);
             let seed = seed.to_le_bytes();
             let seed = spinoso_random::seed_to_key(seed);
             Some(seed)

--- a/artichoke-backend/src/extn/core/regexp/trampoline.rs
+++ b/artichoke-backend/src/extn/core/regexp/trampoline.rs
@@ -132,9 +132,9 @@ pub fn is_fixed_encoding(interp: &mut Artichoke, mut regexp: Value) -> Result<Va
 
 pub fn hash(interp: &mut Artichoke, mut regexp: Value) -> Result<Value, Error> {
     let regexp = unsafe { Regexp::unbox_from_value(&mut regexp, interp)? };
-    let hash = regexp.hash();
     #[allow(clippy::cast_possible_wrap)]
-    Ok(interp.convert(hash as i64))
+    let hash = regexp.hash() as i64;
+    Ok(interp.convert(hash))
 }
 
 pub fn inspect(interp: &mut Artichoke, mut regexp: Value) -> Result<Value, Error> {

--- a/artichoke-backend/src/extn/core/string/ffi.rs
+++ b/artichoke-backend/src/extn/core/string/ffi.rs
@@ -464,8 +464,6 @@ unsafe extern "C" fn mrb_string_cstr(mrb: *mut sys::mrb_state, s: sys::mrb_value
 //
 // This function converts a numeric string to numeric `mrb_value` with the given base.
 #[no_mangle]
-#[allow(clippy::cast_sign_loss)]
-#[allow(clippy::cast_possible_truncation)]
 unsafe extern "C" fn mrb_str_to_inum(
     mrb: *mut sys::mrb_state,
     s: sys::mrb_value,
@@ -510,11 +508,11 @@ unsafe extern "C" fn mrb_str_to_inum(
     let mut x = num;
 
     loop {
-        let m = x % base;
+        let m = u32::try_from(x % base).expect("base must be <= 36, which guarantees the result is in range for u32");
         x /= base;
 
         // will panic if you use a bad radix (< 2 or > 36).
-        result.push(char::from_digit(m as u32, radix).unwrap());
+        result.push(char::from_digit(m, radix).unwrap());
         if x == 0 {
             break;
         }

--- a/artichoke-backend/src/extn/core/string/trampoline.rs
+++ b/artichoke-backend/src/extn/core/string/trampoline.rs
@@ -1194,9 +1194,9 @@ pub fn setbyte(interp: &mut Artichoke, mut value: Value, index: Value, byte: Val
     // [3.0.2] > s
     // => "\xFFbc"
     // ```
-    #[allow(clippy::cast_possible_truncation)]
-    #[allow(clippy::cast_sign_loss)]
-    let u8_byte = (i64_byte % 256) as u8;
+    let u8_byte = (i64_byte % 256)
+        .try_into()
+        .expect("taking mod 256 guarantees the resulting i64 is in range for u8");
     // Safety:
     //
     // No need to repack, this is an in-place mutation.

--- a/artichoke-backend/src/types.rs
+++ b/artichoke-backend/src/types.rs
@@ -6,10 +6,14 @@ use crate::sys;
 /// This function collapses some mruby types into a [`Ruby::Unreachable`] type
 /// that force an interaction with the VM to return an error.
 #[allow(non_upper_case_globals)]
-#[allow(clippy::enum_glob_use)]
 #[must_use]
 pub fn ruby_from_mrb_value(value: sys::mrb_value) -> Ruby {
-    use sys::mrb_vtype::*;
+    use sys::mrb_vtype::{
+        MRB_TT_ARRAY, MRB_TT_BREAK, MRB_TT_CLASS, MRB_TT_CPTR, MRB_TT_DATA, MRB_TT_ENV, MRB_TT_EXCEPTION,
+        MRB_TT_FALSE, MRB_TT_FIBER, MRB_TT_FLOAT, MRB_TT_FREE, MRB_TT_HASH, MRB_TT_ICLASS, MRB_TT_INTEGER,
+        MRB_TT_ISTRUCT, MRB_TT_MAXDEFINE, MRB_TT_MODULE, MRB_TT_OBJECT, MRB_TT_PROC, MRB_TT_RANGE, MRB_TT_SCLASS,
+        MRB_TT_STRING, MRB_TT_SYMBOL, MRB_TT_TRUE, MRB_TT_UNDEF,
+    };
 
     // Suppress lint to enumerate match arms in the same order they are defined
     // in the `sys::mrb_vtype` enum C source.

--- a/spinoso-regexp/src/error.rs
+++ b/spinoso-regexp/src/error.rs
@@ -250,9 +250,8 @@ impl RegexpError {
     /// ```
     #[inline]
     #[must_use]
-    #[allow(clippy::unused_self)]
     pub fn message(&self) -> &str {
-        self.0.as_ref()
+        &*self.0
     }
 }
 
@@ -346,8 +345,7 @@ impl SyntaxError {
     /// ```
     #[inline]
     #[must_use]
-    #[allow(clippy::unused_self)]
     pub fn message(&self) -> &str {
-        self.0.as_ref()
+        &*self.0
     }
 }

--- a/spinoso-regexp/src/options.rs
+++ b/spinoso-regexp/src/options.rs
@@ -319,17 +319,23 @@ mod tests {
     // `Regexp::EXTENDED`, `Regexp::IGNORECASE`, and `Regexp::MULTILINE`, or-ed
     // together. Otherwise, if options is not `nil` or `false`, the regexp will
     // be case insensitive.
+
     #[test]
-    #[allow(clippy::too_many_lines)]
-    fn parse_options() {
+    fn parse_options_from_option_bool() {
         assert_eq!(Options::from(None), Options::new());
         assert_eq!(Options::from(Some(false)), Options::new());
         assert_eq!(Options::from(Some(true)), Options::with_ignore_case());
+    }
 
+    #[test]
+    fn new_is_ignore_case() {
         let mut opts = Options::new();
         opts.flags |= Flags::IGNORECASE;
         assert_eq!(Options::with_ignore_case(), opts);
+    }
 
+    #[test]
+    fn make_options_extended() {
         let mut opts = Options::new();
         opts.flags |= Flags::EXTENDED;
         assert_eq!(Options::from(Flags::EXTENDED), opts);
@@ -348,7 +354,10 @@ mod tests {
         assert_eq!(opts.ignore_case(), RegexpOption::Disabled);
         assert_eq!(opts.extended(), RegexpOption::Enabled);
         assert_eq!(opts.multiline(), RegexpOption::Disabled);
+    }
 
+    #[test]
+    fn make_options_ignore_case() {
         let mut opts = Options::new();
         opts.flags |= Flags::IGNORECASE;
         assert_eq!(Options::from(Flags::IGNORECASE), opts);
@@ -367,7 +376,10 @@ mod tests {
         assert_eq!(opts.ignore_case(), RegexpOption::Enabled);
         assert_eq!(opts.extended(), RegexpOption::Disabled);
         assert_eq!(opts.multiline(), RegexpOption::Disabled);
+    }
 
+    #[test]
+    fn make_options_multiline() {
         let mut opts = Options::new();
         opts.flags |= Flags::MULTILINE;
         assert_eq!(Options::from(Flags::MULTILINE), opts);
@@ -386,7 +398,10 @@ mod tests {
         assert_eq!(opts.ignore_case(), RegexpOption::Disabled);
         assert_eq!(opts.extended(), RegexpOption::Disabled);
         assert_eq!(opts.multiline(), RegexpOption::Enabled);
+    }
 
+    #[test]
+    fn make_options_extended_ignore_case() {
         let mut opts = Options::new();
         opts.flags |= Flags::EXTENDED | Flags::IGNORECASE;
         assert_ne!(Options::from(Flags::EXTENDED), opts);
@@ -421,7 +436,10 @@ mod tests {
         assert_eq!(opts.ignore_case(), RegexpOption::Enabled);
         assert_eq!(opts.extended(), RegexpOption::Enabled);
         assert_eq!(opts.multiline(), RegexpOption::Disabled);
+    }
 
+    #[test]
+    fn make_options_extended_ignore_case_multiline() {
         let mut opts = Options::new();
         opts.flags |= Flags::EXTENDED | Flags::IGNORECASE | Flags::MULTILINE;
         assert_ne!(Options::from(Flags::EXTENDED), opts);
@@ -463,7 +481,10 @@ mod tests {
         assert_eq!(opts.ignore_case(), RegexpOption::Enabled);
         assert_eq!(opts.extended(), RegexpOption::Enabled);
         assert_eq!(opts.multiline(), RegexpOption::Enabled);
+    }
 
+    #[test]
+    fn make_options_all_opts() {
         // `ALL_REGEXP_OPTS` is equivalent to `EXTENDED | IGNORECASE | MULTILINE` flags.
         let mut opts = Options::new();
         opts.flags |= Flags::ALL_REGEXP_OPTS;
@@ -506,7 +527,10 @@ mod tests {
         assert_eq!(opts.ignore_case(), RegexpOption::Enabled);
         assert_eq!(opts.extended(), RegexpOption::Enabled);
         assert_eq!(opts.multiline(), RegexpOption::Enabled);
+    }
 
+    #[test]
+    fn make_options_flags_all() {
         // Ignore encoding and literal flags.
         let opts = Options::from(Flags::all());
         assert_ne!(Options::from(Flags::EXTENDED), opts);

--- a/spinoso-string/src/enc/ascii/mod.rs
+++ b/spinoso-string/src/enc/ascii/mod.rs
@@ -323,28 +323,24 @@ mod tests {
     use super::AsciiString;
 
     quickcheck! {
-        #[allow(clippy::needless_pass_by_value)]
         fn fuzz_char_len_utf8_contents_ascii_string(contents: String) -> bool {
             let expected = contents.len();
             let s = AsciiString::new(contents.into_bytes());
             s.char_len() == expected
         }
 
-        #[allow(clippy::needless_pass_by_value)]
         fn fuzz_len_utf8_contents_ascii_string(contents: String) -> bool {
             let expected = contents.len();
             let s = AsciiString::new(contents.into_bytes());
             s.len() == expected
         }
 
-        #[allow(clippy::needless_pass_by_value)]
         fn fuzz_char_len_binary_contents_ascii_string(contents: Vec<u8>) -> bool {
             let expected = contents.len();
             let s = AsciiString::new(contents);
             s.char_len() == expected
         }
 
-        #[allow(clippy::needless_pass_by_value)]
         fn fuzz_len_binary_contents_ascii_string(contents: Vec<u8>) -> bool {
             let expected = contents.len();
             let s = AsciiString::new(contents);

--- a/spinoso-string/src/enc/binary/mod.rs
+++ b/spinoso-string/src/enc/binary/mod.rs
@@ -264,9 +264,9 @@ impl BinaryString {
         self.inner.is_ascii()
     }
 
-    #[allow(clippy::unused_self)]
     #[inline]
     #[must_use]
+    #[allow(clippy::unused_self)]
     pub fn is_valid_encoding(&self) -> bool {
         true
     }
@@ -323,28 +323,24 @@ mod tests {
     use super::BinaryString;
 
     quickcheck! {
-        #[allow(clippy::needless_pass_by_value)]
         fn fuzz_char_len_utf8_contents_binary_string(contents: String) -> bool {
             let expected = contents.len();
             let s = BinaryString::new(contents.into_bytes());
             s.char_len() == expected
         }
 
-        #[allow(clippy::needless_pass_by_value)]
         fn fuzz_len_utf8_contents_binary_string(contents: String) -> bool {
             let expected = contents.len();
             let s = BinaryString::new(contents.into_bytes());
             s.len() == expected
         }
 
-        #[allow(clippy::needless_pass_by_value)]
         fn fuzz_char_len_binary_contents_binary_string(contents: Vec<u8>) -> bool {
             let expected = contents.len();
             let s = BinaryString::new(contents);
             s.char_len() == expected
         }
 
-        #[allow(clippy::needless_pass_by_value)]
         fn fuzz_len_binary_contents_binary_string(contents: Vec<u8>) -> bool {
             let expected = contents.len();
             let s = BinaryString::new(contents);

--- a/spinoso-string/src/enc/utf8/mod.rs
+++ b/spinoso-string/src/enc/utf8/mod.rs
@@ -661,8 +661,8 @@ impl Utf8String {
     }
 }
 
-#[allow(clippy::invisible_characters)]
 #[cfg(test)]
+#[allow(clippy::invisible_characters)]
 mod tests {
     use alloc::string::String;
     use alloc::vec::Vec;
@@ -676,21 +676,18 @@ mod tests {
     const REPLACEMENT_CHARACTER_BYTES: [u8; 3] = [239, 191, 189];
 
     quickcheck! {
-        #[allow(clippy::needless_pass_by_value)]
         fn fuzz_char_len_utf8_contents_utf8_string(contents: String) -> bool {
             let expected = contents.chars().count();
             let s = Utf8String::new(contents.into_bytes());
             s.char_len() == expected
         }
 
-        #[allow(clippy::needless_pass_by_value)]
         fn fuzz_len_utf8_contents_utf8_string(contents: String) -> bool {
             let expected = contents.len();
             let s = Utf8String::new(contents.into_bytes());
             s.len() == expected
         }
 
-        #[allow(clippy::needless_pass_by_value)]
         fn fuzz_char_len_binary_contents_utf8_string(contents: Vec<u8>) -> bool {
             if let Ok(utf8_contents) = str::from_utf8(&contents) {
                 let expected = utf8_contents.chars().count();
@@ -703,7 +700,6 @@ mod tests {
             }
         }
 
-        #[allow(clippy::needless_pass_by_value)]
         fn fuzz_len_binary_contents_utf8_string(contents: Vec<u8>) -> bool {
             let expected = contents.len();
             let s = Utf8String::new(contents);

--- a/spinoso-string/src/lib.rs
+++ b/spinoso-string/src/lib.rs
@@ -1405,12 +1405,14 @@ impl String {
     /// ```
     #[inline]
     #[must_use]
-    #[allow(clippy::needless_pass_by_value)]
     pub fn chomp<T: AsRef<[u8]>>(&mut self, separator: Option<T>) -> bool {
         // convert to a concrete type and delegate to a single `chomp` impl
         // to minimize code duplication when monomorphizing.
-        let separator = separator.as_ref().map(AsRef::as_ref);
-        chomp(self, separator)
+        if let Some(sep) = separator {
+            chomp(self, Some(sep.as_ref()))
+        } else {
+            chomp(self, None)
+        }
     }
 
     /// Modifies this `String` in-place and removes the last character.
@@ -2066,7 +2068,6 @@ fn chomp(string: &mut String, separator: Option<&[u8]>) -> bool {
 }
 
 #[cfg(test)]
-#[allow(clippy::invisible_characters)]
 mod tests {
     use crate::center::CenterError;
     use crate::String;

--- a/spinoso-time/src/time/chrono/mod.rs
+++ b/spinoso-time/src/time/chrono/mod.rs
@@ -131,6 +131,9 @@ impl Time {
         // precision. The 52-bit mantissa in an `f64` allows storing over 142
         // million years of timestamps.
         let sec = self.timestamp as f64;
+        // Both of these lossy casts are guaranteed to not lose precision since
+        // both operands are <= 1e10, which is representable losslessly by
+        // `f64`.
         let nanos_fractional = self.sub_second_nanos as f64 / (NANOS_IN_SECOND as f64);
         sec + nanos_fractional
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -122,9 +122,11 @@ impl<'a> Parser<'a> {
     ///
     /// If the underlying parser returns a UTF-8 invalid error message, an error
     /// is returned.
-    #[allow(clippy::enum_glob_use)]
     pub fn parse(&mut self, code: &[u8]) -> Result<State, Error> {
-        use sys::mrb_lex_state_enum::*;
+        use sys::mrb_lex_state_enum::{
+            EXPR_ARG, EXPR_BEG, EXPR_CLASS, EXPR_CMDARG, EXPR_DOT, EXPR_END, EXPR_ENDARG, EXPR_ENDFN, EXPR_FNAME,
+            EXPR_MAX_STATE, EXPR_MID, EXPR_VALUE,
+        };
 
         let len = if let Ok(len) = isize::try_from(code.len()) {
             len


### PR DESCRIPTION
Remove `allow(clippy::...)` attributes that no longer suppress warnings. Rework some code to avoid the warnings in the first place.

These PRs were split out of this one and landed before:

- https://github.com/artichoke/artichoke/pull/1771
- https://github.com/artichoke/artichoke/pull/1772