### PR TITLE
Fix `Regexp::escape` for meta characters

### DIFF
--- a/artichoke-backend/src/extn/core/regexp/syntax.rs
+++ b/artichoke-backend/src/extn/core/regexp/syntax.rs
@@ -49,9 +49,7 @@ pub fn escape_into(text: &str, buf: &mut String) {
 #[must_use]
 pub fn is_meta_character(c: char) -> bool {
     match c {
-        '\\' | '.' | '+' | '*' | '?' | '(' | ')' | '|' | '[' | ']' | '{' | '}' | '^' | '$' | '#' | '&' | '-' | '~' => {
-            true
-        }
+        '\\' | '.' | '+' | '*' | '?' | '(' | ')' | '|' | '[' | ']' | '{' | '}' | '^' | '$' | '#' | '-' => true,
         // This match arm differs from `regex-syntax` by including '/'.
         // Ruby uses '/' to mark `Regexp` literals in source code.
         '/' => true,
@@ -89,10 +87,15 @@ mod tests {
     use super::*;
 
     #[test]
-    fn escape_meta() {
+    fn escape_meta_charactors() {
         assert_eq!(
-            escape(r"\.+*?()|[]{}^$#&-~"),
-            r"\\\.\+\*\?\(\)\|\[\]\{\}\^\$\#\&\-\~".to_string()
+            escape(r"\.+*?()|[]{}^$#-"),
+            r"\\\.\+\*\?\(\)\|\[\]\{\}\^\$\#\-".to_string()
         );
+    }
+
+    #[test]
+    fn keep_normal_charactors() {
+        assert_eq!(escape(r"abc&~"), r"abc&~".to_string());
     }
 }

--- a/artichoke-backend/src/extn/core/regexp/syntax.rs
+++ b/artichoke-backend/src/extn/core/regexp/syntax.rs
@@ -47,6 +47,8 @@ pub fn escape_into(text: &str, buf: &mut String) {
 
 /// Returns true if the given character has significance in a regex.
 #[must_use]
+#[allow(clippy::match_like_matches_macro)]
+#[allow(clippy::match_same_arms)]
 pub fn is_meta_character(c: char) -> bool {
     match c {
         '\\' | '.' | '+' | '*' | '?' | '(' | ')' | '|' | '[' | ']' | '{' | '}' | '^' | '$' | '#' | '-' => true,


### PR DESCRIPTION
Close #1738 (Thanks for the detailed description!)

P.s. I tested the same pattern with MRI 3.1.2, 2.6.5, and 2.7.5 and the results are all the same.

