### PR TITLE
Align spinoso-string#make_binary to be more alike the String#b

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -697,7 +697,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-string"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "bstr",
  "bytecount",

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -33,7 +33,7 @@ spinoso-math = { version = "0.2.0", path = "../spinoso-math", optional = true, d
 spinoso-random = { version = "0.2.0", path = "../spinoso-random", optional = true }
 spinoso-regexp = { version = "0.2.0", path = "../spinoso-regexp", optional = true, default-features = false }
 spinoso-securerandom = { version = "0.2.0", path = "../spinoso-securerandom", optional = true }
-spinoso-string = { version = "0.15.0", path = "../spinoso-string" }
+spinoso-string = { version = "0.16.0", path = "../spinoso-string" }
 spinoso-symbol = { version = "0.1.0", path = "../spinoso-symbol" }
 spinoso-time = { version = "0.2.0", path = "../spinoso-time", optional = true }
 

--- a/artichoke-backend/src/extn/core/string/trampoline.rs
+++ b/artichoke-backend/src/extn/core/string/trampoline.rs
@@ -373,9 +373,7 @@ pub fn is_ascii_only(interp: &mut Artichoke, mut value: Value) -> Result<Value, 
 
 pub fn b(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
     let s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
-    let mut dup = s.clone();
-    dup.make_binary();
-    super::String::alloc_value(dup, interp)
+    super::String::alloc_value(s.to_binary(), interp)
 }
 
 pub fn bytes(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -501,7 +501,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-string"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "bstr",
  "bytecount",

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -632,7 +632,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-string"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "bstr",
  "bytecount",

--- a/spinoso-string/Cargo.toml
+++ b/spinoso-string/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spinoso-string"
-version = "0.15.0"
+version = "0.16.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2021"
 rust-version = "1.58.1"

--- a/spinoso-string/src/lib.rs
+++ b/spinoso-string/src/lib.rs
@@ -1199,7 +1199,7 @@ impl String {
     /// assert_eq!(s.encoding(), Encoding::Utf8);
     /// let b = s.to_binary();
     /// assert_eq!(b.encoding(), Encoding::Binary);
-    /// assert_eq!(s.as_slice(), b.as_slice())
+    /// assert_eq!(s.as_slice(), b.as_slice());
     /// ```
     ///
     /// [`String#b`]: https://ruby-doc.org/core-2.6.3/String.html#method-i-b

--- a/spinoso-string/src/lib.rs
+++ b/spinoso-string/src/lib.rs
@@ -1186,7 +1186,7 @@ impl String {
         self.inner.is_ascii_only()
     }
 
-    /// Change the [encoding] of this `String` to [`Encoding::Binary`].
+    /// Return a newly encoded `String` with [`Encoding::Binary`] [encoding].
     ///
     /// This function can be used to implement the Ruby method [`String#b`].
     ///
@@ -1195,18 +1195,18 @@ impl String {
     /// ```
     /// use spinoso_string::{Encoding, String};
     ///
-    /// let mut s = String::utf8(b"xyz".to_vec());
+    /// let s = String::utf8(b"xyz".to_vec());
     /// assert_eq!(s.encoding(), Encoding::Utf8);
-    /// s.make_binary();
-    /// assert_eq!(s.encoding(), Encoding::Binary);
+    /// let b = s.to_binary();
+    /// assert_eq!(b.encoding(), Encoding::Binary);
     /// ```
     ///
     /// [encoding]: crate::Encoding
     /// [`String#b`]: https://ruby-doc.org/core-2.6.3/String.html#method-i-b
     #[inline]
-    pub fn make_binary(&mut self) {
-        let old = self.inner.as_slice().to_vec();
-        self.inner = EncodedString::new(old, Encoding::Binary);
+    #[must_use]
+    pub fn to_binary(&self) -> Self {
+        String::binary(self.inner.as_slice().to_vec())
     }
 
     /// Returns the length of this `String` in bytes.

--- a/spinoso-string/src/lib.rs
+++ b/spinoso-string/src/lib.rs
@@ -1186,7 +1186,7 @@ impl String {
         self.inner.is_ascii_only()
     }
 
-    /// Return a newly encoded `String` with [`Encoding::Binary`] [encoding].
+    /// Return a newly encoded `String` with [`Encoding::Binary`] encoding.
     ///
     /// This function can be used to implement the Ruby method [`String#b`].
     ///
@@ -1199,9 +1199,9 @@ impl String {
     /// assert_eq!(s.encoding(), Encoding::Utf8);
     /// let b = s.to_binary();
     /// assert_eq!(b.encoding(), Encoding::Binary);
+    /// assert_eq!(s.as_slice(), b.as_slice())
     /// ```
     ///
-    /// [encoding]: crate::Encoding
     /// [`String#b`]: https://ruby-doc.org/core-2.6.3/String.html#method-i-b
     #[inline]
     #[must_use]


### PR DESCRIPTION
Fixes #1720 

As talked about in the issue, the implementation in spinoso-string can be a little confusing when looking at how it is implemented in artichoke-backend. Specifically, spinoso-string is changing the encoding, however `String#b` is actually cloning the String before actually changing, so we might as well just do this directly and return a new value.