### PR TITLE
Enable `spinoso-random` to be seeded with `Bignum`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -648,7 +648,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-random"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "getrandom",
  "libm",

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -30,7 +30,7 @@ spinoso-array = { version = "0.9.0", path = "../spinoso-array", default-features
 spinoso-env = { version = "0.2.0", path = "../spinoso-env", optional = true, default-features = false }
 spinoso-exception = { version = "0.1.0", path = "../spinoso-exception" }
 spinoso-math = { version = "0.3.0", path = "../spinoso-math", optional = true, default-features = false }
-spinoso-random = { version = "0.2.0", path = "../spinoso-random", optional = true }
+spinoso-random = { version = "0.3.0", path = "../spinoso-random", optional = true }
 spinoso-regexp = { version = "0.3.0", path = "../spinoso-regexp", optional = true, default-features = false }
 spinoso-securerandom = { version = "0.2.0", path = "../spinoso-securerandom", optional = true }
 spinoso-string = { version = "0.18.0", path = "../spinoso-string" }

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -446,7 +446,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-random"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "getrandom",
  "libm",

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -601,7 +601,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-random"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "getrandom",
  "libm",

--- a/spinoso-random/Cargo.toml
+++ b/spinoso-random/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spinoso-random"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2021"
 rust-version = "1.60.0"

--- a/spinoso-random/README.md
+++ b/spinoso-random/README.md
@@ -31,7 +31,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-spinoso-random = "0.2.0"
+spinoso-random = "0.3.0"
 ```
 
 Generate integers:
@@ -60,7 +60,7 @@ fn example() -> Result<(), Error> {
 ## `no_std`
 
 This crate is `no_std` compatible when built without the `std` feature. This
-crate does not depend on [`alloc`].
+crate depends on [`alloc`].
 
 ## Crate features
 

--- a/spinoso-random/src/lib.rs
+++ b/spinoso-random/src/lib.rs
@@ -94,6 +94,8 @@
 #[doc = include_str!("../README.md")]
 mod readme {}
 
+extern crate alloc;
+
 #[cfg(any(feature = "std", test, doctest))]
 extern crate std;
 

--- a/spinoso-random/src/random/rand.rs
+++ b/spinoso-random/src/random/rand.rs
@@ -21,7 +21,10 @@ impl SeedableRng for Random {
     fn from_seed(seed: Self::Seed) -> Self {
         let seed = seed_to_key(seed);
         let mt = Mt::new_with_key(seed.iter().copied());
-        Self { mt, seed }
+        Self {
+            mt,
+            seed: seed.to_vec(),
+        }
     }
 }
 

--- a/spinoso-random/tests/random.rs
+++ b/spinoso-random/tests/random.rs
@@ -32,6 +32,8 @@ fn u32_reproducibility() {
     assert_eq!(samples[..], vectors::INT32_SEED_32[..]);
 }
 
+// # ruby/spec Random
+//
 // ```ruby
 // # Should double check this is official spec
 // it "returns the same numeric output for a given seed across all implementations and platforms" do
@@ -39,13 +41,6 @@ fn u32_reproducibility() {
 //   rnd.bytes(2).should == "\x14\\"
 //   rnd.bytes(1000) # skip some
 //   rnd.bytes(2).should == "\xA1p"
-// end
-//
-// it "returns the same numeric output for a given huge seed across all implementations and platforms" do
-//   rnd = Random.new(bignum_value ** 4)
-//   rnd.bytes(2).should == "_\x91"
-//   rnd.bytes(1000) # skip some
-//   rnd.bytes(2).should == "\x17\x12"
 // end
 // ```
 #[test]
@@ -61,4 +56,60 @@ fn spec_bytes() {
     let mut buf = [0; 2];
     rng.fill_bytes(&mut buf);
     assert_eq!(buf[..], b"\xA1p"[..]);
+}
+
+// # MSpec helpers
+//
+// ```ruby
+// def bignum_value(plus = 0)
+//   0x8000_0000_0000_0000 + plus
+// end
+// ```
+//
+// # ruby/spec Random
+//
+// ```ruby
+// it "returns the same numeric output for a given huge seed across all implementations and platforms" do
+//   rnd = Random.new(bignum_value ** 4)
+//   rnd.bytes(2).should == "_\x91"
+//   rnd.bytes(1000) # skip some
+//   rnd.bytes(2).should == "\x17\x12"
+// end
+// ```
+#[test]
+fn spec_big_num_bytes() {
+    // ```console
+    // [3.1.2] > big = 0x8000_0000_0000_0000 ** 4
+    // => 7237005577332262213973186563042994240829374041602535252466099000494570602496
+    // [3.1.2] > bytes = big.to_s(16).split("").each_slice(8).map{|s| "0x#{s.join[0, 4]}_#{s.join[4, 4]}"}
+    // => ["0x1000_0000", "0x0000_0000", "0x0000_0000", "0x0000_0000", "0x0000_0000", "0x0000_0000", "0x0000_0000", "0x0000_0000"]
+    // [3.1.2] > puts bytes.inspect.gsub '"', ''
+    // [0x1000_0000, 0x0000_0000, 0x0000_0000, 0x0000_0000, 0x0000_0000, 0x0000_0000, 0x0000_0000, 0x0000_0000]
+    // => nil
+    // ```
+    let seed: [u32; 8] = [
+        0x1000_0000,
+        0x0000_0000,
+        0x0000_0000,
+        0x0000_0000,
+        0x0000_0000,
+        0x0000_0000,
+        0x0000_0000,
+        0x0000_0000,
+    ];
+    // Ruby "packs" a `Bignum` into a `&mut [u32]` with least significant word
+    // first and native byte order.
+    //
+    // https://github.com/ruby/ruby/blob/v2_6_3/random.c#L383-L384
+    let mut rng = Random::with_array_seed(seed.iter().rev().copied());
+    let mut buf = [0; 2];
+    rng.fill_bytes(&mut buf);
+    assert_eq!(buf[..], b"_\x91"[..]);
+
+    let mut skip = [0; 1000];
+    rng.fill_bytes(&mut skip);
+
+    let mut buf = [0; 2];
+    rng.fill_bytes(&mut buf);
+    assert_eq!(buf[..], b"\x17\x12"[..]);
 }


### PR DESCRIPTION
MRI uses an `init_by_array` [0] function to initialize a `Random`
instance with an arbitrarily-wide `Bignum` seed.

[0] https://github.com/ruby/ruby/blob/v2_6_3/random.c#L373-L402

This requires exposing `Mt::new_with_key` from `rand_mt`. This patch
makes a breaking change to `Random::with_array_seed` so that it accepts
an `IntoIterator<Item = u32>`.

Because `spinoso-random` can now have arbitarily wide keys, it stores
the seed in a `Vec`, which means the crate now requires `alloc`.

This patch does the minimum to get `artichoke-backend` working with
these changes.

Bump spinoso-random to 0.3.0.

These changes match these from upstream `rand_mt`:

- https://github.com/artichoke/rand_mt/pull/145