### PR TITLE
Fix `StringScanner` specs broken by #1958

### DIFF
--- a/artichoke-backend/src/extn/stdlib/strscan/strscan.rb
+++ b/artichoke-backend/src/extn/stdlib/strscan/strscan.rb
@@ -95,6 +95,8 @@ class StringScanner
     return nil if eos?
 
     byte = @string.byteslice(@pos)
+    # StringScanner always returns `String` class
+    byte = String.new(byte) unless byte.instance_of?(String)
     @pos += 1
     @last_match_pos = @pos
     @last_match = byte
@@ -180,7 +182,10 @@ class StringScanner
     raise RangeError unless len.is_a?(Integer)
     raise ArgumentError if len.negative?
 
-    @string.byteslice(pos, len)
+    ret = @string.byteslice(pos, len)
+    # StringScanner always returns `String` class
+    ret = String.new(ret) unless ret.instance_of?(String)
+    ret
   end
 
   def peep(len)
@@ -206,6 +211,7 @@ class StringScanner
     return nil if @last_match.nil?
 
     ret = @string.byteslice(@last_match_pos, @string.bytesize - @last_match_pos) || ''
+    # StringScanner always returns `String` class
     ret = String.new(ret) unless ret.instance_of?(String)
     ret
   end
@@ -221,6 +227,7 @@ class StringScanner
         @last_match.bytesize
       end
     ret = @string.byteslice(0, @last_match_pos - match_byte_offset) || ''
+    # StringScanner always returns `String` class
     ret = String.new(ret) unless ret.instance_of?(String)
     ret
   end
@@ -234,6 +241,7 @@ class StringScanner
 
   def rest
     ret = @string.byteslice(@pos, @string.bytesize - @pos)
+    # StringScanner always returns `String` class
     ret = String.new(ret) unless ret.instance_of?(String)
     ret
   end
@@ -278,6 +286,7 @@ class StringScanner
 
     if return_string_p
       ret = @string.byteslice(previous_pos, match_end_byte_pos)
+      # StringScanner always returns `String` class
       ret = String.new(ret) unless ret.instance_of?(String)
       ret
     else
@@ -297,7 +306,10 @@ class StringScanner
     @last_match = match
     @last_match_pos = @pos
 
-    @string.byteslice(previous_pos, match_end_byte_pos)
+    ret = @string.byteslice(previous_pos, match_end_byte_pos)
+    # StringScanner always returns `String` class
+    ret = String.new(ret) unless ret.instance_of?(String)
+    ret
   end
 
   def search_full(pattern, advance_pointer_p, return_string_p)
@@ -310,7 +322,10 @@ class StringScanner
     @pos += match_end_byte_pos if advance_pointer_p
     @previous_pos = previous_pos
     if return_string_p
-      @string.byteslice(previous_pos, match_end_byte_pos)
+      ret = @string.byteslice(previous_pos, match_end_byte_pos)
+      # StringScanner always returns `String` class
+      ret = String.new(ret) unless ret.instance_of?(String)
+      ret
     else
       match.end(0)
     end

--- a/spec-runner/enforced-specs.toml
+++ b/spec-runner/enforced-specs.toml
@@ -98,9 +98,39 @@ include = "all"
 include = "set"
 specs = [
   "bytesize",
-  # missing `Range` support: https://github.com/artichoke/artichoke/issues/1916
+  # `Range` of int, e.g. `1..9`, does not call `#to_int` on start and end.
+  #
+  # ```
+  # String#byteslice with Range calls to_int on range arguments
+  # TypeError: MockObject cannot be converted to Integer
+  #
+  # /artichoke/virtual_root/src/lib/core/string/shared/slice.rb:266:in byteslice
+  # /artichoke/virtual_root/src/lib/core/string/shared/slice.rb:266:in protect
+  # (eval):165:in all?
+  # (eval):590:in each
+  # /artichoke/virtual_root/src/lib/core/string/byteslice_spec.rb:18
+  # (eval):590:in each
+  # /artichoke/virtual_root/src/lib/spec_runner.rb:74:in run_specs
+  # (eval):1
+  #
+  # An exception occurred during: Mock.verify_count
+  # String#byteslice with Range calls to_int on range arguments
+  # SpecExpectationNotMetError: Mock 'from' expected to receive <=>(:any_args) exactly 2 times
+  # but received it 1 times
+  #
+  # (eval):590:in each
+  # (eval):186:in each
+  # (eval):165:in all?
+  # (eval):590:in each
+  # /artichoke/virtual_root/src/lib/core/string/byteslice_spec.rb:18
+  # (eval):590:in each
+  # /artichoke/virtual_root/src/lib/spec_runner.rb:74:in run_specs
+  # (eval):1
+  # ```
+  #
   # "byteslice",
   # `chomp` and `chop` have some improper separator handling
+  #
   # "chomp",
   # "chop",
   "clear",


### PR DESCRIPTION
The changes in #1958 updated `String#byteslice` to properly return
slices with the same class as the receiver.

Some places in the pure Ruby implementation of `StringScanner` did not
properly convert byte slices to plain `String`.

Also update `enforced-specs.toml` to clarify why `String#byteslice` is
still skipped.

Progress on #1912.