### PR TITLE
Remove `AsRef<Vec<u8>>` and `AsMut<Vec<u8>>` from spinoso-string

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -710,7 +710,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-string"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "bstr",
  "bytecount",

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -34,7 +34,7 @@ spinoso-math = { version = "0.3.0", path = "../spinoso-math", optional = true, d
 spinoso-random = { version = "0.2.0", path = "../spinoso-random", optional = true }
 spinoso-regexp = { version = "0.3.0", path = "../spinoso-regexp", optional = true, default-features = false }
 spinoso-securerandom = { version = "0.2.0", path = "../spinoso-securerandom", optional = true }
-spinoso-string = { version = "0.16.0", path = "../spinoso-string" }
+spinoso-string = { version = "0.17.0", path = "../spinoso-string" }
 spinoso-symbol = { version = "0.2.0", path = "../spinoso-symbol" }
 spinoso-time = { version = "0.2.0", path = "../spinoso-time", optional = true }
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -514,7 +514,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-string"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "bstr",
  "bytecount",

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -645,7 +645,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-string"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "bstr",
  "bytecount",

--- a/spinoso-string/Cargo.toml
+++ b/spinoso-string/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spinoso-string"
-version = "0.16.0"
+version = "0.17.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2021"
 rust-version = "1.60.0"

--- a/spinoso-string/README.md
+++ b/spinoso-string/README.md
@@ -27,7 +27,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-spinoso-string = "0.15.0"
+spinoso-string = "0.17.0"
 ```
 
 ## `no_std`

--- a/spinoso-string/src/enc/ascii/impls.rs
+++ b/spinoso-string/src/enc/ascii/impls.rs
@@ -89,20 +89,6 @@ impl AsMut<[u8]> for AsciiString {
     }
 }
 
-impl AsRef<Vec<u8>> for AsciiString {
-    #[inline]
-    fn as_ref(&self) -> &Vec<u8> {
-        &self.inner
-    }
-}
-
-impl AsMut<Vec<u8>> for AsciiString {
-    #[inline]
-    fn as_mut(&mut self) -> &mut Vec<u8> {
-        &mut self.inner
-    }
-}
-
 impl Deref for AsciiString {
     type Target = [u8];
 

--- a/spinoso-string/src/enc/binary/impls.rs
+++ b/spinoso-string/src/enc/binary/impls.rs
@@ -89,20 +89,6 @@ impl AsMut<[u8]> for BinaryString {
     }
 }
 
-impl AsRef<Vec<u8>> for BinaryString {
-    #[inline]
-    fn as_ref(&self) -> &Vec<u8> {
-        &self.inner
-    }
-}
-
-impl AsMut<Vec<u8>> for BinaryString {
-    #[inline]
-    fn as_mut(&mut self) -> &mut Vec<u8> {
-        &mut self.inner
-    }
-}
-
 impl Deref for BinaryString {
     type Target = [u8];
 

--- a/spinoso-string/src/enc/impls.rs
+++ b/spinoso-string/src/enc/impls.rs
@@ -1,4 +1,3 @@
-use alloc::vec::Vec;
 use core::ops::{Deref, DerefMut};
 
 use super::EncodedString;
@@ -50,28 +49,6 @@ impl AsRef<[u8]> for EncodedString {
 impl AsMut<[u8]> for EncodedString {
     #[inline]
     fn as_mut(&mut self) -> &mut [u8] {
-        match self {
-            EncodedString::Ascii(inner) => inner.as_mut(),
-            EncodedString::Binary(inner) => inner.as_mut(),
-            EncodedString::Utf8(inner) => inner.as_mut(),
-        }
-    }
-}
-
-impl AsRef<Vec<u8>> for EncodedString {
-    #[inline]
-    fn as_ref(&self) -> &Vec<u8> {
-        match self {
-            EncodedString::Ascii(inner) => inner.as_ref(),
-            EncodedString::Binary(inner) => inner.as_ref(),
-            EncodedString::Utf8(inner) => inner.as_ref(),
-        }
-    }
-}
-
-impl AsMut<Vec<u8>> for EncodedString {
-    #[inline]
-    fn as_mut(&mut self) -> &mut Vec<u8> {
         match self {
             EncodedString::Ascii(inner) => inner.as_mut(),
             EncodedString::Binary(inner) => inner.as_mut(),

--- a/spinoso-string/src/impls.rs
+++ b/spinoso-string/src/impls.rs
@@ -190,20 +190,6 @@ impl AsMut<[u8]> for String {
     }
 }
 
-impl AsRef<Vec<u8>> for String {
-    #[inline]
-    fn as_ref(&self) -> &Vec<u8> {
-        self.inner.as_ref()
-    }
-}
-
-impl AsMut<Vec<u8>> for String {
-    #[inline]
-    fn as_mut(&mut self) -> &mut Vec<u8> {
-        self.inner.as_mut()
-    }
-}
-
 impl Deref for String {
     type Target = [u8];
 


### PR DESCRIPTION
Remove these impls because:

- they are unused.
- they expose the internal repr of `spinoso_string::String`.
- they limit the opportunities to mark strings as modified with internal
  mutability (for potentially caching whether `String`s are ASCII only
  or have valid encoding).