### PR TITLE
Fix argument unboxing precedence for `MatchData#[]`

### DIFF
--- a/artichoke-backend/src/extn/core/string/mod.rs
+++ b/artichoke-backend/src/extn/core/string/mod.rs
@@ -5,7 +5,7 @@ use std::os::raw::c_char;
 use artichoke_core::value::Value as _;
 use spinoso_exception::TypeError;
 #[doc(inline)]
-use spinoso_string::{Encoding, RawParts, String};
+pub use spinoso_string::{Encoding, RawParts, String};
 
 use crate::convert::{BoxUnboxVmValue, UnboxedValueGuard};
 use crate::error::Error;


### PR DESCRIPTION
Combining the new `Range` parsing in #1958 with the recent discovery that implicit conversions to integer need to be in the tail of argument unboxing (so `TypeError`s can be propagated), we get this new monstrosity in `matchdata::trampoline::element_reference`.

Added lots more docs with REPL output.

This new argument umarshalling code matches better to Sorbet's type signatures (note that sorbet does not support implicit conversions in its type system):

https://github.com/sorbet/sorbet/blob/37cb4686948095ddb795e2eeed0e6f33f3276e1e/rbi/core/match_data.rbi#L97-L122