### PR TITLE
Remove ignore `ansi_term` from Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,11 +12,6 @@ updates:
       - lopopolo
     labels:
       - A-deps
-    ignore:
-      - dependency-name: ansi_term
-        versions:
-          - ">= 0.12.a"
-          - "< 0.13"
   - package-ecosystem: bundler
     directory: "/"
     schedule:


### PR DESCRIPTION
This is a legacy config that is a hangover from exporting the config
into GitHub from dependabot-preview.

Artichoke does not depend on `ansi_term` anymore.