### PR TITLE
Use namespaced and weak dependency features in `Cargo.toml`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -684,7 +684,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-regexp"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bitflags",
  "bstr",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -666,7 +666,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-math"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "libm",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-symbol"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "artichoke-core",
  "bstr",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -642,7 +642,7 @@ checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
 
 [[package]]
 name = "spinoso-array"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "raw-parts",
  "smallvec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -320,7 +320,7 @@ dependencies = [
 
 [[package]]
 name = "mezzaluna-feature-loader"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "same-file",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,7 +26,7 @@ dependencies = [
 
 [[package]]
 name = "artichoke-backend"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "artichoke-core",
  "artichoke-load-path",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,9 +85,9 @@ default = [
 ]
 # Enable a CLI frontend for Artichoke, including a `ruby`-equivalent CLI and
 # REPL.
-cli = ["backtrace", "clap", "log", "rustyline"]
+cli = ["backtrace", "dep:clap", "dep:log", "dep:rustyline"]
 # Enable a module for formtting backtraces from Ruby exceptions.
-backtrace = ["termcolor"]
+backtrace = ["dep:termcolor"]
 # Enable all features of Ruby Core, Standard Library, and the underlying VM.
 kitchen-sink = [
   "core-full",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ rustyline = { version = "9.1.2", optional = true, default-features = false }
 termcolor = { version = "1.1.0", optional = true }
 
 [dependencies.artichoke-backend]
-version = "0.10.0"
+version = "0.11.0"
 path = "artichoke-backend"
 default-features = false
 

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -32,7 +32,7 @@ spinoso-env = { version = "0.2.0", path = "../spinoso-env", optional = true, def
 spinoso-exception = { version = "0.1.0", path = "../spinoso-exception" }
 spinoso-math = { version = "0.3.0", path = "../spinoso-math", optional = true, default-features = false }
 spinoso-random = { version = "0.2.0", path = "../spinoso-random", optional = true }
-spinoso-regexp = { version = "0.2.0", path = "../spinoso-regexp", optional = true, default-features = false }
+spinoso-regexp = { version = "0.3.0", path = "../spinoso-regexp", optional = true, default-features = false }
 spinoso-securerandom = { version = "0.2.0", path = "../spinoso-securerandom", optional = true }
 spinoso-string = { version = "0.16.0", path = "../spinoso-string" }
 spinoso-symbol = { version = "0.1.0", path = "../spinoso-symbol" }

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "artichoke-backend"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2021"
 rust-version = "1.60.0"
@@ -60,14 +60,14 @@ core-full = [
   "core-regexp-oniguruma",
   "core-time",
 ]
-core-env = ["spinoso-env"]
-core-env-system = ["core-env", "spinoso-env/system-env"]
-core-math = ["spinoso-math"]
-core-math-full = ["core-math", "spinoso-math/full"]
-core-random = ["spinoso-random"]
-core-regexp = ["spinoso-regexp"]
-core-regexp-oniguruma = ["core-regexp", "spinoso-regexp/oniguruma", "onig"]
-core-time = ["spinoso-time"]
+core-env = ["dep:spinoso-env"]
+core-env-system = ["core-env", "spinoso-env?/system-env"]
+core-math = ["dep:spinoso-math"]
+core-math-full = ["core-math", "spinoso-math?/full"]
+core-random = ["dep:spinoso-random"]
+core-regexp = ["dep:spinoso-regexp"]
+core-regexp-oniguruma = ["core-regexp", "spinoso-regexp?/oniguruma", "dep:onig"]
+core-time = ["dep:spinoso-time"]
 
 load-path-native-file-system-loader = ["artichoke-load-path/native-file-system-loader"]
 load-path-rubylib-native-file-system-loader = ["load-path-native-file-system-loader", "artichoke-load-path/rubylib-native-file-system-loader"]
@@ -99,7 +99,7 @@ stdlib-forwardable = []
 stdlib-json = []
 stdlib-monitor = []
 stdlib-ostruct = []
-stdlib-securerandom = ["spinoso-securerandom"]
+stdlib-securerandom = ["dep:spinoso-securerandom"]
 stdlib-set = []
 stdlib-shellwords = []
 stdlib-strscan = []

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -30,7 +30,7 @@ scolapasta-string-escape = { version = "0.2.0", path = "../scolapasta-string-esc
 spinoso-array = { version = "0.9.0", path = "../spinoso-array", default-features = false }
 spinoso-env = { version = "0.2.0", path = "../spinoso-env", optional = true, default-features = false }
 spinoso-exception = { version = "0.1.0", path = "../spinoso-exception" }
-spinoso-math = { version = "0.2.0", path = "../spinoso-math", optional = true, default-features = false }
+spinoso-math = { version = "0.3.0", path = "../spinoso-math", optional = true, default-features = false }
 spinoso-random = { version = "0.2.0", path = "../spinoso-random", optional = true }
 spinoso-regexp = { version = "0.2.0", path = "../spinoso-regexp", optional = true, default-features = false }
 spinoso-securerandom = { version = "0.2.0", path = "../spinoso-securerandom", optional = true }

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -27,7 +27,7 @@ qed = "1.0.0"
 # https://github.com/artichoke/artichoke/pull/1729
 regex = "1.5.5"
 scolapasta-string-escape = { version = "0.2.0", path = "../scolapasta-string-escape", default-features = false }
-spinoso-array = { version = "0.8.0", path = "../spinoso-array", default-features = false }
+spinoso-array = { version = "0.9.0", path = "../spinoso-array", default-features = false }
 spinoso-env = { version = "0.2.0", path = "../spinoso-env", optional = true, default-features = false }
 spinoso-exception = { version = "0.1.0", path = "../spinoso-exception" }
 spinoso-math = { version = "0.2.0", path = "../spinoso-math", optional = true, default-features = false }

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -35,7 +35,7 @@ spinoso-random = { version = "0.2.0", path = "../spinoso-random", optional = tru
 spinoso-regexp = { version = "0.3.0", path = "../spinoso-regexp", optional = true, default-features = false }
 spinoso-securerandom = { version = "0.2.0", path = "../spinoso-securerandom", optional = true }
 spinoso-string = { version = "0.16.0", path = "../spinoso-string" }
-spinoso-symbol = { version = "0.1.0", path = "../spinoso-symbol" }
+spinoso-symbol = { version = "0.2.0", path = "../spinoso-symbol" }
 spinoso-time = { version = "0.2.0", path = "../spinoso-time", optional = true }
 
 [dev-dependencies]

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -17,7 +17,7 @@ artichoke-load-path = { version = "0.1.0", path = "../artichoke-load-path", defa
 bstr = { version = "0.2.9", default-features = false, features = ["std"] }
 cstr = "0.2.10"
 intaglio = { version = "1.6.0", default-features = false, features = ["bytes"] }
-mezzaluna-feature-loader = { version = "0.4.0", path = "../mezzaluna-feature-loader", default-features = false }
+mezzaluna-feature-loader = { version = "0.5.0", path = "../mezzaluna-feature-loader", default-features = false }
 onig = { version = "6.3.0", optional = true, default-features = false }
 qed = "1.0.0"
 # Ensure the `regex` minimum version is at least 1.5.5 to pull in a fix for a

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "artichoke-backend"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "artichoke-core",
  "artichoke-load-path",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -222,7 +222,7 @@ checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "mezzaluna-feature-loader"
-version = "0.4.0"
+version = "0.5.0"
 
 [[package]]
 name = "num-integer"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-symbol"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "artichoke-core",
  "bstr",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -470,7 +470,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-math"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "libm",
 ]

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -488,7 +488,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-regexp"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bitflags",
  "bstr",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -448,7 +448,7 @@ checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
 
 [[package]]
 name = "spinoso-array"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "raw-parts",
 ]

--- a/mezzaluna-feature-loader/Cargo.toml
+++ b/mezzaluna-feature-loader/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mezzaluna-feature-loader"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2021"
 rust-version = "1.60.0"
@@ -16,8 +16,8 @@ same-file = { version = "1.0.6", optional = true }
 
 [features]
 default = ["disk", "rubylib"]
-disk = ["same-file"]
 rubylib = ["disk"]
+disk = ["dep:same-file"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -619,7 +619,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-regexp"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bitflags",
  "bstr",

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -579,7 +579,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-array"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "raw-parts",
 ]

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -23,7 +23,7 @@ dependencies = [
 
 [[package]]
 name = "artichoke-backend"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "artichoke-core",
  "artichoke-load-path",

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -264,7 +264,7 @@ checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "mezzaluna-feature-loader"
-version = "0.4.0"
+version = "0.5.0"
 
 [[package]]
 name = "num-integer"

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -651,7 +651,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-symbol"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "artichoke-core",
  "bstr",

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -601,7 +601,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-math"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "libm",
 ]

--- a/spinoso-array/Cargo.toml
+++ b/spinoso-array/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spinoso-array"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2021"
 rust-version = "1.60.0"
@@ -26,10 +26,10 @@ tinyvec = { version = "1.3.0", optional = true, default-features = false, featur
 default = ["small-array", "tiny-array"]
 # Add a `SmallArray` backend that implements the small vector optimization with
 # the `smallvec` crate.
-small-array = ["smallvec"]
+small-array = ["dep:smallvec"]
 # Add a `TinyArray` backend that implements the small vector optimization with
 # the `tinyvec` crate.
-tiny-array = ["tinyvec"]
+tiny-array = ["dep:tinyvec"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/spinoso-array/README.md
+++ b/spinoso-array/README.md
@@ -30,7 +30,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-spinoso-array = "0.8.0"
+spinoso-array = "0.9.0"
 ```
 
 Then construct and manipulate an `Array` like this:

--- a/spinoso-math/Cargo.toml
+++ b/spinoso-math/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spinoso-math"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2021"
 rust-version = "1.60.0"
@@ -20,7 +20,7 @@ libm = { version = "0.2.2", optional = true }
 default = ["full"]
 # Implement the full Ruby `Math` API by including external crates for missing
 # `std` APIs.
-full = ["libm"]
+full = ["dep:libm"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/spinoso-math/README.md
+++ b/spinoso-math/README.md
@@ -30,7 +30,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-spinoso-math = "0.2.0"
+spinoso-math = "0.3.0"
 ```
 
 Compute the hypotenuse:

--- a/spinoso-regexp/Cargo.toml
+++ b/spinoso-regexp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spinoso-regexp"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2021"
 rust-version = "1.60.0"
@@ -27,7 +27,7 @@ scolapasta-string-escape = { version = "0.2.0", path = "../scolapasta-string-esc
 
 [features]
 default = ["oniguruma", "regex-full"]
-oniguruma = ["onig"]
+oniguruma = ["dep:onig"]
 regex-full = ["regex-perf", "regex-unicode"]
 regex-perf = ["regex/perf"]
 regex-unicode = ["regex/unicode"]

--- a/spinoso-regexp/README.md
+++ b/spinoso-regexp/README.md
@@ -31,7 +31,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-spinoso-regexp = "0.2.0"
+spinoso-regexp = "0.3.0"
 ```
 
 ## Crate features

--- a/spinoso-symbol/Cargo.toml
+++ b/spinoso-symbol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spinoso-symbol"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2021"
 rust-version = "1.60.0"
@@ -30,16 +30,17 @@ default = ["artichoke", "std"]
 # on `bstr`.
 #
 # When this feature is enabled, several types are re-exported from `focaccia`.
-artichoke = ["artichoke-core", "focaccia", "inspect"]
+artichoke = ["dep:artichoke-core", "dep:focaccia", "inspect"]
 # Implement an iterator for printing debug output of a byte string associated
 # with a `Symbol` that is suitable for implementing `Symbol#inspect`.
-inspect = ["ident-parser", "scolapasta-string-escape"]
+inspect = ["ident-parser", "dep:scolapasta-string-escape"]
 # Add a parser for valid Ruby identifiers.
-ident-parser = ["bstr"]
+ident-parser = ["dep:bstr"]
 # By default, `spinoso-symbol` is `no_std`. This feature enables
-# `std::error::Error` impls. This feature activates `focaccia/std` to enable
-# `Error` impls on the re-exported error structs.
-std = ["focaccia/std"]
+# `std::error::Error` impls. This feature activates `focaccia/std` if the
+# `focaccia` feature is enabled to enable `Error` impls on the re-exported error
+# structs.
+std = ["focaccia?/std"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/spinoso-symbol/README.md
+++ b/spinoso-symbol/README.md
@@ -30,7 +30,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-spinoso-symbol = "0.1.0"
+spinoso-symbol = "0.2.0"
 ```
 
 Most of the functionality in this crate depends on a Ruby interpreter that


### PR DESCRIPTION
This feature was rolled out in Rust 1.60:

- https://blog.rust-lang.org/2022/04/07/Rust-1.60.0.html#new-syntax-for-cargo-features