### PR TITLE
Simplify `Region` in `extn::matchdata` with newly stabilized APIs

### DIFF
--- a/artichoke-backend/src/extn/core/matchdata/mod.rs
+++ b/artichoke-backend/src/extn/core/matchdata/mod.rs
@@ -37,16 +37,8 @@ impl Region {
     where
         R: RangeBounds<usize>,
     {
-        let start = match bounds.start_bound() {
-            Bound::Included(&bound) => Bound::Included(bound),
-            Bound::Excluded(&bound) => Bound::Excluded(bound),
-            Bound::Unbounded => Bound::Unbounded,
-        };
-        let end = match bounds.end_bound() {
-            Bound::Included(&bound) => Bound::Included(bound),
-            Bound::Excluded(&bound) => Bound::Excluded(bound),
-            Bound::Unbounded => Bound::Unbounded,
-        };
+        let start = bounds.start_bound().cloned();
+        let end = bounds.end_bound().cloned();
         Region { start, end }
     }
 
@@ -61,6 +53,8 @@ impl Region {
 
 impl RangeBounds<usize> for Region {
     fn start_bound(&self) -> Bound<&usize> {
+        // TODO: Use `self.start.as_ref()` when upstream `std` stabilizes:
+        // https://github.com/rust-lang/rust/issues/80996
         match self.start {
             Bound::Included(ref bound) => Bound::Included(bound),
             Bound::Excluded(ref bound) => Bound::Excluded(bound),
@@ -69,6 +63,8 @@ impl RangeBounds<usize> for Region {
     }
 
     fn end_bound(&self) -> Bound<&usize> {
+        // TODO: Use `self.end.as_ref()` when upstream `std` stabilizes:
+        // https://github.com/rust-lang/rust/issues/80996
         match self.end {
             Bound::Included(ref bound) => Bound::Included(bound),
             Bound::Excluded(ref bound) => Bound::Excluded(bound),


### PR DESCRIPTION
Collapse a couple verbose `match` expressions to use the `Bound::cloned` API which was stabilized in Rust 1.55.0.

Add a note and track the stabilization of rust-lang/rust#80996 to replace more `match` expressions with `Bound::as_ref`.