### PR TITLE
Fix String#byteslice so a given length saturates to the end of the string

### DIFF
--- a/artichoke-backend/src/extn/core/string/string_test.rb
+++ b/artichoke-backend/src/extn/core/string/string_test.rb
@@ -31,21 +31,21 @@ def string_element_reference_regexp
 end
 
 def string_byteslice
-  s = "abcdefghijk"
-  raise unless s.byteslice(0, 1000) == "abcdefghijk"
-  raise unless s.byteslice(5, 1000) == "fghijk"
-  raise unless s.byteslice(20, 1000) == nil
-  raise unless s.byteslice(-5, 1000) == "ghijk"
-  raise unless s.byteslice(-25, 1000) == nil
-  raise unless s.byteslice(-25) == nil
-  raise unless s.byteslice(-5) == "g"
-  raise unless s.byteslice(-5, 10) == "ghijk"
-  raise unless s.byteslice(0) == "a"
-  raise unless s.byteslice(2) == "c"
-  raise unless s.byteslice(0, 5) == "abcde"
-  raise unless s.byteslice(5, 3) == "fgh"
-  raise unless s.byteslice(5, -10) == nil
-  raise unless s.byteslice(5, -2) == nil
+  s = 'abcdefghijk'
+  raise unless s.byteslice(0, 1000) == 'abcdefghijk'
+  raise unless s.byteslice(5, 1000) == 'fghijk'
+  raise unless s.byteslice(20, 1000).nil?
+  raise unless s.byteslice(-5, 1000) == 'ghijk'
+  raise unless s.byteslice(-25, 1000).nil?
+  raise unless s.byteslice(-25).nil?
+  raise unless s.byteslice(-5) == 'g'
+  raise unless s.byteslice(-5, 10) == 'ghijk'
+  raise unless s.byteslice(0) == 'a'
+  raise unless s.byteslice(2) == 'c'
+  raise unless s.byteslice(0, 5) == 'abcde'
+  raise unless s.byteslice(5, 3) == 'fgh'
+  raise unless s.byteslice(5, -10).nil?
+  raise unless s.byteslice(5, -2).nil?
 end
 
 def string_scan

--- a/artichoke-backend/src/extn/core/string/string_test.rb
+++ b/artichoke-backend/src/extn/core/string/string_test.rb
@@ -5,6 +5,7 @@
 def spec
   string_match_operator
   string_element_reference_regexp
+  string_byteslice
   string_scan
   string_unary_minus
   string_tr
@@ -27,6 +28,24 @@ def string_element_reference_regexp
   raise unless 'hello there'[/[aeiou](.)\1/, 2].nil?
   raise unless 'hello there'[/(?<vowel>[aeiou])(?<non_vowel>[^aeiou])/, 'non_vowel'] == 'l'
   raise unless 'hello there'[/(?<vowel>[aeiou])(?<non_vowel>[^aeiou])/, 'vowel'] == 'e'
+end
+
+def string_byteslice
+  s = "abcdefghijk"
+  raise unless s.byteslice(0, 1000) == "abcdefghijk"
+  raise unless s.byteslice(5, 1000) == "fghijk"
+  raise unless s.byteslice(20, 1000) == nil
+  raise unless s.byteslice(-5, 1000) == "ghijk"
+  raise unless s.byteslice(-25, 1000) == nil
+  raise unless s.byteslice(-25) == nil
+  raise unless s.byteslice(-5) == "g"
+  raise unless s.byteslice(-5, 10) == "ghijk"
+  raise unless s.byteslice(0) == "a"
+  raise unless s.byteslice(2) == "c"
+  raise unless s.byteslice(0, 5) == "abcde"
+  raise unless s.byteslice(5, 3) == "fgh"
+  raise unless s.byteslice(5, -10) == nil
+  raise unless s.byteslice(5, -2) == nil
 end
 
 def string_scan

--- a/artichoke-backend/src/extn/core/string/trampoline.rs
+++ b/artichoke-backend/src/extn/core/string/trampoline.rs
@@ -529,7 +529,7 @@ pub fn byteslice(
         let end = index
             .checked_add(length)
             .ok_or_else(|| RangeError::with_message("bignum too big to convert into `long'"))?;
-        if let Some(slice) = s.get(index..end) {
+        if let Some(slice) = s.get(index..end).or_else(|| s.get(index..)) {
             // Encoding from the source string is preserved.
             //
             // ```


### PR DESCRIPTION
Fixes an issue on `trunk` where two specs failed from the `enforced-specs.toml` suite:

```
Passed 1839, skipped 242, not implemented 14, failed 2 specs.

StringScanner#peek returns at most the specified number of bytes from the current position
SpecExpectationNotMetError: Expected nil == "is a test"
to be truthy but was false

/artichoke/virtual_root/src/lib/library/stringscanner/shared/peek.rb:11:in protect
(eval):165:in all?
(eval):590:in each
/artichoke/virtual_root/src/lib/library/stringscanner/peek_spec.rb:7
(eval):590:in each
/artichoke/virtual_root/src/lib/spec_runner.rb:74:in run_specs
(eval):1

StringScanner#peep returns at most the specified number of bytes from the current position
SpecExpectationNotMetError: Expected nil == "is a test"
to be truthy but was false

/artichoke/virtual_root/src/lib/library/stringscanner/shared/peek.rb:11:in protect
(eval):165:in all?
(eval):590:in each
/artichoke/virtual_root/src/lib/library/stringscanner/peep_spec.rb:18
(eval):590:in each
/artichoke/virtual_root/src/lib/spec_runner.rb:74:in run_specs
(eval):1

Passed 1839, skipped 242, not implemented 14, failed 2 specs.
```

This was probably broken in:
- 500d1b2e506d95badfecd26b20e4c4dda7964df2
- https://github.com/artichoke/artichoke/pull/1222

Or maybe:

- https://github.com/artichoke/artichoke/pull/1630

Add tests for `String#byteslice`.

TODO: Enable all `String` specs in `enforced-specs.toml`:

- https://github.com/artichoke/artichoke/issues/1912