### PR TITLE
Add builtin constants specs as enforced

### DIFF
--- a/artichoke-backend/src/extn/mod.rs
+++ b/artichoke-backend/src/extn/mod.rs
@@ -44,11 +44,8 @@ pub fn init(interp: &mut Artichoke, config: ReleaseMetadata<'_>) -> InitializeRe
     release_date.freeze(interp)?;
     interp.define_global_constant("RUBY_RELEASE_DATE", release_date)?;
 
-    let revision = config
-        .ruby_revision()
-        .parse::<i64>()
-        .map_err(|_| NotDefinedError::global_constant("RUBY_REVISION"))?;
-    let revision = interp.convert(revision);
+    let revision = config.ruby_revision();
+    let revision = interp.try_convert_mut(revision)?;
     interp.define_global_constant("RUBY_REVISION", revision)?;
 
     let mut version = interp.try_convert_mut(config.ruby_version())?;

--- a/spec-runner/enforced-specs.toml
+++ b/spec-runner/enforced-specs.toml
@@ -58,6 +58,9 @@ specs = [
   "unshift",
 ]
 
+[specs.core.builtin_constants]
+include = "all"
+
 [specs.core.comparable]
 include = "all"
 


### PR DESCRIPTION
Fix bug where `RUBY_REVISION` should be a string.

Previously failing spec:

```
RUBY_REVISION is a String
SpecExpectationNotMetError: Expected 5837 (Integer) to be kind of String

/artichoke/virtual_root/src/lib/core/builtin_constants/builtin_constants_spec.rb:54:in protect
(eval):165:in all?
(eval):590:in each
/artichoke/virtual_root/src/lib/core/builtin_constants/builtin_constants_spec.rb:57
(eval):590:in each
/artichoke/virtual_root/src/lib/spec_runner.rb:74:in run_specs
(eval):1
```