### PR TITLE
Add NUL bytes to the end of `String` allocations in `MRB_API` string FFI functions

### DIFF
--- a/artichoke-backend/src/extn/core/string/ffi.rs
+++ b/artichoke-backend/src/extn/core/string/ffi.rs
@@ -269,10 +269,17 @@ unsafe extern "C" fn mrb_str_plus(mrb: *mut sys::mrb_state, a: sys::mrb_value, b
         return Value::nil().into();
     };
 
-    let mut s = String::with_capacity_and_encoding(a.len() + b.len(), a.encoding());
+    let mut s = String::with_capacity_and_encoding(a.len() + b.len() + 1, a.encoding());
 
     s.extend_from_slice(a.as_slice());
     s.extend_from_slice(b.as_slice());
+
+    // SAFETY: mruby assumes strings are allocated with `capacity = capa + 1`
+    // and that last byte is NUL.
+    //
+    // The capacity stored in the `RString*` is `capa`.
+    s.push_byte(0);
+    s.set_len(a.len() + b.len());
 
     let s = String::alloc_value(s, &mut guard).unwrap_or_default();
     s.into()

--- a/artichoke-backend/src/extn/core/string/ffi.rs
+++ b/artichoke-backend/src/extn/core/string/ffi.rs
@@ -34,10 +34,8 @@ unsafe extern "C" fn mrb_str_new_capa(mrb: *mut sys::mrb_state, capa: usize) -> 
         let err = ArgumentError::with_message("string capacity too large");
         error::raise(guard, err);
     };
-    // SAFETY: mruby assumes strings are allocated with capa = capa + 1 and that
-    // last byte is NUL.
-    //
-    // The capacity stored in the `RString*` is `capa`.
+    // SAFETY: mruby assumes strings are allocated with `capacity = capa + 1`
+    // and that last byte is NUL.
     let mut result = String::with_capacity(alloc_capacity);
     let ptr = result.as_mut_ptr();
     let last = ptr.add(capa);
@@ -276,8 +274,6 @@ unsafe extern "C" fn mrb_str_plus(mrb: *mut sys::mrb_state, a: sys::mrb_value, b
 
     // SAFETY: mruby assumes strings are allocated with `capacity = capa + 1`
     // and that last byte is NUL.
-    //
-    // The capacity stored in the `RString*` is `capa`.
     s.push_byte(0);
     s.set_len(a.len() + b.len());
 
@@ -372,8 +368,8 @@ unsafe extern "C" fn mrb_str_dup(mrb: *mut sys::mrb_state, s: sys::mrb_value) ->
 
     drop(guard);
 
-    // SAFETY: go throw `mrb_str_new` to maintain invariants around capacity and
-    // trailing NUL bytes.
+    // SAFETY: delegate to `mrb_str_new` to maintain invariants around capacity
+    // and trailing NUL bytes.
     let dup = mrb_str_new(mrb, ptr.cast::<c_char>(), len);
     // dup'd strings keep the class of the source `String`.
     let dup_basic = sys::mrb_sys_basic_ptr(dup).cast::<sys::RString>();
@@ -636,8 +632,6 @@ unsafe extern "C" fn mrb_str_cat(
 
         // SAFETY: mruby assumes strings are allocated with `capacity = capa + 1`
         // and that last byte is NUL.
-        //
-        // The capacity stored in the `RString*` is `capa`.
         let len = string_mut.len();
         string_mut.reserve_exact(1);
         string_mut.push_byte(0);

--- a/artichoke-backend/src/extn/core/symbol/ffi.rs
+++ b/artichoke-backend/src/extn/core/symbol/ffi.rs
@@ -100,13 +100,10 @@ unsafe extern "C" fn mrb_intern_check_str(mrb: *mut sys::mrb_state, name: sys::m
     let name = Value::from(name);
     if let Ok(bytes) = name.try_convert_into_mut::<&[u8]>(&mut guard) {
         if let Ok(Some(sym)) = guard.check_interned_bytes(bytes) {
-            sym
-        } else {
-            0
+            return sym;
         }
-    } else {
-        0
     }
+    0
 }
 
 // `mrb_check_intern` series functions returns `nil` if the symbol is not
@@ -166,10 +163,10 @@ unsafe extern "C" fn mrb_check_intern_str(mrb: *mut sys::mrb_state, name: sys::m
 // MRB_API const char *mrb_sym_name(mrb_state*,mrb_sym);
 // ```
 #[no_mangle]
-unsafe extern "C" fn mrb_sym_name(mrb: *mut sys::mrb_state, sym: sys::mrb_sym) -> *const i8 {
+unsafe extern "C" fn mrb_sym_name(mrb: *mut sys::mrb_state, sym: sys::mrb_sym) -> *const c_char {
     unwrap_interpreter!(mrb, to => guard, or_else = ptr::null());
     if let Ok(Some(bytes)) = guard.lookup_symbol_with_trailing_nul(sym) {
-        bytes.as_ptr().cast::<i8>()
+        bytes.as_ptr().cast::<c_char>()
     } else {
         ptr::null()
     }
@@ -209,7 +206,30 @@ unsafe extern "C" fn mrb_sym_name_len(
 unsafe extern "C" fn mrb_sym_dump(mrb: *mut sys::mrb_state, sym: sys::mrb_sym) -> *const c_char {
     unwrap_interpreter!(mrb, to => guard, or_else = ptr::null());
     if let Ok(Some(bytes)) = guard.lookup_symbol(sym) {
-        let bytes = bytes.to_vec();
+        let mut bytes = bytes.to_vec();
+
+        // SAFETY: ensure the byte buffer is NUL-terminated.
+        //
+        // Add a NUL byte to the end of the allocation for the byte buffer in
+        // the new `RString*`.
+        //
+        // mruby assumes that symbols are stored in memory as a null terminated
+        // `char*`s and creates "static" `RString`s from interned bytes that
+        // point at this NUL terminated memory.
+        //
+        // Sometimes mruby grabs the `RString` pointer directly from value
+        // returned by this API call and assumes it is NUL terminated.
+        //
+        // Add a 0 byte to the end of the `Vec` to ensure that the byte at index
+        // `len + 1` is NUL. Then set the length to the length of the `Vec` to
+        // hide the NUL byte.
+        //
+        // See https://github.com/artichoke/artichoke/pull/1969.
+        let len = bytes.len();
+        bytes.reserve_exact(1);
+        bytes.push(0);
+        bytes.set_len(len);
+
         // Allocate a buffer with the lifetime of the interpreter and return
         // a pointer to it.
         if let Ok(string) = guard.try_convert_mut(bytes) {


### PR DESCRIPTION
This PR is a continuation in the same theme as #1969. #1969 was an incomplete fix for the buffer overread that only targeted strings produced from symbols. This PR targets all strings to ensure they have a trailing NUL byte.

The upstream version of `mrb_str_new_capa` always allocates `capa + 1` bytes and sets the last byte of the allocation to zero.

Prior to this commit, Artichoke did not maintain this invariant. This results in the same style of buffer overread as in https://github.com/artichoke/artichoke/pull/1969 because `mrb_str_dup` is another plausible pathway to get an `RSTRING_PTR` from `mrb_class_path`:

https://github.com/artichoke/artichoke/blob/7bf3f033e020dd60f4b5fd5974dcb19af2617f6d/artichoke-backend/vendor/mruby/src/class.c#L2123-L2127

Commits in this PR ensure all `String` FFI routines route through `mrb_str_new_capa` to maintain this invariant, or otherwise ensure a trailing NUL byte is present similar to the mitigation in https://github.com/artichoke/artichoke/pull/1969.

This was observed as similar corruption/garbage bytes in class names in the spec suite:

For example, these subsequent runs as identified in https://github.com/artichoke/artichoke/pull/1969#issuecomment-1193400913:

```
Method#inspect: .XXXXXXX: "#<Method: MethodSpecs::MySub(MethodSpecs::MyMod)#bar>"
.XXXXXXX: "#<Method: MethodSpecs::MySub(MethodSpecs::MyMod)#bar>"
.XXXXXXX: "#<Method: MethodSpecs::MySub:\xB8\xF7\x7F(MethodSpecs::MyMod)#bar>"
X.XXXXXXX: "#<Method: MethodSpecs::MySub(MethodSpecs::MyMod)#bar>"
X.XXXXXXX: "#<Method: MethodSpecs::MySub(MethodSpecs::MyMod)#bar>"
.XXXXXXX: "#<Method: MethodSpecs::MySubW(MethodSpecs::MyMod)#bar>"
```

```
Method#inspect: .XXXXXXX: "#<Method: MethodSpecs::MySub(MethodSpecs::MyMod)#bar>"
.XXXXXXX: "#<Method: MethodSpecs::MySubmethods'-\xBC\xF7\x7F(MethodSpecs::MyMod)#bar>"
X.XXXXXXX: "#<Method: MethodSpecs::MySub(MethodSpecs::MyMod)#bar>"
.XXXXXXX: "#<Method: MethodSpecs::MySubn(MethodSpecs::MyMod)#bar>"
X.XXXXXXX: "#<Method: MethodSpecs::MySub(MethodSpecs::MyMod)#bar>"
X.XXXXXXX: "#<Method: MethodSpecs::MySub(MethodSpecs::MyMod)#bar>"
```

Additional fixes target `mrb_str_new` and `mrb_str_new_cstr`:

To maintain the invariant that all string byte buffers have a trailing NUL byte, Artichoke has added logic to `mrb_str_new_capa` to always allocate an extra byte and write a `0` to it.

To avoid repeating this error prone logic in multiple places, implement `mrb_str_new` in terms of `mrb_str_new_capa` and a raw `memcpy`, remembering to fixup the length in the `RString*`.

Implement `mrb_str_new_cstr` with `mrb_str_new` by finding the `ptr` and `len` with Rust's `CStr`.

## Results and Testing

Compared to the latest trunk, all observed instances of this bug have been fixed, as measured by the Core spec suite.

### trunk

```console
$ cargo run --bin spec-runner -q -- all-core-specs.toml > trunk.txt
$ rg haystack trunk.txt
40646:ArgumentError: regex crate utf8 backend for Regexp only supports UTF-8 haystacks
40660:ArgumentError: regex crate utf8 backend for Regexp only supports UTF-8 haystacks
40674:ArgumentError: regex crate utf8 backend for Regexp only supports UTF-8 haystacks
40880:ArgumentError: regex crate utf8 backend for Regexp only supports UTF-8 haystacks
40894:ArgumentError: regex crate utf8 backend for Regexp only supports UTF-8 haystacks
40908:ArgumentError: regex crate utf8 backend for Regexp only supports UTF-8 haystacks
40922:ArgumentError: regex crate utf8 backend for Regexp only supports UTF-8 haystacks
40936:ArgumentError: regex crate utf8 backend for Regexp only supports UTF-8 haystacks
40950:ArgumentError: regex crate utf8 backend for Regexp only supports UTF-8 haystacks
41685:ArgumentError: regex crate utf8 backend for Regexp only supports UTF-8 haystacks
70970:ArgumentError: regex crate utf8 backend for Regexp only supports UTF-8 haystacks
71027:ArgumentError: regex crate utf8 backend for Regexp only supports UTF-8 haystacks
$
```

### mem-unsafety branch

```console
$ cargo run --bin spec-runner -q -- all-core-specs.toml > mem-unsafety.txt
$ rg haystack mem-unsafety.txt
$
```