### PR TITLE
Update clap `App` and `Arg` builders to use 3.2.x API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ keywords = ["artichoke", "artichoke-ruby", "mri", "cruby", "ruby"]
 categories = ["command-line-utilities"]
 
 [dependencies]
-clap = { version = "3.1.2", optional = true, default-features = false, features = ["std", "suggestions"] }
+clap = { version = "3.2.5", optional = true, default-features = false, features = ["std", "suggestions"] }
 # XXX: load-bearing unused dependency.
 #
 # `rustyline` improperly declares its minimum version on `log` as `0.4` despite

--- a/spec-runner/Cargo.toml
+++ b/spec-runner/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["development-tools::testing"]
 
 [dependencies]
 artichoke = { version = "0.1.0-pre.0", path = "..", default-features = false, features = ["backtrace", "kitchen-sink"] }
-clap = { version = "3.1.2", default-features = false, features = ["std", "suggestions"] }
+clap = { version = "3.2.5", default-features = false, features = ["std", "suggestions"] }
 rust-embed = "6.3.0"
 serde = { version = "1.0.136", features = ["derive"] }
 termcolor = "1.1.0"

--- a/spec-runner/src/main.rs
+++ b/spec-runner/src/main.rs
@@ -113,6 +113,7 @@ pub fn main() {
             Arg::new("formatter")
                 .long("format")
                 .short('f')
+                .takes_value(true)
                 .value_parser(["artichoke", "summary", "tagger", "yaml"])
                 .default_value("artichoke")
                 .help("Choose an output formatter"),

--- a/spec-runner/src/main.rs
+++ b/spec-runner/src/main.rs
@@ -108,6 +108,7 @@ pub fn main() {
 
     let command = Command::new("spec-runner")
         .about("ruby/spec runner for Artichoke.")
+        .version(env!("CARGO_PKG_VERSION"))
         .arg(
             Arg::new("formatter")
                 .long("format")
@@ -127,8 +128,7 @@ pub fn main() {
             Arg::new("config")
                 .value_parser(clap::value_parser!(PathBuf))
                 .help("Path to TOML config file"),
-        )
-        .version(env!("CARGO_PKG_VERSION"));
+        );
 
     let matches = command.get_matches();
 

--- a/spec-runner/src/main.rs
+++ b/spec-runner/src/main.rs
@@ -82,6 +82,7 @@ use std::str;
 
 use artichoke::backtrace;
 use artichoke::prelude::*;
+use clap::builder::ArgAction;
 use clap::{Arg, Command};
 use termcolor::{ColorChoice, StandardStream, WriteColor};
 
@@ -105,56 +106,39 @@ struct Args {
 pub fn main() {
     let mut stderr = StandardStream::stderr(ColorChoice::Auto);
 
-    let command = Command::new("spec-runner");
-    let command = command.about("ruby/spec runner for Artichoke.");
-    let command = command.arg(
-        Arg::new("formatter")
-            .long("format")
-            .short('f')
-            .allow_invalid_utf8(true)
-            .takes_value(true)
-            .possible_values(&["artichoke", "summary", "tagger", "yaml"])
-            .default_value("artichoke")
-            .required(false)
-            .help("Choose an output formatter"),
-    );
-    let command = command.arg(
-        Arg::new("quiet")
-            .long("quiet")
-            .short('q')
-            .required(false)
-            .help("Suppress spec failures when exiting"),
-    );
-    let command = command.arg(
-        Arg::new("config")
-            .allow_invalid_utf8(true)
-            .takes_value(true)
-            .required(true)
-            .help("Path to TOML config file"),
-    );
-    let command = command.version(env!("CARGO_PKG_VERSION"));
+    let command = Command::new("spec-runner")
+        .about("ruby/spec runner for Artichoke.")
+        .arg(
+            Arg::new("formatter")
+                .long("format")
+                .short('f')
+                .value_parser(["artichoke", "summary", "tagger", "yaml"])
+                .default_value("artichoke")
+                .help("Choose an output formatter"),
+        )
+        .arg(
+            Arg::new("quiet")
+                .long("quiet")
+                .short('q')
+                .action(ArgAction::SetTrue)
+                .help("Suppress spec failures when exiting"),
+        )
+        .arg(
+            Arg::new("config")
+                .value_parser(clap::value_parser!(PathBuf))
+                .help("Path to TOML config file"),
+        )
+        .version(env!("CARGO_PKG_VERSION"));
 
     let matches = command.get_matches();
 
     let formatter = matches
-        .value_of_os("formatter")
-        .expect("formatter has a default value, clap should ensure");
-    let formatter = formatter
-        .to_str()
-        .expect("formatter has possible values, clap should ensure");
-    let formatter = formatter.parse::<Formatter>();
-    let formatter = match formatter {
-        Ok(f) => f,
-        Err(err) => {
-            // Suppress all errors at this point (e.g. from a broken pipe) since
-            // we're exiting with an error code anyway.
-            let _ignored = writeln!(&mut stderr, "{}", err);
-            process::exit(1);
-        }
-    };
-    let quiet = matches.is_present("quiet");
+        .get_one::<String>("formatter")
+        .and_then(|f| f.parse::<Formatter>().ok())
+        .expect("defaulted by clap");
+    let quiet = *matches.get_one::<bool>("quiet").expect("defaulted by clap");
 
-    let args = if let Some(config) = matches.value_of_os("config") {
+    let args = if let Some(config) = matches.get_one::<PathBuf>("config").cloned() {
         Args {
             config: config.into(),
             formatter,

--- a/spec-runner/src/main.rs
+++ b/spec-runner/src/main.rs
@@ -139,10 +139,7 @@ pub fn main() {
     let quiet = *matches.get_one::<bool>("quiet").expect("defaulted by clap");
 
     let args = if let Some(config) = matches.get_one::<PathBuf>("config").cloned() {
-        Args {
-            config: config.into(),
-            formatter,
-        }
+        Args { config, formatter }
     } else {
         // Suppress all errors at this point (e.g. from a broken pipe) since
         // we're exiting with an error code anyway.

--- a/src/bin/artichoke.rs
+++ b/src/bin/artichoke.rs
@@ -48,6 +48,7 @@ use std::path::PathBuf;
 use std::process;
 
 use artichoke::ruby::{self, Args};
+use clap::builder::ArgAction;
 use clap::{Arg, ArgMatches, Command};
 use termcolor::{ColorChoice, StandardStream, WriteColor};
 
@@ -84,13 +85,13 @@ fn parse_args() -> Result<Args> {
     let matches = clap_matches(env::args_os())?;
 
     let commands = matches
-        .values_of_os("commands")
+        .get_many::<OsString>("commands")
         .into_iter()
-        .flat_map(|v| v.map(OsString::from))
+        .flat_map(|s| s.map(Clone::clone))
         .collect::<Vec<_>>();
     let mut args = Args::empty()
-        .with_copyright(matches.is_present("copyright"))
-        .with_fixture(matches.value_of_os("fixture").map(PathBuf::from));
+        .with_copyright(*matches.get_one::<bool>("copyright").expect("defaulted by clap"))
+        .with_fixture(matches.get_one::<PathBuf>("fixture").cloned());
 
     // If no `-e` arguments are given, the first positional argument is the
     // `programfile`. All trailing arguments are ARGV to the script.
@@ -109,21 +110,20 @@ fn parse_args() -> Result<Args> {
     // ruby: No such file or directory -- bar.rb (LoadError)
     // ```
     if commands.is_empty() {
-        if let Some(programfile) = matches.value_of_os("programfile") {
-            args = args.with_programfile(Some(PathBuf::from(programfile)));
-            if let Some(argv) = matches.values_of_os("arguments") {
-                let ruby_program_argv = argv.map(OsString::from).collect::<Vec<_>>();
+        if let Some(programfile) = matches.get_one::<PathBuf>("programfile").cloned() {
+            args = args.with_programfile(Some(programfile));
+            if let Some(argv) = matches.get_many::<OsString>("arguments") {
+                let ruby_program_argv = argv.map(Clone::clone).collect::<Vec<_>>();
                 args = args.with_argv(ruby_program_argv);
             }
         }
     } else {
         args = args.with_commands(commands);
-        if let Some(first_arg) = matches.value_of_os("programfile") {
-            if let Some(argv) = matches.values_of_os("arguments") {
-                let ruby_program_argv = [first_arg]
+        if let Some(first_arg) = matches.get_one::<PathBuf>("programfile").cloned() {
+            if let Some(argv) = matches.get_many::<OsString>("arguments") {
+                let ruby_program_argv = [OsString::from(first_arg)]
                     .into_iter()
-                    .chain(argv)
-                    .map(OsString::from)
+                    .chain(argv.map(Clone::clone))
                     .collect::<Vec<_>>();
                 args = args.with_argv(ruby_program_argv);
             } else {
@@ -136,33 +136,36 @@ fn parse_args() -> Result<Args> {
 }
 
 fn command() -> Command<'static> {
-    let command = Command::new("artichoke");
-    let command = command.about("Artichoke is a Ruby made with Rust.");
-    let command = command.arg(
-        Arg::new("copyright")
-            .long("copyright")
-            .takes_value(false)
-            .help("print the copyright"),
-    );
-    let command = command.arg(
-        Arg::new("commands")
-            .short('e')
-            .allow_invalid_utf8(true)
-            .takes_value(true)
-            .multiple_occurrences(true)
-            .help(r"one line of script. Several -e's allowed. Omit [programfile]"),
-    );
-    let command = command.arg(
-        Arg::new("fixture")
-            .long("with-fixture")
-            .allow_invalid_utf8(true)
-            .takes_value(true)
-            .help("file whose contents will be read into the `$fixture` global"),
-    );
-    let command = command.arg(Arg::new("programfile").allow_invalid_utf8(true));
-    let command = command.arg(Arg::new("arguments").multiple_values(true).allow_invalid_utf8(true));
-    let command = command.version(env!("CARGO_PKG_VERSION"));
-    command.trailing_var_arg(true)
+    Command::new("artichoke")
+        .about("Artichoke is a Ruby made with Rust.")
+        .arg(
+            Arg::new("copyright")
+                .long("copyright")
+                .action(ArgAction::SetTrue)
+                .help("print the copyright"),
+        )
+        .arg(
+            Arg::new("commands")
+                .short('e')
+                .action(ArgAction::Append)
+                .value_parser(clap::value_parser!(OsString))
+                .help(r"one line of script. Several -e's allowed. Omit [programfile]"),
+        )
+        .arg(
+            Arg::new("fixture")
+                .long("with-fixture")
+                .takes_value(true)
+                .value_parser(clap::value_parser!(PathBuf))
+                .help("file whose contents will be read into the `$fixture` global"),
+        )
+        .arg(Arg::new("programfile").value_parser(clap::value_parser!(PathBuf)))
+        .arg(
+            Arg::new("arguments")
+                .multiple_values(true)
+                .value_parser(clap::value_parser!(OsString)),
+        )
+        .version(env!("CARGO_PKG_VERSION"))
+        .trailing_var_arg(true)
 }
 
 // NOTE: This routine is plucked from `ripgrep` as of

--- a/src/bin/artichoke.rs
+++ b/src/bin/artichoke.rs
@@ -138,6 +138,7 @@ fn parse_args() -> Result<Args> {
 fn command() -> Command<'static> {
     Command::new("artichoke")
         .about("Artichoke is a Ruby made with Rust.")
+        .version(env!("CARGO_PKG_VERSION"))
         .arg(
             Arg::new("copyright")
                 .long("copyright")
@@ -164,7 +165,6 @@ fn command() -> Command<'static> {
                 .multiple_values(true)
                 .value_parser(clap::value_parser!(OsString)),
         )
-        .version(env!("CARGO_PKG_VERSION"))
         .trailing_var_arg(true)
 }
 


### PR DESCRIPTION
Lots of changes in the clap builder API and deprecations of the prior API. The deprecated APIs are going away in 4.0.0 which will be released soon.

See:

- https://github.com/clap-rs/clap/blob/v3.2.5/CHANGELOG.md#320---2022-06-13
- https://epage.github.io/blog/2022/06/clap-32-last-call-before-40/

I reported a bug while working on this that turned out to be an error on my end:

- https://github.com/clap-rs/clap/issues/3859