### PR TITLE
Add `From` impls for byte arrays for encoded string variants

### DIFF
--- a/spinoso-string/src/enc/ascii/impls.rs
+++ b/spinoso-string/src/enc/ascii/impls.rs
@@ -33,38 +33,59 @@ impl From<Vec<u8>> for AsciiString {
     }
 }
 
+impl<const N: usize> From<[u8; N]> for AsciiString {
+    #[inline]
+    fn from(content: [u8; N]) -> Self {
+        let buf = content.to_vec();
+        Self::new(buf)
+    }
+}
+
+impl<const N: usize> From<&[u8; N]> for AsciiString {
+    #[inline]
+    fn from(content: &[u8; N]) -> Self {
+        let buf = content.to_vec();
+        Self::new(buf)
+    }
+}
+
 impl<'a> From<&'a [u8]> for AsciiString {
     #[inline]
     fn from(content: &'a [u8]) -> Self {
-        Self::new(content.to_vec())
+        let buf = content.to_vec();
+        Self::new(buf)
     }
 }
 
 impl<'a> From<&'a mut [u8]> for AsciiString {
     #[inline]
     fn from(content: &'a mut [u8]) -> Self {
-        Self::new(content.to_vec())
+        let buf = content.to_vec();
+        Self::new(buf)
     }
 }
 
 impl<'a> From<Cow<'a, [u8]>> for AsciiString {
     #[inline]
     fn from(content: Cow<'a, [u8]>) -> Self {
-        Self::new(content.into_owned())
+        let buf = content.into_owned();
+        Self::new(buf)
     }
 }
 
 impl From<String> for AsciiString {
     #[inline]
     fn from(s: String) -> Self {
-        Self::new(s.into_bytes())
+        let buf = s.into_bytes();
+        Self::new(buf)
     }
 }
 
 impl From<&str> for AsciiString {
     #[inline]
     fn from(s: &str) -> Self {
-        Self::new(s.as_bytes().to_vec())
+        let buf = s.as_bytes().to_vec();
+        Self::new(buf)
     }
 }
 

--- a/spinoso-string/src/enc/ascii/inspect.rs
+++ b/spinoso-string/src/enc/ascii/inspect.rs
@@ -72,14 +72,14 @@ impl<'a> FusedIterator for Inspect<'a> {}
 
 #[cfg(test)]
 mod tests {
-    use alloc::string::{String, ToString};
+    use alloc::string::String;
 
     use super::{AsciiString, Inspect};
 
     #[test]
     fn empty() {
         let s = "";
-        let s = AsciiString::new(s.to_string().into_bytes());
+        let s = AsciiString::from(s);
         let inspect = Inspect::from(&s);
 
         assert_eq!(inspect.collect::<String>(), r#""""#);
@@ -88,7 +88,7 @@ mod tests {
     #[test]
     fn fred() {
         let s = "fred";
-        let s = AsciiString::new(s.to_string().into_bytes());
+        let s = AsciiString::from(s);
         let inspect = Inspect::from(&s);
 
         assert_eq!(inspect.collect::<String>(), r#""fred""#);
@@ -97,7 +97,7 @@ mod tests {
     #[test]
     fn invalid_utf8_byte() {
         let s = b"\xFF";
-        let s = AsciiString::new(s.to_vec());
+        let s = AsciiString::from(s);
         let inspect = Inspect::from(&s);
 
         assert_eq!(inspect.collect::<String>(), r#""\xFF""#);
@@ -106,7 +106,7 @@ mod tests {
     #[test]
     fn invalid_utf8() {
         let s = b"invalid-\xFF-utf8";
-        let s = AsciiString::new(s.to_vec());
+        let s = AsciiString::from(s);
         let inspect = Inspect::from(&s);
 
         assert_eq!(inspect.collect::<String>(), r#""invalid-\xFF-utf8""#);
@@ -115,7 +115,7 @@ mod tests {
     #[test]
     fn quote_collect() {
         let s = r#"a"b"#;
-        let s = AsciiString::new(s.to_string().into_bytes());
+        let s = AsciiString::from(s);
         let inspect = Inspect::from(&s);
         assert_eq!(inspect.collect::<String>(), r#""a\"b""#);
     }
@@ -123,7 +123,7 @@ mod tests {
     #[test]
     fn quote_iter() {
         let s = r#"a"b"#;
-        let s = AsciiString::new(s.to_string().into_bytes());
+        let s = AsciiString::from(s);
         let mut inspect = Inspect::from(&s);
 
         assert_eq!(inspect.next(), Some('"'));
@@ -138,7 +138,7 @@ mod tests {
     #[test]
     fn emoji() {
         let s = "💎";
-        let s = AsciiString::new(s.to_string().into_bytes());
+        let s = AsciiString::from(s);
         let inspect = Inspect::from(&s);
 
         assert_eq!(inspect.collect::<String>(), r#""\xF0\x9F\x92\x8E""#);
@@ -147,7 +147,7 @@ mod tests {
     #[test]
     fn unicode_replacement_char() {
         let s = "�";
-        let s = AsciiString::new(s.to_string().into_bytes());
+        let s = AsciiString::from(s);
         let inspect = Inspect::from(&s);
 
         assert_eq!(inspect.collect::<String>(), r#""\xEF\xBF\xBD""#);
@@ -156,7 +156,7 @@ mod tests {
     #[test]
     fn escape_slash() {
         let s = r"\";
-        let s = AsciiString::new(s.to_string().into_bytes());
+        let s = AsciiString::from(s);
         let inspect = Inspect::from(&s);
 
         assert_eq!(inspect.collect::<String>(), r#""\\""#);
@@ -165,7 +165,7 @@ mod tests {
     #[test]
     fn escape_inner_slash() {
         let s = r"foo\bar";
-        let s = AsciiString::new(s.to_string().into_bytes());
+        let s = AsciiString::from(s);
         let inspect = Inspect::from(&s);
 
         assert_eq!(inspect.collect::<String>(), r#""foo\\bar""#);
@@ -174,7 +174,7 @@ mod tests {
     #[test]
     fn nul() {
         let s = "\0";
-        let s = AsciiString::new(s.to_string().into_bytes());
+        let s = AsciiString::from(s);
         let inspect = Inspect::from(&s);
 
         assert_eq!(inspect.collect::<String>(), r#""\x00""#);
@@ -183,7 +183,7 @@ mod tests {
     #[test]
     fn del() {
         let s = "\x7F";
-        let s = AsciiString::new(s.to_string().into_bytes());
+        let s = AsciiString::from(s);
         let inspect = Inspect::from(&s);
 
         assert_eq!(inspect.collect::<String>(), r#""\x7F""#);
@@ -227,7 +227,7 @@ mod tests {
             ["\x20", r#"" ""#],
         ];
         for [s, r] in test_cases {
-            let s = AsciiString::new(s.to_string().into_bytes());
+            let s = AsciiString::from(s);
             let inspect = Inspect::from(&s);
             assert_eq!(inspect.collect::<String>(), r, "For {s:?}, expected {r}");
         }
@@ -236,13 +236,13 @@ mod tests {
     #[test]
     fn special_double_quote() {
         let s = "\x22";
-        let s = AsciiString::new(s.to_string().into_bytes());
+        let s = AsciiString::from(s);
         let inspect = Inspect::from(&s);
 
         assert_eq!(inspect.collect::<String>(), r#""\"""#);
 
         let s = "\"";
-        let s = AsciiString::new(s.to_string().into_bytes());
+        let s = AsciiString::from(s);
         let inspect = Inspect::from(&s);
 
         assert_eq!(inspect.collect::<String>(), r#""\"""#);
@@ -251,13 +251,13 @@ mod tests {
     #[test]
     fn special_backslash() {
         let s = "\x5C";
-        let s = AsciiString::new(s.to_string().into_bytes());
+        let s = AsciiString::from(s);
         let inspect = Inspect::from(&s);
 
         assert_eq!(inspect.collect::<String>(), r#""\\""#);
 
         let s = "\\";
-        let s = AsciiString::new(s.to_string().into_bytes());
+        let s = AsciiString::from(s);
         let inspect = Inspect::from(&s);
 
         assert_eq!(inspect.collect::<String>(), r#""\\""#);

--- a/spinoso-string/src/enc/ascii/mod.rs
+++ b/spinoso-string/src/enc/ascii/mod.rs
@@ -334,38 +334,38 @@ mod tests {
     quickcheck! {
         fn fuzz_char_len_utf8_contents_ascii_string(contents: String) -> bool {
             let expected = contents.len();
-            let s = AsciiString::new(contents.into_bytes());
+            let s = AsciiString::from(contents);
             s.char_len() == expected
         }
 
         fn fuzz_len_utf8_contents_ascii_string(contents: String) -> bool {
             let expected = contents.len();
-            let s = AsciiString::new(contents.into_bytes());
+            let s = AsciiString::from(contents);
             s.len() == expected
         }
 
         fn fuzz_char_len_binary_contents_ascii_string(contents: Vec<u8>) -> bool {
             let expected = contents.len();
-            let s = AsciiString::new(contents);
+            let s = AsciiString::from(contents);
             s.char_len() == expected
         }
 
         fn fuzz_len_binary_contents_ascii_string(contents: Vec<u8>) -> bool {
             let expected = contents.len();
-            let s = AsciiString::new(contents);
+            let s = AsciiString::from(contents);
             s.len() == expected
         }
     }
 
     #[test]
     fn constructs_empty_buffer() {
-        let s = AsciiString::new(Vec::new());
+        let s = AsciiString::from(Vec::new());
         assert_eq!(0, s.len());
     }
 
     #[test]
     fn casing_ascii_string_empty() {
-        let mut s = AsciiString::new(b"".to_vec());
+        let mut s = AsciiString::from(b"");
 
         s.make_capitalized();
         assert_eq!(s, "");
@@ -379,10 +379,10 @@ mod tests {
 
     #[test]
     fn casing_ascii_string_ascii() {
-        let lower = AsciiString::new(b"abc".to_vec());
-        let mid_upper = AsciiString::new(b"aBc".to_vec());
-        let upper = AsciiString::new(b"ABC".to_vec());
-        let long = AsciiString::new(b"aBC, 123, ABC, baby you and me girl".to_vec());
+        let lower = AsciiString::from(b"abc");
+        let mid_upper = AsciiString::from(b"aBc");
+        let upper = AsciiString::from(b"ABC");
+        let long = AsciiString::from(b"aBC, 123, ABC, baby you and me girl");
 
         let capitalize: fn(&AsciiString) -> AsciiString = |value: &AsciiString| {
             let mut value = value.clone();
@@ -478,7 +478,7 @@ mod tests {
 
     #[test]
     fn casing_ascii_string_invalid_utf8() {
-        let mut s = AsciiString::new(b"\xFF\xFE".to_vec());
+        let mut s = AsciiString::from(b"\xFF\xFE");
 
         s.make_capitalized();
         assert_eq!(s, &b"\xFF\xFE"[..]);

--- a/spinoso-string/src/enc/binary/impls.rs
+++ b/spinoso-string/src/enc/binary/impls.rs
@@ -33,38 +33,59 @@ impl From<Vec<u8>> for BinaryString {
     }
 }
 
+impl<const N: usize> From<[u8; N]> for BinaryString {
+    #[inline]
+    fn from(content: [u8; N]) -> Self {
+        let buf = content.to_vec();
+        Self::new(buf)
+    }
+}
+
+impl<const N: usize> From<&[u8; N]> for BinaryString {
+    #[inline]
+    fn from(content: &[u8; N]) -> Self {
+        let buf = content.to_vec();
+        Self::new(buf)
+    }
+}
+
 impl<'a> From<&'a [u8]> for BinaryString {
     #[inline]
     fn from(content: &'a [u8]) -> Self {
-        Self::new(content.to_vec())
+        let buf = content.to_vec();
+        Self::new(buf)
     }
 }
 
 impl<'a> From<&'a mut [u8]> for BinaryString {
     #[inline]
     fn from(content: &'a mut [u8]) -> Self {
-        Self::new(content.to_vec())
+        let buf = content.to_vec();
+        Self::new(buf)
     }
 }
 
 impl<'a> From<Cow<'a, [u8]>> for BinaryString {
     #[inline]
     fn from(content: Cow<'a, [u8]>) -> Self {
-        Self::new(content.into_owned())
+        let buf = content.into_owned();
+        Self::new(buf)
     }
 }
 
 impl From<String> for BinaryString {
     #[inline]
     fn from(s: String) -> Self {
-        Self::new(s.into_bytes())
+        let buf = s.into_bytes();
+        Self::new(buf)
     }
 }
 
 impl From<&str> for BinaryString {
     #[inline]
     fn from(s: &str) -> Self {
-        Self::new(s.as_bytes().to_vec())
+        let buf = s.as_bytes().to_vec();
+        Self::new(buf)
     }
 }
 

--- a/spinoso-string/src/enc/binary/inspect.rs
+++ b/spinoso-string/src/enc/binary/inspect.rs
@@ -72,14 +72,14 @@ impl<'a> FusedIterator for Inspect<'a> {}
 
 #[cfg(test)]
 mod tests {
-    use alloc::string::{String, ToString};
+    use alloc::string::String;
 
     use super::{BinaryString, Inspect};
 
     #[test]
     fn empty() {
         let s = "";
-        let s = BinaryString::new(s.to_string().into_bytes());
+        let s = BinaryString::from(s);
         let inspect = Inspect::from(&s);
 
         assert_eq!(inspect.collect::<String>(), r#""""#);
@@ -88,7 +88,7 @@ mod tests {
     #[test]
     fn fred() {
         let s = "fred";
-        let s = BinaryString::new(s.to_string().into_bytes());
+        let s = BinaryString::from(s);
         let inspect = Inspect::from(&s);
 
         assert_eq!(inspect.collect::<String>(), r#""fred""#);
@@ -97,7 +97,7 @@ mod tests {
     #[test]
     fn invalid_utf8_byte() {
         let s = b"\xFF";
-        let s = BinaryString::new(s.to_vec());
+        let s = BinaryString::from(s);
         let inspect = Inspect::from(&s);
 
         assert_eq!(inspect.collect::<String>(), r#""\xFF""#);
@@ -106,7 +106,7 @@ mod tests {
     #[test]
     fn invalid_utf8() {
         let s = b"invalid-\xFF-utf8";
-        let s = BinaryString::new(s.to_vec());
+        let s = BinaryString::from(s);
         let inspect = Inspect::from(&s);
 
         assert_eq!(inspect.collect::<String>(), r#""invalid-\xFF-utf8""#);
@@ -115,7 +115,7 @@ mod tests {
     #[test]
     fn quote_collect() {
         let s = r#"a"b"#;
-        let s = BinaryString::new(s.to_string().into_bytes());
+        let s = BinaryString::from(s);
         let inspect = Inspect::from(&s);
         assert_eq!(inspect.collect::<String>(), r#""a\"b""#);
     }
@@ -123,7 +123,7 @@ mod tests {
     #[test]
     fn quote_iter() {
         let s = r#"a"b"#;
-        let s = BinaryString::new(s.to_string().into_bytes());
+        let s = BinaryString::from(s);
         let mut inspect = Inspect::from(&s);
 
         assert_eq!(inspect.next(), Some('"'));
@@ -138,7 +138,7 @@ mod tests {
     #[test]
     fn emoji() {
         let s = "💎";
-        let s = BinaryString::new(s.to_string().into_bytes());
+        let s = BinaryString::from(s);
         let inspect = Inspect::from(&s);
 
         assert_eq!(inspect.collect::<String>(), r#""\xF0\x9F\x92\x8E""#);
@@ -147,7 +147,7 @@ mod tests {
     #[test]
     fn unicode_replacement_char() {
         let s = "�";
-        let s = BinaryString::new(s.to_string().into_bytes());
+        let s = BinaryString::from(s);
         let inspect = Inspect::from(&s);
 
         assert_eq!(inspect.collect::<String>(), r#""\xEF\xBF\xBD""#);
@@ -156,7 +156,7 @@ mod tests {
     #[test]
     fn escape_slash() {
         let s = r"\";
-        let s = BinaryString::new(s.to_string().into_bytes());
+        let s = BinaryString::from(s);
         let inspect = Inspect::from(&s);
 
         assert_eq!(inspect.collect::<String>(), r#""\\""#);
@@ -165,7 +165,7 @@ mod tests {
     #[test]
     fn escape_inner_slash() {
         let s = r"foo\bar";
-        let s = BinaryString::new(s.to_string().into_bytes());
+        let s = BinaryString::from(s);
         let inspect = Inspect::from(&s);
 
         assert_eq!(inspect.collect::<String>(), r#""foo\\bar""#);
@@ -174,7 +174,7 @@ mod tests {
     #[test]
     fn nul() {
         let s = "\0";
-        let s = BinaryString::new(s.to_string().into_bytes());
+        let s = BinaryString::from(s);
         let inspect = Inspect::from(&s);
 
         assert_eq!(inspect.collect::<String>(), r#""\x00""#);
@@ -183,7 +183,7 @@ mod tests {
     #[test]
     fn del() {
         let s = "\x7F";
-        let s = BinaryString::new(s.to_string().into_bytes());
+        let s = BinaryString::from(s);
         let inspect = Inspect::from(&s);
 
         assert_eq!(inspect.collect::<String>(), r#""\x7F""#);
@@ -227,7 +227,7 @@ mod tests {
             ["\x20", r#"" ""#],
         ];
         for [s, r] in test_cases {
-            let s = BinaryString::new(s.to_string().into_bytes());
+            let s = BinaryString::from(s);
             let inspect = Inspect::from(&s);
             assert_eq!(inspect.collect::<String>(), r, "For {s:?}, expected {r}");
         }
@@ -236,13 +236,13 @@ mod tests {
     #[test]
     fn special_double_quote() {
         let s = "\x22";
-        let s = BinaryString::new(s.to_string().into_bytes());
+        let s = BinaryString::from(s);
         let inspect = Inspect::from(&s);
 
         assert_eq!(inspect.collect::<String>(), r#""\"""#);
 
         let s = "\"";
-        let s = BinaryString::new(s.to_string().into_bytes());
+        let s = BinaryString::from(s);
         let inspect = Inspect::from(&s);
 
         assert_eq!(inspect.collect::<String>(), r#""\"""#);
@@ -251,13 +251,13 @@ mod tests {
     #[test]
     fn special_backslash() {
         let s = "\x5C";
-        let s = BinaryString::new(s.to_string().into_bytes());
+        let s = BinaryString::from(s);
         let inspect = Inspect::from(&s);
 
         assert_eq!(inspect.collect::<String>(), r#""\\""#);
 
         let s = "\\";
-        let s = BinaryString::new(s.to_string().into_bytes());
+        let s = BinaryString::from(s);
         let inspect = Inspect::from(&s);
 
         assert_eq!(inspect.collect::<String>(), r#""\\""#);

--- a/spinoso-string/src/enc/binary/mod.rs
+++ b/spinoso-string/src/enc/binary/mod.rs
@@ -334,38 +334,38 @@ mod tests {
     quickcheck! {
         fn fuzz_char_len_utf8_contents_binary_string(contents: String) -> bool {
             let expected = contents.len();
-            let s = BinaryString::new(contents.into_bytes());
+            let s = BinaryString::from(contents);
             s.char_len() == expected
         }
 
         fn fuzz_len_utf8_contents_binary_string(contents: String) -> bool {
             let expected = contents.len();
-            let s = BinaryString::new(contents.into_bytes());
+            let s = BinaryString::from(contents);
             s.len() == expected
         }
 
         fn fuzz_char_len_binary_contents_binary_string(contents: Vec<u8>) -> bool {
             let expected = contents.len();
-            let s = BinaryString::new(contents);
+            let s = BinaryString::from(contents);
             s.char_len() == expected
         }
 
         fn fuzz_len_binary_contents_binary_string(contents: Vec<u8>) -> bool {
             let expected = contents.len();
-            let s = BinaryString::new(contents);
+            let s = BinaryString::from(contents);
             s.len() == expected
         }
     }
 
     #[test]
     fn constructs_empty_buffer() {
-        let s = BinaryString::new(Vec::new());
+        let s = BinaryString::from(Vec::new());
         assert_eq!(0, s.len());
     }
 
     #[test]
     fn casing_binary_string_empty() {
-        let mut s = BinaryString::new(b"".to_vec());
+        let mut s = BinaryString::from(b"");
 
         s.make_capitalized();
         assert_eq!(s, "");
@@ -379,10 +379,10 @@ mod tests {
 
     #[test]
     fn casing_binary_string_ascii() {
-        let lower = BinaryString::new(b"abc".to_vec());
-        let mid_upper = BinaryString::new(b"aBc".to_vec());
-        let upper = BinaryString::new(b"ABC".to_vec());
-        let long = BinaryString::new(b"aBC, 123, ABC, baby you and me girl".to_vec());
+        let lower = BinaryString::from(b"abc");
+        let mid_upper = BinaryString::from(b"aBc");
+        let upper = BinaryString::from(b"ABC");
+        let long = BinaryString::from(b"aBC, 123, ABC, baby you and me girl");
 
         let capitalize: fn(&BinaryString) -> BinaryString = |value: &BinaryString| {
             let mut value = value.clone();
@@ -478,7 +478,7 @@ mod tests {
 
     #[test]
     fn casing_binary_string_invalid_utf8() {
-        let mut s = BinaryString::new(b"\xFF\xFE".to_vec());
+        let mut s = BinaryString::from(b"\xFF\xFE");
 
         s.make_capitalized();
         assert_eq!(s, &b"\xFF\xFE"[..]);

--- a/spinoso-string/src/enc/utf8/impls.rs
+++ b/spinoso-string/src/enc/utf8/impls.rs
@@ -33,38 +33,59 @@ impl From<Vec<u8>> for Utf8String {
     }
 }
 
+impl<const N: usize> From<[u8; N]> for Utf8String {
+    #[inline]
+    fn from(content: [u8; N]) -> Self {
+        let buf = content.to_vec();
+        Self::new(buf)
+    }
+}
+
+impl<const N: usize> From<&[u8; N]> for Utf8String {
+    #[inline]
+    fn from(content: &[u8; N]) -> Self {
+        let buf = content.to_vec();
+        Self::new(buf)
+    }
+}
+
 impl<'a> From<&'a [u8]> for Utf8String {
     #[inline]
     fn from(content: &'a [u8]) -> Self {
-        Self::new(content.to_vec())
+        let buf = content.to_vec();
+        Self::new(buf)
     }
 }
 
 impl<'a> From<&'a mut [u8]> for Utf8String {
     #[inline]
     fn from(content: &'a mut [u8]) -> Self {
-        Self::new(content.to_vec())
+        let buf = content.to_vec();
+        Self::new(buf)
     }
 }
 
 impl<'a> From<Cow<'a, [u8]>> for Utf8String {
     #[inline]
     fn from(content: Cow<'a, [u8]>) -> Self {
-        Self::new(content.into_owned())
+        let buf = content.into_owned();
+        Self::new(buf)
     }
 }
 
 impl From<String> for Utf8String {
     #[inline]
     fn from(s: String) -> Self {
-        Self::new(s.into_bytes())
+        let buf = s.into_bytes();
+        Self::new(buf)
     }
 }
 
 impl From<&str> for Utf8String {
     #[inline]
     fn from(s: &str) -> Self {
-        Self::new(s.as_bytes().to_vec())
+        let buf = s.as_bytes().to_vec();
+        Self::new(buf)
     }
 }
 
@@ -86,20 +107,6 @@ impl AsMut<[u8]> for Utf8String {
     #[inline]
     fn as_mut(&mut self) -> &mut [u8] {
         self.inner.as_mut_slice()
-    }
-}
-
-impl AsRef<Vec<u8>> for Utf8String {
-    #[inline]
-    fn as_ref(&self) -> &Vec<u8> {
-        &self.inner
-    }
-}
-
-impl AsMut<Vec<u8>> for Utf8String {
-    #[inline]
-    fn as_mut(&mut self) -> &mut Vec<u8> {
-        &mut self.inner
     }
 }
 

--- a/spinoso-string/src/enc/utf8/inspect.rs
+++ b/spinoso-string/src/enc/utf8/inspect.rs
@@ -97,14 +97,14 @@ impl<'a> FusedIterator for Inspect<'a> {}
 
 #[cfg(test)]
 mod tests {
-    use alloc::string::{String, ToString};
+    use alloc::string::String;
 
     use super::{Inspect, Utf8String};
 
     #[test]
     fn empty() {
         let s = "";
-        let s = Utf8String::new(s.to_string().into_bytes());
+        let s = Utf8String::from(s);
         let inspect = Inspect::from(&s);
 
         assert_eq!(inspect.collect::<String>(), r#""""#);
@@ -113,7 +113,7 @@ mod tests {
     #[test]
     fn fred() {
         let s = "fred";
-        let s = Utf8String::new(s.to_string().into_bytes());
+        let s = Utf8String::from(s);
         let inspect = Inspect::from(&s);
 
         assert_eq!(inspect.collect::<String>(), r#""fred""#);
@@ -122,7 +122,7 @@ mod tests {
     #[test]
     fn invalid_utf8_byte() {
         let s = b"\xFF";
-        let s = Utf8String::new(s.to_vec());
+        let s = Utf8String::from(s);
         let inspect = Inspect::from(&s);
 
         assert_eq!(inspect.collect::<String>(), r#""\xFF""#);
@@ -131,7 +131,7 @@ mod tests {
     #[test]
     fn invalid_utf8() {
         let s = b"invalid-\xFF-utf8";
-        let s = Utf8String::new(s.to_vec());
+        let s = Utf8String::from(s);
         let inspect = Inspect::from(&s);
 
         assert_eq!(inspect.collect::<String>(), r#""invalid-\xFF-utf8""#);
@@ -140,7 +140,7 @@ mod tests {
     #[test]
     fn quote_collect() {
         let s = r#"a"b"#;
-        let s = Utf8String::new(s.to_string().into_bytes());
+        let s = Utf8String::from(s);
         let inspect = Inspect::from(&s);
         assert_eq!(inspect.collect::<String>(), r#""a\"b""#);
     }
@@ -148,7 +148,7 @@ mod tests {
     #[test]
     fn quote_iter() {
         let s = r#"a"b"#;
-        let s = Utf8String::new(s.to_string().into_bytes());
+        let s = Utf8String::from(s);
         let mut inspect = Inspect::from(&s);
 
         assert_eq!(inspect.next(), Some('"'));
@@ -163,7 +163,7 @@ mod tests {
     #[test]
     fn emoji() {
         let s = "💎";
-        let s = Utf8String::new(s.to_string().into_bytes());
+        let s = Utf8String::from(s);
         let inspect = Inspect::from(&s);
 
         assert_eq!(inspect.collect::<String>(), "\"💎\"");
@@ -172,7 +172,7 @@ mod tests {
     #[test]
     fn emoji_global() {
         let s = "$💎";
-        let s = Utf8String::new(s.to_string().into_bytes());
+        let s = Utf8String::from(s);
         let inspect = Inspect::from(&s);
 
         assert_eq!(inspect.collect::<String>(), "\"$💎\"");
@@ -181,7 +181,7 @@ mod tests {
     #[test]
     fn emoji_ivar() {
         let s = "@💎";
-        let s = Utf8String::new(s.to_string().into_bytes());
+        let s = Utf8String::from(s);
         let inspect = Inspect::from(&s);
 
         assert_eq!(inspect.collect::<String>(), "\"@💎\"");
@@ -190,7 +190,7 @@ mod tests {
     #[test]
     fn emoji_cvar() {
         let s = "@@💎";
-        let s = Utf8String::new(s.to_string().into_bytes());
+        let s = Utf8String::from(s);
         let inspect = Inspect::from(&s);
 
         assert_eq!(inspect.collect::<String>(), "\"@@💎\"");
@@ -199,7 +199,7 @@ mod tests {
     #[test]
     fn unicode_replacement_char() {
         let s = "�";
-        let s = Utf8String::new(s.to_string().into_bytes());
+        let s = Utf8String::from(s);
         let inspect = Inspect::from(&s);
 
         assert_eq!(inspect.collect::<String>(), "\"�\"");
@@ -208,7 +208,7 @@ mod tests {
     #[test]
     fn unicode_replacement_char_global() {
         let s = "$�";
-        let s = Utf8String::new(s.to_string().into_bytes());
+        let s = Utf8String::from(s);
         let inspect = Inspect::from(&s);
 
         assert_eq!(inspect.collect::<String>(), "\"$�\"");
@@ -217,7 +217,7 @@ mod tests {
     #[test]
     fn unicode_replacement_char_ivar() {
         let s = "@�";
-        let s = Utf8String::new(s.to_string().into_bytes());
+        let s = Utf8String::from(s);
         let inspect = Inspect::from(&s);
 
         assert_eq!(inspect.collect::<String>(), "\"@�\"");
@@ -226,7 +226,7 @@ mod tests {
     #[test]
     fn unicode_replacement_char_cvar() {
         let s = "@@�";
-        let s = Utf8String::new(s.to_string().into_bytes());
+        let s = Utf8String::from(s);
         let inspect = Inspect::from(&s);
 
         assert_eq!(inspect.collect::<String>(), "\"@@�\"");
@@ -235,7 +235,7 @@ mod tests {
     #[test]
     fn escape_slash() {
         let s = r"\";
-        let s = Utf8String::new(s.to_string().into_bytes());
+        let s = Utf8String::from(s);
         let inspect = Inspect::from(&s);
 
         assert_eq!(inspect.collect::<String>(), r#""\\""#);
@@ -244,7 +244,7 @@ mod tests {
     #[test]
     fn escape_inner_slash() {
         let s = r"foo\bar";
-        let s = Utf8String::new(s.to_string().into_bytes());
+        let s = Utf8String::from(s);
         let inspect = Inspect::from(&s);
 
         assert_eq!(inspect.collect::<String>(), r#""foo\\bar""#);
@@ -253,7 +253,7 @@ mod tests {
     #[test]
     fn nul() {
         let s = "\0";
-        let s = Utf8String::new(s.to_string().into_bytes());
+        let s = Utf8String::from(s);
         let inspect = Inspect::from(&s);
 
         assert_eq!(inspect.collect::<String>(), r#""\x00""#);
@@ -262,7 +262,7 @@ mod tests {
     #[test]
     fn del() {
         let s = "\x7F";
-        let s = Utf8String::new(s.to_string().into_bytes());
+        let s = Utf8String::from(s);
         let inspect = Inspect::from(&s);
 
         assert_eq!(inspect.collect::<String>(), r#""\x7F""#);
@@ -306,7 +306,7 @@ mod tests {
             ["\x20", r#"" ""#],
         ];
         for [s, r] in test_cases {
-            let s = Utf8String::new(s.to_string().into_bytes());
+            let s = Utf8String::from(s);
             let inspect = Inspect::from(&s);
             assert_eq!(inspect.collect::<String>(), r, "For {s:?}, expected {r}");
         }
@@ -315,13 +315,13 @@ mod tests {
     #[test]
     fn special_double_quote() {
         let s = "\x22";
-        let s = Utf8String::new(s.to_string().into_bytes());
+        let s = Utf8String::from(s);
         let inspect = Inspect::from(&s);
 
         assert_eq!(inspect.collect::<String>(), r#""\"""#);
 
         let s = "\"";
-        let s = Utf8String::new(s.to_string().into_bytes());
+        let s = Utf8String::from(s);
         let inspect = Inspect::from(&s);
 
         assert_eq!(inspect.collect::<String>(), r#""\"""#);
@@ -330,13 +330,13 @@ mod tests {
     #[test]
     fn special_backslash() {
         let s = "\x5C";
-        let s = Utf8String::new(s.to_string().into_bytes());
+        let s = Utf8String::from(s);
         let inspect = Inspect::from(&s);
 
         assert_eq!(inspect.collect::<String>(), r#""\\""#);
 
         let s = "\\";
-        let s = Utf8String::new(s.to_string().into_bytes());
+        let s = Utf8String::from(s);
         let inspect = Inspect::from(&s);
 
         assert_eq!(inspect.collect::<String>(), r#""\\""#);
@@ -345,7 +345,7 @@ mod tests {
     #[test]
     fn invalid_utf8_special_global() {
         let s = b"$-\xFF";
-        let s = Utf8String::new(s.to_vec());
+        let s = Utf8String::from(s);
         let inspect = Inspect::from(&s);
 
         assert_eq!(inspect.collect::<String>(), r#""$-\xFF""#);
@@ -354,19 +354,19 @@ mod tests {
     #[test]
     fn replacement_char_special_global() {
         let s = "$-�";
-        let s = Utf8String::new(s.to_string().into_bytes());
+        let s = Utf8String::from(s);
         let inspect = Inspect::from(&s);
 
         assert_eq!(inspect.collect::<String>(), "\"$-�\"");
 
         let s = "$-�a";
-        let s = Utf8String::new(s.to_string().into_bytes());
+        let s = Utf8String::from(s);
         let inspect = Inspect::from(&s);
 
         assert_eq!(inspect.collect::<String>(), r#""$-�a""#);
 
         let s = "$-��";
-        let s = Utf8String::new(s.to_string().into_bytes());
+        let s = Utf8String::from(s);
         let inspect = Inspect::from(&s);
 
         assert_eq!(inspect.collect::<String>(), r#""$-��""#);


### PR DESCRIPTION
This is split out from #1976. It makes the tests way less verbose by
hiding the conversions behind `::from`. Splitting this out from #1976
hides a lot of the diff by preparing to swap out the underlying buffer
type.