### PR TITLE
Rework destructuring patterns that used many `_` bindings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -580,7 +580,7 @@ version = "0.2.0"
 
 [[package]]
 name = "scolapasta-string-escape"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bstr",
 ]
@@ -686,7 +686,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-symbol"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "artichoke-core",
  "bstr",

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -25,7 +25,7 @@ qed = "1.3.0"
 # See: CVE-2022-24713
 # https://github.com/artichoke/artichoke/pull/1729
 regex = "1.5.5"
-scolapasta-string-escape = { version = "0.2.0", path = "../scolapasta-string-escape", default-features = false }
+scolapasta-string-escape = { version = "0.3.0", path = "../scolapasta-string-escape", default-features = false }
 spinoso-array = { version = "0.9.0", path = "../spinoso-array", default-features = false }
 spinoso-env = { version = "0.2.0", path = "../spinoso-env", optional = true, default-features = false }
 spinoso-exception = { version = "0.1.0", path = "../spinoso-exception" }
@@ -34,7 +34,7 @@ spinoso-random = { version = "0.2.0", path = "../spinoso-random", optional = tru
 spinoso-regexp = { version = "0.3.0", path = "../spinoso-regexp", optional = true, default-features = false }
 spinoso-securerandom = { version = "0.2.0", path = "../spinoso-securerandom", optional = true }
 spinoso-string = { version = "0.17.0", path = "../spinoso-string" }
-spinoso-symbol = { version = "0.2.0", path = "../spinoso-symbol" }
+spinoso-symbol = { version = "0.3.0", path = "../spinoso-symbol" }
 spinoso-time = { version = "0.2.0", path = "../spinoso-time", optional = true }
 
 [dev-dependencies]

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -398,7 +398,7 @@ version = "0.2.0"
 
 [[package]]
 name = "scolapasta-string-escape"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bstr",
 ]
@@ -489,7 +489,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-symbol"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "artichoke-core",
  "bstr",

--- a/scolapasta-string-escape/Cargo.toml
+++ b/scolapasta-string-escape/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scolapasta-string-escape"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2021"
 rust-version = "1.60.0"

--- a/scolapasta-string-escape/README.md
+++ b/scolapasta-string-escape/README.md
@@ -40,7 +40,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-scolapasta-string-escape = "0.2.0"
+scolapasta-string-escape = "0.3.0"
 ```
 
 To debug escape a conventionally UTF-8 byte string:

--- a/scolapasta-string-escape/src/literal.rs
+++ b/scolapasta-string-escape/src/literal.rs
@@ -3,7 +3,7 @@ use core::iter::FusedIterator;
 use core::slice;
 use core::str;
 
-/// Returns whether a [`char`] is ASCII and has a literal escape code.
+/// Returns whether the given [`char`] has an ASCII literal escape code.
 ///
 /// Control characters in the range `0x00..=0x1F`, `"`, `\` and `DEL` have
 /// non-trivial escapes.
@@ -12,26 +12,31 @@ use core::str;
 ///
 /// ```
 /// # use core::char::REPLACEMENT_CHARACTER;
-/// # use scolapasta_string_escape::is_ascii_char_with_escape;
-/// assert!(is_ascii_char_with_escape('\x00'));
-/// assert!(is_ascii_char_with_escape('"'));
-/// assert!(is_ascii_char_with_escape('\\'));
+/// # use scolapasta_string_escape::ascii_char_with_escape;
+/// assert_eq!(ascii_char_with_escape('\x00'), Some(r"\x00"));
+/// assert_eq!(ascii_char_with_escape('\n'), Some(r"\n"));
+/// assert_eq!(ascii_char_with_escape('"'), Some(r#"\""#));
+/// assert_eq!(ascii_char_with_escape('\\'), Some("\\"));
 ///
-/// assert!(!is_ascii_char_with_escape('a'));
-/// assert!(!is_ascii_char_with_escape('Z'));
-/// assert!(!is_ascii_char_with_escape(';'));
-/// assert!(!is_ascii_char_with_escape('💎'));
-/// assert!(!is_ascii_char_with_escape(REPLACEMENT_CHARACTER));
+/// assert_eq!(ascii_char_with_escape('a'), None);
+/// assert_eq!(ascii_char_with_escape('Z'), None);
+/// assert_eq!(ascii_char_with_escape(';'), None);
+/// assert_eq!(ascii_char_with_escape('💎'), None);
+/// assert_eq!(ascii_char_with_escape(REPLACEMENT_CHARACTER), None);
 /// ```
 #[inline]
 #[must_use]
-pub const fn is_ascii_char_with_escape(ch: char) -> bool {
+pub const fn ascii_char_with_escape(ch: char) -> Option<&'static str> {
     if !ch.is_ascii() {
-        return false;
+        return None;
     }
     let [ascii_byte, ..] = (ch as u32).to_le_bytes();
     let escape = Literal::debug_escape(ascii_byte);
-    escape.len() > 1
+    if escape.len() > 1 {
+        Some(escape)
+    } else {
+        None
+    }
 }
 
 /// Iterator of Ruby debug escape sequences for a byte.

--- a/scolapasta-string-escape/src/literal.rs
+++ b/scolapasta-string-escape/src/literal.rs
@@ -29,7 +29,7 @@ pub const fn is_ascii_char_with_escape(ch: char) -> bool {
     if !ch.is_ascii() {
         return false;
     }
-    let [ascii_byte, _, _, _] = (ch as u32).to_le_bytes();
+    let [ascii_byte, ..] = (ch as u32).to_le_bytes();
     let escape = Literal::debug_escape(ascii_byte);
     escape.len() > 1
 }

--- a/scolapasta-string-escape/src/literal.rs
+++ b/scolapasta-string-escape/src/literal.rs
@@ -13,10 +13,10 @@ use core::str;
 /// ```
 /// # use core::char::REPLACEMENT_CHARACTER;
 /// # use scolapasta_string_escape::ascii_char_with_escape;
-/// assert_eq!(ascii_char_with_escape('\x00'), Some(r"\x00"));
+/// assert_eq!(ascii_char_with_escape('\0'), Some(r"\x00"));
 /// assert_eq!(ascii_char_with_escape('\n'), Some(r"\n"));
 /// assert_eq!(ascii_char_with_escape('"'), Some(r#"\""#));
-/// assert_eq!(ascii_char_with_escape('\\'), Some("\\"));
+/// assert_eq!(ascii_char_with_escape('\\'), Some(r"\\"));
 ///
 /// assert_eq!(ascii_char_with_escape('a'), None);
 /// assert_eq!(ascii_char_with_escape('Z'), None);

--- a/scolapasta-string-escape/src/string.rs
+++ b/scolapasta-string-escape/src/string.rs
@@ -38,7 +38,7 @@ where
         let (ch, size) = bstr::decode_utf8(message);
         match ch {
             Some(ch) if is_ascii_char_with_escape(ch) => {
-                let [ascii_byte, _, _, _] = u32::from(ch).to_le_bytes();
+                let [ascii_byte, ..] = u32::from(ch).to_le_bytes();
                 let escaped = Literal::debug_escape(ascii_byte);
                 dest.write_str(escaped)?;
             }

--- a/scolapasta-string-escape/src/string.rs
+++ b/scolapasta-string-escape/src/string.rs
@@ -1,6 +1,6 @@
 use core::fmt::{self, Write};
 
-use crate::literal::{is_ascii_char_with_escape, Literal};
+use crate::literal::{ascii_char_with_escape, Literal};
 
 /// Write a UTF-8 debug representation of a byte slice into the given writer.
 ///
@@ -36,13 +36,11 @@ where
     let mut message = message.as_ref();
     while !message.is_empty() {
         let (ch, size) = bstr::decode_utf8(message);
-        match ch {
-            Some(ch) if is_ascii_char_with_escape(ch) => {
-                let [ascii_byte, ..] = u32::from(ch).to_le_bytes();
-                let escaped = Literal::debug_escape(ascii_byte);
+        match ch.map(|ch| ascii_char_with_escape(ch).ok_or(ch)) {
+            Some(Ok(escaped)) => {
                 dest.write_str(escaped)?;
             }
-            Some(ch) => {
+            Some(Err(ch)) => {
                 let enc = ch.encode_utf8(&mut buf);
                 dest.write_str(enc)?;
             }

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -501,7 +501,7 @@ version = "0.2.0"
 
 [[package]]
 name = "scolapasta-string-escape"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bstr",
 ]
@@ -638,7 +638,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-symbol"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "artichoke-core",
  "bstr",

--- a/spinoso-env/Cargo.toml
+++ b/spinoso-env/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["os", "wasm"]
 
 [dependencies]
 bstr = { version = "0.2.9", default-features = false }
-scolapasta-string-escape = { version = "0.2.0", path = "../scolapasta-string-escape", default-features = false }
+scolapasta-string-escape = { version = "0.3.0", path = "../scolapasta-string-escape", default-features = false }
 
 [features]
 default = ["system-env"]

--- a/spinoso-exception/Cargo.toml
+++ b/spinoso-exception/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["error", "exception", "no_std", "spinoso"]
 categories = ["rust-patterns"]
 
 [dependencies]
-scolapasta-string-escape = { version = "0.2.0", path = "../scolapasta-string-escape", default-features = false }
+scolapasta-string-escape = { version = "0.3.0", path = "../scolapasta-string-escape", default-features = false }
 
 [features]
 default = ["std"]

--- a/spinoso-regexp/Cargo.toml
+++ b/spinoso-regexp/Cargo.toml
@@ -23,7 +23,7 @@ onig = { version = "6.3.0", optional = true, default-features = false }
 # See: CVE-2022-24713
 # https://github.com/artichoke/artichoke/pull/1729
 regex = { version = "1.5.5", default-features = false, features = ["std", "unicode-perl"] }
-scolapasta-string-escape = { version = "0.2.0", path = "../scolapasta-string-escape", default-features = false }
+scolapasta-string-escape = { version = "0.3.0", path = "../scolapasta-string-escape", default-features = false }
 
 [features]
 default = ["oniguruma", "regex-full"]

--- a/spinoso-regexp/src/encoding.rs
+++ b/spinoso-regexp/src/encoding.rs
@@ -98,7 +98,7 @@ impl TryFrom<i64> for Encoding {
     type Error = InvalidEncodingError;
 
     fn try_from(flags: i64) -> Result<Self, Self::Error> {
-        let [byte, _, _, _, _, _, _, _] = flags.to_le_bytes();
+        let [byte, ..] = flags.to_le_bytes();
         Self::try_from(byte)
     }
 }

--- a/spinoso-regexp/src/options.rs
+++ b/spinoso-regexp/src/options.rs
@@ -117,7 +117,7 @@ impl From<i64> for Options {
     ///
     /// [`try_from_int`]: Self::try_from_int
     fn from(flags: i64) -> Self {
-        let [byte, _, _, _, _, _, _, _] = flags.to_le_bytes();
+        let [byte, ..] = flags.to_le_bytes();
         Self::from(byte)
     }
 }

--- a/spinoso-string/Cargo.toml
+++ b/spinoso-string/Cargo.toml
@@ -18,7 +18,7 @@ bstr = { version = "0.2.9", default-features = false, features = ["std"] }
 bytecount = "0.6.2"
 focaccia = { version = "1.1.0", optional = true, default-features = false }
 raw-parts = "1.1.1"
-scolapasta-string-escape = { version = "0.2.0", path = "../scolapasta-string-escape", default-features = false }
+scolapasta-string-escape = { version = "0.3.0", path = "../scolapasta-string-escape", default-features = false }
 simdutf8 = { version = "0.1.4", default-features = false }
 
 [dev-dependencies]

--- a/spinoso-symbol/Cargo.toml
+++ b/spinoso-symbol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spinoso-symbol"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2021"
 rust-version = "1.60.0"
@@ -18,7 +18,7 @@ artichoke-core = { version = "0.12.0", path = "../artichoke-core", optional = tr
 bstr = { version = "0.2.9", optional = true, default-features = false }
 focaccia = { version = "1.1.0", optional = true, default-features = false }
 qed = "1.3.0"
-scolapasta-string-escape = { version = "0.2.0", path = "../scolapasta-string-escape", optional = true, default-features = false }
+scolapasta-string-escape = { version = "0.3.0", path = "../scolapasta-string-escape", optional = true, default-features = false }
 
 [features]
 default = ["artichoke", "std"]

--- a/spinoso-symbol/README.md
+++ b/spinoso-symbol/README.md
@@ -30,7 +30,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-spinoso-symbol = "0.2.0"
+spinoso-symbol = "0.3.0"
 ```
 
 Most of the functionality in this crate depends on a Ruby interpreter that

--- a/spinoso-symbol/src/inspect.rs
+++ b/spinoso-symbol/src/inspect.rs
@@ -313,9 +313,8 @@ impl<'a> Iterator for State<'a> {
                 if let Some([head, tail @ ..]) = ascii_char_with_escape(ch).map(str::as_bytes) {
                     self.escaped_bytes = tail;
                     return Some(char::from(*head));
-                } else {
-                    return Some(ch);
                 }
+                return Some(ch);
             }
             None if size == 0 => {}
             None => {

--- a/spinoso-symbol/src/inspect.rs
+++ b/spinoso-symbol/src/inspect.rs
@@ -1,7 +1,7 @@
 use core::fmt;
 use core::iter::FusedIterator;
 
-use scolapasta_string_escape::{is_ascii_char_with_escape, InvalidUtf8ByteSequence};
+use scolapasta_string_escape::{ascii_char_with_escape, InvalidUtf8ByteSequence};
 
 use crate::ident::IdentifierType;
 
@@ -81,12 +81,6 @@ impl<'a> Iterator for Inspect<'a> {
 
     fn next(&mut self) -> Option<Self::Item> {
         self.0.next()
-    }
-}
-
-impl<'a> DoubleEndedIterator for Inspect<'a> {
-    fn next_back(&mut self) -> Option<Self::Item> {
-        self.0.next_back()
     }
 }
 
@@ -246,9 +240,9 @@ impl Flags {
 #[must_use = "this `State` is an `Iterator`, which should be consumed if constructed"]
 struct State<'a> {
     flags: Flags,
+    escaped_bytes: &'static [u8],
     forward_byte_literal: InvalidUtf8ByteSequence,
     bytes: &'a [u8],
-    reverse_byte_literal: InvalidUtf8ByteSequence,
 }
 
 impl<'a> State<'a> {
@@ -260,9 +254,9 @@ impl<'a> State<'a> {
     fn ident(bytes: &'a [u8]) -> Self {
         Self {
             flags: Flags::IDENT,
+            escaped_bytes: &[],
             forward_byte_literal: InvalidUtf8ByteSequence::new(),
             bytes,
-            reverse_byte_literal: InvalidUtf8ByteSequence::new(),
         }
     }
 
@@ -273,9 +267,9 @@ impl<'a> State<'a> {
     fn quoted(bytes: &'a [u8]) -> Self {
         Self {
             flags: Flags::QUOTED,
+            escaped_bytes: &[],
             forward_byte_literal: InvalidUtf8ByteSequence::new(),
             bytes,
-            reverse_byte_literal: InvalidUtf8ByteSequence::new(),
         }
     }
 }
@@ -301,6 +295,10 @@ impl<'a> Iterator for State<'a> {
         if let Some(ch) = self.flags.emit_leading_quote() {
             return Some(ch);
         }
+        if let Some((&head, tail)) = self.escaped_bytes.split_first() {
+            self.escaped_bytes = tail;
+            return Some(head.into());
+        }
         if let Some(ch) = self.forward_byte_literal.next() {
             return Some(ch);
         }
@@ -310,22 +308,14 @@ impl<'a> Iterator for State<'a> {
                 self.bytes = &self.bytes[size..];
                 return ch;
             }
-            Some(ch) if is_ascii_char_with_escape(ch) => {
-                let (ascii_byte, remainder) = self.bytes.split_at(size);
-                // This conversion is safe to unwrap due to the documented
-                // behavior of `bstr::decode_utf8` and `InvalidUtf8ByteSequence`
-                // which indicate that `size` is always in the range of 0..=3.
-                //
-                // While not an invalid byte, we rely on the documented
-                // behavior of `InvalidUtf8ByteSequence` to always escape
-                // any bytes given to it.
-                self.forward_byte_literal = InvalidUtf8ByteSequence::try_from(ascii_byte).unwrap();
-                self.bytes = remainder;
-                return self.forward_byte_literal.next();
-            }
             Some(ch) => {
                 self.bytes = &self.bytes[size..];
-                return Some(ch);
+                if let Some([head, tail @ ..]) = ascii_char_with_escape(ch).map(str::as_bytes) {
+                    self.escaped_bytes = tail;
+                    return Some(char::from(*head));
+                } else {
+                    return Some(ch);
+                }
             }
             None if size == 0 => {}
             None => {
@@ -338,65 +328,7 @@ impl<'a> Iterator for State<'a> {
                 return self.forward_byte_literal.next();
             }
         };
-        if let Some(ch) = self.reverse_byte_literal.next() {
-            return Some(ch);
-        }
         if let Some(ch) = self.flags.emit_trailing_quote() {
-            return Some(ch);
-        }
-        None
-    }
-}
-
-impl<'a> DoubleEndedIterator for State<'a> {
-    fn next_back(&mut self) -> Option<Self::Item> {
-        if let Some(ch) = self.flags.emit_trailing_quote() {
-            return Some(ch);
-        }
-        if let Some(ch) = self.reverse_byte_literal.next_back() {
-            return Some(ch);
-        }
-        let (ch, size) = bstr::decode_last_utf8(self.bytes);
-        match ch {
-            Some('"' | '\\') if self.flags.is_ident() => {
-                self.bytes = &self.bytes[..self.bytes.len() - size];
-                return ch;
-            }
-            Some(ch) if is_ascii_char_with_escape(ch) => {
-                let (remainder, ascii_byte) = self.bytes.split_at(self.bytes.len() - size);
-                // This conversion is safe to unwrap due to the documented
-                // behavior of `bstr::decode_utf8` and `InvalidUtf8ByteSequence`
-                // which indicate that `size` is always in the range of 0..=3.
-                //
-                // While not an invalid byte, we rely on the documented
-                // behavior of `InvalidUtf8ByteSequence` to always escape
-                // any bytes given to it.
-                self.reverse_byte_literal = InvalidUtf8ByteSequence::try_from(ascii_byte).unwrap();
-                self.bytes = remainder;
-                return self.reverse_byte_literal.next_back();
-            }
-            Some(ch) => {
-                self.bytes = &self.bytes[..self.bytes.len() - size];
-                return Some(ch);
-            }
-            None if size == 0 => {}
-            None => {
-                let (remainder, invalid_utf8_bytes) = self.bytes.split_at(self.bytes.len() - size);
-                // This conversion is safe to unwrap due to the documented
-                // behavior of `bstr::decode_utf8` and `InvalidUtf8ByteSequence`
-                // which indicate that `size` is always in the range of 0..=3.
-                self.reverse_byte_literal = InvalidUtf8ByteSequence::try_from(invalid_utf8_bytes).unwrap();
-                self.bytes = remainder;
-                return self.reverse_byte_literal.next_back();
-            }
-        };
-        if let Some(ch) = self.forward_byte_literal.next_back() {
-            return Some(ch);
-        }
-        if let Some(ch) = self.flags.emit_leading_quote() {
-            return Some(ch);
-        }
-        if let Some(ch) = self.flags.emit_leading_colon() {
             return Some(ch);
         }
         None
@@ -419,53 +351,10 @@ mod tests {
     }
 
     #[test]
-    fn empty_backwards() {
-        let mut inspect = Inspect::from("");
-        assert_eq!(inspect.next_back(), Some('"'));
-        assert_eq!(inspect.next_back(), Some('"'));
-        assert_eq!(inspect.next_back(), Some(':'));
-        assert_eq!(inspect.next_back(), None);
-        assert_eq!(inspect.next(), None);
-
-        let mut inspect = Inspect::from("");
-        assert_eq!(inspect.next(), Some(':'));
-        assert_eq!(inspect.next_back(), Some('"'));
-        assert_eq!(inspect.next_back(), Some('"'));
-        assert_eq!(inspect.next_back(), None);
-        assert_eq!(inspect.next(), None);
-
-        let mut inspect = Inspect::from("");
-        assert_eq!(inspect.next(), Some(':'));
-        assert_eq!(inspect.next(), Some('"'));
-        assert_eq!(inspect.next_back(), Some('"'));
-        assert_eq!(inspect.next_back(), None);
-        assert_eq!(inspect.next(), None);
-
-        let mut inspect = Inspect::from("");
-        assert_eq!(inspect.next(), Some(':'));
-        assert_eq!(inspect.next(), Some('"'));
-        assert_eq!(inspect.next(), Some('"'));
-        assert_eq!(inspect.next_back(), None);
-        assert_eq!(inspect.next(), None);
-    }
-
-    #[test]
     fn fred() {
         let inspect = Inspect::from("fred");
         let debug = inspect.collect::<String>();
         assert_eq!(debug, ":fred");
-    }
-
-    #[test]
-    fn fred_backwards() {
-        let mut inspect = Inspect::from("fred");
-        assert_eq!(inspect.next_back(), Some('d'));
-        assert_eq!(inspect.next_back(), Some('e'));
-        assert_eq!(inspect.next_back(), Some('r'));
-        assert_eq!(inspect.next_back(), Some('f'));
-        assert_eq!(inspect.next_back(), Some(':'));
-        assert_eq!(inspect.next_back(), None);
-        assert_eq!(inspect.next(), None);
     }
 
     #[test]
@@ -481,33 +370,6 @@ mod tests {
     }
 
     #[test]
-    fn invalid_utf8_backwards() {
-        let mut inspect = Inspect::from(&b"invalid-\xFF-utf8"[..]);
-        assert_eq!(inspect.next_back(), Some('"'));
-        assert_eq!(inspect.next_back(), Some('8'));
-        assert_eq!(inspect.next_back(), Some('f'));
-        assert_eq!(inspect.next_back(), Some('t'));
-        assert_eq!(inspect.next_back(), Some('u'));
-        assert_eq!(inspect.next_back(), Some('-'));
-        assert_eq!(inspect.next_back(), Some('F'));
-        assert_eq!(inspect.next_back(), Some('F'));
-        assert_eq!(inspect.next_back(), Some('x'));
-        assert_eq!(inspect.next_back(), Some('\\'));
-        assert_eq!(inspect.next_back(), Some('-'));
-        assert_eq!(inspect.next_back(), Some('d'));
-        assert_eq!(inspect.next_back(), Some('i'));
-        assert_eq!(inspect.next_back(), Some('l'));
-        assert_eq!(inspect.next_back(), Some('a'));
-        assert_eq!(inspect.next_back(), Some('v'));
-        assert_eq!(inspect.next_back(), Some('n'));
-        assert_eq!(inspect.next_back(), Some('i'));
-        assert_eq!(inspect.next_back(), Some('"'));
-        assert_eq!(inspect.next_back(), Some(':'));
-        assert_eq!(inspect.next_back(), None);
-        assert_eq!(inspect.next(), None);
-    }
-
-    #[test]
     fn quoted() {
         let mut inspect = Inspect::from(r#"a"b"#);
         assert_eq!(inspect.next(), Some(':'));
@@ -519,77 +381,6 @@ mod tests {
         assert_eq!(inspect.next(), Some('"'));
 
         assert_eq!(Inspect::from(r#"a"b"#).collect::<String>(), r#":"a\"b""#);
-    }
-
-    #[test]
-    fn quote_backwards() {
-        let mut inspect = Inspect::from(r#"a"b"#);
-        assert_eq!(inspect.next_back(), Some('"'));
-        assert_eq!(inspect.next_back(), Some('b'));
-        assert_eq!(inspect.next_back(), Some('"'));
-        assert_eq!(inspect.next_back(), Some('\\'));
-        assert_eq!(inspect.next_back(), Some('a'));
-        assert_eq!(inspect.next_back(), Some('"'));
-        assert_eq!(inspect.next_back(), Some(':'));
-        assert_eq!(inspect.next_back(), None);
-    }
-
-    #[test]
-    fn quote_double_ended() {
-        let mut inspect = Inspect::from(r#"a"b"#);
-        assert_eq!(inspect.next(), Some(':'));
-        assert_eq!(inspect.next(), Some('"'));
-        assert_eq!(inspect.next(), Some('a'));
-        assert_eq!(inspect.next(), Some('\\'));
-        assert_eq!(inspect.next_back(), Some('"'));
-        assert_eq!(inspect.next_back(), Some('b'));
-        assert_eq!(inspect.next_back(), Some('"'));
-        assert_eq!(inspect.next(), None);
-
-        let mut inspect = Inspect::from(r#"a"b"#);
-        assert_eq!(inspect.next(), Some(':'));
-        assert_eq!(inspect.next(), Some('"'));
-        assert_eq!(inspect.next(), Some('a'));
-        assert_eq!(inspect.next(), Some('\\'));
-        assert_eq!(inspect.next_back(), Some('"'));
-        assert_eq!(inspect.next_back(), Some('b'));
-        assert_eq!(inspect.next_back(), Some('"'));
-        assert_eq!(inspect.next_back(), None);
-
-        let mut inspect = Inspect::from(r#"a"b"#);
-        assert_eq!(inspect.next_back(), Some('"'));
-        assert_eq!(inspect.next_back(), Some('b'));
-        assert_eq!(inspect.next_back(), Some('"'));
-        assert_eq!(inspect.next(), Some(':'));
-        assert_eq!(inspect.next(), Some('"'));
-        assert_eq!(inspect.next(), Some('a'));
-        assert_eq!(inspect.next(), Some('\\'));
-        assert_eq!(inspect.next(), None);
-
-        let mut inspect = Inspect::from(r#"a"b"#);
-        assert_eq!(inspect.next_back(), Some('"'));
-        assert_eq!(inspect.next_back(), Some('b'));
-        assert_eq!(inspect.next_back(), Some('"'));
-        assert_eq!(inspect.next(), Some(':'));
-        assert_eq!(inspect.next(), Some('"'));
-        assert_eq!(inspect.next(), Some('a'));
-        assert_eq!(inspect.next(), Some('\\'));
-        assert_eq!(inspect.next_back(), None);
-
-        let mut inspect = Inspect::from(r#"a"b"#);
-        assert_eq!(inspect.next_back(), Some('"'));
-        assert_eq!(inspect.next_back(), Some('b'));
-        assert_eq!(inspect.next_back(), Some('"'));
-        assert_eq!(inspect.next(), Some(':'));
-        assert_eq!(inspect.next_back(), Some('\\'));
-
-        let mut inspect = Inspect::from(r#"a"b"#);
-        assert_eq!(inspect.next(), Some(':'));
-        assert_eq!(inspect.next(), Some('"'));
-        assert_eq!(inspect.next(), Some('a'));
-        assert_eq!(inspect.next(), Some('\\'));
-        assert_eq!(inspect.next_back(), Some('"'));
-        assert_eq!(inspect.next(), Some('"'));
     }
 
     #[test]
@@ -617,20 +408,6 @@ mod tests {
     fn escape_slash() {
         assert_eq!(Inspect::from("\\").collect::<String>(), r#":"\\""#);
         assert_eq!(Inspect::from("foo\\bar").collect::<String>(), r#":"foo\\bar""#);
-    }
-
-    #[test]
-    fn escape_slash_backwards() {
-        let mut inspect = Inspect::from("a\\b");
-        assert_eq!(inspect.next_back(), Some('"'));
-        assert_eq!(inspect.next_back(), Some('b'));
-        assert_eq!(inspect.next_back(), Some('\\'));
-        assert_eq!(inspect.next_back(), Some('\\'));
-        assert_eq!(inspect.next_back(), Some('a'));
-        assert_eq!(inspect.next_back(), Some('"'));
-        assert_eq!(inspect.next_back(), Some(':'));
-        assert_eq!(inspect.next_back(), None);
-        assert_eq!(inspect.next(), None);
     }
 
     #[test]


### PR DESCRIPTION
Some are replaced with `..`.

## ASCII char escapes in `scolapasta-string-escape`

This refactor uncovered an opportunity for doing some parsing instead of validating with ASCII literal escape sequences.

"Parse don't validate": replace `is_ascii_char_with_escape` which returns a `bool` with `ascii_char_with_escape` which returns `Option<&'static str>`.

Rework iterators to use the new method.

Remove the `DoubleEndedIterator` from `spinoso_symbol::Inspect` to mirror the API in `spinoso_string::Inspect`.

Bump the versions of `scolapasta-string-escape` and `spinoso-symbol` to account for the breaking API changes.