### PR TITLE
Update Artichoke's Ruby compatibility target to MRI Ruby 3.1.2

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -157,10 +157,10 @@ must have and how to [convert][core-convert-module] between Ruby VM and Rust
 types.
 
 [artichoke-core-src]: artichoke-core
-[kernel#require]: https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-require
-[`random::default`]: https://ruby-doc.org/core-2.6.3/Random.html#DEFAULT
+[kernel#require]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-require
+[`random::default`]: https://ruby-doc.org/core-3.1.2/Random.html#DEFAULT
 [regexp-globals]:
-  https://ruby-doc.org/core-2.6.3/Regexp.html#class-Regexp-label-Special+global+variables
+  https://ruby-doc.org/core-3.1.2/Regexp.html#class-Regexp-label-Special+global+variables
 [core-convert-module]:
   https://artichoke.github.io/artichoke/artichoke_core/convert/index.html
 [core-define-constant]:
@@ -218,8 +218,8 @@ crates as possible.
 [`spinoso-array`] and [`spinoso-env`] are two examples of typical _Spinoso_
 crates.
 
-[ruby core]: https://ruby-doc.org/core-2.6.3/
-[standard library]: https://ruby-doc.org/stdlib-2.6.3/
+[ruby core]: https://ruby-doc.org/core-3.1.2/
+[standard library]: https://ruby-doc.org/stdlib-3.1.2/
 [source-compatible]: https://hyperbo.la/w/source-level-polymorphism/
 [`spinoso-array`]: https://artichoke.github.io/artichoke/spinoso_array/
 [`spinoso-env`]: https://artichoke.github.io/artichoke/spinoso_env/
@@ -240,7 +240,7 @@ two implementations:
 `SmallArray`) which allows downstream consumers of these data structures to swap
 out implementations by changing an import.
 
-[ruby `array`]: https://ruby-doc.org/core-2.6.3/Array.html
+[ruby `array`]: https://ruby-doc.org/core-3.1.2/Array.html
 [spinoso-array-src]: spinoso-array
 [rust-alloc-vec]: https://doc.rust-lang.org/alloc/vec/struct.Vec.html
 [`smallvec`]:
@@ -270,7 +270,7 @@ import.
 where it may be undesirable for Ruby code to modify the host process's
 environment.
 
-[ruby-core-env]: https://ruby-doc.org/core-2.6.3/ENV.html
+[ruby-core-env]: https://ruby-doc.org/core-3.1.2/ENV.html
 [spinoso-env-src]: spinoso-env
 [rust-std-hashmap]:
   https://doc.rust-lang.org/nightly/std/collections/hash/map/struct.HashMap.html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,8 +3,11 @@
 👋 Hi and welcome to [Artichoke]. Thanks for taking the time to contribute!
 💪💎🙌
 
-Artichoke aspires to be a Ruby 2.6.3-compatible implementation of the Ruby
-programming language. [There is lots to do].
+Artichoke aspires to be an [MRI Ruby-compatible][mri-target] implementation of
+the Ruby programming language. [There is lots to do].
+
+[mri-target]:
+  https://github.com/artichoke/artichoke/blob/trunk/RUBYSPEC.md#mri-target
 
 If Artichoke does not run Ruby source code in the same way that MRI does, it is
 a bug and we would appreciate if you [filed an issue so we can fix it].

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@
 </p>
 
 Artichoke is a Ruby implementation written in Rust and Ruby. Artichoke intends
-to be [MRI-compatible][ruby-spec] and targets Ruby 2.6.3. Artichoke provides a
-Ruby runtime implemented in Rust and Ruby.
+to be [MRI-compatible][ruby-spec] and targets [recent MRI Ruby][mri-target].
+Artichoke provides a Ruby runtime implemented in Rust and Ruby.
 
 ## Try Artichoke
 
@@ -128,8 +128,8 @@ the project are:
 
 ## Contributing
 
-Artichoke aspires to be a Ruby 2.6.3-compatible implementation of the Ruby
-programming language. [There is lots to do][github-issues].
+Artichoke aspires to be an [MRI Ruby-compatible][mri-target] implementation of
+the Ruby programming language. [There is lots to do][github-issues].
 
 If Artichoke does not run Ruby source code in the same way that MRI does, it is
 a bug and we would appreciate if you [filed an issue so we can fix
@@ -154,6 +154,8 @@ each workspace crate discuss which third party licenses are applicable to the
 sources and derived works in Artichoke.
 
 [ruby-spec]: https://github.com/ruby/spec
+[mri-target]:
+  https://github.com/artichoke/artichoke/blob/trunk/RUBYSPEC.md#mri-target
 [playground]: https://artichoke.run
 [playground-repo]: https://github.com/artichoke/playground
 [webassembly]: https://webassembly.org/

--- a/RUBYSPEC.md
+++ b/RUBYSPEC.md
@@ -7,6 +7,15 @@ core, and standard library packages.
 Artichoke enforces that some ruby/specs pass. These specs are tracked in
 [`spec-runner/enforced-specs.toml`].
 
+## MRI Target
+
+**Target**: MRI Ruby 3.1.2.
+
+Artichoke targets recent MRI Ruby. Compatibility with this target is currently
+very work in progress. As portions of Ruby Core and Stdlib are implemented in
+Artichoke, their behavior targets the most recent MRI. There are many spec
+failures.
+
 ## Running Specs
 
 You can run these specs for Artichoke crate with the `spec-runner` crate.

--- a/artichoke-backend/src/extn/core/array/wrapper.rs
+++ b/artichoke-backend/src/extn/core/array/wrapper.rs
@@ -23,7 +23,7 @@ use crate::value::Value;
 /// `Array` implements [`BoxUnboxVmValue`] which enables it to be serialized to
 /// a mruby value and unboxed to the Rust `Array` type.
 ///
-/// [ruby-array]: https://ruby-doc.org/core-2.6.3/Array.html
+/// [ruby-array]: https://ruby-doc.org/core-3.1.2/Array.html
 /// [`shift`]: Array::shift
 /// [`shift_n`]: Array::shift_n
 /// [`drop_n`]: Array::drop_n

--- a/artichoke-backend/src/extn/core/env/mod.rs
+++ b/artichoke-backend/src/extn/core/env/mod.rs
@@ -16,7 +16,7 @@
 //! ENV['PS1'] = 'artichoke> '
 //! ```
 //!
-//! [`ENV`]: https://ruby-doc.org/core-2.6.3/ENV.html
+//! [`ENV`]: https://ruby-doc.org/core-3.1.2/ENV.html
 
 use std::borrow::Cow;
 use std::collections::HashMap;

--- a/artichoke-backend/src/extn/core/exception/mod.rs
+++ b/artichoke-backend/src/extn/core/exception/mod.rs
@@ -16,8 +16,8 @@
 //! This module implements the core exception types with [`spinoso-exception`]
 //! and re-exports these types.
 //!
-//! [`Exception`]: https://ruby-doc.org/core-2.6.3/Exception.html
-//! [`Kernel#raise`]: https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-raise
+//! [`Exception`]: https://ruby-doc.org/core-3.1.2/Exception.html
+//! [`Kernel#raise`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-raise
 //! [`spinoso-exception`]: spinoso_exception
 
 use std::borrow::Cow;

--- a/artichoke-backend/src/extn/core/kernel/require.rs
+++ b/artichoke-backend/src/extn/core/kernel/require.rs
@@ -1,4 +1,4 @@
-//! [`Kernel#require`](https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-require)
+//! [`Kernel#require`](https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-require)
 
 use std::path::{Path, PathBuf};
 

--- a/artichoke-backend/src/extn/core/matchdata/mod.rs
+++ b/artichoke-backend/src/extn/core/matchdata/mod.rs
@@ -6,7 +6,7 @@
 //!
 //! `MatchData` passes all non-skipped [ruby/spec][rubyspec]s.
 //!
-//! [matchdata]: https://ruby-doc.org/core-2.6.3/MatchData.html
+//! [matchdata]: https://ruby-doc.org/core-3.1.2/MatchData.html
 //! [rubyspec]: https://github.com/ruby/spec
 
 use std::collections::HashMap;

--- a/artichoke-backend/src/extn/core/math/mod.rs
+++ b/artichoke-backend/src/extn/core/math/mod.rs
@@ -14,7 +14,7 @@
 //! This module implements the core math module with [`spinoso-math`] and
 //! re-exports some of its internals.
 //!
-//! [`Float`]: https://ruby-doc.org/core-2.6.3/Float.html
+//! [`Float`]: https://ruby-doc.org/core-3.1.2/Float.html
 //! [`spinoso-math`]: spinoso_math
 
 use std::borrow::Cow;

--- a/artichoke-backend/src/extn/core/numeric/mod.rs
+++ b/artichoke-backend/src/extn/core/numeric/mod.rs
@@ -66,7 +66,7 @@ pub enum Coercion {
 /// # example().unwrap();
 /// ```
 ///
-/// [numeric]: https://ruby-doc.org/core-2.6.3/Numeric.html#method-i-coerce
+/// [numeric]: https://ruby-doc.org/core-3.1.2/Numeric.html#method-i-coerce
 pub fn coerce(interp: &mut Artichoke, x: Value, y: Value) -> Result<Coercion, Error> {
     fn do_coerce(interp: &mut Artichoke, x: Value, y: Value, depth: u8) -> Result<Coercion, Error> {
         if depth > MAX_COERCE_DEPTH {

--- a/artichoke-backend/src/extn/core/random/mod.rs
+++ b/artichoke-backend/src/extn/core/random/mod.rs
@@ -17,7 +17,7 @@
 //! r.rand
 //! ```
 //!
-//! [`Random`]: https://ruby-doc.org/core-2.6.3/Random.html
+//! [`Random`]: https://ruby-doc.org/core-3.1.2/Random.html
 
 use core::mem;
 

--- a/artichoke-backend/src/extn/core/regexp/mod.rs
+++ b/artichoke-backend/src/extn/core/regexp/mod.rs
@@ -1,5 +1,5 @@
 //! [ruby/spec](https://github.com/ruby/spec) compliant implementation of
-//! [`Regexp`](https://ruby-doc.org/core-2.6.3/Regexp.html).
+//! [`Regexp`](https://ruby-doc.org/core-3.1.2/Regexp.html).
 //!
 //! Each function on `Regexp` is implemented as its own module which contains
 //! the `Args` struct for invoking the function.

--- a/artichoke-backend/src/extn/core/string/trampoline.rs
+++ b/artichoke-backend/src/extn/core/string/trampoline.rs
@@ -544,7 +544,7 @@ pub fn byteslice(
     let length = if let Some(length) = length {
         length
     } else {
-        // Per the docs -- https://ruby-doc.org/core-3.0.2/String.html#method-i-byteslice
+        // Per the docs -- https://ruby-doc.org/core-3.1.2/String.html#method-i-byteslice
         //
         // > If passed a single Integer, returns a substring of one byte at that position.
         //

--- a/artichoke-backend/src/extn/core/time/mod.rs
+++ b/artichoke-backend/src/extn/core/time/mod.rs
@@ -16,7 +16,7 @@
 //! This implementation of `Time` supports the system clock via the
 //! [`chrono`] and [`chrono-tz`] crates.
 //!
-//! [`Time`]: https://ruby-doc.org/core-2.6.3/Time.html
+//! [`Time`]: https://ruby-doc.org/core-3.1.2/Time.html
 //! [`chrono`]: https://crates.io/crates/chrono
 //! [`chrono-tz`]: https://crates.io/crates/chrono-tz
 

--- a/artichoke-backend/src/extn/stdlib/securerandom/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/securerandom/mod.rs
@@ -13,7 +13,7 @@
 //! This implementation of `SecureRandom` supports the system RNG via the
 //! [`getrandom`] crate. This implementation does not depend on OpenSSL.
 //!
-//! [`SecureRandom`]: https://ruby-doc.org/stdlib-2.6.3/libdoc/securerandom/rdoc/SecureRandom.html
+//! [`SecureRandom`]: https://ruby-doc.org/stdlib-3.1.2/libdoc/securerandom/rdoc/SecureRandom.html
 //! [`getrandom`]: https://crates.io/crates/getrandom
 
 use crate::convert::implicitly_convert_to_int;

--- a/artichoke-backend/src/release_metadata.rs
+++ b/artichoke-backend/src/release_metadata.rs
@@ -74,7 +74,7 @@ impl<'a> ReleaseMetadata<'a> {
             platform: "host",
             release_date: "",
             revision: "1",
-            ruby_version: "2.6.3",
+            ruby_version: "3.1.2",
             compiler_version: Some("rustc"),
         }
     }

--- a/artichoke-core/README.md
+++ b/artichoke-core/README.md
@@ -77,10 +77,10 @@ All features are enabled by default:
 
 `artichoke-core` is licensed with the [MIT License](LICENSE) (c) Ryan Lopopolo.
 
-[kernel#require]: https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-require
-[`random::default`]: https://ruby-doc.org/core-2.6.3/Random.html#DEFAULT
+[kernel#require]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-require
+[`random::default`]: https://ruby-doc.org/core-3.1.2/Random.html#DEFAULT
 [regexp-globals]:
-  https://ruby-doc.org/core-2.6.3/Regexp.html#class-Regexp-label-Special+global+variables
+  https://ruby-doc.org/core-3.1.2/Regexp.html#class-Regexp-label-Special+global+variables
 [core-class-registry]:
   https://artichoke.github.io/artichoke/artichoke_core/class_registry/trait.ClassRegistry.html
 [core-coerce-numeric]:

--- a/artichoke-core/src/coerce_to_numeric.rs
+++ b/artichoke-core/src/coerce_to_numeric.rs
@@ -32,8 +32,8 @@ pub trait CoerceToNumeric {
     /// If the underlying interpreter returns an error when calling `#to_f` or
     /// [`Numeric#coerce`], the error is returned.
     ///
-    /// [`Numeric`]: https://ruby-doc.org/core-2.6.3/Numeric.html
-    /// [`Numeric` class]: https://ruby-doc.org/core-2.6.3/Numeric.html
-    /// [`Numeric#coerce`]: https://ruby-doc.org/core-2.6.3/Numeric.html#method-i-coerce
+    /// [`Numeric`]: https://ruby-doc.org/core-3.1.2/Numeric.html
+    /// [`Numeric` class]: https://ruby-doc.org/core-3.1.2/Numeric.html
+    /// [`Numeric#coerce`]: https://ruby-doc.org/core-3.1.2/Numeric.html#method-i-coerce
     fn coerce_to_float(&mut self, value: Self::Value) -> Result<Self::Float, Self::Error>;
 }

--- a/artichoke-core/src/intern.rs
+++ b/artichoke-core/src/intern.rs
@@ -3,7 +3,7 @@
 //! `Symbol`s are immutable byte strings that have the same lifetime as the
 //! interpreter.
 //!
-//! [symbol]: https://ruby-doc.org/core-2.6.3/Symbol.html
+//! [symbol]: https://ruby-doc.org/core-3.1.2/Symbol.html
 
 use alloc::borrow::Cow;
 
@@ -12,7 +12,7 @@ use alloc::borrow::Cow;
 ///
 /// See the [Ruby `Symbol` type][symbol].
 ///
-/// [symbol]: https://ruby-doc.org/core-2.6.3/Symbol.html
+/// [symbol]: https://ruby-doc.org/core-3.1.2/Symbol.html
 pub trait Intern {
     /// Concrete type for symbol identifiers.
     ///

--- a/artichoke-core/src/lib.rs
+++ b/artichoke-core/src/lib.rs
@@ -108,9 +108,9 @@
 //!   this feature adds several trait methods that depend on `OsStr` and `Path`
 //!   as well as several implementations of `std::error::Error`.
 //!
-//! [Kernel#require]: https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-require
-//! [`Random::DEFAULT`]: https://ruby-doc.org/core-2.6.3/Random.html#DEFAULT
-//! [`Regexp`]: https://ruby-doc.org/core-2.6.3/Regexp.html#class-Regexp-label-Special+global+variables
+//! [Kernel#require]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-require
+//! [`Random::DEFAULT`]: https://ruby-doc.org/core-3.1.2/Random.html#DEFAULT
+//! [`Regexp`]: https://ruby-doc.org/core-3.1.2/Regexp.html#class-Regexp-label-Special+global+variables
 //! [convert]: crate::convert
 
 #![no_std]

--- a/artichoke-core/src/load.rs
+++ b/artichoke-core/src/load.rs
@@ -30,7 +30,7 @@ use crate::file::File;
 ///
 /// See the documentation of [`require_source`] for more details.
 ///
-/// [`Kernel#require`]: https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-require
+/// [`Kernel#require`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-require
 /// [`require_source`]: LoadSources::require_source
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Required {
@@ -42,7 +42,7 @@ pub enum Required {
     /// This variant has value `true` when converting to a Boolean as returned
     /// by `Kernel#require`.
     ///
-    /// [`Kernel#require`]: https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-require
+    /// [`Kernel#require`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-require
     Success,
     /// [`Kernel#require`] did not require the file because it has already been
     /// required.
@@ -55,9 +55,9 @@ pub enum Required {
     /// This variant has value `false` when converting to a Boolean as returned
     /// by `Kernel#require`.
     ///
-    /// [`Kernel#require`]: https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-require
+    /// [`Kernel#require`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-require
     /// [`load_source`]: LoadSources::load_source
-    /// [`Kernel#load`]: https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-load
+    /// [`Kernel#load`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-load
     AlreadyRequired,
 }
 
@@ -65,7 +65,7 @@ impl From<Required> for bool {
     /// Convert a [`Required`] enum into a [`bool`] as returned by
     /// [`Kernel#require`].
     ///
-    /// [`Kernel#require`]: https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-require
+    /// [`Kernel#require`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-require
     fn from(req: Required) -> Self {
         match req {
             Required::Success => true,
@@ -89,7 +89,7 @@ impl From<Required> for bool {
 ///
 /// See the documentation of [`load_source`] for more details.
 ///
-/// [`Kernel#load`]: https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-load
+/// [`Kernel#load`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-load
 /// [`load_source`]: LoadSources::load_source
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Loaded {
@@ -98,7 +98,7 @@ pub enum Loaded {
     /// This variant has value `true` when converting to a Boolean as returned
     /// by `Kernel#load`.
     ///
-    /// [`Kernel#load`]: https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-load
+    /// [`Kernel#load`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-load
     Success,
 }
 
@@ -106,7 +106,7 @@ impl From<Loaded> for bool {
     /// Convert a [`Loaded`] enum into a [`bool`] as returned by
     /// [`Kernel#load`].
     ///
-    /// [`Kernel#load`]: https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-load
+    /// [`Kernel#load`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-load
     fn from(loaded: Loaded) -> Self {
         let Loaded::Success = loaded;
         true

--- a/artichoke-core/src/prng.rs
+++ b/artichoke-core/src/prng.rs
@@ -9,7 +9,7 @@
 /// cryptographically secure. For example, MRI's PRNG is a variant of Mersenne
 /// Twister.
 ///
-/// [`Random::DEFAULT`]: https://ruby-doc.org/core-2.6.3/Random.html#DEFAULT
+/// [`Random::DEFAULT`]: https://ruby-doc.org/core-3.1.2/Random.html#DEFAULT
 pub trait Prng {
     /// Concrete type for errors when retrieving the pseudorandom number
     /// generator.

--- a/artichoke-core/src/regexp.rs
+++ b/artichoke-core/src/regexp.rs
@@ -3,8 +3,8 @@
 /// Track the state of [`Regexp`] special [global variables] and global
 /// interpreter state.
 ///
-/// [`Regexp`]: https://ruby-doc.org/core-2.6.3/Regexp.html
-/// [global variables]: https://ruby-doc.org/core-2.6.3/Regexp.html#class-Regexp-label-Special+global+variables
+/// [`Regexp`]: https://ruby-doc.org/core-3.1.2/Regexp.html
+/// [global variables]: https://ruby-doc.org/core-3.1.2/Regexp.html#class-Regexp-label-Special+global+variables
 pub trait Regexp {
     /// Concrete error type for errors encountered when manipulating `Regexp`
     /// state.

--- a/artichoke-core/src/release_metadata.rs
+++ b/artichoke-core/src/release_metadata.rs
@@ -91,7 +91,7 @@ pub trait ReleaseMetadata {
     ///
     /// # Examples
     ///
-    /// > 2.6.3
+    /// > 3.1.2
     fn ruby_version(&self) -> &str;
 
     /// A description of the compiler used to build Artichoke.

--- a/artichoke-core/src/warn.rs
+++ b/artichoke-core/src/warn.rs
@@ -6,7 +6,7 @@
 /// invalid behavior and ruby/spec expects a warning to be emitted to `$stderr`
 /// using the [`Warning`][warningmod] module from the standard library.
 ///
-/// [warningmod]: https://ruby-doc.org/core-2.6.3/Warning.html#method-i-warn
+/// [warningmod]: https://ruby-doc.org/core-3.1.2/Warning.html#method-i-warn
 pub trait Warn {
     /// Concrete error type for errors encountered when outputting warnings.
     type Error;

--- a/artichoke-load-path/src/rubylib.rs
+++ b/artichoke-load-path/src/rubylib.rs
@@ -58,7 +58,7 @@ use same_file::Handle;
 /// # example().unwrap();
 /// ```
 ///
-/// [require]: https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-require
+/// [require]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-require
 /// [resolves to the same file]: same_file
 #[derive(Debug, PartialEq, Eq)]
 #[cfg_attr(docsrs, doc(cfg(feature = "rubylib-native-file-system-loader")))]
@@ -284,7 +284,7 @@ impl Rubylib {
     /// If `path` does not exist, an [`io::Error`] with error kind
     /// [`io::ErrorKind::NotFound`] is returned.
     ///
-    /// [`Kernel#require`]: https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-require
+    /// [`Kernel#require`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-require
     #[inline]
     pub fn mark_required(&mut self, path: &Path) -> io::Result<()> {
         for load_path in &*self.load_paths {

--- a/mezzaluna-feature-loader/src/loaded_features/mod.rs
+++ b/mezzaluna-feature-loader/src/loaded_features/mod.rs
@@ -12,9 +12,9 @@
 //! See [`LoadedFeatures`] for more documentation on how to use the types in
 //! this module.
 //!
-//! [required]: https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-require
-//! [`require`]: https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-require
-//! [`require_relative`]: https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-require_relative
+//! [required]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-require
+//! [`require`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-require
+//! [`require_relative`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-require_relative
 
 use core::hash::BuildHasher;
 use std::collections::hash_map::RandomState;
@@ -61,8 +61,8 @@ use crate::Feature;
 /// features.shrink_to_fit();
 /// ```
 ///
-/// [`require`]: https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-require
-/// [`require_relative`]: https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-require_relative
+/// [`require`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-require
+/// [`require_relative`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-require_relative
 #[derive(Debug)]
 pub struct LoadedFeatures<S = RandomState> {
     features: HashSet<Feature, S>,

--- a/mezzaluna-feature-loader/src/loaders/disk.rs
+++ b/mezzaluna-feature-loader/src/loaders/disk.rs
@@ -45,7 +45,7 @@ use crate::paths::is_explicit_relative;
 /// # example().unwrap();
 /// ```
 ///
-/// [require]: https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-require
+/// [require]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-require
 /// [explicit relative]: is_explicit_relative
 /// [resolves to the same file]: same_file
 /// [`Rubylib`]: super::Rubylib

--- a/mezzaluna-feature-loader/src/loaders/rubylib.rs
+++ b/mezzaluna-feature-loader/src/loaders/rubylib.rs
@@ -55,7 +55,7 @@ use same_file::Handle;
 /// # example().unwrap();
 /// ```
 ///
-/// [require]: https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-require
+/// [require]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-require
 /// [resolves to the same file]: same_file
 #[derive(Debug, PartialEq, Eq)]
 #[cfg_attr(docsrs, doc(cfg(feature = "rubylib")))]

--- a/mezzaluna-feature-loader/src/paths.rs
+++ b/mezzaluna-feature-loader/src/paths.rs
@@ -156,7 +156,7 @@ pub fn is_explicit_relative<P: AsRef<Path>>(path: P) -> bool {
 ///
 /// [loaders]: crate::loaders
 /// [current working directory]: std::env::current_dir
-/// [ruby-string]: https://ruby-doc.org/core-2.6.3/String.html
+/// [ruby-string]: https://ruby-doc.org/core-3.1.2/String.html
 /// [reference implementation]: https://github.com/artichoke/ruby/blob/v3_0_2/file.c#L6287-L6293
 #[must_use]
 pub fn is_explicit_relative_bytes<P: AsRef<[u8]>>(path: P) -> bool {

--- a/scolapasta-string-escape/README.md
+++ b/scolapasta-string-escape/README.md
@@ -96,6 +96,6 @@ This crate is `no_std`. This crate does not depend on [`alloc`].
 `scolapasta-string-escape` is licensed with the [MIT License](LICENSE) (c) Ryan
 Lopopolo.
 
-[`string#inspect`]: https://ruby-doc.org/core-2.6.3/String.html#method-i-inspect
-[`symbol#inspect`]: https://ruby-doc.org/core-2.6.3/Symbol.html#method-i-inspect
+[`string#inspect`]: https://ruby-doc.org/core-3.1.2/String.html#method-i-inspect
+[`symbol#inspect`]: https://ruby-doc.org/core-3.1.2/Symbol.html#method-i-inspect
 [`alloc`]: https://doc.rust-lang.org/alloc/

--- a/scolapasta-string-escape/src/lib.rs
+++ b/scolapasta-string-escape/src/lib.rs
@@ -78,8 +78,8 @@
 //!
 //! This crate is `no_std` compatible. This crate does not depend on [`alloc`].
 //!
-//! [`String#inspect`]: https://ruby-doc.org/core-2.6.3/String.html#method-i-inspect
-//! [`Symbol#inspect`]: https://ruby-doc.org/core-2.6.3/Symbol.html#method-i-inspect
+//! [`String#inspect`]: https://ruby-doc.org/core-3.1.2/String.html#method-i-inspect
+//! [`Symbol#inspect`]: https://ruby-doc.org/core-3.1.2/Symbol.html#method-i-inspect
 //! [`alloc`]: https://doc.rust-lang.org/alloc/
 
 #![no_std]

--- a/spinoso-array/README.md
+++ b/spinoso-array/README.md
@@ -79,7 +79,7 @@ All features are enabled by default.
 
 `spinoso-array` is licensed with the [MIT License](LICENSE) (c) Ryan Lopopolo.
 
-[ruby-array]: https://ruby-doc.org/core-2.6.3/Array.html
+[ruby-array]: https://ruby-doc.org/core-3.1.2/Array.html
 [artichoke]: https://github.com/artichoke/artichoke
 [`vec`]: https://doc.rust-lang.org/alloc/vec/struct.Vec.html
 [`smallvec`]: https://docs.rs/smallvec/latest/smallvec/struct.SmallVec.html

--- a/spinoso-array/src/array/mod.rs
+++ b/spinoso-array/src/array/mod.rs
@@ -11,7 +11,7 @@
 //! The `SmallArray` backend requires the `small-array` Cargo feature to be
 //! enabled.
 //!
-//! [`Array`]: https://ruby-doc.org/core-2.6.3/Array.html
+//! [`Array`]: https://ruby-doc.org/core-3.1.2/Array.html
 //! [`Vec`]: alloc::vec::Vec
 //! [`SmallVec`]: ::smallvec::SmallVec
 //! [`TinyVec`]: ::tinyvec::TinyVec

--- a/spinoso-array/src/array/smallvec/mod.rs
+++ b/spinoso-array/src/array/smallvec/mod.rs
@@ -66,7 +66,7 @@ mod iter;
 /// ```
 ///
 /// [`Array`]: crate::Array
-/// [ruby-array]: https://ruby-doc.org/core-2.6.3/Array.html
+/// [ruby-array]: https://ruby-doc.org/core-3.1.2/Array.html
 /// [`shift`]: SmallArray::shift
 /// [`shift_n`]: SmallArray::shift_n
 /// [`drop_n`]: SmallArray::drop_n

--- a/spinoso-array/src/array/tinyvec/mod.rs
+++ b/spinoso-array/src/array/tinyvec/mod.rs
@@ -68,7 +68,7 @@ mod iter;
 /// ```
 ///
 /// [`Array`]: crate::Array
-/// [ruby-array]: https://ruby-doc.org/core-2.6.3/Array.html
+/// [ruby-array]: https://ruby-doc.org/core-3.1.2/Array.html
 /// [`shift`]: TinyArray::shift
 /// [`shift_n`]: TinyArray::shift_n
 /// [`drop_n`]: TinyArray::drop_n

--- a/spinoso-array/src/array/vec/mod.rs
+++ b/spinoso-array/src/array/vec/mod.rs
@@ -50,7 +50,7 @@ mod iter;
 /// assert_eq!(ary, &[7, 1, 2, 3]);
 /// ```
 ///
-/// [ruby-array]: https://ruby-doc.org/core-2.6.3/Array.html
+/// [ruby-array]: https://ruby-doc.org/core-3.1.2/Array.html
 /// [`shift`]: Array::shift
 /// [`shift_n`]: Array::shift_n
 /// [`drop_n`]: Array::drop_n

--- a/spinoso-array/src/lib.rs
+++ b/spinoso-array/src/lib.rs
@@ -114,7 +114,7 @@
 //! slicing APIs operate until the end of the vector or return `&[]`. Mutating
 //! APIs extend `Array`s on out of bounds access.
 //!
-//! [Ruby `Array`]: https://ruby-doc.org/core-2.6.3/Array.html
+//! [Ruby `Array`]: https://ruby-doc.org/core-3.1.2/Array.html
 //! [collection of crates]: https://crates.io/keywords/spinoso
 //! [Artichoke Ruby]: https://www.artichokeruby.org/
 //! [`Vec`]: alloc::vec::Vec

--- a/spinoso-env/README.md
+++ b/spinoso-env/README.md
@@ -86,7 +86,7 @@ All features are enabled by default:
 
 `spinoso-env` is licensed with the [MIT License](LICENSE) (c) Ryan Lopopolo.
 
-[`env`]: https://ruby-doc.org/core-2.6.3/ENV.html
+[`env`]: https://ruby-doc.org/core-3.1.2/ENV.html
 [`hashmap`]: std::collections::HashMap
 [rust standard library]: https://doc.rust-lang.org/std/
 [`std`]: https://doc.rust-lang.org/std/

--- a/spinoso-env/src/lib.rs
+++ b/spinoso-env/src/lib.rs
@@ -85,7 +85,7 @@
 //! - **system-env** - Enable an `ENV` backend that accesses the host system's
 //!   environment variables via the [`std::env`] module.
 //!
-//! [`ENV`]: https://ruby-doc.org/core-2.6.3/ENV.html
+//! [`ENV`]: https://ruby-doc.org/core-3.1.2/ENV.html
 //! [`HashMap`]: std::collections::HashMap
 //! [Rust Standard Library]: std
 //! [`std::env`]: module@std::env
@@ -188,7 +188,7 @@ impl error::Error for Error {
 /// assert_eq!(err.message(), "bad environment variable name: contains null byte");
 /// ```
 ///
-/// [Ruby `ArgumentError` Exception class]: https://ruby-doc.org/core-2.6.3/ArgumentError.html
+/// [Ruby `ArgumentError` Exception class]: https://ruby-doc.org/core-3.1.2/ArgumentError.html
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ArgumentError(&'static str);
 

--- a/spinoso-exception/README.md
+++ b/spinoso-exception/README.md
@@ -78,9 +78,9 @@ All features are enabled by default.
 `spinoso-exception` is licensed with the [MIT License](LICENSE) (c) Ryan
 Lopopolo.
 
-[`exception`]: https://ruby-doc.org/core-2.6.3/Exception.html
-[`kernel#raise`]: https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-raise
-[`nameerror#name`]: https://ruby-doc.org/core-2.6.3/NameError.html#method-i-name
+[`exception`]: https://ruby-doc.org/core-3.1.2/Exception.html
+[`kernel#raise`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-raise
+[`nameerror#name`]: https://ruby-doc.org/core-3.1.2/NameError.html#method-i-name
 [object safe]:
   https://doc.rust-lang.org/book/ch17-02-trait-objects.html#object-safety-is-required-for-trait-objects
 [`alloc`]: https://doc.rust-lang.org/alloc/

--- a/spinoso-exception/scripts/autogen.rb
+++ b/spinoso-exception/scripts/autogen.rb
@@ -30,9 +30,9 @@ def render(exc:, type:)
     /// traceback information. `Exception` subclasses may add additional information
     /// like [`NameError#name`].
     ///
-    /// [`Exception`]: https://ruby-doc.org/core-2.6.3/Exception.html
-    /// [`Kernel#raise`]: https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-raise
-    /// [`NameError#name`]: https://ruby-doc.org/core-2.6.3/NameError.html#method-i-name
+    /// [`Exception`]: https://ruby-doc.org/core-3.1.2/Exception.html
+    /// [`Kernel#raise`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-raise
+    /// [`NameError#name`]: https://ruby-doc.org/core-3.1.2/NameError.html#method-i-name
     #[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]#{clippy_suppressions}
     pub struct #{type} {
         message: Cow<'static, [u8]>,

--- a/spinoso-exception/src/core/argumenterror.rs
+++ b/spinoso-exception/src/core/argumenterror.rs
@@ -20,9 +20,9 @@ use crate::RubyException;
 /// traceback information. `Exception` subclasses may add additional information
 /// like [`NameError#name`].
 ///
-/// [`Exception`]: https://ruby-doc.org/core-2.6.3/Exception.html
-/// [`Kernel#raise`]: https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-raise
-/// [`NameError#name`]: https://ruby-doc.org/core-2.6.3/NameError.html#method-i-name
+/// [`Exception`]: https://ruby-doc.org/core-3.1.2/Exception.html
+/// [`Kernel#raise`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-raise
+/// [`NameError#name`]: https://ruby-doc.org/core-3.1.2/NameError.html#method-i-name
 #[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ArgumentError {
     message: Cow<'static, [u8]>,

--- a/spinoso-exception/src/core/encodingerror.rs
+++ b/spinoso-exception/src/core/encodingerror.rs
@@ -20,9 +20,9 @@ use crate::RubyException;
 /// traceback information. `Exception` subclasses may add additional information
 /// like [`NameError#name`].
 ///
-/// [`Exception`]: https://ruby-doc.org/core-2.6.3/Exception.html
-/// [`Kernel#raise`]: https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-raise
-/// [`NameError#name`]: https://ruby-doc.org/core-2.6.3/NameError.html#method-i-name
+/// [`Exception`]: https://ruby-doc.org/core-3.1.2/Exception.html
+/// [`Kernel#raise`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-raise
+/// [`NameError#name`]: https://ruby-doc.org/core-3.1.2/NameError.html#method-i-name
 #[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct EncodingError {
     message: Cow<'static, [u8]>,

--- a/spinoso-exception/src/core/eoferror.rs
+++ b/spinoso-exception/src/core/eoferror.rs
@@ -20,9 +20,9 @@ use crate::RubyException;
 /// traceback information. `Exception` subclasses may add additional information
 /// like [`NameError#name`].
 ///
-/// [`Exception`]: https://ruby-doc.org/core-2.6.3/Exception.html
-/// [`Kernel#raise`]: https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-raise
-/// [`NameError#name`]: https://ruby-doc.org/core-2.6.3/NameError.html#method-i-name
+/// [`Exception`]: https://ruby-doc.org/core-3.1.2/Exception.html
+/// [`Kernel#raise`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-raise
+/// [`NameError#name`]: https://ruby-doc.org/core-3.1.2/NameError.html#method-i-name
 #[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[allow(clippy::upper_case_acronyms)]
 pub struct EOFError {

--- a/spinoso-exception/src/core/exception.rs
+++ b/spinoso-exception/src/core/exception.rs
@@ -20,9 +20,9 @@ use crate::RubyException;
 /// traceback information. `Exception` subclasses may add additional information
 /// like [`NameError#name`].
 ///
-/// [`Exception`]: https://ruby-doc.org/core-2.6.3/Exception.html
-/// [`Kernel#raise`]: https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-raise
-/// [`NameError#name`]: https://ruby-doc.org/core-2.6.3/NameError.html#method-i-name
+/// [`Exception`]: https://ruby-doc.org/core-3.1.2/Exception.html
+/// [`Kernel#raise`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-raise
+/// [`NameError#name`]: https://ruby-doc.org/core-3.1.2/NameError.html#method-i-name
 #[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Exception {
     message: Cow<'static, [u8]>,

--- a/spinoso-exception/src/core/fatal.rs
+++ b/spinoso-exception/src/core/fatal.rs
@@ -20,9 +20,9 @@ use crate::RubyException;
 /// traceback information. `Exception` subclasses may add additional information
 /// like [`NameError#name`].
 ///
-/// [`Exception`]: https://ruby-doc.org/core-2.6.3/Exception.html
-/// [`Kernel#raise`]: https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-raise
-/// [`NameError#name`]: https://ruby-doc.org/core-2.6.3/NameError.html#method-i-name
+/// [`Exception`]: https://ruby-doc.org/core-3.1.2/Exception.html
+/// [`Kernel#raise`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-raise
+/// [`NameError#name`]: https://ruby-doc.org/core-3.1.2/NameError.html#method-i-name
 #[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Fatal {
     message: Cow<'static, [u8]>,

--- a/spinoso-exception/src/core/fibererror.rs
+++ b/spinoso-exception/src/core/fibererror.rs
@@ -20,9 +20,9 @@ use crate::RubyException;
 /// traceback information. `Exception` subclasses may add additional information
 /// like [`NameError#name`].
 ///
-/// [`Exception`]: https://ruby-doc.org/core-2.6.3/Exception.html
-/// [`Kernel#raise`]: https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-raise
-/// [`NameError#name`]: https://ruby-doc.org/core-2.6.3/NameError.html#method-i-name
+/// [`Exception`]: https://ruby-doc.org/core-3.1.2/Exception.html
+/// [`Kernel#raise`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-raise
+/// [`NameError#name`]: https://ruby-doc.org/core-3.1.2/NameError.html#method-i-name
 #[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct FiberError {
     message: Cow<'static, [u8]>,

--- a/spinoso-exception/src/core/floatdomainerror.rs
+++ b/spinoso-exception/src/core/floatdomainerror.rs
@@ -20,9 +20,9 @@ use crate::RubyException;
 /// traceback information. `Exception` subclasses may add additional information
 /// like [`NameError#name`].
 ///
-/// [`Exception`]: https://ruby-doc.org/core-2.6.3/Exception.html
-/// [`Kernel#raise`]: https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-raise
-/// [`NameError#name`]: https://ruby-doc.org/core-2.6.3/NameError.html#method-i-name
+/// [`Exception`]: https://ruby-doc.org/core-3.1.2/Exception.html
+/// [`Kernel#raise`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-raise
+/// [`NameError#name`]: https://ruby-doc.org/core-3.1.2/NameError.html#method-i-name
 #[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct FloatDomainError {
     message: Cow<'static, [u8]>,

--- a/spinoso-exception/src/core/frozenerror.rs
+++ b/spinoso-exception/src/core/frozenerror.rs
@@ -20,9 +20,9 @@ use crate::RubyException;
 /// traceback information. `Exception` subclasses may add additional information
 /// like [`NameError#name`].
 ///
-/// [`Exception`]: https://ruby-doc.org/core-2.6.3/Exception.html
-/// [`Kernel#raise`]: https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-raise
-/// [`NameError#name`]: https://ruby-doc.org/core-2.6.3/NameError.html#method-i-name
+/// [`Exception`]: https://ruby-doc.org/core-3.1.2/Exception.html
+/// [`Kernel#raise`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-raise
+/// [`NameError#name`]: https://ruby-doc.org/core-3.1.2/NameError.html#method-i-name
 #[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct FrozenError {
     message: Cow<'static, [u8]>,

--- a/spinoso-exception/src/core/indexerror.rs
+++ b/spinoso-exception/src/core/indexerror.rs
@@ -20,9 +20,9 @@ use crate::RubyException;
 /// traceback information. `Exception` subclasses may add additional information
 /// like [`NameError#name`].
 ///
-/// [`Exception`]: https://ruby-doc.org/core-2.6.3/Exception.html
-/// [`Kernel#raise`]: https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-raise
-/// [`NameError#name`]: https://ruby-doc.org/core-2.6.3/NameError.html#method-i-name
+/// [`Exception`]: https://ruby-doc.org/core-3.1.2/Exception.html
+/// [`Kernel#raise`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-raise
+/// [`NameError#name`]: https://ruby-doc.org/core-3.1.2/NameError.html#method-i-name
 #[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct IndexError {
     message: Cow<'static, [u8]>,

--- a/spinoso-exception/src/core/interrupt.rs
+++ b/spinoso-exception/src/core/interrupt.rs
@@ -20,9 +20,9 @@ use crate::RubyException;
 /// traceback information. `Exception` subclasses may add additional information
 /// like [`NameError#name`].
 ///
-/// [`Exception`]: https://ruby-doc.org/core-2.6.3/Exception.html
-/// [`Kernel#raise`]: https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-raise
-/// [`NameError#name`]: https://ruby-doc.org/core-2.6.3/NameError.html#method-i-name
+/// [`Exception`]: https://ruby-doc.org/core-3.1.2/Exception.html
+/// [`Kernel#raise`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-raise
+/// [`NameError#name`]: https://ruby-doc.org/core-3.1.2/NameError.html#method-i-name
 #[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Interrupt {
     message: Cow<'static, [u8]>,

--- a/spinoso-exception/src/core/ioerror.rs
+++ b/spinoso-exception/src/core/ioerror.rs
@@ -20,9 +20,9 @@ use crate::RubyException;
 /// traceback information. `Exception` subclasses may add additional information
 /// like [`NameError#name`].
 ///
-/// [`Exception`]: https://ruby-doc.org/core-2.6.3/Exception.html
-/// [`Kernel#raise`]: https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-raise
-/// [`NameError#name`]: https://ruby-doc.org/core-2.6.3/NameError.html#method-i-name
+/// [`Exception`]: https://ruby-doc.org/core-3.1.2/Exception.html
+/// [`Kernel#raise`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-raise
+/// [`NameError#name`]: https://ruby-doc.org/core-3.1.2/NameError.html#method-i-name
 #[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[allow(clippy::upper_case_acronyms)]
 pub struct IOError {

--- a/spinoso-exception/src/core/keyerror.rs
+++ b/spinoso-exception/src/core/keyerror.rs
@@ -20,9 +20,9 @@ use crate::RubyException;
 /// traceback information. `Exception` subclasses may add additional information
 /// like [`NameError#name`].
 ///
-/// [`Exception`]: https://ruby-doc.org/core-2.6.3/Exception.html
-/// [`Kernel#raise`]: https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-raise
-/// [`NameError#name`]: https://ruby-doc.org/core-2.6.3/NameError.html#method-i-name
+/// [`Exception`]: https://ruby-doc.org/core-3.1.2/Exception.html
+/// [`Kernel#raise`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-raise
+/// [`NameError#name`]: https://ruby-doc.org/core-3.1.2/NameError.html#method-i-name
 #[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct KeyError {
     message: Cow<'static, [u8]>,

--- a/spinoso-exception/src/core/loaderror.rs
+++ b/spinoso-exception/src/core/loaderror.rs
@@ -20,9 +20,9 @@ use crate::RubyException;
 /// traceback information. `Exception` subclasses may add additional information
 /// like [`NameError#name`].
 ///
-/// [`Exception`]: https://ruby-doc.org/core-2.6.3/Exception.html
-/// [`Kernel#raise`]: https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-raise
-/// [`NameError#name`]: https://ruby-doc.org/core-2.6.3/NameError.html#method-i-name
+/// [`Exception`]: https://ruby-doc.org/core-3.1.2/Exception.html
+/// [`Kernel#raise`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-raise
+/// [`NameError#name`]: https://ruby-doc.org/core-3.1.2/NameError.html#method-i-name
 #[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct LoadError {
     message: Cow<'static, [u8]>,

--- a/spinoso-exception/src/core/localjumperror.rs
+++ b/spinoso-exception/src/core/localjumperror.rs
@@ -20,9 +20,9 @@ use crate::RubyException;
 /// traceback information. `Exception` subclasses may add additional information
 /// like [`NameError#name`].
 ///
-/// [`Exception`]: https://ruby-doc.org/core-2.6.3/Exception.html
-/// [`Kernel#raise`]: https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-raise
-/// [`NameError#name`]: https://ruby-doc.org/core-2.6.3/NameError.html#method-i-name
+/// [`Exception`]: https://ruby-doc.org/core-3.1.2/Exception.html
+/// [`Kernel#raise`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-raise
+/// [`NameError#name`]: https://ruby-doc.org/core-3.1.2/NameError.html#method-i-name
 #[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct LocalJumpError {
     message: Cow<'static, [u8]>,

--- a/spinoso-exception/src/core/nameerror.rs
+++ b/spinoso-exception/src/core/nameerror.rs
@@ -20,9 +20,9 @@ use crate::RubyException;
 /// traceback information. `Exception` subclasses may add additional information
 /// like [`NameError#name`].
 ///
-/// [`Exception`]: https://ruby-doc.org/core-2.6.3/Exception.html
-/// [`Kernel#raise`]: https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-raise
-/// [`NameError#name`]: https://ruby-doc.org/core-2.6.3/NameError.html#method-i-name
+/// [`Exception`]: https://ruby-doc.org/core-3.1.2/Exception.html
+/// [`Kernel#raise`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-raise
+/// [`NameError#name`]: https://ruby-doc.org/core-3.1.2/NameError.html#method-i-name
 #[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct NameError {
     message: Cow<'static, [u8]>,

--- a/spinoso-exception/src/core/nomemoryerror.rs
+++ b/spinoso-exception/src/core/nomemoryerror.rs
@@ -20,9 +20,9 @@ use crate::RubyException;
 /// traceback information. `Exception` subclasses may add additional information
 /// like [`NameError#name`].
 ///
-/// [`Exception`]: https://ruby-doc.org/core-2.6.3/Exception.html
-/// [`Kernel#raise`]: https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-raise
-/// [`NameError#name`]: https://ruby-doc.org/core-2.6.3/NameError.html#method-i-name
+/// [`Exception`]: https://ruby-doc.org/core-3.1.2/Exception.html
+/// [`Kernel#raise`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-raise
+/// [`NameError#name`]: https://ruby-doc.org/core-3.1.2/NameError.html#method-i-name
 #[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct NoMemoryError {
     message: Cow<'static, [u8]>,

--- a/spinoso-exception/src/core/nomethoderror.rs
+++ b/spinoso-exception/src/core/nomethoderror.rs
@@ -20,9 +20,9 @@ use crate::RubyException;
 /// traceback information. `Exception` subclasses may add additional information
 /// like [`NameError#name`].
 ///
-/// [`Exception`]: https://ruby-doc.org/core-2.6.3/Exception.html
-/// [`Kernel#raise`]: https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-raise
-/// [`NameError#name`]: https://ruby-doc.org/core-2.6.3/NameError.html#method-i-name
+/// [`Exception`]: https://ruby-doc.org/core-3.1.2/Exception.html
+/// [`Kernel#raise`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-raise
+/// [`NameError#name`]: https://ruby-doc.org/core-3.1.2/NameError.html#method-i-name
 #[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct NoMethodError {
     message: Cow<'static, [u8]>,

--- a/spinoso-exception/src/core/notimplementederror.rs
+++ b/spinoso-exception/src/core/notimplementederror.rs
@@ -20,9 +20,9 @@ use crate::RubyException;
 /// traceback information. `Exception` subclasses may add additional information
 /// like [`NameError#name`].
 ///
-/// [`Exception`]: https://ruby-doc.org/core-2.6.3/Exception.html
-/// [`Kernel#raise`]: https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-raise
-/// [`NameError#name`]: https://ruby-doc.org/core-2.6.3/NameError.html#method-i-name
+/// [`Exception`]: https://ruby-doc.org/core-3.1.2/Exception.html
+/// [`Kernel#raise`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-raise
+/// [`NameError#name`]: https://ruby-doc.org/core-3.1.2/NameError.html#method-i-name
 #[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct NotImplementedError {
     message: Cow<'static, [u8]>,

--- a/spinoso-exception/src/core/rangeerror.rs
+++ b/spinoso-exception/src/core/rangeerror.rs
@@ -20,9 +20,9 @@ use crate::RubyException;
 /// traceback information. `Exception` subclasses may add additional information
 /// like [`NameError#name`].
 ///
-/// [`Exception`]: https://ruby-doc.org/core-2.6.3/Exception.html
-/// [`Kernel#raise`]: https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-raise
-/// [`NameError#name`]: https://ruby-doc.org/core-2.6.3/NameError.html#method-i-name
+/// [`Exception`]: https://ruby-doc.org/core-3.1.2/Exception.html
+/// [`Kernel#raise`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-raise
+/// [`NameError#name`]: https://ruby-doc.org/core-3.1.2/NameError.html#method-i-name
 #[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct RangeError {
     message: Cow<'static, [u8]>,

--- a/spinoso-exception/src/core/regexperror.rs
+++ b/spinoso-exception/src/core/regexperror.rs
@@ -20,9 +20,9 @@ use crate::RubyException;
 /// traceback information. `Exception` subclasses may add additional information
 /// like [`NameError#name`].
 ///
-/// [`Exception`]: https://ruby-doc.org/core-2.6.3/Exception.html
-/// [`Kernel#raise`]: https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-raise
-/// [`NameError#name`]: https://ruby-doc.org/core-2.6.3/NameError.html#method-i-name
+/// [`Exception`]: https://ruby-doc.org/core-3.1.2/Exception.html
+/// [`Kernel#raise`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-raise
+/// [`NameError#name`]: https://ruby-doc.org/core-3.1.2/NameError.html#method-i-name
 #[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct RegexpError {
     message: Cow<'static, [u8]>,

--- a/spinoso-exception/src/core/runtimeerror.rs
+++ b/spinoso-exception/src/core/runtimeerror.rs
@@ -20,9 +20,9 @@ use crate::RubyException;
 /// traceback information. `Exception` subclasses may add additional information
 /// like [`NameError#name`].
 ///
-/// [`Exception`]: https://ruby-doc.org/core-2.6.3/Exception.html
-/// [`Kernel#raise`]: https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-raise
-/// [`NameError#name`]: https://ruby-doc.org/core-2.6.3/NameError.html#method-i-name
+/// [`Exception`]: https://ruby-doc.org/core-3.1.2/Exception.html
+/// [`Kernel#raise`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-raise
+/// [`NameError#name`]: https://ruby-doc.org/core-3.1.2/NameError.html#method-i-name
 #[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct RuntimeError {
     message: Cow<'static, [u8]>,

--- a/spinoso-exception/src/core/scripterror.rs
+++ b/spinoso-exception/src/core/scripterror.rs
@@ -20,9 +20,9 @@ use crate::RubyException;
 /// traceback information. `Exception` subclasses may add additional information
 /// like [`NameError#name`].
 ///
-/// [`Exception`]: https://ruby-doc.org/core-2.6.3/Exception.html
-/// [`Kernel#raise`]: https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-raise
-/// [`NameError#name`]: https://ruby-doc.org/core-2.6.3/NameError.html#method-i-name
+/// [`Exception`]: https://ruby-doc.org/core-3.1.2/Exception.html
+/// [`Kernel#raise`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-raise
+/// [`NameError#name`]: https://ruby-doc.org/core-3.1.2/NameError.html#method-i-name
 #[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ScriptError {
     message: Cow<'static, [u8]>,

--- a/spinoso-exception/src/core/securityerror.rs
+++ b/spinoso-exception/src/core/securityerror.rs
@@ -20,9 +20,9 @@ use crate::RubyException;
 /// traceback information. `Exception` subclasses may add additional information
 /// like [`NameError#name`].
 ///
-/// [`Exception`]: https://ruby-doc.org/core-2.6.3/Exception.html
-/// [`Kernel#raise`]: https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-raise
-/// [`NameError#name`]: https://ruby-doc.org/core-2.6.3/NameError.html#method-i-name
+/// [`Exception`]: https://ruby-doc.org/core-3.1.2/Exception.html
+/// [`Kernel#raise`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-raise
+/// [`NameError#name`]: https://ruby-doc.org/core-3.1.2/NameError.html#method-i-name
 #[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct SecurityError {
     message: Cow<'static, [u8]>,

--- a/spinoso-exception/src/core/signalexception.rs
+++ b/spinoso-exception/src/core/signalexception.rs
@@ -20,9 +20,9 @@ use crate::RubyException;
 /// traceback information. `Exception` subclasses may add additional information
 /// like [`NameError#name`].
 ///
-/// [`Exception`]: https://ruby-doc.org/core-2.6.3/Exception.html
-/// [`Kernel#raise`]: https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-raise
-/// [`NameError#name`]: https://ruby-doc.org/core-2.6.3/NameError.html#method-i-name
+/// [`Exception`]: https://ruby-doc.org/core-3.1.2/Exception.html
+/// [`Kernel#raise`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-raise
+/// [`NameError#name`]: https://ruby-doc.org/core-3.1.2/NameError.html#method-i-name
 #[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct SignalException {
     message: Cow<'static, [u8]>,

--- a/spinoso-exception/src/core/standarderror.rs
+++ b/spinoso-exception/src/core/standarderror.rs
@@ -20,9 +20,9 @@ use crate::RubyException;
 /// traceback information. `Exception` subclasses may add additional information
 /// like [`NameError#name`].
 ///
-/// [`Exception`]: https://ruby-doc.org/core-2.6.3/Exception.html
-/// [`Kernel#raise`]: https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-raise
-/// [`NameError#name`]: https://ruby-doc.org/core-2.6.3/NameError.html#method-i-name
+/// [`Exception`]: https://ruby-doc.org/core-3.1.2/Exception.html
+/// [`Kernel#raise`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-raise
+/// [`NameError#name`]: https://ruby-doc.org/core-3.1.2/NameError.html#method-i-name
 #[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct StandardError {
     message: Cow<'static, [u8]>,

--- a/spinoso-exception/src/core/stopiteration.rs
+++ b/spinoso-exception/src/core/stopiteration.rs
@@ -20,9 +20,9 @@ use crate::RubyException;
 /// traceback information. `Exception` subclasses may add additional information
 /// like [`NameError#name`].
 ///
-/// [`Exception`]: https://ruby-doc.org/core-2.6.3/Exception.html
-/// [`Kernel#raise`]: https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-raise
-/// [`NameError#name`]: https://ruby-doc.org/core-2.6.3/NameError.html#method-i-name
+/// [`Exception`]: https://ruby-doc.org/core-3.1.2/Exception.html
+/// [`Kernel#raise`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-raise
+/// [`NameError#name`]: https://ruby-doc.org/core-3.1.2/NameError.html#method-i-name
 #[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct StopIteration {
     message: Cow<'static, [u8]>,

--- a/spinoso-exception/src/core/syntaxerror.rs
+++ b/spinoso-exception/src/core/syntaxerror.rs
@@ -20,9 +20,9 @@ use crate::RubyException;
 /// traceback information. `Exception` subclasses may add additional information
 /// like [`NameError#name`].
 ///
-/// [`Exception`]: https://ruby-doc.org/core-2.6.3/Exception.html
-/// [`Kernel#raise`]: https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-raise
-/// [`NameError#name`]: https://ruby-doc.org/core-2.6.3/NameError.html#method-i-name
+/// [`Exception`]: https://ruby-doc.org/core-3.1.2/Exception.html
+/// [`Kernel#raise`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-raise
+/// [`NameError#name`]: https://ruby-doc.org/core-3.1.2/NameError.html#method-i-name
 #[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct SyntaxError {
     message: Cow<'static, [u8]>,

--- a/spinoso-exception/src/core/systemcallerror.rs
+++ b/spinoso-exception/src/core/systemcallerror.rs
@@ -20,9 +20,9 @@ use crate::RubyException;
 /// traceback information. `Exception` subclasses may add additional information
 /// like [`NameError#name`].
 ///
-/// [`Exception`]: https://ruby-doc.org/core-2.6.3/Exception.html
-/// [`Kernel#raise`]: https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-raise
-/// [`NameError#name`]: https://ruby-doc.org/core-2.6.3/NameError.html#method-i-name
+/// [`Exception`]: https://ruby-doc.org/core-3.1.2/Exception.html
+/// [`Kernel#raise`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-raise
+/// [`NameError#name`]: https://ruby-doc.org/core-3.1.2/NameError.html#method-i-name
 #[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct SystemCallError {
     message: Cow<'static, [u8]>,

--- a/spinoso-exception/src/core/systemexit.rs
+++ b/spinoso-exception/src/core/systemexit.rs
@@ -20,9 +20,9 @@ use crate::RubyException;
 /// traceback information. `Exception` subclasses may add additional information
 /// like [`NameError#name`].
 ///
-/// [`Exception`]: https://ruby-doc.org/core-2.6.3/Exception.html
-/// [`Kernel#raise`]: https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-raise
-/// [`NameError#name`]: https://ruby-doc.org/core-2.6.3/NameError.html#method-i-name
+/// [`Exception`]: https://ruby-doc.org/core-3.1.2/Exception.html
+/// [`Kernel#raise`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-raise
+/// [`NameError#name`]: https://ruby-doc.org/core-3.1.2/NameError.html#method-i-name
 #[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct SystemExit {
     message: Cow<'static, [u8]>,

--- a/spinoso-exception/src/core/systemstackerror.rs
+++ b/spinoso-exception/src/core/systemstackerror.rs
@@ -20,9 +20,9 @@ use crate::RubyException;
 /// traceback information. `Exception` subclasses may add additional information
 /// like [`NameError#name`].
 ///
-/// [`Exception`]: https://ruby-doc.org/core-2.6.3/Exception.html
-/// [`Kernel#raise`]: https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-raise
-/// [`NameError#name`]: https://ruby-doc.org/core-2.6.3/NameError.html#method-i-name
+/// [`Exception`]: https://ruby-doc.org/core-3.1.2/Exception.html
+/// [`Kernel#raise`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-raise
+/// [`NameError#name`]: https://ruby-doc.org/core-3.1.2/NameError.html#method-i-name
 #[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct SystemStackError {
     message: Cow<'static, [u8]>,

--- a/spinoso-exception/src/core/threaderror.rs
+++ b/spinoso-exception/src/core/threaderror.rs
@@ -20,9 +20,9 @@ use crate::RubyException;
 /// traceback information. `Exception` subclasses may add additional information
 /// like [`NameError#name`].
 ///
-/// [`Exception`]: https://ruby-doc.org/core-2.6.3/Exception.html
-/// [`Kernel#raise`]: https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-raise
-/// [`NameError#name`]: https://ruby-doc.org/core-2.6.3/NameError.html#method-i-name
+/// [`Exception`]: https://ruby-doc.org/core-3.1.2/Exception.html
+/// [`Kernel#raise`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-raise
+/// [`NameError#name`]: https://ruby-doc.org/core-3.1.2/NameError.html#method-i-name
 #[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ThreadError {
     message: Cow<'static, [u8]>,

--- a/spinoso-exception/src/core/typeerror.rs
+++ b/spinoso-exception/src/core/typeerror.rs
@@ -20,9 +20,9 @@ use crate::RubyException;
 /// traceback information. `Exception` subclasses may add additional information
 /// like [`NameError#name`].
 ///
-/// [`Exception`]: https://ruby-doc.org/core-2.6.3/Exception.html
-/// [`Kernel#raise`]: https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-raise
-/// [`NameError#name`]: https://ruby-doc.org/core-2.6.3/NameError.html#method-i-name
+/// [`Exception`]: https://ruby-doc.org/core-3.1.2/Exception.html
+/// [`Kernel#raise`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-raise
+/// [`NameError#name`]: https://ruby-doc.org/core-3.1.2/NameError.html#method-i-name
 #[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct TypeError {
     message: Cow<'static, [u8]>,

--- a/spinoso-exception/src/core/uncaughtthrowerror.rs
+++ b/spinoso-exception/src/core/uncaughtthrowerror.rs
@@ -20,9 +20,9 @@ use crate::RubyException;
 /// traceback information. `Exception` subclasses may add additional information
 /// like [`NameError#name`].
 ///
-/// [`Exception`]: https://ruby-doc.org/core-2.6.3/Exception.html
-/// [`Kernel#raise`]: https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-raise
-/// [`NameError#name`]: https://ruby-doc.org/core-2.6.3/NameError.html#method-i-name
+/// [`Exception`]: https://ruby-doc.org/core-3.1.2/Exception.html
+/// [`Kernel#raise`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-raise
+/// [`NameError#name`]: https://ruby-doc.org/core-3.1.2/NameError.html#method-i-name
 #[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct UncaughtThrowError {
     message: Cow<'static, [u8]>,

--- a/spinoso-exception/src/core/zerodivisionerror.rs
+++ b/spinoso-exception/src/core/zerodivisionerror.rs
@@ -20,9 +20,9 @@ use crate::RubyException;
 /// traceback information. `Exception` subclasses may add additional information
 /// like [`NameError#name`].
 ///
-/// [`Exception`]: https://ruby-doc.org/core-2.6.3/Exception.html
-/// [`Kernel#raise`]: https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-raise
-/// [`NameError#name`]: https://ruby-doc.org/core-2.6.3/NameError.html#method-i-name
+/// [`Exception`]: https://ruby-doc.org/core-3.1.2/Exception.html
+/// [`Kernel#raise`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-raise
+/// [`NameError#name`]: https://ruby-doc.org/core-3.1.2/NameError.html#method-i-name
 #[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ZeroDivisionError {
     message: Cow<'static, [u8]>,

--- a/spinoso-exception/src/lib.rs
+++ b/spinoso-exception/src/lib.rs
@@ -79,41 +79,41 @@
 //!   this feature enables [`std::error::Error`] impls on error types in this
 //!   crate.
 //!
-//! [`Exception`]: https://ruby-doc.org/core-2.6.3/Exception.html
-//! [`Kernel#raise`]: https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-raise
-//! [`NameError#name`]: https://ruby-doc.org/core-2.6.3/NameError.html#method-i-name
-//! [`NoMemoryError`]: https://ruby-doc.org/core-2.6.3/NoMemoryError.html
-//! [`ScriptError`]: https://ruby-doc.org/core-2.6.3/ScriptError.html
-//! [`LoadError`]: https://ruby-doc.org/core-2.6.3/LoadError.html
-//! [`NotImplementedError`]: https://ruby-doc.org/core-2.6.3/NotImplementedError.html
-//! [`SyntaxError`]: https://ruby-doc.org/core-2.6.3/SyntaxError.html
-//! [`SecurityError`]: https://ruby-doc.org/core-2.6.3/SecurityError.html
-//! [`SignalException`]: https://ruby-doc.org/core-2.6.3/SignalException.html
-//! [`Interrupt`]: https://ruby-doc.org/core-2.6.3/Interrupt.html
-//! [`StandardError`]: https://ruby-doc.org/core-2.6.3/StandardError.html
-//! [`ArgumentError`]: https://ruby-doc.org/core-2.6.3/ArgumentError.html
-//! [`UncaughtThrowError`]: https://ruby-doc.org/core-2.6.3/UncaughtThrowError.html
-//! [`EncodingError`]: https://ruby-doc.org/core-2.6.3/EncodingError.html
-//! [`FiberError`]: https://ruby-doc.org/core-2.6.3/FiberError.html
-//! [`IOError`]: https://ruby-doc.org/core-2.6.3/IOError.html
-//! [`EOFError`]: https://ruby-doc.org/core-2.6.3/EOFError.html
-//! [`IndexError`]: https://ruby-doc.org/core-2.6.3/IndexError.html
-//! [`KeyError`]: https://ruby-doc.org/core-2.6.3/KeyError.html
-//! [`StopIteration`]: https://ruby-doc.org/core-2.6.3/StopIteration.html
-//! [`LocalJumpError`]: https://ruby-doc.org/core-2.6.3/LocalJumpError.html
-//! [`NameError`]: https://ruby-doc.org/core-2.6.3/NameError.html
-//! [`NoMethodError`]: https://ruby-doc.org/core-2.6.3/NoMethodError.html
-//! [`RangeError`]: https://ruby-doc.org/core-2.6.3/RangeError.html
-//! [`FloatDomainError`]: https://ruby-doc.org/core-2.6.3/FloatDomainError.html
-//! [`RegexpError`]: https://ruby-doc.org/core-2.6.3/RegexpError.html
-//! [`RuntimeError`]: https://ruby-doc.org/core-2.6.3/RuntimeError.html
-//! [`FrozenError`]: https://ruby-doc.org/core-2.6.3/FrozenError.html
-//! [`SystemCallError`]: https://ruby-doc.org/core-2.6.3/SystemCallError.html
-//! [`ThreadError`]: https://ruby-doc.org/core-2.6.3/ThreadError.html
-//! [`TypeError`]: https://ruby-doc.org/core-2.6.3/TypeError.html
-//! [`ZeroDivisionError`]: https://ruby-doc.org/core-2.6.3/ZeroDivisionError.html
-//! [`SystemExit`]: https://ruby-doc.org/core-2.6.3/SystemExit.html
-//! [`SystemStackError`]: https://ruby-doc.org/core-2.6.3/SystemStackError.html
+//! [`Exception`]: https://ruby-doc.org/core-3.1.2/Exception.html
+//! [`Kernel#raise`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-raise
+//! [`NameError#name`]: https://ruby-doc.org/core-3.1.2/NameError.html#method-i-name
+//! [`NoMemoryError`]: https://ruby-doc.org/core-3.1.2/NoMemoryError.html
+//! [`ScriptError`]: https://ruby-doc.org/core-3.1.2/ScriptError.html
+//! [`LoadError`]: https://ruby-doc.org/core-3.1.2/LoadError.html
+//! [`NotImplementedError`]: https://ruby-doc.org/core-3.1.2/NotImplementedError.html
+//! [`SyntaxError`]: https://ruby-doc.org/core-3.1.2/SyntaxError.html
+//! [`SecurityError`]: https://ruby-doc.org/core-3.1.2/SecurityError.html
+//! [`SignalException`]: https://ruby-doc.org/core-3.1.2/SignalException.html
+//! [`Interrupt`]: https://ruby-doc.org/core-3.1.2/Interrupt.html
+//! [`StandardError`]: https://ruby-doc.org/core-3.1.2/StandardError.html
+//! [`ArgumentError`]: https://ruby-doc.org/core-3.1.2/ArgumentError.html
+//! [`UncaughtThrowError`]: https://ruby-doc.org/core-3.1.2/UncaughtThrowError.html
+//! [`EncodingError`]: https://ruby-doc.org/core-3.1.2/EncodingError.html
+//! [`FiberError`]: https://ruby-doc.org/core-3.1.2/FiberError.html
+//! [`IOError`]: https://ruby-doc.org/core-3.1.2/IOError.html
+//! [`EOFError`]: https://ruby-doc.org/core-3.1.2/EOFError.html
+//! [`IndexError`]: https://ruby-doc.org/core-3.1.2/IndexError.html
+//! [`KeyError`]: https://ruby-doc.org/core-3.1.2/KeyError.html
+//! [`StopIteration`]: https://ruby-doc.org/core-3.1.2/StopIteration.html
+//! [`LocalJumpError`]: https://ruby-doc.org/core-3.1.2/LocalJumpError.html
+//! [`NameError`]: https://ruby-doc.org/core-3.1.2/NameError.html
+//! [`NoMethodError`]: https://ruby-doc.org/core-3.1.2/NoMethodError.html
+//! [`RangeError`]: https://ruby-doc.org/core-3.1.2/RangeError.html
+//! [`FloatDomainError`]: https://ruby-doc.org/core-3.1.2/FloatDomainError.html
+//! [`RegexpError`]: https://ruby-doc.org/core-3.1.2/RegexpError.html
+//! [`RuntimeError`]: https://ruby-doc.org/core-3.1.2/RuntimeError.html
+//! [`FrozenError`]: https://ruby-doc.org/core-3.1.2/FrozenError.html
+//! [`SystemCallError`]: https://ruby-doc.org/core-3.1.2/SystemCallError.html
+//! [`ThreadError`]: https://ruby-doc.org/core-3.1.2/ThreadError.html
+//! [`TypeError`]: https://ruby-doc.org/core-3.1.2/TypeError.html
+//! [`ZeroDivisionError`]: https://ruby-doc.org/core-3.1.2/ZeroDivisionError.html
+//! [`SystemExit`]: https://ruby-doc.org/core-3.1.2/SystemExit.html
+//! [`SystemStackError`]: https://ruby-doc.org/core-3.1.2/SystemStackError.html
 
 #![no_std]
 

--- a/spinoso-math/README.md
+++ b/spinoso-math/README.md
@@ -67,7 +67,7 @@ All features are enabled by default.
 
 `spinoso-math` is licensed with the [MIT License](LICENSE) (c) Ryan Lopopolo.
 
-[`float`]: https://ruby-doc.org/core-2.6.3/Float.html
+[`float`]: https://ruby-doc.org/core-3.1.2/Float.html
 [`core`]: https://doc.rust-lang.org/core/
 [`nan`]: https://doc.rust-lang.org/std/primitive.f64.html#associatedconstant.NAN
 [`f64`]: https://doc.rust-lang.org/std/primitive.f64.html

--- a/spinoso-math/src/lib.rs
+++ b/spinoso-math/src/lib.rs
@@ -62,7 +62,7 @@
 //!   implementations in Rust [`core`]. Dropping this feature removes the
 //!   [`libm`] dependency.
 //!
-//! [`Float`]: https://ruby-doc.org/core-2.6.3/Float.html
+//! [`Float`]: https://ruby-doc.org/core-3.1.2/Float.html
 //! [`NaN`]: f64::NAN
 //! [`alloc`]: https://doc.rust-lang.org/alloc/
 
@@ -213,7 +213,7 @@ impl error::Error for Error {
 /// assert_eq!(err.message(), r#"Numerical argument is out of domain - "acos""#);
 /// ```
 ///
-/// [Ruby `Math::DomainError` Exception class]: https://ruby-doc.org/core-2.6.3/Math/DomainError.html
+/// [Ruby `Math::DomainError` Exception class]: https://ruby-doc.org/core-3.1.2/Math/DomainError.html
 #[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct DomainError(&'static str);
 
@@ -316,7 +316,7 @@ impl error::Error for DomainError {}
 ///
 /// [Rust core library]: https://doc.rust-lang.org/std/primitive.f64.html
 /// [additional dependencies]: https://crates.io/crates/libm
-/// [Ruby `NotImplementedError` Exception class]: https://ruby-doc.org/core-2.6.3/NotImplementedError.html
+/// [Ruby `NotImplementedError` Exception class]: https://ruby-doc.org/core-3.1.2/NotImplementedError.html
 #[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct NotImplementedError(&'static str);
 

--- a/spinoso-random/README.md
+++ b/spinoso-random/README.md
@@ -82,7 +82,7 @@ All features are enabled by default.
 [2.6.3][ruby-2.6.3] which is copyright Yukihiro Matsumoto \<matz@netlab.jp\>.
 Ruby is licensed with the [2-clause BSDL License][ruby-license].
 
-[ruby-random]: https://ruby-doc.org/core-2.6.3/Random.html
+[ruby-random]: https://ruby-doc.org/core-3.1.2/Random.html
 [`alloc`]: https://doc.rust-lang.org/alloc/
 [`rngcore`]: https://docs.rs/rand_core/latest/rand_core/trait.RngCore.html
 [`rand`]: https://crates.io/crates/rand

--- a/spinoso-random/src/lib.rs
+++ b/spinoso-random/src/lib.rs
@@ -82,7 +82,7 @@
 //!   this feature enables [`std::error::Error`] impls on error types in this
 //!   crate.
 //!
-//! [ruby-random]: https://ruby-doc.org/core-2.6.3/Random.html
+//! [ruby-random]: https://ruby-doc.org/core-3.1.2/Random.html
 //! [`alloc`]: https://doc.rust-lang.org/alloc/
 //! [`rand`]: ::rand
 //! [`RngCore`]: rand_core::RngCore
@@ -207,7 +207,7 @@ impl error::Error for Error {
 /// assert_eq!(err.message(), "failed to get urandom");
 /// ```
 ///
-/// [Ruby `RuntimeError` Exception class]: https://ruby-doc.org/core-2.6.3/RuntimeError.html
+/// [Ruby `RuntimeError` Exception class]: https://ruby-doc.org/core-3.1.2/RuntimeError.html
 #[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct InitializeError {
     _private: (),
@@ -275,7 +275,7 @@ impl error::Error for InitializeError {}
 /// assert_eq!(err.message(), "failed to get urandom");
 /// ```
 ///
-/// [Ruby `RuntimeError` Exception class]: https://ruby-doc.org/core-2.6.3/RuntimeError.html
+/// [Ruby `RuntimeError` Exception class]: https://ruby-doc.org/core-3.1.2/RuntimeError.html
 #[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct UrandomError {
     _private: (),
@@ -342,7 +342,7 @@ impl error::Error for UrandomError {}
 /// assert_eq!(err.message(), "failed to get urandom");
 /// ```
 ///
-/// [Ruby `RuntimeError` Exception class]: https://ruby-doc.org/core-2.6.3/RuntimeError.html
+/// [Ruby `RuntimeError` Exception class]: https://ruby-doc.org/core-3.1.2/RuntimeError.html
 #[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct NewSeedError {
     _private: (),
@@ -407,7 +407,7 @@ impl error::Error for NewSeedError {}
 /// assert_eq!(err.message(), "ArgumentError");
 /// ```
 ///
-/// [Ruby `ArgumentError` Exception class]: https://ruby-doc.org/core-2.6.3/ArgumentError.html
+/// [Ruby `ArgumentError` Exception class]: https://ruby-doc.org/core-3.1.2/ArgumentError.html
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
 pub struct ArgumentError(ArgumentErrorInner);
 

--- a/spinoso-random/src/random/mod.rs
+++ b/spinoso-random/src/random/mod.rs
@@ -133,7 +133,7 @@ impl Random {
     /// failed to completely generate a seed, an error is returned. This error
     /// should be raised as a [Ruby `RuntimeError`].
     ///
-    /// [Ruby `RuntimeError`]: https://ruby-doc.org/core-2.6.3/RuntimeError.html
+    /// [Ruby `RuntimeError`]: https://ruby-doc.org/core-3.1.2/RuntimeError.html
     #[inline]
     pub fn new() -> Result<Self, InitializeError> {
         if let Ok(seed) = new_seed() {
@@ -368,7 +368,7 @@ pub fn seed_to_key(seed: [u8; DEFAULT_SEED_BYTES]) -> [u32; DEFAULT_SEED_CNT] {
 /// to completely generate a seed, an error is returned. This error should be
 /// raised as a [Ruby `RuntimeError`].
 ///
-/// [Ruby `RuntimeError`]: https://ruby-doc.org/core-2.6.3/RuntimeError.html
+/// [Ruby `RuntimeError`]: https://ruby-doc.org/core-3.1.2/RuntimeError.html
 #[inline]
 pub fn new_seed() -> Result<[u32; DEFAULT_SEED_CNT], NewSeedError> {
     let mut seed = [0; DEFAULT_SEED_BYTES];

--- a/spinoso-random/src/urandom.rs
+++ b/spinoso-random/src/urandom.rs
@@ -29,7 +29,7 @@ use crate::UrandomError;
 /// to completely fill `dest`, an error is returned. This error should be raised
 /// as a [Ruby `RuntimeError`].
 ///
-/// [Ruby `RuntimeError`]: https://ruby-doc.org/core-2.6.3/RuntimeError.html
+/// [Ruby `RuntimeError`]: https://ruby-doc.org/core-3.1.2/RuntimeError.html
 pub fn urandom(dest: &mut [u8]) -> Result<(), UrandomError> {
     if getrandom::getrandom(dest).is_err() {
         return Err(UrandomError::new());

--- a/spinoso-regexp/src/encoding.rs
+++ b/spinoso-regexp/src/encoding.rs
@@ -37,7 +37,7 @@ impl error::Error for InvalidEncodingError {}
 ///
 /// See [`Regexp` encoding][regexp-encoding].
 ///
-/// [regexp-encoding]: https://ruby-doc.org/core-2.6.3/Regexp.html#class-Regexp-label-Encoding
+/// [regexp-encoding]: https://ruby-doc.org/core-3.1.2/Regexp.html#class-Regexp-label-Encoding
 #[derive(Debug, Clone, Copy, PartialOrd, Ord)]
 pub enum Encoding {
     Fixed,
@@ -241,7 +241,7 @@ impl Encoding {
     ///
     /// See also [`Regexp#inspect`][regexp-inspect].
     ///
-    /// [regexp-inspect]: https://ruby-doc.org/core-2.6.3/Regexp.html#method-i-inspect
+    /// [regexp-inspect]: https://ruby-doc.org/core-3.1.2/Regexp.html#method-i-inspect
     #[must_use]
     pub const fn as_modifier_str(self) -> &'static str {
         match self {

--- a/spinoso-regexp/src/error.rs
+++ b/spinoso-regexp/src/error.rs
@@ -76,7 +76,7 @@ impl error::Error for Error {
 /// assert_eq!(err.message(), "invalid byte sequence in UTF-8");
 /// ```
 ///
-/// [Ruby `ArgumentError` Exception class]: https://ruby-doc.org/core-2.6.3/ArgumentError.html
+/// [Ruby `ArgumentError` Exception class]: https://ruby-doc.org/core-3.1.2/ArgumentError.html
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[allow(clippy::module_name_repetitions)]
 pub struct ArgumentError(Cow<'static, str>);
@@ -177,8 +177,8 @@ impl ArgumentError {
 /// assert_eq!(err.message(), r"invalid multibyte character: /\xFF\xFE/");
 /// ```
 ///
-/// [`Regexp::compile`]: https://ruby-doc.org/core-2.6.3/Regexp.html#method-c-compile
-/// [Ruby `RegexpError` Exception class]: https://ruby-doc.org/core-2.6.3/RegexpError.html
+/// [`Regexp::compile`]: https://ruby-doc.org/core-3.1.2/Regexp.html#method-c-compile
+/// [Ruby `RegexpError` Exception class]: https://ruby-doc.org/core-3.1.2/RegexpError.html
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[allow(clippy::module_name_repetitions)]
 pub struct RegexpError(Cow<'static, str>);
@@ -273,7 +273,7 @@ impl RegexpError {
 /// assert_eq!(err.message(), "premature end of char-class");
 /// ```
 ///
-/// [Ruby `SyntaxError` Exception class]: https://ruby-doc.org/core-2.6.3/SyntaxError.html
+/// [Ruby `SyntaxError` Exception class]: https://ruby-doc.org/core-3.1.2/SyntaxError.html
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[allow(clippy::module_name_repetitions)]
 pub struct SyntaxError(Cow<'static, str>);

--- a/spinoso-regexp/src/lib.rs
+++ b/spinoso-regexp/src/lib.rs
@@ -86,10 +86,10 @@ pub const LAST_MATCH: &[u8] = b"$~";
 ///
 /// [`Regexp#inspect`] prints `"/#{source}/"`.
 ///
-/// [`Regexp`]: https://ruby-doc.org/core-2.6.3/Regexp.html
-/// [`Regexp#source`]: https://ruby-doc.org/core-2.6.3/Regexp.html#method-i-source
-/// [`Regexp::compile`]: https://ruby-doc.org/core-2.6.3/Regexp.html#method-c-compile
-/// [`Regexp#inspect`]: https://ruby-doc.org/core-2.6.3/Regexp.html#method-i-inspect
+/// [`Regexp`]: https://ruby-doc.org/core-3.1.2/Regexp.html
+/// [`Regexp#source`]: https://ruby-doc.org/core-3.1.2/Regexp.html#method-i-source
+/// [`Regexp::compile`]: https://ruby-doc.org/core-3.1.2/Regexp.html#method-c-compile
+/// [`Regexp#inspect`]: https://ruby-doc.org/core-3.1.2/Regexp.html#method-i-inspect
 #[derive(Default, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Source {
     pattern: Vec<u8>,

--- a/spinoso-regexp/src/options.rs
+++ b/spinoso-regexp/src/options.rs
@@ -259,7 +259,7 @@ impl Options {
     ///
     /// See also [`Regexp#inspect`][regexp-inspect].
     ///
-    /// [regexp-inspect]: https://ruby-doc.org/core-2.6.3/Regexp.html#method-i-inspect
+    /// [regexp-inspect]: https://ruby-doc.org/core-3.1.2/Regexp.html#method-i-inspect
     #[must_use]
     pub const fn as_display_modifier(self) -> &'static str {
         use RegexpOption::{Disabled, Enabled};

--- a/spinoso-securerandom/README.md
+++ b/spinoso-securerandom/README.md
@@ -88,5 +88,5 @@ fn example() -> Result<(), spinoso_securerandom::Error> {
 Lopopolo.
 
 [`securerandom`]:
-  https://ruby-doc.org/stdlib-2.6.3/libdoc/securerandom/rdoc/SecureRandom.html
+  https://ruby-doc.org/stdlib-3.1.2/libdoc/securerandom/rdoc/SecureRandom.html
 [`getrandom`]: https://crates.io/crates/getrandom

--- a/spinoso-securerandom/src/lib.rs
+++ b/spinoso-securerandom/src/lib.rs
@@ -83,7 +83,7 @@
 //! # example().unwrap()
 //! ```
 //!
-//! [`SecureRandom`]: https://ruby-doc.org/stdlib-2.6.3/libdoc/securerandom/rdoc/SecureRandom.html
+//! [`SecureRandom`]: https://ruby-doc.org/stdlib-3.1.2/libdoc/securerandom/rdoc/SecureRandom.html
 //! [`getrandom`]: https://crates.io/crates/getrandom
 
 // Ensure code blocks in `README.md` compile
@@ -194,7 +194,7 @@ impl error::Error for Error {
 /// assert_eq!(err.message(), "negative string size (or size too big)");
 /// ```
 ///
-/// [Ruby `ArgumentError` Exception class]: https://ruby-doc.org/core-2.6.3/ArgumentError.html
+/// [Ruby `ArgumentError` Exception class]: https://ruby-doc.org/core-3.1.2/ArgumentError.html
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ArgumentError(&'static str);
 

--- a/spinoso-string/src/center.rs
+++ b/spinoso-string/src/center.rs
@@ -15,7 +15,7 @@ use crate::chars::Chars;
 /// implements [`std::error::Error`].
 ///
 /// [`String::center`]: crate::String::center
-/// [Ruby `ArgumentError` Exception class]: https://ruby-doc.org/core-2.6.3/ArgumentError.html
+/// [Ruby `ArgumentError` Exception class]: https://ruby-doc.org/core-3.1.2/ArgumentError.html
 /// [`std::error::Error`]: https://doc.rust-lang.org/std/error/trait.Error.html
 #[allow(clippy::module_name_repetitions)]
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]

--- a/spinoso-string/src/codepoints.rs
+++ b/spinoso-string/src/codepoints.rs
@@ -17,7 +17,7 @@ use crate::{Encoding, String};
 /// When the **std** feature of `spinoso-string` is enabled, this struct
 /// implements [`std::error::Error`].
 ///
-/// [Ruby `ArgumentError` Exception class]: https://ruby-doc.org/core-2.6.3/ArgumentError.html
+/// [Ruby `ArgumentError` Exception class]: https://ruby-doc.org/core-3.1.2/ArgumentError.html
 /// [`std::error::Error`]: https://doc.rust-lang.org/std/error/trait.Error.html
 #[allow(clippy::module_name_repetitions)]
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]

--- a/spinoso-string/src/encoding.rs
+++ b/spinoso-string/src/encoding.rs
@@ -84,7 +84,7 @@ impl std::error::Error for InvalidEncodingError {}
 /// [`String::char_len`]: crate::String::char_len
 /// [UTF-8]: Self::Utf8
 /// [conventionally UTF-8]: https://docs.rs/bstr/0.2.*/bstr/#differences-with-standard-strings
-/// [`String#encode`]: https://ruby-doc.org/core-2.6.3/String.html#method-i-encode
+/// [`String#encode`]: https://ruby-doc.org/core-3.1.2/String.html#method-i-encode
 #[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Encoding {
     /// Conventionally UTF-8.

--- a/spinoso-string/src/lib.rs
+++ b/spinoso-string/src/lib.rs
@@ -1072,8 +1072,8 @@ impl String {
     /// [binary]: crate::Encoding::Binary
     /// [`push_char`]: Self::push_char
     /// [`push_byte`]: Self::push_byte
-    /// [`String#<<`]: https://ruby-doc.org/core-2.6.3/String.html#method-i-3C-3C
-    /// [ruby-integer]: https://ruby-doc.org/core-2.6.3/Integer.html
+    /// [`String#<<`]: https://ruby-doc.org/core-3.1.2/String.html#method-i-3C-3C
+    /// [ruby-integer]: https://ruby-doc.org/core-3.1.2/Integer.html
     /// [conventionally UTF-8]: crate::Encoding::Utf8
     #[inline]
     pub fn try_push_codepoint(&mut self, codepoint: i64) -> Result<(), InvalidCodepointError> {
@@ -1154,8 +1154,8 @@ impl String {
     /// assert_eq!(s, "abc, easy as 123");
     /// ```
     ///
-    /// [`String#<<`]: https://ruby-doc.org/core-2.6.3/String.html#method-i-3C-3C
-    /// [ruby-string]: https://ruby-doc.org/core-2.6.3/String.html
+    /// [`String#<<`]: https://ruby-doc.org/core-3.1.2/String.html#method-i-3C-3C
+    /// [ruby-string]: https://ruby-doc.org/core-3.1.2/String.html
     #[inline]
     pub fn concat<T: AsRef<[u8]>>(&mut self, other: T) {
         let other = other.as_ref();
@@ -1204,7 +1204,7 @@ impl String {
     /// assert_eq!(s.as_slice(), b.as_slice());
     /// ```
     ///
-    /// [`String#b`]: https://ruby-doc.org/core-2.6.3/String.html#method-i-b
+    /// [`String#b`]: https://ruby-doc.org/core-3.1.2/String.html#method-i-b
     #[inline]
     #[must_use]
     pub fn to_binary(&self) -> Self {
@@ -1229,7 +1229,7 @@ impl String {
     /// assert_eq!(s.bytesize(), s.len());
     /// ```
     ///
-    /// [`String#bytesize`]: https://ruby-doc.org/core-2.6.3/String.html#method-i-bytesize
+    /// [`String#bytesize`]: https://ruby-doc.org/core-3.1.2/String.html#method-i-bytesize
     #[inline]
     #[must_use]
     pub fn bytesize(&self) -> usize {
@@ -1548,7 +1548,7 @@ impl String {
     /// assert_eq!(s.index("l", Some(3)), Some(3));
     /// ```
     ///
-    /// [`String#index`]: https://ruby-doc.org/core-2.6.3/String.html#method-i-index
+    /// [`String#index`]: https://ruby-doc.org/core-3.1.2/String.html#method-i-index
     #[inline]
     #[must_use]
     pub fn index<T: AsRef<[u8]>>(&self, needle: T, offset: Option<usize>) -> Option<usize> {
@@ -1602,7 +1602,7 @@ impl String {
     /// `char`s for the same underlying byte contents depending on the string's
     /// encoding.
     ///
-    /// [`String#inspect`]: https://ruby-doc.org/core-2.6.3/String.html#method-i-inspect:
+    /// [`String#inspect`]: https://ruby-doc.org/core-3.1.2/String.html#method-i-inspect:
     #[inline]
     pub fn inspect(&self) -> Inspect<'_> {
         Inspect::new(self.inner.inspect())
@@ -2013,7 +2013,7 @@ impl String {
     /// [conventionally UTF-8]: crate::Encoding::Utf8
     /// [ASCII]: crate::Encoding::Ascii
     /// [binary]: crate::Encoding::Binary
-    /// [`String#valid_encoding?`]: https://ruby-doc.org/core-3.0.0/String.html#method-i-valid_encoding-3F
+    /// [`String#valid_encoding?`]: https://ruby-doc.org/core-3.1.2/String.html#method-i-valid_encoding-3F
     #[inline]
     #[must_use]
     pub fn is_valid_encoding(&self) -> bool {

--- a/spinoso-string/src/ord.rs
+++ b/spinoso-string/src/ord.rs
@@ -15,7 +15,7 @@ pub enum OrdError {
 impl OrdError {
     /// `OrdError` corresponds to an [`ArgumentError`] Ruby exception.
     ///
-    /// [`ArgumentError`]: https://ruby-doc.org/core-2.6.3/ArgumentError.html
+    /// [`ArgumentError`]: https://ruby-doc.org/core-3.1.2/ArgumentError.html
     pub const EXCEPTION_TYPE: &'static str = "ArgumentError";
 
     /// Construct a new `OrdError` for an invalid UTF-8 byte sequence.
@@ -74,7 +74,7 @@ impl OrdError {
     /// assert_eq!(OrdError::empty_string().message(), "empty string");
     /// ```
     ///
-    /// [`ArgumentError`]: https://ruby-doc.org/core-2.6.3/ArgumentError.html
+    /// [`ArgumentError`]: https://ruby-doc.org/core-3.1.2/ArgumentError.html
     #[inline]
     #[must_use]
     pub const fn message(self) -> &'static str {

--- a/spinoso-symbol/README.md
+++ b/spinoso-symbol/README.md
@@ -103,14 +103,14 @@ Core.
 
 `spinoso-symbol` is licensed with the [MIT License](LICENSE) (c) Ryan Lopopolo.
 
-[the `symbol` api from ruby core]: https://ruby-doc.org/core-2.6.3/Symbol.html
+[the `symbol` api from ruby core]: https://ruby-doc.org/core-3.1.2/Symbol.html
 [`intern`]:
   https://artichoke.github.io/artichoke/artichoke_core/intern/trait.Intern.html
 [`symbol::all_symbols`]:
-  https://ruby-doc.org/core-2.6.3/Symbol.html#method-c-all_symbols
-[`symbol#inspect`]: https://ruby-doc.org/core-2.6.3/Symbol.html#method-i-inspect
+  https://ruby-doc.org/core-3.1.2/Symbol.html#method-c-all_symbols
+[`symbol#inspect`]: https://ruby-doc.org/core-3.1.2/Symbol.html#method-i-inspect
 [byte string interning apis]:
   https://artichoke.github.io/artichoke/artichoke_core/intern/trait.Intern.html
-[`symbol#inspect`]: https://ruby-doc.org/core-2.6.3/Symbol.html#method-i-inspect
+[`symbol#inspect`]: https://ruby-doc.org/core-3.1.2/Symbol.html#method-i-inspect
 [`alloc`]: https://doc.rust-lang.org/alloc/
 [`std::error::error`]: https://doc.rust-lang.org/std/error/trait.Error.html

--- a/spinoso-symbol/src/casecmp/ascii.rs
+++ b/spinoso-symbol/src/casecmp/ascii.rs
@@ -18,8 +18,8 @@ use artichoke_core::intern::Intern;
 /// If the interner returns an error while retrieving a symbol, that error is
 /// returned. See [`Intern::lookup_symbol`].
 ///
-/// [`Symbol#casecmp`]: https://ruby-doc.org/core-2.6.3/Symbol.html#method-i-casecmp
-/// [`Symbol`]: https://ruby-doc.org/core-2.6.3/Symbol.html
+/// [`Symbol#casecmp`]: https://ruby-doc.org/core-3.1.2/Symbol.html#method-i-casecmp
+/// [`Symbol`]: https://ruby-doc.org/core-3.1.2/Symbol.html
 #[inline]
 #[cfg_attr(docsrs, doc(cfg(feature = "artichoke")))]
 pub fn casecmp<T, U>(interner: &T, left: U, right: U) -> Result<Ordering, T::Error>

--- a/spinoso-symbol/src/casecmp/unicode.rs
+++ b/spinoso-symbol/src/casecmp/unicode.rs
@@ -29,8 +29,8 @@ use focaccia::CaseFold;
 ///
 /// [Unicode case folding]: https://www.w3.org/International/wiki/Case_folding
 /// [`ascii_casecmp`]: crate::casecmp::ascii_casecmp
-/// [`Symbol#casecmp?`]: https://ruby-doc.org/core-2.6.3/Symbol.html#method-i-casecmp-3F
-/// [`Symbol`]: https://ruby-doc.org/core-2.6.3/Symbol.html
+/// [`Symbol#casecmp?`]: https://ruby-doc.org/core-3.1.2/Symbol.html#method-i-casecmp-3F
+/// [`Symbol`]: https://ruby-doc.org/core-3.1.2/Symbol.html
 #[inline]
 #[cfg_attr(docsrs, doc(cfg(feature = "artichoke")))]
 pub fn case_eq<T, U>(interner: &T, left: U, right: U, fold: CaseFold) -> Result<Option<bool>, T::Error>
@@ -51,7 +51,7 @@ where
         //
         // > `nil` is returned if the two symbols have incompatible encodings,
         // > or if `other_symbol` is not a symbol.
-        // > <https://ruby-doc.org/core-2.6.3/Symbol.html#method-i-casecmp-3F>
+        // > <https://ruby-doc.org/core-3.1.2/Symbol.html#method-i-casecmp-3F>
         (Ok(_), Err(_)) | (Err(_), Ok(_)) => return Ok(None),
     };
     Ok(Some(cmp))

--- a/spinoso-symbol/src/lib.rs
+++ b/spinoso-symbol/src/lib.rs
@@ -66,9 +66,9 @@
 //!   this feature enables [`std::error::Error`] impls on error types in this
 //!   crate.
 //!
-//! [the `Symbol` API from Ruby Core]: https://ruby-doc.org/core-2.6.3/Symbol.html
-//! [`Symbol::all_symbols`]: https://ruby-doc.org/core-2.6.3/Symbol.html#method-c-all_symbols
-//! [`Symbol#inspect`]: https://ruby-doc.org/core-2.6.3/Symbol.html#method-i-inspect
+//! [the `Symbol` API from Ruby Core]: https://ruby-doc.org/core-3.1.2/Symbol.html
+//! [`Symbol::all_symbols`]: https://ruby-doc.org/core-3.1.2/Symbol.html#method-c-all_symbols
+//! [`Symbol#inspect`]: https://ruby-doc.org/core-3.1.2/Symbol.html#method-i-inspect
 //! [`alloc`]: https://doc.rust-lang.org/alloc/
 //! [`std::error::Error`]: https://doc.rust-lang.org/std/error/trait.Error.html
 
@@ -291,7 +291,7 @@ impl Symbol {
     /// error looking up the symbol in the underlying interner, a default
     /// iterator is returned.
     ///
-    /// [`Symbol#inspect`]: https://ruby-doc.org/core-2.6.3/Symbol.html#method-i-inspect
+    /// [`Symbol#inspect`]: https://ruby-doc.org/core-3.1.2/Symbol.html#method-i-inspect
     #[inline]
     #[cfg(feature = "artichoke")]
     #[cfg_attr(docsrs, doc(cfg(feature = "artichoke")))]

--- a/spinoso-time/README.md
+++ b/spinoso-time/README.md
@@ -82,7 +82,7 @@ This crate requires [`std`], the Rust Standard Library.
 
 `spinoso-time` is licensed with the [MIT License](LICENSE) (c) Ryan Lopopolo.
 
-[`time`]: https://ruby-doc.org/core-2.6.3/Time.html
+[`time`]: https://ruby-doc.org/core-3.1.2/Time.html
 [`chrono`]: https://crates.io/crates/chrono
 [`tz-rs`]: https://crates.io/crates/tz-rs
 [`tzdb`]: https://crates.io/crates/tzdb

--- a/spinoso-time/src/lib.rs
+++ b/spinoso-time/src/lib.rs
@@ -60,7 +60,7 @@
 //!
 //! This crate requires [`std`], the Rust Standard Library.
 //!
-//! [`Time`]: https://ruby-doc.org/core-2.6.3/Time.html
+//! [`Time`]: https://ruby-doc.org/core-3.1.2/Time.html
 //! [`chrono`]: https://crates.io/crates/chrono
 //! [`tz-rs`]: https://crates.io/crates/tz-rs
 //! [`tzdb`]: https://crates.io/crates/tzdb

--- a/spinoso-time/src/time/chrono/build.rs
+++ b/spinoso-time/src/time/chrono/build.rs
@@ -7,7 +7,7 @@ impl Default for Time {
     /// The zero-argument [`Time#new`] constructor creates a local time set to
     /// the current system time.
     ///
-    /// [`Time#new`]: https://ruby-doc.org/core-2.6.3/Time.html#method-c-new
+    /// [`Time#new`]: https://ruby-doc.org/core-3.1.2/Time.html#method-c-new
     fn default() -> Self {
         Self::new()
     }

--- a/spinoso-time/src/time/chrono/mod.rs
+++ b/spinoso-time/src/time/chrono/mod.rs
@@ -61,7 +61,7 @@ pub use offset::Offset;
 /// computation. [`chrono`] provides an aware datetime view over the raw
 /// timestamp.
 ///
-/// [`Time`]: https://ruby-doc.org/core-2.6.3/Time.html
+/// [`Time`]: https://ruby-doc.org/core-3.1.2/Time.html
 #[derive(Debug, Clone, Copy)]
 pub struct Time {
     /// The number of non-leap seconds since January 1, 1970 0:00:00 UTC (aka

--- a/spinoso-time/src/time/mod.rs
+++ b/spinoso-time/src/time/mod.rs
@@ -15,7 +15,7 @@
 //! nanoseconds as a `u32`, and a timezone offset which can be one of several
 //! types.
 //!
-//! [`Time`]: https://ruby-doc.org/core-2.6.3/Time.html
+//! [`Time`]: https://ruby-doc.org/core-3.1.2/Time.html
 //! [`chrono`]: https://crates.io/crates/chrono
 //! [`tzrs`]: https://crates.io/crates/tz-rs
 //! [Unix timestamp]: https://en.wikipedia.org/wiki/Unix_time

--- a/spinoso-time/src/time/tzrs/build.rs
+++ b/spinoso-time/src/time/tzrs/build.rs
@@ -9,8 +9,8 @@ impl Time {
     ///
     /// Can produce a [`super::TimeError`], generally when provided values are out of range
     ///
-    /// [`Time#local`]: https://ruby-doc.org/core-2.6.3/Time.html#method-c-local
-    /// [`Time#mktime`]: https://ruby-doc.org/core-2.6.3/Time.html#method-c-mktime
+    /// [`Time#local`]: https://ruby-doc.org/core-3.1.2/Time.html#method-c-local
+    /// [`Time#mktime`]: https://ruby-doc.org/core-3.1.2/Time.html#method-c-mktime
     #[inline]
     pub fn local(
         year: i32,
@@ -41,8 +41,8 @@ impl Time {
     ///
     /// Can produce a [`super::TimeError`], generally when provided values are out of range
     ///
-    /// [`Time#utc`]: https://ruby-doc.org/core-2.6.3/Time.html#method-c-utc
-    /// [`Time#gm`]: https://ruby-doc.org/core-2.6.3/Time.html#method-c-gm
+    /// [`Time#utc`]: https://ruby-doc.org/core-3.1.2/Time.html#method-c-utc
+    /// [`Time#gm`]: https://ruby-doc.org/core-3.1.2/Time.html#method-c-gm
     #[inline]
     pub fn utc(
         year: i32,

--- a/spinoso-time/src/time/tzrs/convert.rs
+++ b/spinoso-time/src/time/tzrs/convert.rs
@@ -20,10 +20,10 @@ impl Display for Time {
     /// # example().unwrap()
     /// ```
     ///
-    /// [`Time#asctime`]: https://ruby-doc.org/core-2.6.3/Time.html#method-i-asctime
-    /// [`Time#ctime`]: https://ruby-doc.org/core-2.6.3/Time.html#method-i-ctime
-    /// [`Time#to_s`]: https://ruby-doc.org/core-2.6.3/Time.html#method-i-to_s
-    /// [`Time#inspect`]: https://ruby-doc.org/core-2.6.3/Time.html#method-i-inspect
+    /// [`Time#asctime`]: https://ruby-doc.org/core-3.1.2/Time.html#method-i-asctime
+    /// [`Time#ctime`]: https://ruby-doc.org/core-3.1.2/Time.html#method-i-ctime
+    /// [`Time#to_s`]: https://ruby-doc.org/core-3.1.2/Time.html#method-i-to_s
+    /// [`Time#inspect`]: https://ruby-doc.org/core-3.1.2/Time.html#method-i-inspect
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         // TODO: future
         //self.strftime("%Y-%m-%d %H:%M:%S %z")
@@ -51,7 +51,7 @@ impl Time {
     ///
     /// Panics on every invocation. Functionality is not implemented.
     ///
-    /// [ruby-time-strftime]: https://ruby-doc.org/core-2.6.3/Time.html#method-i-strftime
+    /// [ruby-time-strftime]: https://ruby-doc.org/core-3.1.2/Time.html#method-i-strftime
     #[inline]
     #[must_use]
     pub fn strftime(_: Self, _format: &str) -> String {
@@ -82,7 +82,7 @@ impl Time {
     /// # example().unwrap()
     /// ```
     ///
-    /// [`Time#to_a`]: https://ruby-doc.org/core-2.6.3/Time.html#method-i-to_a
+    /// [`Time#to_a`]: https://ruby-doc.org/core-3.1.2/Time.html#method-i-to_a
     #[inline]
     #[must_use]
     pub fn to_array(self) -> ToA {

--- a/spinoso-time/src/time/tzrs/math.rs
+++ b/spinoso-time/src/time/tzrs/math.rs
@@ -26,7 +26,7 @@ impl Time {
     /// # example().unwrap()
     /// ```
     ///
-    /// [`Time#round`]: https://ruby-doc.org/core-2.6.3/Time.html#method-i-round
+    /// [`Time#round`]: https://ruby-doc.org/core-3.1.2/Time.html#method-i-round
     #[allow(clippy::cast_possible_truncation)]
     #[allow(clippy::cast_sign_loss)]
     #[inline]

--- a/spinoso-time/src/time/tzrs/mod.rs
+++ b/spinoso-time/src/time/tzrs/mod.rs
@@ -62,7 +62,7 @@ use crate::NANOS_IN_SECOND;
 /// ```
 ///
 /// [`tz-rs`]: tz
-/// [`Time`]: https://ruby-doc.org/core-2.6.3/Time.html
+/// [`Time`]: https://ruby-doc.org/core-3.1.2/Time.html
 #[must_use]
 #[derive(Debug, Clone, Copy)]
 pub struct Time {
@@ -142,8 +142,8 @@ impl Time {
     ///
     /// Can produce a [`TimeError`], generally when provided values are out of range.
     ///
-    /// [`Time#new`]: https://ruby-doc.org/core-2.6.3/Time.html#method-c-new
-    /// [`Timezone`]: https://ruby-doc.org/core-2.6.3/Time.html#class-Time-label-Timezone+argument
+    /// [`Time#new`]: https://ruby-doc.org/core-3.1.2/Time.html#method-c-new
+    /// [`Timezone`]: https://ruby-doc.org/core-3.1.2/Time.html#class-Time-label-Timezone+argument
     #[inline]
     #[allow(clippy::too_many_arguments)]
     pub fn new(
@@ -184,7 +184,7 @@ impl Time {
     ///
     /// Can produce a [`TimeError`], however these should never been seen in regular usage.
     ///
-    /// [`Time#now`]: https://ruby-doc.org/core-2.6.3/Time.html#method-c-now
+    /// [`Time#now`]: https://ruby-doc.org/core-3.1.2/Time.html#method-c-now
     #[inline]
     pub fn now() -> Result<Self> {
         let offset = Offset::local();
@@ -215,7 +215,7 @@ impl Time {
     ///
     /// Can produce a [`TimeError`], however these should not be seen during regular usage.
     ///
-    /// [`Time#at`]: https://ruby-doc.org/core-2.6.3/Time.html#method-c-at
+    /// [`Time#at`]: https://ruby-doc.org/core-3.1.2/Time.html#method-c-at
     #[inline]
     pub fn with_timespec_and_offset(seconds: i64, nanoseconds: u32, offset: Offset) -> Result<Self> {
         let time_zone_ref = offset.time_zone_ref();
@@ -279,8 +279,8 @@ impl Time {
     /// # example().unwrap();
     /// ```
     ///
-    /// [`Time#to_i`]: https://ruby-doc.org/core-2.6.3/Time.html#method-i-to_i
-    /// [`Time#tv_sec`]: https://ruby-doc.org/core-2.6.3/Time.html#method-i-tv_sec
+    /// [`Time#to_i`]: https://ruby-doc.org/core-3.1.2/Time.html#method-i-to_i
+    /// [`Time#tv_sec`]: https://ruby-doc.org/core-3.1.2/Time.html#method-i-tv_sec
     #[inline]
     #[must_use]
     pub fn to_int(&self) -> i64 {
@@ -304,7 +304,7 @@ impl Time {
     /// # example().unwrap();
     /// ```
     ///
-    /// [`Time#to_f`]: https://ruby-doc.org/core-2.6.3/Time.html#method-i-to_f
+    /// [`Time#to_f`]: https://ruby-doc.org/core-3.1.2/Time.html#method-i-to_f
     #[inline]
     #[must_use]
     pub fn to_float(&self) -> f64 {
@@ -337,9 +337,9 @@ impl Time {
     /// # example().unwrap();
     /// ```
     ///
-    /// [`Time#subsec`]: https://ruby-doc.org/core-2.6.3/Time.html#method-i-subsec
+    /// [`Time#subsec`]: https://ruby-doc.org/core-3.1.2/Time.html#method-i-subsec
     /// [`to_int`]: struct.Time.html#method.to_int
-    /// [`Time#to_r`]: https://ruby-doc.org/core-2.6.3/Time.html#method-i-to_r
+    /// [`Time#to_r`]: https://ruby-doc.org/core-3.1.2/Time.html#method-i-to_r
     #[inline]
     #[must_use]
     pub fn subsec_fractional(&self) -> (u32, u32) {

--- a/spinoso-time/src/time/tzrs/offset.rs
+++ b/spinoso-time/src/time/tzrs/offset.rs
@@ -184,7 +184,7 @@ impl TryFrom<&str> for Offset {
     /// - N-Y representing -01:00 to -12:00.
     /// - Z representing UTC/Zulu time (0 offset).
     ///
-    /// [accepted MRI values]: https://ruby-doc.org/core-2.6.3/Time.html#method-c-new
+    /// [accepted MRI values]: https://ruby-doc.org/core-3.1.2/Time.html#method-c-new
     #[inline]
     fn try_from(input: &str) -> Result<Self, Self::Error> {
         match input {

--- a/spinoso-time/src/time/tzrs/parts.rs
+++ b/spinoso-time/src/time/tzrs/parts.rs
@@ -26,8 +26,8 @@ impl Time {
     /// # example().unwrap()
     /// ```
     ///
-    /// [`Time#nsec`]: https://ruby-doc.org/core-2.6.3/Time.html#method-i-nsec
-    /// [`Time#tv_nsec`]: https://ruby-doc.org/core-2.6.3/Time.html#method-i-tv_nsec
+    /// [`Time#nsec`]: https://ruby-doc.org/core-3.1.2/Time.html#method-i-nsec
+    /// [`Time#tv_nsec`]: https://ruby-doc.org/core-3.1.2/Time.html#method-i-tv_nsec
     #[inline]
     #[must_use]
     pub fn nanoseconds(&self) -> u32 {
@@ -50,8 +50,8 @@ impl Time {
     /// # example().unwrap()
     /// ```
     ///
-    /// [`Time#usec`]: https://ruby-doc.org/core-2.6.3/Time.html#method-i-usec
-    /// [`Time#tv_usec`]: https://ruby-doc.org/core-2.6.3/Time.html#method-i-tv_usec
+    /// [`Time#usec`]: https://ruby-doc.org/core-3.1.2/Time.html#method-i-usec
+    /// [`Time#tv_usec`]: https://ruby-doc.org/core-3.1.2/Time.html#method-i-tv_usec
     #[inline]
     #[must_use]
     pub fn microseconds(&self) -> u32 {
@@ -78,7 +78,7 @@ impl Time {
     /// # example().unwrap()
     /// ```
     ///
-    /// [`Time#sec`]: https://ruby-doc.org/core-2.6.3/Time.html#method-i-sec
+    /// [`Time#sec`]: https://ruby-doc.org/core-3.1.2/Time.html#method-i-sec
     /// [leap seconds]: https://en.wikipedia.org/wiki/Leap_second
     #[inline]
     #[must_use]
@@ -103,7 +103,7 @@ impl Time {
     /// # example().unwrap()
     /// ```
     ///
-    /// [`Time#minute`]: https://ruby-doc.org/core-2.6.3/Time.html#method-i-min
+    /// [`Time#minute`]: https://ruby-doc.org/core-3.1.2/Time.html#method-i-min
     #[inline]
     #[must_use]
     pub fn minute(&self) -> u8 {
@@ -127,7 +127,7 @@ impl Time {
     /// # example().unwrap()
     /// ```
     ///
-    /// [`Time#hour`]: https://ruby-doc.org/core-2.6.3/Time.html#method-i-hour
+    /// [`Time#hour`]: https://ruby-doc.org/core-3.1.2/Time.html#method-i-hour
     #[inline]
     #[must_use]
     pub fn hour(&self) -> u8 {
@@ -151,8 +151,8 @@ impl Time {
     /// # example().unwrap()
     /// ```
     ///
-    /// [`Time#day`]: https://ruby-doc.org/core-2.6.3/Time.html#method-i-day
-    /// [`Time#mday`]: https://ruby-doc.org/core-2.6.3/Time.html#method-i-mday
+    /// [`Time#day`]: https://ruby-doc.org/core-3.1.2/Time.html#method-i-day
+    /// [`Time#mday`]: https://ruby-doc.org/core-3.1.2/Time.html#method-i-mday
     #[inline]
     #[must_use]
     pub fn day(&self) -> u8 {
@@ -176,8 +176,8 @@ impl Time {
     /// # example().unwrap()
     /// ```
     ///
-    /// [`Time#mon`]: https://ruby-doc.org/core-2.6.3/Time.html#method-i-mon
-    /// [`Time#month`]: https://ruby-doc.org/core-2.6.3/Time.html#method-i-mon
+    /// [`Time#mon`]: https://ruby-doc.org/core-3.1.2/Time.html#method-i-mon
+    /// [`Time#month`]: https://ruby-doc.org/core-3.1.2/Time.html#method-i-mon
     #[inline]
     #[must_use]
     pub fn month(&self) -> u8 {
@@ -200,7 +200,7 @@ impl Time {
     /// # example().unwrap()
     /// ```
     ///
-    /// [`Time#year`]: https://ruby-doc.org/core-2.6.3/Time.html#method-i-year
+    /// [`Time#year`]: https://ruby-doc.org/core-3.1.2/Time.html#method-i-year
     #[inline]
     #[must_use]
     pub fn year(&self) -> i32 {
@@ -256,8 +256,8 @@ impl Time {
     /// # example().unwrap()
     /// ```
     ///
-    /// [`Time#utc?`]: https://ruby-doc.org/core-2.6.3/Time.html#method-i-utc-3F
-    /// [`Time#gmt?`]: https://ruby-doc.org/core-2.6.3/Time.html#method-i-gmt-3F
+    /// [`Time#utc?`]: https://ruby-doc.org/core-3.1.2/Time.html#method-i-utc-3F
+    /// [`Time#gmt?`]: https://ruby-doc.org/core-3.1.2/Time.html#method-i-gmt-3F
     #[inline]
     #[must_use]
     pub fn is_utc(&self) -> bool {
@@ -280,8 +280,8 @@ impl Time {
     /// # example().unwrap()
     /// ```
     ///
-    /// [`Time#utc_offset`]: https://ruby-doc.org/core-2.6.3/Time.html#method-i-utc_offset
-    /// [`Time#gmt_offset`]: https://ruby-doc.org/core-2.6.3/Time.html#method-i-gmt_offset
+    /// [`Time#utc_offset`]: https://ruby-doc.org/core-3.1.2/Time.html#method-i-utc_offset
+    /// [`Time#gmt_offset`]: https://ruby-doc.org/core-3.1.2/Time.html#method-i-gmt_offset
     #[inline]
     #[must_use]
     pub fn utc_offset(&self) -> i32 {
@@ -308,8 +308,8 @@ impl Time {
     /// # example().unwrap()
     /// ```
     ///
-    /// [`Time#dst?`]: https://ruby-doc.org/core-2.6.3/Time.html#method-i-dst-3F
-    /// [`Time#isdst`]: https://ruby-doc.org/core-2.6.3/Time.html#method-i-isdst
+    /// [`Time#dst?`]: https://ruby-doc.org/core-3.1.2/Time.html#method-i-dst-3F
+    /// [`Time#isdst`]: https://ruby-doc.org/core-3.1.2/Time.html#method-i-isdst
     #[inline]
     #[must_use]
     pub fn is_dst(&self) -> bool {
@@ -334,7 +334,7 @@ impl Time {
     /// # example().unwrap()
     /// ```
     ///
-    /// [`Time#wday`]: https://ruby-doc.org/core-2.6.3/Time.html#method-i-wday
+    /// [`Time#wday`]: https://ruby-doc.org/core-3.1.2/Time.html#method-i-wday
     #[inline]
     #[must_use]
     pub fn day_of_week(&self) -> u8 {
@@ -358,7 +358,7 @@ impl Time {
     /// # example().unwrap()
     /// ```
     ///
-    /// [`Time#sunday?`]: https://ruby-doc.org/core-2.6.3/Time.html#method-i-sunday-3F
+    /// [`Time#sunday?`]: https://ruby-doc.org/core-3.1.2/Time.html#method-i-sunday-3F
     #[inline]
     #[must_use]
     pub fn is_sunday(&self) -> bool {
@@ -382,7 +382,7 @@ impl Time {
     /// # example().unwrap()
     /// ```
     ///
-    /// [`Time#monday?`]: https://ruby-doc.org/core-2.6.3/Time.html#method-i-sunday-3F
+    /// [`Time#monday?`]: https://ruby-doc.org/core-3.1.2/Time.html#method-i-sunday-3F
     #[inline]
     #[must_use]
     pub fn is_monday(&self) -> bool {
@@ -406,7 +406,7 @@ impl Time {
     /// # example().unwrap()
     /// ```
     ///
-    /// [`Time#tuesday?`]: https://ruby-doc.org/core-2.6.3/Time.html#method-i-sunday-3F
+    /// [`Time#tuesday?`]: https://ruby-doc.org/core-3.1.2/Time.html#method-i-sunday-3F
     #[inline]
     #[must_use]
     pub fn is_tuesday(&self) -> bool {
@@ -430,7 +430,7 @@ impl Time {
     /// # example().unwrap()
     /// ```
     ///
-    /// [`Time#wednesday?`]: https://ruby-doc.org/core-2.6.3/Time.html#method-i-wednesday-3F
+    /// [`Time#wednesday?`]: https://ruby-doc.org/core-3.1.2/Time.html#method-i-wednesday-3F
     #[inline]
     #[must_use]
     pub fn is_wednesday(&self) -> bool {
@@ -454,7 +454,7 @@ impl Time {
     /// # example().unwrap()
     /// ```
     ///
-    /// [`Time#thursday?`]: https://ruby-doc.org/core-2.6.3/Time.html#method-i-thursday-3F
+    /// [`Time#thursday?`]: https://ruby-doc.org/core-3.1.2/Time.html#method-i-thursday-3F
     #[inline]
     #[must_use]
     pub fn is_thursday(&self) -> bool {
@@ -477,7 +477,7 @@ impl Time {
     /// # example().unwrap()
     /// ```
     ///
-    /// [`Time#friday?`]: https://ruby-doc.org/core-2.6.3/Time.html#method-i-friday-3F
+    /// [`Time#friday?`]: https://ruby-doc.org/core-3.1.2/Time.html#method-i-friday-3F
     #[inline]
     #[must_use]
     pub fn is_friday(&self) -> bool {
@@ -501,7 +501,7 @@ impl Time {
     /// # example().unwrap()
     /// ```
     ///
-    /// [`Time#saturday?`]: https://ruby-doc.org/core-2.6.3/Time.html#method-i-saturday-3F
+    /// [`Time#saturday?`]: https://ruby-doc.org/core-3.1.2/Time.html#method-i-saturday-3F
     #[inline]
     #[must_use]
     pub fn is_saturday(&self) -> bool {
@@ -524,7 +524,7 @@ impl Time {
     /// # example().unwrap()
     /// ```
     ///
-    /// [`Time#yday`]: https://ruby-doc.org/core-2.6.3/Time.html#method-i-yday
+    /// [`Time#yday`]: https://ruby-doc.org/core-3.1.2/Time.html#method-i-yday
     #[inline]
     #[must_use]
     pub fn day_of_year(&self) -> u16 {

--- a/spinoso-time/src/time/tzrs/timezone.rs
+++ b/spinoso-time/src/time/tzrs/timezone.rs
@@ -29,7 +29,7 @@ impl Time {
     /// Can produce a [`super::TimeError`], might come as a result of an offset
     /// causing the `unix_time` to exceed `i64::MAX`.
     ///
-    /// [`Time#getlocal`]: https://ruby-doc.org/core-2.6.3/Time.html#method-i-getlocal
+    /// [`Time#getlocal`]: https://ruby-doc.org/core-3.1.2/Time.html#method-i-getlocal
     #[inline]
     pub fn to_offset(&self, offset: Offset) -> Result<Self> {
         Self::with_timespec_and_offset(self.inner.unix_time(), self.inner.nanoseconds(), offset)
@@ -58,8 +58,8 @@ impl Time {
     /// causing the `unix_time` to exceed `i64::MAX`.
     ///
     ///
-    /// [`Time#getutc`]: https://ruby-doc.org/core-2.6.3/Time.html#method-i-getutc
-    /// [`Time#getgm`]: https://ruby-doc.org/core-2.6.3/Time.html#method-i-getgm
+    /// [`Time#getutc`]: https://ruby-doc.org/core-3.1.2/Time.html#method-i-getutc
+    /// [`Time#getgm`]: https://ruby-doc.org/core-3.1.2/Time.html#method-i-getgm
     #[inline]
     pub fn to_utc(&self) -> Result<Self> {
         self.to_offset(Offset::utc())
@@ -89,7 +89,7 @@ impl Time {
     /// Can produce a [`super::TimeError`], might come as a result of an offset
     /// causing the `unix_time` to exceed `i64::MAX`.
     ///
-    /// [`Time#getlocal`]: https://ruby-doc.org/core-2.6.3/Time.html#method-i-getlocal
+    /// [`Time#getlocal`]: https://ruby-doc.org/core-3.1.2/Time.html#method-i-getlocal
     #[inline]
     pub fn to_local(&self) -> Result<Self> {
         self.to_offset(Offset::local())
@@ -153,7 +153,7 @@ impl Time {
     /// Can produce a [`super::TimeError`], might come as a result of an offset
     /// causing the `unix_time` to exceed `i64::MAX`.
     ///
-    /// [`Time#localtime`]: https://ruby-doc.org/core-2.6.3/Time.html#method-i-localtime
+    /// [`Time#localtime`]: https://ruby-doc.org/core-3.1.2/Time.html#method-i-localtime
     #[inline]
     pub fn set_local(&mut self) -> Result<()> {
         self.set_offset(Offset::local())
@@ -183,8 +183,8 @@ impl Time {
     /// Can produce a [`super::TimeError`], might come as a result of an offset
     /// causing the `unix_time` to exceed `i64::MAX`.
     ///
-    /// [`Time#utc`]: https://ruby-doc.org/core-2.6.3/Time.html#method-i-utc
-    /// [`Time#gmtime`]: https://ruby-doc.org/core-2.6.3/Time.html#method-i-gmtime
+    /// [`Time#utc`]: https://ruby-doc.org/core-3.1.2/Time.html#method-i-utc
+    /// [`Time#gmtime`]: https://ruby-doc.org/core-3.1.2/Time.html#method-i-gmtime
     #[inline]
     pub fn set_utc(&mut self) -> Result<()> {
         self.set_offset(Offset::utc())
@@ -215,7 +215,7 @@ impl Time {
     /// Can produce a [`super::TimeError`], might come as a result of an offset
     /// causing the `unix_time` to exceed `i64::MAX`.
     ///
-    /// [`Time#localtime`]: https://ruby-doc.org/core-2.6.3/Time.html#method-i-localtime
+    /// [`Time#localtime`]: https://ruby-doc.org/core-3.1.2/Time.html#method-i-localtime
     #[inline]
     pub fn set_offset_from_utc(&mut self, offset: Offset) -> Result<()> {
         let time_zone_ref = offset.time_zone_ref();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,9 @@
 //!
 //! This crate is a Rust and Ruby implementation of the [Ruby programming
 //! language][rubylang]. Artichoke is not production-ready, but intends to be a
-//! [MRI-compliant][rubyspec] implementation of Ruby 2.6.3.
+//! [MRI-compliant][rubyspec] implementation of [recent MRI Ruby][mri-target].
+//!
+//! [mri-target]: https://github.com/artichoke/artichoke/blob/trunk/RUBYSPEC.md#mri-target
 //!
 //! This crate provides:
 //!
@@ -131,7 +133,7 @@ pub fn interpreter() -> Result<Artichoke, Error> {
         .with_ruby_platform(env!("RUBY_PLATFORM"))
         .with_ruby_release_date(env!("RUBY_RELEASE_DATE"))
         .with_ruby_revision(env!("RUBY_REVISION"))
-        .with_ruby_version("2.6.3") // Artichoke targets MRI Ruby 2.6.3
+        .with_ruby_version("3.1.2") // Artichoke targets MRI Ruby 3.1.2
         .with_artichoke_compiler_version(Some(env!("ARTICHOKE_COMPILER_VERSION")));
     artichoke_backend::interpreter_with_config(release)
 }


### PR DESCRIPTION
MRI Ruby 2.6.x is [EOL as of April 2022](https://www.ruby-lang.org/en/downloads/branches/).

This change also better reflects the way new Ruby Core support is added to Artichoke, which uses recent MRI for spec compliance validation. See https://twitter.com/artichokeruby/status/1514027254715584513.

This restructures the docs so this target is easier to update moving forward (only in `RUBYSPEC.md` and `src/bin/artichoke.rs`).

The new section in `RUBYSPEC.md` is the one place in the entire project where the Ruby target is mentioned. All other references to MRI compatibility link back here. See all of the linked PRs below.