### PR TITLE
Replace `target-lexicon` build dep with Cargo build.rs env vars

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,6 @@ dependencies = [
  "clap",
  "log",
  "rustyline",
- "target-lexicon",
  "termcolor",
  "tz-rs",
 ]
@@ -49,7 +48,6 @@ dependencies = [
  "spinoso-string",
  "spinoso-symbol",
  "spinoso-time",
- "target-lexicon",
 ]
 
 [[package]]
@@ -716,12 +714,6 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "target-lexicon"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7fa7e55043acb85fca6b3c01485a2eeb6b69c5d21002e273c79e465f43b7ac1"
 
 [[package]]
 name = "termcolor"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,6 @@ default-features = false
 
 [build-dependencies]
 tz-rs = { version = "0.6.9", default-features = false }
-target-lexicon = "0.12.3"
 
 [[bin]]
 name = "airb"

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -42,7 +42,6 @@ quickcheck = { version = "1.0.3", default-features = false }
 
 [build-dependencies]
 cc = "1.0.72"
-target-lexicon = "0.12.3"
 
 [features]
 default = [

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -22,7 +22,6 @@ name = "artichoke"
 version = "0.1.0-pre.0"
 dependencies = [
  "artichoke-backend",
- "target-lexicon",
  "tz-rs",
 ]
 
@@ -50,7 +49,6 @@ dependencies = [
  "spinoso-string",
  "spinoso-symbol",
  "spinoso-time",
- "target-lexicon",
 ]
 
 [[package]]
@@ -507,12 +505,6 @@ dependencies = [
  "chrono",
  "chrono-tz",
 ]
-
-[[package]]
-name = "target-lexicon"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7fa7e55043acb85fca6b3c01485a2eeb6b69c5d21002e273c79e465f43b7ac1"
 
 [[package]]
 name = "tz-rs"

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -16,7 +16,6 @@ name = "artichoke"
 version = "0.1.0-pre.0"
 dependencies = [
  "artichoke-backend",
- "target-lexicon",
  "termcolor",
  "tz-rs",
 ]
@@ -45,7 +44,6 @@ dependencies = [
  "spinoso-string",
  "spinoso-symbol",
  "spinoso-time",
- "target-lexicon",
 ]
 
 [[package]]
@@ -673,12 +671,6 @@ dependencies = [
  "quote",
  "unicode-xid",
 ]
-
-[[package]]
-name = "target-lexicon"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7fa7e55043acb85fca6b3c01485a2eeb6b69c5d21002e273c79e465f43b7ac1"
 
 [[package]]
 name = "termcolor"


### PR DESCRIPTION
- Artichoke's `build.rs` only used `target-lexicon` for its `Display`
  impl, which is trivially provided by the `TARGET` triple env variable.
- artichoke-backend's `build.rs` only uses `target-lexicon` to enable
  platform support for Wasm targets. Replace `target-lexicon` with some
  bespoke code that parses Cargo env vars `CARGO_CFG_TARGET_OS` and
  `CARGO_CFG_TARGET_ARCH`.