### PR TITLE
Add specialized byte buffer backends to `spinoso-string`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-string"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "bstr",
  "bytecount",

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -33,7 +33,7 @@ spinoso-math = { version = "0.3.0", path = "../spinoso-math", optional = true, d
 spinoso-random = { version = "0.3.0", path = "../spinoso-random", optional = true }
 spinoso-regexp = { version = "0.3.0", path = "../spinoso-regexp", optional = true, default-features = false }
 spinoso-securerandom = { version = "0.2.0", path = "../spinoso-securerandom", optional = true }
-spinoso-string = { version = "0.19.0", path = "../spinoso-string" }
+spinoso-string = { version = "0.19.0", path = "../spinoso-string", features = ["always-nul-terminated-c-string-compat"] }
 spinoso-symbol = { version = "0.3.0", path = "../spinoso-symbol" }
 spinoso-time = { version = "0.5.0", path = "../spinoso-time", features = ["chrono"], default-features = false, optional = true }
 

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -33,7 +33,7 @@ spinoso-math = { version = "0.3.0", path = "../spinoso-math", optional = true, d
 spinoso-random = { version = "0.3.0", path = "../spinoso-random", optional = true }
 spinoso-regexp = { version = "0.3.0", path = "../spinoso-regexp", optional = true, default-features = false }
 spinoso-securerandom = { version = "0.2.0", path = "../spinoso-securerandom", optional = true }
-spinoso-string = { version = "0.18.0", path = "../spinoso-string" }
+spinoso-string = { version = "0.19.0", path = "../spinoso-string" }
 spinoso-symbol = { version = "0.3.0", path = "../spinoso-symbol" }
 spinoso-time = { version = "0.5.0", path = "../spinoso-time", features = ["chrono"], default-features = false, optional = true }
 

--- a/artichoke-backend/src/extn/core/string/ffi.rs
+++ b/artichoke-backend/src/extn/core/string/ffi.rs
@@ -27,20 +27,7 @@ use crate::value::Value;
 #[no_mangle]
 unsafe extern "C" fn mrb_str_new_capa(mrb: *mut sys::mrb_state, capa: usize) -> sys::mrb_value {
     unwrap_interpreter!(mrb, to => guard);
-
-    let alloc_capacity = if let Some(capacity) = capa.checked_add(1) {
-        capacity
-    } else {
-        let err = ArgumentError::with_message("string capacity too large");
-        error::raise(guard, err);
-    };
-    // SAFETY: mruby assumes strings are allocated with `capacity = capa + 1`
-    // and that last byte is NUL.
-    let mut result = String::with_capacity(alloc_capacity);
-    let ptr = result.as_mut_ptr();
-    let last = ptr.add(capa);
-    *last = 0;
-
+    let result = String::with_capacity(capa);
     let result = String::alloc_value(result, &mut guard);
     match result {
         Ok(value) => value.inner(),
@@ -53,25 +40,19 @@ unsafe extern "C" fn mrb_str_new_capa(mrb: *mut sys::mrb_state, capa: usize) -> 
 // ```
 #[no_mangle]
 unsafe extern "C" fn mrb_str_new(mrb: *mut sys::mrb_state, p: *const c_char, len: usize) -> sys::mrb_value {
-    // SAFETY: delegate to `mrb_str_new_capa` to properly handle allocation and
-    // trailing NUL bytes.
-    let s = mrb_str_new_capa(mrb, len);
-
-    let rstring = s.value.p.cast::<sys::RString>();
-    let rstring_ptr = (*rstring).as_.heap.ptr;
-    let dest_slice = slice::from_raw_parts_mut(rstring_ptr, len);
-
-    if p.is_null() {
-        for byte in dest_slice {
-            *byte = 0;
-        }
+    unwrap_interpreter!(mrb, to => guard);
+    let s = if p.is_null() {
+        String::utf8(vec![0; len])
     } else {
-        let bytes = slice::from_raw_parts(p, len);
-        dest_slice.copy_from_slice(bytes);
+        let bytes = slice::from_raw_parts(p.cast::<u8>(), len);
+        let bytes = bytes.to_vec();
+        String::utf8(bytes)
+    };
+    let result = String::alloc_value(s, &mut guard);
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => error::raise(guard, exception),
     }
-    // Pack the new length from the `memcpy` into the `RString*`.
-    (*rstring).as_.heap.len = len as sys::mrb_int;
-    s
 }
 
 // ```c
@@ -79,9 +60,15 @@ unsafe extern "C" fn mrb_str_new(mrb: *mut sys::mrb_state, p: *const c_char, len
 // ```
 #[no_mangle]
 unsafe extern "C" fn mrb_str_new_cstr(mrb: *mut sys::mrb_state, p: *const c_char) -> sys::mrb_value {
+    unwrap_interpreter!(mrb, to => guard);
     let cstr = CStr::from_ptr(p);
-    let len = cstr.to_bytes().len();
-    mrb_str_new(mrb, p, len)
+    let bytes = cstr.to_bytes().to_vec();
+    let result = String::utf8(bytes);
+    let result = String::alloc_value(result, &mut guard);
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => error::raise(guard, exception),
+    }
 }
 
 // ```c
@@ -267,15 +254,10 @@ unsafe extern "C" fn mrb_str_plus(mrb: *mut sys::mrb_state, a: sys::mrb_value, b
         return Value::nil().into();
     };
 
-    let mut s = String::with_capacity_and_encoding(a.len() + b.len() + 1, a.encoding());
+    let mut s = String::with_capacity_and_encoding(a.len() + b.len(), a.encoding());
 
     s.extend_from_slice(a.as_slice());
     s.extend_from_slice(b.as_slice());
-
-    // SAFETY: mruby assumes strings are allocated with `capacity = capa + 1`
-    // and that last byte is NUL.
-    s.push_byte(0);
-    s.set_len(a.len() + b.len());
 
     let s = String::alloc_value(s, &mut guard).unwrap_or_default();
     s.into()
@@ -357,25 +339,19 @@ unsafe extern "C" fn mrb_str_dup(mrb: *mut sys::mrb_state, s: sys::mrb_value) ->
     let basic = sys::mrb_sys_basic_ptr(s).cast::<sys::RString>();
     let class = (*basic).c;
 
-    let (ptr, len) = if let Ok(mut string) = String::unbox_from_value(&mut string, &mut guard) {
-        // SAFETY: string is not modified.
-        let string_mut = string.as_inner_mut();
+    if let Ok(string) = String::unbox_from_value(&mut string, &mut guard) {
+        let dup = string.clone();
+        if let Ok(value) = String::alloc_value(dup, &mut guard) {
+            let value = value.inner();
 
-        (string_mut.as_mut_ptr(), string_mut.len())
-    } else {
-        return Value::nil().into();
-    };
+            // dup'd strings keep the class of the source `String`.
+            let dup_basic = sys::mrb_sys_basic_ptr(value).cast::<sys::RString>();
+            (*dup_basic).c = class;
 
-    drop(guard);
-
-    // SAFETY: delegate to `mrb_str_new` to maintain invariants around capacity
-    // and trailing NUL bytes.
-    let dup = mrb_str_new(mrb, ptr.cast::<c_char>(), len);
-    // dup'd strings keep the class of the source `String`.
-    let dup_basic = sys::mrb_sys_basic_ptr(dup).cast::<sys::RString>();
-    (*dup_basic).c = class;
-
-    dup
+            return value;
+        }
+    }
+    Value::nil().into()
 }
 
 // ```c
@@ -629,14 +605,6 @@ unsafe extern "C" fn mrb_str_cat(
         // The string is repacked before any intervening mruby heap allocations.
         let string_mut = string.as_inner_mut();
         string_mut.extend_from_slice(slice);
-
-        // SAFETY: mruby assumes strings are allocated with `capacity = capa + 1`
-        // and that last byte is NUL.
-        let len = string_mut.len();
-        string_mut.reserve_exact(1);
-        string_mut.push_byte(0);
-        string_mut.set_len(len);
-
         let inner = string.take();
         let value = String::box_into_value(inner, s, &mut guard).expect("String reboxing should not fail");
 

--- a/artichoke-backend/src/extn/core/symbol/ffi.rs
+++ b/artichoke-backend/src/extn/core/symbol/ffi.rs
@@ -100,13 +100,10 @@ unsafe extern "C" fn mrb_intern_check_str(mrb: *mut sys::mrb_state, name: sys::m
     let name = Value::from(name);
     if let Ok(bytes) = name.try_convert_into_mut::<&[u8]>(&mut guard) {
         if let Ok(Some(sym)) = guard.check_interned_bytes(bytes) {
-            sym
-        } else {
-            0
+            return sym;
         }
-    } else {
-        0
     }
+    0
 }
 
 // `mrb_check_intern` series functions returns `nil` if the symbol is not
@@ -166,10 +163,10 @@ unsafe extern "C" fn mrb_check_intern_str(mrb: *mut sys::mrb_state, name: sys::m
 // MRB_API const char *mrb_sym_name(mrb_state*,mrb_sym);
 // ```
 #[no_mangle]
-unsafe extern "C" fn mrb_sym_name(mrb: *mut sys::mrb_state, sym: sys::mrb_sym) -> *const i8 {
+unsafe extern "C" fn mrb_sym_name(mrb: *mut sys::mrb_state, sym: sys::mrb_sym) -> *const c_char {
     unwrap_interpreter!(mrb, to => guard, or_else = ptr::null());
     if let Ok(Some(bytes)) = guard.lookup_symbol_with_trailing_nul(sym) {
-        bytes.as_ptr().cast::<i8>()
+        bytes.as_ptr().cast::<c_char>()
     } else {
         ptr::null()
     }

--- a/artichoke-backend/src/extn/core/symbol/ffi.rs
+++ b/artichoke-backend/src/extn/core/symbol/ffi.rs
@@ -228,35 +228,12 @@ unsafe extern "C" fn mrb_sym_dump(mrb: *mut sys::mrb_state, sym: sys::mrb_sym) -
 unsafe extern "C" fn mrb_sym_str(mrb: *mut sys::mrb_state, sym: sys::mrb_sym) -> sys::mrb_value {
     unwrap_interpreter!(mrb, to => guard);
 
-    let mut bytes = if let Ok(Some(bytes)) = guard.lookup_symbol(sym) {
-        bytes.to_vec()
+    let value = if let Ok(Some(bytes)) = guard.lookup_symbol(sym) {
+        let bytes = bytes.to_vec();
+        guard.try_convert_mut(bytes)
     } else {
-        vec![]
+        guard.try_convert_mut("")
     };
-
-    // SAFETY: ensure the byte buffer is NUL-terminated.
-    //
-    // Add a NUL byte to the end of the allocation for the byte buffer in
-    // the new `RString*`.
-    //
-    // mruby assumes that symbols are stored in memory as a null terminated
-    // `char*`s and creates "static" `RString`s from interned bytes that
-    // point at this NUL terminated memory.
-    //
-    // Sometimes mruby grabs the `RString` pointer directly from value
-    // returned by this API call and assumes it is NUL terminated.
-    //
-    // Add a 0 byte to the end of the `Vec` to ensure that the byte at index
-    // `len + 1` is NUL. Then set the length to the length of the `Vec` to
-    // hide the NUL byte.
-    //
-    // See https://github.com/artichoke/artichoke/pull/1969.
-    let len = bytes.len();
-    bytes.reserve_exact(1);
-    bytes.push(0);
-    bytes.set_len(len);
-
-    let value = guard.try_convert_mut(bytes);
     value.unwrap_or_default().inner()
 }
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -477,7 +477,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-string"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "bstr",
  "bytecount",

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -632,7 +632,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-string"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "bstr",
  "bytecount",

--- a/spinoso-string/Cargo.toml
+++ b/spinoso-string/Cargo.toml
@@ -31,6 +31,10 @@ casecmp = ["focaccia"]
 #
 # Enable runtime SIMD dispatch in `bytecount` and `simdutf8` dependencies.
 std = ["bytecount/runtime-dispatch-simd", "simdutf8/std"]
+# Use an alternate byte buffer backend that ensures string content is always
+# followed by a NUL byte. This feature can be used to ensure spinoso strings are
+# FFI compatible with C code that expects byte content to be NUL terminated.
+always-nul-terminated-c-string-compat = []
 
 [package.metadata.docs.rs]
 all-features = true

--- a/spinoso-string/Cargo.toml
+++ b/spinoso-string/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spinoso-string"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2021"
 rust-version = "1.62.0"

--- a/spinoso-string/README.md
+++ b/spinoso-string/README.md
@@ -38,12 +38,16 @@ This crate is `no_std` compatible with a required dependency on [`alloc`].
 
 ## Crate features
 
-All features are enabled by default.
+All features are enabled by default unless otherwise noted.
 
 - **casecmp** - Enables ASCII and Unicode `casecmp` methods on `String`.
   Activating this feature enables a dependency on [`focaccia`].
 - **std** - Enables a dependency on the Rust Standard Library. Activating this
   feature enables [`std::error::Error`] impls on error types in this crate.
+- **always-nul-terminated-c-string-compat** - NOT enabled by default. Use an
+  alternate byte buffer backend that ensures string content is always followed
+  by a NUL byte. This feature can be used to ensure spinoso strings are FFI
+  compatible with C code that expects byte content to be NUL terminated.
 
 [`focaccia`]: https://docs.rs/focaccia
 [`std::error::error`]: https://doc.rust-lang.org/std/error/trait.Error.html

--- a/spinoso-string/README.md
+++ b/spinoso-string/README.md
@@ -27,7 +27,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-spinoso-string = "0.18.0"
+spinoso-string = "0.19.0"
 ```
 
 ## `no_std`

--- a/spinoso-string/src/buf/mod.rs
+++ b/spinoso-string/src/buf/mod.rs
@@ -1,0 +1,5 @@
+mod vec;
+
+use vec as imp;
+
+pub use imp::Buf;

--- a/spinoso-string/src/buf/mod.rs
+++ b/spinoso-string/src/buf/mod.rs
@@ -1,5 +1,8 @@
+mod nul_terminated_vec;
 mod vec;
 
-use vec as imp;
-
 pub use imp::Buf;
+#[cfg(feature = "always-nul-terminated-c-string-compat")]
+use nul_terminated_vec as imp;
+#[cfg(not(feature = "always-nul-terminated-c-string-compat"))]
+use vec as imp;

--- a/spinoso-string/src/buf/nul_terminated_vec.rs
+++ b/spinoso-string/src/buf/nul_terminated_vec.rs
@@ -1,0 +1,376 @@
+use alloc::boxed::Box;
+use alloc::collections::TryReserveError;
+use alloc::vec::{Drain, Splice, Vec};
+use core::borrow::Borrow;
+#[cfg(feature = "std")]
+use core::fmt::Arguments;
+use core::mem::MaybeUninit;
+use core::ops::{Deref, DerefMut, RangeBounds};
+#[cfg(feature = "std")]
+use std::io::{self, IoSlice, Write};
+
+use bstr::ByteVec;
+use raw_parts::RawParts;
+
+#[repr(transparent)]
+#[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Buf {
+    inner: Vec<u8>,
+}
+
+impl From<Vec<u8>> for Buf {
+    #[inline]
+    fn from(vec: Vec<u8>) -> Self {
+        Self { inner: vec }
+    }
+}
+
+impl From<Buf> for Vec<u8> {
+    #[inline]
+    fn from(buf: Buf) -> Self {
+        buf.inner
+    }
+}
+
+impl Deref for Buf {
+    type Target = [u8];
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        &*self.inner
+    }
+}
+
+impl DerefMut for Buf {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut *self.inner
+    }
+}
+
+impl Borrow<[u8]> for Buf {
+    #[inline]
+    fn borrow(&self) -> &[u8] {
+        &self.inner
+    }
+}
+
+impl FromIterator<u8> for Buf {
+    #[inline]
+    fn from_iter<T>(iter: T) -> Self
+    where
+        T: IntoIterator<Item = u8>,
+    {
+        let inner = iter.into_iter().collect();
+        Self { inner }
+    }
+}
+
+impl Extend<u8> for Buf {
+    #[inline]
+    fn extend<I: IntoIterator<Item = u8>>(&mut self, iter: I) {
+        self.inner.extend(iter.into_iter());
+    }
+}
+
+impl Buf {
+    #[inline]
+    pub fn new() -> Self {
+        let inner = Vec::new();
+        Self { inner }
+    }
+
+    #[inline]
+    pub fn with_capacity(capacity: usize) -> Self {
+        let inner = Vec::with_capacity(capacity);
+        Self { inner }
+    }
+
+    #[inline]
+    pub unsafe fn from_raw_parts(raw_parts: RawParts<u8>) -> Self {
+        let inner = RawParts::into_vec(raw_parts);
+        Self { inner }
+    }
+
+    #[inline]
+    pub fn into_raw_parts(self) -> RawParts<u8> {
+        RawParts::from_vec(self.inner)
+    }
+
+    #[inline]
+    pub fn capacity(&self) -> usize {
+        self.inner.capacity()
+    }
+
+    #[inline]
+    pub fn reserve(&mut self, additional: usize) {
+        self.inner.reserve(additional);
+    }
+
+    #[inline]
+    pub fn reserve_exact(&mut self, additional: usize) {
+        self.inner.reserve_exact(additional);
+    }
+
+    #[inline]
+    pub fn try_reserve(&mut self, additional: usize) -> Result<(), TryReserveError> {
+        self.inner.try_reserve(additional)
+    }
+
+    #[inline]
+    pub fn try_reserve_exact(&mut self, additional: usize) -> Result<(), TryReserveError> {
+        self.inner.try_reserve_exact(additional)
+    }
+
+    #[inline]
+    pub fn shrink_to_fit(&mut self) {
+        self.inner.shrink_to_fit();
+    }
+
+    #[inline]
+    pub fn shrink_to(&mut self, min_capacity: usize) {
+        self.inner.shrink_to(min_capacity);
+    }
+
+    #[inline]
+    pub fn into_boxed_slice(self) -> Box<[u8]> {
+        self.inner.into_boxed_slice()
+    }
+
+    #[inline]
+    pub fn truncate(&mut self, len: usize) {
+        self.inner.truncate(len);
+    }
+
+    #[inline]
+    pub fn as_slice(&self) -> &[u8] {
+        self.inner.as_slice()
+    }
+
+    #[inline]
+    pub fn as_mut_slice(&mut self) -> &mut [u8] {
+        self.inner.as_mut_slice()
+    }
+
+    #[inline]
+    pub fn as_ptr(&self) -> *const u8 {
+        self.inner.as_ptr()
+    }
+
+    #[inline]
+    pub fn as_mut_ptr(&mut self) -> *mut u8 {
+        self.inner.as_mut_ptr()
+    }
+
+    #[inline]
+    pub unsafe fn set_len(&mut self, new_len: usize) {
+        self.inner.set_len(new_len)
+    }
+
+    #[inline]
+    pub fn swap_remove(&mut self, index: usize) -> u8 {
+        self.inner.swap_remove(index)
+    }
+
+    #[inline]
+    pub fn insert(&mut self, index: usize, element: u8) {
+        self.inner.insert(index, element);
+    }
+
+    #[inline]
+    pub fn remove(&mut self, index: usize) -> u8 {
+        self.inner.remove(index)
+    }
+
+    #[inline]
+    pub fn retain<F>(&mut self, f: F)
+    where
+        F: FnMut(&u8) -> bool,
+    {
+        self.inner.retain(f);
+    }
+
+    #[inline]
+    pub fn retain_mut<F>(&mut self, f: F)
+    where
+        F: FnMut(&mut u8) -> bool,
+    {
+        self.inner.retain_mut(f);
+    }
+
+    #[inline]
+    pub fn dedup_by_key<F, K>(&mut self, key: F)
+    where
+        F: FnMut(&mut u8) -> K,
+        K: PartialEq<K>,
+    {
+        self.inner.dedup_by_key(key);
+    }
+
+    #[inline]
+    pub fn dedup_by<F>(&mut self, same_bucket: F)
+    where
+        F: FnMut(&mut u8, &mut u8) -> bool,
+    {
+        self.inner.dedup_by(same_bucket);
+    }
+
+    #[inline]
+    pub fn push(&mut self, value: u8) {
+        self.inner.push(value);
+    }
+
+    #[inline]
+    pub fn pop(&mut self) -> Option<u8> {
+        self.inner.pop()
+    }
+
+    #[inline]
+    pub fn append(&mut self, other: &mut Buf) {
+        self.inner.append(&mut other.inner);
+    }
+
+    #[inline]
+    pub fn drain<R>(&mut self, range: R) -> Drain<'_, u8>
+    where
+        R: RangeBounds<usize>,
+    {
+        self.inner.drain(range)
+    }
+
+    #[inline]
+    pub fn clear(&mut self) {
+        self.inner.clear();
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    #[inline]
+    pub fn split_off(&mut self, at: usize) -> Buf {
+        let split = self.inner.split_off(at);
+        Self { inner: split }
+    }
+
+    #[inline]
+    pub fn resize_with<F>(&mut self, new_len: usize, f: F)
+    where
+        F: FnMut() -> u8,
+    {
+        self.inner.resize_with(new_len, f);
+    }
+
+    #[inline]
+    pub fn leak<'a>(self) -> &'a mut [u8] {
+        self.inner.leak()
+    }
+
+    #[inline]
+    pub fn spare_capacity_mut(&mut self) -> &mut [MaybeUninit<u8>] {
+        self.inner.spare_capacity_mut()
+    }
+}
+
+impl Buf
+where
+    u8: Clone,
+{
+    #[inline]
+    pub fn resize(&mut self, new_len: usize, value: u8) {
+        self.inner.resize(new_len, value);
+    }
+
+    #[inline]
+    pub fn extend_from_slice(&mut self, other: &[u8]) {
+        self.inner.extend_from_slice(other);
+    }
+
+    #[inline]
+    pub fn extend_from_within<R>(&mut self, src: R)
+    where
+        R: RangeBounds<usize>,
+    {
+        self.inner.extend_from_within(src);
+    }
+}
+
+impl Buf
+where
+    u8: PartialEq<u8>,
+{
+    #[inline]
+    pub fn dedup(&mut self) {
+        self.inner.dedup();
+    }
+}
+
+impl Buf {
+    #[inline]
+    pub fn splice<R, I>(&mut self, range: R, replace_with: I) -> Splice<'_, <I as IntoIterator>::IntoIter>
+    where
+        R: RangeBounds<usize>,
+        I: IntoIterator<Item = u8>,
+    {
+        self.inner.splice(range, replace_with)
+    }
+}
+
+impl Buf {
+    #[inline]
+    pub fn into_inner(self) -> Vec<u8> {
+        self.inner
+    }
+}
+
+// bstr bytevec impls
+impl Buf {
+    #[inline]
+    pub fn push_byte(&mut self, byte: u8) {
+        self.inner.push_byte(byte);
+    }
+
+    #[inline]
+    pub fn push_char(&mut self, ch: char) {
+        self.inner.push_char(ch);
+    }
+
+    #[inline]
+    pub fn push_str<B: AsRef<[u8]>>(&mut self, bytes: B) {
+        self.inner.push_str(bytes);
+    }
+}
+
+#[cfg(feature = "std")]
+impl Write for Buf {
+    #[inline]
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.inner.write(buf)
+    }
+
+    #[inline]
+    fn flush(&mut self) -> io::Result<()> {
+        self.inner.flush()
+    }
+
+    #[inline]
+    fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
+        self.inner.write_vectored(bufs)
+    }
+
+    #[inline]
+    fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
+        self.inner.write_all(buf)
+    }
+
+    #[inline]
+    fn write_fmt(&mut self, fmt: Arguments<'_>) -> io::Result<()> {
+        self.inner.write_fmt(fmt)
+    }
+}

--- a/spinoso-string/src/buf/nul_terminated_vec.rs
+++ b/spinoso-string/src/buf/nul_terminated_vec.rs
@@ -69,6 +69,8 @@ impl Deref for Buf {
 impl DerefMut for Buf {
     #[inline]
     fn deref_mut(&mut self) -> &mut Self::Target {
+        // SAFETY: the mutable reference given out is a slice, NOT the underlying
+        // `Vec`, so the allocation cannot change size.
         &mut *self.inner
     }
 }
@@ -118,7 +120,10 @@ impl Buf {
 
     #[inline]
     pub unsafe fn from_raw_parts(raw_parts: RawParts<u8>) -> Self {
-        let inner = RawParts::into_vec(raw_parts);
+        let mut inner = RawParts::into_vec(raw_parts);
+        // SAFETY: callers may have written into the spare capacity of the `Vec`
+        // so we must ensure the NUL termination byte is still present.
+        ensure_nul_terminated(&mut inner);
         Self { inner }
     }
 

--- a/spinoso-string/src/buf/nul_terminated_vec.rs
+++ b/spinoso-string/src/buf/nul_terminated_vec.rs
@@ -151,6 +151,7 @@ impl Buf {
 
     #[inline]
     pub fn try_reserve(&mut self, additional: usize) -> Result<(), TryReserveError> {
+        let additional = additional.checked_add(1).unwrap_or(additional);
         self.inner.try_reserve(additional)?;
         ensure_nul_terminated(&mut self.inner);
         Ok(())
@@ -158,6 +159,7 @@ impl Buf {
 
     #[inline]
     pub fn try_reserve_exact(&mut self, additional: usize) -> Result<(), TryReserveError> {
+        let additional = additional.checked_add(1).unwrap_or(additional);
         self.inner.try_reserve_exact(additional)?;
         ensure_nul_terminated(&mut self.inner);
         Ok(())

--- a/spinoso-string/src/buf/nul_terminated_vec.rs
+++ b/spinoso-string/src/buf/nul_terminated_vec.rs
@@ -29,14 +29,23 @@ fn ensure_nul_terminated(vec: &mut Vec<u8>) {
 }
 
 #[repr(transparent)]
-#[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Default, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Buf {
     inner: Vec<u8>,
 }
 
+impl Clone for Buf {
+    fn clone(&self) -> Self {
+        let mut vec = self.inner.clone();
+        ensure_nul_terminated(&mut vec);
+        Self { inner: vec }
+    }
+}
+
 impl From<Vec<u8>> for Buf {
     #[inline]
-    fn from(vec: Vec<u8>) -> Self {
+    fn from(mut vec: Vec<u8>) -> Self {
+        ensure_nul_terminated(&mut vec);
         Self { inner: vec }
     }
 }

--- a/spinoso-string/src/buf/nul_terminated_vec.rs
+++ b/spinoso-string/src/buf/nul_terminated_vec.rs
@@ -103,13 +103,15 @@ impl Extend<u8> for Buf {
 impl Buf {
     #[inline]
     pub fn new() -> Self {
-        let inner = Vec::new();
+        let mut inner = Vec::with_capacity(1);
+        ensure_nul_terminated(&mut inner);
         Self { inner }
     }
 
     #[inline]
     pub fn with_capacity(capacity: usize) -> Self {
-        let inner = Vec::with_capacity(capacity);
+        let capacity = capacity.checked_add(1).expect("capacity overflow");
+        let mut inner = Vec::with_capacity(capacity);
         ensure_nul_terminated(&mut inner);
         Self { inner }
     }

--- a/spinoso-string/src/buf/vec.rs
+++ b/spinoso-string/src/buf/vec.rs
@@ -164,7 +164,7 @@ impl Buf {
 
     #[inline]
     pub unsafe fn set_len(&mut self, new_len: usize) {
-        self.inner.set_len(new_len)
+        self.inner.set_len(new_len);
     }
 
     #[inline]

--- a/spinoso-string/src/buf/vec.rs
+++ b/spinoso-string/src/buf/vec.rs
@@ -1,0 +1,376 @@
+use alloc::boxed::Box;
+use alloc::collections::TryReserveError;
+use alloc::vec::{Drain, Splice, Vec};
+use core::borrow::Borrow;
+#[cfg(feature = "std")]
+use core::fmt::Arguments;
+use core::mem::MaybeUninit;
+use core::ops::{Deref, DerefMut, RangeBounds};
+#[cfg(feature = "std")]
+use std::io::{self, IoSlice, Write};
+
+use bstr::ByteVec;
+use raw_parts::RawParts;
+
+#[repr(transparent)]
+#[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Buf {
+    inner: Vec<u8>,
+}
+
+impl From<Vec<u8>> for Buf {
+    #[inline]
+    fn from(vec: Vec<u8>) -> Self {
+        Self { inner: vec }
+    }
+}
+
+impl From<Buf> for Vec<u8> {
+    #[inline]
+    fn from(buf: Buf) -> Self {
+        buf.inner
+    }
+}
+
+impl Deref for Buf {
+    type Target = [u8];
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        &*self.inner
+    }
+}
+
+impl DerefMut for Buf {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut *self.inner
+    }
+}
+
+impl Borrow<[u8]> for Buf {
+    #[inline]
+    fn borrow(&self) -> &[u8] {
+        &self.inner
+    }
+}
+
+impl FromIterator<u8> for Buf {
+    #[inline]
+    fn from_iter<T>(iter: T) -> Self
+    where
+        T: IntoIterator<Item = u8>,
+    {
+        let inner = iter.into_iter().collect();
+        Self { inner }
+    }
+}
+
+impl Extend<u8> for Buf {
+    #[inline]
+    fn extend<I: IntoIterator<Item = u8>>(&mut self, iter: I) {
+        self.inner.extend(iter.into_iter());
+    }
+}
+
+impl Buf {
+    #[inline]
+    pub fn new() -> Self {
+        let inner = Vec::new();
+        Self { inner }
+    }
+
+    #[inline]
+    pub fn with_capacity(capacity: usize) -> Self {
+        let inner = Vec::with_capacity(capacity);
+        Self { inner }
+    }
+
+    #[inline]
+    pub unsafe fn from_raw_parts(raw_parts: RawParts<u8>) -> Self {
+        let inner = RawParts::into_vec(raw_parts);
+        Self { inner }
+    }
+
+    #[inline]
+    pub fn into_raw_parts(self) -> RawParts<u8> {
+        RawParts::from_vec(self.inner)
+    }
+
+    #[inline]
+    pub fn capacity(&self) -> usize {
+        self.inner.capacity()
+    }
+
+    #[inline]
+    pub fn reserve(&mut self, additional: usize) {
+        self.inner.reserve(additional);
+    }
+
+    #[inline]
+    pub fn reserve_exact(&mut self, additional: usize) {
+        self.inner.reserve_exact(additional);
+    }
+
+    #[inline]
+    pub fn try_reserve(&mut self, additional: usize) -> Result<(), TryReserveError> {
+        self.inner.try_reserve(additional)
+    }
+
+    #[inline]
+    pub fn try_reserve_exact(&mut self, additional: usize) -> Result<(), TryReserveError> {
+        self.inner.try_reserve_exact(additional)
+    }
+
+    #[inline]
+    pub fn shrink_to_fit(&mut self) {
+        self.inner.shrink_to_fit();
+    }
+
+    #[inline]
+    pub fn shrink_to(&mut self, min_capacity: usize) {
+        self.inner.shrink_to(min_capacity);
+    }
+
+    #[inline]
+    pub fn into_boxed_slice(self) -> Box<[u8]> {
+        self.inner.into_boxed_slice()
+    }
+
+    #[inline]
+    pub fn truncate(&mut self, len: usize) {
+        self.inner.truncate(len);
+    }
+
+    #[inline]
+    pub fn as_slice(&self) -> &[u8] {
+        self.inner.as_slice()
+    }
+
+    #[inline]
+    pub fn as_mut_slice(&mut self) -> &mut [u8] {
+        self.inner.as_mut_slice()
+    }
+
+    #[inline]
+    pub fn as_ptr(&self) -> *const u8 {
+        self.inner.as_ptr()
+    }
+
+    #[inline]
+    pub fn as_mut_ptr(&mut self) -> *mut u8 {
+        self.inner.as_mut_ptr()
+    }
+
+    #[inline]
+    pub unsafe fn set_len(&mut self, new_len: usize) {
+        self.inner.set_len(new_len)
+    }
+
+    #[inline]
+    pub fn swap_remove(&mut self, index: usize) -> u8 {
+        self.inner.swap_remove(index)
+    }
+
+    #[inline]
+    pub fn insert(&mut self, index: usize, element: u8) {
+        self.inner.insert(index, element);
+    }
+
+    #[inline]
+    pub fn remove(&mut self, index: usize) -> u8 {
+        self.inner.remove(index)
+    }
+
+    #[inline]
+    pub fn retain<F>(&mut self, f: F)
+    where
+        F: FnMut(&u8) -> bool,
+    {
+        self.inner.retain(f);
+    }
+
+    #[inline]
+    pub fn retain_mut<F>(&mut self, f: F)
+    where
+        F: FnMut(&mut u8) -> bool,
+    {
+        self.inner.retain_mut(f);
+    }
+
+    #[inline]
+    pub fn dedup_by_key<F, K>(&mut self, key: F)
+    where
+        F: FnMut(&mut u8) -> K,
+        K: PartialEq<K>,
+    {
+        self.inner.dedup_by_key(key);
+    }
+
+    #[inline]
+    pub fn dedup_by<F>(&mut self, same_bucket: F)
+    where
+        F: FnMut(&mut u8, &mut u8) -> bool,
+    {
+        self.inner.dedup_by(same_bucket);
+    }
+
+    #[inline]
+    pub fn push(&mut self, value: u8) {
+        self.inner.push(value);
+    }
+
+    #[inline]
+    pub fn pop(&mut self) -> Option<u8> {
+        self.inner.pop()
+    }
+
+    #[inline]
+    pub fn append(&mut self, other: &mut Buf) {
+        self.inner.append(&mut other.inner);
+    }
+
+    #[inline]
+    pub fn drain<R>(&mut self, range: R) -> Drain<'_, u8>
+    where
+        R: RangeBounds<usize>,
+    {
+        self.inner.drain(range)
+    }
+
+    #[inline]
+    pub fn clear(&mut self) {
+        self.inner.clear();
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    #[inline]
+    pub fn split_off(&mut self, at: usize) -> Buf {
+        let split = self.inner.split_off(at);
+        Self { inner: split }
+    }
+
+    #[inline]
+    pub fn resize_with<F>(&mut self, new_len: usize, f: F)
+    where
+        F: FnMut() -> u8,
+    {
+        self.inner.resize_with(new_len, f);
+    }
+
+    #[inline]
+    pub fn leak<'a>(self) -> &'a mut [u8] {
+        self.inner.leak()
+    }
+
+    #[inline]
+    pub fn spare_capacity_mut(&mut self) -> &mut [MaybeUninit<u8>] {
+        self.inner.spare_capacity_mut()
+    }
+}
+
+impl Buf
+where
+    u8: Clone,
+{
+    #[inline]
+    pub fn resize(&mut self, new_len: usize, value: u8) {
+        self.inner.resize(new_len, value);
+    }
+
+    #[inline]
+    pub fn extend_from_slice(&mut self, other: &[u8]) {
+        self.inner.extend_from_slice(other);
+    }
+
+    #[inline]
+    pub fn extend_from_within<R>(&mut self, src: R)
+    where
+        R: RangeBounds<usize>,
+    {
+        self.inner.extend_from_within(src);
+    }
+}
+
+impl Buf
+where
+    u8: PartialEq<u8>,
+{
+    #[inline]
+    pub fn dedup(&mut self) {
+        self.inner.dedup();
+    }
+}
+
+impl Buf {
+    #[inline]
+    pub fn splice<R, I>(&mut self, range: R, replace_with: I) -> Splice<'_, <I as IntoIterator>::IntoIter>
+    where
+        R: RangeBounds<usize>,
+        I: IntoIterator<Item = u8>,
+    {
+        self.inner.splice(range, replace_with)
+    }
+}
+
+impl Buf {
+    #[inline]
+    pub fn into_inner(self) -> Vec<u8> {
+        self.inner
+    }
+}
+
+// bstr bytevec impls
+impl Buf {
+    #[inline]
+    pub fn push_byte(&mut self, byte: u8) {
+        self.inner.push_byte(byte);
+    }
+
+    #[inline]
+    pub fn push_char(&mut self, ch: char) {
+        self.inner.push_char(ch);
+    }
+
+    #[inline]
+    pub fn push_str<B: AsRef<[u8]>>(&mut self, bytes: B) {
+        self.inner.push_str(bytes);
+    }
+}
+
+#[cfg(feature = "std")]
+impl Write for Buf {
+    #[inline]
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.inner.write(buf)
+    }
+
+    #[inline]
+    fn flush(&mut self) -> io::Result<()> {
+        self.inner.flush()
+    }
+
+    #[inline]
+    fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
+        self.inner.write_vectored(bufs)
+    }
+
+    #[inline]
+    fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
+        self.inner.write_all(buf)
+    }
+
+    #[inline]
+    fn write_fmt(&mut self, fmt: Arguments<'_>) -> io::Result<()> {
+        self.inner.write_fmt(fmt)
+    }
+}

--- a/spinoso-string/src/enc/ascii/impls.rs
+++ b/spinoso-string/src/enc/ascii/impls.rs
@@ -4,6 +4,7 @@ use alloc::vec::Vec;
 use core::ops::{Deref, DerefMut};
 
 use super::AsciiString;
+use crate::buf::Buf;
 
 impl Extend<u8> for AsciiString {
     #[inline]
@@ -26,10 +27,18 @@ impl<'a> Extend<&'a mut u8> for AsciiString {
     }
 }
 
+impl From<Buf> for AsciiString {
+    #[inline]
+    fn from(content: Buf) -> Self {
+        Self::new(content)
+    }
+}
+
 impl From<Vec<u8>> for AsciiString {
     #[inline]
     fn from(content: Vec<u8>) -> Self {
-        Self::new(content)
+        let buf = content.into();
+        Self::new(buf)
     }
 }
 
@@ -37,7 +46,7 @@ impl<const N: usize> From<[u8; N]> for AsciiString {
     #[inline]
     fn from(content: [u8; N]) -> Self {
         let buf = content.to_vec();
-        Self::new(buf)
+        Self::new(buf.into())
     }
 }
 
@@ -45,7 +54,7 @@ impl<const N: usize> From<&[u8; N]> for AsciiString {
     #[inline]
     fn from(content: &[u8; N]) -> Self {
         let buf = content.to_vec();
-        Self::new(buf)
+        Self::new(buf.into())
     }
 }
 
@@ -53,7 +62,7 @@ impl<'a> From<&'a [u8]> for AsciiString {
     #[inline]
     fn from(content: &'a [u8]) -> Self {
         let buf = content.to_vec();
-        Self::new(buf)
+        Self::new(buf.into())
     }
 }
 
@@ -61,7 +70,7 @@ impl<'a> From<&'a mut [u8]> for AsciiString {
     #[inline]
     fn from(content: &'a mut [u8]) -> Self {
         let buf = content.to_vec();
-        Self::new(buf)
+        Self::new(buf.into())
     }
 }
 
@@ -69,7 +78,7 @@ impl<'a> From<Cow<'a, [u8]>> for AsciiString {
     #[inline]
     fn from(content: Cow<'a, [u8]>) -> Self {
         let buf = content.into_owned();
-        Self::new(buf)
+        Self::new(buf.into())
     }
 }
 
@@ -77,7 +86,7 @@ impl From<String> for AsciiString {
     #[inline]
     fn from(s: String) -> Self {
         let buf = s.into_bytes();
-        Self::new(buf)
+        Self::new(buf.into())
     }
 }
 
@@ -85,14 +94,14 @@ impl From<&str> for AsciiString {
     #[inline]
     fn from(s: &str) -> Self {
         let buf = s.as_bytes().to_vec();
-        Self::new(buf)
+        Self::new(buf.into())
     }
 }
 
-impl From<AsciiString> for Vec<u8> {
+impl From<AsciiString> for Buf {
     #[inline]
     fn from(s: AsciiString) -> Self {
-        s.into_vec()
+        s.into_buf()
     }
 }
 

--- a/spinoso-string/src/enc/ascii/mod.rs
+++ b/spinoso-string/src/enc/ascii/mod.rs
@@ -1,11 +1,11 @@
 use alloc::collections::TryReserveError;
-use alloc::vec::Vec;
 use core::fmt;
 use core::ops::Range;
 use core::slice::SliceIndex;
 
-use bstr::{ByteSlice, ByteVec};
+use bstr::ByteSlice;
 
+use crate::buf::Buf;
 use crate::codepoints::InvalidCodepointError;
 use crate::iter::{Bytes, IntoIter, Iter, IterMut};
 use crate::ord::OrdError;
@@ -22,12 +22,12 @@ pub use inspect::Inspect;
 #[allow(clippy::module_name_repetitions)]
 #[derive(Default, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct AsciiString {
-    inner: Vec<u8>,
+    inner: Buf,
 }
 
 // Constructors
 impl AsciiString {
-    pub const fn new(buf: Vec<u8>) -> Self {
+    pub const fn new(buf: Buf) -> Self {
         Self { inner: buf }
     }
 }
@@ -44,7 +44,7 @@ impl fmt::Debug for AsciiString {
 impl AsciiString {
     #[inline]
     #[must_use]
-    pub fn into_vec(self) -> Vec<u8> {
+    pub fn into_buf(self) -> Buf {
         self.inner
     }
 
@@ -96,7 +96,7 @@ impl AsciiString {
     #[inline]
     #[must_use]
     pub fn into_iter(self) -> IntoIter {
-        IntoIter::from_vec(self.inner)
+        IntoIter::from_vec(self.inner.into_inner())
     }
 }
 

--- a/spinoso-string/src/enc/binary/impls.rs
+++ b/spinoso-string/src/enc/binary/impls.rs
@@ -4,6 +4,7 @@ use alloc::vec::Vec;
 use core::ops::{Deref, DerefMut};
 
 use super::BinaryString;
+use crate::buf::Buf;
 
 impl Extend<u8> for BinaryString {
     #[inline]
@@ -26,10 +27,18 @@ impl<'a> Extend<&'a mut u8> for BinaryString {
     }
 }
 
+impl From<Buf> for BinaryString {
+    #[inline]
+    fn from(content: Buf) -> Self {
+        Self::new(content)
+    }
+}
+
 impl From<Vec<u8>> for BinaryString {
     #[inline]
     fn from(content: Vec<u8>) -> Self {
-        Self::new(content)
+        let buf = content.into();
+        Self::new(buf)
     }
 }
 
@@ -37,7 +46,7 @@ impl<const N: usize> From<[u8; N]> for BinaryString {
     #[inline]
     fn from(content: [u8; N]) -> Self {
         let buf = content.to_vec();
-        Self::new(buf)
+        Self::new(buf.into())
     }
 }
 
@@ -45,7 +54,7 @@ impl<const N: usize> From<&[u8; N]> for BinaryString {
     #[inline]
     fn from(content: &[u8; N]) -> Self {
         let buf = content.to_vec();
-        Self::new(buf)
+        Self::new(buf.into())
     }
 }
 
@@ -53,7 +62,7 @@ impl<'a> From<&'a [u8]> for BinaryString {
     #[inline]
     fn from(content: &'a [u8]) -> Self {
         let buf = content.to_vec();
-        Self::new(buf)
+        Self::new(buf.into())
     }
 }
 
@@ -61,7 +70,7 @@ impl<'a> From<&'a mut [u8]> for BinaryString {
     #[inline]
     fn from(content: &'a mut [u8]) -> Self {
         let buf = content.to_vec();
-        Self::new(buf)
+        Self::new(buf.into())
     }
 }
 
@@ -69,7 +78,7 @@ impl<'a> From<Cow<'a, [u8]>> for BinaryString {
     #[inline]
     fn from(content: Cow<'a, [u8]>) -> Self {
         let buf = content.into_owned();
-        Self::new(buf)
+        Self::new(buf.into())
     }
 }
 
@@ -77,7 +86,7 @@ impl From<String> for BinaryString {
     #[inline]
     fn from(s: String) -> Self {
         let buf = s.into_bytes();
-        Self::new(buf)
+        Self::new(buf.into())
     }
 }
 
@@ -85,14 +94,14 @@ impl From<&str> for BinaryString {
     #[inline]
     fn from(s: &str) -> Self {
         let buf = s.as_bytes().to_vec();
-        Self::new(buf)
+        Self::new(buf.into())
     }
 }
 
-impl From<BinaryString> for Vec<u8> {
+impl From<BinaryString> for Buf {
     #[inline]
     fn from(s: BinaryString) -> Self {
-        s.into_vec()
+        s.into_buf()
     }
 }
 

--- a/spinoso-string/src/enc/binary/mod.rs
+++ b/spinoso-string/src/enc/binary/mod.rs
@@ -1,11 +1,11 @@
 use alloc::collections::TryReserveError;
-use alloc::vec::Vec;
 use core::fmt;
 use core::ops::Range;
 use core::slice::SliceIndex;
 
-use bstr::{ByteSlice, ByteVec};
+use bstr::ByteSlice;
 
+use crate::buf::Buf;
 use crate::codepoints::InvalidCodepointError;
 use crate::iter::{Bytes, IntoIter, Iter, IterMut};
 use crate::ord::OrdError;
@@ -22,12 +22,12 @@ pub use inspect::Inspect;
 #[allow(clippy::module_name_repetitions)]
 #[derive(Default, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct BinaryString {
-    inner: Vec<u8>,
+    inner: Buf,
 }
 
 // Constructors
 impl BinaryString {
-    pub const fn new(buf: Vec<u8>) -> Self {
+    pub const fn new(buf: Buf) -> Self {
         Self { inner: buf }
     }
 }
@@ -44,7 +44,7 @@ impl fmt::Debug for BinaryString {
 impl BinaryString {
     #[inline]
     #[must_use]
-    pub fn into_vec(self) -> Vec<u8> {
+    pub fn into_buf(self) -> Buf {
         self.inner
     }
 
@@ -96,7 +96,7 @@ impl BinaryString {
     #[inline]
     #[must_use]
     pub fn into_iter(self) -> IntoIter {
-        IntoIter::from_vec(self.inner)
+        IntoIter::from_vec(self.inner.into_inner())
     }
 }
 

--- a/spinoso-string/src/enc/mod.rs
+++ b/spinoso-string/src/enc/mod.rs
@@ -1,5 +1,4 @@
 use alloc::collections::TryReserveError;
-use alloc::vec::Vec;
 use core::borrow::Borrow;
 use core::cmp::Ordering;
 use core::hash::{Hash, Hasher};
@@ -10,6 +9,7 @@ use ascii::AsciiString;
 use binary::BinaryString;
 use utf8::Utf8String;
 
+use crate::buf::Buf;
 use crate::codepoints::InvalidCodepointError;
 use crate::encoding::Encoding;
 use crate::iter::{Bytes, IntoIter, Iter, IterMut};
@@ -34,7 +34,7 @@ pub enum EncodedString {
 
 impl Default for EncodedString {
     fn default() -> Self {
-        Self::utf8(Vec::new())
+        Self::utf8(Buf::new())
     }
 }
 
@@ -110,7 +110,7 @@ impl Borrow<[u8]> for EncodedString {
 impl EncodedString {
     #[inline]
     #[must_use]
-    pub const fn new(buf: Vec<u8>, encoding: Encoding) -> Self {
+    pub fn new(buf: Buf, encoding: Encoding) -> Self {
         match encoding {
             Encoding::Ascii => Self::ascii(buf),
             Encoding::Binary => Self::binary(buf),
@@ -120,19 +120,19 @@ impl EncodedString {
 
     #[inline]
     #[must_use]
-    pub const fn ascii(buf: Vec<u8>) -> Self {
+    pub fn ascii(buf: Buf) -> Self {
         Self::Ascii(AsciiString::new(buf))
     }
 
     #[inline]
     #[must_use]
-    pub const fn binary(buf: Vec<u8>) -> Self {
+    pub fn binary(buf: Buf) -> Self {
         Self::Binary(BinaryString::new(buf))
     }
 
     #[inline]
     #[must_use]
-    pub const fn utf8(buf: Vec<u8>) -> Self {
+    pub fn utf8(buf: Buf) -> Self {
         Self::Utf8(Utf8String::new(buf))
     }
 }
@@ -153,11 +153,11 @@ impl EncodedString {
 impl EncodedString {
     #[inline]
     #[must_use]
-    pub fn into_vec(self) -> Vec<u8> {
+    pub fn into_buf(self) -> Buf {
         match self {
-            EncodedString::Ascii(inner) => inner.into_vec(),
-            EncodedString::Binary(inner) => inner.into_vec(),
-            EncodedString::Utf8(inner) => inner.into_vec(),
+            EncodedString::Ascii(inner) => inner.into_buf(),
+            EncodedString::Binary(inner) => inner.into_buf(),
+            EncodedString::Utf8(inner) => inner.into_buf(),
         }
     }
 

--- a/spinoso-string/src/enc/utf8/impls.rs
+++ b/spinoso-string/src/enc/utf8/impls.rs
@@ -4,6 +4,7 @@ use alloc::vec::Vec;
 use core::ops::{Deref, DerefMut};
 
 use super::Utf8String;
+use crate::buf::Buf;
 
 impl Extend<u8> for Utf8String {
     #[inline]
@@ -26,10 +27,18 @@ impl<'a> Extend<&'a mut u8> for Utf8String {
     }
 }
 
+impl From<Buf> for Utf8String {
+    #[inline]
+    fn from(content: Buf) -> Self {
+        Self::new(content)
+    }
+}
+
 impl From<Vec<u8>> for Utf8String {
     #[inline]
     fn from(content: Vec<u8>) -> Self {
-        Self::new(content)
+        let buf = content.into();
+        Self::new(buf)
     }
 }
 
@@ -37,7 +46,7 @@ impl<const N: usize> From<[u8; N]> for Utf8String {
     #[inline]
     fn from(content: [u8; N]) -> Self {
         let buf = content.to_vec();
-        Self::new(buf)
+        Self::new(buf.into())
     }
 }
 
@@ -45,7 +54,7 @@ impl<const N: usize> From<&[u8; N]> for Utf8String {
     #[inline]
     fn from(content: &[u8; N]) -> Self {
         let buf = content.to_vec();
-        Self::new(buf)
+        Self::new(buf.into())
     }
 }
 
@@ -53,7 +62,7 @@ impl<'a> From<&'a [u8]> for Utf8String {
     #[inline]
     fn from(content: &'a [u8]) -> Self {
         let buf = content.to_vec();
-        Self::new(buf)
+        Self::new(buf.into())
     }
 }
 
@@ -61,7 +70,7 @@ impl<'a> From<&'a mut [u8]> for Utf8String {
     #[inline]
     fn from(content: &'a mut [u8]) -> Self {
         let buf = content.to_vec();
-        Self::new(buf)
+        Self::new(buf.into())
     }
 }
 
@@ -69,7 +78,7 @@ impl<'a> From<Cow<'a, [u8]>> for Utf8String {
     #[inline]
     fn from(content: Cow<'a, [u8]>) -> Self {
         let buf = content.into_owned();
-        Self::new(buf)
+        Self::new(buf.into())
     }
 }
 
@@ -77,7 +86,7 @@ impl From<String> for Utf8String {
     #[inline]
     fn from(s: String) -> Self {
         let buf = s.into_bytes();
-        Self::new(buf)
+        Self::new(buf.into())
     }
 }
 
@@ -85,14 +94,14 @@ impl From<&str> for Utf8String {
     #[inline]
     fn from(s: &str) -> Self {
         let buf = s.as_bytes().to_vec();
-        Self::new(buf)
+        Self::new(buf.into())
     }
 }
 
-impl From<Utf8String> for Vec<u8> {
+impl From<Utf8String> for Buf {
     #[inline]
     fn from(s: Utf8String) -> Self {
-        s.into_vec()
+        s.into_buf()
     }
 }
 

--- a/spinoso-string/src/enc/utf8/mod.rs
+++ b/spinoso-string/src/enc/utf8/mod.rs
@@ -4,8 +4,9 @@ use core::fmt;
 use core::ops::Range;
 use core::slice::SliceIndex;
 
-use bstr::{ByteSlice, ByteVec};
+use bstr::ByteSlice;
 
+use crate::buf::Buf;
 use crate::chars::ConventionallyUtf8;
 use crate::codepoints::InvalidCodepointError;
 use crate::iter::{Bytes, IntoIter, Iter, IterMut};
@@ -23,12 +24,12 @@ pub use inspect::Inspect;
 #[allow(clippy::module_name_repetitions)]
 #[derive(Default, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Utf8String {
-    inner: Vec<u8>,
+    inner: Buf,
 }
 
 // Constructors
 impl Utf8String {
-    pub const fn new(buf: Vec<u8>) -> Self {
+    pub const fn new(buf: Buf) -> Self {
         Self { inner: buf }
     }
 }
@@ -45,7 +46,7 @@ impl fmt::Debug for Utf8String {
 impl Utf8String {
     #[inline]
     #[must_use]
-    pub fn into_vec(self) -> Vec<u8> {
+    pub fn into_buf(self) -> Buf {
         self.inner
     }
 
@@ -97,7 +98,7 @@ impl Utf8String {
     #[inline]
     #[must_use]
     pub fn into_iter(self) -> IntoIter {
-        IntoIter::from_vec(self.inner)
+        IntoIter::from_vec(self.inner.into_inner())
     }
 }
 
@@ -548,7 +549,7 @@ impl Utf8String {
         // This allocation assumes that in the common case, capitalizing
         // and lower-casing `char`s do not change the length of the
         // `String`.
-        let mut replacement = Vec::with_capacity(self.len());
+        let mut replacement = Buf::with_capacity(self.len());
         let mut bytes = self.inner.as_slice();
 
         match bstr::decode_utf8(bytes) {
@@ -590,7 +591,7 @@ impl Utf8String {
     pub fn make_lowercase(&mut self) {
         // This allocation assumes that in the common case, lower-casing
         // `char`s do not change the length of the `String`.
-        let mut replacement = Vec::with_capacity(self.len());
+        let mut replacement = Buf::with_capacity(self.len());
         let mut bytes = self.inner.as_slice();
 
         while !bytes.is_empty() {
@@ -615,7 +616,7 @@ impl Utf8String {
     pub fn make_uppercase(&mut self) {
         // This allocation assumes that in the common case, upper-casing
         // `char`s do not change the length of the `String`.
-        let mut replacement = Vec::with_capacity(self.len());
+        let mut replacement = Buf::with_capacity(self.len());
         let mut bytes = self.inner.as_slice();
 
         while !bytes.is_empty() {
@@ -674,7 +675,7 @@ impl Utf8String {
         // FIXME: this allocation can go away if `ConventionallyUtf8` impls
         // `DoubleEndedIterator`.
         let chars = ConventionallyUtf8::from(&self.inner[..]).collect::<Vec<_>>();
-        let mut replacement = Vec::with_capacity(self.inner.len());
+        let mut replacement = Buf::with_capacity(self.inner.len());
         for &bytes in chars.iter().rev() {
             replacement.extend_from_slice(bytes);
         }

--- a/spinoso-string/src/impls.rs
+++ b/spinoso-string/src/impls.rs
@@ -172,7 +172,7 @@ impl From<&str> for String {
 impl From<String> for Vec<u8> {
     #[inline]
     fn from(s: String) -> Self {
-        s.inner.into_vec()
+        s.inner.into_buf().into_inner()
     }
 }
 

--- a/spinoso-string/src/lib.rs
+++ b/spinoso-string/src/lib.rs
@@ -100,8 +100,8 @@ impl String {
     /// ```
     /// use spinoso_string::{Encoding, String};
     ///
-    /// const S: String = String::new();
-    /// assert_eq!(S.encoding(), Encoding::Utf8);
+    /// let s = String::new();
+    /// assert_eq!(s.encoding(), Encoding::Utf8);
     /// ```
     ///
     /// [conventionally UTF-8]: crate::Encoding::Utf8
@@ -117,7 +117,7 @@ impl String {
     ///
     /// The `String` is [conventionally UTF-8].
     ///
-    /// The string will be able to hold exactly `capacity` bytes without
+    /// The string will be able to hold at least `capacity` bytes without
     /// reallocating. If `capacity` is 0, the string will not allocate.
     ///
     /// It is important to note that although the returned string has the
@@ -134,7 +134,7 @@ impl String {
     ///
     /// let s = String::with_capacity(10);
     /// assert_eq!(s.encoding(), Encoding::Utf8);
-    /// assert_eq!(s.capacity(), 10);
+    /// assert!(s.capacity() >= 10);
     /// assert_eq!(s.len(), 0);
     /// ```
     ///
@@ -149,7 +149,7 @@ impl String {
     ///     s.push_byte(ch as u8);
     /// }
     /// // 10 elements have been inserted without reallocating.
-    /// assert_eq!(s.capacity(), 10);
+    /// assert!(s.capacity() >= 10);
     /// assert_eq!(s.len(), 10);
     /// ```
     ///
@@ -166,7 +166,7 @@ impl String {
     /// Constructs a new, empty `String` with the specified capacity and
     /// encoding.
     ///
-    /// The string will be able to hold exactly `capacity` bytes without
+    /// The string will be able to hold at least `capacity` bytes without
     /// reallocating. If `capacity` is 0, the string will not allocate.
     ///
     /// It is important to note that although the returned string has the
@@ -183,7 +183,7 @@ impl String {
     ///
     /// let s = String::with_capacity(10);
     /// assert_eq!(s.encoding(), Encoding::Utf8);
-    /// assert_eq!(s.capacity(), 10);
+    /// assert!(s.capacity() >= 10);
     /// assert_eq!(s.len(), 0);
     /// ```
     ///
@@ -199,7 +199,7 @@ impl String {
     ///     s.push_byte(ch as u8);
     /// }
     /// // 10 elements have been inserted without reallocating.
-    /// assert_eq!(s.capacity(), 10);
+    /// assert!(s.capacity() >= 10);
     /// assert_eq!(s.len(), 10);
     /// ```
     ///
@@ -529,7 +529,7 @@ impl String {
     /// let mut s = String::with_capacity(10);
     /// s.extend_from_slice(&[b'a', b'b', b'c']);
     ///
-    /// assert_eq!(s.capacity(), 10);
+    /// assert!(s.capacity() >= 10);
     /// let slice = s.into_boxed_slice();
     /// assert_eq!(slice.into_vec().capacity(), 3);
     /// ```
@@ -549,7 +549,7 @@ impl String {
     /// use spinoso_string::String;
     ///
     /// let s = String::with_capacity(10);
-    /// assert_eq!(s.capacity(), 10);
+    /// assert!(s.capacity() >= 10);
     /// ```
     #[inline]
     #[must_use]
@@ -831,7 +831,7 @@ impl String {
     ///
     /// let mut s = String::with_capacity(10);
     /// s.extend_from_slice(b"abc");
-    /// assert_eq!(s.capacity(), 10);
+    /// assert!(s.capacity() >= 10);
     /// s.shrink_to_fit();
     /// assert!(s.capacity() >= 3);
     /// ```
@@ -854,7 +854,7 @@ impl String {
     ///
     /// let mut s = String::with_capacity(10);
     /// s.extend_from_slice(b"abc");
-    /// assert_eq!(s.capacity(), 10);
+    /// assert!(s.capacity() >= 10);
     /// s.shrink_to(5);
     /// assert!(s.capacity() >= 5);
     /// ```


### PR DESCRIPTION
This PR takes a more robust approach to fixing the buffer over-read memory corruption issues that were mitigated in #1969 and #1975. Rather than playing whack-a-mole at `String` allocation sites to ensure the byte content of the underlying `Vec<u8>` is NUL terminated, this PR bakes this invariant into the type system.

## Implement custom wrappers around `Vec` in `spinoso-string`

Issues https://github.com/artichoke/artichoke/pull/1969 and https://github.com/artichoke/artichoke/pull/1975 fixed memory unsafety due to a failure to uphold mruby's invariants that byte buffers stored in an `RString*` are always NUL terminated.

PRs https://github.com/artichoke/artichoke/pull/1969 and https://github.com/artichoke/artichoke/pull/1975 made tactical fixes at critical "FFI" portions of the `MRB_API` surface that are likely to be used directly by the mruby VM, but these tactical fixes are incomplete – not all `String` allocations went through these code paths, notably `TryConvertMut` implementations and trampoline methods that directly allocate `String` return values.

ca9644e07c007651ffd12e7a0069db9191eaaa4d adds two custom `Vec` types to `spinoso-string` in a new type called `Buf`. These crate-internal `Vec`s will be used by all encoded string types and can be specified at compile time by either enabling or disabling the `always-nul-terminated-c-string-compat` Cargo feature. The `always-nul-terminated-c-string-compat` is disabled by default because enabling it tends to incur extra allocations.

One variant added is a transparent wrapper around `Vec`; it does not change the semantics of any APIs or influence the way the inner `alloc::vec::Vec` allocates. The various encoded string variants in `spinoso-string` are updated to use the exported `Buf` type at `spinoso_string::buf::Buf` as their internal byte buffer.

A second variant is added that on construction (e.g. `new`, `with_capacity`, `From` impls) and mutation (methods that take `&mut self`) ensures that the buffer is NUL terminated in the spare capacity of the `Vec` by using the `Vec::spare_capacity_mut` and `Vec::reserve_exact` APIs. The NUL terminator will be present in the uninitialized memory that is part of the `Vec`'s allocation and follows the `len` of the `Vec`. This is the magic of asserting this invariant, which requires no unsafe code:

```rust
fn ensure_nul_terminated(vec: &mut Vec<u8>) {
    const NUL_BYTE: u8 = 0;

    let spare_capacity = vec.spare_capacity_mut();
    // If the vec has spare capacity, set the first and last bytes to NUL.
    match spare_capacity {
        [] => {}
        [next] => {
            next.write(NUL_BYTE);
            return;
        }
        [head, .., tail] => {
            head.write(NUL_BYTE);
            tail.write(NUL_BYTE);
            return;
        }
    }
    // Else `vec.len == vec.capacity`, so reserve an extra byte.
    vec.reserve_exact(1);
    let spare_capacity = vec.spare_capacity_mut();
    match spare_capacity {
        [] => panic!("Vec should have spare capacity"),
        [next] => {
            next.write(NUL_BYTE);
        }
        [head, .., tail] => {
            head.write(NUL_BYTE);
            tail.write(NUL_BYTE);
        }
    }
}
```

## Compatibility

Several `const` APIs have been made non-`const` to allow for future variants to allocate (for example, in `String::new`). The crate version has been bumped to 0.19.0.

When the `always-nul-terminated-c-string-compat` feature is enabled, Spinoso strings may allocate more than requested to enforce the NUL termination invariant.

The `Buf` variant that is activated when the `always-nul-terminated-c-string-compat` feature is enabled does not export methods for the `Drain` and `Splice` iterators. If this is required in a future iteration, wrappers around the types from `std` must be made to enforce the NUL termination invariant on `drop` of these iterator types.

## Memory Safety

The mitigations in #1969 and #1975 are mostly reverted.

This test from #1975 yields no results and was verified by reverting e37c53c10c41b016be22f5cda796fcf13c6b31e1 and verifying that the memory corruptions still reproduce.

```
cargo run --bin spec-runner -q -- all-core-specs.toml > dump.txt
rg 'ArgumentError: regex crate utf8 backend for Regexp only supports UTF-8 haystacks' dump.txt
```