### PR TITLE
Replace `actions-rs/toolchain` and `actions-rs/clippy` with shell

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -36,16 +36,27 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
+        run: |
+          echo "::group::rustup toolchain install"
+          rustup toolchain install stable --profile minimal
+          echo "::endgroup::"
+          echo "::group::set default toolchain"
+          rustup default stable
+          echo "::endgroup::"
+          echo "::group::rustup version"
+          rustup -Vv
+          echo "::endgroup::"
+          echo "::group::rustc version"
+          rustc -Vv
+          echo "::endgroup::"
+          echo "::group::cargo version"
+          cargo version --verbose
+          echo "::endgroup::"
 
       - name: Generate Cargo.lock
         run: |
           if [[ ! -f "Cargo.lock" ]]; then
-            cargo generate-lockfile --verbose
+            cargo +stable generate-lockfile --verbose
           fi
 
       - name: Setup cargo-deny

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Rust toolchain
         run: |
           echo "::group::rustup toolchain install"
-          rustup toolchain install --profile minimal 1.58.1
+          rustup toolchain install 1.58.1 --profile minimal
           echo "::endgroup::"
           echo "::group::rustup version"
           rustup -Vv
@@ -65,7 +65,7 @@ jobs:
       - name: Install Rust toolchain
         run: |
           echo "::group::rustup toolchain install"
-          rustup toolchain install --profile minimal --component clippy 1.58.1
+          rustup toolchain install 1.58.1 --profile minimal --component clippy
           echo "::endgroup::"
           echo "::group::rustup version"
           rustup -Vv
@@ -83,7 +83,7 @@ jobs:
       - name: Install nightly Rust toolchain
         run: |
           echo "::group::rustup toolchain install"
-          rustup toolchain install --profile minimal --component rustfmt nightly
+          rustup toolchain install nightly --profile minimal --component rustfmt
           echo "::endgroup::"
           echo "::group::rustup version"
           rustup -Vv
@@ -131,7 +131,7 @@ jobs:
       - name: Install Rust toolchain
         run: |
           echo "::group::rustup toolchain install"
-          rustup toolchain install --profile minimal 1.58.1
+          rustup toolchain install 1.58.1 --profile minimal
           echo "::endgroup::"
           echo "::group::rustup version"
           rustup -Vv
@@ -164,7 +164,7 @@ jobs:
       - name: Install Rust toolchain
         run: |
           echo "::group::rustup toolchain install"
-          rustup toolchain install --profile minimal --component clippy 1.58.1
+          rustup toolchain install 1.58.1 --profile minimal --component clippy
           echo "::endgroup::"
           echo "::group::rustup version"
           rustup -Vv
@@ -182,7 +182,7 @@ jobs:
       - name: Install nightly Rust toolchain
         run: |
           echo "::group::rustup toolchain install"
-          rustup toolchain install --profile minimal --component rustfmt nightly
+          rustup toolchain install nightly --profile minimal --component rustfmt
           echo "::endgroup::"
           echo "::group::rustup version"
           rustup -Vv
@@ -230,7 +230,7 @@ jobs:
       - name: Install Rust toolchain
         run: |
           echo "::group::rustup toolchain install"
-          rustup toolchain install --profile minimal --component clippy 1.58.1
+          rustup toolchain install 1.58.1 --profile minimal --component clippy
           echo "::endgroup::"
           echo "::group::rustup version"
           rustup -Vv
@@ -248,7 +248,7 @@ jobs:
       - name: Install nightly Rust toolchain
         run: |
           echo "::group::rustup toolchain install"
-          rustup toolchain install --profile minimal --component rustfmt nightly
+          rustup toolchain install nightly --profile minimal --component rustfmt
           echo "::endgroup::"
           echo "::group::rustup version"
           rustup -Vv
@@ -307,7 +307,7 @@ jobs:
       - name: Install Rust toolchain
         run: |
           echo "::group::rustup toolchain install"
-          rustup toolchain install --profile minimal 1.58.1
+          rustup toolchain install 1.58.1 --profile minimal
           echo "::endgroup::"
           echo "::group::rustup version"
           rustup -Vv
@@ -466,7 +466,7 @@ jobs:
       - name: Install Rust toolchain
         run: |
           echo "::group::rustup toolchain install"
-          rustup toolchain install --profile minimal 1.58.1
+          rustup toolchain install 1.58.1 --profile minimal
           echo "::endgroup::"
           echo "::group::rustup version"
           rustup -Vv
@@ -481,7 +481,7 @@ jobs:
       - name: Install nightly Rust toolchain
         run: |
           echo "::group::rustup toolchain install"
-          rustup toolchain install --profile minimal nightly
+          rustup toolchain install nightly --profile minimal
           echo "::endgroup::"
           echo "::group::rustup version"
           rustup -Vv

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,9 +25,19 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
+        run: |
+          echo "::group::rustup toolchain install"
+          rustup toolchain install --profile minimal
+          echo "::endgroup::"
+          echo "::group::rustup version"
+          rustup -Vv
+          echo "::endgroup::"
+          echo "::group::rustc version"
+          rustc -Vv
+          echo "::endgroup::"
+          echo "::group::cargo version"
+          cargo version --verbose
+          echo "::endgroup::"
 
       - uses: Swatinem/rust-cache@v1
         with:
@@ -53,28 +63,48 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          components: clippy
+        run: |
+          echo "::group::rustup toolchain install"
+          rustup toolchain install --profile minimal --component clippy
+          echo "::endgroup::"
+          echo "::group::rustup version"
+          rustup -Vv
+          echo "::endgroup::"
+          echo "::group::rustc version"
+          rustc -Vv
+          echo "::endgroup::"
+          echo "::group::cargo version"
+          cargo version --verbose
+          echo "::endgroup::"
+          echo "::group::clippy version"
+          cargo clippy --version
+          echo "::endgroup::"
 
       - name: Install nightly Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          profile: minimal
-          components: rustfmt
+        run: |
+          echo "::group::rustup toolchain install"
+          rustup toolchain install --profile minimal --component rustfmt nightly
+          echo "::endgroup::"
+          echo "::group::rustup version"
+          rustup -Vv
+          echo "::endgroup::"
+          echo "::group::rustc version"
+          rustc +nightly -Vv
+          echo "::endgroup::"
+          echo "::group::cargo version"
+          cargo +nightly version --verbose
+          echo "::endgroup::"
+          echo "::group::rustfmt version"
+          rustfmt +nightly -Vv
+          echo "::endgroup::"
 
       - uses: Swatinem/rust-cache@v1
 
       - name: Check artichoke formatting
-        run: cargo +nightly fmt -- --check --color=auto
+        run: cargo +nightly fmt --check
 
       - name: Lint artichoke with Clippy
-        uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --workspace --all-features --all-targets
+        run: cargo clippy --workspace --all-features --all-targets
 
       - name: Check artichoke with locked Cargo.lock
         run: cargo check --locked --all-targets --profile=test
@@ -99,9 +129,19 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
+        run: |
+          echo "::group::rustup toolchain install"
+          rustup toolchain install --profile minimal
+          echo "::endgroup::"
+          echo "::group::rustup version"
+          rustup -Vv
+          echo "::endgroup::"
+          echo "::group::rustc version"
+          rustc -Vv
+          echo "::endgroup::"
+          echo "::group::cargo version"
+          cargo version --verbose
+          echo "::endgroup::"
 
       - uses: Swatinem/rust-cache@v1
         with:
@@ -122,24 +162,47 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          components: clippy
+        run: |
+          echo "::group::rustup toolchain install"
+          rustup toolchain install --profile minimal --component clippy
+          echo "::endgroup::"
+          echo "::group::rustup version"
+          rustup -Vv
+          echo "::endgroup::"
+          echo "::group::rustc version"
+          rustc -Vv
+          echo "::endgroup::"
+          echo "::group::cargo version"
+          cargo version --verbose
+          echo "::endgroup::"
+          echo "::group::clippy version"
+          cargo clippy --version
+          echo "::endgroup::"
 
       - name: Install nightly Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          profile: minimal
-          components: rustfmt
+        run: |
+          echo "::group::rustup toolchain install"
+          rustup toolchain install --profile minimal --component rustfmt nightly
+          echo "::endgroup::"
+          echo "::group::rustup version"
+          rustup -Vv
+          echo "::endgroup::"
+          echo "::group::rustc version"
+          rustc +nightly -Vv
+          echo "::endgroup::"
+          echo "::group::cargo version"
+          cargo +nightly version --verbose
+          echo "::endgroup::"
+          echo "::group::rustfmt version"
+          rustfmt +nightly -Vv
+          echo "::endgroup::"
 
       - uses: Swatinem/rust-cache@v1
         with:
           working-directory: "spec-runner"
 
       - name: Check spec-runner formatting
-        run: cargo +nightly fmt -- --check --color=auto
+        run: cargo +nightly fmt --check
         working-directory: "spec-runner"
 
       - name: Check spec-runner with locked Cargo.lock
@@ -165,17 +228,40 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          components: clippy
+        run: |
+          echo "::group::rustup toolchain install"
+          rustup toolchain install --profile minimal --component clippy
+          echo "::endgroup::"
+          echo "::group::rustup version"
+          rustup -Vv
+          echo "::endgroup::"
+          echo "::group::rustc version"
+          rustc -Vv
+          echo "::endgroup::"
+          echo "::group::cargo version"
+          cargo version --verbose
+          echo "::endgroup::"
+          echo "::group::clippy version"
+          cargo clippy --version
+          echo "::endgroup::"
 
       - name: Install nightly Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          profile: minimal
-          components: rustfmt
+        run: |
+          echo "::group::rustup toolchain install"
+          rustup toolchain install --profile minimal --component rustfmt nightly
+          echo "::endgroup::"
+          echo "::group::rustup version"
+          rustup -Vv
+          echo "::endgroup::"
+          echo "::group::rustc version"
+          rustc +nightly -Vv
+          echo "::endgroup::"
+          echo "::group::cargo version"
+          cargo +nightly version --verbose
+          echo "::endgroup::"
+          echo "::group::rustfmt version"
+          rustfmt +nightly -Vv
+          echo "::endgroup::"
 
       - uses: Swatinem/rust-cache@v1
         with:
@@ -186,7 +272,7 @@ jobs:
           working-directory: "ui-tests"
 
       - name: Check ui-tests formatting
-        run: cargo +nightly fmt -- --check --color=auto
+        run: cargo +nightly fmt --check
         working-directory: "ui-tests"
 
       - name: Check ui-tests with locked Cargo.lock
@@ -219,9 +305,19 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
+        run: |
+          echo "::group::rustup toolchain install"
+          rustup toolchain install --profile minimal
+          echo "::endgroup::"
+          echo "::group::rustup version"
+          rustup -Vv
+          echo "::endgroup::"
+          echo "::group::rustc version"
+          rustc -Vv
+          echo "::endgroup::"
+          echo "::group::cargo version"
+          cargo version --verbose
+          echo "::endgroup::"
 
       - uses: Swatinem/rust-cache@v1
 
@@ -368,16 +464,34 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          components: rustfmt, clippy
+        run: |
+          echo "::group::rustup toolchain install"
+          rustup toolchain install --profile minimal
+          echo "::endgroup::"
+          echo "::group::rustup version"
+          rustup -Vv
+          echo "::endgroup::"
+          echo "::group::rustc version"
+          rustc -Vv
+          echo "::endgroup::"
+          echo "::group::cargo version"
+          cargo version --verbose
+          echo "::endgroup::"
 
-      - name: Install Rust nightly toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          profile: minimal
+      - name: Install nightly Rust toolchain
+        run: |
+          echo "::group::rustup toolchain install"
+          rustup toolchain install --profile minimal nightly
+          echo "::endgroup::"
+          echo "::group::rustup version"
+          rustup -Vv
+          echo "::endgroup::"
+          echo "::group::rustc version"
+          rustc +nightly -Vv
+          echo "::endgroup::"
+          echo "::group::cargo version"
+          cargo +nightly version --verbose
+          echo "::endgroup::"
 
       - uses: Swatinem/rust-cache@v1
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Rust toolchain
         run: |
           echo "::group::rustup toolchain install"
-          rustup toolchain install --profile minimal
+          rustup toolchain install --profile minimal 1.58.1
           echo "::endgroup::"
           echo "::group::rustup version"
           rustup -Vv
@@ -131,7 +131,7 @@ jobs:
       - name: Install Rust toolchain
         run: |
           echo "::group::rustup toolchain install"
-          rustup toolchain install --profile minimal
+          rustup toolchain install --profile minimal 1.58.1
           echo "::endgroup::"
           echo "::group::rustup version"
           rustup -Vv
@@ -307,7 +307,7 @@ jobs:
       - name: Install Rust toolchain
         run: |
           echo "::group::rustup toolchain install"
-          rustup toolchain install --profile minimal
+          rustup toolchain install --profile minimal 1.58.1
           echo "::endgroup::"
           echo "::group::rustup version"
           rustup -Vv
@@ -466,7 +466,7 @@ jobs:
       - name: Install Rust toolchain
         run: |
           echo "::group::rustup toolchain install"
-          rustup toolchain install --profile minimal
+          rustup toolchain install --profile minimal 1.58.1
           echo "::endgroup::"
           echo "::group::rustup version"
           rustup -Vv

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,7 +65,7 @@ jobs:
       - name: Install Rust toolchain
         run: |
           echo "::group::rustup toolchain install"
-          rustup toolchain install --profile minimal --component clippy
+          rustup toolchain install --profile minimal --component clippy 1.58.1
           echo "::endgroup::"
           echo "::group::rustup version"
           rustup -Vv
@@ -164,7 +164,7 @@ jobs:
       - name: Install Rust toolchain
         run: |
           echo "::group::rustup toolchain install"
-          rustup toolchain install --profile minimal --component clippy
+          rustup toolchain install --profile minimal --component clippy 1.58.1
           echo "::endgroup::"
           echo "::group::rustup version"
           rustup -Vv
@@ -230,7 +230,7 @@ jobs:
       - name: Install Rust toolchain
         run: |
           echo "::group::rustup toolchain install"
-          rustup toolchain install --profile minimal --component clippy
+          rustup toolchain install --profile minimal --component clippy 1.58.1
           echo "::endgroup::"
           echo "::group::rustup version"
           rustup -Vv

--- a/.github/workflows/crash.yaml
+++ b/.github/workflows/crash.yaml
@@ -16,9 +16,19 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
+        run: |
+          echo "::group::rustup toolchain install"
+          rustup toolchain install 1.58.1 --profile minimal
+          echo "::endgroup::"
+          echo "::group::rustup version"
+          rustup -Vv
+          echo "::endgroup::"
+          echo "::group::rustc version"
+          rustc -Vv
+          echo "::endgroup::"
+          echo "::group::cargo version"
+          cargo version --verbose
+          echo "::endgroup::"
 
       - uses: Swatinem/rust-cache@v1
         with:

--- a/.github/workflows/fuzz.yaml
+++ b/.github/workflows/fuzz.yaml
@@ -17,12 +17,20 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          profile: minimal
-          override: true
+      - name: Install nightly Rust toolchain
+        run: |
+          echo "::group::rustup toolchain install"
+          rustup toolchain install nightly --profile minimal
+          echo "::endgroup::"
+          echo "::group::rustup version"
+          rustup -Vv
+          echo "::endgroup::"
+          echo "::group::rustc version"
+          rustc -Vv
+          echo "::endgroup::"
+          echo "::group::cargo version"
+          cargo version --verbose
+          echo "::endgroup::"
 
       - name: Install cargo-fuzz
         run: cargo install cargo-fuzz
@@ -45,12 +53,19 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install nightly Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          profile: minimal
-          target: x86_64-unknown-linux-gnu
-          override: true
+        run: |
+          echo "::group::rustup toolchain install"
+          rustup toolchain install nightly --profile minimal --target x86_64-unknown-linux-gnu
+          echo "::endgroup::"
+          echo "::group::rustup version"
+          rustup -Vv
+          echo "::endgroup::"
+          echo "::group::rustc version"
+          rustc -Vv
+          echo "::endgroup::"
+          echo "::group::cargo version"
+          cargo version --verbose
+          echo "::endgroup::"
 
       - name: Test with leak sanitizer and all features
         run: cargo test --workspace --all-features --target x86_64-unknown-linux-gnu

--- a/.github/workflows/rustdoc.yaml
+++ b/.github/workflows/rustdoc.yaml
@@ -23,17 +23,25 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          profile: minimal
-          override: true
+      - name: Install nightly Rust toolchain
+        run: |
+          echo "::group::rustup toolchain install"
+          rustup toolchain install nightly --profile minimal
+          echo "::endgroup::"
+          echo "::group::rustup version"
+          rustup -Vv
+          echo "::endgroup::"
+          echo "::group::rustc version"
+          rustc -Vv
+          echo "::endgroup::"
+          echo "::group::cargo version"
+          cargo version --verbose
+          echo "::endgroup::"
 
       - uses: Swatinem/rust-cache@v1
 
       - name: Build Documentation
-        run: cargo doc --workspace
+        run: cargo +nightly doc --workspace
 
       - name: Copy static content
         run: cp --verbose .github/rustdoc/* target/doc/

--- a/.github/workflows/spec-state.yaml
+++ b/.github/workflows/spec-state.yaml
@@ -19,13 +19,23 @@ jobs:
         with:
           path: artichoke
 
-      - name: Setup rust-toolchain override
-        run: cp artichoke/rust-toolchain rust-toolchain
-
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
+        run: |
+          echo "::group::rustup toolchain install"
+          rustup toolchain install 1.58.1 --profile minimal
+          echo "::endgroup::"
+          echo "::group::set default toolchain"
+          rustup default 1.58.1
+          echo "::endgroup::"
+          echo "::group::rustup version"
+          rustup -Vv
+          echo "::endgroup::"
+          echo "::group::rustc version"
+          rustc -Vv
+          echo "::endgroup::"
+          echo "::group::cargo version"
+          cargo version --verbose
+          echo "::endgroup::"
 
       - uses: Swatinem/rust-cache@v1
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,6 +108,7 @@ rake lint:clippy:restriction      # Lint Rust sources with Clippy restriction pa
 rake lint:rubocop                 # Run RuboCop
 rake lint:rubocop:auto_correct    # Auto-correct RuboCop offenses
 rake pkg:rust_version:sync        # Sync the root rust-toolchain version to all crates
+rake pkg:toolchain:sync           # Sync the root rust-toolchain version to CI jobs
 rake release:markdown_link_check  # Check for broken links in markdown files
 rake sanitizer:leak               # Run Artichoke with LeakSanitizer
 rake spec                         # Run enforced ruby/spec suite

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,8 +107,6 @@ rake lint:clippy                  # Lint Rust sources with Clippy
 rake lint:clippy:restriction      # Lint Rust sources with Clippy restriction pass (unenforced lints)
 rake lint:rubocop                 # Run RuboCop
 rake lint:rubocop:auto_correct    # Auto-correct RuboCop offenses
-rake pkg:rust_version:sync        # Sync the root rust-toolchain version to all crates
-rake pkg:toolchain:sync           # Sync the root rust-toolchain version to CI jobs
 rake release:markdown_link_check  # Check for broken links in markdown files
 rake sanitizer:leak               # Run Artichoke with LeakSanitizer
 rake spec                         # Run enforced ruby/spec suite
@@ -117,6 +115,9 @@ rake test:all                     # Run all tests
 rake test:fuzz                    # Run fuzz tests (Fuzz the interpreter for crashes with arbitrary input)
 rake test:ui                      # Run ui tests (check exact stdout/stderr of Artichoke binaries)
 rake test:unit                    # Run unit tests
+rake toolchain:sync               # Sync Rust toolchain to all sources
+rake toolchain:sync:ci            # Sync the root rust-toolchain version to CI jobs
+rake toolchain:sync:manifests     # Sync the root rust-toolchain version to all crate manifests
 ```
 
 To lint Ruby sources, Artichoke uses [RuboCop]. RuboCop runs as part of the

--- a/Rakefile
+++ b/Rakefile
@@ -229,7 +229,7 @@ namespace :toolchain do
       workflow_files.each do |file|
         contents = File.read(file)
 
-        File.write(file, contents.gsub(/(rustup toolchain install .*) \d+\.\d+\.\d+$/, "\\1 #{rust_toolchain}"))
+        File.write(file, contents.gsub(/(rustup toolchain install) \d+\.\d+\.\d+/, "\\1 #{rust_toolchain}"))
       end
     end
   end

--- a/Rakefile
+++ b/Rakefile
@@ -228,8 +228,10 @@ namespace :toolchain do
 
       workflow_files.each do |file|
         contents = File.read(file)
+        contents = contents.gsub(/(rustup toolchain install) \d+\.\d+\.\d+/, "\\1 #{rust_toolchain}")
+        contents = contents.gsub(/(rustup default) \d+\.\d+\.\d+/, "\\1 #{rust_toolchain}")
 
-        File.write(file, contents.gsub(/(rustup toolchain install) \d+\.\d+\.\d+/, "\\1 #{rust_toolchain}"))
+        File.write(file, contents)
       end
     end
   end

--- a/Rakefile
+++ b/Rakefile
@@ -215,4 +215,17 @@ namespace :pkg do
 
     raise 'Failed to update some rust-versions' if failures.any?
   end
+
+  desc 'Sync the root rust-toolchain version to CI jobs'
+  task :'toolchain:sync' do
+    rust_version = File.read('rust-toolchain').chomp
+
+    workflow_files = FileList.new('.github/workflows/*.yaml')
+
+    failures = workflow_files.map do |file|
+      contents = File.read(file)
+
+      File.write(file, contents.gsub(/(rustup toolchain install .*) \d+\.\d+\.\d+$/, "\\1 #{rust_version}"))
+    end.compact
+  end
 end


### PR DESCRIPTION
It appears that the GitHub Actions in the actions-rs organization may be
unmaintained. Replace these actions in the CI workflow with raw shell
invocations of rustup and cargo.

This fixes up `cargo fmt` calls to stop passing flags directly to
rustmt since `cargo fmt --check` is now a thing.

Several places now install fewer components than before.

The toolchain install steps use log groups to group version output
separately from rustup install output.