### PR TITLE
Rename `panic!` to `unreachable!` in the NUL terminated string buffer

### DIFF
--- a/spinoso-string/src/buf/nul_terminated_vec.rs
+++ b/spinoso-string/src/buf/nul_terminated_vec.rs
@@ -37,7 +37,7 @@ fn ensure_nul_terminated(vec: &mut Vec<u8>) {
     vec.reserve_exact(1);
     let spare_capacity = vec.spare_capacity_mut();
     match spare_capacity {
-        [] => panic!("Vec should have spare capacity"),
+        [] => unreachable!("Vec should have spare capacity"),
         [next] => {
             next.write(NUL_BYTE);
         }


### PR DESCRIPTION
The only way to enter this branch is if the call to `Vec::reserve_exact` fails, but in that case, the process will abort anyway.

Rename `panic!` to `unreachable!` to signal this intent.

This intent became ambiguous in c4c17b851c4d0cc5bb7533fb71896b998e2ee5c0 when a call to `Option::expect` was changed into a `match` with slice patterns.

cc @b-n re: our discussion on Discord.