### PR TITLE
Refactor `Random` impl to rely on `spinoso-random`

### DIFF
--- a/artichoke-backend/src/extn/core/random/trampoline.rs
+++ b/artichoke-backend/src/extn/core/random/trampoline.rs
@@ -6,8 +6,12 @@ use crate::extn::prelude::*;
 
 pub fn initialize(interp: &mut Artichoke, seed: Option<Value>, into: Value) -> Result<Value, Error> {
     let seed: Seed = interp.try_convert_mut(seed)?;
-    let random = Random::with_array_seed(seed.to_mt_seed())?;
-    let random = Rng::Value(Box::new(random));
+    let random = if let Some(seed) = seed.to_mt_seed() {
+        Random::with_array_seed(seed)
+    } else {
+        Random::new()?
+    };
+    let random = Rng::Instance(Box::new(random));
     let random = Rng::box_into_value(random, into, interp)?;
     Ok(random)
 }
@@ -22,10 +26,15 @@ pub fn equal(interp: &mut Artichoke, mut rand: Value, mut other: Value) -> Resul
 pub fn bytes(interp: &mut Artichoke, mut rand: Value, size: Value) -> Result<Value, Error> {
     let mut random = unsafe { Rng::unbox_from_value(&mut rand, interp)? };
     let size = implicitly_convert_to_int(interp, size)?;
-    let buf = match &mut *random {
-        Rng::Global => interp.prng_mut()?.bytes(size)?,
-        Rng::Value(random) => random.bytes(size)?,
+    let mut buf = match usize::try_from(size) {
+        Ok(0) => return interp.try_convert_mut(Vec::<u8>::new()),
+        Ok(len) => vec![0; len],
+        Err(_) => return Err(ArgumentError::with_message("negative string size (or size too big)").into()),
     };
+    match &mut *random {
+        Rng::Global => interp.prng_mut()?.fill_bytes(&mut buf),
+        Rng::Instance(random) => random.fill_bytes(&mut buf),
+    }
     interp.try_convert_mut(buf)
 }
 
@@ -33,8 +42,8 @@ pub fn rand(interp: &mut Artichoke, mut rand: Value, max: Option<Value>) -> Resu
     let mut random = unsafe { Rng::unbox_from_value(&mut rand, interp)? };
     let max = interp.try_convert_mut(max)?;
     let num = match &mut *random {
-        Rng::Global => interp.prng_mut()?.rand(max)?,
-        Rng::Value(random) => random.rand(max)?,
+        Rng::Global => spinoso_random::rand(interp.prng_mut()?, max)?,
+        Rng::Instance(random) => spinoso_random::rand(random, max)?,
     };
     Ok(interp.convert_mut(num))
 }
@@ -43,24 +52,40 @@ pub fn seed(interp: &mut Artichoke, mut rand: Value) -> Result<Value, Error> {
     let random = unsafe { Rng::unbox_from_value(&mut rand, interp)? };
     let seed = match random.as_ref() {
         Rng::Global => interp.prng()?.seed(),
-        Rng::Value(random) => random.seed(),
+        Rng::Instance(random) => random.seed(),
     };
-    Ok(interp.convert(seed))
+    interp.try_convert(Seed::from_mt_seed_lossy(seed))
 }
 
 pub fn new_seed(interp: &mut Artichoke) -> Result<Value, Error> {
-    let seed = super::new_seed()?;
-    Ok(interp.convert(seed))
+    let seed = spinoso_random::new_seed()?;
+    let seed = Seed::from_mt_seed_lossy(seed);
+    interp.try_convert(seed)
 }
 
 pub fn srand(interp: &mut Artichoke, seed: Option<Value>) -> Result<Value, Error> {
-    let seed = interp.try_convert_mut(seed)?;
-    let old_seed = super::srand(interp, seed)?;
-    Ok(interp.convert(old_seed))
+    let seed: Seed = interp.try_convert_mut(seed)?;
+    let old_seed = Seed::from_mt_seed_lossy(interp.prng()?.seed());
+
+    let new_random = if let Some(seed) = seed.to_mt_seed() {
+        Random::with_array_seed(seed)
+    } else {
+        Random::new()?
+    };
+    // "Reseed" by replacing the RNG with a newly seeded one.
+    let prng = interp.prng_mut()?;
+    *prng = new_random;
+
+    interp.try_convert(old_seed)
 }
 
 pub fn urandom(interp: &mut Artichoke, size: Value) -> Result<Value, Error> {
     let size = implicitly_convert_to_int(interp, size)?;
-    let buf = super::urandom(size)?;
+    let mut buf = match usize::try_from(size) {
+        Ok(0) => return interp.try_convert_mut(Vec::<u8>::new()),
+        Ok(len) => vec![0; len],
+        Err(_) => return Err(ArgumentError::with_message("negative string size (or size too big)").into()),
+    };
+    spinoso_random::urandom(&mut buf)?;
     interp.try_convert_mut(buf)
 }


### PR DESCRIPTION
The implementation of `Random` in `extn::core::random` differs from my
preferred way of implementing types in `extn`, which is like that of
`Time`: the Spinoso type is re-exported untouched and all argument
marshaling is done in the trampoline.

This commit reimplements `extn::core::random` so that all type
transforms, boxing, and unboxing happens in `random::trampoline`. This
allows `spinoso_random::Random` to be re-exported. The only remaining
code in `mod.rs` in `extn::core::random` is a bunch of trait
implementations to make that argument marshaling easier.

I also took the opportunity to factor out the seed truncation to a
single spot and make the logic a bit more clear with a transmute and
memcpy.