### PR TITLE
Attempt to fix LeakSan linker errors in CI

### DIFF
--- a/artichoke-backend/build.rs
+++ b/artichoke-backend/build.rs
@@ -207,6 +207,11 @@ mod libs {
 
         for source in sources {
             println!("cargo:rerun-if-changed={}", source.to_str().unwrap());
+            // relative paths ensure that `cc` will preserve directory hierarchy
+            // which allows C sources with the same file name to be built.
+            let source = source
+                .strip_prefix(paths::crate_root())
+                .expect("All C sources are found within the crate root");
             build.file(source);
         }
 
@@ -321,9 +326,14 @@ mod libs {
     }
 
     pub fn build(target: &Triple, out_dir: &OsStr) {
-        staticlib(target, "libmruby.a", mruby_include_dirs(), mruby_sources());
-        staticlib(target, "libmrbgems.a", mrbgems_include_dirs(), mrbgems_sources());
-        staticlib(target, "libmrbsys.a", mrbsys_include_dirs(), mrbsys_sources());
+        staticlib(
+            target,
+            "libartichokemruby.a",
+            mruby_include_dirs()
+                .chain(mrbgems_include_dirs())
+                .chain(mrbsys_include_dirs()),
+            mruby_sources().chain(mrbgems_sources()).chain(mrbsys_sources()),
+        );
         bindgen(target, out_dir);
     }
 }


### PR DESCRIPTION
From CI logs, it looks like leaksan isn't liking resolving symbols from libmruby.a for
libmrbgems.a, specifically in the parser and codegen.

Use relative paths when feeding files to `cc` so all C sources, even if
they have the same filename, can be built into a single static lib.

When given a relative path, `cc` will preserve directory structure
rather than simply copying the filename to the compile directory.

This is a better way to fix #1821.