### PR TITLE
Override rust-toolchain file in CI

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -41,8 +41,8 @@ jobs:
           rustup toolchain install stable --profile minimal
           echo "::endgroup::"
           echo "::group::set default toolchain"
-          rustup default stable
           rm -rf rust-toolchain
+          rustup default stable
           echo "::endgroup::"
           echo "::group::rustup version"
           rustup -Vv

--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -42,6 +42,7 @@ jobs:
           echo "::endgroup::"
           echo "::group::set default toolchain"
           rustup default stable
+          rm -rf rust-toolchain
           echo "::endgroup::"
           echo "::group::rustup version"
           rustup -Vv

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,6 +25,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Rust toolchain
+        shell: bash
         run: |
           echo "::group::rustup toolchain install"
           rustup toolchain install 1.58.1 --profile minimal

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,6 +31,7 @@ jobs:
           echo "::endgroup::"
           echo "::group::set default toolchain"
           rustup default 1.58.1
+          rm -rf rust-toolchain
           echo "::endgroup::"
           echo "::group::rustup version"
           rustup -Vv
@@ -72,6 +73,7 @@ jobs:
           echo "::endgroup::"
           echo "::group::set default toolchain"
           rustup default 1.58.1
+          rm -rf rust-toolchain
           echo "::endgroup::"
           echo "::group::rustup version"
           rustup -Vv
@@ -141,6 +143,7 @@ jobs:
           echo "::endgroup::"
           echo "::group::set default toolchain"
           rustup default 1.58.1
+          rm -rf rust-toolchain
           echo "::endgroup::"
           echo "::group::rustup version"
           rustup -Vv
@@ -177,6 +180,7 @@ jobs:
           echo "::endgroup::"
           echo "::group::set default toolchain"
           rustup default 1.58.1
+          rm -rf rust-toolchain
           echo "::endgroup::"
           echo "::group::rustup version"
           rustup -Vv
@@ -246,6 +250,7 @@ jobs:
           echo "::endgroup::"
           echo "::group::set default toolchain"
           rustup default 1.58.1
+          rm -rf rust-toolchain
           echo "::endgroup::"
           echo "::group::rustup version"
           rustup -Vv
@@ -326,6 +331,7 @@ jobs:
           echo "::endgroup::"
           echo "::group::set default toolchain"
           rustup default 1.58.1
+          rm -rf rust-toolchain
           echo "::endgroup::"
           echo "::group::rustup version"
           rustup -Vv
@@ -488,6 +494,7 @@ jobs:
           echo "::endgroup::"
           echo "::group::set default toolchain"
           rustup default 1.58.1
+          rm -rf rust-toolchain
           echo "::endgroup::"
           echo "::group::rustup version"
           rustup -Vv

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,8 +30,8 @@ jobs:
           rustup toolchain install 1.58.1 --profile minimal
           echo "::endgroup::"
           echo "::group::set default toolchain"
-          rustup default 1.58.1
           rm -rf rust-toolchain
+          rustup default 1.58.1
           echo "::endgroup::"
           echo "::group::rustup version"
           rustup -Vv
@@ -72,8 +72,8 @@ jobs:
           rustup toolchain install 1.58.1 --profile minimal --component clippy
           echo "::endgroup::"
           echo "::group::set default toolchain"
-          rustup default 1.58.1
           rm -rf rust-toolchain
+          rustup default 1.58.1
           echo "::endgroup::"
           echo "::group::rustup version"
           rustup -Vv
@@ -142,8 +142,8 @@ jobs:
           rustup toolchain install 1.58.1 --profile minimal
           echo "::endgroup::"
           echo "::group::set default toolchain"
-          rustup default 1.58.1
           rm -rf rust-toolchain
+          rustup default 1.58.1
           echo "::endgroup::"
           echo "::group::rustup version"
           rustup -Vv
@@ -179,8 +179,8 @@ jobs:
           rustup toolchain install 1.58.1 --profile minimal --component clippy
           echo "::endgroup::"
           echo "::group::set default toolchain"
-          rustup default 1.58.1
           rm -rf rust-toolchain
+          rustup default 1.58.1
           echo "::endgroup::"
           echo "::group::rustup version"
           rustup -Vv
@@ -249,8 +249,8 @@ jobs:
           rustup toolchain install 1.58.1 --profile minimal --component clippy
           echo "::endgroup::"
           echo "::group::set default toolchain"
-          rustup default 1.58.1
           rm -rf rust-toolchain
+          rustup default 1.58.1
           echo "::endgroup::"
           echo "::group::rustup version"
           rustup -Vv
@@ -330,8 +330,8 @@ jobs:
           rustup toolchain install 1.58.1 --profile minimal
           echo "::endgroup::"
           echo "::group::set default toolchain"
-          rustup default 1.58.1
           rm -rf rust-toolchain
+          rustup default 1.58.1
           echo "::endgroup::"
           echo "::group::rustup version"
           rustup -Vv
@@ -493,8 +493,8 @@ jobs:
           rustup toolchain install 1.58.1 --profile minimal
           echo "::endgroup::"
           echo "::group::set default toolchain"
-          rustup default 1.58.1
           rm -rf rust-toolchain
+          rustup default 1.58.1
           echo "::endgroup::"
           echo "::group::rustup version"
           rustup -Vv

--- a/.github/workflows/crash.yaml
+++ b/.github/workflows/crash.yaml
@@ -21,8 +21,8 @@ jobs:
           rustup toolchain install 1.58.1 --profile minimal
           echo "::endgroup::"
           echo "::group::set default toolchain"
-          rustup default 1.58.1
           rm -rf rust-toolchain
+          rustup default 1.58.1
           echo "::endgroup::"
           echo "::group::rustup version"
           rustup -Vv

--- a/.github/workflows/crash.yaml
+++ b/.github/workflows/crash.yaml
@@ -22,6 +22,7 @@ jobs:
           echo "::endgroup::"
           echo "::group::set default toolchain"
           rustup default 1.58.1
+          rm -rf rust-toolchain
           echo "::endgroup::"
           echo "::group::rustup version"
           rustup -Vv

--- a/.github/workflows/fuzz.yaml
+++ b/.github/workflows/fuzz.yaml
@@ -24,6 +24,7 @@ jobs:
           echo "::endgroup::"
           echo "::group::set default toolchain"
           rustup default nightly
+          rm -rf rust-toolchain
           echo "::endgroup::"
           echo "::group::rustup version"
           rustup -Vv
@@ -39,11 +40,11 @@ jobs:
         run: cargo install cargo-fuzz
 
       - name: Build fuzz targets
-        run: cargo +nightly fuzz build
+        run: cargo fuzz build
 
       - name: Fuzz eval
         if: github.event_name == 'schedule'
-        run: cargo +nightly fuzz run eval -- -max_total_time=1800 # 30 minutes
+        run: cargo fuzz run eval -- -max_total_time=1800 # 30 minutes
 
   leak-san:
     name: Compile and test with LeakSanitizer
@@ -62,6 +63,7 @@ jobs:
           echo "::endgroup::"
           echo "::group::set default toolchain"
           rustup default nightly
+          rm -rf rust-toolchain
           echo "::endgroup::"
           echo "::group::rustup version"
           rustup -Vv
@@ -74,8 +76,8 @@ jobs:
           echo "::endgroup::"
 
       - name: Test with leak sanitizer and all features
-        run: cargo +nightly test --workspace --all-features --target x86_64-unknown-linux-gnu
+        run: cargo test --workspace --all-features --target x86_64-unknown-linux-gnu
 
       - name: Test spec-runner with leak sanitizer and all features
-        run: cargo +nightly test --workspace --all-features --target x86_64-unknown-linux-gnu
+        run: cargo test --workspace --all-features --target x86_64-unknown-linux-gnu
         working-directory: "spec-runner"

--- a/.github/workflows/fuzz.yaml
+++ b/.github/workflows/fuzz.yaml
@@ -23,8 +23,8 @@ jobs:
           rustup toolchain install nightly --profile minimal
           echo "::endgroup::"
           echo "::group::set default toolchain"
-          rustup default nightly
           rm -rf rust-toolchain
+          rustup default nightly
           echo "::endgroup::"
           echo "::group::rustup version"
           rustup -Vv
@@ -62,8 +62,8 @@ jobs:
           rustup toolchain install nightly --profile minimal --target x86_64-unknown-linux-gnu
           echo "::endgroup::"
           echo "::group::set default toolchain"
-          rustup default nightly
           rm -rf rust-toolchain
+          rustup default nightly
           echo "::endgroup::"
           echo "::group::rustup version"
           rustup -Vv

--- a/.github/workflows/rustdoc.yaml
+++ b/.github/workflows/rustdoc.yaml
@@ -29,8 +29,8 @@ jobs:
           rustup toolchain install nightly --profile minimal
           echo "::endgroup::"
           echo "::group::set default toolchain"
-          rustup default nightly
           rm -rf rust-toolchain
+          rustup default nightly
           echo "::endgroup::"
           echo "::group::rustup version"
           rustup -Vv

--- a/.github/workflows/rustdoc.yaml
+++ b/.github/workflows/rustdoc.yaml
@@ -30,6 +30,7 @@ jobs:
           echo "::endgroup::"
           echo "::group::set default toolchain"
           rustup default nightly
+          rm -rf rust-toolchain
           echo "::endgroup::"
           echo "::group::rustup version"
           rustup -Vv
@@ -44,7 +45,7 @@ jobs:
       - uses: Swatinem/rust-cache@v1
 
       - name: Build Documentation
-        run: cargo +nightly doc --workspace
+        run: cargo doc --workspace
 
       - name: Copy static content
         run: cp --verbose .github/rustdoc/* target/doc/

--- a/.github/workflows/spec-state.yaml
+++ b/.github/workflows/spec-state.yaml
@@ -25,6 +25,7 @@ jobs:
           rustup toolchain install 1.58.1 --profile minimal
           echo "::endgroup::"
           echo "::group::set default toolchain"
+          rm -rf rust-toolchain
           rustup default 1.58.1
           echo "::endgroup::"
           echo "::group::rustup version"


### PR DESCRIPTION
Remove unnecessary `+nightly` opts to `cargo`.

Followup to:

- https://github.com/artichoke/artichoke/pull/1813
- https://github.com/artichoke/artichoke/pull/1820