### PR TITLE
Encoding-aware `String#inspect`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -697,7 +697,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-string"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "bstr",
  "bytecount",

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -33,7 +33,7 @@ spinoso-math = { version = "0.2.0", path = "../spinoso-math", optional = true, d
 spinoso-random = { version = "0.2.0", path = "../spinoso-random", optional = true }
 spinoso-regexp = { version = "0.2.0", path = "../spinoso-regexp", optional = true, default-features = false }
 spinoso-securerandom = { version = "0.2.0", path = "../spinoso-securerandom", optional = true }
-spinoso-string = { version = "0.14.0", path = "../spinoso-string" }
+spinoso-string = { version = "0.15.0", path = "../spinoso-string" }
 spinoso-symbol = { version = "0.1.0", path = "../spinoso-symbol" }
 spinoso-time = { version = "0.2.0", path = "../spinoso-time", optional = true }
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -501,7 +501,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-string"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "bstr",
  "bytecount",

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -632,7 +632,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-string"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "bstr",
  "bytecount",

--- a/spinoso-string/Cargo.toml
+++ b/spinoso-string/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spinoso-string"
-version = "0.14.0"
+version = "0.15.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2021"
 rust-version = "1.58.1"

--- a/spinoso-string/README.md
+++ b/spinoso-string/README.md
@@ -27,7 +27,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-spinoso-string = "0.14.0"
+spinoso-string = "0.15.0"
 ```
 
 ## `no_std`

--- a/spinoso-string/src/enc/ascii/inspect.rs
+++ b/spinoso-string/src/enc/ascii/inspect.rs
@@ -1,0 +1,278 @@
+use core::iter::FusedIterator;
+use core::slice;
+use core::str::Chars;
+
+use scolapasta_string_escape::Literal;
+
+use super::AsciiString;
+use crate::inspect::Flags;
+
+#[derive(Default, Debug, Clone)]
+#[must_use = "this `Inspect` is an `Iterator`, which should be consumed if constructed"]
+pub struct Inspect<'a>(State<'a>);
+
+impl<'a> From<&'a AsciiString> for Inspect<'a> {
+    #[inline]
+    fn from(value: &'a AsciiString) -> Self {
+        Self(State::new(value.as_slice()))
+    }
+}
+
+impl<'a> Iterator for Inspect<'a> {
+    type Item = char;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+}
+
+impl<'a> FusedIterator for Inspect<'a> {}
+
+#[derive(Debug, Clone)]
+#[must_use = "this `State` is an `Iterator`, which should be consumed if constructed"]
+struct State<'a> {
+    flags: Flags,
+    literal: Chars<'static>,
+    bytes: slice::Iter<'a, u8>,
+}
+
+impl<'a> State<'a> {
+    /// Construct a `State` for the given byte slice.
+    ///
+    /// This constructor produces inspect contents like `"fred"`.
+    #[inline]
+    fn new(bytes: &'a [u8]) -> Self {
+        Self {
+            flags: Flags::DEFAULT,
+            literal: "".chars(),
+            bytes: bytes.iter(),
+        }
+    }
+}
+
+impl<'a> Default for State<'a> {
+    /// Construct a `State` that will render debug output for the empty slice.
+    ///
+    /// This constructor produces inspect contents like `""`.
+    #[inline]
+    fn default() -> Self {
+        Self::new(b"")
+    }
+}
+
+impl<'a> Iterator for State<'a> {
+    type Item = char;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some(ch) = self.flags.emit_leading_quote() {
+            return Some(ch);
+        }
+        if let Some(ch) = self.literal.next() {
+            return Some(ch);
+        }
+        if let Some(&ch) = self.bytes.next() {
+            self.literal = Literal::debug_escape(ch).chars();
+        }
+        if let Some(ch) = self.literal.next() {
+            return Some(ch);
+        }
+        self.flags.emit_trailing_quote()
+    }
+}
+
+impl<'a> FusedIterator for State<'a> {}
+
+#[cfg(test)]
+mod tests {
+    use alloc::string::{String, ToString};
+
+    use super::{AsciiString, Inspect};
+
+    #[test]
+    fn empty() {
+        let s = "";
+        let s = AsciiString::new(s.to_string().into_bytes());
+        let inspect = Inspect::from(&s);
+
+        assert_eq!(inspect.collect::<String>(), r#""""#);
+    }
+
+    #[test]
+    fn fred() {
+        let s = "fred";
+        let s = AsciiString::new(s.to_string().into_bytes());
+        let inspect = Inspect::from(&s);
+
+        assert_eq!(inspect.collect::<String>(), r#""fred""#);
+    }
+
+    #[test]
+    fn invalid_utf8_byte() {
+        let s = b"\xFF";
+        let s = AsciiString::new(s.to_vec());
+        let inspect = Inspect::from(&s);
+
+        assert_eq!(inspect.collect::<String>(), r#""\xFF""#);
+    }
+
+    #[test]
+    fn invalid_utf8() {
+        let s = b"invalid-\xFF-utf8";
+        let s = AsciiString::new(s.to_vec());
+        let inspect = Inspect::from(&s);
+
+        assert_eq!(inspect.collect::<String>(), r#""invalid-\xFF-utf8""#);
+    }
+
+    #[test]
+    fn quote_collect() {
+        let s = r#"a"b"#;
+        let s = AsciiString::new(s.to_string().into_bytes());
+        let inspect = Inspect::from(&s);
+        assert_eq!(inspect.collect::<String>(), r#""a\"b""#);
+    }
+
+    #[test]
+    fn quote_iter() {
+        let s = r#"a"b"#;
+        let s = AsciiString::new(s.to_string().into_bytes());
+        let mut inspect = Inspect::from(&s);
+
+        assert_eq!(inspect.next(), Some('"'));
+        assert_eq!(inspect.next(), Some('a'));
+        assert_eq!(inspect.next(), Some('\\'));
+        assert_eq!(inspect.next(), Some('"'));
+        assert_eq!(inspect.next(), Some('b'));
+        assert_eq!(inspect.next(), Some('"'));
+        assert_eq!(inspect.next(), None);
+    }
+
+    #[test]
+    fn emoji() {
+        let s = "💎";
+        let s = AsciiString::new(s.to_string().into_bytes());
+        let inspect = Inspect::from(&s);
+
+        assert_eq!(inspect.collect::<String>(), r#""\xF0\x9F\x92\x8E""#);
+    }
+
+    #[test]
+    fn unicode_replacement_char() {
+        let s = "�";
+        let s = AsciiString::new(s.to_string().into_bytes());
+        let inspect = Inspect::from(&s);
+
+        assert_eq!(inspect.collect::<String>(), r#""\xEF\xBF\xBD""#);
+    }
+
+    #[test]
+    fn escape_slash() {
+        let s = r"\";
+        let s = AsciiString::new(s.to_string().into_bytes());
+        let inspect = Inspect::from(&s);
+
+        assert_eq!(inspect.collect::<String>(), r#""\\""#);
+    }
+
+    #[test]
+    fn escape_inner_slash() {
+        let s = r"foo\bar";
+        let s = AsciiString::new(s.to_string().into_bytes());
+        let inspect = Inspect::from(&s);
+
+        assert_eq!(inspect.collect::<String>(), r#""foo\\bar""#);
+    }
+
+    #[test]
+    fn nul() {
+        let s = "\0";
+        let s = AsciiString::new(s.to_string().into_bytes());
+        let inspect = Inspect::from(&s);
+
+        assert_eq!(inspect.collect::<String>(), r#""\x00""#);
+    }
+
+    #[test]
+    fn del() {
+        let s = "\x7F";
+        let s = AsciiString::new(s.to_string().into_bytes());
+        let inspect = Inspect::from(&s);
+
+        assert_eq!(inspect.collect::<String>(), r#""\x7F""#);
+    }
+
+    #[test]
+    fn ascii_control() {
+        let test_cases = [
+            ["\x00", r#""\x00""#],
+            ["\x01", r#""\x01""#],
+            ["\x02", r#""\x02""#],
+            ["\x03", r#""\x03""#],
+            ["\x04", r#""\x04""#],
+            ["\x05", r#""\x05""#],
+            ["\x06", r#""\x06""#],
+            ["\x07", r#""\a""#],
+            ["\x08", r#""\b""#],
+            ["\x09", r#""\t""#],
+            ["\x0A", r#""\n""#],
+            ["\x0B", r#""\v""#],
+            ["\x0C", r#""\f""#],
+            ["\x0D", r#""\r""#],
+            ["\x0E", r#""\x0E""#],
+            ["\x0F", r#""\x0F""#],
+            ["\x10", r#""\x10""#],
+            ["\x11", r#""\x11""#],
+            ["\x12", r#""\x12""#],
+            ["\x13", r#""\x13""#],
+            ["\x14", r#""\x14""#],
+            ["\x15", r#""\x15""#],
+            ["\x16", r#""\x16""#],
+            ["\x17", r#""\x17""#],
+            ["\x18", r#""\x18""#],
+            ["\x19", r#""\x19""#],
+            ["\x1A", r#""\x1A""#],
+            ["\x1B", r#""\e""#],
+            ["\x1C", r#""\x1C""#],
+            ["\x1D", r#""\x1D""#],
+            ["\x1E", r#""\x1E""#],
+            ["\x1F", r#""\x1F""#],
+            ["\x20", r#"" ""#],
+        ];
+        for [s, r] in test_cases {
+            let s = AsciiString::new(s.to_string().into_bytes());
+            let inspect = Inspect::from(&s);
+            assert_eq!(inspect.collect::<String>(), r, "For {s:?}, expected {r}");
+        }
+    }
+
+    #[test]
+    fn special_double_quote() {
+        let s = "\x22";
+        let s = AsciiString::new(s.to_string().into_bytes());
+        let inspect = Inspect::from(&s);
+
+        assert_eq!(inspect.collect::<String>(), r#""\"""#);
+
+        let s = "\"";
+        let s = AsciiString::new(s.to_string().into_bytes());
+        let inspect = Inspect::from(&s);
+
+        assert_eq!(inspect.collect::<String>(), r#""\"""#);
+    }
+
+    #[test]
+    fn special_backslash() {
+        let s = "\x5C";
+        let s = AsciiString::new(s.to_string().into_bytes());
+        let inspect = Inspect::from(&s);
+
+        assert_eq!(inspect.collect::<String>(), r#""\\""#);
+
+        let s = "\\";
+        let s = AsciiString::new(s.to_string().into_bytes());
+        let inspect = Inspect::from(&s);
+
+        assert_eq!(inspect.collect::<String>(), r#""\\""#);
+    }
+}

--- a/spinoso-string/src/enc/ascii/inspect.rs
+++ b/spinoso-string/src/enc/ascii/inspect.rs
@@ -7,37 +7,23 @@ use scolapasta_string_escape::Literal;
 use super::AsciiString;
 use crate::inspect::Flags;
 
-#[derive(Default, Debug, Clone)]
-#[must_use = "this `Inspect` is an `Iterator`, which should be consumed if constructed"]
-pub struct Inspect<'a>(State<'a>);
-
-impl<'a> From<&'a AsciiString> for Inspect<'a> {
-    #[inline]
-    fn from(value: &'a AsciiString) -> Self {
-        Self(State::new(value.as_slice()))
-    }
-}
-
-impl<'a> Iterator for Inspect<'a> {
-    type Item = char;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.0.next()
-    }
-}
-
-impl<'a> FusedIterator for Inspect<'a> {}
-
 #[derive(Debug, Clone)]
-#[must_use = "this `State` is an `Iterator`, which should be consumed if constructed"]
-struct State<'a> {
+#[must_use = "this `Inspect` is an `Iterator`, which should be consumed if constructed"]
+pub struct Inspect<'a> {
     flags: Flags,
     literal: Chars<'static>,
     bytes: slice::Iter<'a, u8>,
 }
 
-impl<'a> State<'a> {
-    /// Construct a `State` for the given byte slice.
+impl<'a> From<&'a AsciiString> for Inspect<'a> {
+    #[inline]
+    fn from(value: &'a AsciiString) -> Self {
+        Self::new(value.as_slice())
+    }
+}
+
+impl<'a> Inspect<'a> {
+    /// Construct an ASCII `Inspect` for the given byte slice.
     ///
     /// This constructor produces inspect contents like `"fred"`.
     #[inline]
@@ -50,7 +36,7 @@ impl<'a> State<'a> {
     }
 }
 
-impl<'a> Default for State<'a> {
+impl<'a> Default for Inspect<'a> {
     /// Construct a `State` that will render debug output for the empty slice.
     ///
     /// This constructor produces inspect contents like `""`.
@@ -60,7 +46,7 @@ impl<'a> Default for State<'a> {
     }
 }
 
-impl<'a> Iterator for State<'a> {
+impl<'a> Iterator for Inspect<'a> {
     type Item = char;
 
     #[inline]
@@ -81,7 +67,7 @@ impl<'a> Iterator for State<'a> {
     }
 }
 
-impl<'a> FusedIterator for State<'a> {}
+impl<'a> FusedIterator for Inspect<'a> {}
 
 #[cfg(test)]
 mod tests {

--- a/spinoso-string/src/enc/ascii/inspect.rs
+++ b/spinoso-string/src/enc/ascii/inspect.rs
@@ -37,7 +37,8 @@ impl<'a> Inspect<'a> {
 }
 
 impl<'a> Default for Inspect<'a> {
-    /// Construct a `State` that will render debug output for the empty slice.
+    /// Construct an `Inspect` that will render debug output for the empty
+    /// slice.
     ///
     /// This constructor produces inspect contents like `""`.
     #[inline]

--- a/spinoso-string/src/enc/ascii/mod.rs
+++ b/spinoso-string/src/enc/ascii/mod.rs
@@ -12,8 +12,11 @@ use crate::ord::OrdError;
 
 mod eq;
 mod impls;
+mod inspect;
 #[cfg(feature = "std")]
 mod io;
+
+pub use inspect::Inspect;
 
 #[allow(clippy::module_name_repetitions)]
 #[derive(Default, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]

--- a/spinoso-string/src/enc/binary/inspect.rs
+++ b/spinoso-string/src/enc/binary/inspect.rs
@@ -1,0 +1,278 @@
+use core::iter::FusedIterator;
+use core::slice;
+use core::str::Chars;
+
+use scolapasta_string_escape::Literal;
+
+use super::BinaryString;
+use crate::inspect::Flags;
+
+#[derive(Default, Debug, Clone)]
+#[must_use = "this `Inspect` is an `Iterator`, which should be consumed if constructed"]
+pub struct Inspect<'a>(State<'a>);
+
+impl<'a> From<&'a BinaryString> for Inspect<'a> {
+    #[inline]
+    fn from(value: &'a BinaryString) -> Self {
+        Self(State::new(value.as_slice()))
+    }
+}
+
+impl<'a> Iterator for Inspect<'a> {
+    type Item = char;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+}
+
+impl<'a> FusedIterator for Inspect<'a> {}
+
+#[derive(Debug, Clone)]
+#[must_use = "this `State` is an `Iterator`, which should be consumed if constructed"]
+struct State<'a> {
+    flags: Flags,
+    literal: Chars<'static>,
+    bytes: slice::Iter<'a, u8>,
+}
+
+impl<'a> State<'a> {
+    /// Construct a `State` for the given byte slice.
+    ///
+    /// This constructor produces inspect contents like `"fred"`.
+    #[inline]
+    fn new(bytes: &'a [u8]) -> Self {
+        Self {
+            flags: Flags::DEFAULT,
+            literal: "".chars(),
+            bytes: bytes.iter(),
+        }
+    }
+}
+
+impl<'a> Default for State<'a> {
+    /// Construct a `State` that will render debug output for the empty slice.
+    ///
+    /// This constructor produces inspect contents like `""`.
+    #[inline]
+    fn default() -> Self {
+        Self::new(b"")
+    }
+}
+
+impl<'a> Iterator for State<'a> {
+    type Item = char;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some(ch) = self.flags.emit_leading_quote() {
+            return Some(ch);
+        }
+        if let Some(ch) = self.literal.next() {
+            return Some(ch);
+        }
+        if let Some(&ch) = self.bytes.next() {
+            self.literal = Literal::debug_escape(ch).chars();
+        }
+        if let Some(ch) = self.literal.next() {
+            return Some(ch);
+        }
+        self.flags.emit_trailing_quote()
+    }
+}
+
+impl<'a> FusedIterator for State<'a> {}
+
+#[cfg(test)]
+mod tests {
+    use alloc::string::{String, ToString};
+
+    use super::{BinaryString, Inspect};
+
+    #[test]
+    fn empty() {
+        let s = "";
+        let s = BinaryString::new(s.to_string().into_bytes());
+        let inspect = Inspect::from(&s);
+
+        assert_eq!(inspect.collect::<String>(), r#""""#);
+    }
+
+    #[test]
+    fn fred() {
+        let s = "fred";
+        let s = BinaryString::new(s.to_string().into_bytes());
+        let inspect = Inspect::from(&s);
+
+        assert_eq!(inspect.collect::<String>(), r#""fred""#);
+    }
+
+    #[test]
+    fn invalid_utf8_byte() {
+        let s = b"\xFF";
+        let s = BinaryString::new(s.to_vec());
+        let inspect = Inspect::from(&s);
+
+        assert_eq!(inspect.collect::<String>(), r#""\xFF""#);
+    }
+
+    #[test]
+    fn invalid_utf8() {
+        let s = b"invalid-\xFF-utf8";
+        let s = BinaryString::new(s.to_vec());
+        let inspect = Inspect::from(&s);
+
+        assert_eq!(inspect.collect::<String>(), r#""invalid-\xFF-utf8""#);
+    }
+
+    #[test]
+    fn quote_collect() {
+        let s = r#"a"b"#;
+        let s = BinaryString::new(s.to_string().into_bytes());
+        let inspect = Inspect::from(&s);
+        assert_eq!(inspect.collect::<String>(), r#""a\"b""#);
+    }
+
+    #[test]
+    fn quote_iter() {
+        let s = r#"a"b"#;
+        let s = BinaryString::new(s.to_string().into_bytes());
+        let mut inspect = Inspect::from(&s);
+
+        assert_eq!(inspect.next(), Some('"'));
+        assert_eq!(inspect.next(), Some('a'));
+        assert_eq!(inspect.next(), Some('\\'));
+        assert_eq!(inspect.next(), Some('"'));
+        assert_eq!(inspect.next(), Some('b'));
+        assert_eq!(inspect.next(), Some('"'));
+        assert_eq!(inspect.next(), None);
+    }
+
+    #[test]
+    fn emoji() {
+        let s = "💎";
+        let s = BinaryString::new(s.to_string().into_bytes());
+        let inspect = Inspect::from(&s);
+
+        assert_eq!(inspect.collect::<String>(), r#""\xF0\x9F\x92\x8E""#);
+    }
+
+    #[test]
+    fn unicode_replacement_char() {
+        let s = "�";
+        let s = BinaryString::new(s.to_string().into_bytes());
+        let inspect = Inspect::from(&s);
+
+        assert_eq!(inspect.collect::<String>(), r#""\xEF\xBF\xBD""#);
+    }
+
+    #[test]
+    fn escape_slash() {
+        let s = r"\";
+        let s = BinaryString::new(s.to_string().into_bytes());
+        let inspect = Inspect::from(&s);
+
+        assert_eq!(inspect.collect::<String>(), r#""\\""#);
+    }
+
+    #[test]
+    fn escape_inner_slash() {
+        let s = r"foo\bar";
+        let s = BinaryString::new(s.to_string().into_bytes());
+        let inspect = Inspect::from(&s);
+
+        assert_eq!(inspect.collect::<String>(), r#""foo\\bar""#);
+    }
+
+    #[test]
+    fn nul() {
+        let s = "\0";
+        let s = BinaryString::new(s.to_string().into_bytes());
+        let inspect = Inspect::from(&s);
+
+        assert_eq!(inspect.collect::<String>(), r#""\x00""#);
+    }
+
+    #[test]
+    fn del() {
+        let s = "\x7F";
+        let s = BinaryString::new(s.to_string().into_bytes());
+        let inspect = Inspect::from(&s);
+
+        assert_eq!(inspect.collect::<String>(), r#""\x7F""#);
+    }
+
+    #[test]
+    fn ascii_control() {
+        let test_cases = [
+            ["\x00", r#""\x00""#],
+            ["\x01", r#""\x01""#],
+            ["\x02", r#""\x02""#],
+            ["\x03", r#""\x03""#],
+            ["\x04", r#""\x04""#],
+            ["\x05", r#""\x05""#],
+            ["\x06", r#""\x06""#],
+            ["\x07", r#""\a""#],
+            ["\x08", r#""\b""#],
+            ["\x09", r#""\t""#],
+            ["\x0A", r#""\n""#],
+            ["\x0B", r#""\v""#],
+            ["\x0C", r#""\f""#],
+            ["\x0D", r#""\r""#],
+            ["\x0E", r#""\x0E""#],
+            ["\x0F", r#""\x0F""#],
+            ["\x10", r#""\x10""#],
+            ["\x11", r#""\x11""#],
+            ["\x12", r#""\x12""#],
+            ["\x13", r#""\x13""#],
+            ["\x14", r#""\x14""#],
+            ["\x15", r#""\x15""#],
+            ["\x16", r#""\x16""#],
+            ["\x17", r#""\x17""#],
+            ["\x18", r#""\x18""#],
+            ["\x19", r#""\x19""#],
+            ["\x1A", r#""\x1A""#],
+            ["\x1B", r#""\e""#],
+            ["\x1C", r#""\x1C""#],
+            ["\x1D", r#""\x1D""#],
+            ["\x1E", r#""\x1E""#],
+            ["\x1F", r#""\x1F""#],
+            ["\x20", r#"" ""#],
+        ];
+        for [s, r] in test_cases {
+            let s = BinaryString::new(s.to_string().into_bytes());
+            let inspect = Inspect::from(&s);
+            assert_eq!(inspect.collect::<String>(), r, "For {s:?}, expected {r}");
+        }
+    }
+
+    #[test]
+    fn special_double_quote() {
+        let s = "\x22";
+        let s = BinaryString::new(s.to_string().into_bytes());
+        let inspect = Inspect::from(&s);
+
+        assert_eq!(inspect.collect::<String>(), r#""\"""#);
+
+        let s = "\"";
+        let s = BinaryString::new(s.to_string().into_bytes());
+        let inspect = Inspect::from(&s);
+
+        assert_eq!(inspect.collect::<String>(), r#""\"""#);
+    }
+
+    #[test]
+    fn special_backslash() {
+        let s = "\x5C";
+        let s = BinaryString::new(s.to_string().into_bytes());
+        let inspect = Inspect::from(&s);
+
+        assert_eq!(inspect.collect::<String>(), r#""\\""#);
+
+        let s = "\\";
+        let s = BinaryString::new(s.to_string().into_bytes());
+        let inspect = Inspect::from(&s);
+
+        assert_eq!(inspect.collect::<String>(), r#""\\""#);
+    }
+}

--- a/spinoso-string/src/enc/binary/inspect.rs
+++ b/spinoso-string/src/enc/binary/inspect.rs
@@ -7,37 +7,23 @@ use scolapasta_string_escape::Literal;
 use super::BinaryString;
 use crate::inspect::Flags;
 
-#[derive(Default, Debug, Clone)]
-#[must_use = "this `Inspect` is an `Iterator`, which should be consumed if constructed"]
-pub struct Inspect<'a>(State<'a>);
-
-impl<'a> From<&'a BinaryString> for Inspect<'a> {
-    #[inline]
-    fn from(value: &'a BinaryString) -> Self {
-        Self(State::new(value.as_slice()))
-    }
-}
-
-impl<'a> Iterator for Inspect<'a> {
-    type Item = char;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.0.next()
-    }
-}
-
-impl<'a> FusedIterator for Inspect<'a> {}
-
 #[derive(Debug, Clone)]
-#[must_use = "this `State` is an `Iterator`, which should be consumed if constructed"]
-struct State<'a> {
+#[must_use = "this `Inspect` is an `Iterator`, which should be consumed if constructed"]
+pub struct Inspect<'a> {
     flags: Flags,
     literal: Chars<'static>,
     bytes: slice::Iter<'a, u8>,
 }
 
-impl<'a> State<'a> {
-    /// Construct a `State` for the given byte slice.
+impl<'a> From<&'a BinaryString> for Inspect<'a> {
+    #[inline]
+    fn from(value: &'a BinaryString) -> Self {
+        Self::new(value.as_slice())
+    }
+}
+
+impl<'a> Inspect<'a> {
+    /// Construct a binary `Inspect` for the given byte slice.
     ///
     /// This constructor produces inspect contents like `"fred"`.
     #[inline]
@@ -50,7 +36,7 @@ impl<'a> State<'a> {
     }
 }
 
-impl<'a> Default for State<'a> {
+impl<'a> Default for Inspect<'a> {
     /// Construct a `State` that will render debug output for the empty slice.
     ///
     /// This constructor produces inspect contents like `""`.
@@ -60,7 +46,7 @@ impl<'a> Default for State<'a> {
     }
 }
 
-impl<'a> Iterator for State<'a> {
+impl<'a> Iterator for Inspect<'a> {
     type Item = char;
 
     #[inline]
@@ -81,7 +67,7 @@ impl<'a> Iterator for State<'a> {
     }
 }
 
-impl<'a> FusedIterator for State<'a> {}
+impl<'a> FusedIterator for Inspect<'a> {}
 
 #[cfg(test)]
 mod tests {

--- a/spinoso-string/src/enc/binary/inspect.rs
+++ b/spinoso-string/src/enc/binary/inspect.rs
@@ -37,7 +37,8 @@ impl<'a> Inspect<'a> {
 }
 
 impl<'a> Default for Inspect<'a> {
-    /// Construct a `State` that will render debug output for the empty slice.
+    /// Construct an `Inspect` that will render debug output for the empty
+    /// slice.
     ///
     /// This constructor produces inspect contents like `""`.
     #[inline]

--- a/spinoso-string/src/enc/binary/mod.rs
+++ b/spinoso-string/src/enc/binary/mod.rs
@@ -12,8 +12,11 @@ use crate::ord::OrdError;
 
 mod eq;
 mod impls;
+mod inspect;
 #[cfg(feature = "std")]
 mod io;
+
+pub use inspect::Inspect;
 
 #[allow(clippy::module_name_repetitions)]
 #[derive(Default, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]

--- a/spinoso-string/src/enc/inspect.rs
+++ b/spinoso-string/src/enc/inspect.rs
@@ -1,0 +1,59 @@
+use core::iter::FusedIterator;
+
+use super::{ascii, binary, utf8};
+
+#[derive(Default, Debug, Clone)]
+#[must_use = "this `Inspect` is an `Iterator`, which should be consumed if constructed"]
+pub struct Inspect<'a>(State<'a>);
+
+impl<'a> From<&'a ascii::AsciiString> for Inspect<'a> {
+    #[inline]
+    fn from(value: &'a ascii::AsciiString) -> Self {
+        Self(State::Ascii(value.into()))
+    }
+}
+
+impl<'a> From<&'a binary::BinaryString> for Inspect<'a> {
+    #[inline]
+    fn from(value: &'a binary::BinaryString) -> Self {
+        Self(State::Binary(value.into()))
+    }
+}
+
+impl<'a> From<&'a utf8::Utf8String> for Inspect<'a> {
+    #[inline]
+    fn from(value: &'a utf8::Utf8String) -> Self {
+        Self(State::Utf8(value.into()))
+    }
+}
+
+#[derive(Debug, Clone)]
+enum State<'a> {
+    Ascii(ascii::Inspect<'a>),
+    Binary(binary::Inspect<'a>),
+    Utf8(utf8::Inspect<'a>),
+}
+
+impl<'a> Default for State<'a> {
+    /// Construct a `State` that will render debug output for the empty slice.
+    ///
+    /// This constructor produces inspect contents like `""`.
+    #[inline]
+    fn default() -> Self {
+        Self::Ascii(Default::default())
+    }
+}
+
+impl<'a> Iterator for Inspect<'a> {
+    type Item = char;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match &mut self.0 {
+            State::Ascii(iter) => iter.next(),
+            State::Binary(iter) => iter.next(),
+            State::Utf8(iter) => iter.next(),
+        }
+    }
+}
+
+impl<'a> FusedIterator for Inspect<'a> {}

--- a/spinoso-string/src/enc/inspect.rs
+++ b/spinoso-string/src/enc/inspect.rs
@@ -40,7 +40,7 @@ impl<'a> Default for State<'a> {
     /// This constructor produces inspect contents like `""`.
     #[inline]
     fn default() -> Self {
-        Self::Ascii(Default::default())
+        Self::Ascii(ascii::Inspect::default())
     }
 }
 

--- a/spinoso-string/src/enc/mod.rs
+++ b/spinoso-string/src/enc/mod.rs
@@ -18,9 +18,12 @@ use crate::ord::OrdError;
 mod ascii;
 mod binary;
 mod impls;
+mod inspect;
 #[cfg(feature = "std")]
 mod io;
 mod utf8;
+
+pub use inspect::Inspect;
 
 #[derive(Clone)]
 pub enum EncodedString {
@@ -302,6 +305,15 @@ impl EncodedString {
             EncodedString::Ascii(inner) => inner.bytes(),
             EncodedString::Binary(inner) => inner.bytes(),
             EncodedString::Utf8(inner) => inner.bytes(),
+        }
+    }
+
+    #[inline]
+    pub fn inspect(&self) -> Inspect<'_> {
+        match self {
+            EncodedString::Ascii(inner) => inner.into(),
+            EncodedString::Binary(inner) => inner.into(),
+            EncodedString::Utf8(inner) => inner.into(),
         }
     }
 

--- a/spinoso-string/src/enc/utf8/inspect.rs
+++ b/spinoso-string/src/enc/utf8/inspect.rs
@@ -1,0 +1,387 @@
+use core::iter::FusedIterator;
+
+use scolapasta_string_escape::{is_ascii_char_with_escape, InvalidUtf8ByteSequence};
+
+use super::Utf8String;
+use crate::inspect::Flags;
+
+#[derive(Default, Debug, Clone)]
+#[must_use = "this `Inspect` is an `Iterator`, which should be consumed if constructed"]
+pub struct Inspect<'a>(State<'a>);
+
+impl<'a> From<&'a Utf8String> for Inspect<'a> {
+    #[inline]
+    fn from(value: &'a Utf8String) -> Self {
+        Self(State::new(value.as_slice()))
+    }
+}
+
+impl<'a> Iterator for Inspect<'a> {
+    type Item = char;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+}
+
+impl<'a> FusedIterator for Inspect<'a> {}
+
+#[derive(Debug, Clone)]
+#[must_use = "this `State` is an `Iterator`, which should be consumed if constructed"]
+struct State<'a> {
+    flags: Flags,
+    byte_literal: InvalidUtf8ByteSequence,
+    bytes: &'a [u8],
+}
+
+impl<'a> State<'a> {
+    /// Construct a `State` for the given byte slice.
+    ///
+    /// This constructor produces inspect contents like `"fred"`.
+    #[inline]
+    fn new(bytes: &'a [u8]) -> Self {
+        Self {
+            flags: Flags::DEFAULT,
+            byte_literal: InvalidUtf8ByteSequence::new(),
+            bytes,
+        }
+    }
+}
+
+impl<'a> Default for State<'a> {
+    /// Construct a `State` that will render debug output for the empty slice.
+    ///
+    /// This constructor produces inspect contents like `""`.
+    #[inline]
+    fn default() -> Self {
+        Self::new(b"")
+    }
+}
+
+impl<'a> Iterator for State<'a> {
+    type Item = char;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some(ch) = self.flags.emit_leading_quote() {
+            return Some(ch);
+        }
+        if let Some(ch) = self.byte_literal.next() {
+            return Some(ch);
+        }
+        let (ch, size) = bstr::decode_utf8(self.bytes);
+        match ch {
+            Some(ch) if is_ascii_char_with_escape(ch) => {
+                let (ascii_byte, remainder) = self.bytes.split_at(size);
+                // This conversion is safe to unwrap due to the documented
+                // behavior of `bstr::decode_utf8` and `InvalidUtf8ByteSequence`
+                // which indicate that `size` is always in the range of 0..=3.
+                //
+                // While not an invalid byte, we rely on the documented
+                // behavior of `InvalidUtf8ByteSequence` to always escape
+                // any bytes given to it.
+                self.byte_literal = InvalidUtf8ByteSequence::try_from(ascii_byte).unwrap();
+                self.bytes = remainder;
+                return self.byte_literal.next();
+            }
+            Some(ch) => {
+                self.bytes = &self.bytes[size..];
+                return Some(ch);
+            }
+            None if size == 0 => {}
+            None => {
+                let (invalid_utf8_bytes, remainder) = self.bytes.split_at(size);
+                // This conversion is safe to unwrap due to the documented
+                // behavior of `bstr::decode_utf8` and `InvalidUtf8ByteSequence`
+                // which indicate that `size` is always in the range of 0..=3.
+                self.byte_literal = InvalidUtf8ByteSequence::try_from(invalid_utf8_bytes).unwrap();
+                self.bytes = remainder;
+                return self.byte_literal.next();
+            }
+        };
+        if let Some(ch) = self.flags.emit_trailing_quote() {
+            return Some(ch);
+        }
+        None
+    }
+}
+
+impl<'a> FusedIterator for State<'a> {}
+
+#[cfg(test)]
+mod tests {
+    use alloc::string::{String, ToString};
+
+    use super::{Inspect, Utf8String};
+
+    #[test]
+    fn empty() {
+        let s = "";
+        let s = Utf8String::new(s.to_string().into_bytes());
+        let inspect = Inspect::from(&s);
+
+        assert_eq!(inspect.collect::<String>(), r#""""#);
+    }
+
+    #[test]
+    fn fred() {
+        let s = "fred";
+        let s = Utf8String::new(s.to_string().into_bytes());
+        let inspect = Inspect::from(&s);
+
+        assert_eq!(inspect.collect::<String>(), r#""fred""#);
+    }
+
+    #[test]
+    fn invalid_utf8_byte() {
+        let s = b"\xFF";
+        let s = Utf8String::new(s.to_vec());
+        let inspect = Inspect::from(&s);
+
+        assert_eq!(inspect.collect::<String>(), r#""\xFF""#);
+    }
+
+    #[test]
+    fn invalid_utf8() {
+        let s = b"invalid-\xFF-utf8";
+        let s = Utf8String::new(s.to_vec());
+        let inspect = Inspect::from(&s);
+
+        assert_eq!(inspect.collect::<String>(), r#""invalid-\xFF-utf8""#);
+    }
+
+    #[test]
+    fn quote_collect() {
+        let s = r#"a"b"#;
+        let s = Utf8String::new(s.to_string().into_bytes());
+        let inspect = Inspect::from(&s);
+        assert_eq!(inspect.collect::<String>(), r#""a\"b""#);
+    }
+
+    #[test]
+    fn quote_iter() {
+        let s = r#"a"b"#;
+        let s = Utf8String::new(s.to_string().into_bytes());
+        let mut inspect = Inspect::from(&s);
+
+        assert_eq!(inspect.next(), Some('"'));
+        assert_eq!(inspect.next(), Some('a'));
+        assert_eq!(inspect.next(), Some('\\'));
+        assert_eq!(inspect.next(), Some('"'));
+        assert_eq!(inspect.next(), Some('b'));
+        assert_eq!(inspect.next(), Some('"'));
+        assert_eq!(inspect.next(), None);
+    }
+
+    #[test]
+    fn emoji() {
+        let s = "💎";
+        let s = Utf8String::new(s.to_string().into_bytes());
+        let inspect = Inspect::from(&s);
+
+        assert_eq!(inspect.collect::<String>(), "\"💎\"");
+    }
+
+    #[test]
+    fn emoji_global() {
+        let s = "$💎";
+        let s = Utf8String::new(s.to_string().into_bytes());
+        let inspect = Inspect::from(&s);
+
+        assert_eq!(inspect.collect::<String>(), "\"$💎\"");
+    }
+
+    #[test]
+    fn emoji_ivar() {
+        let s = "@💎";
+        let s = Utf8String::new(s.to_string().into_bytes());
+        let inspect = Inspect::from(&s);
+
+        assert_eq!(inspect.collect::<String>(), "\"@💎\"");
+    }
+
+    #[test]
+    fn emoji_cvar() {
+        let s = "@@💎";
+        let s = Utf8String::new(s.to_string().into_bytes());
+        let inspect = Inspect::from(&s);
+
+        assert_eq!(inspect.collect::<String>(), "\"@@💎\"");
+    }
+
+    #[test]
+    fn unicode_replacement_char() {
+        let s = "�";
+        let s = Utf8String::new(s.to_string().into_bytes());
+        let inspect = Inspect::from(&s);
+
+        assert_eq!(inspect.collect::<String>(), "\"�\"");
+    }
+
+    #[test]
+    fn unicode_replacement_char_global() {
+        let s = "$�";
+        let s = Utf8String::new(s.to_string().into_bytes());
+        let inspect = Inspect::from(&s);
+
+        assert_eq!(inspect.collect::<String>(), "\"$�\"");
+    }
+
+    #[test]
+    fn unicode_replacement_char_ivar() {
+        let s = "@�";
+        let s = Utf8String::new(s.to_string().into_bytes());
+        let inspect = Inspect::from(&s);
+
+        assert_eq!(inspect.collect::<String>(), "\"@�\"");
+    }
+
+    #[test]
+    fn unicode_replacement_char_cvar() {
+        let s = "@@�";
+        let s = Utf8String::new(s.to_string().into_bytes());
+        let inspect = Inspect::from(&s);
+
+        assert_eq!(inspect.collect::<String>(), "\"@@�\"");
+    }
+
+    #[test]
+    fn escape_slash() {
+        let s = r"\";
+        let s = Utf8String::new(s.to_string().into_bytes());
+        let inspect = Inspect::from(&s);
+
+        assert_eq!(inspect.collect::<String>(), r#""\\""#);
+    }
+
+    #[test]
+    fn escape_inner_slash() {
+        let s = r"foo\bar";
+        let s = Utf8String::new(s.to_string().into_bytes());
+        let inspect = Inspect::from(&s);
+
+        assert_eq!(inspect.collect::<String>(), r#""foo\\bar""#);
+    }
+
+    #[test]
+    fn nul() {
+        let s = "\0";
+        let s = Utf8String::new(s.to_string().into_bytes());
+        let inspect = Inspect::from(&s);
+
+        assert_eq!(inspect.collect::<String>(), r#""\x00""#);
+    }
+
+    #[test]
+    fn del() {
+        let s = "\x7F";
+        let s = Utf8String::new(s.to_string().into_bytes());
+        let inspect = Inspect::from(&s);
+
+        assert_eq!(inspect.collect::<String>(), r#""\x7F""#);
+    }
+
+    #[test]
+    fn ascii_control() {
+        let test_cases = [
+            ["\x00", r#""\x00""#],
+            ["\x01", r#""\x01""#],
+            ["\x02", r#""\x02""#],
+            ["\x03", r#""\x03""#],
+            ["\x04", r#""\x04""#],
+            ["\x05", r#""\x05""#],
+            ["\x06", r#""\x06""#],
+            ["\x07", r#""\a""#],
+            ["\x08", r#""\b""#],
+            ["\x09", r#""\t""#],
+            ["\x0A", r#""\n""#],
+            ["\x0B", r#""\v""#],
+            ["\x0C", r#""\f""#],
+            ["\x0D", r#""\r""#],
+            ["\x0E", r#""\x0E""#],
+            ["\x0F", r#""\x0F""#],
+            ["\x10", r#""\x10""#],
+            ["\x11", r#""\x11""#],
+            ["\x12", r#""\x12""#],
+            ["\x13", r#""\x13""#],
+            ["\x14", r#""\x14""#],
+            ["\x15", r#""\x15""#],
+            ["\x16", r#""\x16""#],
+            ["\x17", r#""\x17""#],
+            ["\x18", r#""\x18""#],
+            ["\x19", r#""\x19""#],
+            ["\x1A", r#""\x1A""#],
+            ["\x1B", r#""\e""#],
+            ["\x1C", r#""\x1C""#],
+            ["\x1D", r#""\x1D""#],
+            ["\x1E", r#""\x1E""#],
+            ["\x1F", r#""\x1F""#],
+            ["\x20", r#"" ""#],
+        ];
+        for [s, r] in test_cases {
+            let s = Utf8String::new(s.to_string().into_bytes());
+            let inspect = Inspect::from(&s);
+            assert_eq!(inspect.collect::<String>(), r, "For {s:?}, expected {r}");
+        }
+    }
+
+    #[test]
+    fn special_double_quote() {
+        let s = "\x22";
+        let s = Utf8String::new(s.to_string().into_bytes());
+        let inspect = Inspect::from(&s);
+
+        assert_eq!(inspect.collect::<String>(), r#""\"""#);
+
+        let s = "\"";
+        let s = Utf8String::new(s.to_string().into_bytes());
+        let inspect = Inspect::from(&s);
+
+        assert_eq!(inspect.collect::<String>(), r#""\"""#);
+    }
+
+    #[test]
+    fn special_backslash() {
+        let s = "\x5C";
+        let s = Utf8String::new(s.to_string().into_bytes());
+        let inspect = Inspect::from(&s);
+
+        assert_eq!(inspect.collect::<String>(), r#""\\""#);
+
+        let s = "\\";
+        let s = Utf8String::new(s.to_string().into_bytes());
+        let inspect = Inspect::from(&s);
+
+        assert_eq!(inspect.collect::<String>(), r#""\\""#);
+    }
+
+    #[test]
+    fn invalid_utf8_special_global() {
+        let s = b"$-\xFF";
+        let s = Utf8String::new(s.to_vec());
+        let inspect = Inspect::from(&s);
+
+        assert_eq!(inspect.collect::<String>(), r#""$-\xFF""#);
+    }
+
+    #[test]
+    fn replacement_char_special_global() {
+        let s = "$-�";
+        let s = Utf8String::new(s.to_string().into_bytes());
+        let inspect = Inspect::from(&s);
+
+        assert_eq!(inspect.collect::<String>(), "\"$-�\"");
+
+        let s = "$-�a";
+        let s = Utf8String::new(s.to_string().into_bytes());
+        let inspect = Inspect::from(&s);
+
+        assert_eq!(inspect.collect::<String>(), r#""$-�a""#);
+
+        let s = "$-��";
+        let s = Utf8String::new(s.to_string().into_bytes());
+        let inspect = Inspect::from(&s);
+
+        assert_eq!(inspect.collect::<String>(), r#""$-��""#);
+    }
+}

--- a/spinoso-string/src/enc/utf8/inspect.rs
+++ b/spinoso-string/src/enc/utf8/inspect.rs
@@ -67,7 +67,8 @@ impl<'a> Iterator for Inspect<'a> {
                 // While not an invalid byte, we rely on the documented
                 // behavior of `InvalidUtf8ByteSequence` to always escape
                 // any bytes given to it.
-                self.byte_literal = InvalidUtf8ByteSequence::try_from(ascii_byte).unwrap();
+                self.byte_literal =
+                    InvalidUtf8ByteSequence::try_from(ascii_byte).expect("ASCII char should have byte slice length 1");
                 self.bytes = remainder;
                 return self.byte_literal.next();
             }
@@ -81,7 +82,8 @@ impl<'a> Iterator for Inspect<'a> {
                 // This conversion is safe to unwrap due to the documented
                 // behavior of `bstr::decode_utf8` and `InvalidUtf8ByteSequence`
                 // which indicate that `size` is always in the range of 0..=3.
-                self.byte_literal = InvalidUtf8ByteSequence::try_from(invalid_utf8_bytes).unwrap();
+                self.byte_literal = InvalidUtf8ByteSequence::try_from(invalid_utf8_bytes)
+                    .expect("Invalid UTF-8 byte sequence should be at most 3 bytes long");
                 self.bytes = remainder;
                 return self.byte_literal.next();
             }

--- a/spinoso-string/src/enc/utf8/inspect.rs
+++ b/spinoso-string/src/enc/utf8/inspect.rs
@@ -88,10 +88,7 @@ impl<'a> Iterator for Inspect<'a> {
                 return self.byte_literal.next();
             }
         };
-        if let Some(ch) = self.flags.emit_trailing_quote() {
-            return Some(ch);
-        }
-        None
+        self.flags.emit_trailing_quote()
     }
 }
 

--- a/spinoso-string/src/enc/utf8/inspect.rs
+++ b/spinoso-string/src/enc/utf8/inspect.rs
@@ -5,37 +5,23 @@ use scolapasta_string_escape::{is_ascii_char_with_escape, InvalidUtf8ByteSequenc
 use super::Utf8String;
 use crate::inspect::Flags;
 
-#[derive(Default, Debug, Clone)]
-#[must_use = "this `Inspect` is an `Iterator`, which should be consumed if constructed"]
-pub struct Inspect<'a>(State<'a>);
-
-impl<'a> From<&'a Utf8String> for Inspect<'a> {
-    #[inline]
-    fn from(value: &'a Utf8String) -> Self {
-        Self(State::new(value.as_slice()))
-    }
-}
-
-impl<'a> Iterator for Inspect<'a> {
-    type Item = char;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.0.next()
-    }
-}
-
-impl<'a> FusedIterator for Inspect<'a> {}
-
 #[derive(Debug, Clone)]
-#[must_use = "this `State` is an `Iterator`, which should be consumed if constructed"]
-struct State<'a> {
+#[must_use = "this `Inspect` is an `Iterator`, which should be consumed if constructed"]
+pub struct Inspect<'a> {
     flags: Flags,
     byte_literal: InvalidUtf8ByteSequence,
     bytes: &'a [u8],
 }
 
-impl<'a> State<'a> {
-    /// Construct a `State` for the given byte slice.
+impl<'a> From<&'a Utf8String> for Inspect<'a> {
+    #[inline]
+    fn from(value: &'a Utf8String) -> Self {
+        Self::new(value.as_slice())
+    }
+}
+
+impl<'a> Inspect<'a> {
+    /// Construct a UTF-8 `Inspect` for the given byte slice.
     ///
     /// This constructor produces inspect contents like `"fred"`.
     #[inline]
@@ -48,8 +34,9 @@ impl<'a> State<'a> {
     }
 }
 
-impl<'a> Default for State<'a> {
-    /// Construct a `State` that will render debug output for the empty slice.
+impl<'a> Default for Inspect<'a> {
+    /// Construct an `Inspect` that will render debug output for the empty
+    /// slice.
     ///
     /// This constructor produces inspect contents like `""`.
     #[inline]
@@ -58,7 +45,7 @@ impl<'a> Default for State<'a> {
     }
 }
 
-impl<'a> Iterator for State<'a> {
+impl<'a> Iterator for Inspect<'a> {
     type Item = char;
 
     #[inline]
@@ -106,7 +93,7 @@ impl<'a> Iterator for State<'a> {
     }
 }
 
-impl<'a> FusedIterator for State<'a> {}
+impl<'a> FusedIterator for Inspect<'a> {}
 
 #[cfg(test)]
 mod tests {

--- a/spinoso-string/src/enc/utf8/mod.rs
+++ b/spinoso-string/src/enc/utf8/mod.rs
@@ -12,8 +12,11 @@ use crate::ord::OrdError;
 
 mod eq;
 mod impls;
+mod inspect;
 #[cfg(feature = "std")]
 mod io;
+
+pub use inspect::Inspect;
 
 #[allow(clippy::module_name_repetitions)]
 #[derive(Default, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]

--- a/spinoso-string/src/inspect.rs
+++ b/spinoso-string/src/inspect.rs
@@ -1,7 +1,7 @@
 use core::fmt;
 use core::iter::FusedIterator;
 
-use scolapasta_string_escape::{is_ascii_char_with_escape, InvalidUtf8ByteSequence};
+use crate::enc;
 
 /// An iterator that yields a debug representation of a `String` and its byte
 /// contents as a sequence of `char`s.
@@ -31,7 +31,8 @@ use scolapasta_string_escape::{is_ascii_char_with_escape, InvalidUtf8ByteSequenc
 /// # extern crate alloc;
 /// use alloc::string::String;
 /// # use spinoso_string::Inspect;
-/// let inspect = Inspect::from("spinoso");
+/// let s = spinoso_string::String::from("spinoso");
+/// let inspect = s.inspect();
 /// let debug = inspect.collect::<String>();
 /// assert_eq!(debug, "\"spinoso\"");
 /// ```
@@ -42,9 +43,22 @@ use scolapasta_string_escape::{is_ascii_char_with_escape, InvalidUtf8ByteSequenc
 /// # extern crate alloc;
 /// use alloc::string::String;
 /// # use spinoso_string::Inspect;
-/// let inspect = Inspect::from(&b"invalid-\xFF-utf8"[..]);
+/// let s = spinoso_string::String::utf8(b"invalid-\xFF-utf8".to_vec());
+/// let inspect = s.inspect();
 /// let debug = inspect.collect::<String>();
 /// assert_eq!(debug, r#""invalid-\xFF-utf8""#);
+/// ```
+///
+/// To inspect a binary string:
+///
+/// ```
+/// # extern crate alloc;
+/// use alloc::string::String;
+/// # use spinoso_string::Inspect;
+/// let s = spinoso_string::String::binary("💎".as_bytes().to_vec());
+/// let inspect = s.inspect();
+/// let debug = inspect.collect::<String>();
+/// assert_eq!(debug, r#""\xF0\x9F\x92\x8E""#);
 /// ```
 ///
 /// [`inspect`]: crate::String::inspect
@@ -53,20 +67,11 @@ use scolapasta_string_escape::{is_ascii_char_with_escape, InvalidUtf8ByteSequenc
 /// [`write_into`]: Self::write_into
 #[derive(Default, Debug, Clone)]
 #[must_use = "this `Inspect` is an `Iterator`, which should be consumed if constructed"]
-#[cfg_attr(docsrs, doc(cfg(feature = "inspect")))]
-pub struct Inspect<'a>(State<'a>);
+pub struct Inspect<'a>(enc::Inspect<'a>);
 
-impl<'a> From<&'a str> for Inspect<'a> {
-    #[inline]
-    fn from(value: &'a str) -> Self {
-        Self::from(value.as_bytes())
-    }
-}
-
-impl<'a> From<&'a [u8]> for Inspect<'a> {
-    #[inline]
-    fn from(value: &'a [u8]) -> Self {
-        Self(State::new(value))
+impl<'a> From<enc::Inspect<'a>> for Inspect<'a> {
+    fn from(value: enc::Inspect<'a>) -> Self {
+        Self(value)
     }
 }
 
@@ -75,12 +80,6 @@ impl<'a> Iterator for Inspect<'a> {
 
     fn next(&mut self) -> Option<Self::Item> {
         self.0.next()
-    }
-}
-
-impl<'a> DoubleEndedIterator for Inspect<'a> {
-    fn next_back(&mut self) -> Option<Self::Item> {
-        self.0.next_back()
     }
 }
 
@@ -105,15 +104,19 @@ impl<'a> Inspect<'a> {
     /// # Examples
     ///
     /// ```
+    /// # extern crate alloc;
     /// # use core::fmt::Write;
+    /// use alloc::string::String;
     /// # use spinoso_string::Inspect;
     /// let mut buf = String::new();
-    /// let iter = Inspect::from("spinoso");
+    /// let s = spinoso_string::String::from("spinoso");
+    /// let iter = s.inspect();
     /// iter.format_into(&mut buf);
     /// assert_eq!(buf, "\"spinoso\"");
     ///
     /// let mut buf = String::new();
-    /// let iter = Inspect::from(&b"\xFF"[..]);
+    /// let s = spinoso_string::String::utf8(b"\xFF".to_vec());
+    /// let iter = s.inspect();
     /// iter.format_into(&mut buf);
     /// assert_eq!(buf, r#""\xFF""#);
     /// ```
@@ -148,14 +151,16 @@ impl<'a> Inspect<'a> {
     ///
     /// ```
     /// # use std::io::Write;
-    /// # use spinoso_string::Inspect;
+    /// # use spinoso_string::{Inspect, String};
     /// let mut buf = Vec::new();
-    /// let iter = Inspect::from("spinoso");
+    /// let s = String::from("spinoso");
+    /// let iter = s.inspect();
     /// iter.write_into(&mut buf);
     /// assert_eq!(buf, &b"\"spinoso\""[..]);
     ///
     /// let mut buf = Vec::new();
-    /// let iter = Inspect::from(&b"\xFF"[..]);
+    /// let s = String::utf8(b"\xFF".to_vec());
+    /// let iter = s.inspect();
     /// iter.write_into(&mut buf);
     /// assert_eq!(buf, &[b'"', b'\\', b'x', b'F', b'F', b'"']);
     /// ```
@@ -178,8 +183,10 @@ impl<'a> Inspect<'a> {
     }
 }
 
+/// Helper iterator-ish struct for tracking when to emit wrapping quotes for
+/// inspect iterators.
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-struct Flags {
+pub struct Flags {
     bits: u8,
 }
 
@@ -189,12 +196,12 @@ impl Flags {
     const EMIT_TRAILING_QUOTE: Self = Self { bits: 0b0000_0010 };
 
     // Initial states
-    const DEFAULT: Self = Self {
+    pub const DEFAULT: Self = Self {
         bits: Self::EMIT_LEADING_QUOTE.bits | Self::EMIT_TRAILING_QUOTE.bits,
     };
 
     #[inline]
-    fn emit_leading_quote(&mut self) -> Option<char> {
+    pub fn emit_leading_quote(&mut self) -> Option<char> {
         if (self.bits & Self::EMIT_LEADING_QUOTE.bits) == Self::EMIT_LEADING_QUOTE.bits {
             self.bits &= !Self::EMIT_LEADING_QUOTE.bits;
             Some('"')
@@ -204,7 +211,7 @@ impl Flags {
     }
 
     #[inline]
-    fn emit_trailing_quote(&mut self) -> Option<char> {
+    pub fn emit_trailing_quote(&mut self) -> Option<char> {
         if (self.bits & Self::EMIT_TRAILING_QUOTE.bits) == Self::EMIT_TRAILING_QUOTE.bits {
             self.bits &= !Self::EMIT_TRAILING_QUOTE.bits;
             Some('"')
@@ -214,427 +221,12 @@ impl Flags {
     }
 }
 
-#[derive(Debug, Clone)]
-#[must_use = "this `State` is an `Iterator`, which should be consumed if constructed"]
-struct State<'a> {
-    flags: Flags,
-    forward_byte_literal: InvalidUtf8ByteSequence,
-    bytes: &'a [u8],
-    reverse_byte_literal: InvalidUtf8ByteSequence,
-}
-
-impl<'a> State<'a> {
-    /// Construct a `State` for the given byte slice.
-    ///
-    /// This constructor produces inspect contents like `"fred"`.
-    #[inline]
-    fn new(bytes: &'a [u8]) -> Self {
-        Self {
-            flags: Flags::DEFAULT,
-            forward_byte_literal: InvalidUtf8ByteSequence::new(),
-            bytes,
-            reverse_byte_literal: InvalidUtf8ByteSequence::new(),
-        }
-    }
-}
-
-impl<'a> Default for State<'a> {
-    /// Construct a `State` that will render debug output for the empty slice.
-    ///
-    /// This constructor produces inspect contents like `""`.
-    #[inline]
-    fn default() -> Self {
-        Self::new(b"")
-    }
-}
-
-impl<'a> Iterator for State<'a> {
-    type Item = char;
-
-    #[inline]
-    fn next(&mut self) -> Option<Self::Item> {
-        if let Some(ch) = self.flags.emit_leading_quote() {
-            return Some(ch);
-        }
-        if let Some(ch) = self.forward_byte_literal.next() {
-            return Some(ch);
-        }
-        let (ch, size) = bstr::decode_utf8(self.bytes);
-        match ch {
-            Some(ch) if is_ascii_char_with_escape(ch) => {
-                let (ascii_byte, remainder) = self.bytes.split_at(size);
-                // This conversion is safe to unwrap due to the documented
-                // behavior of `bstr::decode_utf8` and `InvalidUtf8ByteSequence`
-                // which indicate that `size` is always in the range of 0..=3.
-                //
-                // While not an invalid byte, we rely on the documented
-                // behavior of `InvalidUtf8ByteSequence` to always escape
-                // any bytes given to it.
-                self.forward_byte_literal = InvalidUtf8ByteSequence::try_from(ascii_byte).unwrap();
-                self.bytes = remainder;
-                return self.forward_byte_literal.next();
-            }
-            Some(ch) => {
-                self.bytes = &self.bytes[size..];
-                return Some(ch);
-            }
-            None if size == 0 => {}
-            None => {
-                let (invalid_utf8_bytes, remainder) = self.bytes.split_at(size);
-                // This conversion is safe to unwrap due to the documented
-                // behavior of `bstr::decode_utf8` and `InvalidUtf8ByteSequence`
-                // which indicate that `size` is always in the range of 0..=3.
-                self.forward_byte_literal = InvalidUtf8ByteSequence::try_from(invalid_utf8_bytes).unwrap();
-                self.bytes = remainder;
-                return self.forward_byte_literal.next();
-            }
-        };
-        if let Some(ch) = self.reverse_byte_literal.next() {
-            return Some(ch);
-        }
-        if let Some(ch) = self.flags.emit_trailing_quote() {
-            return Some(ch);
-        }
-        None
-    }
-}
-
-impl<'a> DoubleEndedIterator for State<'a> {
-    fn next_back(&mut self) -> Option<Self::Item> {
-        if let Some(ch) = self.flags.emit_trailing_quote() {
-            return Some(ch);
-        }
-        if let Some(ch) = self.reverse_byte_literal.next_back() {
-            return Some(ch);
-        }
-        let (ch, size) = bstr::decode_last_utf8(self.bytes);
-        match ch {
-            Some(ch) if is_ascii_char_with_escape(ch) => {
-                let (remainder, ascii_byte) = self.bytes.split_at(self.bytes.len() - size);
-                // This conversion is safe to unwrap due to the documented
-                // behavior of `bstr::decode_utf8` and `InvalidUtf8ByteSequence`
-                // which indicate that `size` is always in the range of 0..=3.
-                //
-                // While not an invalid byte, we rely on the documented
-                // behavior of `InvalidUtf8ByteSequence` to always escape
-                // any bytes given to it.
-                self.reverse_byte_literal = InvalidUtf8ByteSequence::try_from(ascii_byte).unwrap();
-                self.bytes = remainder;
-                return self.reverse_byte_literal.next_back();
-            }
-            Some(ch) => {
-                self.bytes = &self.bytes[..self.bytes.len() - size];
-                return Some(ch);
-            }
-            None if size == 0 => {}
-            None => {
-                let (remainder, invalid_utf8_bytes) = self.bytes.split_at(self.bytes.len() - size);
-                // This conversion is safe to unwrap due to the documented
-                // behavior of `bstr::decode_utf8` and `InvalidUtf8ByteSequence`
-                // which indicate that `size` is always in the range of 0..=3.
-                self.reverse_byte_literal = InvalidUtf8ByteSequence::try_from(invalid_utf8_bytes).unwrap();
-                self.bytes = remainder;
-                return self.reverse_byte_literal.next_back();
-            }
-        };
-        if let Some(ch) = self.forward_byte_literal.next_back() {
-            return Some(ch);
-        }
-        if let Some(ch) = self.flags.emit_leading_quote() {
-            return Some(ch);
-        }
-        None
-    }
-}
-
-impl<'a> FusedIterator for State<'a> {}
-
 #[cfg(test)]
 mod tests {
-    use alloc::string::String;
-
-    use super::Inspect;
-
-    #[test]
-    fn empty() {
-        let inspect = Inspect::from("");
-        let debug = inspect.collect::<String>();
-        assert_eq!(debug, r#""""#);
-    }
-
-    #[test]
-    fn empty_backwards() {
-        let mut inspect = Inspect::from("");
-        assert_eq!(inspect.next_back(), Some('"'));
-        assert_eq!(inspect.next_back(), Some('"'));
-        assert_eq!(inspect.next_back(), None);
-        assert_eq!(inspect.next(), None);
-
-        let mut inspect = Inspect::from("");
-        assert_eq!(inspect.next(), Some('"'));
-        assert_eq!(inspect.next_back(), Some('"'));
-        assert_eq!(inspect.next_back(), None);
-        assert_eq!(inspect.next(), None);
-
-        let mut inspect = Inspect::from("");
-        assert_eq!(inspect.next(), Some('"'));
-        assert_eq!(inspect.next(), Some('"'));
-        assert_eq!(inspect.next_back(), None);
-        assert_eq!(inspect.next(), None);
-    }
-
-    #[test]
-    fn fred() {
-        let inspect = Inspect::from("fred");
-        let debug = inspect.collect::<String>();
-        assert_eq!(debug, "\"fred\"");
-    }
-
-    #[test]
-    fn fred_backwards() {
-        let mut inspect = Inspect::from("fred");
-        assert_eq!(inspect.next_back(), Some('"'));
-        assert_eq!(inspect.next_back(), Some('d'));
-        assert_eq!(inspect.next_back(), Some('e'));
-        assert_eq!(inspect.next_back(), Some('r'));
-        assert_eq!(inspect.next_back(), Some('f'));
-        assert_eq!(inspect.next_back(), Some('"'));
-        assert_eq!(inspect.next_back(), None);
-        assert_eq!(inspect.next(), None);
-    }
-
-    #[test]
-    fn invalid_utf8_byte() {
-        assert_eq!(Inspect::from(&b"\xFF"[..]).collect::<String>(), r#""\xFF""#);
-    }
-
-    #[test]
-    fn invalid_utf8() {
-        let inspect = Inspect::from(&b"invalid-\xFF-utf8"[..]);
-        let debug = inspect.collect::<String>();
-        assert_eq!(debug, r#""invalid-\xFF-utf8""#);
-    }
-
-    #[test]
-    fn invalid_utf8_backwards() {
-        let mut inspect = Inspect::from(&b"invalid-\xFF-utf8"[..]);
-        assert_eq!(inspect.next_back(), Some('"'));
-        assert_eq!(inspect.next_back(), Some('8'));
-        assert_eq!(inspect.next_back(), Some('f'));
-        assert_eq!(inspect.next_back(), Some('t'));
-        assert_eq!(inspect.next_back(), Some('u'));
-        assert_eq!(inspect.next_back(), Some('-'));
-        assert_eq!(inspect.next_back(), Some('F'));
-        assert_eq!(inspect.next_back(), Some('F'));
-        assert_eq!(inspect.next_back(), Some('x'));
-        assert_eq!(inspect.next_back(), Some('\\'));
-        assert_eq!(inspect.next_back(), Some('-'));
-        assert_eq!(inspect.next_back(), Some('d'));
-        assert_eq!(inspect.next_back(), Some('i'));
-        assert_eq!(inspect.next_back(), Some('l'));
-        assert_eq!(inspect.next_back(), Some('a'));
-        assert_eq!(inspect.next_back(), Some('v'));
-        assert_eq!(inspect.next_back(), Some('n'));
-        assert_eq!(inspect.next_back(), Some('i'));
-        assert_eq!(inspect.next_back(), Some('"'));
-        assert_eq!(inspect.next_back(), None);
-        assert_eq!(inspect.next(), None);
-    }
-
-    #[test]
-    fn quoted() {
-        let mut inspect = Inspect::from(r#"a"b"#);
-        assert_eq!(inspect.next(), Some('"'));
-        assert_eq!(inspect.next(), Some('a'));
-        assert_eq!(inspect.next(), Some('\\'));
-        assert_eq!(inspect.next(), Some('"'));
-        assert_eq!(inspect.next(), Some('b'));
-        assert_eq!(inspect.next(), Some('"'));
-
-        assert_eq!(Inspect::from(r#"a"b"#).collect::<String>(), r#""a\"b""#);
-    }
-
-    #[test]
-    fn quote_backwards() {
-        let mut inspect = Inspect::from(r#"a"b"#);
-        assert_eq!(inspect.next_back(), Some('"'));
-        assert_eq!(inspect.next_back(), Some('b'));
-        assert_eq!(inspect.next_back(), Some('"'));
-        assert_eq!(inspect.next_back(), Some('\\'));
-        assert_eq!(inspect.next_back(), Some('a'));
-        assert_eq!(inspect.next_back(), Some('"'));
-        assert_eq!(inspect.next_back(), None);
-    }
-
-    #[test]
-    fn quote_double_ended() {
-        let mut inspect = Inspect::from(r#"a"b"#);
-        assert_eq!(inspect.next(), Some('"'));
-        assert_eq!(inspect.next(), Some('a'));
-        assert_eq!(inspect.next(), Some('\\'));
-        assert_eq!(inspect.next_back(), Some('"'));
-        assert_eq!(inspect.next_back(), Some('b'));
-        assert_eq!(inspect.next_back(), Some('"'));
-        assert_eq!(inspect.next(), None);
-
-        let mut inspect = Inspect::from(r#"a"b"#);
-        assert_eq!(inspect.next(), Some('"'));
-        assert_eq!(inspect.next(), Some('a'));
-        assert_eq!(inspect.next(), Some('\\'));
-        assert_eq!(inspect.next_back(), Some('"'));
-        assert_eq!(inspect.next_back(), Some('b'));
-        assert_eq!(inspect.next_back(), Some('"'));
-        assert_eq!(inspect.next_back(), None);
-
-        let mut inspect = Inspect::from(r#"a"b"#);
-        assert_eq!(inspect.next_back(), Some('"'));
-        assert_eq!(inspect.next_back(), Some('b'));
-        assert_eq!(inspect.next_back(), Some('"'));
-        assert_eq!(inspect.next(), Some('"'));
-        assert_eq!(inspect.next(), Some('a'));
-        assert_eq!(inspect.next(), Some('\\'));
-        assert_eq!(inspect.next(), None);
-
-        let mut inspect = Inspect::from(r#"a"b"#);
-        assert_eq!(inspect.next_back(), Some('"'));
-        assert_eq!(inspect.next_back(), Some('b'));
-        assert_eq!(inspect.next_back(), Some('"'));
-        assert_eq!(inspect.next(), Some('"'));
-        assert_eq!(inspect.next(), Some('a'));
-        assert_eq!(inspect.next(), Some('\\'));
-        assert_eq!(inspect.next_back(), None);
-
-        let mut inspect = Inspect::from(r#"a"b"#);
-        assert_eq!(inspect.next_back(), Some('"'));
-        assert_eq!(inspect.next_back(), Some('b'));
-        assert_eq!(inspect.next_back(), Some('"'));
-        assert_eq!(inspect.next(), Some('"'));
-        assert_eq!(inspect.next_back(), Some('\\'));
-
-        let mut inspect = Inspect::from(r#"a"b"#);
-        assert_eq!(inspect.next(), Some('"'));
-        assert_eq!(inspect.next(), Some('a'));
-        assert_eq!(inspect.next(), Some('\\'));
-        assert_eq!(inspect.next_back(), Some('"'));
-        assert_eq!(inspect.next(), Some('"'));
-    }
-
-    #[test]
-    fn emoji() {
-        assert_eq!(Inspect::from("💎").collect::<String>(), "\"💎\"");
-        assert_eq!(Inspect::from("$💎").collect::<String>(), "\"$💎\"");
-        assert_eq!(Inspect::from("@💎").collect::<String>(), "\"@💎\"");
-        assert_eq!(Inspect::from("@@💎").collect::<String>(), "\"@@💎\"");
-    }
-
-    #[test]
-    fn unicode_replacement_char() {
-        assert_eq!(Inspect::from("�").collect::<String>(), "\"�\"");
-        assert_eq!(Inspect::from("$�").collect::<String>(), "\"$�\"");
-        assert_eq!(Inspect::from("@�").collect::<String>(), "\"@�\"");
-        assert_eq!(Inspect::from("@@�").collect::<String>(), "\"@@�\"");
-
-        assert_eq!(Inspect::from("abc�").collect::<String>(), "\"abc�\"");
-        assert_eq!(Inspect::from("$abc�").collect::<String>(), "\"$abc�\"");
-        assert_eq!(Inspect::from("@abc�").collect::<String>(), "\"@abc�\"");
-        assert_eq!(Inspect::from("@@abc�").collect::<String>(), "\"@@abc�\"");
-    }
-
-    #[test]
-    fn escape_slash() {
-        assert_eq!(Inspect::from("\\").collect::<String>(), r#""\\""#);
-        assert_eq!(Inspect::from("foo\\bar").collect::<String>(), r#""foo\\bar""#);
-    }
-
-    #[test]
-    fn escape_slash_backwards() {
-        let mut inspect = Inspect::from("a\\b");
-        assert_eq!(inspect.next_back(), Some('"'));
-        assert_eq!(inspect.next_back(), Some('b'));
-        assert_eq!(inspect.next_back(), Some('\\'));
-        assert_eq!(inspect.next_back(), Some('\\'));
-        assert_eq!(inspect.next_back(), Some('a'));
-        assert_eq!(inspect.next_back(), Some('"'));
-        assert_eq!(inspect.next_back(), None);
-        assert_eq!(inspect.next(), None);
-    }
-
-    #[test]
-    fn nul() {
-        assert_eq!(Inspect::from("\0").collect::<String>(), r#""\x00""#);
-    }
-
-    #[test]
-    fn del() {
-        assert_eq!(Inspect::from("\x7F").collect::<String>(), r#""\x7F""#);
-    }
-
-    #[test]
-    fn ascii_control() {
-        assert_eq!(Inspect::from("\0").collect::<String>(), r#""\x00""#);
-        assert_eq!(Inspect::from("\x01").collect::<String>(), r#""\x01""#);
-        assert_eq!(Inspect::from("\x02").collect::<String>(), r#""\x02""#);
-        assert_eq!(Inspect::from("\x03").collect::<String>(), r#""\x03""#);
-        assert_eq!(Inspect::from("\x04").collect::<String>(), r#""\x04""#);
-        assert_eq!(Inspect::from("\x05").collect::<String>(), r#""\x05""#);
-        assert_eq!(Inspect::from("\x06").collect::<String>(), r#""\x06""#);
-        assert_eq!(Inspect::from("\x07").collect::<String>(), r#""\a""#);
-        assert_eq!(Inspect::from("\x08").collect::<String>(), r#""\b""#);
-        assert_eq!(Inspect::from("\x09").collect::<String>(), r#""\t""#);
-        assert_eq!(Inspect::from("\x0A").collect::<String>(), r#""\n""#);
-        assert_eq!(Inspect::from("\x0B").collect::<String>(), r#""\v""#);
-        assert_eq!(Inspect::from("\x0C").collect::<String>(), r#""\f""#);
-        assert_eq!(Inspect::from("\x0D").collect::<String>(), r#""\r""#);
-        assert_eq!(Inspect::from("\x0E").collect::<String>(), r#""\x0E""#);
-        assert_eq!(Inspect::from("\x0F").collect::<String>(), r#""\x0F""#);
-        assert_eq!(Inspect::from("\x10").collect::<String>(), r#""\x10""#);
-        assert_eq!(Inspect::from("\x11").collect::<String>(), r#""\x11""#);
-        assert_eq!(Inspect::from("\x12").collect::<String>(), r#""\x12""#);
-        assert_eq!(Inspect::from("\x13").collect::<String>(), r#""\x13""#);
-        assert_eq!(Inspect::from("\x14").collect::<String>(), r#""\x14""#);
-        assert_eq!(Inspect::from("\x15").collect::<String>(), r#""\x15""#);
-        assert_eq!(Inspect::from("\x16").collect::<String>(), r#""\x16""#);
-        assert_eq!(Inspect::from("\x17").collect::<String>(), r#""\x17""#);
-        assert_eq!(Inspect::from("\x18").collect::<String>(), r#""\x18""#);
-        assert_eq!(Inspect::from("\x19").collect::<String>(), r#""\x19""#);
-        assert_eq!(Inspect::from("\x1A").collect::<String>(), r#""\x1A""#);
-        assert_eq!(Inspect::from("\x1B").collect::<String>(), r#""\e""#);
-        assert_eq!(Inspect::from("\x1C").collect::<String>(), r#""\x1C""#);
-        assert_eq!(Inspect::from("\x1D").collect::<String>(), r#""\x1D""#);
-        assert_eq!(Inspect::from("\x1E").collect::<String>(), r#""\x1E""#);
-        assert_eq!(Inspect::from("\x1F").collect::<String>(), r#""\x1F""#);
-        assert_eq!(Inspect::from("\x20").collect::<String>(), r#"" ""#);
-    }
-
-    #[test]
-    fn special_escapes() {
-        // double quote
-        assert_eq!(Inspect::from("\x22").collect::<String>(), r#""\"""#);
-        assert_eq!(Inspect::from("\"").collect::<String>(), r#""\"""#);
-        // backslash
-        assert_eq!(Inspect::from("\x5C").collect::<String>(), r#""\\""#);
-        assert_eq!(Inspect::from("\\").collect::<String>(), r#""\\""#);
-    }
-
-    #[test]
-    fn invalid_utf8_special_global() {
-        assert_eq!(Inspect::from(&b"$-\xFF"[..]).collect::<String>(), r#""$-\xFF""#);
-    }
-
-    #[test]
-    fn replacement_char_special_global() {
-        assert_eq!(Inspect::from("$-�").collect::<String>(), "\"$-�\"");
-        assert_eq!(Inspect::from("$-�a").collect::<String>(), r#""$-�a""#);
-        assert_eq!(Inspect::from("$-��").collect::<String>(), r#""$-��""#);
-    }
-}
-
-#[cfg(test)]
-mod specs {
     use super::Flags;
 
     #[test]
-    fn flags_default() {
+    fn flags_default_emit_quotes() {
         let mut flags = Flags::DEFAULT;
 
         assert_eq!(flags.emit_leading_quote(), Some('"'));

--- a/spinoso-string/src/inspect.rs
+++ b/spinoso-string/src/inspect.rs
@@ -69,12 +69,6 @@ use crate::enc;
 #[must_use = "this `Inspect` is an `Iterator`, which should be consumed if constructed"]
 pub struct Inspect<'a>(enc::Inspect<'a>);
 
-impl<'a> From<enc::Inspect<'a>> for Inspect<'a> {
-    fn from(value: enc::Inspect<'a>) -> Self {
-        Self(value)
-    }
-}
-
 impl<'a> Iterator for Inspect<'a> {
     type Item = char;
 
@@ -86,6 +80,10 @@ impl<'a> Iterator for Inspect<'a> {
 impl<'a> FusedIterator for Inspect<'a> {}
 
 impl<'a> Inspect<'a> {
+    pub(crate) fn new(value: enc::Inspect<'a>) -> Self {
+        Self(value)
+    }
+
     /// Write an `Inspect` iterator into the given destination using the debug
     /// representation of the byte buffer associated with a source `String`.
     ///

--- a/spinoso-string/src/lib.rs
+++ b/spinoso-string/src/lib.rs
@@ -1603,7 +1603,7 @@ impl String {
     /// [`String#inspect`]: https://ruby-doc.org/core-2.6.3/String.html#method-i-inspect:
     #[inline]
     pub fn inspect(&self) -> Inspect<'_> {
-        Inspect::from(self.inner.inspect())
+        Inspect::new(self.inner.inspect())
     }
 
     /// Returns the Integer ordinal of a one-character string.

--- a/spinoso-string/src/lib.rs
+++ b/spinoso-string/src/lib.rs
@@ -1596,10 +1596,14 @@ impl String {
     /// This function can be used to implement the Ruby method
     /// [`String#inspect`].
     ///
+    /// This iterator is encoding-aware. This iterator may yield different
+    /// `char`s for the same underlying byte contents depending on the string's
+    /// encoding.
+    ///
     /// [`String#inspect`]: https://ruby-doc.org/core-2.6.3/String.html#method-i-inspect:
     #[inline]
     pub fn inspect(&self) -> Inspect<'_> {
-        Inspect::from(self.as_slice())
+        Inspect::from(self.inner.inspect())
     }
 
     /// Returns the Integer ordinal of a one-character string.


### PR DESCRIPTION
Add encoding support to `String#inspect` and the iterators that implement it.

Binary and ASCII strings always treat non-ASCII bytes as `\xYY` escapes.

This does not address https://github.com/artichoke/artichoke/issues/1350, but moves closer to being able to fix this because UTF-8 iter is separate from bytes as hex codes in ASCII and Binary.

<img width="680" alt="Screen Shot 2022-04-04 at 9 52 30 PM" src="https://user-images.githubusercontent.com/860434/161681306-c6147449-ab61-46de-bf5e-878187aa5733.png">