### PR TITLE
Add support for a `Range` argument to `String#byteslice`

### DIFF
--- a/artichoke-backend/src/extn/core/array/args.rs
+++ b/artichoke-backend/src/extn/core/array/args.rs
@@ -83,27 +83,28 @@ pub fn element_assignment(
             write!(&mut message, "negative length ({})", slice_len).map_err(WriteError::from)?;
             Err(IndexError::from(message).into())
         }
-    } else if let Ok(index) = implicitly_convert_to_int(interp, first) {
-        if let Ok(index) = usize::try_from(index) {
-            Ok((index, None, second))
-        } else {
-            let idx = index
-                .checked_neg()
-                .and_then(|index| usize::try_from(index).ok())
-                .and_then(|index| len.checked_sub(index));
-            if let Some(idx) = idx {
-                Ok((idx, None, second))
-            } else {
-                let mut message = String::new();
-                write!(&mut message, "index {} too small for array; minimum: -{}", index, len)
-                    .map_err(WriteError::from)?;
-                Err(IndexError::from(message).into())
-            }
-        }
     } else {
         let rangelen = i64::try_from(len).map_err(|_| Fatal::from("Range length exceeds Integer max"))?;
         match first.is_range(interp, rangelen)? {
-            None => {}
+            None => {
+                let index = implicitly_convert_to_int(interp, first)?;
+                if let Ok(index) = usize::try_from(index) {
+                    Ok((index, None, second))
+                } else {
+                    let idx = index
+                        .checked_neg()
+                        .and_then(|index| usize::try_from(index).ok())
+                        .and_then(|index| len.checked_sub(index));
+                    if let Some(idx) = idx {
+                        Ok((idx, None, second))
+                    } else {
+                        let mut message = String::new();
+                        write!(&mut message, "index {} too small for array; minimum: -{}", index, len)
+                            .map_err(WriteError::from)?;
+                        Err(IndexError::from(message).into())
+                    }
+                }
+            }
             // ```
             // [3.1.2] > a = []
             // => []
@@ -114,46 +115,12 @@ pub fn element_assignment(
             //         from /usr/local/var/rbenv/versions/3.1.2/bin/irb:25:in `load'
             //         from /usr/local/var/rbenv/versions/3.1.2/bin/irb:25:in `<main>'
             // ```
-            Some(protect::Range::Out) => return Err(RangeError::with_message("out of range").into()),
+            Some(protect::Range::Out) => Err(RangeError::with_message("out of range").into()),
             Some(protect::Range::Valid { start, len }) => {
                 let start = usize::try_from(start)
                     .unwrap_or_else(|_| unimplemented!("should throw RangeError (-11..1 out of range)"));
                 let len = usize::try_from(len).unwrap_or_else(|_| unreachable!("Range can't have negative length"));
-                return Ok((start, Some(len), second));
-            }
-        };
-        let start = first.funcall(interp, "begin", &[], None)?;
-        let start = implicitly_convert_to_int(interp, start)?;
-        let end = first.funcall(interp, "last", &[], None)?;
-        let end = implicitly_convert_to_int(interp, end)?;
-        // TODO: This conditional is probably not doing the right thing
-        if start + (end - start) < 0 {
-            let mut message = String::new();
-            write!(&mut message, "{}..{} out of range", start, end).map_err(WriteError::from)?;
-            return Err(RangeError::from(message).into());
-        }
-        match (usize::try_from(start), usize::try_from(end)) {
-            (Ok(start), Ok(end)) => Ok((start, end.checked_sub(start), second)),
-            (Err(_), Ok(end)) => {
-                let pos = start
-                    .checked_neg()
-                    .and_then(|start| usize::try_from(start).ok())
-                    .and_then(|start| len.checked_sub(start));
-                if let Some(start) = pos {
-                    Ok((start, end.checked_sub(start), second))
-                } else {
-                    let mut message = String::new();
-                    write!(&mut message, "index {} too small for array; minimum: -{}", start, len)
-                        .map_err(WriteError::from)?;
-                    Err(IndexError::from(message).into())
-                }
-            }
-            (Ok(start), Err(_)) => Ok((start, None, second)),
-            (Err(_), Err(_)) => {
-                let mut message = String::new();
-                write!(&mut message, "index {} too small for array; minimum: -{}", start, len)
-                    .map_err(WriteError::from)?;
-                Err(IndexError::from(message).into())
+                Ok((start, Some(len), second))
             }
         }
     }

--- a/artichoke-backend/src/extn/core/array/args.rs
+++ b/artichoke-backend/src/extn/core/array/args.rs
@@ -20,23 +20,31 @@ pub fn element_reference(
     if let Some(len) = len {
         let start = implicitly_convert_to_int(interp, elem)?;
         let len = implicitly_convert_to_int(interp, len)?;
-        if let Ok(len) = usize::try_from(len) {
+        return if let Ok(len) = usize::try_from(len) {
             Ok(ElementReference::StartLen(start, len))
         } else {
             Ok(ElementReference::Empty)
+        };
+    }
+    let rangelen = i64::try_from(ary_len).map_err(|_| Fatal::from("Range length exceeds Integer max"))?;
+    match elem.is_range(interp, rangelen)? {
+        None => {
+            let index = implicitly_convert_to_int(interp, elem)?;
+            Ok(ElementReference::Index(index))
         }
-    } else if let Ok(index) = implicitly_convert_to_int(interp, elem) {
-        Ok(ElementReference::Index(index))
-    } else {
-        let rangelen = i64::try_from(ary_len).map_err(|_| Fatal::from("Range length exceeds Integer max"))?;
-        if let Some(protect::Range { start, len }) = elem.is_range(interp, rangelen)? {
+        // ```
+        // [3.1.2] > a = []
+        // => []
+        // [3.1.2] > a[-1..-1]
+        // => nil
+        // ```
+        Some(protect::Range::Out) => Ok(ElementReference::Empty),
+        Some(protect::Range::Valid { start, len }) => {
             if let Ok(len) = usize::try_from(len) {
                 Ok(ElementReference::StartLen(start, len))
             } else {
                 Ok(ElementReference::Empty)
             }
-        } else {
-            Ok(ElementReference::Empty)
         }
     }
 }
@@ -94,45 +102,58 @@ pub fn element_assignment(
         }
     } else {
         let rangelen = i64::try_from(len).map_err(|_| Fatal::from("Range length exceeds Integer max"))?;
-        if let Some(protect::Range { start, len }) = first.is_range(interp, rangelen)? {
-            let start = usize::try_from(start)
-                .unwrap_or_else(|_| unimplemented!("should throw RangeError (-11..1 out of range)"));
-            let len = usize::try_from(len).unwrap_or_else(|_| unreachable!("Range can't have negative length"));
-            Ok((start, Some(len), second))
-        } else {
-            let start = first.funcall(interp, "begin", &[], None)?;
-            let start = implicitly_convert_to_int(interp, start)?;
-            let end = first.funcall(interp, "last", &[], None)?;
-            let end = implicitly_convert_to_int(interp, end)?;
-            // TODO: This conditional is probably not doing the right thing
-            if start + (end - start) < 0 {
-                let mut message = String::new();
-                write!(&mut message, "{}..{} out of range", start, end).map_err(WriteError::from)?;
-                return Err(RangeError::from(message).into());
+        match first.is_range(interp, rangelen)? {
+            None => {}
+            // ```
+            // [3.1.2] > a = []
+            // => []
+            // [3.1.2] > a[-1..-1] = 'x'
+            // (irb):13:in `[]=': -1..-1 out of range (RangeError)
+            //         from (irb):13:in `<main>'
+            //         from /usr/local/var/rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/irb-1.4.1/exe/irb:11:in `<top (required)>'
+            //         from /usr/local/var/rbenv/versions/3.1.2/bin/irb:25:in `load'
+            //         from /usr/local/var/rbenv/versions/3.1.2/bin/irb:25:in `<main>'
+            // ```
+            Some(protect::Range::Out) => return Err(RangeError::with_message("out of range").into()),
+            Some(protect::Range::Valid { start, len }) => {
+                let start = usize::try_from(start)
+                    .unwrap_or_else(|_| unimplemented!("should throw RangeError (-11..1 out of range)"));
+                let len = usize::try_from(len).unwrap_or_else(|_| unreachable!("Range can't have negative length"));
+                return Ok((start, Some(len), second));
             }
-            match (usize::try_from(start), usize::try_from(end)) {
-                (Ok(start), Ok(end)) => Ok((start, end.checked_sub(start), second)),
-                (Err(_), Ok(end)) => {
-                    let pos = start
-                        .checked_neg()
-                        .and_then(|start| usize::try_from(start).ok())
-                        .and_then(|start| len.checked_sub(start));
-                    if let Some(start) = pos {
-                        Ok((start, end.checked_sub(start), second))
-                    } else {
-                        let mut message = String::new();
-                        write!(&mut message, "index {} too small for array; minimum: -{}", start, len)
-                            .map_err(WriteError::from)?;
-                        Err(IndexError::from(message).into())
-                    }
-                }
-                (Ok(start), Err(_)) => Ok((start, None, second)),
-                (Err(_), Err(_)) => {
+        };
+        let start = first.funcall(interp, "begin", &[], None)?;
+        let start = implicitly_convert_to_int(interp, start)?;
+        let end = first.funcall(interp, "last", &[], None)?;
+        let end = implicitly_convert_to_int(interp, end)?;
+        // TODO: This conditional is probably not doing the right thing
+        if start + (end - start) < 0 {
+            let mut message = String::new();
+            write!(&mut message, "{}..{} out of range", start, end).map_err(WriteError::from)?;
+            return Err(RangeError::from(message).into());
+        }
+        match (usize::try_from(start), usize::try_from(end)) {
+            (Ok(start), Ok(end)) => Ok((start, end.checked_sub(start), second)),
+            (Err(_), Ok(end)) => {
+                let pos = start
+                    .checked_neg()
+                    .and_then(|start| usize::try_from(start).ok())
+                    .and_then(|start| len.checked_sub(start));
+                if let Some(start) = pos {
+                    Ok((start, end.checked_sub(start), second))
+                } else {
                     let mut message = String::new();
                     write!(&mut message, "index {} too small for array; minimum: -{}", start, len)
                         .map_err(WriteError::from)?;
                     Err(IndexError::from(message).into())
                 }
+            }
+            (Ok(start), Err(_)) => Ok((start, None, second)),
+            (Err(_), Err(_)) => {
+                let mut message = String::new();
+                write!(&mut message, "index {} too small for array; minimum: -{}", start, len)
+                    .map_err(WriteError::from)?;
+                Err(IndexError::from(message).into())
             }
         }
     }

--- a/artichoke-backend/src/extn/core/string/string_test.rb
+++ b/artichoke-backend/src/extn/core/string/string_test.rb
@@ -49,17 +49,59 @@ def string_byteslice
   raise unless s.byteslice(5, -10).nil?
   raise unless s.byteslice(5, -2).nil?
   # range
-  raise unless s.byteslice(1..4) == 'bcde'
-  raise unless s.byteslice(1..-1) == 'bcdefghijk'
-  raise unless s.byteslice(10..-1) == 'k'
-  raise unless s.byteslice(20..-1).nil?
-  raise unless s.byteslice(20..-20).nil?
-  raise unless s.byteslice(2..-20) == ''
-  raise unless s.byteslice(-1..20) == 'k'
-  raise unless s.byteslice(-20..20).nil?
-  raise unless s.byteslice(-5..-1) == 'ghijk'
-  raise unless s.byteslice(-5..1) == ''
-  raise unless s.byteslice(-5..8) == 'ghi'
+  raise unless s.byteslice(0..0) == "a"
+  raise unless s.byteslice(0..1) == "ab"
+  raise unless s.byteslice(0..10) == "abcdefghijk"
+  raise unless s.byteslice(1..9) == "bcdefghij"
+  raise unless s.byteslice(9..10) == "jk"
+  raise unless s.byteslice(9..11) == "jk"
+  raise unless s.byteslice(10..10) == "k"
+  raise unless s.byteslice(10..11) == "k"
+  raise unless s.byteslice(11..11) == ""
+  raise unless s.byteslice(11..12) == ""
+  raise unless s.byteslice(1..0) == "" 
+  raise unless s.byteslice(10..0) == "" 
+  raise unless s.byteslice(9..1) == ""
+  raise unless s.byteslice(10..9) == ""
+  raise unless s.byteslice(11..9) == ""
+  raise unless s.byteslice(11..10) == ""
+  raise unless s.byteslice(12..11).nil?
+  raise unless s.byteslice(-12..0).nil? 
+  raise unless s.byteslice(-12..1).nil?
+  raise unless s.byteslice(-11..0) == "a"
+  raise unless s.byteslice(-11..1) == "ab"
+  raise unless s.byteslice(-11..10) == "abcdefghijk"
+  raise unless s.byteslice(-11..11) == "abcdefghijk"
+  raise unless s.byteslice(-10..9) == "bcdefghij"
+  raise unless s.byteslice(-2..10) == "jk"
+  raise unless s.byteslice(-1..10) == "k"
+  raise unless s.byteslice(0..-11) == "a"
+  raise unless s.byteslice(0..-10) == "ab"
+  raise unless s.byteslice(0..-1) == "abcdefghijk"
+  raise unless s.byteslice(1..-2) == "bcdefghij"
+  raise unless s.byteslice(9..-1) == "jk"
+  raise unless s.byteslice(10..-1) == "k"
+  raise unless s.byteslice(0..-12) == ""
+  raise unless s.byteslice(1..-12) == ""
+  raise unless s.byteslice(1..-11) == ""
+  raise unless s.byteslice(10..-2) == ""
+  raise unless s.byteslice(11..-2) == ""
+  raise unless s.byteslice(11..-1) == ""
+  raise unless s.byteslice(-13..-12).nil?
+  raise unless s.byteslice(-12..-12).nil?
+  raise unless s.byteslice(-12..-11).nil?
+  raise unless s.byteslice(-12..-10).nil?
+  raise unless s.byteslice(-11..-11) == "a"
+  raise unless s.byteslice(-11..-10) == "ab"
+  raise unless s.byteslice(-11..-1) == "abcdefghijk"
+  raise unless s.byteslice(-2..-1) == "jk"
+  raise unless s.byteslice(-1..-1) == "k"
+  raise unless s.byteslice(-12..-13).nil?
+  raise unless s.byteslice(-11..-12) == ""
+  raise unless s.byteslice(-10..-12) == ""
+  raise unless s.byteslice(-10..-11) == ""
+  raise unless s.byteslice(-1..-11) == ""
+  raise unless s.byteslice(-1..-2) == ""
 end
 
 def string_scan

--- a/artichoke-backend/src/extn/core/string/string_test.rb
+++ b/artichoke-backend/src/extn/core/string/string_test.rb
@@ -49,59 +49,59 @@ def string_byteslice
   raise unless s.byteslice(5, -10).nil?
   raise unless s.byteslice(5, -2).nil?
   # range
-  raise unless s.byteslice(0..0) == "a"
-  raise unless s.byteslice(0..1) == "ab"
-  raise unless s.byteslice(0..10) == "abcdefghijk"
-  raise unless s.byteslice(1..9) == "bcdefghij"
-  raise unless s.byteslice(9..10) == "jk"
-  raise unless s.byteslice(9..11) == "jk"
-  raise unless s.byteslice(10..10) == "k"
-  raise unless s.byteslice(10..11) == "k"
-  raise unless s.byteslice(11..11) == ""
-  raise unless s.byteslice(11..12) == ""
-  raise unless s.byteslice(1..0) == "" 
-  raise unless s.byteslice(10..0) == "" 
-  raise unless s.byteslice(9..1) == ""
-  raise unless s.byteslice(10..9) == ""
-  raise unless s.byteslice(11..9) == ""
-  raise unless s.byteslice(11..10) == ""
+  raise unless s.byteslice(0..0) == 'a'
+  raise unless s.byteslice(0..1) == 'ab'
+  raise unless s.byteslice(0..10) == 'abcdefghijk'
+  raise unless s.byteslice(1..9) == 'bcdefghij'
+  raise unless s.byteslice(9..10) == 'jk'
+  raise unless s.byteslice(9..11) == 'jk'
+  raise unless s.byteslice(10..10) == 'k'
+  raise unless s.byteslice(10..11) == 'k'
+  raise unless s.byteslice(11..11) == ''
+  raise unless s.byteslice(11..12) == ''
+  raise unless s.byteslice(1..0) == ''
+  raise unless s.byteslice(10..0) == ''
+  raise unless s.byteslice(9..1) == ''
+  raise unless s.byteslice(10..9) == ''
+  raise unless s.byteslice(11..9) == ''
+  raise unless s.byteslice(11..10) == ''
   raise unless s.byteslice(12..11).nil?
-  raise unless s.byteslice(-12..0).nil? 
+  raise unless s.byteslice(-12..0).nil?
   raise unless s.byteslice(-12..1).nil?
-  raise unless s.byteslice(-11..0) == "a"
-  raise unless s.byteslice(-11..1) == "ab"
-  raise unless s.byteslice(-11..10) == "abcdefghijk"
-  raise unless s.byteslice(-11..11) == "abcdefghijk"
-  raise unless s.byteslice(-10..9) == "bcdefghij"
-  raise unless s.byteslice(-2..10) == "jk"
-  raise unless s.byteslice(-1..10) == "k"
-  raise unless s.byteslice(0..-11) == "a"
-  raise unless s.byteslice(0..-10) == "ab"
-  raise unless s.byteslice(0..-1) == "abcdefghijk"
-  raise unless s.byteslice(1..-2) == "bcdefghij"
-  raise unless s.byteslice(9..-1) == "jk"
-  raise unless s.byteslice(10..-1) == "k"
-  raise unless s.byteslice(0..-12) == ""
-  raise unless s.byteslice(1..-12) == ""
-  raise unless s.byteslice(1..-11) == ""
-  raise unless s.byteslice(10..-2) == ""
-  raise unless s.byteslice(11..-2) == ""
-  raise unless s.byteslice(11..-1) == ""
+  raise unless s.byteslice(-11..0) == 'a'
+  raise unless s.byteslice(-11..1) == 'ab'
+  raise unless s.byteslice(-11..10) == 'abcdefghijk'
+  raise unless s.byteslice(-11..11) == 'abcdefghijk'
+  raise unless s.byteslice(-10..9) == 'bcdefghij'
+  raise unless s.byteslice(-2..10) == 'jk'
+  raise unless s.byteslice(-1..10) == 'k'
+  raise unless s.byteslice(0..-11) == 'a'
+  raise unless s.byteslice(0..-10) == 'ab'
+  raise unless s.byteslice(0..-1) == 'abcdefghijk'
+  raise unless s.byteslice(1..-2) == 'bcdefghij'
+  raise unless s.byteslice(9..-1) == 'jk'
+  raise unless s.byteslice(10..-1) == 'k'
+  raise unless s.byteslice(0..-12) == ''
+  raise unless s.byteslice(1..-12) == ''
+  raise unless s.byteslice(1..-11) == ''
+  raise unless s.byteslice(10..-2) == ''
+  raise unless s.byteslice(11..-2) == ''
+  raise unless s.byteslice(11..-1) == ''
   raise unless s.byteslice(-13..-12).nil?
   raise unless s.byteslice(-12..-12).nil?
   raise unless s.byteslice(-12..-11).nil?
   raise unless s.byteslice(-12..-10).nil?
-  raise unless s.byteslice(-11..-11) == "a"
-  raise unless s.byteslice(-11..-10) == "ab"
-  raise unless s.byteslice(-11..-1) == "abcdefghijk"
-  raise unless s.byteslice(-2..-1) == "jk"
-  raise unless s.byteslice(-1..-1) == "k"
+  raise unless s.byteslice(-11..-11) == 'a'
+  raise unless s.byteslice(-11..-10) == 'ab'
+  raise unless s.byteslice(-11..-1) == 'abcdefghijk'
+  raise unless s.byteslice(-2..-1) == 'jk'
+  raise unless s.byteslice(-1..-1) == 'k'
   raise unless s.byteslice(-12..-13).nil?
-  raise unless s.byteslice(-11..-12) == ""
-  raise unless s.byteslice(-10..-12) == ""
-  raise unless s.byteslice(-10..-11) == ""
-  raise unless s.byteslice(-1..-11) == ""
-  raise unless s.byteslice(-1..-2) == ""
+  raise unless s.byteslice(-11..-12) == ''
+  raise unless s.byteslice(-10..-12) == ''
+  raise unless s.byteslice(-10..-11) == ''
+  raise unless s.byteslice(-1..-11) == ''
+  raise unless s.byteslice(-1..-2) == ''
 end
 
 def string_scan

--- a/artichoke-backend/src/extn/core/string/string_test.rb
+++ b/artichoke-backend/src/extn/core/string/string_test.rb
@@ -32,7 +32,7 @@ def string_element_reference_regexp
 end
 
 def string_byteslice
-  s = 'abcdefghijk'
+  s = 'abcdefghijk' # bytesize == 11
   # scalar
   raise unless s.byteslice(0, 1000) == 'abcdefghijk'
   raise unless s.byteslice(5, 1000) == 'fghijk'
@@ -96,6 +96,62 @@ def string_byteslice
   raise unless s.byteslice(-11..-1) == 'abcdefghijk'
   raise unless s.byteslice(-2..-1) == 'jk'
   raise unless s.byteslice(-1..-1) == 'k'
+  raise unless s.byteslice(-12..-13).nil?
+  raise unless s.byteslice(-11..-12) == ''
+  raise unless s.byteslice(-10..-12) == ''
+  raise unless s.byteslice(-10..-11) == ''
+  raise unless s.byteslice(-1..-11) == ''
+  raise unless s.byteslice(-1..-2) == ''
+
+  # non-ascii range test
+  s = '太贵了!!' # bytesize == 11
+  raise unless s.byteslice(0..0) == "\xE5"
+  raise unless s.byteslice(0..1) == "\xE5\xA4"
+  raise unless s.byteslice(0..10) == '太贵了!!'
+  raise unless s.byteslice(1..9) == "\xA4\xAA贵了!"
+  raise unless s.byteslice(9..10) == '!!'
+  raise unless s.byteslice(9..11) == '!!'
+  raise unless s.byteslice(10..10) == '!'
+  raise unless s.byteslice(10..11) == '!'
+  raise unless s.byteslice(11..11) == ''
+  raise unless s.byteslice(11..12) == ''
+  raise unless s.byteslice(1..0) == ''
+  raise unless s.byteslice(10..0) == ''
+  raise unless s.byteslice(9..1) == ''
+  raise unless s.byteslice(10..9) == ''
+  raise unless s.byteslice(11..9) == ''
+  raise unless s.byteslice(11..10) == ''
+  raise unless s.byteslice(12..11).nil?
+  raise unless s.byteslice(-12..0).nil?
+  raise unless s.byteslice(-12..1).nil?
+  raise unless s.byteslice(-11..0) == "\xE5"
+  raise unless s.byteslice(-11..1) == "\xE5\xA4"
+  raise unless s.byteslice(-11..10) == '太贵了!!'
+  raise unless s.byteslice(-11..11) == '太贵了!!'
+  raise unless s.byteslice(-10..9) == "\xA4\xAA贵了!"
+  raise unless s.byteslice(-2..10) == '!!'
+  raise unless s.byteslice(-1..10) == '!'
+  raise unless s.byteslice(0..-11) == "\xE5"
+  raise unless s.byteslice(0..-10) == "\xE5\xA4"
+  raise unless s.byteslice(0..-1) == '太贵了!!'
+  raise unless s.byteslice(1..-2) == "\xA4\xAA贵了!"
+  raise unless s.byteslice(9..-1) == '!!'
+  raise unless s.byteslice(10..-1) == '!'
+  raise unless s.byteslice(0..-12) == ''
+  raise unless s.byteslice(1..-12) == ''
+  raise unless s.byteslice(1..-11) == ''
+  raise unless s.byteslice(10..-2) == ''
+  raise unless s.byteslice(11..-2) == ''
+  raise unless s.byteslice(11..-1) == ''
+  raise unless s.byteslice(-13..-12).nil?
+  raise unless s.byteslice(-12..-12).nil?
+  raise unless s.byteslice(-12..-11).nil?
+  raise unless s.byteslice(-12..-10).nil?
+  raise unless s.byteslice(-11..-11) == "\xE5"
+  raise unless s.byteslice(-11..-10) == "\xE5\xA4"
+  raise unless s.byteslice(-11..-1) == '太贵了!!'
+  raise unless s.byteslice(-2..-1) == '!!'
+  raise unless s.byteslice(-1..-1) == '!'
   raise unless s.byteslice(-12..-13).nil?
   raise unless s.byteslice(-11..-12) == ''
   raise unless s.byteslice(-10..-12) == ''

--- a/artichoke-backend/src/extn/core/string/string_test.rb
+++ b/artichoke-backend/src/extn/core/string/string_test.rb
@@ -33,7 +33,7 @@ end
 
 def string_byteslice
   s = 'abcdefghijk'
-  #scalar
+  # scalar
   raise unless s.byteslice(0, 1000) == 'abcdefghijk'
   raise unless s.byteslice(5, 1000) == 'fghijk'
   raise unless s.byteslice(20, 1000).nil?

--- a/artichoke-backend/src/extn/core/string/string_test.rb
+++ b/artichoke-backend/src/extn/core/string/string_test.rb
@@ -33,6 +33,7 @@ end
 
 def string_byteslice
   s = 'abcdefghijk'
+  #scalar
   raise unless s.byteslice(0, 1000) == 'abcdefghijk'
   raise unless s.byteslice(5, 1000) == 'fghijk'
   raise unless s.byteslice(20, 1000).nil?
@@ -47,6 +48,18 @@ def string_byteslice
   raise unless s.byteslice(5, 3) == 'fgh'
   raise unless s.byteslice(5, -10).nil?
   raise unless s.byteslice(5, -2).nil?
+  # range
+  raise unless s.byteslice(1..4) == 'bcde'
+  raise unless s.byteslice(1..-1) == 'bcdefghijk'
+  raise unless s.byteslice(10..-1) == 'k'
+  raise unless s.byteslice(20..-1).nil?
+  raise unless s.byteslice(20..-20).nil?
+  raise unless s.byteslice(2..-20) == ''
+  raise unless s.byteslice(-1..20) == 'k'
+  raise unless s.byteslice(-20..20).nil?
+  raise unless s.byteslice(-5..-1) == 'ghijk'
+  raise unless s.byteslice(-5..1) == ''
+  raise unless s.byteslice(-5..8) == 'ghi'
 end
 
 def string_scan

--- a/artichoke-backend/src/extn/core/string/trampoline.rs
+++ b/artichoke-backend/src/extn/core/string/trampoline.rs
@@ -419,7 +419,7 @@ pub fn byteslice(
 ) -> Result<Value, Error> {
     let s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
     let maybe_range = if length.is_none() {
-        index.is_range(interp, s.char_len() as i64)?
+        index.is_range(interp, s.bytesize() as i64)?
     } else {
         None
     };

--- a/artichoke-backend/src/extn/core/string/trampoline.rs
+++ b/artichoke-backend/src/extn/core/string/trampoline.rs
@@ -233,30 +233,38 @@ pub fn aref(
         }
         return matchdata::trampoline::element_reference(interp, match_data, interp.convert(0), None);
     }
-    if let Some(protect::Range { start: index, len }) = first.is_range(interp, s.char_len() as i64)? {
-        let index = if let Ok(index) = usize::try_from(index) {
-            Some(index)
-        } else {
-            index
-                .checked_neg()
-                .and_then(|index| usize::try_from(index).ok())
-                .and_then(|index| s.len().checked_sub(index))
-        };
-        let index = match index {
-            None => return Ok(Value::nil()),
-            Some(index) if index > s.len() => return Ok(Value::nil()),
-            Some(index) => index,
-        };
-        if let Ok(length) = usize::try_from(len) {
-            let end = index
-                .checked_add(length)
-                .ok_or_else(|| RangeError::with_message("bignum too big to convert into `long'"))?;
-            if let Some(slice) = s.get_char_slice(index..end) {
-                let s = super::String::with_bytes_and_encoding(slice.to_vec(), s.encoding());
-                return super::String::alloc_value(s, interp);
+    match first.is_range(interp, s.char_len() as i64)? {
+        None => {}
+        // ```
+        // [3.1.2] > ""[-1..-1]
+        // => nil
+        // ``
+        Some(protect::Range::Out) => return Ok(Value::nil()),
+        Some(protect::Range::Valid { start: index, len }) => {
+            let index = if let Ok(index) = usize::try_from(index) {
+                Some(index)
+            } else {
+                index
+                    .checked_neg()
+                    .and_then(|index| usize::try_from(index).ok())
+                    .and_then(|index| s.len().checked_sub(index))
+            };
+            let index = match index {
+                None => return Ok(Value::nil()),
+                Some(index) if index > s.len() => return Ok(Value::nil()),
+                Some(index) => index,
+            };
+            if let Ok(length) = usize::try_from(len) {
+                let end = index
+                    .checked_add(length)
+                    .ok_or_else(|| RangeError::with_message("bignum too big to convert into `long'"))?;
+                if let Some(slice) = s.get_char_slice(index..end) {
+                    let s = super::String::with_bytes_and_encoding(slice.to_vec(), s.encoding());
+                    return super::String::alloc_value(s, interp);
+                }
             }
+            return Ok(Value::nil());
         }
-        return Ok(Value::nil());
     }
     // The overload of `String#[]` that takes a `String` **only** takes `String`s.
     // No implicit conversion is performed.
@@ -410,6 +418,74 @@ pub fn byteslice(
     length: Option<Value>,
 ) -> Result<Value, Error> {
     let s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
+    let maybe_range = if length.is_none() {
+        index.is_range(interp, s.char_len() as i64)?
+    } else {
+        None
+    };
+    match maybe_range {
+        None => {}
+        Some(protect::Range::Out) => return Ok(Value::nil()),
+        Some(protect::Range::Valid { start: index, len }) => {
+            let index = if let Ok(index) = usize::try_from(index) {
+                Some(index)
+            } else {
+                index
+                    .checked_neg()
+                    .and_then(|index| usize::try_from(index).ok())
+                    .and_then(|index| s.len().checked_sub(index))
+            };
+            let index = match index {
+                None => return Ok(Value::nil()),
+                Some(index) if index > s.len() => return Ok(Value::nil()),
+                Some(index) => index,
+            };
+            if let Ok(length) = usize::try_from(len) {
+                let end = index
+                    .checked_add(length)
+                    .ok_or_else(|| RangeError::with_message("bignum too big to convert into `long'"))?;
+                if let Some(slice) = s.get(index..end).or_else(|| s.get(index..)) {
+                    // Encoding from the source string is preserved.
+                    //
+                    // ```
+                    // [3.1.2] > s = "abc"
+                    // => "abc"
+                    // [3.1.2] > s.encoding
+                    // => #<Encoding:UTF-8>
+                    // [3.1.2] > s.byteslice(1..3).encoding
+                    // => #<Encoding:UTF-8>
+                    // [3.1.2] > t = s.force_encoding(Encoding::ASCII)
+                    // => "abc"
+                    // [3.1.2] > t.byteslice(1..3).encoding
+                    // => #<Encoding:US-ASCII>
+                    // ```
+                    let s = super::String::with_bytes_and_encoding(slice.to_vec(), s.encoding());
+                    // ```
+                    // [3.1.2] > class S < String; end
+                    // => nil
+                    // [3.1.2] > S.new("abc").byteslice(1..3).class
+                    // => String
+                    // ```
+                    //
+                    // The returned `String` is never frozen:
+                    //
+                    // ```
+                    // [3.1.2] > s = "abc"
+                    // => "abc"
+                    // [3.1.2] > s.frozen?
+                    // => false
+                    // [3.1.2] > s.byteslice(1..3).frozen?
+                    // => false
+                    // [3.1.2] > t = "abc".freeze
+                    // => "abc"
+                    // [3.1.2] > t.byteslice(1..3).frozen?
+                    // => false
+                    // ```
+                    return super::String::alloc_value(s, interp);
+                }
+            }
+        }
+    }
     // ```
     // [3.0.2] > class A; def to_int; 1; end; end
     // => :to_int


### PR DESCRIPTION
Add support for `Range` arguments in `String#byteslice` of the form:

```ruby
s = "abc"
raise unless s.byteslice(1..2) == "bc"
```

As of this commit all `String#byteslice` specs pass except for two which
require the `begin` and `end` components of the `Range` to go through
the "implicitly convert to int" flow. Range parsing is still implemented
in mruby which does not do implicit conversions.

Getting the specs to pass required significant rework of the
`protect::is_range` function to distinguish between the "range out" case
and the "valid" case. For example:

```ruby
"".byteslice(-1..-1)
```

was previously squashing this range into the `None` case, which led to
`byteslice` blowing up further down the routine when attempting to fall
back to the integer argument path.

This change led to re-evaluating all other instances of range argument
handling and corrected the response when the "out of range" case is
encountered. The most significant change was in `Array#[]=` which raises
an exception in this case.

Fixes #1916.

Among the core specs:

Before:
Passed 3944, skipped 1063, not implemented 724, failed 4494 specs.

After:
~~Passed 4014, skipped 1065, not implemented 724, failed 4561 specs.~~
Passed 4051, skipped 1075, not implemented 746, failed 4469 specs.

The relevant mruby code is here:

https://github.com/artichoke/artichoke/blob/f86225f2256b51939d7a2ea0c73ddb36a99f64ab/artichoke-backend/vendor/mruby/src/range.c#L456-L488