### PR TITLE
Pull in upstream mruby fix to compile mruby as C++

### DIFF
--- a/artichoke-backend/vendor/mruby/src/vm.c
+++ b/artichoke-backend/vendor/mruby/src/vm.c
@@ -31,6 +31,12 @@ void abort(void);
 #endif
 #endif
 
+#if defined(MRB_USE_CXX_EXCEPTION) && defined(__cplusplus)
+# if !defined(MRB_USE_CXX_ABI)
+extern "C" {
+# endif
+#endif
+
 #define STACK_INIT_SIZE 128
 #define CALLINFO_INIT_SIZE 32
 
@@ -3066,7 +3072,4 @@ mrb_top_run(mrb_state *mrb, const struct RProc *proc, mrb_value self, mrb_int st
 } /* end of extern "C" */
 # endif
 mrb_int mrb_jmpbuf::jmpbuf_id = 0;
-# if !defined(MRB_USE_CXX_ABI)
-extern "C" {
-# endif
 #endif


### PR DESCRIPTION
- https://github.com/mruby/mruby/pull/5728
- https://github.com/artichoke/mruby/commit/d4d902b072d51bbed505b1f550c14cc3065de537
- https://github.com/artichoke/mruby/issues/11
- https://github.com/artichoke/mruby/pull/12
- https://github.com/artichoke/mruby/releases/tag/artichoke-vendor.10

This fix is required to make progress on:

- https://github.com/artichoke/artichoke/pull/1904