### PR TITLE
Add tests and update patterns for parser `Context`

### DIFF
--- a/artichoke-backend/src/state/parser.rs
+++ b/artichoke-backend/src/state/parser.rs
@@ -152,7 +152,7 @@ impl Context {
         T: Into<Cow<'static, [u8]>>,
     {
         let filename = filename.into();
-        let cstring = CString::new(filename.as_ref()).ok()?;
+        let cstring = CString::new(filename.clone()).ok()?;
         Some(Self {
             filename,
             filename_cstr: cstring.into_boxed_c_str(),
@@ -188,7 +188,7 @@ impl Context {
     /// Filename of this `Context`.
     #[must_use]
     pub fn filename(&self) -> &[u8] {
-        self.filename.as_ref()
+        &*self.filename
     }
 
     /// FFI-safe NUL-terminated C String of this `Context`.
@@ -196,15 +196,22 @@ impl Context {
     /// This [`CStr`] is valid as long as this `Context` is not dropped.
     #[must_use]
     pub fn filename_as_c_str(&self) -> &CStr {
-        self.filename_cstr.as_ref()
+        &*self.filename_cstr
     }
 }
 
 #[cfg(test)]
-mod context_test {
+mod test {
+    use super::Context;
+
     #[test]
     fn top_filename_does_not_contain_nul_byte() {
         let contains_nul_byte = super::TOP_FILENAME.iter().copied().any(|b| b == b'\0');
         assert!(!contains_nul_byte);
+    }
+
+    #[test]
+    fn top_filename_context_new_unchecked_safety() {
+        Context::new(super::TOP_FILENAME).unwrap();
     }
 }

--- a/src/filename.rs
+++ b/src/filename.rs
@@ -27,6 +27,8 @@ pub const REPL: &[u8] = b"(airb)";
 // makes them safe to use with `Context::new_unchecked`.
 #[cfg(test)]
 mod tests {
+    use crate::backend::state::parser::Context;
+
     #[test]
     fn inline_eval_switch_filename_does_not_contain_nul_byte() {
         let contains_nul_byte = super::INLINE_EVAL_SWITCH.contains(&b'\0');
@@ -34,8 +36,18 @@ mod tests {
     }
 
     #[test]
+    fn inline_eval_switch_context_new_unchecked_safety() {
+        Context::new(super::INLINE_EVAL_SWITCH).unwrap();
+    }
+
+    #[test]
     fn repl_filename_does_not_contain_nul_byte() {
         let contains_nul_byte = super::REPL.contains(&b'\0');
         assert!(!contains_nul_byte);
+    }
+
+    #[test]
+    fn repl_context_new_unchecked_safety() {
+        Context::new(super::REPL).unwrap();
     }
 }


### PR DESCRIPTION
- Use deref syntax instead of `as_ref()`.
- Add tests for filenames safety with `Context::new_unchecked` by calling `Context::new(...).unwrap()`.
- Collapse `cow.clone().into_owned()` into `cow.clone()` for APIs that take `Into<Vec<u8>>`.