### PR TITLE
Update crate READMEs

### DIFF
--- a/artichoke-backend/README.md
+++ b/artichoke-backend/README.md
@@ -7,7 +7,18 @@
 [![Backend documentation](https://img.shields.io/badge/docs-artichoke--backend-blue.svg)](https://artichoke.github.io/artichoke/artichoke_backend/)
 
 `artichoke-backend` crate provides a Ruby interpreter. It currently is
-implemented with [mruby] bindings exported by the [`sys`](src/sys) module.
+implemented with [mruby] ABI-compatible bindings, some of which are implemented
+in the vendored mruby C and exported by the [`sys`](src/sys) module, others of
+which are implemented in Rust as `#[no_mangle] unsafe extern "C" fn`.
+
+`artichoke-backend` is slowly [strangling] its embedded mruby interpreter by
+reimplementing (oxidizing) the APIs in Rust with Artichoke-sourced components.
+For example, `Array` is fully implemented in Rust with [`spinoso-array`] and
+[`MRB_API` compatible functions defined in Rust][array-ffi].
+
+[strangling]: https://martinfowler.com/bliki/StranglerFigApplication.html
+[`spinoso-array`]: https://artichoke.github.io/artichoke/spinoso_array/
+[array-ffi]: src/extn/core/array/ffi.rs
 
 ## Execute Ruby Code
 

--- a/scolapasta-string-escape/README.md
+++ b/scolapasta-string-escape/README.md
@@ -40,7 +40,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-scolapasta-string-escape = "0.2"
+scolapasta-string-escape = "0.2.0"
 ```
 
 To debug escape a conventionally UTF-8 byte string:

--- a/spinoso-array/README.md
+++ b/spinoso-array/README.md
@@ -57,6 +57,8 @@ spinoso-array has two backends:
   This Spinoso array type is enabled by default.
 - `SmallArray` is based on [`SmallVec`] and implements the small vector
   optimization – small arrays are stored inline without a heap allocation.
+- `TinyArray` is based on [`TinyVec`] and implements the small vector
+  optimization – small arrays are stored inline without a heap allocation.
 
 ## `no_std`
 
@@ -69,6 +71,9 @@ All features are enabled by default.
 - **small-array** - Enables an additional `SmallArray` array backend based on
   `SmallVec` that implements the small vector optimization. Disabling this
   feature drops the `smallvec` dependency.
+- **tiny-array** - Enables an additional `TinyArray` array backend based on
+  `TinyVec` that implements the small vector optimization. Disabling this
+  feature drops the `tinyvec` dependency.
 
 ## License
 
@@ -78,4 +83,5 @@ All features are enabled by default.
 [artichoke]: https://github.com/artichoke/artichoke
 [`vec`]: https://doc.rust-lang.org/alloc/vec/struct.Vec.html
 [`smallvec`]: https://docs.rs/smallvec/latest/smallvec/struct.SmallVec.html
+[`tinyvec`]: https://docs.rs/tinyvec/latest/tinyvec/enum.TinyVec.html
 [`alloc`]: https://doc.rust-lang.org/alloc/

--- a/spinoso-exception/README.md
+++ b/spinoso-exception/README.md
@@ -26,7 +26,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-spinoso-exception = "0.1"
+spinoso-exception = "0.1.0"
 ```
 
 Create exceptions and return Ruby errors:

--- a/spinoso-random/README.md
+++ b/spinoso-random/README.md
@@ -31,7 +31,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-spinoso-random = "0.1"
+spinoso-random = "0.2.0"
 ```
 
 Generate integers:
@@ -78,12 +78,6 @@ All features are enabled by default.
 
 `spinoso-random` is licensed with the [MIT License](LICENSE) (c) Ryan Lopopolo.
 
-`spinoso-random` is a substantially rewritten fork of [`rand_mt`] @
-[`aeb3274a`][rand-mt-forked-at], which is copyright rust-mersenne-twister
-developers and Ryan Lopopolo \<rjl@hyperbo.la\>. `rand_mt` is licensed with
-either the [MIT License][rand-mt-mit] or [Apache 2.0 License][rand-mt-apache].
-`spinoso-random` opts for the MIT license for its fork.
-
 `spinoso-random` is partially derived from [`random.c`] in Ruby @
 [2.6.3][ruby-2.6.3] which is copyright Yukihiro Matsumoto \<matz@netlab.jp\>.
 Ruby is licensed with the [2-clause BSDL License][ruby-license].
@@ -94,13 +88,6 @@ Ruby is licensed with the [2-clause BSDL License][ruby-license].
 [`rand`]: https://crates.io/crates/rand
 [`rand_core`]: https://crates.io/crates/rand_core
 [`std::error::error`]: https://doc.rust-lang.org/std/error/trait.Error.html
-[`rand_mt`]: https://crates.io/crates/rand_mt/3.0.0
-[rand-mt-forked-at]:
-  https://github.com/artichoke/rand_mt/tree/aeb3274a3aa3caa68ba379c141d2c55b1b21828e
-[rand-mt-mit]:
-  https://github.com/artichoke/rand_mt/blob/aeb3274a3aa3caa68ba379c141d2c55b1b21828e/LICENSE-MIT
-[rand-mt-apache]:
-  https://github.com/artichoke/rand_mt/blob/aeb3274a3aa3caa68ba379c141d2c55b1b21828e/LICENSE-APACHE
 [`random.c`]: https://github.com/ruby/ruby/blob/v2_6_3/random.c
 [ruby-2.6.3]: https://github.com/ruby/ruby/tree/v2_6_3
 [ruby-license]: https://github.com/ruby/ruby/blob/v2_6_3/COPYING

--- a/spinoso-regexp/README.md
+++ b/spinoso-regexp/README.md
@@ -16,7 +16,7 @@ constructor.
 
 `spinoso-regexp` includes several `Regexp` implementations with support for
 multiple underlying regex engines, including the Rust [`regex` crate] and
-[Onigurma].
+[Oniguruma].
 
 [`regex` crate]: https://docs.rs/regex
 [oniguruma]: https://github.com/kkos/oniguruma
@@ -31,7 +31,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-spinoso-regexp = "0.2"
+spinoso-regexp = "0.2.0"
 ```
 
 ## Crate features

--- a/spinoso-symbol/README.md
+++ b/spinoso-symbol/README.md
@@ -24,31 +24,13 @@ _Spinoso_ refers to _Carciofo spinoso di Sardegna_, the thorny artichoke of
 Sardinia. The data structures defined in the `spinoso` family of crates form the
 backbone of Ruby Core in Artichoke.
 
-# Artichoke integration
-
-This crate has an `artichoke` Cargo feature. When this feature is active, this
-crate implements [the `Symbol` API from Ruby Core]. These APIs require resolving
-the underlying bytes associated with the `Symbol` via a type that implements
-`Intern` from `artichoke-core`.
-
-APIs that require this feature to be active are highlighted in the
-documentation.
-
-This crate provides an `AllSymbols` iterator for walking all symbols stored in
-an [`Intern`]er and an extension trait for constructing it which is suitable for
-implementing [`Symbol::all_symbols`] from Ruby Core.
-
-This crate provides an `Inspect` iterator for converting `Symbol` byte content
-to a debug representation suitable for implementing [`Symbol#inspect`] from Ruby
-Core.
-
 ## Usage
 
 Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-spinoso-symbol = "0.1"
+spinoso-symbol = "0.1.0"
 ```
 
 Most of the functionality in this crate depends on a Ruby interpreter that
@@ -98,6 +80,24 @@ All features are enabled by default.
   `scolapasta-string-escape` dependencies.
 - **std** - Enables a dependency on the Rust Standard Library. Activating this
   feature enables [`std::error::Error`] impls on error types in this crate.
+
+### Artichoke integration
+
+This crate has an `artichoke` Cargo feature. When this feature is active, this
+crate implements [the `Symbol` API from Ruby Core]. These APIs require resolving
+the underlying bytes associated with the `Symbol` via a type that implements
+`Intern` from `artichoke-core`.
+
+APIs that require this feature to be active are highlighted in the
+documentation.
+
+This crate provides an `AllSymbols` iterator for walking all symbols stored in
+an [`Intern`]er and an extension trait for constructing it which is suitable for
+implementing [`Symbol::all_symbols`] from Ruby Core.
+
+This crate provides an `Inspect` iterator for converting `Symbol` byte content
+to a debug representation suitable for implementing [`Symbol#inspect`] from Ruby
+Core.
 
 ## License
 

--- a/spinoso-time/README.md
+++ b/spinoso-time/README.md
@@ -23,7 +23,8 @@ class, it is globally available:
 Time.now
 ```
 
-This implementation of `Time` supports the system clock via the [`chrono`] crate.
+This implementation of `Time` supports the system clock via the [`chrono`]
+crate.
 
 _Spinoso_ refers to _Carciofo spinoso di Sardegna_, the thorny artichoke of
 Sardinia. The data structures defined in the `spinoso` family of crates form the

--- a/spinoso-time/README.md
+++ b/spinoso-time/README.md
@@ -23,8 +23,7 @@ class, it is globally available:
 Time.now
 ```
 
-This implementation of `Time` supports the system clock via the [`chrono`] and
-crates.
+This implementation of `Time` supports the system clock via the [`chrono`] crate.
 
 _Spinoso_ refers to _Carciofo spinoso di Sardegna_, the thorny artichoke of
 Sardinia. The data structures defined in the `spinoso` family of crates form the
@@ -36,7 +35,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-spinoso-time = "0.2"
+spinoso-time = "0.2.0"
 ```
 
 ## Examples


### PR DESCRIPTION
This PR goes over all the directories that currently have READMEs for https://github.com/artichoke/artichoke/issues/1733.

Fix typos, TOML snippets, drift, and broken links.

The `artichoke-backend` README grew a section on the strangler fig pattern and oxidizing mruby.