### PR TITLE
Fix spelling mistakes in comments

### DIFF
--- a/.config/artichoke.dic
+++ b/.config/artichoke.dic
@@ -1,10 +1,18 @@
 250
++
+=
+<
+>
+–
+—
 @generated
 API
 APIs
 ARGV
 BNF
 Booleans
+CEST
+CET
 CLI
 DoS
 ENV
@@ -12,6 +20,7 @@ EOF
 FFI
 FIXME
 GC
+IANA
 IEEE
 JDK
 JSON
@@ -23,6 +32,7 @@ Onigmo
 Oniguruma
 OOM
 OpenSSL
+POSIX
 PRNG/MS
 README/MS
 REPL
@@ -31,6 +41,7 @@ RTL
 SipHash
 Spinoso
 TODO
+TZif
 UTC
 UUID/MS
 VM/MS
@@ -86,6 +97,7 @@ enum
 env
 environ
 errno
+erroring
 eval
 evaled
 evaling
@@ -152,11 +164,13 @@ radix
 raisable
 rbenv
 readline
+read–eval–print–loop
 reallocate
 reallocation/S
 rebox
 reboxed
 representable
+rescuable
 resize
 rjl@hyperbo
 rubygem/S
@@ -190,6 +204,9 @@ truthy
 tuple
 typedef
 typesafe
+tz
+tzrs
+tz-rs
 unbox
 unboxed
 unboxing
@@ -199,6 +216,7 @@ unescaped
 unhandled
 unparseable
 unsetting
+unsimplified
 unterminated
 untrusted
 urandom

--- a/.config/spellcheck.toml
+++ b/.config/spellcheck.toml
@@ -1,10 +1,18 @@
+# Also take into account developer comments
 dev_comments = true
+# Skip the README.md file as defined in the cargo manifest
 skip_readme = false
 
 [Hunspell]
 # lang and name of `.dic` file
 lang = "en_US"
+# OS specific additives
+# Linux: [ /usr/share/myspell ]
+# Windows: []
+# macOS [ /home/alice/Libraries/hunspell, /Libraries/hunspell ]
 
+# Additional search paths, which take presedence over the default
+# os specific search dirs, searched in order, defaults last
 search_dirs = ["."]
 
 # Adds additional dictionaries, can be specified as

--- a/artichoke-backend/src/extn/core/float/mod.rs
+++ b/artichoke-backend/src/extn/core/float/mod.rs
@@ -91,7 +91,7 @@ impl Float {
     /// The largest possible integer in a double-precision floating point
     /// number.
     ///
-    /// Usually defaults to 1.7976931348623157e+308.
+    /// Usually defaults to `1.7976931348623157e+308`.
     pub const MAX: f64 = f64::MAX;
 
     /// The largest positive exponent in a double-precision floating point where

--- a/artichoke-backend/src/extn/core/regexp/syntax.rs
+++ b/artichoke-backend/src/extn/core/regexp/syntax.rs
@@ -1,4 +1,4 @@
-// This module is forked from `regex-syntax` crate @ 26f7318e.
+// This module is forked from `regex-syntax` crate @ `26f7318e`.
 //
 // https://github.com/rust-lang/regex/blob/26f7318e2895eae56e95a260e81e2d48b90e7c25/regex-syntax/src/lib.rs
 //

--- a/artichoke-backend/src/extn/core/string/trampoline.rs
+++ b/artichoke-backend/src/extn/core/string/trampoline.rs
@@ -36,7 +36,7 @@ pub fn add(interp: &mut Artichoke, mut value: Value, mut other: Value) -> Result
     let s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
     // Safety:
     //
-    // The borrowed byte slice is immediately memcpy'd into the `s` byte
+    // The borrowed byte slice is immediately `memcpy`'d into the `s` byte
     // buffer. There are no intervening interpreter accesses.
     let to_append = unsafe { implicitly_convert_to_string(interp, &mut other)? };
 

--- a/artichoke-backend/src/extn/core/symbol/ffi.rs
+++ b/artichoke-backend/src/extn/core/symbol/ffi.rs
@@ -60,7 +60,7 @@ unsafe extern "C" fn mrb_intern_str(mrb: *mut sys::mrb_state, name: sys::mrb_val
     }
 }
 
-/* mrb_intern_check series functions returns 0 if the symbol is not defined */
+/* `mrb_intern_check` series functions returns 0 if the symbol is not defined */
 
 // ```c
 // MRB_API mrb_sym mrb_intern_check(mrb_state*,const char*,size_t);

--- a/artichoke-backend/src/sys/protect.rs
+++ b/artichoke-backend/src/sys/protect.rs
@@ -78,7 +78,7 @@ impl<'a> Protect for Funcall<'a> {
 
         // This will always unwrap because we've already checked that we
         // have fewer than `MRB_FUNCALL_ARGC_MAX` args, which is less than
-        // i64 max value.
+        // `i64` max value.
         let argslen = if let Ok(argslen) = i64::try_from(args.len()) {
             argslen
         } else {

--- a/mezzaluna-feature-loader/src/paths/windows.rs
+++ b/mezzaluna-feature-loader/src/paths/windows.rs
@@ -19,7 +19,7 @@ pub fn is_explicit_relative<P: AsRef<OsStr>>(path: P) -> bool {
 //
 // This function attempts to handle such paths by decoding them and manually
 // checking for `./`, `.\`, `../`, and `..\`-prefixed paths by looking at raw
-// u16 codepoints.
+// `u16` codepoints.
 fn is_unpaired_surrogate_path_explicit_relative<P: AsRef<OsStr>>(path: P) -> bool {
     let mut wide = path.as_ref().encode_wide().peekable();
 

--- a/spinoso-math/src/math.rs
+++ b/spinoso-math/src/math.rs
@@ -438,7 +438,7 @@ pub fn frexp(value: f64) -> Result<(f64, i32), NotImplementedError> {
 
 /// Calculates the gamma function of the given value.
 ///
-/// Note that `gamma(n)` is same as `fact(n-1)` for integer n > 0. However
+/// Note that `gamma(n)` is same as `fact(n-1)` for integer `n > 0`. However
 /// `gamma(n)` returns float and can be an approximation.
 ///
 /// # Errors
@@ -455,7 +455,7 @@ pub const fn gamma(value: f64) -> Result<f64, NotImplementedError> {
 
 /// Calculates the gamma function of the given value.
 ///
-/// Note that `gamma(n)` is same as `fact(n-1)` for integer n > 0. However
+/// Note that `gamma(n)` is same as `fact(n-1)` for integer `n > 0`. However
 /// `gamma(n)` returns float and can be an approximation.
 ///
 /// # Examples
@@ -482,7 +482,7 @@ pub const fn gamma(value: f64) -> Result<f64, NotImplementedError> {
 #[inline]
 #[cfg(feature = "full")]
 pub fn gamma(value: f64) -> Result<f64, DomainError> {
-    // `gamma(n)` is the same as `n!` for integer n > 0. `gamma` returns float
+    // `gamma(n)` is the same as `n!` for integer `n > 0`. `gamma` returns float
     // and might be an approximation so include a lookup table for as many `n`
     // as can fit in the float mantissa.
     const FACTORIAL_TABLE: [f64; 23] = [

--- a/spinoso-time/README.md
+++ b/spinoso-time/README.md
@@ -64,7 +64,7 @@ are enabled by default:
 
 - **chrono**: Enable a `Time` backend which is implemented with the [`chrono`]
   crate.
-- **tzrs**: Enable a `Time` backend wich is implemented by the [`tz-rs`] and
+- **tzrs**: Enable a `Time` backend which is implemented by the [`tz-rs`] and
   [`tzdb`] crates.
 
 ### Additional features

--- a/spinoso-time/src/lib.rs
+++ b/spinoso-time/src/lib.rs
@@ -46,7 +46,7 @@
 //!
 //! - **chrono**: Enable a `Time` backend which is implemented with the
 //!   [`chrono`] crate.
-//! - **tzrs**: Enable a `Time` backend wich is implemented by the [`tz-rs`] and
+//! - **tzrs**: Enable a `Time` backend which is implemented by the [`tz-rs`] and
 //!   [`tzdb`] crates.
 //!
 //! ## Additional features

--- a/spinoso-time/src/time/tzrs/convert.rs
+++ b/spinoso-time/src/time/tzrs/convert.rs
@@ -3,7 +3,7 @@ use core::fmt::{Display, Formatter, Result};
 use super::{Time, ToA};
 
 impl Display for Time {
-    /// Returns a conanocial string representation of _time_.
+    /// Returns a canonical string representation of _time_.
     ///
     /// Can be used to implement the Ruby method [`Time#asctime`],
     /// [`Time#ctime`], [`Time#to_s`], and [`Time#inspect`].

--- a/spinoso-time/src/time/tzrs/error.rs
+++ b/spinoso-time/src/time/tzrs/error.rs
@@ -9,25 +9,25 @@ use tz::error::{DateTimeError, ProjectDateTimeError, TzError};
 #[allow(clippy::module_name_repetitions)]
 #[derive(Debug)]
 pub enum TimeError {
-    /// Created when trying to create a DateTime, however the projection to a
-    /// unix timestamp wasn't achieveable. Generally thrown when exceeding the
+    /// Created when trying to create a `DateTime`, however the projection to a
+    /// UNIX timestamp wasn't achievable. Generally thrown when exceeding the
     /// range of integers (e.g. `> i64::Max`).
     ///
     /// Note: This is just a wrapper over [`tz::error::ProjectDateTimeError`].
     ProjectionError(ProjectDateTimeError),
 
-    /// Created when one of the parameters of a Datetime falls outside the
+    /// Created when one of the parameters of a `DateTime` falls outside the
     /// allowed ranges (e.g. 13th month, 32 day, 24th hour, etc).
     ///
     /// Note: [`tz::error::DateTimeError`] is only thrown from `tz-rs` when a
     /// provided component value is out of range.
     ///
-    /// Note2: This is different from how MRI ruby is implemented. e.g. Second
+    /// Note: This is different from how MRI ruby is implemented. e.g. Second
     /// 60 is valid in MRI, and will just add an additional second instead of
     /// erroring.
     ComponentOutOfRangeError(DateTimeError),
 
-    /// A rescuable error originally from the tz-rs library.
+    /// A rescuable error originally from the `tz-rs` library.
     UnknownTzError(TzError),
 
     /// Indicates that there was an issue when parsing a string for an offset.
@@ -114,23 +114,23 @@ impl From<TzError> for TimeError {
             TzError::TzFileError(_) => Self::UnknownTzError(error),
             // Occurs during parsing of TZif files (POSIX string parsing)
             TzError::TzStringError(_) => Self::UnknownTzError(error),
-            // Occurs during int conversion (e.g. i64 => i32)
+            // Occurs during int conversion (e.g. `i64` => `i32`)
             TzError::OutOfRangeError(_) => Self::UnknownTzError(error),
-            // Occurs during creation of TimeZoneRef
+            // Occurs during creation of `TimeZoneRef`
             TzError::LocalTimeTypeError(_) => Self::UnknownTzError(error),
-            // Occurs during creation of TimeZoneRef
+            // Occurs during creation of `TimeZoneRef`
             TzError::TransitionRuleError(_) => Self::UnknownTzError(error),
-            // Occurs during creation of TimeZoneRef
+            // Occurs during creation of `TimeZoneRef`
             TzError::TimeZoneError(_) => Self::UnknownTzError(error),
-            // Wrapped by ProjectDateTimeError
+            // Wrapped by `ProjectDateTimeError`
             TzError::FindLocalTimeTypeError(_) => Self::UnknownTzError(error),
             // Never explicitly returned
             TzError::IoError(_) => Self::UnknownTzError(error),
-            // Never explicity returned
+            // Never explicitly returned
             TzError::Utf8Error(_) => Self::UnknownTzError(error),
             // Never explicitly returned
             TzError::TryFromSliceError(_) => Self::UnknownTzError(error),
-            // TzError is non_exhaustive, so the rest are caught as Unknown
+            // `TzError` is non-exhaustive, so the rest are caught as `Unknown`
             _ => Self::Unknown,
         }
     }

--- a/spinoso-time/src/time/tzrs/math.rs
+++ b/spinoso-time/src/time/tzrs/math.rs
@@ -35,7 +35,7 @@ impl Time {
             9..=u32::MAX => *self,
             // Does integer truncation with round up at 5.
             //
-            // ``console
+            // ```console
             // [3.1.2] > t = Time.at(Time.new(2010, 3, 30, 5, 43, 25).to_i, 123_456_789, :nsec)
             // => 2010-03-30 05:43:25.123456789 -0700
             // [3.1.2] > (0..9).each {|d| u = t.round(d); puts "#{d}: #{u.nsec}" }
@@ -89,12 +89,12 @@ impl Time {
 // Addition
 impl Time {
     /// Addition — Adds some duration to _time_ and returns that value as a new
-    /// Time object.
+    /// `Time` object.
     ///
     /// # Errors
     ///
     /// If this function attempts to overflow the the number of seconds as an
-    /// i64 then a [`TimeError`] will be returned.
+    /// [`i64`] then a [`TimeError`] will be returned.
     pub fn checked_add(self, duration: Duration) -> Result<Self, TimeError> {
         let unix_time = self.inner.unix_time();
         let nanoseconds = self.inner.nanoseconds();
@@ -116,13 +116,13 @@ impl Time {
         Self::with_timespec_and_offset(seconds, nanoseconds, offset)
     }
 
-    /// Addition — Adds some i64 to _time_ and returns that value as a new Time
-    /// object.
+    /// Addition — Adds some [`i64`] to _time_ and returns that value as a new
+    /// `Time` object.
     ///
     /// # Errors
     ///
     /// If this function attempts to overflow the the number of seconds as an
-    /// i64 then a [`TimeError`] will be returned.
+    /// [`i64`] then a [`TimeError`] will be returned.
     pub fn checked_add_i64(&self, seconds: i64) -> Result<Self, TimeError> {
         if seconds.is_negative() {
             let seconds = seconds
@@ -136,27 +136,27 @@ impl Time {
         }
     }
 
-    /// Addition — Adds some u64 to _time_ and returns that value as a new Time
-    /// object.
+    /// Addition — Adds some [`u64`] to _time_ and returns that value as a new
+    /// `Time` object.
     ///
     /// # Errors
     ///
     /// If this function attempts to overflow the the number of seconds as an
-    /// i64 then a [`TimeError`] will be returned.
+    /// [`i64`] then a [`TimeError`] will be returned.
     pub fn checked_add_u64(&self, seconds: u64) -> Result<Self, TimeError> {
         let duration = Duration::from_secs(seconds);
         self.checked_add(duration)
     }
 
-    /// Addition — Adds some f64 fraction seconds to _time_ and returns that
-    /// value as a new Time object.
+    /// Addition — Adds some [`f64`] fraction seconds to _time_ and returns that
+    /// value as a new `Time` object.
     ///
     /// # Errors
     ///
     /// If this function attempts to overflow the the number of seconds as an
-    /// i64 then a [`TimeError`] will be returned.
+    /// [`i64`] then a [`TimeError`] will be returned.
     pub fn checked_add_f64(&self, seconds: f64) -> Result<Self, TimeError> {
-        // Fail safely during f64 conversion to duration
+        // Fail safely during `f64` conversion to duration
         if seconds.is_nan() || seconds.is_infinite() {
             return Err(TzOutOfRangeError::new().into());
         }
@@ -171,13 +171,13 @@ impl Time {
 
 // Subtraction
 impl Time {
-    /// Subtraction — Subtracts the given duration from _time_ and returns that
-    /// value as a new Time object.
+    /// Subtraction — Subtracts the given duration from _time_ and returns
+    /// that value as a new `Time` object.
     ///
     /// # Errors
     ///
     /// If this function attempts to overflow the the number of seconds as an
-    /// i64 then a [`TimeError`] will be returned.
+    /// [`i64`] then a [`TimeError`] will be returned.
     pub fn checked_sub(self, duration: Duration) -> Result<Self, TimeError> {
         let unix_time = self.inner.unix_time();
         let nanoseconds = self.inner.nanoseconds();
@@ -197,13 +197,13 @@ impl Time {
         Self::with_timespec_and_offset(seconds, nanoseconds, offset)
     }
 
-    /// Subtraction — Subtracts the given i64 from _time_ and returns that value
-    /// as a new Time object.
+    /// Subtraction — Subtracts the given [`i64`] from _time_ and returns that
+    /// value as a new `Time` object.
     ///
     /// # Errors
     ///
     /// If this function attempts to overflow the the number of seconds as an
-    /// i64 then a [`TimeError`] will be returned.
+    /// [`i64`] then a [`TimeError`] will be returned.
     pub fn checked_sub_i64(self, seconds: i64) -> Result<Self, TimeError> {
         if seconds.is_negative() {
             let seconds = seconds
@@ -217,27 +217,27 @@ impl Time {
         }
     }
 
-    /// Subtraction — Subtracts the given u64 from _time_ and returns that value
-    /// as a new Time object.
+    /// Subtraction — Subtracts the given [`u64`] from _time_ and returns that
+    /// value as a new `Time` object.
     ///
     /// # Errors
     ///
     /// If this function attempts to overflow the the number of seconds as an
-    /// i64 then a [`TimeError`] will be returned.
+    /// [`i64`] then a [`TimeError`] will be returned.
     pub fn checked_sub_u64(self, seconds: u64) -> Result<Self, TimeError> {
         let duration = Duration::from_secs(seconds);
         self.checked_sub(duration)
     }
 
-    /// Subtraction — Subtracts the given f64 as fraction seconds from _time_
-    /// and returns that value as a new Time object.
+    /// Subtraction — Subtracts the given [`f64`] as fraction seconds from
+    /// _time_ and returns that value as a new `Time` object.
     ///
     /// # Errors
     ///
     /// If this function attempts to overflow the the number of seconds as an
-    /// i64 then a [`TimeError`] will be returned.
+    /// [`i64`] then a [`TimeError`] will be returned.
     pub fn checked_sub_f64(self, seconds: f64) -> Result<Self, TimeError> {
-        // Fail safely during f64 conversion to duration
+        // Fail safely during `f64` conversion to duration
         if seconds.is_nan() || seconds.is_infinite() {
             return Err(TzOutOfRangeError::new().into());
         }

--- a/spinoso-time/src/time/tzrs/mod.rs
+++ b/spinoso-time/src/time/tzrs/mod.rs
@@ -120,7 +120,7 @@ impl Ord for Time {
 impl Time {
     /// Returns a new Time from the given values in the provided `offset`.
     ///
-    /// Can be used to implment the Ruby method [`Time#new`] (using a
+    /// Can be used to implement the Ruby method [`Time#new`] (using a
     /// [`Timezone`] Object).
     ///
     /// **Note**: During DST transitions, a specific time can be ambiguous. This
@@ -159,7 +159,8 @@ impl Time {
         let tz = offset.time_zone_ref();
         let found_date_times = DateTime::find(year, month, day, hour, minute, second, nanoseconds, tz)?;
 
-        // .latest() will always return Some(DateTime)
+        // .latest() will always return `Some(DateTime)`
+        // FIXME: this assertion is not consistent with the docs in `tz-rs`.
         let dt = found_date_times.latest().expect("No datetime found with this offset");
         Ok(Self { inner: dt, offset })
     }
@@ -307,16 +308,16 @@ impl Time {
     #[inline]
     #[must_use]
     pub fn to_float(&self) -> f64 {
-        // A f64 mantissa is only 52 bits wide, so putting 64 bits in there will
-        // result in a rounding issues, however this is expected in the Ruby
-        // spec.
+        // A `f64` mantissa is only 52 bits wide, so putting 64 bits in there
+        // will result in a rounding issues, however this is expected in the
+        // Ruby spec.
         #[allow(clippy::cast_precision_loss)]
         let sec = self.to_int() as f64;
         let nanos_fractional = f64::from(self.inner.nanoseconds()) / f64::from(NANOS_IN_SECOND);
         sec + nanos_fractional
     }
 
-    /// Returns the numerator and denominator for the number of nano seconds of
+    /// Returns the numerator and denominator for the number of nanoseconds of
     /// the Time struct unsimplified.
     ///
     /// This can be used directly to implement [`Time#subsec`].

--- a/spinoso-time/src/time/tzrs/offset.rs
+++ b/spinoso-time/src/time/tzrs/offset.rs
@@ -19,12 +19,12 @@ pub const MAX_OFFSET_SECONDS: i32 = 24 * 60 * 60 - 1;
 /// offset. This is equal to the number of seconds in 1 day, minus 1
 pub const MIN_OFFSET_SECONDS: i32 = -MAX_OFFSET_SECONDS;
 
-/// tzdb provides [`local_tz`] to get the local system timezone. If this ever
+/// `tzdb` provides [`local_tz`] to get the local system timezone. If this ever
 /// fails, we can assume `GMT`. `GMT` is used instead of `UTC` since it has a
 /// [`time_zone_designation`] - which if it is an empty string, then it is
 /// considered to be a UTC time.
 ///
-/// Note: this matches MRI Ruby implmentation. Where `TZ="" ruby -e "puts
+/// Note: this matches MRI Ruby implementation. Where `TZ="" ruby -e "puts
 /// Time::now"` will return a new _time_ with 0 offset from UTC, but still still
 /// report as a non UTC time:
 ///
@@ -123,7 +123,7 @@ impl Offset {
         }
 
         let offset_name = offset_hhmm_from_seconds(offset);
-        // creation of the LocalTimeType is never expected to fail, since the
+        // Creation of the `LocalTimeType` is never expected to fail, since the
         // bounds we are more restrictive of the values than the struct itself.
         let local_time_type = LocalTimeType::new(offset, false, Some(offset_name.as_bytes()))
             .expect("Failed to LocalTimeType for fixed offset");

--- a/spinoso-time/src/time/tzrs/parts.rs
+++ b/spinoso-time/src/time/tzrs/parts.rs
@@ -229,8 +229,8 @@ impl Time {
     #[inline]
     #[must_use]
     pub fn time_zone(&self) -> &str {
-        // We can usually get the name from wrapped DateTime, however UTC is a
-        // special case which is an empty string, thus the OffsetType is safer.
+        // We can usually get the name from wrapped `DateTime`, however UTC is a
+        // special case which is an empty string, thus the `OffsetType` is safer.
         //
         // Note: The offset cannot be relied upon for the timezone name, as it
         // may contain many options (e.g. CEST/CET)

--- a/src/bin/artichoke.rs
+++ b/src/bin/artichoke.rs
@@ -168,8 +168,8 @@ fn command() -> Command<'static> {
         .trailing_var_arg(true)
 }
 
-// NOTE: This routine is plucked from `ripgrep` as of
-// 9f924ee187d4c62aa6ebe4903d0cfc6507a5adb5.
+// NOTE: This routine is plucked from `ripgrep` as of commit
+// `9f924ee187d4c62aa6ebe4903d0cfc6507a5adb5`.
 //
 // `ripgrep` is licensed with the MIT License Copyright (c) 2015 Andrew Gallant.
 //


### PR DESCRIPTION
Do a pass through the code with cargo-spellcheck.