### PR TITLE
Improve ruby/spec compliance of `String`

### DIFF
--- a/artichoke-backend/src/extn/core/string/mruby.rs
+++ b/artichoke-backend/src/extn/core/string/mruby.rs
@@ -295,7 +295,16 @@ unsafe extern "C" fn string_chomp(mrb: *mut sys::mrb_state, slf: sys::mrb_value)
     let separator = separator.map(Value::from);
     let result = trampoline::chomp(&mut guard, value, separator);
     match result {
-        Ok(value) => value.inner(),
+        Ok(value) => {
+            let rclass = sys::mrb_sys_class_of_value(mrb, slf);
+            let value = value.inner();
+            let target_rbasic = value.value.p.cast::<sys::RBasic>();
+
+            // Copy `RClass` from source class to newly allocated `Array`.
+            (*target_rbasic).c = rclass;
+
+            value
+        }
         Err(exception) => error::raise(guard, exception),
     }
 }
@@ -318,7 +327,16 @@ unsafe extern "C" fn string_chop(mrb: *mut sys::mrb_state, slf: sys::mrb_value) 
     let value = Value::from(slf);
     let result = trampoline::chop(&mut guard, value);
     match result {
-        Ok(value) => value.inner(),
+        Ok(value) => {
+            let rclass = sys::mrb_sys_class_of_value(mrb, slf);
+            let value = value.inner();
+            let target_rbasic = value.value.p.cast::<sys::RBasic>();
+
+            // Copy `RClass` from source class to newly allocated `Array`.
+            (*target_rbasic).c = rclass;
+
+            value
+        }
         Err(exception) => error::raise(guard, exception),
     }
 }

--- a/artichoke-backend/src/extn/core/string/string.rb
+++ b/artichoke-backend/src/extn/core/string/string.rb
@@ -381,7 +381,7 @@ class String
 
   # https://ruby-doc.org/core-3.0.2/String.html#method-i-delete
   def delete(*args)
-    args.inject(self) { |string, pattern| string.tr(pattern, '') }
+    args.inject(self) { |string, pattern| Artichoke::String.implicit_conversion(string).tr(pattern, '') }
   end
 
   # https://ruby-doc.org/core-3.0.2/String.html#method-i-delete-21

--- a/artichoke-backend/src/extn/core/string/string.rb
+++ b/artichoke-backend/src/extn/core/string/string.rb
@@ -573,7 +573,20 @@ class String
   # https://ruby-doc.org/core-3.0.2/String.html#method-i-end_with-3F
   def end_with?(*suffixes)
     suffixes.each do |suffix|
-      return true if self[-suffix.length..-1] == suffix
+      case suffix
+      when String
+        return true if suffix.empty?
+        return true if self[-suffix.length..-1] == suffix
+      when Regexp
+        m = suffix.match(self)
+        next if m.nil?
+
+        return true if m.end(0) == self.length
+      else
+        suffix = Artichoke::String.implicit_conversion(suffix)
+        return true if suffix.empty?
+        return true if self[-suffix.length..-1] == suffix
+      end
     end
     false
   end
@@ -1020,7 +1033,18 @@ class String
   # https://ruby-doc.org/core-3.0.2/String.html#method-i-start_with-3F
   def start_with?(*prefixes)
     prefixes.each do |prefix|
-      return true if self[0...prefix.length] == prefix
+      case prefix
+      when String
+        return true if self[0...prefix.length] == prefix
+      when Regexp
+        m = prefix.match(self)
+        next if m.nil?
+
+        return true if m.begin(0).zero?
+      else
+        prefix = Artichoke::String.implicit_conversion(prefix)
+        return true if self[0...prefix.length] == prefix
+      end
     end
     false
   end

--- a/artichoke-backend/src/extn/core/string/string.rb
+++ b/artichoke-backend/src/extn/core/string/string.rb
@@ -386,6 +386,8 @@ class String
 
   # https://ruby-doc.org/core-3.0.2/String.html#method-i-delete-21
   def delete!(*args)
+    raise FrozenError, "can't modify frozen String: #{inspect}" if frozen?
+
     replaced = delete(*args)
     replace(replaced) unless self == replaced
   end
@@ -400,6 +402,8 @@ class String
 
   # https://ruby-doc.org/core-3.0.2/String.html#method-i-delete_prefix-21
   def delete_prefix!(prefix)
+    raise FrozenError, "can't modify frozen String: #{inspect}" if frozen?
+
     replaced = delete_prefix(prefix)
     replace(replaced) unless self == replaced
   end
@@ -415,6 +419,8 @@ class String
 
   # https://ruby-doc.org/core-3.0.2/String.html#method-i-delete_suffix-21
   def delete_suffix!(prefix)
+    raise FrozenError, "can't modify frozen String: #{inspect}" if frozen?
+
     replaced = delete_suffix(prefix)
     replace(replaced) unless self == replaced
   end
@@ -630,6 +636,8 @@ class String
 
   # https://ruby-doc.org/core-3.0.2/String.html#method-i-gsub-21
   def gsub!(pattern, replacement = nil, &blk)
+    raise FrozenError, "can't modify frozen String: #{inspect}" if frozen?
+
     replaced = gsub(pattern, replacement, &blk)
     replace(replaced) unless self == replaced
   end
@@ -729,6 +737,8 @@ class String
 
   # https://ruby-doc.org/core-3.0.2/String.html#method-i-lstrip-21
   def lstrip!
+    raise FrozenError, "can't modify frozen String: #{inspect}" if frozen?
+
     replaced = lstrip
     replace(replaced) unless self == replaced
   end
@@ -756,6 +766,8 @@ class String
 
   # https://ruby-doc.org/core-3.0.2/String.html#method-i-next-21
   def next!
+    raise FrozenError, "can't modify frozen String: #{inspect}" if frozen?
+
     raise NotImplementedError
   end
   alias succ! next!
@@ -849,6 +861,8 @@ class String
 
   # https://ruby-doc.org/core-3.0.2/String.html#method-i-rstrip-21
   def rstrip!
+    raise FrozenError, "can't modify frozen String: #{inspect}" if frozen?
+
     replaced = rstrip
     replace(replaced) unless self == replaced
   end
@@ -867,6 +881,8 @@ class String
 
   # https://ruby-doc.org/core-3.0.2/String.html#method-i-scrub-21
   def scrub!
+    raise FrozenError, "can't modify frozen String: #{inspect}" if frozen?
+
     # TODO: This is a stub. Implement scrub! correctly.
     self
   end
@@ -986,6 +1002,8 @@ class String
 
   # https://ruby-doc.org/core-3.0.2/String.html#method-i-squeeze-21
   def squeeze!(*other_str)
+    raise FrozenError, "can't modify frozen String: #{inspect}" if frozen?
+
     replaced = squeeze(*other_str)
     replace(replaced) unless self == replaced
   end
@@ -1007,6 +1025,8 @@ class String
 
   # https://ruby-doc.org/core-3.0.2/String.html#method-i-strip-21
   def strip!
+    raise FrozenError, "can't modify frozen String: #{inspect}" if frozen?
+
     replaced = strip
     replace(replaced) unless self == replaced
   end
@@ -1039,6 +1059,8 @@ class String
 
   # https://ruby-doc.org/core-3.0.2/String.html#method-i-sub-21
   def sub!(pattern, replacement = nil, &blk)
+    raise FrozenError, "can't modify frozen String: #{inspect}" if frozen?
+
     replaced = sub(pattern, replacement, &blk)
     replace(replaced) unless self == replaced
   end
@@ -1055,6 +1077,8 @@ class String
 
   # https://ruby-doc.org/core-3.0.2/String.html#method-i-swapcase-21
   def swapcase!(*_args)
+    raise FrozenError, "can't modify frozen String: #{inspect}" if frozen?
+
     raise NotImplementedError
   end
 
@@ -1111,7 +1135,7 @@ class String
 
   # https://ruby-doc.org/core-3.0.2/String.html#method-i-tr-21
   def tr!(from_str, to_str)
-    raise FrozenError if frozen?
+    raise FrozenError, "can't modify frozen String: #{inspect}" if frozen?
 
     replaced = tr(from_str, to_str)
     replace(replaced) unless self == replaced
@@ -1124,7 +1148,7 @@ class String
 
   # https://ruby-doc.org/core-3.0.2/String.html#method-i-tr_s-21
   def tr_s!(from_str, to_str)
-    raise FrozenError if frozen?
+    raise FrozenError, "can't modify frozen String: #{inspect}" if frozen?
 
     replaced = tr_s(from_str, to_str)
     replace(replaced) unless self == replaced
@@ -1142,6 +1166,8 @@ class String
 
   # https://ruby-doc.org/core-3.0.2/String.html#method-i-unicode_normalize-21
   def unicode_normalize!(_form = :nfc)
+    raise FrozenError, "can't modify frozen String: #{inspect}" if frozen?
+
     raise NotImplementedError
   end
 

--- a/artichoke-backend/src/extn/core/string/string.rb
+++ b/artichoke-backend/src/extn/core/string/string.rb
@@ -59,6 +59,25 @@ module Artichoke
       end
       result
     end
+
+    def self.implicit_conversion(target)
+      return target if target.is_a?(::String)
+      raise TypeError, "no implicit conversion of nil into String" if target.nil?
+      raise TypeError, "no implicit conversion of Symbol into String" if target.is_a?(Symbol)
+
+      converted = target.to_str
+      return converted if converted.is_a?(::String)
+
+      inspect_name = target.class.name
+      inspect_name = target.inspect if target.is_a?(TrueClass) || target.is_a?(FalseClass) || target.nil?
+      message = "can't convert #{inspect_name} to String (#{inspect_name}#to_str gives #{converted.class})"
+      raise TypeError, message
+    rescue NoMethodError
+      inspect_name = target.class.name
+      inspect_name = target.inspect if target.is_a?(TrueClass) || target.is_a?(FalseClass) || target.nil?
+      message = "no implicit conversion of #{inspect_name} into String"
+      raise TypeError, message
+    end
   end
 end
 

--- a/artichoke-backend/src/extn/core/string/string.rb
+++ b/artichoke-backend/src/extn/core/string/string.rb
@@ -394,9 +394,14 @@ class String
 
   # https://ruby-doc.org/core-3.0.2/String.html#method-i-delete_prefix
   def delete_prefix(prefix)
-    raise TypeError, "no implicit conversion of #{prefix.class} into String" unless prefix.is_a?(String)
-    return self[prefix.length..-1] if start_with?(prefix)
+    prefix = Artichoke::String.implicit_conversion(prefix)
+    return dup if prefix.empty?
 
+    if start_with?(prefix)
+      slice = self[prefix.length..-1]
+      return slice if self.class == String
+      return self.class.new(slice)
+    end
     dup
   end
 
@@ -410,10 +415,14 @@ class String
 
   # https://ruby-doc.org/core-3.0.2/String.html#method-i-delete_suffix
   def delete_suffix(suffix)
-    raise TypeError, "no implicit conversion of #{suffix.class} into String" unless suffix.is_a?(String)
+    suffix = Artichoke::String.implicit_conversion(suffix)
+    return dup if suffix.empty?
 
-    return self[0..-suffix.length] if end_with?(suffix)
-
+    if end_with?(suffix)
+      slice = self[0...-suffix.length]
+      return slice if self.class == String
+      return self.class.new(slice)
+    end
     dup
   end
 

--- a/artichoke-backend/src/extn/core/string/string.rb
+++ b/artichoke-backend/src/extn/core/string/string.rb
@@ -99,6 +99,7 @@ class Encoding
   Shift_JIS = new('Shift_JIS')
   SHIFT_JIS = Shift_JIS
   UTF_8 = new('UTF-8')
+  UTF_32BE = new('UTF-32BE')
 
   def self.default_external
     UTF_8

--- a/artichoke-backend/src/extn/core/string/string.rb
+++ b/artichoke-backend/src/extn/core/string/string.rb
@@ -1231,7 +1231,7 @@ class String
   #
   # NOTE: Implemented in native code.
   #
-  # def upccase!; end
+  # def upcase!; end
 
   # https://ruby-doc.org/core-3.0.2/String.html#method-i-upto
   def upto(max, exclusive = false, &block) # rubocop:disable Style/OptionalBooleanParameter

--- a/artichoke-backend/src/extn/core/string/string.rb
+++ b/artichoke-backend/src/extn/core/string/string.rb
@@ -62,8 +62,8 @@ module Artichoke
 
     def self.implicit_conversion(target)
       return target if target.is_a?(::String)
-      raise TypeError, "no implicit conversion of nil into String" if target.nil?
-      raise TypeError, "no implicit conversion of Symbol into String" if target.is_a?(Symbol)
+      raise TypeError, 'no implicit conversion of nil into String' if target.nil?
+      raise TypeError, 'no implicit conversion of Symbol into String' if target.is_a?(Symbol)
 
       converted = target.to_str
       return converted if converted.is_a?(::String)
@@ -399,7 +399,8 @@ class String
 
     if start_with?(prefix)
       slice = self[prefix.length..-1]
-      return slice if self.class == String
+      return slice if instance_of?(String)
+
       return self.class.new(slice)
     end
     dup
@@ -420,7 +421,8 @@ class String
 
     if end_with?(suffix)
       slice = self[0...-suffix.length]
-      return slice if self.class == String
+      return slice if instance_of?(String)
+
       return self.class.new(slice)
     end
     dup
@@ -581,7 +583,7 @@ class String
         m = suffix.match(self)
         next if m.nil?
 
-        return true if m.end(0) == self.length
+        return true if m.end(0) == length
       else
         suffix = Artichoke::String.implicit_conversion(suffix)
         return true if suffix.empty?

--- a/artichoke-backend/src/extn/core/string/trampoline.rs
+++ b/artichoke-backend/src/extn/core/string/trampoline.rs
@@ -4,6 +4,7 @@ use core::hash::{BuildHasher, Hash, Hasher};
 use core::str;
 
 use artichoke_core::hash::Hash as _;
+use artichoke_core::value::Value as _;
 use bstr::ByteSlice;
 
 use crate::convert::implicitly_convert_to_int;
@@ -361,6 +362,15 @@ pub fn aref(
 }
 
 pub fn aset(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
+    if value.is_frozen(interp) {
+        let s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
+        let message = "can't modify frozen String: "
+            .chars()
+            .chain(s.inspect())
+            .collect::<super::String>();
+        return Err(FrozenError::from(message.into_vec()).into());
+    }
+
     let _s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
     Err(NotImplementedError::new().into())
 }
@@ -580,6 +590,15 @@ pub fn capitalize(interp: &mut Artichoke, mut value: Value) -> Result<Value, Err
 }
 
 pub fn capitalize_bang(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
+    if value.is_frozen(interp) {
+        let s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
+        let message = "can't modify frozen String: "
+            .chars()
+            .chain(s.inspect())
+            .collect::<super::String>();
+        return Err(FrozenError::from(message.into_vec()).into());
+    }
+
     let mut s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
     // Safety:
     //
@@ -679,6 +698,15 @@ pub fn chomp(interp: &mut Artichoke, mut value: Value, separator: Option<Value>)
 }
 
 pub fn chomp_bang(interp: &mut Artichoke, mut value: Value, separator: Option<Value>) -> Result<Value, Error> {
+    if value.is_frozen(interp) {
+        let s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
+        let message = "can't modify frozen String: "
+            .chars()
+            .chain(s.inspect())
+            .collect::<super::String>();
+        return Err(FrozenError::from(message.into_vec()).into());
+    }
+
     let mut s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
     unsafe {
         let string_mut = s.as_inner_mut();
@@ -704,6 +732,15 @@ pub fn chop(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
 }
 
 pub fn chop_bang(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
+    if value.is_frozen(interp) {
+        let s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
+        let message = "can't modify frozen String: "
+            .chars()
+            .chain(s.inspect())
+            .collect::<super::String>();
+        return Err(FrozenError::from(message.into_vec()).into());
+    }
+
     let mut s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
     if s.is_empty() {
         return Ok(Value::nil());
@@ -726,6 +763,15 @@ pub fn chr(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
 }
 
 pub fn clear(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
+    if value.is_frozen(interp) {
+        let s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
+        let message = "can't modify frozen String: "
+            .chars()
+            .chain(s.inspect())
+            .collect::<super::String>();
+        return Err(FrozenError::from(message.into_vec()).into());
+    }
+
     let mut s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
     // Safety:
     //
@@ -983,6 +1029,15 @@ pub fn reverse(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error>
 }
 
 pub fn reverse_bang(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
+    if value.is_frozen(interp) {
+        let s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
+        let message = "can't modify frozen String: "
+            .chars()
+            .chain(s.inspect())
+            .collect::<super::String>();
+        return Err(FrozenError::from(message.into_vec()).into());
+    }
+
     let mut s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
     // Safety:
     //
@@ -1146,8 +1201,19 @@ pub fn scan(interp: &mut Artichoke, value: Value, mut pattern: Value, block: Opt
 }
 
 pub fn setbyte(interp: &mut Artichoke, mut value: Value, index: Value, byte: Value) -> Result<Value, Error> {
-    let mut s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
     let index = implicitly_convert_to_int(interp, index)?;
+    let i64_byte = implicitly_convert_to_int(interp, byte)?;
+
+    if value.is_frozen(interp) {
+        let s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
+        let message = "can't modify frozen String: "
+            .chars()
+            .chain(s.inspect())
+            .collect::<super::String>();
+        return Err(FrozenError::from(message.into_vec()).into());
+    }
+
+    let mut s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
     let index = if let Ok(index) = usize::try_from(index) {
         index
     } else {
@@ -1165,7 +1231,6 @@ pub fn setbyte(interp: &mut Artichoke, mut value: Value, index: Value, byte: Val
             return Err(IndexError::from(message).into());
         }
     };
-    let i64_byte = implicitly_convert_to_int(interp, byte)?;
     // Wrapping when negative is intentional
     //
     // ```

--- a/spec-runner/enforced-specs.toml
+++ b/spec-runner/enforced-specs.toml
@@ -95,18 +95,20 @@ include = "all"
 include = "set"
 specs = [
   "bytesize",
-  "byteslice",
-  "chomp",
-  "chop",
+  # missing `Range` support: https://github.com/artichoke/artichoke/issues/1916
+  # "byteslice",
+  # `chomp` and `chop` have some improper separator handling
+  # "chomp",
+  # "chop",
   "clear",
   "delete_prefix",
-  "delete",
   "empty",
   "end_with",
   "getbyte",
   "include",
   "length",
-  "reverse",
+  # missing encoding-aware, character-oriented reverse for UTF-8 encoding.
+  # "reverse",
   "scan",
   "setbyte",
   "size",

--- a/spec-runner/enforced-specs.toml
+++ b/spec-runner/enforced-specs.toml
@@ -93,7 +93,27 @@ include = "all"
 
 [specs.core.string]
 include = "set"
-specs = ["scan", "tr", "tr_s"]
+specs = [
+  "bytesize",
+  "byteslice",
+  "chomp",
+  "chop",
+  "clear",
+  "delete_prefix",
+  "delete",
+  "empty",
+  "end_with",
+  "getbyte",
+  "include",
+  "length",
+  "reverse",
+  "scan",
+  "setbyte",
+  "size",
+  "start_with",
+  "tr",
+  "tr_s",
+]
 
 [specs.core.symbol]
 include = "all"


### PR DESCRIPTION
For `enforced-specs.toml`, increase passing specs from 1841 to 1911.

Filed these tickets as a result of this work:

- https://github.com/artichoke/artichoke/issues/1915
- https://github.com/artichoke/artichoke/issues/1916