### PR TITLE
Add a NUL byte to the end of the allocation from `mrb_sym_str`

### DIFF
--- a/artichoke-backend/src/extn/core/symbol/ffi.rs
+++ b/artichoke-backend/src/extn/core/symbol/ffi.rs
@@ -228,34 +228,35 @@ unsafe extern "C" fn mrb_sym_dump(mrb: *mut sys::mrb_state, sym: sys::mrb_sym) -
 unsafe extern "C" fn mrb_sym_str(mrb: *mut sys::mrb_state, sym: sys::mrb_sym) -> sys::mrb_value {
     unwrap_interpreter!(mrb, to => guard);
 
-    let value = if let Ok(Some(bytes)) = guard.lookup_symbol(sym) {
-        let mut bytes = bytes.to_vec();
-
-        // SAFETY: ensure the byte buffer is NUL-terminated.
-        //
-        // Add a NUL byte to the end of the allocation for the byte buffer in
-        // the new `RString`.
-        //
-        // mruby assumes that symbols are stored in memory as a null terminated
-        // `char*`s and creates "static" `RString`s from interned bytes that
-        // point at this NUL terminated memory.
-        //
-        // Sometimes mruby grabs the `RString` pointer directly from value
-        // returned by this API call and assumes it is NUL terminated.
-        //
-        // Add a 0 byte to the end of the `Vec` to force an allocation and then
-        // set the length to the length of the byte content.
-        //
-        // See https://github.com/artichoke/artichoke/pull/1969.
-        let len = bytes.len();
-        bytes.reserve_exact(1);
-        bytes.push(0);
-        bytes.set_len(len);
-
-        guard.try_convert_mut(bytes)
+    let mut bytes = if let Ok(Some(bytes)) = guard.lookup_symbol(sym) {
+        bytes.to_vec()
     } else {
-        guard.try_convert_mut("")
+        vec![]
     };
+
+    // SAFETY: ensure the byte buffer is NUL-terminated.
+    //
+    // Add a NUL byte to the end of the allocation for the byte buffer in
+    // the new `RString*`.
+    //
+    // mruby assumes that symbols are stored in memory as a null terminated
+    // `char*`s and creates "static" `RString`s from interned bytes that
+    // point at this NUL terminated memory.
+    //
+    // Sometimes mruby grabs the `RString` pointer directly from value
+    // returned by this API call and assumes it is NUL terminated.
+    //
+    // Add a 0 byte to the end of the `Vec` to ensure that the byte at index
+    // `len + 1` is NUL. Then set the length to the length of the `Vec` to
+    // hide the NUL byte.
+    //
+    // See https://github.com/artichoke/artichoke/pull/1969.
+    let len = bytes.len();
+    bytes.reserve_exact(1);
+    bytes.push(0);
+    bytes.set_len(len);
+
+    let value = guard.try_convert_mut(bytes);
     value.unwrap_or_default().inner()
 }
 


### PR DESCRIPTION
mruby assumes that the byte content associated with symbols are stored in memory as a null terminated `char*`s in the symbol table. Artichoke stores symbols as NUL terminated strings in the symbol table.

When creating a Ruby value from the symbol table with `mrb_sym_str`, mruby creates "static" `RString*`s from interned bytes that point at this NUL terminated memory. This behavior differs from Artichoke that does not have a static string/`Cow` optimization.

Sometimes mruby grabs the underlying `RSTRING_PTR` from these symbol table-backed `RString*`s and relies on the pointer being NUL terminated.

## Flow

In mruby, `Class#name` is implemented with a `__classname__` ivar on `Class` objects that points to an interned string via a `Symbol`.

In native code, mruby resolves this symbol to a byte buffer and wants to get access to the underlying `RSTRING_PTR`.

When mruby wants to pass around a byte buffer, it uses an `mrb_value` of type `MRB_TT_STRING` that is backed by an `RString*`.

In some cases, when getting `RSTRING_PTR`s from strings backed by the symbol table, mruby assumes the pointer is NUL terminated.

This assumption is made because mruby assumes that symbols are stored in memory as a null terminated `char*`s. When converting a symbol into string `mrb_value`, mruby creates "static" `RString`s from interned bytes that point at this NUL terminated memory.

### C Call Graph

`mrb_class_name` directly grabs the `RSTRING_PTR` from a String value:

https://github.com/artichoke/artichoke/blob/7bf3f033e020dd60f4b5fd5974dcb19af2617f6d/artichoke-backend/vendor/mruby/src/class.c#L2148

which searches the class path:

https://github.com/artichoke/artichoke/blob/7bf3f033e020dd60f4b5fd5974dcb19af2617f6d/artichoke-backend/vendor/mruby/src/class.c#L396

which is returns a class name from the symbol table:

https://github.com/artichoke/artichoke/blob/7bf3f033e020dd60f4b5fd5974dcb19af2617f6d/artichoke-backend/vendor/mruby/src/class.c#L2125

## Detection

This memory corruption was observed when printing out class names in ARGF specs. I observed this error while running the spec suite for `ARGF` where I got unexpected errors like:

```
An exception occurred during: loading core/argf/argf_spec.rb
ARGF is extended by the Enumerable module
ArgumentError: regex crate utf8 backend for Regexp only supports UTF-8 haystacks
```

This comes from the spec harness attempting to `Regexp` match on exception class names:

https://github.com/artichoke/artichoke/blob/7bf3f033e020dd60f4b5fd5974dcb19af2617f6d/spec-runner/src/spec_runner.rb#L133

After adding this diff:

```diff
diff --git i/spec-runner/src/spec_runner.rb w/spec-runner/src/spec_runner.rb
index 85b2cc8f327..51fa352ee86 100755
--- i/spec-runner/src/spec_runner.rb
+++ w/spec-runner/src/spec_runner.rb
@@ -130,6 +130,7 @@ module Artichoke
             skipped = true if state.message =~ /'untrusted\?'/
             skipped = true if state.message =~ /undefined method 'Rational'/
           when NameError
+            puts state.message.inspect
             skipped = true if state.message =~ /uninitialized constant Bignum/
           when SpecExpectationNotMetError
             skipped = true if state.it =~ /encoding/
```

Output showed this exception message:


```
"NameError: uninitialized constant #<Class:#<MSpecEnv\xFB\ae__:0x7fd6600c08a0>>::ARGF"
```

oh noes! memory unsafety 😧 

## Fix

Artichoke does not have a "static"/`Cow` string optimization, so `mrb_sym_str` allocates:

https://github.com/artichoke/artichoke/blob/7bf3f033e020dd60f4b5fd5974dcb19af2617f6d/artichoke-backend/src/extn/core/symbol/ffi.rs#L228-L232

In practice the call to `<[u8]>::clone` does not allocate excess capacity so the symbol `MSpecEnv` allocates a buffer with `capacity = len = 8`.

This means the memory beyond the `v` byte can have any value.

To ensure the buffer is "NUL terminated": Add a 0 byte to the end of the `Vec` to ensure that the byte at index `len + 1` is NUL.

https://github.com/artichoke/artichoke/blob/80f5397d0bf9025bb87b416e092b3a2a06e749d7/artichoke-backend/src/extn/core/symbol/ffi.rs#L237-L257