### PR TITLE
Fix spec compliance for `String#<<`

### DIFF
--- a/artichoke-backend/src/convert.rs
+++ b/artichoke-backend/src/convert.rs
@@ -22,7 +22,10 @@ mod nilable;
 mod string;
 
 pub use boxing::{BoxUnboxVmValue, HeapAllocated, HeapAllocatedData, Immediate, UnboxedValueGuard};
-pub use implicit::{implicitly_convert_to_int, implicitly_convert_to_nilable_string, implicitly_convert_to_string};
+pub use implicit::{
+    implicitly_convert_to_int, implicitly_convert_to_nilable_string, implicitly_convert_to_spinoso_string,
+    implicitly_convert_to_string,
+};
 
 /// Provide a fallible converter for types that implement an infallible
 /// conversion.

--- a/artichoke-backend/src/convert/implicit.rs
+++ b/artichoke-backend/src/convert/implicit.rs
@@ -1,7 +1,10 @@
+use core::mem;
+
 use artichoke_core::debug::Debug as _;
 use artichoke_core::value::Value as _;
 use spinoso_exception::TypeError;
 
+use crate::convert::{BoxUnboxVmValue, UnboxedValueGuard};
 use crate::error::Error;
 use crate::types::Ruby;
 use crate::value::Value;
@@ -481,5 +484,215 @@ pub unsafe fn implicitly_convert_to_nilable_string<'a>(
     } else {
         let string = implicitly_convert_to_string(interp, value)?;
         Ok(Some(string))
+    }
+}
+
+/// Attempt to implicitly convert a [`Value`] to a [`spinoso_string::String`]
+/// (Ruby `String`).
+///
+/// Attempt to extract a [`spinoso_string::String`] from the given `Value` by
+/// trying the following conversions:
+///
+/// - If the given value is a Ruby string, return the inner byte slice.
+/// - If the given value is `nil`, return a [`TypeError`].
+/// - If the given value responds to the `:to_str` method, call `value.to_str`:
+///   - If `value.to_str` raises an exception, propagate that exception.
+///   - If `value.to_str` returns a Ruby string, return the inner byte slice.
+///   - If `value.to_str` returs any other type, return a [`TypeError`].
+/// - If the given value does not respond to the `:to_str` method, return a
+///   [`TypeError`].
+///
+/// [`Symbol`]s are not coerced to byte slice by this implicit conversion.
+///
+/// # Examples
+///
+/// ```
+/// # use artichoke_backend::prelude::*;
+/// # use artichoke_backend::convert::implicitly_convert_to_spinoso_string;
+/// # use artichoke_backend::value::Value;
+/// # fn example() -> Result<(), Error> {
+/// let mut interp = artichoke_backend::interpreter()?;
+/// // successful conversions
+/// let mut string = interp.try_convert_mut("artichoke")?;
+/// let mut a = interp.eval(b"class A; def to_str; 'spinoso'; end; end; A.new")?;
+///
+/// # unsafe {
+/// assert!(matches!(implicitly_convert_to_spinoso_string(&mut interp, &mut string), Ok(s) if *s == b"artichoke"[..]));
+/// assert!(matches!(implicitly_convert_to_spinoso_string(&mut interp, &mut a), Ok(s) if *s == b"spinoso"[..]));
+///
+/// // failed conversions
+/// let mut nil = Value::nil();
+/// let mut b = interp.eval(b"class B; end; B.new")?;
+/// let mut c = interp.eval(b"class C; def to_str; nil; end; end; C.new")?;
+/// let mut d = interp.eval(b"class D; def to_str; 17; end; end; D.new")?;
+/// let mut e = interp.eval(b"class E; def to_str; :artichoke; end; end; E.new")?;
+/// let mut f = interp.eval(b"class F; def to_str; raise ArgumentError, 'not a string'; end; end; F.new")?;
+///
+/// assert!(implicitly_convert_to_spinoso_string(&mut interp, &mut nil).is_err());
+/// assert!(implicitly_convert_to_spinoso_string(&mut interp, &mut b).is_err());
+/// assert!(implicitly_convert_to_spinoso_string(&mut interp, &mut c).is_err());
+/// assert!(implicitly_convert_to_spinoso_string(&mut interp, &mut d).is_err());
+/// assert!(implicitly_convert_to_spinoso_string(&mut interp, &mut e).is_err());
+/// assert!(implicitly_convert_to_spinoso_string(&mut interp, &mut f).is_err());
+/// # }
+/// # Ok(())
+/// # }
+/// # example().unwrap();
+/// ```
+///
+/// # Errors
+///
+/// This function returns an error if:
+///
+/// - The given value is `nil`.
+/// - The given value is not a string and does not respond to `:to_str`.
+/// - The given value is not a string and returns a non-string value from its
+///   `:to_str` method.
+/// - The given value is not a string and raises an error in its `:to_str`
+///   method.
+///
+/// # Safety
+///
+/// Callers must ensure that `value` does not outlive the given interpreter.
+///
+/// If a garbage collection can possibly run between calling this function and
+/// using the returned slice, callers should convert the slice to an owned byte
+/// vec.
+///
+/// [`Symbol`]: crate::extn::core::symbol::Symbol
+pub unsafe fn implicitly_convert_to_spinoso_string<'a>(
+    interp: &mut Artichoke,
+    value: &'a mut Value,
+) -> Result<UnboxedValueGuard<'a, spinoso_string::String>, Error> {
+    let value_copy = *value;
+    if value.is_nil() {
+        // `nil` does not implicitly convert to string:
+        //
+        // ```console
+        // [2.6.6] > ENV[nil]
+        // Traceback (most recent call last):
+        //         6: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `<main>'
+        //         5: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `load'
+        //         4: from /usr/local/var/rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
+        //         3: from (irb):7
+        //         2: from (irb):7:in `rescue in irb_binding'
+        //         1: from (irb):7:in `[]'
+        // TypeError (no implicit conversion of nil into String)
+        // ```
+        return Err(TypeError::with_message("no implicit conversion of nil into String").into());
+    }
+    if let Ruby::Symbol = value.ruby_type() {
+        return Err(TypeError::with_message("no implicit conversion of Symbol into String").into());
+    }
+    if let Ok(s) = spinoso_string::String::unbox_from_value(value, interp) {
+        return Ok(s);
+    }
+    let value = value_copy;
+    if let Ok(true) = value.respond_to(interp, "to_str") {
+        // Propagate exceptions raised in `#to_str`:
+        //
+        // ```console
+        // [2.6.6] >  class A; def to_str; raise ArgumentError, 'a message'; end; end
+        // => :to_str
+        // [2.6.6] > ENV[A.new]
+        // Traceback (most recent call last):
+        //         6: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `<main>'
+        //         5: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `load'
+        //         4: from /usr/local/var/rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
+        //         3: from (irb):10
+        //         2: from (irb):10:in `[]'
+        //         1: from (irb):9:in `to_str'
+        // ArgumentError (a message)
+        // ```
+        let mut maybe = value.funcall(interp, "to_str", &[], None)?;
+        if let Ok(s) = spinoso_string::String::unbox_from_value(&mut maybe, interp) {
+            // successful conversion: `#to_str` returned a string.
+            //
+            // XXX: lifetime extension.
+            Ok(mem::transmute(s))
+        } else {
+            // Non `String` types returned from `#to_str` result in a
+            // `TypeError`:
+            //
+            // ```console
+            // [2.6.6] > class A; def to_str; 17; end; end
+            // => :to_str
+            // [2.6.6] > ENV[A.new]
+            // Traceback (most recent call last):
+            //         5: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `<main>'
+            //         4: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `load'
+            //         3: from /usr/local/var/rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
+            //         2: from (irb):5
+            //         1: from (irb):5:in `[]'
+            // TypeError (can't convert A to String (A#to_str gives Integer))
+            // [2.6.6] > class B; def to_str; true; end; end
+            // => :to_str
+            // [2.6.6] > ENV[B.new]
+            // Traceback (most recent call last):
+            //         5: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `<main>'
+            //         4: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `load'
+            //         3: from /usr/local/var/rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
+            //         2: from (irb):7
+            //         1: from (irb):7:in `[]'
+            // TypeError (can't convert B to String (B#to_str gives TrueClass))
+            // [2.6.6] > class C; def to_str; nil; end; end
+            // => :to_str
+            // [2.6.6] > ENV[C.new]
+            // Traceback (most recent call last):
+            //         5: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `<main>'
+            //         4: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `load'
+            //         3: from /usr/local/var/rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
+            //         2: from (irb):9
+            //         1: from (irb):9:in `[]'
+            // TypeError (can't convert C to String (C#to_str gives NilClass))
+            // [2.6.6] > module X; class Y; class Z; def to_str; 92; end; end; end; end
+            // => :to_str
+            // [2.6.6] > ENV[X::Y::Z.new]
+            // Traceback (most recent call last):
+            //         5: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `<main>'
+            //         4: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `load'
+            //         3: from /usr/local/var/rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
+            //         2: from (irb):11
+            //         1: from (irb):11:in `[]'
+            // TypeError (can't convert X::Y::Z to String (X::Y::Z#to_str gives Integer))
+            // ```
+            let mut message = String::from("can't convert ");
+            let name = interp.inspect_type_name_for_value(value);
+            message.push_str(name);
+            message.push_str(" to String (");
+            message.push_str(name);
+            message.push_str("#to_str gives ");
+            message.push_str(interp.class_name_for_value(maybe));
+            message.push(')');
+            Err(TypeError::from(message).into())
+        }
+    } else {
+        // The given value is not a string and cannot be converted with
+        // `#to_str`:
+        //
+        // ```console
+        // [2.6.6] > ENV[true]
+        // Traceback (most recent call last):
+        //         5: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `<main>'
+        //         4: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `load'
+        //         3: from /usr/local/var/rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
+        //         2: from (irb):1
+        //         1: from (irb):1:in `[]'
+        // TypeError (no implicit conversion of true into String)
+        // [2.6.6] > class A; end
+        // => nil
+        // [2.6.6] > ENV[A.new]
+        // Traceback (most recent call last):
+        //         5: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `<main>'
+        //         4: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `load'
+        //         3: from /usr/local/var/rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
+        //         2: from (irb):3
+        //         1: from (irb):3:in `[]'
+        // TypeError (no implicit conversion of A into String)
+        // ```
+        let mut message = String::from("no implicit conversion of ");
+        message.push_str(interp.inspect_type_name_for_value(value));
+        message.push_str(" into String");
+        Err(TypeError::from(message).into())
     }
 }

--- a/artichoke-backend/src/extn/core/string/mod.rs
+++ b/artichoke-backend/src/extn/core/string/mod.rs
@@ -89,7 +89,8 @@ impl BoxUnboxVmValue for String {
         unsafe {
             let flags = string.as_ref().unwrap().flags();
             let encoding_bits = encoding.to_flag();
-            let flags_with_encoding = flags | (u32::from(encoding_bits) << ENCODING_FLAG_BITPOS);
+            let flags_with_zeroed_encoding = flags & !(0b1111 << ENCODING_FLAG_BITPOS);
+            let flags_with_encoding = flags_with_zeroed_encoding | (u32::from(encoding_bits) << ENCODING_FLAG_BITPOS);
             string.as_mut().unwrap().set_flags(flags_with_encoding);
         }
         Ok(interp.protect(value.into()))
@@ -121,7 +122,8 @@ impl BoxUnboxVmValue for String {
         unsafe {
             let flags = string.as_ref().unwrap().flags();
             let encoding_bits = encoding.to_flag();
-            let flags_with_encoding = flags | (u32::from(encoding_bits) << ENCODING_FLAG_BITPOS);
+            let flags_with_zeroed_encoding = flags & !(0b1111 << ENCODING_FLAG_BITPOS);
+            let flags_with_encoding = flags_with_zeroed_encoding | (u32::from(encoding_bits) << ENCODING_FLAG_BITPOS);
             string.as_mut().unwrap().set_flags(flags_with_encoding);
         }
 

--- a/artichoke-backend/src/extn/core/string/mod.rs
+++ b/artichoke-backend/src/extn/core/string/mod.rs
@@ -163,4 +163,17 @@ mod tests {
         let result = interp.eval(b"spec");
         unwrap_or_panic_with_backtrace(&mut interp, SUBJECT, result);
     }
+
+    #[test]
+    fn modifying_and_repacking_encoding_zeroes_old_encoding_flags() {
+        let mut interp = interpreter();
+        // Modify the encoding of a binary string in place to be UTF-8 by
+        // pushing a UTF-8 string into an empty binary string.
+        //
+        // Test for the newly taken UTF-8 encoding by ensuring that the char
+        // length of the string is 1.
+        let test = "be = ''.b ; be << '😀' ; raise 'unexpected encoding' unless be.length == 1";
+        let result = interp.eval(test.as_bytes());
+        unwrap_or_panic_with_backtrace(&mut interp, SUBJECT, result);
+    }
 }

--- a/artichoke-backend/src/extn/core/string/string.rb
+++ b/artichoke-backend/src/extn/core/string/string.rb
@@ -99,6 +99,7 @@ class Encoding
   Shift_JIS = new('Shift_JIS')
   SHIFT_JIS = Shift_JIS
   UTF_8 = new('UTF-8')
+  UTF_16LE = new('UTF-16LE')
   UTF_32BE = new('UTF-32BE')
 
   def self.default_external

--- a/artichoke-backend/src/extn/core/string/trampoline.rs
+++ b/artichoke-backend/src/extn/core/string/trampoline.rs
@@ -52,9 +52,6 @@ pub fn add(interp: &mut Artichoke, mut value: Value, mut other: Value) -> Result
 pub fn push(interp: &mut Artichoke, mut value: Value, mut other: Value) -> Result<Value, Error> {
     let mut s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
     if let Ok(int) = other.try_convert_into::<i64>(interp) {
-        if int < 0 {
-            return Err(RangeError::from(format!("{int} out of char range")).into());
-        }
         return match s.encoding() {
             Encoding::Utf8 => {
                 // Safety:

--- a/artichoke-backend/src/extn/core/string/trampoline.rs
+++ b/artichoke-backend/src/extn/core/string/trampoline.rs
@@ -120,20 +120,230 @@ pub fn push(interp: &mut Artichoke, mut value: Value, mut other: Value) -> Resul
     //
     // The byte slice is immediately used and discarded after extraction. There
     // are no intervening interpreter accesses.
-    let other = unsafe { implicitly_convert_to_string(interp, &mut other)? };
-    // Safety:
-    //
-    // The string is reboxed before any intervening operations on the
-    // interpreter.
-    // The string is reboxed without any intervening mruby allocations.
-    unsafe {
-        let string_mut = s.as_inner_mut();
-        // XXX: This call doesn't do a check to see if we'll exceed the max allocation
-        //    size and may panic.
-        string_mut.extend_from_slice(other);
 
-        let s = s.take();
-        super::String::box_into_value(s, value, interp)
+    // TODO: need to get the spinoso string to get at its encoding.
+    let other = unsafe { implicitly_convert_to_string(interp, &mut other)? };
+    match s.encoding() {
+        // ```
+        // [3.1.2] > s = ""
+        // => ""
+        // [3.1.2] > b = "abc".b
+        // => "abc"
+        // [3.1.2] > s << b
+        // => "abc"
+        // [3.1.2] > s.encoding
+        // => #<Encoding:UTF-8>
+        // [3.1.2] > b = "\xFF\xFE".b
+        // => "\xFF\xFE"
+        // [3.1.2] > s = ""
+        // => ""
+        // [3.1.2] > s << b
+        // => "\xFF\xFE"
+        // [3.1.2] > s.encoding
+        // => #<Encoding:ASCII-8BIT>
+        // [3.1.2] > s = "abc"
+        // => "abc"
+        // [3.1.2] > s << b
+        // => "abc\xFF\xFE"
+        // [3.1.2] > s.encoding
+        // => #<Encoding:ASCII-8BIT>
+        // [3.1.2] > s = ""
+        // => ""
+        // [3.1.2] > b = "abc".b
+        // => "abc"
+        // [3.1.2] > b.ascii_only?
+        // => true
+        // [3.1.2] > s << b
+        // => "abc"
+        // [3.1.2] > s.encoding
+        // => #<Encoding:UTF-8>
+        // [3.1.2] > a = "\xFF\xFE".force_encoding(Encoding::ASCII)
+        // => "\xFF\xFE"
+        // [3.1.2] > s = ""
+        // => ""
+        // [3.1.2] > s << a
+        // => "\xFF\xFE"
+        // [3.1.2] > s.encoding
+        // => #<Encoding:US-ASCII>
+        // [3.1.2] > s = "abc"
+        // => "abc"
+        // [3.1.2] > s << a
+        // => "abc\xFF\xFE"
+        // [3.1.2] > s.encoding
+        // => #<Encoding:US-ASCII>
+        // ```
+        Encoding::Utf8 => {
+            // Safety:
+            //
+            // The string is reboxed before any intervening operations on the
+            // interpreter.
+            // The string is reboxed without any intervening mruby allocations.
+            unsafe {
+                let string_mut = s.as_inner_mut();
+                // XXX: This call doesn't do a check to see if we'll exceed the max allocation
+                //    size and may panic or abort.
+                string_mut.extend_from_slice(other);
+
+                // TODO: set encoding to `other.encoding()` if other's byte
+                // content and encoding is incompatible with UTF-8.
+                //
+                // ```
+                // if !matches!(other.encoding(), Encoding::Utf8) && !other.is_ascii_only() {
+                //     // encodings are incompatible if other is not UTF-8 and is non-ASCII
+                //     string_mut.set_encoding(other.encoding());
+                // }
+                // ```
+
+                let s = s.take();
+                super::String::box_into_value(s, value, interp)
+            }
+        }
+        // Empty ASCII strings take on the encoding of the argument if the
+        // argument is not ASCII-compatible, even if the argument does not have
+        // a valid encoding.
+        //
+        // ```
+        // [3.1.2] > ae = "".force_encoding(Encoding::ASCII)
+        // => ""
+        // [3.1.2] > ae << "😀"
+        // => "😀"
+        // [3.1.2] > ae.encoding
+        // => #<Encoding:UTF-8>
+        // [3.1.2] > ae = "".force_encoding(Encoding::ASCII)
+        // => ""
+        // [3.1.2] > ae << "abc"
+        // => "abc"
+        // [3.1.2] > ae.encoding
+        // => #<Encoding:US-ASCII>
+        // [3.1.2] > ae = "".force_encoding(Encoding::ASCII)
+        // => ""
+        // [3.1.2] > ae << "\xFF\xFE"
+        // => "\xFF\xFE"
+        // [3.1.2] > ae.encoding
+        // => #<Encoding:UTF-8>
+        // [3.1.2] > ae = "".force_encoding(Encoding::ASCII)
+        // => ""
+        // [3.1.2] > ae << "\xFF\xFE".b
+        // => "\xFF\xFE"
+        // [3.1.2] > ae.encoding
+        // => #<Encoding:ASCII-8BIT>
+        // ```
+        Encoding::Ascii if s.is_empty() => {
+            // Safety:
+            //
+            // The string is reboxed before any intervening operations on the
+            // interpreter.
+            // The string is reboxed without any intervening mruby allocations.
+            unsafe {
+                let string_mut = s.as_inner_mut();
+                // XXX: This call doesn't do a check to see if we'll exceed the max allocation
+                //    size and may panic or abort.
+                string_mut.extend_from_slice(other);
+
+                // TODO: set encoding to `other.encoding()` if other is
+                //     non-ASCII.
+
+                let s = s.take();
+                super::String::box_into_value(s, value, interp)
+            }
+        }
+        // ```
+        // [3.1.2] > a
+        // => "\xFF\xFE"
+        // [3.1.2] > a.encoding
+        // => #<Encoding:US-ASCII>
+        // [3.1.2] > a << "\xFF".b
+        // (irb):46:in `<main>': incompatible character encodings: US-ASCII and ASCII-8BIT (Encoding::CompatibilityError)
+        //         from /usr/local/var/rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/irb-1.4.1/exe/irb:11:in `<top (required)>'
+        //         from /usr/local/var/rbenv/versions/3.1.2/bin/irb:25:in `load'
+        //         from /usr/local/var/rbenv/versions/3.1.2/bin/irb:25:in `<main>'
+        // [3.1.2] > a << "abc"
+        // => "\xFF\xFEabc"
+        // [3.1.2] > s.encoding
+        // => #<Encoding:US-ASCII>
+        // [3.1.2] > a << "😀"
+        // (irb):49:in `<main>': incompatible character encodings: US-ASCII and UTF-8 (Encoding::CompatibilityError)
+        //         from /usr/local/var/rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/irb-1.4.1/exe/irb:11:in `<top (required)>'
+        //         from /usr/local/var/rbenv/versions/3.1.2/bin/irb:25:in `load'
+        //         from /usr/local/var/rbenv/versions/3.1.2/bin/irb:25:in `<main>'
+        // [3.1.2] > a << "😀".b
+        // (irb):50:in `<main>': incompatible character encodings: US-ASCII and ASCII-8BIT (Encoding::CompatibilityError)
+        //         from /usr/local/var/rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/irb-1.4.1/exe/irb:11:in `<top (required)>'
+        //         from /usr/local/var/rbenv/versions/3.1.2/bin/irb:25:in `load'
+        //         from /usr/local/var/rbenv/versions/3.1.2/bin/irb:25:in `<main>'
+        // ```
+        Encoding::Ascii => {
+            if !other.is_ascii() {
+                // TODO: This exception should be an `Encoding::CompatibilityError`.
+                // TODO: Need access to the spinoso string from the implicit
+                //     conversion to get its name in the exception message.
+                return Err(ArgumentError::with_message("incompatible character encodings").into());
+            }
+            // Safety:
+            //
+            // The string is reboxed before any intervening operations on the
+            // interpreter.
+            // The string is reboxed without any intervening mruby allocations.
+            unsafe {
+                let string_mut = s.as_inner_mut();
+                // XXX: This call doesn't do a check to see if we'll exceed the max allocation
+                //    size and may panic or abort.
+                string_mut.extend_from_slice(other);
+
+                let s = s.take();
+                super::String::box_into_value(s, value, interp)
+            }
+        }
+        // TODO: Add `Encoding::Binary if s.is_empty() {}` branch.
+        //
+        // If the receiver is an empty string with `Encoding::Binary` encoding
+        // and the argument is non-ASCII, take on the encoding of the arugment.
+        //
+        // This requires the implicit conversion to string to return the
+        // underlying spinoso string.
+        //
+        // ```
+        // [3.1.2] > be = "".b
+        // => ""
+        // [3.1.2] > be << "abc"
+        // => "abc"
+        // [3.1.2] > be.encoding
+        // => #<Encoding:ASCII-8BIT>
+        // [3.1.2] > be = "".b
+        // => ""
+        // [3.1.2] > be << "😀"
+        // => "😀"
+        // [3.1.2] > be.encoding
+        // => #<Encoding:UTF-8>
+        // [3.1.2] > be = "".b
+        // => ""
+        // [3.1.2] > be << "\xFF\xFE".force_encoding(Encoding::ASCII)
+        // => "\xFF\xFE"
+        // [3.1.2] > be.encoding
+        // => #<Encoding:US-ASCII>
+        // [3.1.2] > be = "".b
+        // => ""
+        // [3.1.2] > be << "abc".force_encoding(Encoding::ASCII)
+        // => "abc"
+        // [3.1.2] > be.encoding
+        // => #<Encoding:ASCII-8BIT>
+        // ```
+        Encoding::Binary => {
+            // Safety:
+            //
+            // The string is reboxed before any intervening operations on the
+            // interpreter.
+            // The string is reboxed without any intervening mruby allocations.
+            unsafe {
+                let string_mut = s.as_inner_mut();
+                // XXX: This call doesn't do a check to see if we'll exceed the max allocation
+                //    size and may panic or abort.
+                string_mut.extend_from_slice(other);
+
+                let s = s.take();
+                super::String::box_into_value(s, value, interp)
+            }
+        }
     }
 }
 

--- a/artichoke-backend/src/extn/core/string/trampoline.rs
+++ b/artichoke-backend/src/extn/core/string/trampoline.rs
@@ -42,7 +42,7 @@ pub fn add(interp: &mut Artichoke, mut value: Value, mut other: Value) -> Result
 
     let mut concatenated = s.clone();
     // XXX: This call doesn't do a check to see if we'll exceed the max allocation
-    //    size and may panic.
+    //    size and may panic or abort.
     concatenated.extend_from_slice(to_append);
     super::String::alloc_value(concatenated, interp)
 }

--- a/artichoke-backend/src/extn/core/string/trampoline.rs
+++ b/artichoke-backend/src/extn/core/string/trampoline.rs
@@ -7,6 +7,7 @@ use artichoke_core::hash::Hash as _;
 use artichoke_core::value::Value as _;
 use bstr::ByteSlice;
 
+use super::Encoding;
 use crate::convert::implicitly_convert_to_int;
 use crate::convert::implicitly_convert_to_nilable_string;
 use crate::convert::implicitly_convert_to_spinoso_string;
@@ -19,8 +20,6 @@ use crate::extn::core::regexp::{self, Regexp};
 use crate::extn::core::symbol::Symbol;
 use crate::extn::prelude::*;
 use crate::sys::protect;
-
-use super::Encoding;
 
 pub fn mul(interp: &mut Artichoke, mut value: Value, count: Value) -> Result<Value, Error> {
     let count = implicitly_convert_to_int(interp, count)?;

--- a/artichoke-backend/src/extn/core/string/trampoline.rs
+++ b/artichoke-backend/src/extn/core/string/trampoline.rs
@@ -50,6 +50,15 @@ pub fn add(interp: &mut Artichoke, mut value: Value, mut other: Value) -> Result
 }
 
 pub fn push(interp: &mut Artichoke, mut value: Value, mut other: Value) -> Result<Value, Error> {
+    if value.is_frozen(interp) {
+        let s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
+        let message = "can't modify frozen String: "
+            .chars()
+            .chain(s.inspect())
+            .collect::<super::String>();
+        return Err(FrozenError::from(message.into_vec()).into());
+    }
+
     let mut s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
     if let Ok(int) = other.try_convert_into::<i64>(interp) {
         return match s.encoding() {

--- a/spec-runner/enforced-specs.toml
+++ b/spec-runner/enforced-specs.toml
@@ -97,6 +97,9 @@ include = "all"
 [specs.core.string]
 include = "set"
 specs = [
+  # Missing support for `"UTF-16LE"` encoding, but the underlying behavior being
+  # tested is implemented.
+  # "append",
   "bytesize",
   # `Range` of int, e.g. `1..9`, does not call `#to_int` on start and end.
   #

--- a/spinoso-string/src/enc/mod.rs
+++ b/spinoso-string/src/enc/mod.rs
@@ -2,6 +2,7 @@ use alloc::collections::TryReserveError;
 use core::borrow::Borrow;
 use core::cmp::Ordering;
 use core::hash::{Hash, Hasher};
+use core::mem;
 use core::ops::Range;
 use core::slice::SliceIndex;
 
@@ -146,6 +147,16 @@ impl EncodedString {
             EncodedString::Binary(_) => Encoding::Binary,
             EncodedString::Utf8(_) => Encoding::Utf8,
         }
+    }
+
+    #[inline]
+    pub fn set_encoding(&mut self, encoding: Encoding) {
+        if self.encoding() == encoding {
+            return;
+        };
+        let s = mem::take(self);
+        let buf = s.into_buf();
+        *self = Self::new(buf, encoding);
     }
 }
 

--- a/spinoso-string/src/lib.rs
+++ b/spinoso-string/src/lib.rs
@@ -259,6 +259,23 @@ impl String {
         self.inner.encoding()
     }
 
+    /// Set the [`Encoding`] of this `String`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use spinoso_string::{Encoding, String};
+    ///
+    /// let mut s = String::utf8(b"xyz".to_vec());
+    /// assert_eq!(s.encoding(), Encoding::Utf8);
+    /// s.set_encoding(Encoding::Binary);
+    /// assert_eq!(s.encoding(), Encoding::Binary);
+    /// ```
+    #[inline]
+    pub fn set_encoding(&mut self, encoding: Encoding) {
+        self.inner.set_encoding(encoding);
+    }
+
     /// Shortens the string, keeping the first `len` bytes and dropping the
     /// rest.
     ///


### PR DESCRIPTION
Fix issues with `String#<<`:

- Raise `FrozenError` if the receiver is frozen.
- Add support for pushing codepoints to a string.
- Make pushing codepoints to a string encoding-aware.
- Add support for in-place encoding mutations when pushing non-ASCII bytes to an ASCII-encoded string.
- Make pushing strings to a string encoding-aware.
- Add support for in-place encoding mutations when pushing to an empty string.

Progress on https://github.com/artichoke/artichoke/issues/1912.

To make these changes, some additional feature work was required:

- Add a `spinoso_string::String::set_encoding` API (@b-n: it's back!).
- Fix a bug in `impl BoxUnboxVmValue for String` where encoding flags were not being zeroed before repacking.
- Add a new implicit conversion routine to string where the underlying `spinoso_string::String` is returned instead of the underlying bytes.

## ruby/spec

Before: Passed 1917, skipped 250, not implemented 15, failed 0 specs.
After: Passed 1932, skipped 260, not implemented 15, failed 2 specs.

I declined to add any additional tests since all of this new feature work is exercised by ruby/spec. After these changes, these are the only failures (due to missing support for `String#encode` and `Encoding::UTF16_LE`):

```
Passed 1932, skipped 260, not implemented 15, failed 2 specs.

String#<< when self is in an ASCII-incompatible encoding incompatible with the argument's encoding raises Encoding::CompatibilityError if neither are empty
SpecExpectationNotMetError: Expected Encoding::CompatibilityError
but no exception was raised ("xy" was returned)

/artichoke/virtual_root/src/lib/core/string/shared/concat.rb:115:in protect
(eval):165:in all?
(eval):590:in each
(eval):590:in each
/artichoke/virtual_root/src/lib/core/string/append_spec.rb:8
(eval):590:in each
/artichoke/virtual_root/src/lib/spec_runner.rb:74:in run_specs
(eval):1

String#<< when the argument is in an ASCII-incompatible encoding incompatible with self's encoding raises Encoding::CompatibilityError if neither are empty
SpecExpectationNotMetError: Expected Encoding::CompatibilityError
but no exception was raised ("xy" was returned)

/artichoke/virtual_root/src/lib/core/string/shared/concat.rb:133:in protect
(eval):165:in all?
(eval):590:in each
(eval):590:in each
/artichoke/virtual_root/src/lib/core/string/append_spec.rb:8
(eval):590:in each
/artichoke/virtual_root/src/lib/spec_runner.rb:74:in run_specs
(eval):1

Passed 1932, skipped 260, not implemented 15, failed 2 specs.
```
