### PR TITLE
Cleanup `mrbsys` C extension

### DIFF
--- a/artichoke-backend/cext/mrbgems/src/gem_init.c
+++ b/artichoke-backend/cext/mrbgems/src/gem_init.c
@@ -57,5 +57,5 @@ mrb_init_mrbgems(mrb_state *mrb)
 }
 
 #ifdef __cplusplus
-}  /* extern "C" { */
+} /* extern "C" { */
 #endif

--- a/artichoke-backend/cext/mrbgems/src/gem_init.c
+++ b/artichoke-backend/cext/mrbgems/src/gem_init.c
@@ -1,5 +1,9 @@
 #include <mruby.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void artichoke_mrbgem_mruby_error_gem_init(mrb_state *);
 void artichoke_mrbgem_mruby_error_gem_final(mrb_state *);
 void artichoke_mrbgem_mruby_eval_gem_init(mrb_state *);
@@ -51,3 +55,7 @@ mrb_init_mrbgems(mrb_state *mrb)
   artichoke_mrbgem_mruby_class_ext_gem_init(mrb);
   mrb_state_atexit(mrb, mrb_final_mrbgems);
 }
+
+#ifdef __cplusplus
+}  /* extern "C" { */
+#endif

--- a/artichoke-backend/cext/mrbgems/src/mrbgems.c
+++ b/artichoke-backend/cext/mrbgems/src/mrbgems.c
@@ -166,5 +166,5 @@ artichoke_mrbgem_mruby_toplevel_ext_gem_final(mrb_state *mrb)
 }
 
 #ifdef __cplusplus
-}  /* extern "C" { */
+} /* extern "C" { */
 #endif

--- a/artichoke-backend/cext/mrbgems/src/mrbgems.c
+++ b/artichoke-backend/cext/mrbgems/src/mrbgems.c
@@ -2,6 +2,10 @@
 #include <mruby.h>
 #include <mruby/proc.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void mrb_mruby_class_ext_gem_init(mrb_state *mrb);
 void mrb_mruby_class_ext_gem_final(mrb_state *mrb);
 void mrb_mruby_error_gem_init(mrb_state *mrb);
@@ -160,3 +164,7 @@ void
 artichoke_mrbgem_mruby_toplevel_ext_gem_final(mrb_state *mrb)
 {
 }
+
+#ifdef __cplusplus
+}  /* extern "C" { */
+#endif

--- a/artichoke-backend/cext/mrbsys/include/mrbsys/ext.h
+++ b/artichoke-backend/cext/mrbsys/include/mrbsys/ext.h
@@ -140,5 +140,5 @@ MRB_API int mrb_sys_gc_live_objects(mrb_state *mrb);
 MRB_API void mrb_sys_safe_gc_mark(mrb_state *mrb, mrb_value value);
 
 #ifdef __cplusplus
-}  /* extern "C" { */
+} /* extern "C" { */
 #endif

--- a/artichoke-backend/cext/mrbsys/include/mrbsys/ext.h
+++ b/artichoke-backend/cext/mrbsys/include/mrbsys/ext.h
@@ -6,6 +6,8 @@
  * initializers).
  */
 
+#include <stdbool.h>
+
 #include <mruby.h>
 #include <mruby/class.h>
 #include <mruby/common.h>
@@ -15,17 +17,21 @@
 #include <mruby/value.h>
 #include <mruby/variable.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 // Check whether `mrb_value` is nil, false, or true
 
-MRB_API _Bool mrb_sys_value_is_nil(mrb_value value);
+MRB_API bool mrb_sys_value_is_nil(mrb_value value);
 
-MRB_API _Bool mrb_sys_value_is_false(mrb_value value);
+MRB_API bool mrb_sys_value_is_false(mrb_value value);
 
-MRB_API _Bool mrb_sys_value_is_true(mrb_value value);
+MRB_API bool mrb_sys_value_is_true(mrb_value value);
 
-MRB_API _Bool mrb_sys_range_excl(mrb_state *mrb, mrb_value value);
+MRB_API bool mrb_sys_range_excl(mrb_state *mrb, mrb_value value);
 
-MRB_API _Bool mrb_sys_obj_frozen(mrb_state *mrb, mrb_value value);
+MRB_API bool mrb_sys_obj_frozen(mrb_state *mrb, mrb_value value);
 
 // Extract pointers from `mrb_value`s
 
@@ -77,13 +83,13 @@ MRB_API mrb_value mrb_sys_new_symbol(mrb_sym id);
 
 // Manage Rust-backed `mrb_value`s
 
-MRB_API void mrb_sys_set_instance_tt(struct RClass *class, enum mrb_vtype type);
+MRB_API void mrb_sys_set_instance_tt(struct RClass *klass, enum mrb_vtype type);
 
 MRB_API void mrb_sys_data_init(mrb_value *value, void *ptr, const mrb_data_type *type);
 
 // Raise exceptions and debug info
 
-MRB_API mrb_noreturn void mrb_sys_raise(struct mrb_state *mrb, const char *eclass, const char *msg);
+MRB_API mrb_noreturn void mrb_sys_raise(struct mrb_state *mrb, const char *eklass, const char *msg);
 
 MRB_API void mrb_sys_raise_current_exception(struct mrb_state *mrb);
 
@@ -120,15 +126,19 @@ MRB_API void mrb_sys_gc_arena_restore(mrb_state *mrb, int arena_index);
 /**
  * Disable GC. Returns previous enabled state.
  */
-MRB_API _Bool mrb_sys_gc_disable(mrb_state *mrb);
+MRB_API bool mrb_sys_gc_disable(mrb_state *mrb);
 
 /**
  * Enable GC. Returns previous enabled state.
  */
-MRB_API _Bool mrb_sys_gc_enable(mrb_state *mrb);
+MRB_API bool mrb_sys_gc_enable(mrb_state *mrb);
 
-MRB_API _Bool mrb_sys_value_is_dead(mrb_state *_mrb, mrb_value value);
+MRB_API bool mrb_sys_value_is_dead(mrb_state *_mrb, mrb_value value);
 
 MRB_API int mrb_sys_gc_live_objects(mrb_state *mrb);
 
 MRB_API void mrb_sys_safe_gc_mark(mrb_state *mrb, mrb_value value);
+
+#ifdef __cplusplus
+}  /* extern "C" { */
+#endif

--- a/artichoke-backend/cext/mrbsys/include/mrbsys/reexports.h
+++ b/artichoke-backend/cext/mrbsys/include/mrbsys/reexports.h
@@ -9,5 +9,5 @@ extern "C" {
 MRB_API void mrb_init_mrbgems(mrb_state *mrb);
 
 #ifdef __cplusplus
-}  /* extern "C" { */
+} /* extern "C" { */
 #endif

--- a/artichoke-backend/cext/mrbsys/include/mrbsys/reexports.h
+++ b/artichoke-backend/cext/mrbsys/include/mrbsys/reexports.h
@@ -1,5 +1,13 @@
 #include <mruby.h>
 #include <mruby/common.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 // Expose mrbgems subsystem initializer
 MRB_API void mrb_init_mrbgems(mrb_state *mrb);
+
+#ifdef __cplusplus
+}  /* extern "C" { */
+#endif

--- a/artichoke-backend/cext/mrbsys/src/ext.c
+++ b/artichoke-backend/cext/mrbsys/src/ext.c
@@ -1,15 +1,10 @@
-#include <stdbool.h>
+#include <mrbsys/ext.h>
 
-#include <mruby.h>
 #include <mruby/array.h>
-#include <mruby/class.h>
 #include <mruby/numeric.h>
 #include <mruby/presym.h>
 #include <mruby/range.h>
 #include <mruby/string.h>
-#include <mruby/value.h>
-
-#include <mrbsys/ext.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/artichoke-backend/cext/mrbsys/src/ext.c
+++ b/artichoke-backend/cext/mrbsys/src/ext.c
@@ -378,7 +378,7 @@ mrb_obj_as_string(mrb_state *mrb, mrb_value obj)
     case MRB_TT_SYMBOL:
       return mrb_sym_str(mrb, mrb_symbol(obj));
     case MRB_TT_INTEGER:
-      return mrb_fixnum_to_str(mrb, obj, 10);
+      return mrb_integer_to_str(mrb, obj, 10);
     case MRB_TT_SCLASS:
     case MRB_TT_CLASS:
     case MRB_TT_MODULE:

--- a/artichoke-backend/cext/mrbsys/src/ext.c
+++ b/artichoke-backend/cext/mrbsys/src/ext.c
@@ -1,3 +1,5 @@
+#include <stdbool.h>
+
 #include <mruby.h>
 #include <mruby/array.h>
 #include <mruby/class.h>
@@ -9,37 +11,41 @@
 
 #include <mrbsys/ext.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 const uint8_t mrblib_irep[] = {0};
 
 const char mrb_digitmap[] = "0123456789abcdefghijklmnopqrstuvwxyz";
 
 // Check whether `mrb_value` is nil, false, or true
 
-MRB_API _Bool
+MRB_API bool
 mrb_sys_value_is_nil(mrb_value value)
 {
   return mrb_nil_p(value);
 }
 
-MRB_API _Bool
+MRB_API bool
 mrb_sys_value_is_false(mrb_value value)
 {
   return mrb_false_p(value);
 }
 
-MRB_API _Bool
+MRB_API bool
 mrb_sys_value_is_true(mrb_value value)
 {
   return mrb_true_p(value);
 }
 
-MRB_API _Bool
+MRB_API bool
 mrb_sys_range_excl(mrb_state *mrb, mrb_value value)
 {
   return mrb_range_excl_p(mrb, value);
 }
 
-MRB_API _Bool
+MRB_API bool
 mrb_sys_obj_frozen(mrb_state *mrb, mrb_value value)
 {
   (void)(mrb);
@@ -209,9 +215,9 @@ mrb_sys_new_symbol(mrb_sym id)
 // Manage Rust-backed `mrb_value`s
 
 MRB_API void
-mrb_sys_set_instance_tt(struct RClass *class, enum mrb_vtype type)
+mrb_sys_set_instance_tt(struct RClass *klass, enum mrb_vtype type)
 {
-  MRB_SET_INSTANCE_TT(class, type);
+  MRB_SET_INSTANCE_TT(klass, type);
 }
 
 MRB_API void
@@ -223,9 +229,9 @@ mrb_sys_data_init(mrb_value *value, void *ptr, const mrb_data_type *type)
 // Raise exceptions and debug info
 
 MRB_API mrb_noreturn void
-mrb_sys_raise(struct mrb_state *mrb, const char *eclass, const char *msg)
+mrb_sys_raise(struct mrb_state *mrb, const char *eklass, const char *msg)
 {
-  mrb_raise(mrb, mrb_class_get(mrb, eclass), msg);
+  mrb_raise(mrb, mrb_class_get(mrb, eklass), msg);
 }
 
 MRB_API void
@@ -423,25 +429,25 @@ mrb_sys_gc_arena_restore(mrb_state *mrb, int arena_index)
   mrb_gc_arena_restore(mrb, arena_index);
 }
 
-MRB_API _Bool
+MRB_API bool
 mrb_sys_gc_disable(mrb_state *mrb)
 {
   mrb_gc *gc = &mrb->gc;
-  _Bool was_enabled = !gc->disabled;
+  bool was_enabled = !gc->disabled;
   gc->disabled = 1;
   return was_enabled;
 }
 
-MRB_API _Bool
+MRB_API bool
 mrb_sys_gc_enable(mrb_state *mrb)
 {
   mrb_gc *gc = &mrb->gc;
-  _Bool was_enabled = !gc->disabled;
+  bool was_enabled = !gc->disabled;
   gc->disabled = 0;
   return was_enabled;
 }
 
-MRB_API _Bool
+MRB_API bool
 mrb_sys_value_is_dead(mrb_state *mrb, mrb_value value)
 {
   // immediate values such as Fixnums and Symbols are never garbage
@@ -473,3 +479,7 @@ mrb_sys_safe_gc_mark(mrb_state *mrb, mrb_value value)
     mrb_gc_mark(mrb, mrb_basic_ptr(value));
   }
 }
+
+#ifdef __cplusplus
+}  /* extern "C" { */
+#endif

--- a/artichoke-backend/cext/mrbsys/src/ext.c
+++ b/artichoke-backend/cext/mrbsys/src/ext.c
@@ -476,5 +476,5 @@ mrb_sys_safe_gc_mark(mrb_state *mrb, mrb_value value)
 }
 
 #ifdef __cplusplus
-}  /* extern "C" { */
+} /* extern "C" { */
 #endif


### PR DESCRIPTION
- Enable the `mrbsys` C extension to compile with a C++ compiler. See 24dd693d4da78f178ce32d3774ae874a27a86aa7 for details of these changes.
- Remove some extraneous `#include`s in `mrbsys/src/ext.c`.
- Update legacy call to deprecated API with the Fixnum refactor in mruby 3.1.0. See 93c51cb07ee5cb257c70a694b5211344f8cdf199 for details of these changes.

This PR was partially extracted from #1904 commit 9aa36b90c9f9f3d4ba0202b7e9a12a93316f1159.