### PR TITLE
Remove `AsRef` and `AsMut` impls from smart pointer types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,7 +26,7 @@ dependencies = [
 
 [[package]]
 name = "artichoke-backend"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "artichoke-core",
  "artichoke-load-path",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ rustyline = { version = "9.1.2", optional = true, default-features = false }
 termcolor = { version = "1.1.0", optional = true }
 
 [dependencies.artichoke-backend]
-version = "0.11.0"
+version = "0.12.0"
 path = "artichoke-backend"
 default-features = false
 

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "artichoke-backend"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2021"
 rust-version = "1.60.0"

--- a/artichoke-backend/src/artichoke.rs
+++ b/artichoke-backend/src/artichoke.rs
@@ -216,20 +216,6 @@ impl<'a> Guard<'a> {
     }
 }
 
-impl<'a> AsRef<Artichoke> for Guard<'a> {
-    #[inline]
-    fn as_ref(&self) -> &Artichoke {
-        &*self.0
-    }
-}
-
-impl<'a> AsMut<Artichoke> for Guard<'a> {
-    #[inline]
-    fn as_mut(&mut self) -> &mut Artichoke {
-        self.0
-    }
-}
-
 impl<'a> Deref for Guard<'a> {
     type Target = Artichoke;
 

--- a/artichoke-backend/src/convert/boxing.rs
+++ b/artichoke-backend/src/convert/boxing.rs
@@ -94,18 +94,6 @@ impl<T> HeapAllocated<T> {
     }
 }
 
-impl<'a, T> AsRef<T> for UnboxedValueGuard<'a, HeapAllocated<T>> {
-    fn as_ref(&self) -> &T {
-        self.guarded.deref().0.as_ref()
-    }
-}
-
-impl<'a, T> AsMut<T> for UnboxedValueGuard<'a, HeapAllocated<T>> {
-    fn as_mut(&mut self) -> &mut T {
-        self.guarded.deref_mut().0.as_mut()
-    }
-}
-
 impl<'a, T> Deref for UnboxedValueGuard<'a, HeapAllocated<T>> {
     type Target = T;
 

--- a/artichoke-backend/src/extn/core/array/mod.rs
+++ b/artichoke-backend/src/extn/core/array/mod.rs
@@ -324,12 +324,6 @@ impl BoxUnboxVmValue for Array {
     }
 }
 
-impl<'a> AsRef<Array> for UnboxedValueGuard<'a, Array> {
-    fn as_ref(&self) -> &Array {
-        self.as_inner_ref()
-    }
-}
-
 impl<'a> Deref for UnboxedValueGuard<'a, Array> {
     type Target = Array;
 

--- a/artichoke-backend/src/extn/core/random/trampoline.rs
+++ b/artichoke-backend/src/extn/core/random/trampoline.rs
@@ -15,7 +15,7 @@ pub fn initialize(interp: &mut Artichoke, seed: Option<Value>, into: Value) -> R
 pub fn equal(interp: &mut Artichoke, mut rand: Value, mut other: Value) -> Result<Value, Error> {
     let random = unsafe { Rng::unbox_from_value(&mut rand, interp)? };
     let other = unsafe { Rng::unbox_from_value(&mut other, interp)? };
-    let eql = random.as_ref() == other.as_ref();
+    let eql = *random == *other;
     Ok(interp.convert(eql))
 }
 
@@ -41,7 +41,7 @@ pub fn rand(interp: &mut Artichoke, mut rand: Value, max: Option<Value>) -> Resu
 
 pub fn seed(interp: &mut Artichoke, mut rand: Value) -> Result<Value, Error> {
     let random = unsafe { Rng::unbox_from_value(&mut rand, interp)? };
-    let seed = match random.as_ref() {
+    let seed = match &*random {
         Rng::Global => interp.prng()?.seed(),
         Rng::Value(random) => random.seed(),
     };

--- a/artichoke-backend/src/extn/core/string/mod.rs
+++ b/artichoke-backend/src/extn/core/string/mod.rs
@@ -139,12 +139,6 @@ impl BoxUnboxVmValue for String {
     }
 }
 
-impl<'a> AsRef<String> for UnboxedValueGuard<'a, String> {
-    fn as_ref(&self) -> &String {
-        self.as_inner_ref()
-    }
-}
-
 impl<'a> Deref for UnboxedValueGuard<'a, String> {
     type Target = String;
 

--- a/artichoke-backend/src/gc/arena.rs
+++ b/artichoke-backend/src/gc/arena.rs
@@ -131,20 +131,6 @@ impl<'a> ArenaIndex<'a> {
     }
 }
 
-impl<'a> AsRef<Artichoke> for ArenaIndex<'a> {
-    #[inline]
-    fn as_ref(&self) -> &Artichoke {
-        &*self.interp
-    }
-}
-
-impl<'a> AsMut<Artichoke> for ArenaIndex<'a> {
-    #[inline]
-    fn as_mut(&mut self) -> &mut Artichoke {
-        self.interp
-    }
-}
-
 impl<'a> Deref for ArenaIndex<'a> {
     type Target = Artichoke;
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "artichoke-backend"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "artichoke-core",
  "artichoke-load-path",

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -23,7 +23,7 @@ dependencies = [
 
 [[package]]
 name = "artichoke-backend"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "artichoke-core",
  "artichoke-load-path",


### PR DESCRIPTION
There are many types in artichoke-backend that are smart pointers or
proxy objects. These types typically should implement `Deref` and
`DerefMut`.

`artichoke-backend` _also_ tends to implement `AsRef` and `AsMut` on
these types, which is incorrect.

Remove these impls and bump the version of `artichoke-backend`.