### PR TITLE
Make `String#reverse` encoding-aware

### DIFF
--- a/artichoke-backend/src/extn/core/string/string_test.rb
+++ b/artichoke-backend/src/extn/core/string/string_test.rb
@@ -8,6 +8,7 @@ def spec
   string_byteslice
   string_scan
   string_unary_minus
+  string_reverse
   string_tr
 
   true
@@ -60,6 +61,10 @@ def string_unary_minus
   s = -'abababa'
   raise unless s.frozen?
   raise unless s.itself == 'abababa'
+end
+
+def string_reverse
+  raise unless "再见".reverse == "见再"
 end
 
 def string_tr

--- a/artichoke-backend/src/extn/core/string/string_test.rb
+++ b/artichoke-backend/src/extn/core/string/string_test.rb
@@ -64,7 +64,7 @@ def string_unary_minus
 end
 
 def string_reverse
-  raise unless "再见".reverse == "见再"
+  raise unless '再见'.reverse == '见再'
 end
 
 def string_tr

--- a/spinoso-string/src/enc/ascii/mod.rs
+++ b/spinoso-string/src/enc/ascii/mod.rs
@@ -315,6 +315,11 @@ impl AsciiString {
     pub fn ends_with(&self, slice: &[u8]) -> bool {
         self.inner.ends_with(slice)
     }
+
+    #[inline]
+    pub fn reverse(&mut self) {
+        self.inner.reverse();
+    }
 }
 
 #[cfg(test)]

--- a/spinoso-string/src/enc/binary/mod.rs
+++ b/spinoso-string/src/enc/binary/mod.rs
@@ -315,6 +315,11 @@ impl BinaryString {
     pub fn ends_with(&self, slice: &[u8]) -> bool {
         self.inner.ends_with(slice)
     }
+
+    #[inline]
+    pub fn reverse(&mut self) {
+        self.inner.reverse();
+    }
 }
 
 #[cfg(test)]

--- a/spinoso-string/src/enc/mod.rs
+++ b/spinoso-string/src/enc/mod.rs
@@ -563,4 +563,13 @@ impl EncodedString {
             EncodedString::Utf8(inner) => inner.ends_with(slice),
         }
     }
+
+    #[inline]
+    pub fn reverse(&mut self) {
+        match self {
+            EncodedString::Ascii(inner) => inner.reverse(),
+            EncodedString::Binary(inner) => inner.reverse(),
+            EncodedString::Utf8(inner) => inner.reverse(),
+        }
+    }
 }

--- a/spinoso-string/src/enc/utf8/mod.rs
+++ b/spinoso-string/src/enc/utf8/mod.rs
@@ -671,10 +671,12 @@ impl Utf8String {
             self.inner.reverse();
             return;
         }
-        let chars = ConventionallyUtf8::from(&self.inner[..]);
+        // FIXME: this allocation can go away if `ConventionallyUtf8` impls
+        // `DoubleEndedIterator`.
+        let chars = ConventionallyUtf8::from(&self.inner[..]).collect::<Vec<_>>();
         let mut replacement = Vec::with_capacity(self.inner.len());
-        for bytes in chars {
-            replacement.splice(0..0, bytes.iter().copied());
+        for &bytes in chars.iter().rev() {
+            replacement.extend_from_slice(bytes);
         }
         self.inner = replacement;
     }

--- a/spinoso-string/src/enc/utf8/mod.rs
+++ b/spinoso-string/src/enc/utf8/mod.rs
@@ -6,6 +6,7 @@ use core::slice::SliceIndex;
 
 use bstr::{ByteSlice, ByteVec};
 
+use crate::chars::ConventionallyUtf8;
 use crate::codepoints::InvalidCodepointError;
 use crate::iter::{Bytes, IntoIter, Iter, IterMut};
 use crate::ord::OrdError;
@@ -662,6 +663,20 @@ impl Utf8String {
     #[must_use]
     pub fn ends_with(&self, slice: &[u8]) -> bool {
         self.inner.ends_with(slice)
+    }
+
+    #[inline]
+    pub fn reverse(&mut self) {
+        if self.is_ascii() {
+            self.inner.reverse();
+            return;
+        }
+        let chars = ConventionallyUtf8::from(&self.inner[..]);
+        let mut replacement = Vec::with_capacity(self.inner.len());
+        for bytes in chars {
+            replacement.splice(0..0, bytes.iter().copied());
+        }
+        self.inner = replacement;
     }
 }
 

--- a/spinoso-string/src/lib.rs
+++ b/spinoso-string/src/lib.rs
@@ -2017,6 +2017,31 @@ impl String {
     pub fn is_valid_encoding(&self) -> bool {
         self.inner.is_valid_encoding()
     }
+
+    /// Reverse the characters in the string.
+    ///
+    /// This function is encoding-aware. For `String`s with [UTF-8 encoding],
+    /// multi-byte Unicode characters are reversed treated as one element.
+    /// For `String`s with [ASCII encoding] or [binary encoding], this
+    /// function is equivalent to reversing the underlying byte slice.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use spinoso_string::String;
+    ///
+    /// let mut s = String::utf8("再见".as_bytes().to_vec());
+    /// s.reverse();
+    /// assert_eq!(s, "见再");
+    /// ```
+    ///
+    /// [UTF-8 encoding]: crate::Encoding::Utf8
+    /// [ASCII encoding]: crate::Encoding::Ascii
+    /// [binary encoding]: crate::Encoding::Binary
+    #[inline]
+    pub fn reverse(&mut self) {
+        self.inner.reverse();
+    }
 }
 
 #[must_use]


### PR DESCRIPTION
Properly handle multibyte UTF-8 characters in UTF-8 encoded strings.

Fixes https://github.com/artichoke/artichoke/issues/1915.