### PR TITLE
Prefer `if let ...` over `matches!`

### DIFF
--- a/artichoke-backend/src/extn/core/array/trampoline.rs
+++ b/artichoke-backend/src/extn/core/array/trampoline.rs
@@ -188,7 +188,7 @@ pub fn first(interp: &mut Artichoke, mut ary: Value, num: Option<Value>) -> Resu
     let array = unsafe { Array::unbox_from_value(&mut ary, interp)? };
     if let Some(num) = num {
         // Hack to detect `BigNum`
-        if matches!(num.ruby_type(), Ruby::Float) {
+        if let Ruby::Float = num.ruby_type() {
             return Err(RangeError::with_message("bignum too big to convert into `long'").into());
         }
         let n = implicitly_convert_to_int(interp, num)?;
@@ -242,7 +242,7 @@ pub fn last(interp: &mut Artichoke, mut ary: Value, num: Option<Value>) -> Resul
     let array = unsafe { Array::unbox_from_value(&mut ary, interp)? };
     if let Some(num) = num {
         // Hack to detect `BigNum`
-        if matches!(num.ruby_type(), Ruby::Float) {
+        if let Ruby::Float = num.ruby_type() {
             return Err(RangeError::with_message("bignum too big to convert into `long'").into());
         }
         let n = implicitly_convert_to_int(interp, num)?;

--- a/artichoke-backend/src/extn/core/regexp/mod.rs
+++ b/artichoke-backend/src/extn/core/regexp/mod.rs
@@ -193,7 +193,7 @@ impl Regexp {
 
     pub fn case_compare(&self, interp: &mut Artichoke, mut other: Value) -> Result<bool, Error> {
         let pattern_vec;
-        let pattern = if matches!(other.ruby_type(), Ruby::Symbol) {
+        let pattern = if let Ruby::Symbol = other.ruby_type() {
             let symbol = unsafe { Symbol::unbox_from_value(&mut other, interp)? };
             pattern_vec = symbol.bytes(interp).to_vec();
             pattern_vec.as_slice()

--- a/artichoke-backend/src/extn/core/regexp/trampoline.rs
+++ b/artichoke-backend/src/extn/core/regexp/trampoline.rs
@@ -25,7 +25,7 @@ pub fn initialize(
 
 pub fn escape(interp: &mut Artichoke, mut pattern: Value) -> Result<Value, Error> {
     let pattern_vec;
-    if matches!(pattern.ruby_type(), Ruby::Symbol) {
+    if let Ruby::Symbol = pattern.ruby_type() {
         let symbol = unsafe { Symbol::unbox_from_value(&mut pattern, interp)? };
         pattern_vec = symbol.bytes(interp).to_vec();
     } else {
@@ -73,7 +73,7 @@ pub fn match_(
 ) -> Result<Value, Error> {
     let regexp = unsafe { Regexp::unbox_from_value(&mut regexp, interp)? };
     let pattern_vec;
-    let pattern = if matches!(pattern.ruby_type(), Ruby::Symbol) {
+    let pattern = if let Ruby::Symbol = pattern.ruby_type() {
         let symbol = unsafe { Symbol::unbox_from_value(&mut pattern, interp)? };
         pattern_vec = symbol.bytes(interp).to_vec();
         Some(pattern_vec.as_slice())
@@ -103,7 +103,7 @@ pub fn case_compare(interp: &mut Artichoke, mut regexp: Value, other: Value) -> 
 pub fn match_operator(interp: &mut Artichoke, mut regexp: Value, mut pattern: Value) -> Result<Value, Error> {
     let regexp = unsafe { Regexp::unbox_from_value(&mut regexp, interp)? };
     let pattern_vec;
-    let pattern = if matches!(pattern.ruby_type(), Ruby::Symbol) {
+    let pattern = if let Ruby::Symbol = pattern.ruby_type() {
         let symbol = unsafe { Symbol::unbox_from_value(&mut pattern, interp)? };
         pattern_vec = symbol.bytes(interp).to_vec();
         Some(pattern_vec.as_slice())


### PR DESCRIPTION
`matches!` is most useful in match arms or when attempting to pattern
match and use an if guard. A simple check that a value is a single enum
variant is more readily expressible with `if let ...` and expands to
simpler code.