### PR TITLE
Private offsettypes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -747,7 +747,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-time"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "chrono",
  "chrono-tz",

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -35,7 +35,7 @@ spinoso-regexp = { version = "0.3.0", path = "../spinoso-regexp", optional = tru
 spinoso-securerandom = { version = "0.2.0", path = "../spinoso-securerandom", optional = true }
 spinoso-string = { version = "0.18.0", path = "../spinoso-string" }
 spinoso-symbol = { version = "0.3.0", path = "../spinoso-symbol" }
-spinoso-time = { version = "0.4.0", path = "../spinoso-time", features = ["chrono"], default-features = false, optional = true }
+spinoso-time = { version = "0.4.1", path = "../spinoso-time", features = ["chrono"], default-features = false, optional = true }
 
 [dev-dependencies]
 quickcheck = { version = "1.0.3", default-features = false }

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -500,7 +500,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-time"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "chrono",
  "chrono-tz",

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -655,7 +655,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-time"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "chrono",
  "chrono-tz",

--- a/spinoso-time/Cargo.toml
+++ b/spinoso-time/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spinoso-time"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2021"
 rust-version = "1.60.0"

--- a/spinoso-time/src/time/tzrs/mod.rs
+++ b/spinoso-time/src/time/tzrs/mod.rs
@@ -117,8 +117,7 @@ impl Time {
     ///
     /// ```
     /// use spinoso_time::tzrs::{Time, Offset};
-    /// use tzdb::time_zone::pacific::AUCKLAND;
-    /// let offset = Offset::tz(AUCKLAND);
+    /// let offset = Offset::from("+1200");
     /// let t = Time::new(2022, 9, 25, 1, 30, 0, 0, offset);
     /// ```
     ///

--- a/spinoso-time/src/time/tzrs/offset.rs
+++ b/spinoso-time/src/time/tzrs/offset.rs
@@ -63,13 +63,13 @@ fn offset_hhmm_from_seconds(seconds: i32) -> String {
 /// Represents the number of seconds offset from UTC.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct Offset {
-    pub(crate) inner: OffsetType,
+    inner: OffsetType,
 }
 
 /// Represents the type of offset from UTC.
 #[allow(variant_size_differences)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub(crate) enum OffsetType {
+enum OffsetType {
     /// UTC offset, zero offset, Zulu time
     Utc,
     /// Fixed offset from UTC.
@@ -120,10 +120,17 @@ impl<'a> Offset {
     /// predefined IANA time zones.
     #[inline]
     #[must_use]
-    pub(crate) fn tz(tz: TimeZoneRef<'static>) -> Self {
+    fn tz(tz: TimeZoneRef<'static>) -> Self {
         Self {
             inner: OffsetType::Tz(tz),
         }
+    }
+
+    /// Returns whether this offset is UTC.
+    #[inline]
+    #[must_use]
+    pub fn is_utc(&self) -> bool {
+        matches!(self.inner, OffsetType::Utc)
     }
 
     /// Returns a `TimeZoneRef` which can be used to generate and project
@@ -269,20 +276,26 @@ mod tests {
     #[test]
     fn fixed_zero_is_not_utc() {
         let offset = Offset::from(0);
-        assert!(matches!(offset.inner, OffsetType::Fixed(_)));
+        assert!(!offset.is_utc());
+    }
+
+    #[test]
+    fn utc_is_utc() {
+        let offset = Offset::utc();
+        assert!(offset.is_utc());
     }
 
     #[test]
     fn z_is_utc() {
         let offset = Offset::from("Z");
-        assert!(matches!(offset.inner, OffsetType::Utc));
+        assert!(offset.is_utc());
     }
 
     #[test]
     fn from_binary_string() {
         let tz: &[u8] = b"Z";
         let offset = Offset::from(tz);
-        assert!(matches!(offset.inner, OffsetType::Utc));
+        assert!(offset.is_utc());
     }
 
     #[test]

--- a/spinoso-time/src/time/tzrs/offset.rs
+++ b/spinoso-time/src/time/tzrs/offset.rs
@@ -1,3 +1,4 @@
+use std::slice;
 use std::str;
 
 use once_cell::sync::Lazy;
@@ -59,13 +60,13 @@ fn offset_hhmm_from_seconds(seconds: i32) -> String {
     format!("{}{:0>2}{:0>2}", flag, offset_hours, offset_minutes)
 }
 
-/// Represents the number of seconds offset from UTC
+/// Represents the number of seconds offset from UTC.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct Offset {
     pub(crate) inner: OffsetType,
 }
 
-/// Represents the type of offset from UTC
+/// Represents the type of offset from UTC.
 #[allow(variant_size_differences)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub(crate) enum OffsetType {
@@ -117,9 +118,6 @@ impl<'a> Offset {
     ///
     /// This can be combined with [`tzdb`] to generate offsets based on
     /// predefined IANA time zones.
-    ///
-    /// [`tz:timezone::TimeZoneRef`]: https://docs.rs/tz-rs/0.6.9/tz/timezone/struct.TimeZoneRef.html
-    /// [`tzdb`]: https://docs.rs/tzdb/latest/tzdb/index.html
     #[inline]
     #[must_use]
     pub(crate) fn tz(tz: TimeZoneRef<'static>) -> Self {
@@ -136,7 +134,7 @@ impl<'a> Offset {
         match self.inner {
             OffsetType::Utc => TimeZoneRef::utc(),
             OffsetType::Fixed(ref local_time_type) => {
-                match TimeZoneRef::new(&[], std::slice::from_ref(local_time_type), &[], &None) {
+                match TimeZoneRef::new(&[], slice::from_ref(local_time_type), &[], &None) {
                     Ok(tz) => tz,
                     Err(_) => GMT,
                 }

--- a/spinoso-time/src/time/tzrs/parts.rs
+++ b/spinoso-time/src/time/tzrs/parts.rs
@@ -1,4 +1,4 @@
-use super::Offset;
+use super::offset::OffsetType;
 use super::Time;
 use crate::MICROS_IN_NANO;
 
@@ -194,8 +194,10 @@ impl Time {
     #[inline]
     #[must_use]
     pub fn time_zone(&self) -> &str {
-        match self.offset {
-            Offset::Utc => "UTC",
+        // We can usually get the name from wrapped DateTime, however UTC is a
+        // special case which is an empty string, thus the OffsetType is safer.
+        match self.offset.inner {
+            OffsetType::Utc => "UTC",
             _ => self.inner.local_time_type().time_zone_designation(),
         }
     }
@@ -216,7 +218,7 @@ impl Time {
     #[inline]
     #[must_use]
     pub fn is_utc(&self) -> bool {
-        Offset::Utc == self.offset
+        OffsetType::Utc == self.offset.inner
     }
 
     /// Returns the offset in seconds between the timezone of _time_ and UTC.

--- a/spinoso-time/src/time/tzrs/parts.rs
+++ b/spinoso-time/src/time/tzrs/parts.rs
@@ -1,4 +1,3 @@
-use super::offset::OffsetType;
 use super::Time;
 use crate::MICROS_IN_NANO;
 
@@ -196,9 +195,13 @@ impl Time {
     pub fn time_zone(&self) -> &str {
         // We can usually get the name from wrapped DateTime, however UTC is a
         // special case which is an empty string, thus the OffsetType is safer.
-        match self.offset.inner {
-            OffsetType::Utc => "UTC",
-            _ => self.inner.local_time_type().time_zone_designation(),
+        //
+        // Note: The offset cannot be relied upon for the timezone name, as it
+        // may contain many options (e.g. CEST/CET)
+        if self.offset.is_utc() {
+            "UTC"
+        } else {
+            self.inner.local_time_type().time_zone_designation()
         }
     }
 
@@ -218,7 +221,7 @@ impl Time {
     #[inline]
     #[must_use]
     pub fn is_utc(&self) -> bool {
-        matches!(self.offset.inner, OffsetType::Utc)
+        self.offset.is_utc()
     }
 
     /// Returns the offset in seconds between the timezone of _time_ and UTC.

--- a/spinoso-time/src/time/tzrs/parts.rs
+++ b/spinoso-time/src/time/tzrs/parts.rs
@@ -218,7 +218,7 @@ impl Time {
     #[inline]
     #[must_use]
     pub fn is_utc(&self) -> bool {
-        OffsetType::Utc == self.offset.inner
+        matches!(self.offset.inner, OffsetType::Utc)
     }
 
     /// Returns the offset in seconds between the timezone of _time_ and UTC.


### PR DESCRIPTION
A quick change/fix for `spinoso-time::tzrs`.

With this PR, we hide all the tz-rs dependencies from anyone that implements this library.

Future: We will add a feature from tzdb called `find_from_name` as a feature, which will allow people to do things like `Offset::try_from("Europe/Amsterdam")`.

This is a follow on from #1902