### PR TITLE
Switch artichoke-backend to use spinoso-time tzrs feature

### DIFF
--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -36,7 +36,7 @@ spinoso-regexp = { version = "0.4.0", path = "../spinoso-regexp", optional = tru
 spinoso-securerandom = { version = "0.2.0", path = "../spinoso-securerandom", optional = true }
 spinoso-string = { version = "0.20.0", path = "../spinoso-string", features = ["always-nul-terminated-c-string-compat"] }
 spinoso-symbol = { version = "0.3.0", path = "../spinoso-symbol" }
-spinoso-time = { version = "0.6.0", path = "../spinoso-time", features = ["chrono"], default-features = false, optional = true }
+spinoso-time = { version = "0.6.0", path = "../spinoso-time", features = ["tzrs"], default-features = false, optional = true }
 
 [dev-dependencies]
 quickcheck = { version = "1.0.3", default-features = false }

--- a/artichoke-backend/src/extn/core/time/mod.rs
+++ b/artichoke-backend/src/extn/core/time/mod.rs
@@ -21,13 +21,18 @@
 //! [`chrono-tz`]: https://crates.io/crates/chrono-tz
 
 use crate::convert::HeapAllocatedData;
+use crate::extn::prelude::*;
 
 pub mod mruby;
 pub mod trampoline;
 
 #[doc(inline)]
-pub use spinoso_time::chrono::Time;
+pub use spinoso_time::tzrs::*;
 
 impl HeapAllocatedData for Time {
     const RUBY_TYPE: &'static str = "Time";
+}
+
+pub(crate) fn convert_time_error_to_argument_error(error: TimeError) -> ArgumentError {
+    ArgumentError::from(format!("{}", error))
 }

--- a/artichoke-backend/src/extn/core/time/mod.rs
+++ b/artichoke-backend/src/extn/core/time/mod.rs
@@ -25,6 +25,7 @@ use crate::extn::prelude::*;
 
 pub mod mruby;
 pub mod trampoline;
+pub mod subsec;
 
 #[doc(inline)]
 pub use spinoso_time::tzrs::*;

--- a/artichoke-backend/src/extn/core/time/mod.rs
+++ b/artichoke-backend/src/extn/core/time/mod.rs
@@ -24,9 +24,9 @@ use crate::convert::HeapAllocatedData;
 use crate::extn::prelude::*;
 
 pub mod mruby;
-pub mod trampoline;
-pub mod subsec;
 pub mod offset;
+pub mod subsec;
+pub mod trampoline;
 
 #[doc(inline)]
 pub use spinoso_time::tzrs::*;

--- a/artichoke-backend/src/extn/core/time/mod.rs
+++ b/artichoke-backend/src/extn/core/time/mod.rs
@@ -26,6 +26,7 @@ use crate::extn::prelude::*;
 pub mod mruby;
 pub mod trampoline;
 pub mod subsec;
+pub mod offset;
 
 #[doc(inline)]
 pub use spinoso_time::tzrs::*;

--- a/artichoke-backend/src/extn/core/time/mod.rs
+++ b/artichoke-backend/src/extn/core/time/mod.rs
@@ -33,6 +33,8 @@ impl HeapAllocatedData for Time {
     const RUBY_TYPE: &'static str = "Time";
 }
 
-pub(crate) fn convert_time_error_to_argument_error(error: TimeError) -> ArgumentError {
-    ArgumentError::from(format!("{}", error))
+impl From<TimeError> for Error {
+    fn from(error: TimeError) -> Error {
+        ArgumentError::from(format!("{}", error)).into()
+    }
 }

--- a/artichoke-backend/src/extn/core/time/mruby.rs
+++ b/artichoke-backend/src/extn/core/time/mruby.rs
@@ -19,7 +19,7 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
         .value_is_rust_object()
         // Constructor
         .add_self_method("now", time_self_now, sys::mrb_args_none())?
-        .add_self_method("at", time_self_at, sys::mrb_args_req(1) | sys::mrb_args_opt(3))?
+        .add_self_method("at", time_self_at, sys::mrb_args_req_and_opt(1, 3))?
         .add_self_method("utc", time_self_mkutc, sys::mrb_args_any())?
         .add_self_method("gm", time_self_mkutc, sys::mrb_args_any())?
         .add_self_method("local", time_self_mktime, sys::mrb_args_any())?

--- a/artichoke-backend/src/extn/core/time/mruby.rs
+++ b/artichoke-backend/src/extn/core/time/mruby.rs
@@ -19,7 +19,7 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
         .value_is_rust_object()
         // Constructor
         .add_self_method("now", time_self_now, sys::mrb_args_none())?
-        .add_self_method("at", time_self_at, sys::mrb_args_req(1))?
+        .add_self_method("at", time_self_at, sys::mrb_args_req(1) | sys::mrb_args_opt(3))?
         .add_self_method("utc", time_self_mkutc, sys::mrb_args_any())?
         .add_self_method("gm", time_self_mkutc, sys::mrb_args_any())?
         .add_self_method("local", time_self_mktime, sys::mrb_args_any())?
@@ -112,11 +112,15 @@ unsafe extern "C" fn time_self_now(mrb: *mut sys::mrb_state, _slf: sys::mrb_valu
 }
 
 unsafe extern "C" fn time_self_at(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {
-    let (seconds, microseconds) = mrb_get_args!(mrb, required = 1, optional = 1);
+    let (seconds, opt1, opt2, opt3) = mrb_get_args!(mrb, required = 1, optional = 3);
     unwrap_interpreter!(mrb, to => guard);
     let seconds = Value::from(seconds);
-    let microseconds = microseconds.map(Value::from);
-    let result = trampoline::at(&mut guard, seconds, microseconds);
+
+    let opt1 = opt1.map(Value::from);
+    let opt2 = opt2.map(Value::from);
+    let opt3 = opt3.map(Value::from);
+
+    let result = trampoline::at(&mut guard, seconds, opt1, opt2, opt3);
     match result {
         Ok(value) => value.inner(),
         Err(exception) => error::raise(guard, exception),

--- a/artichoke-backend/src/extn/core/time/offset.rs
+++ b/artichoke-backend/src/extn/core/time/offset.rs
@@ -95,6 +95,8 @@ impl TryConvertMut<Value, Option<Offset>> for Artichoke {
 
 #[cfg(test)]
 mod tests {
+    use bstr::ByteSlice;
+
     use crate::extn::core::time::Offset;
     use crate::test::prelude::*;
 
@@ -118,7 +120,7 @@ mod tests {
         let error = result.unwrap_err();
 
         assert_eq!(error.name(), "ArgumentError");
-        assert_eq!(error.message(), b"unknown keyword: foo".as_slice());
+        assert_eq!(error.message().as_bstr(), b"unknown keyword: foo".as_slice().as_bstr());
     }
 
     #[test]
@@ -132,8 +134,10 @@ mod tests {
 
         assert_eq!(error.name(), "ArgumentError");
         assert_eq!(
-            error.message(),
-            br#"+HH:MM", "-HH:MM", "UTC" or "A".."I","K".."Z" expected for utc_offset: J"#.as_slice()
+            error.message().as_bstr(),
+            br#"+HH:MM", "-HH:MM", "UTC" or "A".."I","K".."Z" expected for utc_offset: J"#
+                .as_slice()
+                .as_bstr()
         );
     }
 
@@ -186,7 +190,10 @@ mod tests {
         let result: Result<Option<Offset>, Error> = interp.try_convert_mut(options);
         let error = result.unwrap_err();
 
-        assert_eq!(error.message(), b"utc_offset out of range".as_slice());
+        assert_eq!(
+            error.message().as_bstr(),
+            b"utc_offset out of range".as_slice().as_bstr()
+        );
         assert_eq!(error.name(), "ArgumentError");
     }
 
@@ -200,7 +207,10 @@ mod tests {
         let result: Result<Option<Offset>, Error> = interp.try_convert_mut(options);
         let error = result.unwrap_err();
 
-        assert_eq!(error.message(), b"utc_offset out of range".as_slice());
+        assert_eq!(
+            error.message().as_bstr(),
+            b"utc_offset out of range".as_slice().as_bstr()
+        );
         assert_eq!(error.name(), "ArgumentError");
 
         // this value is i32::MAX + 1.
@@ -209,7 +219,10 @@ mod tests {
         let result: Result<Option<Offset>, Error> = interp.try_convert_mut(options);
         let error = result.unwrap_err();
 
-        assert_eq!(error.message(), b"utc_offset out of range".as_slice());
+        assert_eq!(
+            error.message().as_bstr(),
+            b"utc_offset out of range".as_slice().as_bstr()
+        );
         assert_eq!(error.name(), "ArgumentError");
     }
 }

--- a/artichoke-backend/src/extn/core/time/offset.rs
+++ b/artichoke-backend/src/extn/core/time/offset.rs
@@ -1,0 +1,78 @@
+use crate::extn::core::time::Offset;
+use crate::extn::prelude::*;
+use crate::convert::{implicitly_convert_to_int, implicitly_convert_to_string};
+use crate::extn::core::symbol::Symbol;
+
+const MAX_FLOAT_OFFSET: f64 = i32::MAX as f64;
+const MIN_FLOAT_OFFSET: f64 = i32::MIN as f64;
+
+impl TryConvertMut<Value, Option<Offset>> for Artichoke {
+    type Error = Error;
+
+    fn try_convert_mut(&mut self, options: Value) -> Result<Option<Offset>, Self::Error> {
+        let hash: Vec<(Value, Value)> = self.try_convert_mut(options)?;
+
+        // Short circuit the offset parameter fetching.
+        if hash.len() == 0 {
+            return Ok(None)
+        }
+
+        // Extract the value from the options hash with the key `:in`,
+        // rejecting any other values as ArgumentError.
+        let mut in_param: Option<Value> = None;
+
+        for (mut key, value) in hash.iter() {
+            let k = unsafe { Symbol::unbox_from_value(&mut key, self)? }.bytes(self);
+            if k == b"in" {
+                in_param = Some(*value)
+            } else {
+                let mut message = b"unknown keyword: ".to_vec();
+                message.extend(k.to_vec());
+                Err(ArgumentError::from(message))?
+            }
+        }
+
+        if let Some(mut in_param) = in_param {
+            match in_param.ruby_type() {
+                Ruby::String => {
+                    let offset_str = unsafe { implicitly_convert_to_string(self, &mut in_param) }?;
+
+                    let offset = Offset::try_from(offset_str)
+                        .map_err(|_| {
+                            let mut message = b"\"+HH:MM\", \"-HH:MM\", \"UTC\" or \"A\"..\"I\",\"K\"..\"Z\" expected for utc_offset: ".to_vec();
+                            message.extend(offset_str.to_vec());
+                            ArgumentError::from(message)
+                        })?;
+
+                    Ok(Some(offset))
+                },
+                Ruby::Float => {
+                    // This impl differs from MRI. MRI supports any float
+                    // value and will set an offset with subsec fractions
+                    // however this is not supported in spinoso_time with
+                    // the `tzrs` feature.
+                    let offset_seconds: f64 = self.try_convert(in_param)?;
+
+                    if !(MIN_FLOAT_OFFSET..=MAX_FLOAT_OFFSET).contains(&offset_seconds) {
+                        Err(ArgumentError::with_message("utc_offset out of range").into())
+                    } else {
+                        Ok(Some(Offset::try_from(offset_seconds as i32)?))
+                    }
+                },
+                _ => {
+                    let offset_seconds = implicitly_convert_to_int(self, in_param)
+                        .and_then(|seconds| {
+                            i32::try_from(seconds)
+                                .map_err(|_| ArgumentError::with_message("utc_offset out of range").into())
+                        })?;
+
+                    Ok(Some(Offset::try_from(offset_seconds)?))
+                }
+            }
+        } else {
+            // The parameter parsing loop will rejected all params except `in`,
+            // so the side affect is that this branch is never reachable.
+            unreachable!("should not have attempted to parse an empty `in` option");
+        }
+    }
+}

--- a/artichoke-backend/src/extn/core/time/offset.rs
+++ b/artichoke-backend/src/extn/core/time/offset.rs
@@ -54,7 +54,7 @@ impl TryConvertMut<Value, Option<Offset>> for Artichoke {
 
                 let offset = Offset::try_from(offset_str).map_err(|_| {
                     let mut message =
-                        b"\"+HH:MM\", \"-HH:MM\", \"UTC\" or \"A\"..\"I\",\"K\"..\"Z\" expected for utc_offset: "
+                        br#"+HH:MM", "-HH:MM", "UTC" or "A".."I","K".."Z" expected for utc_offset: "#
                             .to_vec();
                     message.extend_from_slice(offset_str);
                     ArgumentError::from(message)
@@ -126,7 +126,7 @@ mod tests {
         assert_eq!(error.name(), "ArgumentError");
         assert_eq!(
             error.message(),
-            b"\"+HH:MM\", \"-HH:MM\", \"UTC\" or \"A\"..\"I\",\"K\"..\"Z\" expected for utc_offset: J".as_slice()
+            br#"+HH:MM", "-HH:MM", "UTC" or "A".."I","K".."Z" expected for utc_offset: J"#.as_slice()
         );
     }
 
@@ -134,7 +134,6 @@ mod tests {
     fn provides_an_int_based_offset() {
         let mut interp = interpreter();
 
-        // this value is i32::MIN - 1.
         let options = interp.eval(b"{ in: 3600 }").unwrap();
 
         let result: Option<Offset> = interp.try_convert_mut(options).unwrap();
@@ -145,7 +144,6 @@ mod tests {
     fn provides_a_float_based_offset() {
         let mut interp = interpreter();
 
-        // this value is i32::MIN - 1.
         let options = interp.eval(b"{ in: 3600.0 }").unwrap();
 
         let result: Option<Offset> = interp.try_convert_mut(options).unwrap();
@@ -156,7 +154,6 @@ mod tests {
     fn provides_a_string_based_offset() {
         let mut interp = interpreter();
 
-        // this value is i32::MIN - 1.
         let options = interp.eval(b"{ in: 'A' }").unwrap();
 
         let result: Option<Offset> = interp.try_convert_mut(options).unwrap();

--- a/artichoke-backend/src/extn/core/time/offset.rs
+++ b/artichoke-backend/src/extn/core/time/offset.rs
@@ -1,3 +1,5 @@
+//! Parser for Ruby Time offset parameter to help generate `Time`.
+
 use crate::convert::{implicitly_convert_to_int, implicitly_convert_to_string};
 use crate::extn::core::symbol::Symbol;
 use crate::extn::core::time::Offset;

--- a/artichoke-backend/src/extn/core/time/offset.rs
+++ b/artichoke-backend/src/extn/core/time/offset.rs
@@ -1,7 +1,7 @@
-use crate::extn::core::time::Offset;
-use crate::extn::prelude::*;
 use crate::convert::{implicitly_convert_to_int, implicitly_convert_to_string};
 use crate::extn::core::symbol::Symbol;
+use crate::extn::core::time::Offset;
+use crate::extn::prelude::*;
 
 const MAX_FLOAT_OFFSET: f64 = i32::MAX as f64;
 const MIN_FLOAT_OFFSET: f64 = i32::MIN as f64;
@@ -12,67 +12,71 @@ impl TryConvertMut<Value, Option<Offset>> for Artichoke {
     fn try_convert_mut(&mut self, options: Value) -> Result<Option<Offset>, Self::Error> {
         let hash: Vec<(Value, Value)> = self.try_convert_mut(options)?;
 
-        // Short circuit the offset parameter fetching.
+        // Short circuit. An empty options hash does not error.
+        //
+        // Example:
+        //
+        // ```console
+        // [2.6.3]> Time.at(0, {})
+        // => 1970-01-01 01:00:00 +0100
+        // ```
         if hash.len() == 0 {
-            return Ok(None)
+            return Ok(None);
         }
 
-        // Extract the value from the options hash with the key `:in`,
-        // rejecting any other values as ArgumentError.
-        let mut in_param: Option<Value> = None;
-
-        for (mut key, value) in hash.iter() {
+        // All other keys are rejected.
+        //
+        // Example:
+        // ```console
+        // [2.6.3]> Time.at(0, i: 0)
+        // ArgumentError (unknown keyword: i)
+        // ```
+        for (mut key, _) in hash.iter() {
             let k = unsafe { Symbol::unbox_from_value(&mut key, self)? }.bytes(self);
-            if k == b"in" {
-                in_param = Some(*value)
-            } else {
+            if k != b"in" {
                 let mut message = b"unknown keyword: ".to_vec();
                 message.extend_from_slice(k);
                 Err(ArgumentError::from(message))?
             }
         }
 
-        if let Some(mut in_param) = in_param {
-            match in_param.ruby_type() {
-                Ruby::String => {
-                    let offset_str = unsafe { implicitly_convert_to_string(self, &mut in_param) }?;
+        // Based on the above logic, the only option in the hash is `in`.
+        // >0 keys, and all other keys are rejected).
+        let mut in_value = hash.get(0).expect("Only the `in` parameter should be available").1;
 
-                    let offset = Offset::try_from(offset_str)
-                        .map_err(|_| {
-                            let mut message = b"\"+HH:MM\", \"-HH:MM\", \"UTC\" or \"A\"..\"I\",\"K\"..\"Z\" expected for utc_offset: ".to_vec();
-                            message.extend_from_slice(offset_str);
-                            ArgumentError::from(message)
-                        })?;
+        match in_value.ruby_type() {
+            Ruby::String => {
+                let offset_str = unsafe { implicitly_convert_to_string(self, &mut in_value) }?;
 
-                    Ok(Some(offset))
-                },
-                Ruby::Float => {
-                    // This impl differs from MRI. MRI supports any float
-                    // value and will set an offset with subsec fractions
-                    // however this is not supported in spinoso_time with
-                    // the `tzrs` feature.
-                    let offset_seconds: f64 = self.try_convert(in_param)?;
+                let offset = Offset::try_from(offset_str).map_err(|_| {
+                    let mut message =
+                        b"\"+HH:MM\", \"-HH:MM\", \"UTC\" or \"A\"..\"I\",\"K\"..\"Z\" expected for utc_offset: "
+                            .to_vec();
+                    message.extend_from_slice(offset_str);
+                    ArgumentError::from(message)
+                })?;
 
-                    if !(MIN_FLOAT_OFFSET..=MAX_FLOAT_OFFSET).contains(&offset_seconds) {
-                        Err(ArgumentError::with_message("utc_offset out of range").into())
-                    } else {
-                        Ok(Some(Offset::try_from(offset_seconds as i32)?))
-                    }
-                },
-                _ => {
-                    let offset_seconds = implicitly_convert_to_int(self, in_param)
-                        .and_then(|seconds| {
-                            i32::try_from(seconds)
-                                .map_err(|_| ArgumentError::with_message("utc_offset out of range").into())
-                        })?;
+                Ok(Some(offset))
+            }
+            Ruby::Float => {
+                // This impl differs from MRI. MRI supports any float value and
+                // will set an offset with subsec fractions however this is not
+                // supported in spinoso_time with the `tzrs` feature.
+                let offset_seconds: f64 = self.try_convert(in_value)?;
 
-                    Ok(Some(Offset::try_from(offset_seconds)?))
+                if !(MIN_FLOAT_OFFSET..=MAX_FLOAT_OFFSET).contains(&offset_seconds) {
+                    Err(ArgumentError::with_message("utc_offset out of range").into())
+                } else {
+                    Ok(Some(Offset::try_from(offset_seconds as i32)?))
                 }
             }
-        } else {
-            // The parameter parsing loop will rejected all params except `in`,
-            // so the side affect is that this branch is never reachable.
-            unreachable!("should not have attempted to parse an empty `in` option");
+            _ => {
+                let offset_seconds = implicitly_convert_to_int(self, in_value).and_then(|seconds| {
+                    i32::try_from(seconds).map_err(|_| ArgumentError::with_message("utc_offset out of range").into())
+                })?;
+
+                Ok(Some(Offset::try_from(offset_seconds)?))
+            }
         }
     }
 }

--- a/artichoke-backend/src/extn/core/time/offset.rs
+++ b/artichoke-backend/src/extn/core/time/offset.rs
@@ -35,6 +35,14 @@ impl TryConvertMut<Value, Option<Offset>> for Artichoke {
         // [2.6.3]> Time.at(0, i: 0)
         // ArgumentError (unknown keyword: i)
         // ```
+        //
+        // FIXME: In Ruby 3.1.2, this exception message formats the symbol with
+        // `Symbol#inspect`:
+        //
+        // ```console
+        // [3.1.2] > Time.at(0, i: 0)
+        // <internal:timev>:270:in `at': unknown keyword: :i (ArgumentError)
+        // ```
         for (mut key, _) in &hash {
             let k = unsafe { Symbol::unbox_from_value(&mut key, self)? }.bytes(self);
             if k != b"in" {
@@ -54,8 +62,7 @@ impl TryConvertMut<Value, Option<Offset>> for Artichoke {
 
                 let offset = Offset::try_from(offset_str).map_err(|_| {
                     let mut message =
-                        br#"+HH:MM", "-HH:MM", "UTC" or "A".."I","K".."Z" expected for utc_offset: "#
-                            .to_vec();
+                        br#"+HH:MM", "-HH:MM", "UTC" or "A".."I","K".."Z" expected for utc_offset: "#.to_vec();
                     message.extend_from_slice(offset_str);
                     ArgumentError::from(message)
                 })?;

--- a/artichoke-backend/src/extn/core/time/offset.rs
+++ b/artichoke-backend/src/extn/core/time/offset.rs
@@ -27,7 +27,7 @@ impl TryConvertMut<Value, Option<Offset>> for Artichoke {
                 in_param = Some(*value)
             } else {
                 let mut message = b"unknown keyword: ".to_vec();
-                message.extend(k.to_vec());
+                message.extend_from_slice(k);
                 Err(ArgumentError::from(message))?
             }
         }
@@ -40,7 +40,7 @@ impl TryConvertMut<Value, Option<Offset>> for Artichoke {
                     let offset = Offset::try_from(offset_str)
                         .map_err(|_| {
                             let mut message = b"\"+HH:MM\", \"-HH:MM\", \"UTC\" or \"A\"..\"I\",\"K\"..\"Z\" expected for utc_offset: ".to_vec();
-                            message.extend(offset_str.to_vec());
+                            message.extend_from_slice(offset_str);
                             ArgumentError::from(message)
                         })?;
 

--- a/artichoke-backend/src/extn/core/time/subsec.rs
+++ b/artichoke-backend/src/extn/core/time/subsec.rs
@@ -547,7 +547,7 @@ mod tests {
         let err = subsec(&mut interp, (Some(b"Float::INFINITY"), None)).unwrap_err();
 
         assert_eq!(err.name(), "FloatDomainError");
-        assert_eq!(err.message(), b"Infinity".as_slice());
+        assert_eq!(err.message().as_bstr(), b"Infinity".as_slice().as_bstr());
     }
 
     #[test]
@@ -557,6 +557,9 @@ mod tests {
         let err = subsec(&mut interp, (Some(b"1"), Some(b":bad_unit"))).unwrap_err();
 
         assert_eq!(err.name(), "ArgumentError");
-        assert_eq!(err.message(), b"unexpected unit: bad_unit".as_slice());
+        assert_eq!(
+            err.message().as_bstr(),
+            b"unexpected unit: bad_unit".as_slice().as_bstr()
+        );
     }
 }

--- a/artichoke-backend/src/extn/core/time/subsec.rs
+++ b/artichoke-backend/src/extn/core/time/subsec.rs
@@ -128,7 +128,7 @@ impl TryConvertMut<(Option<Value>, Option<Value>), Subsec> for Artichoke {
                 let mut nanos = (subsec % seconds_base) * multiplier_nanos;
 
                 // is_sign_negative() is not enough here, since this logic
-                // should als be skilled for negative zero.
+                // should also be skilled for negative zero.
                 if subsec < -0.0 {
                     // Nanos always needs to be a positive u32. If subsec
                     // is negative, we will always need remove one second.

--- a/artichoke-backend/src/extn/core/time/subsec.rs
+++ b/artichoke-backend/src/extn/core/time/subsec.rs
@@ -15,6 +15,11 @@ const MILLIS_IN_NANO: i64 = 1_000_000;
 const MICROS_IN_NANO: i64 = 1_000;
 const NANOS_IN_NANO: i64 = 1;
 
+const MAX_FLOAT_SECONDS: f64 = i64::MAX as f64;
+const MIN_FLOAT_SECONDS: f64 = i64::MIN as f64;
+const MIN_FLOAT_NANOS: f64 = 0.0;
+const MAX_FLOAT_NANOS: f64 = NANOS_IN_SECOND as f64;
+
 enum SubsecMultiplier {
     Millis,
     Micros,
@@ -66,24 +71,75 @@ impl Subsec {
     }
 }
 
-
 impl TryConvertMut<(Option<Value>, Option<Value>), Subsec> for Artichoke {
     type Error = Error;
 
     fn try_convert_mut(&mut self, params: (Option<Value>, Option<Value>)) -> Result<Subsec, Self::Error> {
-        let (subsec, subsec_type) = params;
+        let (subsec, subsec_unit) = params;
 
         if let Some(subsec) = subsec {
-            let multiplier: SubsecMultiplier = self.try_convert_mut(subsec_type)?;
+            let multiplier: SubsecMultiplier = self.try_convert_mut(subsec_unit)?;
             let multiplier_nanos = multiplier.as_nanos();
+            // subsec will represent the user provided value in subsec_unit
+            // resolution. This means the base to be used for the number of
+            // seconds will change dependant on unit.
+            //
+            // For example, there are 1_000_000 micros in a second. This means
+            // that 1_000_001 micros seconds is 1 second, and 1 microsecond.
+            // In this example, seconds_base will be 1_000_000. For millis and
+            // nanos unit types, these would be 1_000 and 1_000_000_000
+            // respectively.
             let seconds_base = NANOS_IN_SECOND / multiplier_nanos;
 
             match subsec.ruby_type() {
                 Ruby::Float => {
-                    // TODO: Safe conversions here are really hard, there may end up being some
-                    // loss in accuracy.
-                    unreachable!("Not yet implemented")
-                },
+                    // FIXME: The below deviates from the MRI implementation of
+                    // Time. MRI uses `to_r` for subsec calculation on floats
+                    // subsec nanos, and this could result in different values.
+
+                    let subsec: f64 = self.try_convert(subsec)?;
+
+                    if subsec.is_nan() {
+                        return Err(FloatDomainError::with_message("NaN").into());
+                    }
+                    if subsec.is_infinite() {
+                        return Err(FloatDomainError::with_message("Infinity").into());
+                    }
+
+                    // These conversions are luckily not lossy. `seconds_base`
+                    // and `multiplier_nanos` are gauranteed to be represented
+                    // without loss in a f64.
+                    let seconds_base = seconds_base as f64;
+                    let multiplier_nanos = multiplier_nanos as f64;
+
+                    let mut secs = subsec / seconds_base;
+                    let mut nanos = (subsec % seconds_base) * multiplier_nanos;
+
+                    // is_sign_negative() is not enough here, since this logic
+                    // should als be skilled for negative zero.
+                    if subsec < -0.0 {
+                        // Nanos always needs to be a positive u32. If subsec
+                        // is negative, we will always need remove one second.
+                        // Nanos can then be adjusted since it will always be
+                        // the inverse of the total nanos in a second.
+                        secs -= 1.0;
+
+                        if nanos != 0.0 && nanos != -0.0 {
+                            nanos += NANOS_IN_SECOND as f64;
+                        }
+                    }
+
+                    if !(MIN_FLOAT_SECONDS..=MAX_FLOAT_SECONDS).contains(&secs)
+                        || !(MIN_FLOAT_NANOS..=MAX_FLOAT_NANOS).contains(&nanos)
+                    {
+                        return Err(ArgumentError::with_message("subsec outside of bounds").into());
+                    }
+
+                    Ok(Subsec {
+                        secs: secs as i64,
+                        nanos: nanos as u32,
+                    })
+                }
                 _ => {
                     let subsec: i64 = implicitly_convert_to_int(self, subsec)?;
 
@@ -279,5 +335,201 @@ mod tests {
                 expectation.1
             );
         }
+    }
+
+    #[test]
+    fn float_no_unit_implies_micros() {
+        let mut interp = interpreter();
+
+        let expectations = [
+            // Numbers in and around 0.
+            (b"-1000000.5".as_slice(), (-2, 999_999_500)),
+            (b"-1000000.0".as_slice(), (-2, 0)),
+            (b"-999999.5".as_slice(), (-1, 500)),
+            (b"-999999.0".as_slice(), (-1, 1_000)),
+            (b"-1000.5".as_slice(), (-1, 998_999_500)),
+            (b"-1.5".as_slice(), (-1, 999_998_500)),
+            (b"-1.0".as_slice(), (-1, 999_999_000)),
+            (b"-0.0".as_slice(), (0, 0)),
+            (b"0.0".as_slice(), (0, 0)),
+            (b"1.0".as_slice(), (0, 1_000)),
+            (b"1.5".as_slice(), (0, 1_500)),
+            (b"1000.5".as_slice(), (0, 1_000_500)),
+            (b"999999.0".as_slice(), (0, 999_999_000)),
+            (b"999999.5".as_slice(), (0, 999_999_500)),
+            (b"1000000.0".as_slice(), (1, 0)),
+            (b"1000000.5".as_slice(), (1, 500)),
+            (b"1000001.0".as_slice(), (1, 1000)),
+            // Nanosecond and below (truncates, does not round).
+            (b"0.123".as_slice(), (0, 123)),
+            (b"0.001".as_slice(), (0, 1)),
+            (b"0.0001".as_slice(), (0, 0)),
+            (b"0.0009".as_slice(), (0, 0)),
+        ];
+
+        let subsec_unit: Option<&[u8]> = None;
+
+        for (input, expectation) in expectations.iter() {
+            let result = subsec(&mut interp, (Some(input), subsec_unit)).unwrap();
+            assert_eq!(
+                result.to_tuple(),
+                *expectation,
+                "Expected TryConvertMut<(Some({}), None), Result<Subsec>>, to return {} secs, {} nanos",
+                input.as_bstr(),
+                expectation.0,
+                expectation.1
+            );
+        }
+    }
+
+    #[test]
+    fn float_subsec_millis() {
+        let mut interp = interpreter();
+
+        let expectations = [
+            // Numbers in and around 0.
+            (b"-1000.5".as_slice(), (-2, 999_500_000)),
+            (b"-1000.0".as_slice(), (-2, 0)),
+            (b"-999.5".as_slice(), (-1, 500_000)),
+            (b"-999.0".as_slice(), (-1, 1_000_000)),
+            (b"-1.5".as_slice(), (-1, 998_500_000)),
+            (b"-1.0".as_slice(), (-1, 999_000_000)),
+            (b"-0.0".as_slice(), (0, 0)),
+            (b"0.0".as_slice(), (0, 0)),
+            (b"1.0".as_slice(), (0, 1_000_000)),
+            (b"1.5".as_slice(), (0, 1_500_000)),
+            (b"999.0".as_slice(), (0, 999_000_000)),
+            (b"999.5".as_slice(), (0, 999_500_000)),
+            (b"1000.0".as_slice(), (1, 0)),
+            (b"1000.5".as_slice(), (1, 500_000)),
+            (b"1001.0".as_slice(), (1, 1_000_000)),
+            // Nanosecond and below (truncates, does not round).
+            (b"0.123456".as_slice(), (0, 123_456)),
+            (b"0.000001".as_slice(), (0, 1)),
+            (b"0.0000001".as_slice(), (0, 0)),
+            (b"0.0000009".as_slice(), (0, 0)),
+        ];
+
+        let subsec_unit: Option<&[u8]> = Some(b":milliseconds");
+
+        for (input, expectation) in expectations.iter() {
+            let result = subsec(&mut interp, (Some(input), subsec_unit)).unwrap();
+            assert_eq!(
+                result.to_tuple(),
+                *expectation,
+                "Expected TryConvertMut<(Some({}), None), Result<Subsec>>, to return {} secs, {} nanos",
+                input.as_bstr(),
+                expectation.0,
+                expectation.1
+            );
+        }
+    }
+
+    #[test]
+    fn float_subsec_micros() {
+        let mut interp = interpreter();
+
+        let expectations = [
+            // Numbers in and around 0.
+            (b"-1000000.5".as_slice(), (-2, 999_999_500)),
+            (b"-1000000.0".as_slice(), (-2, 0)),
+            (b"-999999.5".as_slice(), (-1, 500)),
+            (b"-999999.0".as_slice(), (-1, 1_000)),
+            (b"-1000.5".as_slice(), (-1, 998_999_500)),
+            (b"-1.5".as_slice(), (-1, 999_998_500)),
+            (b"-1.0".as_slice(), (-1, 999_999_000)),
+            (b"-0.0".as_slice(), (0, 0)),
+            (b"0.0".as_slice(), (0, 0)),
+            (b"1.0".as_slice(), (0, 1_000)),
+            (b"1.5".as_slice(), (0, 1_500)),
+            (b"1000.5".as_slice(), (0, 1_000_500)),
+            (b"999999.0".as_slice(), (0, 999_999_000)),
+            (b"999999.5".as_slice(), (0, 999_999_500)),
+            (b"1000000.0".as_slice(), (1, 0)),
+            (b"1000000.5".as_slice(), (1, 500)),
+            (b"1000001.0".as_slice(), (1, 1000)),
+            // Nanosecond and below (truncates, does not round).
+            (b"0.123".as_slice(), (0, 123)),
+            (b"0.001".as_slice(), (0, 1)),
+            (b"0.0001".as_slice(), (0, 0)),
+            (b"0.0009".as_slice(), (0, 0)),
+        ];
+
+        let subsec_unit: Option<&[u8]> = Some(b":usec");
+
+        for (input, expectation) in expectations.iter() {
+            let result = subsec(&mut interp, (Some(input), subsec_unit)).unwrap();
+            assert_eq!(
+                result.to_tuple(),
+                *expectation,
+                "Expected TryConvertMut<(Some({}), None), Result<Subsec>>, to return {} secs, {} nanos",
+                input.as_bstr(),
+                expectation.0,
+                expectation.1
+            );
+        }
+    }
+
+    #[test]
+    fn float_subsec_nanos() {
+        let mut interp = interpreter();
+
+        let expectations = [
+            // Numbers in and around 0.
+            (b"-1000000000.5".as_slice(), (-2, 999999999)),
+            (b"-1000000000.0".as_slice(), (-2, 0)),
+            (b"-999999999.5".as_slice(), (-1, 0)),
+            (b"-999999999.0".as_slice(), (-1, 1)),
+            (b"-1000.5".as_slice(), (-1, 999_998_999)),
+            (b"-1.5".as_slice(), (-1, 999_999_998)),
+            (b"-1.0".as_slice(), (-1, 999_999_999)),
+            (b"-0.0".as_slice(), (0, 0)),
+            (b"0.0".as_slice(), (0, 0)),
+            (b"1.0".as_slice(), (0, 1)),
+            (b"1.5".as_slice(), (0, 1)),
+            (b"1000.5".as_slice(), (0, 1_000)),
+            (b"999999999.0".as_slice(), (0, 999_999_999)),
+            (b"999999999.5".as_slice(), (0, 999_999_999)),
+            (b"1000000000.0".as_slice(), (1, 0)),
+            (b"1000000000.5".as_slice(), (1, 0)),
+            (b"1000000001.0".as_slice(), (1, 1)),
+            // Nanosecond and below (truncates, does not round).
+            (b"-0.1".as_slice(), (-1, 999_999_999)),
+            (b"0.1".as_slice(), (0, 0)),
+        ];
+
+        let subsec_unit: Option<&[u8]> = Some(b":nsec");
+
+        for (input, expectation) in expectations.iter() {
+            let result = subsec(&mut interp, (Some(input), subsec_unit)).unwrap();
+            assert_eq!(
+                result.to_tuple(),
+                *expectation,
+                "Expected TryConvertMut<(Some({}), None), Result<Subsec>>, to return {} secs, {} nanos",
+                input.as_bstr(),
+                expectation.0,
+                expectation.1
+            );
+        }
+    }
+
+    #[test]
+    fn float_nan_raises() {
+        let mut interp = interpreter();
+
+        let err = subsec(&mut interp, (Some(b"Float::NAN"), None)).unwrap_err();
+
+        assert_eq!(err.name(), "FloatDomainError");
+        assert_eq!(err.message(), b"NaN".as_slice());
+    }
+
+    #[test]
+    fn float_infinite_raises() {
+        let mut interp = interpreter();
+
+        let err = subsec(&mut interp, (Some(b"Float::INFINITY"), None)).unwrap_err();
+
+        assert_eq!(err.name(), "FloatDomainError");
+        assert_eq!(err.message(), b"Infinity".as_slice());
     }
 }

--- a/artichoke-backend/src/extn/core/time/subsec.rs
+++ b/artichoke-backend/src/extn/core/time/subsec.rs
@@ -113,6 +113,9 @@ impl TryConvertMut<(Option<Value>, Option<Value>), Subsec> for Artichoke {
                     return Err(FloatDomainError::with_message("NaN").into());
                 }
                 if subsec.is_infinite() {
+                    if subsec.is_sign_negative() {
+                        return Err(FloatDomainError::with_message("-Infinity").into());
+                    }
                     return Err(FloatDomainError::with_message("Infinity").into());
                 }
 
@@ -548,6 +551,11 @@ mod tests {
 
         assert_eq!(err.name(), "FloatDomainError");
         assert_eq!(err.message().as_bstr(), b"Infinity".as_slice().as_bstr());
+
+        let err = subsec(&mut interp, (Some(b"-Float::INFINITY"), None)).unwrap_err();
+
+        assert_eq!(err.name(), "FloatDomainError");
+        assert_eq!(err.message().as_bstr(), b"-Infinity".as_slice().as_bstr());
     }
 
     #[test]

--- a/artichoke-backend/src/extn/core/time/subsec.rs
+++ b/artichoke-backend/src/extn/core/time/subsec.rs
@@ -14,8 +14,8 @@ const MILLIS_IN_NANO: i64 = 1_000_000;
 const MICROS_IN_NANO: i64 = 1_000;
 const NANOS_IN_NANO: i64 = 1;
 
-const MAX_FLOAT_SECONDS: f64 = i64::MAX as f64;
 const MIN_FLOAT_SECONDS: f64 = i64::MIN as f64;
+const MAX_FLOAT_SECONDS: f64 = i64::MAX as f64;
 const MIN_FLOAT_NANOS: f64 = 0.0;
 const MAX_FLOAT_NANOS: f64 = NANOS_IN_SECOND as f64;
 

--- a/artichoke-backend/src/extn/core/time/subsec.rs
+++ b/artichoke-backend/src/extn/core/time/subsec.rs
@@ -124,8 +124,6 @@ mod tests {
     use super::Subsec;
     use bstr::ByteSlice;
 
-    use std::collections::HashMap;
-
     fn subsec(interp: &mut Artichoke, params: (Option<&[u8]>, Option<&[u8]>)) -> Result<Subsec, Error> {
         let (subsec, subsec_type) = params;
         let subsec = subsec.map(|s| interp.eval(s).unwrap());
@@ -159,7 +157,7 @@ mod tests {
     fn no_unit_implies_micros() {
         let mut interp = interpreter();
 
-        let expectations: HashMap<&[u8], (i64, u32)> = HashMap::from([
+        let expectations = [
             (b"-1000001".as_slice(), (-2, 999_999_000)),
             (b"-1000000".as_slice(), (-2, 0)),
             (b"-999999".as_slice(), (-1, 1_000)),
@@ -169,15 +167,15 @@ mod tests {
             (b"999999".as_slice(), (0, 999_999_000)),
             (b"1000000".as_slice(), (1, 0)),
             (b"1000001".as_slice(), (1, 1_000))
-        ]);
+        ];
 
         let subsec_unit = None;
 
-        for (input, expectation) in expectations {
+        for (input, expectation) in expectations.iter() {
             let result = subsec(&mut interp, (Some(input), subsec_unit)).unwrap();
             assert_eq!(
                 result.to_tuple(),
-                expectation,
+                *expectation,
                 "Expected TryConvertMut<(Some({}), None), Result<Subsec>>, to return {} secs, {} nanos",
                 input.as_bstr(),
                 expectation.0,
@@ -190,7 +188,7 @@ mod tests {
     fn subsec_millis() {
         let mut interp = interpreter();
 
-        let expectations: HashMap<&[u8], (i64, u32)> = HashMap::from([
+        let expectations = [
             (b"-1001".as_slice(), (-2, 999_000_000)),
             (b"-1000".as_slice(), (-2, 0)),
             (b"-999".as_slice(), (-1, 1_000_000)),
@@ -200,15 +198,15 @@ mod tests {
             (b"999".as_slice(), (0, 999_000_000)),
             (b"1000".as_slice(), (1, 0)),
             (b"1001".as_slice(), (1, 1_000_000))
-        ]);
+        ];
 
         let subsec_unit = b":milliseconds";
 
-        for (input, expectation) in expectations {
+        for (input, expectation) in expectations.iter() {
             let result = subsec(&mut interp, (Some(input), Some(subsec_unit))).unwrap();
             assert_eq!(
                 result.to_tuple(),
-                expectation,
+                *expectation,
                 "Expected TryConvertMut<(Some({}), Some({})), Result<Subsec>>, to return {} secs, {} nanos",
                 input.as_bstr(),
                 subsec_unit.as_bstr(),
@@ -222,7 +220,8 @@ mod tests {
     fn subsec_micros() {
         let mut interp = interpreter();
 
-        let expectations: HashMap<&[u8], (i64, u32)> = HashMap::from([
+        //let expectations: [(&[u8], (i64, u32))] = [
+        let expectations = [
             (b"-1000001".as_slice(), (-2, 999_999_000)),
             (b"-1000000".as_slice(), (-2, 0)),
             (b"-999999".as_slice(), (-1, 1_000)),
@@ -232,15 +231,15 @@ mod tests {
             (b"999999".as_slice(), (0, 999_999_000)),
             (b"1000000".as_slice(), (1, 0)),
             (b"1000001".as_slice(), (1, 1_000))
-        ]);
+        ];
 
         let subsec_unit = b":usec";
 
-        for (input, expectation) in expectations {
+        for (input, expectation) in expectations.iter() {
             let result = subsec(&mut interp, (Some(input), Some(subsec_unit))).unwrap();
             assert_eq!(
                 result.to_tuple(),
-                expectation,
+                *expectation,
                 "Expected TryConvertMut<(Some({}), Some({})), Result<Subsec>>, to return {} secs, {} nanos",
                 input.as_bstr(),
                 subsec_unit.as_bstr(),
@@ -254,7 +253,7 @@ mod tests {
     fn subsec_nanos() {
         let mut interp = interpreter();
 
-        let expectations: HashMap<&[u8], (i64, u32)> = HashMap::from([
+        let expectations = [
             (b"-1000000001".as_slice(), (-2, 999_999_999)),
             (b"-1000000000".as_slice(), (-2, 0)),
             (b"-999999999".as_slice(), (-1, 1)),
@@ -264,15 +263,15 @@ mod tests {
             (b"999999999".as_slice(), (0, 999_999_999)),
             (b"1000000000".as_slice(), (1, 0)),
             (b"1000000001".as_slice(), (1, 1))
-        ]);
+        ];
 
         let subsec_unit = b":nsec";
 
-        for (input, expectation) in expectations {
+        for (input, expectation) in expectations.iter() {
             let result = subsec(&mut interp, (Some(input), Some(subsec_unit))).unwrap();
             assert_eq!(
                 result.to_tuple(),
-                expectation,
+                *expectation,
                 "Expected TryConvertMut<(Some({}), Some({})), Result<Subsec>>, to return {} secs, {} nanos",
                 input.as_bstr(),
                 subsec_unit.as_bstr(),

--- a/artichoke-backend/src/extn/core/time/subsec.rs
+++ b/artichoke-backend/src/extn/core/time/subsec.rs
@@ -214,7 +214,7 @@ mod tests {
     }
 
     #[test]
-    fn no_unit_implies_micros() {
+    fn int_no_unit_implies_micros() {
         let mut interp = interpreter();
 
         let expectations = [
@@ -229,7 +229,7 @@ mod tests {
             (b"1000001".as_slice(), (1, 1_000))
         ];
 
-        let subsec_unit = None;
+        let subsec_unit: Option<&[u8]> = None;
 
         for (input, expectation) in expectations.iter() {
             let result = subsec(&mut interp, (Some(input), subsec_unit)).unwrap();
@@ -245,7 +245,7 @@ mod tests {
     }
 
     #[test]
-    fn subsec_millis() {
+    fn int_subsec_millis() {
         let mut interp = interpreter();
 
         let expectations = [
@@ -260,16 +260,16 @@ mod tests {
             (b"1001".as_slice(), (1, 1_000_000))
         ];
 
-        let subsec_unit = b":milliseconds";
+        let subsec_unit: Option<&[u8]> = Some(b":milliseconds");
 
         for (input, expectation) in expectations.iter() {
-            let result = subsec(&mut interp, (Some(input), Some(subsec_unit))).unwrap();
+            let result = subsec(&mut interp, (Some(input), subsec_unit)).unwrap();
             assert_eq!(
                 result.to_tuple(),
                 *expectation,
                 "Expected TryConvertMut<(Some({}), Some({})), Result<Subsec>>, to return {} secs, {} nanos",
                 input.as_bstr(),
-                subsec_unit.as_bstr(),
+                subsec_unit.unwrap().as_bstr(),
                 expectation.0,
                 expectation.1
             );
@@ -277,7 +277,7 @@ mod tests {
     }
 
     #[test]
-    fn subsec_micros() {
+    fn int_subsec_micros() {
         let mut interp = interpreter();
 
         //let expectations: [(&[u8], (i64, u32))] = [
@@ -293,16 +293,16 @@ mod tests {
             (b"1000001".as_slice(), (1, 1_000))
         ];
 
-        let subsec_unit = b":usec";
+        let subsec_unit: Option<&[u8]> = Some(b":usec");
 
         for (input, expectation) in expectations.iter() {
-            let result = subsec(&mut interp, (Some(input), Some(subsec_unit))).unwrap();
+            let result = subsec(&mut interp, (Some(input), subsec_unit)).unwrap();
             assert_eq!(
                 result.to_tuple(),
                 *expectation,
                 "Expected TryConvertMut<(Some({}), Some({})), Result<Subsec>>, to return {} secs, {} nanos",
                 input.as_bstr(),
-                subsec_unit.as_bstr(),
+                subsec_unit.unwrap().as_bstr(),
                 expectation.0,
                 expectation.1
             );
@@ -310,7 +310,7 @@ mod tests {
     }
 
     #[test]
-    fn subsec_nanos() {
+    fn int_subsec_nanos() {
         let mut interp = interpreter();
 
         let expectations = [
@@ -325,16 +325,16 @@ mod tests {
             (b"1000000001".as_slice(), (1, 1))
         ];
 
-        let subsec_unit = b":nsec";
+        let subsec_unit: Option<&[u8]> = Some(b":nsec");
 
         for (input, expectation) in expectations.iter() {
-            let result = subsec(&mut interp, (Some(input), Some(subsec_unit))).unwrap();
+            let result = subsec(&mut interp, (Some(input), subsec_unit)).unwrap();
             assert_eq!(
                 result.to_tuple(),
                 *expectation,
                 "Expected TryConvertMut<(Some({}), Some({})), Result<Subsec>>, to return {} secs, {} nanos",
                 input.as_bstr(),
-                subsec_unit.as_bstr(),
+                subsec_unit.unwrap().as_bstr(),
                 expectation.0,
                 expectation.1
             );

--- a/artichoke-backend/src/extn/core/time/subsec.rs
+++ b/artichoke-backend/src/extn/core/time/subsec.rs
@@ -1,13 +1,12 @@
+use crate::convert::implicitly_convert_to_int;
+use crate::extn::core::symbol::Symbol;
 ///! Parser of Ruby Time subsecond parameters to help generate `Time`.
 ///!
 ///! This module implements the logic to parse two optional parameters in the
 ///! `Time.at` function call. These parameters (if specified) provide the number
 ///! of subsecond parts to add, and a scale of those subsecond parts (millis, micros,
 ///! and nanos).
-
 use crate::extn::prelude::*;
-use crate::extn::core::symbol::Symbol;
-use crate::convert::implicitly_convert_to_int;
 
 const NANOS_IN_SECOND: i64 = 1_000_000_000;
 
@@ -29,9 +28,9 @@ enum SubsecMultiplier {
 impl SubsecMultiplier {
     const fn as_nanos(self) -> i64 {
         match self {
-           Self::Millis => MILLIS_IN_NANO,
-           Self::Micros => MICROS_IN_NANO,
-           Self::Nanos => NANOS_IN_NANO,
+            Self::Millis => MILLIS_IN_NANO,
+            Self::Micros => MICROS_IN_NANO,
+            Self::Nanos => NANOS_IN_NANO,
         }
     }
 }
@@ -57,8 +56,6 @@ impl TryConvertMut<Option<Value>, SubsecMultiplier> for Artichoke {
         }
     }
 }
-
-
 
 #[derive(Debug, Copy, Clone)]
 pub struct Subsec {
@@ -159,7 +156,8 @@ impl TryConvertMut<(Option<Value>, Option<Value>), Subsec> for Artichoke {
                         // is negative, we will always need remove one second.
                         // Nanos can then be adjusted since it will always be
                         // the inverse of the total nanos in a second.
-                        secs = secs.checked_sub(1)
+                        secs = secs
+                            .checked_sub(1)
                             .ok_or(ArgumentError::with_message("Time too small"))?;
 
                         if nanos.signum() != 0 {
@@ -168,7 +166,10 @@ impl TryConvertMut<(Option<Value>, Option<Value>), Subsec> for Artichoke {
                     }
 
                     // Cast to u32 is safe since it will always be less than NANOS_IN_SECOND due to modulo and negative adjustments.
-                    Ok(Subsec { secs, nanos: nanos as u32 })
+                    Ok(Subsec {
+                        secs,
+                        nanos: nanos as u32,
+                    })
                 }
             }
         } else {
@@ -226,7 +227,7 @@ mod tests {
             (b"1".as_slice(), (0, 1_000)),
             (b"999999".as_slice(), (0, 999_999_000)),
             (b"1000000".as_slice(), (1, 0)),
-            (b"1000001".as_slice(), (1, 1_000))
+            (b"1000001".as_slice(), (1, 1_000)),
         ];
 
         let subsec_unit: Option<&[u8]> = None;
@@ -257,7 +258,7 @@ mod tests {
             (b"1".as_slice(), (0, 1_000_000)),
             (b"999".as_slice(), (0, 999_000_000)),
             (b"1000".as_slice(), (1, 0)),
-            (b"1001".as_slice(), (1, 1_000_000))
+            (b"1001".as_slice(), (1, 1_000_000)),
         ];
 
         let subsec_unit: Option<&[u8]> = Some(b":milliseconds");
@@ -290,7 +291,7 @@ mod tests {
             (b"1".as_slice(), (0, 1_000)),
             (b"999999".as_slice(), (0, 999_999_000)),
             (b"1000000".as_slice(), (1, 0)),
-            (b"1000001".as_slice(), (1, 1_000))
+            (b"1000001".as_slice(), (1, 1_000)),
         ];
 
         let subsec_unit: Option<&[u8]> = Some(b":usec");
@@ -322,7 +323,7 @@ mod tests {
             (b"1".as_slice(), (0, 1)),
             (b"999999999".as_slice(), (0, 999_999_999)),
             (b"1000000000".as_slice(), (1, 0)),
-            (b"1000000001".as_slice(), (1, 1))
+            (b"1000000001".as_slice(), (1, 1)),
         ];
 
         let subsec_unit: Option<&[u8]> = Some(b":nsec");

--- a/artichoke-backend/src/extn/core/time/subsec.rs
+++ b/artichoke-backend/src/extn/core/time/subsec.rs
@@ -47,7 +47,7 @@ impl TryConvertMut<Option<Value>, SubsecMultiplier> for Artichoke {
                 b"nsec" => Ok(SubsecMultiplier::Nanos),
                 _ => {
                     let mut message = b"unexpected unit: ".to_vec();
-                    message.extend(subsec_symbol.to_vec());
+                    message.extend_from_slice(subsec_symbol);
                     Err(ArgumentError::from(message).into())
                 }
             }

--- a/artichoke-backend/src/extn/core/time/subsec.rs
+++ b/artichoke-backend/src/extn/core/time/subsec.rs
@@ -1,0 +1,216 @@
+///! Parser of Ruby Time subsecond parameters to help generate `Time`.
+///!
+///! This module implements the logic to parse two optional parameters in the
+///! `Time.at` function call. These parameters (if specified) provide the number
+///! of subsecond parts to add, and a scale of those subsecond parts (millis, micros,
+///! and nanos).
+
+use crate::extn::prelude::*;
+use crate::extn::core::symbol::Symbol;
+use crate::convert::implicitly_convert_to_int;
+
+const NANOS_IN_SECOND: i64 = 1_000_000_000;
+
+const MILLIS_IN_NANO: i64 = 1_000_000;
+const MICROS_IN_NANO: i64 = 1_000;
+const NANOS_IN_NANO: i64 = 1;
+
+enum SubsecMultiplier {
+    Millis,
+    Micros,
+    Nanos,
+}
+
+impl SubsecMultiplier {
+    const fn as_nanos(self) -> i64 {
+        match self {
+           Self::Millis => MILLIS_IN_NANO,
+           Self::Micros => MICROS_IN_NANO,
+           Self::Nanos => NANOS_IN_NANO,
+        }
+    }
+}
+
+impl TryConvertMut<Option<Value>, SubsecMultiplier> for Artichoke {
+    type Error = Error;
+
+    fn try_convert_mut(&mut self, subsec_type: Option<Value>) -> Result<SubsecMultiplier, Self::Error> {
+        if let Some(mut subsec_type) = subsec_type {
+            let subsec_symbol = unsafe { Symbol::unbox_from_value(&mut subsec_type, self)? }.bytes(self);
+            match subsec_symbol {
+                b"milliseconds" => Ok(SubsecMultiplier::Millis),
+                b"usec" => Ok(SubsecMultiplier::Micros),
+                b"nsec" => Ok(SubsecMultiplier::Nanos),
+                _ => Err(ArgumentError::with_message("unexpected unit. expects :milliseconds, :usec, :nsec").into()),
+            }
+        } else {
+            Ok(SubsecMultiplier::Micros)
+        }
+    }
+}
+
+
+
+#[derive(Debug, Copy, Clone)]
+pub struct Subsec {
+    secs: i64,
+    nanos: u32,
+}
+
+impl Subsec {
+    /// Returns a tuple of (seconds, nanoseconds). Subseconds are provided in
+    /// various accuracies, and can overflow. e.g. 1001 milliseconds, is 1
+    /// second, and 1_000_000 nanoseconds.
+    pub fn to_tuple(&self) -> (i64, u32) {
+        (self.secs, self.nanos)
+    }
+}
+
+
+impl TryConvertMut<(Option<Value>, Option<Value>), Subsec> for Artichoke {
+    type Error = Error;
+
+    fn try_convert_mut(&mut self, params: (Option<Value>, Option<Value>)) -> Result<Subsec, Self::Error> {
+        let (subsec, subsec_type) = params;
+
+        if let Some(subsec) = subsec {
+            let multiplier: SubsecMultiplier = self.try_convert_mut(subsec_type)?;
+            let multiplier_nanos = multiplier.as_nanos();
+            let seconds_base = NANOS_IN_SECOND / multiplier_nanos;
+
+            match subsec.ruby_type() {
+                Ruby::Fixnum => {
+                    let subsec: i64 = subsec.try_convert_into(self)?;
+
+                    // The below conversions should be safe. The multiplier is gauranteed to not be
+                    // 0, the remainder should never overflow, and is gauranteed to be less than
+                    // u32::MAX;
+                    let secs = subsec / seconds_base;
+                    let nanos = ((subsec % seconds_base) * multiplier_nanos) as u32;
+                    Ok(Subsec { secs, nanos })
+                },
+                Ruby::Float => {
+                    // TODO: Safe conversions here are really hard, there may end up being some
+                    // loss in accuracy.
+                    unreachable!("Not yet implemented")
+                },
+                _ => {
+                    let subsec: i64 = implicitly_convert_to_int(self, subsec)?;
+
+                    // The below conversions should be safe. The multiplier is gauranteed to not be
+                    // 0, the remainder should never overflow, and is gauranteed to be less than
+                    // u32::MAX;
+                    let secs = subsec / seconds_base;
+                    let nanos = ((subsec % seconds_base) * multiplier_nanos) as u32;
+                    Ok(Subsec { secs, nanos })
+                }
+            }
+        } else {
+            Ok(Subsec { secs: 0, nanos: 0 })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::prelude::*;
+
+    use super::Subsec;
+
+    fn subsec(interp: &mut Artichoke, params: (Option<&[u8]>, Option<&[u8]>)) -> Result<Subsec, Error> {
+        let (subsec, subsec_type) = params;
+        let subsec = subsec.map(|s| interp.eval(s).unwrap());
+        let subsec_type = subsec_type.map(|s| interp.eval(s).unwrap());
+
+        interp.try_convert_mut((subsec, subsec_type))
+    }
+
+    #[test]
+    fn no_subsec_provided() {
+        let mut interp = interpreter();
+
+        let result: Subsec = interp.try_convert_mut((None, None)).unwrap();
+        let (secs, nanos) = result.to_tuple();
+        assert_eq!(secs, 0);
+        assert_eq!(nanos, 0);
+    }
+
+    #[test]
+    fn no_subsec_provided_but_has_unit() {
+        let mut interp = interpreter();
+        let unit = interp.eval(b":usec").unwrap();
+
+        let result: Subsec = interp.try_convert_mut((None, Some(unit))).unwrap();
+        let (secs, nanos) = result.to_tuple();
+        assert_eq!(secs, 0);
+        assert_eq!(nanos, 0);
+    }
+
+    #[test]
+    fn no_unit_implies_micros() {
+        let mut interp = interpreter();
+
+        let result = subsec(&mut interp, (Some(b"0"), None)).unwrap();
+        assert_eq!(result.to_tuple(), (0, 0));
+
+        let result = subsec(&mut interp, (Some(b"999999"), None)).unwrap();
+        assert_eq!(result.to_tuple(), (0, 999_999_000));
+
+        let result = subsec(&mut interp, (Some(b"1000000"), None)).unwrap();
+        assert_eq!(result.to_tuple(), (1, 0));
+
+        let result = subsec(&mut interp, (Some(b"1000001"), None)).unwrap();
+        assert_eq!(result.to_tuple(), (1, 1_000));
+    }
+
+    #[test]
+    fn subsec_millis() {
+        let mut interp = interpreter();
+
+        let result = subsec(&mut interp, (Some(b"0"), Some(b":milliseconds"))).unwrap();
+        assert_eq!(result.to_tuple(), (0, 0));
+
+        let result = subsec(&mut interp, (Some(b"999"), Some(b":milliseconds"))).unwrap();
+        assert_eq!(result.to_tuple(), (0, 999_000_000));
+
+        let result = subsec(&mut interp, (Some(b"1000"), Some(b":milliseconds"))).unwrap();
+        assert_eq!(result.to_tuple(), (1, 0));
+
+        let result = subsec(&mut interp, (Some(b"1001"), Some(b":milliseconds"))).unwrap();
+        assert_eq!(result.to_tuple(), (1, 1_000_000));
+    }
+
+    #[test]
+    fn subsec_micros() {
+        let mut interp = interpreter();
+
+        let result = subsec(&mut interp, (Some(b"0"), Some(b":usec"))).unwrap();
+        assert_eq!(result.to_tuple(), (0, 0));
+
+        let result = subsec(&mut interp, (Some(b"999999"), Some(b":usec"))).unwrap();
+        assert_eq!(result.to_tuple(), (0, 999_999_000));
+
+        let result = subsec(&mut interp, (Some(b"1000000"), Some(b":usec"))).unwrap();
+        assert_eq!(result.to_tuple(), (1, 0));
+
+        let result = subsec(&mut interp, (Some(b"1000001"), Some(b":usec"))).unwrap();
+        assert_eq!(result.to_tuple(), (1, 1_000));
+    }
+
+    #[test]
+    fn subsub_nanos() {
+        let mut interp = interpreter();
+
+        let result = subsec(&mut interp, (Some(b"0"), Some(b":nsec"))).unwrap();
+        assert_eq!(result.to_tuple(), (0, 0));
+
+        let result = subsec(&mut interp, (Some(b"999999999"), Some(b":nsec"))).unwrap();
+        assert_eq!(result.to_tuple(), (0, 999_999_999));
+
+        let result = subsec(&mut interp, (Some(b"1000000000"), Some(b":nsec"))).unwrap();
+        assert_eq!(result.to_tuple(), (1, 0));
+
+        let result = subsec(&mut interp, (Some(b"1000000001"), Some(b":nsec"))).unwrap();
+        assert_eq!(result.to_tuple(), (1, 1));
+    }
+}

--- a/artichoke-backend/src/extn/core/time/trampoline.rs
+++ b/artichoke-backend/src/extn/core/time/trampoline.rs
@@ -47,22 +47,23 @@ pub fn at(
     // `Time.at` without the optional parameters will end up placing the
     // options hash in the incorrect parameter position.
     //
-    // e.g.
+    // ```console
     // Time.at(0, in: "A")
-    //              ^--first
+    // #          ^--first
     // Time.at(0, 1, in: "A")
-    //                 ^-- second
+    // #             ^-- second
     // Time.at(0, 1, :nsec, in: "A")
-    //                        ^-- third
+    // #                    ^-- third
+    // ```
     //
     // The below logic:
-    // - ensures the third parameter is a Ruby::Hash if provided
+    // - ensures the third parameter is a Ruby::Hash if provided.
     // - if third param is not options, check the second paramter, if it is a
     //   Ruby::Hash then assume this is the options hash, and clear out the
-    //   second parameter
+    //   second parameter.
     // - if second param is not options, check the first param, if it is a
     //   Ruby::Hash then assume this is the options hash, and clear out the
-    //   first parameter
+    //   first parameter.
     if let Some(third_param) = third {
         if third_param.ruby_type() != Ruby::Hash {
             return Err(ArgumentError::with_message("invalid offset options").into());

--- a/artichoke-backend/src/extn/core/time/trampoline.rs
+++ b/artichoke-backend/src/extn/core/time/trampoline.rs
@@ -1,7 +1,7 @@
 //! Glue between mruby FFI and `Time` Rust implementation.
 
-use crate::convert::{implicitly_convert_to_int};
-use crate::extn::core::time::{Offset, Time, subsec::Subsec};
+use crate::convert::implicitly_convert_to_int;
+use crate::extn::core::time::{subsec::Subsec, Offset, Time};
 use crate::extn::prelude::*;
 
 // Constructor
@@ -65,7 +65,7 @@ pub fn at(
     //   first parameter
     if let Some(third_param) = third {
         if third_param.ruby_type() != Ruby::Hash {
-            return Err(ArgumentError::with_message("invalid offset options").into())
+            return Err(ArgumentError::with_message("invalid offset options").into());
         }
     } else {
         options = if let Some(second_param) = second {
@@ -96,7 +96,7 @@ pub fn at(
 
     let offset: Offset = if let Some(options) = options {
         let offset: Option<Offset> = interp.try_convert_mut(options)?;
-        offset.unwrap_or(Offset::local())
+        offset.unwrap_or_else(Offset::local)
     } else {
         Offset::local()
     };

--- a/artichoke-backend/src/extn/core/time/trampoline.rs
+++ b/artichoke-backend/src/extn/core/time/trampoline.rs
@@ -258,12 +258,12 @@ pub fn plus(interp: &mut Artichoke, mut time: Value, mut other: Value) -> Result
     let time = unsafe { Time::unbox_from_value(&mut time, interp)? };
     if unsafe { Time::unbox_from_value(&mut other, interp) }.is_ok() {
         Err(TypeError::with_message("time + time?").into())
-    } else if let Ok(other) = implicitly_convert_to_int(interp, other) {
-        let result = time.checked_add_i64(other)?;
-
-        Time::alloc_value(result, interp)
     } else if let Ok(other) = other.try_convert_into::<f64>(interp) {
         let result = time.checked_add_f64(other)?;
+
+        Time::alloc_value(result, interp)
+    } else if let Ok(other) = implicitly_convert_to_int(interp, other) {
+        let result = time.checked_add_i64(other)?;
 
         Time::alloc_value(result, interp)
     } else {

--- a/artichoke-backend/src/extn/core/time/trampoline.rs
+++ b/artichoke-backend/src/extn/core/time/trampoline.rs
@@ -257,6 +257,14 @@ pub fn to_array(interp: &mut Artichoke, time: Value) -> Result<Value, Error> {
 pub fn plus(interp: &mut Artichoke, mut time: Value, mut other: Value) -> Result<Value, Error> {
     let time = unsafe { Time::unbox_from_value(&mut time, interp)? };
     if unsafe { Time::unbox_from_value(&mut other, interp) }.is_ok() {
+        // ```console
+        // [3.1.2] > Time.now + Time.now
+        // (irb):15:in `+': time + time? (TypeError)
+        //         from (irb):15:in `<main>'
+        //         from /usr/local/var/rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/irb-1.4.1/exe/irb:11:in `<top (required)>'
+        //         from /usr/local/var/rbenv/versions/3.1.2/bin/irb:25:in `load'
+        //         from /usr/local/var/rbenv/versions/3.1.2/bin/irb:25:in `<main>'
+        // ```
         Err(TypeError::with_message("time + time?").into())
     } else if let Ok(other) = other.try_convert_into::<f64>(interp) {
         let result = time.checked_add_f64(other)?;

--- a/artichoke-backend/src/macros.rs
+++ b/artichoke-backend/src/macros.rs
@@ -85,6 +85,7 @@ pub mod argspec {
     pub const OPT1: &CStr = qed::const_cstr_from_str!("|o\0");
     pub const REQ1_OPT1: &CStr = qed::const_cstr_from_str!("o|o\0");
     pub const REQ1_OPT2: &CStr = qed::const_cstr_from_str!("o|oo\0");
+    pub const REQ1_OPT3: &CStr = qed::const_cstr_from_str!("o|ooo\0");
     pub const REQ1_REQBLOCK: &CStr = qed::const_cstr_from_str!("o&\0");
     pub const REQ1_REQBLOCK_OPT1: &CStr = qed::const_cstr_from_str!("o&|o?\0");
     pub const REQ1_REQBLOCK_OPT2: &CStr = qed::const_cstr_from_str!("o&|o?o?\0");
@@ -179,6 +180,45 @@ macro_rules! mrb_get_args {
             1 => {
                 let req1 = req1.assume_init();
                 (req1, None, None)
+            }
+            _ => unreachable!("mrb_get_args should have raised"),
+        }
+    }};
+    ($mrb:expr, required = 1, optional = 3) => {{
+        let mut req1 = std::mem::MaybeUninit::<$crate::sys::mrb_value>::uninit();
+        let mut opt1 = std::mem::MaybeUninit::<$crate::sys::mrb_value>::uninit();
+        let mut opt2 = std::mem::MaybeUninit::<$crate::sys::mrb_value>::uninit();
+        let mut opt3 = std::mem::MaybeUninit::<$crate::sys::mrb_value>::uninit();
+        let argc = $crate::sys::mrb_get_args(
+            $mrb,
+            $crate::macros::argspec::REQ1_OPT3.as_ptr(),
+            req1.as_mut_ptr(),
+            opt1.as_mut_ptr(),
+            opt2.as_mut_ptr(),
+            opt3.as_mut_ptr(),
+        );
+        match argc {
+            4 => {
+                let req1 = req1.assume_init();
+                let opt1 = opt1.assume_init();
+                let opt2 = opt2.assume_init();
+                let opt3 = opt3.assume_init();
+                (req1, Some(opt1), Some(opt2), Some(opt3))
+            }
+            3 => {
+                let req1 = req1.assume_init();
+                let opt1 = opt1.assume_init();
+                let opt2 = opt2.assume_init();
+                (req1, Some(opt1), Some(opt2), None)
+            }
+            2 => {
+                let req1 = req1.assume_init();
+                let opt1 = opt1.assume_init();
+                (req1, Some(opt1), None, None)
+            }
+            1 => {
+                let req1 = req1.assume_init();
+                (req1, None, None, None)
             }
             _ => unreachable!("mrb_get_args should have raised"),
         }

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -73,12 +73,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "autocfg"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
-
-[[package]]
 name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -100,12 +94,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bumpalo"
-version = "3.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ccbd214614c6783386c1af30caf03192f17891059cecc394b4fb119e363de3"
-
-[[package]]
 name = "bytecount"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -124,39 +112,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "chrono"
-version = "0.4.20"
+name = "const_fn"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6127248204b9aba09a362f6c930ef6a78f2c1b2215f8a7b398c06e1083f17af0"
-dependencies = [
- "js-sys",
- "num-integer",
- "num-traits",
- "wasm-bindgen",
- "winapi",
-]
-
-[[package]]
-name = "chrono-tz"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c39203181991a7dd4343b8005bd804e7a9a37afb8ac070e43771e8c820bbde"
-dependencies = [
- "chrono",
- "chrono-tz-build",
- "phf",
-]
-
-[[package]]
-name = "chrono-tz-build"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f509c3a87b33437b05e2458750a0700e5bdd6956176773e6c7d6dd15a283a0c"
-dependencies = [
- "parse-zoneinfo",
- "phf",
- "phf_codegen",
-]
+checksum = "fbdcdcb6d86f71c5e97409ad45898af11cbc995b4ee8112d59095a28d376c935"
 
 [[package]]
 name = "focaccia"
@@ -182,15 +141,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd49aef5b63b46af0844b99cea402c3063d9a052249265d322657d83cf464211"
 
 [[package]]
-name = "js-sys"
-version = "0.3.59"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "258451ab10b34f8af53416d1fdab72c22e805f0c92a1136d59470ec0b11138b2"
-dependencies = [
- "wasm-bindgen",
-]
-
-[[package]]
 name = "libc"
 version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -214,15 +164,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da83a57f3f5ba3680950aa3cbc806fc297bc0b289d42e8942ed528ace71b8145"
 
 [[package]]
-name = "log"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -231,25 +172,6 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 [[package]]
 name = "mezzaluna-feature-loader"
 version = "0.5.0"
-
-[[package]]
-name = "num-integer"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
-dependencies = [
- "autocfg",
- "num-traits",
-]
-
-[[package]]
-name = "num-traits"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "once_cell"
@@ -280,54 +202,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parse-zoneinfo"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c705f256449c60da65e11ff6626e0c16a0a0b96aaa348de61376b249bc340f41"
-dependencies = [
- "regex",
-]
-
-[[package]]
-name = "phf"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4724fa946c8d1e7cd881bd3dbee63ce32fc1e9e191e35786b3dc1320a3f68131"
-dependencies = [
- "phf_shared",
-]
-
-[[package]]
-name = "phf_codegen"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32ba0c43d7a1b6492b2924a62290cfd83987828af037b0743b38e6ab092aee58"
-dependencies = [
- "phf_generator",
- "phf_shared",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b450720b6f75cfbfabc195814bd3765f337a4f9a83186f8537297cac12f6705"
-dependencies = [
- "phf_shared",
- "rand",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd5609d4b2df87167f908a32e1b146ce309c16cf35df76bc11f440b756048e4"
-dependencies = [
- "siphasher",
- "uncased",
-]
-
-[[package]]
 name = "pkg-config"
 version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -340,34 +214,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "774dd2ef2e014ad005e8a6833f5b5d26c89e9801c20637f69f3af489f7b03bff"
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
-
-[[package]]
-name = "proc-macro2"
-version = "1.0.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
-dependencies = [
- "unicode-ident",
-]
-
-[[package]]
 name = "qed"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90d0abf294960e1e7e22949cddc9cc2c96a05dc52f5567fd65c2bbd4899ff47e"
-
-[[package]]
-name = "quote"
-version = "1.0.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
-dependencies = [
- "proc-macro2",
-]
 
 [[package]]
 name = "rand"
@@ -375,18 +225,6 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
- "libc",
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
  "rand_core",
 ]
 
@@ -461,12 +299,6 @@ name = "simdutf8"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
-
-[[package]]
-name = "siphasher"
-version = "0.3.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
 
 [[package]]
 name = "spinoso-array"
@@ -556,107 +388,42 @@ dependencies = [
 name = "spinoso-time"
 version = "0.6.0"
 dependencies = [
- "chrono",
- "chrono-tz",
+ "once_cell",
+ "regex",
+ "strftime-ruby",
+ "tz-rs",
+ "tzdb",
 ]
 
 [[package]]
-name = "syn"
-version = "1.0.99"
+name = "strftime-ruby"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
+checksum = "6b02d24309580475dca1e01d10378f9a0d979aa95ee6c00bdbbf883f5315c905"
 
 [[package]]
 name = "tz-rs"
 version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b3d23fda22515e0e3f4f903e159ad4fd32e37dc94d63522a091df70a247fbb0"
-
-[[package]]
-name = "uncased"
-version = "0.9.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09b01702b0fd0b3fadcf98e098780badda8742d4f4a7676615cad90e8ac73622"
 dependencies = [
- "version_check",
+ "const_fn",
 ]
 
 [[package]]
-name = "unicode-ident"
-version = "1.0.3"
+name = "tzdb"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
-
-[[package]]
-name = "version_check"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+checksum = "bca7a9f150d3038bd779d8400a9099032fc8daacc25843e2fa29cfdc24382086"
+dependencies = [
+ "tz-rs",
+]
 
 [[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
-
-[[package]]
-name = "wasm-bindgen"
-version = "0.2.82"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7652e3f6c4706c8d9cd54832c4a4ccb9b5336e2c3bd154d5cccfbf1c1f5f7d"
-dependencies = [
- "cfg-if",
- "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.82"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "662cd44805586bd52971b9586b1df85cdbbd9112e4ef4d8f41559c334dc6ac3f"
-dependencies = [
- "bumpalo",
- "log",
- "once_cell",
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.82"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b260f13d3012071dfb1512849c033b1925038373aea48ced3012c09df952c602"
-dependencies = [
- "quote",
- "wasm-bindgen-macro-support",
-]
-
-[[package]]
-name = "wasm-bindgen-macro-support"
-version = "0.2.82"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be8e654bdd9b79216c2929ab90721aa82faf65c48cdf08bdc4e7f51357b80da"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-backend",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-shared"
-version = "0.2.82"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6598dd0bd3c7d51095ff6531a5b23e02acdc81804e30d8f07afb77b7215a140a"
 
 [[package]]
 name = "winapi"

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -125,12 +125,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bumpalo"
-version = "3.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ccbd214614c6783386c1af30caf03192f17891059cecc394b4fb119e363de3"
-
-[[package]]
 name = "bytecount"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -147,41 +141,6 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "chrono"
-version = "0.4.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6127248204b9aba09a362f6c930ef6a78f2c1b2215f8a7b398c06e1083f17af0"
-dependencies = [
- "js-sys",
- "num-integer",
- "num-traits",
- "wasm-bindgen",
- "winapi",
-]
-
-[[package]]
-name = "chrono-tz"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c39203181991a7dd4343b8005bd804e7a9a37afb8ac070e43771e8c820bbde"
-dependencies = [
- "chrono",
- "chrono-tz-build",
- "phf",
-]
-
-[[package]]
-name = "chrono-tz-build"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f509c3a87b33437b05e2458750a0700e5bdd6956176773e6c7d6dd15a283a0c"
-dependencies = [
- "parse-zoneinfo",
- "phf",
- "phf_codegen",
-]
 
 [[package]]
 name = "clap"
@@ -204,6 +163,12 @@ checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
  "os_str_bytes",
 ]
+
+[[package]]
+name = "const_fn"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbdcdcb6d86f71c5e97409ad45898af11cbc995b4ee8112d59095a28d376c935"
 
 [[package]]
 name = "cpufeatures"
@@ -309,15 +274,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
 
 [[package]]
-name = "js-sys"
-version = "0.3.59"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "258451ab10b34f8af53416d1fdab72c22e805f0c92a1136d59470ec0b11138b2"
-dependencies = [
- "wasm-bindgen",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -346,15 +302,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "log"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -371,25 +318,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f5c75688da582b8ffc1f1799e9db273f32133c49e048f614d22ec3256773ccc"
 dependencies = [
  "adler",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
-dependencies = [
- "autocfg",
- "num-traits",
-]
-
-[[package]]
-name = "num-traits"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
-dependencies = [
- "autocfg",
 ]
 
 [[package]]
@@ -467,54 +395,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parse-zoneinfo"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c705f256449c60da65e11ff6626e0c16a0a0b96aaa348de61376b249bc340f41"
-dependencies = [
- "regex",
-]
-
-[[package]]
-name = "phf"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4724fa946c8d1e7cd881bd3dbee63ce32fc1e9e191e35786b3dc1320a3f68131"
-dependencies = [
- "phf_shared",
-]
-
-[[package]]
-name = "phf_codegen"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32ba0c43d7a1b6492b2924a62290cfd83987828af037b0743b38e6ab092aee58"
-dependencies = [
- "phf_generator",
- "phf_shared",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b450720b6f75cfbfabc195814bd3765f337a4f9a83186f8537297cac12f6705"
-dependencies = [
- "phf_shared",
- "rand",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd5609d4b2df87167f908a32e1b146ce309c16cf35df76bc11f440b756048e4"
-dependencies = [
- "siphasher",
- "uncased",
-]
-
-[[package]]
 name = "pkg-config"
 version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -525,12 +405,6 @@ name = "posix-space"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "774dd2ef2e014ad005e8a6833f5b5d26c89e9801c20637f69f3af489f7b03bff"
-
-[[package]]
-name = "ppv-lite86"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "proc-macro2"
@@ -562,18 +436,6 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
- "libc",
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
  "rand_core",
 ]
 
@@ -761,12 +623,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
 
 [[package]]
-name = "siphasher"
-version = "0.3.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
-
-[[package]]
 name = "smallvec"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -874,9 +730,18 @@ dependencies = [
 name = "spinoso-time"
 version = "0.6.0"
 dependencies = [
- "chrono",
- "chrono-tz",
+ "once_cell",
+ "regex",
+ "strftime-ruby",
+ "tz-rs",
+ "tzdb",
 ]
+
+[[package]]
+name = "strftime-ruby"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b02d24309580475dca1e01d10378f9a0d979aa95ee6c00bdbbf883f5315c905"
 
 [[package]]
 name = "strsim"
@@ -936,14 +801,17 @@ name = "tz-rs"
 version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b3d23fda22515e0e3f4f903e159ad4fd32e37dc94d63522a091df70a247fbb0"
+dependencies = [
+ "const_fn",
+]
 
 [[package]]
-name = "uncased"
-version = "0.9.7"
+name = "tzdb"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09b01702b0fd0b3fadcf98e098780badda8742d4f4a7676615cad90e8ac73622"
+checksum = "bca7a9f150d3038bd779d8400a9099032fc8daacc25843e2fa29cfdc24382086"
 dependencies = [
- "version_check",
+ "tz-rs",
 ]
 
 [[package]]
@@ -974,60 +842,6 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
-
-[[package]]
-name = "wasm-bindgen"
-version = "0.2.82"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7652e3f6c4706c8d9cd54832c4a4ccb9b5336e2c3bd154d5cccfbf1c1f5f7d"
-dependencies = [
- "cfg-if",
- "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.82"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "662cd44805586bd52971b9586b1df85cdbbd9112e4ef4d8f41559c334dc6ac3f"
-dependencies = [
- "bumpalo",
- "log",
- "once_cell",
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.82"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b260f13d3012071dfb1512849c033b1925038373aea48ced3012c09df952c602"
-dependencies = [
- "quote",
- "wasm-bindgen-macro-support",
-]
-
-[[package]]
-name = "wasm-bindgen-macro-support"
-version = "0.2.82"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be8e654bdd9b79216c2929ab90721aa82faf65c48cdf08bdc4e7f51357b80da"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-backend",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-shared"
-version = "0.2.82"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6598dd0bd3c7d51095ff6531a5b23e02acdc81804e30d8f07afb77b7215a140a"
 
 [[package]]
 name = "winapi"


### PR DESCRIPTION
#1927 Added enough to hopefully make tzrs feature safe for replacement of the chrono feature in arthicoke-backend. This PR achieves to do exactly that

## Compatibility

The previous version of `Time#at` supported only the syntax that `mruby` did. This PR introduces all options available as at MRI 3.1.2.

`Time#succ` now uses the same logic as `Time#+` which wasn't implemented before.

`Time#+` is now implemented, and follows MRI

`Time#-` changes:

- The previous version use to just return rhs when subtracting one time from another (this now returns a float as per MRI)
- Arthimetic with intergers/floats now works