### PR TITLE
Clean up safety comments

### DIFF
--- a/artichoke-backend/src/class.rs
+++ b/artichoke-backend/src/class.rs
@@ -94,12 +94,10 @@ impl<'a> Builder<'a> {
         let mut super_class = if let Some(super_class) = self.super_class {
             super_class
         } else {
-            // Safety:
-            //
-            // This direct access of the `mrb` property on `Artichoke` does not
-            // go through `Artichoke::with_ffi_boundary`. This is safe because
-            // no `MRB_API` functions are called, which means it is not required
-            // to re-box the Artichoke `State` into the `mrb_state->ud` pointer.
+            // SAFETY: Although this direct access of the `mrb` property on the
+            // interp does not go through `Artichoke::with_ffi_boundary`, no
+            // `MRB_API` functions are called, which means it is not required to
+            // re-box the Artichoke `State` into the `mrb_state->ud` pointer.
             //
             // This code only performs a memory access to read a field from the
             // `mrb_state`.
@@ -219,16 +217,10 @@ impl Spec {
         T: Into<Cow<'static, str>>,
     {
         let name = name.into();
-        // Safety:
+        // SAFETY: The constructed `mrb_data_type` has `'static` lifetime:
         //
-        // `name_cstr` is `&'static` so it will outlive the `data_type`.
-        //
-        // `Spec` does not offer mutable access to these fields.
-        //
-        // This, the `struct_name` pointer in `data_type` will point to valid
-        // memory as long as this `Spec` is not dropped.
-        //
-        // This has implications on drop order of components in the `State`.
+        // - `name_cstr` is `&'static` so it will outlive the `data_type`.
+        // - `Spec` does not offer mutable access to these fields.
         let data_type = sys::mrb_data_type {
             struct_name: name_cstr.as_ptr(),
             dfree: free,

--- a/artichoke-backend/src/convert/boolean.rs
+++ b/artichoke-backend/src/convert/boolean.rs
@@ -8,10 +8,8 @@ use crate::Artichoke;
 
 impl Convert<bool, Value> for Artichoke {
     fn convert(&self, value: bool) -> Value {
-        // Safety
-        //
-        // Boolean Ruby Values do not need to be protected because they are
-        // immediates and do not live on the mruby heap.
+        // SAFETY: Boolean Ruby Values do not need to be protected because they
+        // are immediates and do not live on the mruby heap.
         if value {
             Value::from(unsafe { sys::mrb_sys_true_value() })
         } else {

--- a/artichoke-backend/src/convert/boxing.rs
+++ b/artichoke-backend/src/convert/boxing.rs
@@ -104,14 +104,9 @@ impl<'a, T> Deref for UnboxedValueGuard<'a, HeapAllocated<T>> {
 
 impl<'a, T> DerefMut for UnboxedValueGuard<'a, HeapAllocated<T>> {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        // Safety:
-        //
-        // `HeapAllocated` data objects are boxed and the raw box pointer is
-        // stored in the `mrb_value`.
-        //
-        // `Deref::Target` is `T`, not `Box<T>`.
-        //
-        // Giving out a `&mut T` means the box pointer cannot be invalidated.
+        // SAFETY: `HeapAllocated` data objects are boxed and the raw box
+        // pointer is stored in the `mrb_value`. Because `Deref::Target` is `T`,
+        // not `Box<T>`, the box pointer cannot be invalidated.
         let inner = unsafe { self.as_inner_mut() };
         inner.0.as_mut()
     }

--- a/artichoke-backend/src/convert/fixnum.rs
+++ b/artichoke-backend/src/convert/fixnum.rs
@@ -31,10 +31,8 @@ impl TryConvert<u64, Value> for Artichoke {
     type Error = Error;
 
     fn try_convert(&self, value: u64) -> Result<Value, Self::Error> {
-        // Safety
-        //
-        // i64eger Ruby Values do not need to be protected because they are
-        // immediates and do not live on the mruby heap.
+        // SAFETY: `i64` Ruby Values do not need to be protected because they
+        // are immediates and do not live on the mruby heap.
         if let Ok(value) = i64::try_from(value) {
             let fixnum = unsafe { sys::mrb_sys_fixnum_value(value) };
             Ok(Value::from(fixnum))
@@ -48,10 +46,8 @@ impl TryConvert<usize, Value> for Artichoke {
     type Error = Error;
 
     fn try_convert(&self, value: usize) -> Result<Value, Self::Error> {
-        // Safety
-        //
-        // i64eger Ruby Values do not need to be protected because they are
-        // immediates and do not live on the mruby heap.
+        // SAFETY: `i64` Ruby Values do not need to be protected because they
+        // are immediates and do not live on the mruby heap.
         if let Ok(value) = i64::try_from(value) {
             let fixnum = unsafe { sys::mrb_sys_fixnum_value(value) };
             Ok(Value::from(fixnum))
@@ -86,10 +82,8 @@ impl TryConvert<isize, Value> for Artichoke {
     type Error = Error;
 
     fn try_convert(&self, value: isize) -> Result<Value, Self::Error> {
-        // Safety
-        //
-        // i64eger Ruby Values do not need to be protected because they are
-        // immediates and do not live on the mruby heap.
+        // SAFETY: `i64` Ruby Values do not need to be protected because they
+        // are immediates and do not live on the mruby heap.
         if let Ok(value) = i64::try_from(value) {
             let fixnum = unsafe { sys::mrb_sys_fixnum_value(value) };
             Ok(Value::from(fixnum))
@@ -102,10 +96,8 @@ impl TryConvert<isize, Value> for Artichoke {
 impl Convert<i64, Value> for Artichoke {
     #[inline]
     fn convert(&self, value: i64) -> Value {
-        // Safety
-        //
-        // i64eger Ruby Values do not need to be protected because they are
-        // immediates and do not live on the mruby heap.
+        // SAFETY: `i64` Ruby Values do not need to be protected because they
+        // are immediates and do not live on the mruby heap.
         let fixnum = unsafe { sys::mrb_sys_fixnum_value(value) };
         Value::from(fixnum)
     }

--- a/artichoke-backend/src/error.rs
+++ b/artichoke-backend/src/error.rs
@@ -79,11 +79,9 @@ where
         // `mrb_exc_raise` will call longjmp which will unwind the stack.
         sys::mrb_exc_raise(mrb, exc);
 
-        // Safety:
-        //
-        // This line is unreachable because `raise` will unwind the stack with
-        // longjmp when calling either `sys::mrb_exc_raise` in the preceding
-        // line.
+        // SAFETY: This line is unreachable because `raise` will unwind the
+        // stack with `longjmp` when calling `sys::mrb_exc_raise` in the
+        // preceding line.
         hint::unreachable_unchecked()
     }
 
@@ -98,10 +96,8 @@ where
     // `mrb_sys_raise` will call longjmp which will unwind the stack.
     sys::mrb_sys_raise(mrb, RUNTIME_ERROR_CSTR.as_ptr(), UNABLE_TO_RAISE_MESSAGE.as_ptr());
 
-    // Safety:
-    //
-    // This line is unreachable because `raise` will unwind the stack with
-    // longjmp when calling either `sys::mrb_sys_raise` in the preceding line.
+    // SAFETY: This line is unreachable because `raise` will unwind the stack
+    // with `longjmp` when calling `sys::mrb_exc_raise` in the preceding line.
     hint::unreachable_unchecked()
 }
 

--- a/artichoke-backend/src/extn/core/array/ffi.rs
+++ b/artichoke-backend/src/extn/core/array/ffi.rs
@@ -114,10 +114,8 @@ unsafe extern "C" fn mrb_ary_concat(mrb: *mut sys::mrb_state, ary: sys::mrb_valu
     let mut other = Value::from(other);
     if let Ok(mut array) = Array::unbox_from_value(&mut array, &mut guard) {
         if let Ok(other) = Array::unbox_from_value(&mut other, &mut guard) {
-            // Safety:
-            //
-            // The array is repacked before any intervening uses of `interp`.
-            // The array is repacked before any intervening mruby allocations.
+            // SAFETY: The array is repacked before any intervening uses of
+            // `interp` which means no mruby heap allocations can occur.
             let array_mut = array.as_inner_mut();
             array_mut.extend(other.iter());
 
@@ -144,10 +142,8 @@ unsafe extern "C" fn mrb_ary_pop(mrb: *mut sys::mrb_state, ary: sys::mrb_value) 
     unwrap_interpreter!(mrb, to => guard);
     let mut array = Value::from(ary);
     let result = if let Ok(mut array) = Array::unbox_from_value(&mut array, &mut guard) {
-        // Safety:
-        //
-        // The array is repacked before any intervening uses of `interp`.
-        // The array is repacked before any intervening mruby allocations.
+        // SAFETY: The array is repacked before any intervening uses of `interp`
+        // which means no mruby heap allocations can occur.
         let array_mut = array.as_inner_mut();
         let popped = array_mut.pop();
 
@@ -172,10 +168,8 @@ unsafe extern "C" fn mrb_ary_push(mrb: *mut sys::mrb_state, ary: sys::mrb_value,
     let mut array = Value::from(ary);
     let value = Value::from(value);
     if let Ok(mut array) = Array::unbox_from_value(&mut array, &mut guard) {
-        // Safety:
-        //
-        // The array is repacked before any intervening uses of `interp`.
-        // The array is repacked before any intervening mruby allocations.
+        // SAFETY: The array is repacked before any intervening uses of `interp`
+        // which means no mruby heap allocations can occur.
         let array_mut = array.as_inner_mut();
         array_mut.push(value);
 
@@ -236,10 +230,8 @@ unsafe extern "C" fn mrb_ary_set(
         };
         // TODO: properly handle self-referential sets.
         if Value::from(ary) != value {
-            // Safety:
-            //
-            // The array is repacked before any intervening uses of `interp`.
-            // The array is repacked before any intervening mruby allocations.
+            // SAFETY: The array is repacked before any intervening uses of
+            // `interp` which means no mruby heap allocations can occur.
             let array_mut = array.as_inner_mut();
             array_mut.set(offset, value);
 
@@ -259,10 +251,8 @@ unsafe extern "C" fn mrb_ary_shift(mrb: *mut sys::mrb_state, ary: sys::mrb_value
     unwrap_interpreter!(mrb, to => guard);
     let mut array = Value::from(ary);
     let result = if let Ok(mut array) = Array::unbox_from_value(&mut array, &mut guard) {
-        // Safety:
-        //
-        // The array is repacked before any intervening uses of `interp`.
-        // The array is repacked before any intervening mruby allocations.
+        // SAFETY: The array is repacked before any intervening uses of `interp`
+        // which means no mruby heap allocations can occur.
         let array_mut = array.as_inner_mut();
         let result = array_mut.shift();
 
@@ -290,10 +280,8 @@ unsafe extern "C" fn mrb_ary_unshift(
     unwrap_interpreter!(mrb, to => guard);
     let mut array = Value::from(ary);
     if let Ok(mut array) = Array::unbox_from_value(&mut array, &mut guard) {
-        // Safety:
-        //
-        // The array is repacked before any intervening uses of `interp`.
-        // The array is repacked before any intervening mruby allocations.
+        // SAFETY: The array is repacked before any intervening uses of `interp`
+        // which means no mruby heap allocations can occur.
         let array_mut = array.as_inner_mut();
         array_mut.unshift(value.into());
 

--- a/artichoke-backend/src/extn/core/kernel/integer.rs
+++ b/artichoke-backend/src/extn/core/kernel/integer.rs
@@ -14,8 +14,7 @@ pub struct Radix(NonZeroU32);
 
 impl Default for Radix {
     fn default() -> Self {
-        // Safety:
-        // Constant `10` is non-zero.
+        // SAFETY: Constant `10` is non-zero and between 2 and 36.
         unsafe { Self::new_unchecked(10) }
     }
 }
@@ -186,10 +185,8 @@ impl<'a> TryConvertMut<&'a mut Value, IntegerString<'a>> for Artichoke {
         message.push_str(self.inspect_type_name_for_value(*value));
         message.push_str(" into Integer");
 
-        // Safety:
-        //
-        // There is no use of an `Artichoke` in this module, which means a
-        // garbage collection of `value` cannot be triggered.
+        // SAFETY: There is no use of an `Artichoke` in this module, which means
+        // a garbage collection of `value` cannot be triggered.
         if let Ok(arg) = unsafe { implicitly_convert_to_string(self, value) } {
             if let Some(converted) = IntegerString::from_slice(arg) {
                 Ok(converted)

--- a/artichoke-backend/src/extn/core/kernel/require.rs
+++ b/artichoke-backend/src/extn/core/kernel/require.rs
@@ -11,12 +11,9 @@ use crate::platform_string::bytes_to_os_str;
 use crate::state::parser::Context;
 
 pub fn load(interp: &mut Artichoke, mut filename: Value) -> Result<Loaded, Error> {
-    // Safety:
-    //
-    // Converting the extracted byte slice to an owned `Vec<u8>` is required to
-    // prevent a use after free. evaling code on the interpreter with `require`
-    // may cause a garbage collection which might free the `RString` backing
-    // `filename`.
+    // SAFETY: The extracted byte slice is converted to an owned `Vec<u8>`
+    // before the interp is used again which protects against a garbage
+    // collection invalidating the pointer.
     let filename = unsafe { implicitly_convert_to_string(interp, &mut filename)? };
     if filename.find_byte(b'\0').is_some() {
         return Err(ArgumentError::with_message("path name contains null byte").into());
@@ -44,12 +41,9 @@ pub fn load(interp: &mut Artichoke, mut filename: Value) -> Result<Loaded, Error
 }
 
 pub fn require(interp: &mut Artichoke, mut filename: Value) -> Result<Required, Error> {
-    // Safety:
-    //
-    // Converting the extracted byte slice to an owned `Vec<u8>` is required to
-    // prevent a use after free. evaling code on the interpreter with `require`
-    // may cause a garbage collection which might free the `RString` backing
-    // `filename`.
+    // SAFETY: The extracted byte slice is converted to an owned `Vec<u8>`
+    // before the interp is used again which protects against a garbage
+    // collection invalidating the pointer.
     let filename = unsafe { implicitly_convert_to_string(interp, &mut filename)? };
     if filename.find_byte(b'\0').is_some() {
         return Err(ArgumentError::with_message("path name contains null byte").into());
@@ -78,12 +72,9 @@ pub fn require(interp: &mut Artichoke, mut filename: Value) -> Result<Required, 
 
 #[allow(clippy::module_name_repetitions)]
 pub fn require_relative(interp: &mut Artichoke, mut filename: Value, base: RelativePath) -> Result<Required, Error> {
-    // Safety:
-    //
-    // Converting the extracted byte slice to an owned `Vec<u8>` is required to
-    // prevent a use after free. evaling code on the interpreter with `require`
-    // may cause a garbage collection which might free the `RString` backing
-    // `filename`.
+    // SAFETY: The extracted byte slice is converted to an owned `Vec<u8>`
+    // before the interp is used again which protects against a garbage
+    // collection invalidating the pointer.
     let filename = unsafe { implicitly_convert_to_string(interp, &mut filename)? };
     if filename.find_byte(b'\0').is_some() {
         return Err(ArgumentError::with_message("path name contains null byte").into());

--- a/artichoke-backend/src/extn/core/kernel/trampoline.rs
+++ b/artichoke-backend/src/extn/core/kernel/trampoline.rs
@@ -4,10 +4,8 @@ use crate::extn::prelude::*;
 
 pub fn integer(interp: &mut Artichoke, mut arg: Value, base: Option<Value>) -> Result<Value, Error> {
     let base = base.and_then(|base| interp.convert(base));
-    // Safety:
-    //
-    // Extract the `Copy` radix integer first since implicit conversions can
-    // trigger garbage collections.
+    // SAFETY: Extract the `Copy` radix integer first since implicit conversions
+    // can trigger garbage collections.
     let base = interp.try_convert_mut(base)?;
     let arg = interp.try_convert_mut(&mut arg)?;
     let integer = kernel::integer::method(arg, base)?;

--- a/artichoke-backend/src/extn/core/regexp/mod.rs
+++ b/artichoke-backend/src/extn/core/regexp/mod.rs
@@ -107,11 +107,10 @@ impl Regexp {
             }
             regexp.inner().source().clone()
         } else {
-            // Safety:
-            //
-            // `bytes` is converted to an owned byte vec before any additional
-            // operations are run on the interpreter which might trigger a
-            // garbage collection of `pattern` and its backing `RString`.
+            // SAFETY: `bytes` is converted to an owned byte vec before any
+            // additional operations are run on the interpreter which might
+            // trigger a garbage collection of `pattern` and its backing
+            // `RString*`.
             let bytes = unsafe { implicitly_convert_to_string(interp, &mut pattern)? };
             Source::with_pattern_and_options(bytes.to_vec(), options.unwrap_or_default())
         };
@@ -138,12 +137,10 @@ impl Regexp {
                 let source = regexp.inner().config();
                 Ok(source.pattern().to_vec())
             } else {
-                // Safety:
-                //
-                // `bytes` is converted to an owned `String` before any
+                // SAFETY: `bytes` is converted to an owned `String` before any
                 // additional operations are run on the interpreter which might
                 // trigger a garbage collection of `pattern` and its backing
-                // `RString`.
+                // `RString*`.
                 let bytes = unsafe { implicitly_convert_to_string(interp, value)? };
                 if let Ok(pattern) = str::from_utf8(bytes) {
                     Ok(syntax::escape(pattern).into_bytes())
@@ -198,11 +195,9 @@ impl Regexp {
             pattern_vec = symbol.bytes(interp).to_vec();
             pattern_vec.as_slice()
         } else if let Ok(pattern) = unsafe { implicitly_convert_to_string(interp, &mut other) } {
-            // Safety:
-            //
-            // `pattern` is converted to an owned byte vec before any
+            // SAFETY: `pattern` is converted to an owned byte vec before any
             // intervening operations on the VM which may trigger a garbage
-            // collection of the `RString` that backs `other`.
+            // collection of the `RString*` that backs `other`.
             pattern_vec = pattern.to_vec();
             pattern_vec.as_slice()
         } else {

--- a/artichoke-backend/src/extn/core/regexp/trampoline.rs
+++ b/artichoke-backend/src/extn/core/regexp/trampoline.rs
@@ -28,10 +28,9 @@ pub fn escape(interp: &mut Artichoke, mut pattern: Value) -> Result<Value, Error
         let symbol = unsafe { Symbol::unbox_from_value(&mut pattern, interp)? };
         symbol.bytes(interp).to_vec()
     } else {
-        // Safety:
-        //
-        // Convert the bytes to an owned vec to prevent the underlying `RString`
-        // backing `pattern` from being freed during a garbage collection.
+        // SAFETY: Convert the bytes to an owned vec to prevent the underlying
+        // `RString*` backing `pattern` from being freed during a garbage
+        // collection.
         unsafe { implicitly_convert_to_string(interp, &mut pattern)?.to_vec() }
     };
     let pattern = Regexp::escape(&pattern_vec)?;

--- a/artichoke-backend/src/extn/core/string/ffi.rs
+++ b/artichoke-backend/src/extn/core/string/ffi.rs
@@ -189,10 +189,8 @@ unsafe extern "C" fn mrb_str_resize(mrb: *mut sys::mrb_state, s: sys::mrb_value,
     } else {
         return s;
     };
-    // Safety:
-    //
-    // The string is repacked before any intervening use of the interpreter.
-    // The string is repacked before any intervening mruby heap allocations.
+    // SAFETY: The string is repacked before any intervening uses of `interp`
+    // which means no mruby heap allocations can occur.
     let string_mut = string.as_inner_mut();
 
     let result = try_resize(string_mut, len);
@@ -435,16 +433,12 @@ unsafe extern "C" fn mrb_string_value_cstr(mrb: *mut sys::mrb_state, ptr: *mut s
     } else {
         return ptr::null();
     };
-    // Safety:
-    //
-    // The string is repacked before any intervening use of the interpreter.
-    // The string is repacked before any intervening mruby heap allocations.
+    // SAFETY: The string is repacked before any intervening uses of `interp`
+    // which means no mruby heap allocations can occur.
     let string_mut = string.as_inner_mut();
     string_mut.push_byte(b'\0');
-    // Safety:
-    //
-    // This raw pointer will not be invalidated since we rebox this `String`
-    // into the mruby heap where the GC will keep it alive.
+    // SAFETY: This raw pointer will not be invalidated since we rebox this
+    // `String` into the mruby heap where the GC will keep it alive.
     let cstr = string.as_ptr().cast::<c_char>();
 
     let inner = string.take();
@@ -468,16 +462,12 @@ unsafe extern "C" fn mrb_string_cstr(mrb: *mut sys::mrb_state, s: sys::mrb_value
     } else {
         return ptr::null();
     };
-    // Safety:
-    //
-    // The string is repacked before any intervening use of the interpreter.
-    // The string is repacked before any intervening mruby heap allocations.
+    // SAFETY: The string is repacked before any intervening uses of `interp`
+    // which means no mruby heap allocations can occur.
     let string_mut = string.as_inner_mut();
     string_mut.push_byte(b'\0');
-    // Safety:
-    //
-    // This raw pointer will not be invalidated since we rebox this `String`
-    // into the mruby heap where the GC will keep it alive.
+    // SAFETY: This raw pointer will not be invalidated since we rebox this
+    // `String` into the mruby heap where the GC will keep it alive.
     let cstr = string.as_ptr().cast::<c_char>();
 
     let inner = string.take();
@@ -602,10 +592,8 @@ unsafe extern "C" fn mrb_str_cat(
     if let Ok(mut string) = String::unbox_from_value(&mut s, &mut guard) {
         let slice = slice::from_raw_parts(ptr.cast::<u8>(), len);
 
-        // Safety:
-        //
-        // The string is repacked before any intervening use of the interpreter.
-        // The string is repacked before any intervening mruby heap allocations.
+        // SAFETY: The string is repacked before any intervening uses of
+        // `interp` which means no mruby heap allocations can occur.
         let string_mut = string.as_inner_mut();
         string_mut.extend_from_slice(slice);
         let inner = string.take();

--- a/artichoke-backend/src/extn/core/string/mod.rs
+++ b/artichoke-backend/src/extn/core/string/mod.rs
@@ -42,11 +42,9 @@ impl BoxUnboxVmValue for String {
             return Err(TypeError::from(message).into());
         }
 
-        // Safety:
-        //
-        // The above check on the data type ensures the `value` union holds an
-        // `RString` in the `p` variant.
         let value = value.inner();
+        // SAFETY: The above check on the data type ensures the `value` union
+        // holds an `RString*` in the `p` variant.
         let string = sys::mrb_sys_basic_ptr(value).cast::<sys::RString>();
 
         let ptr = (*string).as_.heap.ptr;

--- a/artichoke-backend/src/extn/core/string/trampoline.rs
+++ b/artichoke-backend/src/extn/core/string/trampoline.rs
@@ -36,9 +36,7 @@ pub fn mul(interp: &mut Artichoke, mut value: Value, count: Value) -> Result<Val
 
 pub fn add(interp: &mut Artichoke, mut value: Value, mut other: Value) -> Result<Value, Error> {
     let s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
-    // Safety:
-    //
-    // The borrowed byte slice is immediately `memcpy`'d into the `s` byte
+    // SAFETY: The borrowed byte slice is immediately copied into the `s` byte
     // buffer. There are no intervening interpreter accesses.
     let to_append = unsafe { implicitly_convert_to_string(interp, &mut other)? };
 
@@ -63,11 +61,8 @@ pub fn push(interp: &mut Artichoke, mut value: Value, mut other: Value) -> Resul
     if let Ok(int) = other.try_convert_into::<i64>(interp) {
         return match s.encoding() {
             Encoding::Utf8 => {
-                // Safety:
-                //
-                // The string is reboxed before any intervening operations on the
-                // interpreter.
-                // The string is reboxed without any intervening mruby allocations.
+                // SAFETY: The string is repacked before any intervening uses of
+                // `interp` which means no mruby heap allocations can occur.
                 unsafe {
                     let string_mut = s.as_inner_mut();
                     // XXX: This call doesn't do a check to see if we'll exceed the max allocation
@@ -81,11 +76,8 @@ pub fn push(interp: &mut Artichoke, mut value: Value, mut other: Value) -> Resul
             }
             Encoding::Ascii => {
                 let byte = u8::try_from(int).map_err(|_| RangeError::from(format!("{int} out of char range")))?;
-                // Safety:
-                //
-                // The string is reboxed before any intervening operations on the
-                // interpreter.
-                // The string is reboxed without any intervening mruby allocations.
+                // SAFETY: The string is repacked before any intervening uses of
+                // `interp` which means no mruby heap allocations can occur.
                 unsafe {
                     let string_mut = s.as_inner_mut();
                     // XXX: This call doesn't do a check to see if we'll exceed the max allocation
@@ -100,11 +92,8 @@ pub fn push(interp: &mut Artichoke, mut value: Value, mut other: Value) -> Resul
             }
             Encoding::Binary => {
                 let byte = u8::try_from(int).map_err(|_| RangeError::from(format!("{int} out of char range")))?;
-                // Safety:
-                //
-                // The string is reboxed before any intervening operations on the
-                // interpreter.
-                // The string is reboxed without any intervening mruby allocations.
+                // SAFETY: The string is repacked before any intervening uses of
+                // `interp` which means no mruby heap allocations can occur.
                 unsafe {
                     let string_mut = s.as_inner_mut();
                     // XXX: This call doesn't do a check to see if we'll exceed the max allocation
@@ -116,12 +105,8 @@ pub fn push(interp: &mut Artichoke, mut value: Value, mut other: Value) -> Resul
             }
         };
     }
-    // Safety:
-    //
-    // The byte slice is immediately used and discarded after extraction. There
-    // are no intervening interpreter accesses.
-
-    // TODO: need to get the spinoso string to get at its encoding.
+    // SAFETY: The byte slice is immediately used and discarded after extraction.
+    // There are no intervening interpreter accesses.
     let other = unsafe { implicitly_convert_to_spinoso_string(interp, &mut other)? };
     match s.encoding() {
         // ```
@@ -173,11 +158,8 @@ pub fn push(interp: &mut Artichoke, mut value: Value, mut other: Value) -> Resul
         // => #<Encoding:US-ASCII>
         // ```
         Encoding::Utf8 => {
-            // Safety:
-            //
-            // The string is reboxed before any intervening operations on the
-            // interpreter.
-            // The string is reboxed without any intervening mruby allocations.
+            // SAFETY: The string is repacked before any intervening uses of
+            // `interp` which means no mruby heap allocations can occur.
             unsafe {
                 let string_mut = s.as_inner_mut();
                 // XXX: This call doesn't do a check to see if we'll exceed the max allocation
@@ -224,11 +206,8 @@ pub fn push(interp: &mut Artichoke, mut value: Value, mut other: Value) -> Resul
         // => #<Encoding:ASCII-8BIT>
         // ```
         Encoding::Ascii if s.is_empty() => {
-            // Safety:
-            //
-            // The string is reboxed before any intervening operations on the
-            // interpreter.
-            // The string is reboxed without any intervening mruby allocations.
+            // SAFETY: The string is repacked before any intervening uses of
+            // `interp` which means no mruby heap allocations can occur.
             unsafe {
                 let string_mut = s.as_inner_mut();
                 // XXX: This call doesn't do a check to see if we'll exceed the max allocation
@@ -279,11 +258,8 @@ pub fn push(interp: &mut Artichoke, mut value: Value, mut other: Value) -> Resul
                 interp.eval(code.as_bytes())?;
                 unreachable!("raised exception");
             }
-            // Safety:
-            //
-            // The string is reboxed before any intervening operations on the
-            // interpreter.
-            // The string is reboxed without any intervening mruby allocations.
+            // SAFETY: The string is repacked before any intervening uses of
+            // `interp` which means no mruby heap allocations can occur.
             unsafe {
                 let string_mut = s.as_inner_mut();
                 // XXX: This call doesn't do a check to see if we'll exceed the max allocation
@@ -327,11 +303,8 @@ pub fn push(interp: &mut Artichoke, mut value: Value, mut other: Value) -> Resul
         // => #<Encoding:ASCII-8BIT>
         // ```
         Encoding::Binary if s.is_empty() => {
-            // Safety:
-            //
-            // The string is reboxed before any intervening operations on the
-            // interpreter.
-            // The string is reboxed without any intervening mruby allocations.
+            // SAFETY: The string is repacked before any intervening uses of
+            // `interp` which means no mruby heap allocations can occur.
             unsafe {
                 let string_mut = s.as_inner_mut();
                 // XXX: This call doesn't do a check to see if we'll exceed the max allocation
@@ -347,11 +320,8 @@ pub fn push(interp: &mut Artichoke, mut value: Value, mut other: Value) -> Resul
             }
         }
         Encoding::Binary => {
-            // Safety:
-            //
-            // The string is reboxed before any intervening operations on the
-            // interpreter.
-            // The string is reboxed without any intervening mruby allocations.
+            // SAFETY: The string is repacked before any intervening uses of
+            // `interp` which means no mruby heap allocations can occur.
             unsafe {
                 let string_mut = s.as_inner_mut();
                 // XXX: This call doesn't do a check to see if we'll exceed the max allocation
@@ -381,10 +351,6 @@ pub fn equals_equals(interp: &mut Artichoke, mut value: Value, mut other: Value)
         let equals = *s == *other;
         return Ok(interp.convert(equals));
     }
-    // Safety:
-    //
-    // The byte slice is immediately discarded after extraction. There are no
-    // intervening interpreter accesses.
     if value.respond_to(interp, "to_str")? {
         let result = other.funcall(interp, "==", &[value], None)?;
         // any falsy returned value yields `false`, otherwise `true`.
@@ -972,11 +938,8 @@ pub fn capitalize_bang(interp: &mut Artichoke, mut value: Value) -> Result<Value
     }
 
     let mut s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
-    // Safety:
-    //
-    // The string is reboxed before any intervening operations on the
-    // interpreter.
-    // The string is reboxed without any intervening mruby allocations.
+    // SAFETY: The string is repacked before any intervening uses of `interp`
+    // which means no mruby heap allocations can occur.
     unsafe {
         let string_mut = s.as_inner_mut();
         // `make_capitalized` might reallocate the string and invalidate the
@@ -990,10 +953,8 @@ pub fn capitalize_bang(interp: &mut Artichoke, mut value: Value) -> Result<Value
 
 pub fn casecmp_ascii(interp: &mut Artichoke, mut value: Value, mut other: Value) -> Result<Value, Error> {
     let s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
-    // Safety:
-    //
-    // The byte slice is immediately discarded after extraction. There are no
-    // intervening interpreter accesses.
+    // SAFETY: The byte slice is immediately discarded after extraction. There
+    // are no intervening interpreter accesses.
     if let Ok(other) = unsafe { implicitly_convert_to_string(interp, &mut other) } {
         let cmp = s.ascii_casecmp(other) as i64;
         Ok(interp.convert(cmp))
@@ -1034,10 +995,8 @@ pub fn center(interp: &mut Artichoke, mut value: Value, width: Value, padstr: Op
         let dup = s.clone();
         return super::String::alloc_value(dup, interp);
     };
-    // Safety:
-    //
-    // The byte slice is immediately discarded after extraction and turned into
-    // an owned value. There are no intervening interpreter accesses.
+    // SAFETY: The byte slice is immediately converted to an owned `Vec` after
+    // extraction. There are no intervening interpreter accesses.
     let padstr = if let Some(mut padstr) = padstr {
         let padstr = unsafe { implicitly_convert_to_string(interp, &mut padstr)? };
         Some(padstr.to_vec())
@@ -1151,11 +1110,8 @@ pub fn clear(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
     }
 
     let mut s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
-    // Safety:
-    //
-    // The string is reboxed before any intervening operations on the
-    // interpreter.
-    // The string is reboxed without any intervening mruby allocations.
+    // SAFETY: The string is repacked before any intervening uses of `interp`
+    // which means no mruby heap allocations can occur.
     unsafe {
         let string_mut = s.as_inner_mut();
         string_mut.clear();
@@ -1188,11 +1144,8 @@ pub fn downcase(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error
 
 pub fn downcase_bang(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
     let mut s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
-    // Safety:
-    //
-    // The string is reboxed before any intervening operations on the
-    // interpreter.
-    // The string is reboxed without any intervening mruby allocations.
+    // SAFETY: The string is repacked before any intervening uses of `interp`
+    // which means no mruby heap allocations can occur.
     unsafe {
         let string_mut = s.as_inner_mut();
         // `make_lowercase` might reallocate the string and invalidate the
@@ -1307,10 +1260,7 @@ pub fn initialize(interp: &mut Artichoke, mut value: Value, from: Option<Value>)
     // => "abc"
     // ```
     let buf = if let Some(mut from) = from {
-        // Safety:
-        //
-        // The extracted slice is immediately copied to an owned buffer.
-        //
+        // SAFETY: The extracted slice is immediately copied to an owned buffer.
         // No intervening operations on the mruby VM occur.
         let from = unsafe { implicitly_convert_to_string(interp, &mut from)? };
         from.to_vec()
@@ -1344,11 +1294,8 @@ pub fn initialize(interp: &mut Artichoke, mut value: Value, from: Option<Value>)
 }
 
 pub fn initialize_copy(interp: &mut Artichoke, mut value: Value, mut other: Value) -> Result<Value, Error> {
-    // Safety:
-    //
-    // The extracted slice is immediately copied to an owned buffer.
-    //
-    // No intervening operations on the mruby VM occur.
+    // SAFETY: The extracted slice is immediately copied to an owned buffer. No
+    // intervening operations on the mruby VM occur.
     let buf = unsafe {
         let from = implicitly_convert_to_string(interp, &mut other)?;
         from.to_vec()
@@ -1417,11 +1364,8 @@ pub fn reverse_bang(interp: &mut Artichoke, mut value: Value) -> Result<Value, E
     }
 
     let mut s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
-    // Safety:
-    //
-    // The string is reboxed before any intervening operations on the
-    // interpreter.
-    // The string is reboxed without any intervening mruby allocations.
+    // SAFETY: The string is repacked before any intervening uses of `interp`
+    // which means no mruby heap allocations can occur.
     unsafe {
         let string_mut = s.as_inner_mut();
         string_mut.reverse();
@@ -1475,10 +1419,8 @@ pub fn scan(interp: &mut Artichoke, value: Value, mut pattern: Value, block: Opt
         return Ok(interp.try_convert_mut(scan)?.unwrap_or(value));
     }
     #[cfg(feature = "core-regexp")]
-    // Safety:
-    //
-    // Convert `pattern_bytes` to an owned byte vec to ensure the underlying
-    // `RString` is not garbage collected when yielding matches.
+    // SAFETY: `pattern_bytes` is converted to an owned byte vec to ensure the
+    // underlying `RString*` is not garbage collected when yielding matches.
     if let Ok(pattern_bytes) = unsafe { implicitly_convert_to_string(interp, &mut pattern) } {
         let pattern_bytes = pattern_bytes.to_vec();
 
@@ -1537,10 +1479,8 @@ pub fn scan(interp: &mut Artichoke, value: Value, mut pattern: Value, block: Opt
         return interp.try_convert_mut(result);
     }
     #[cfg(not(feature = "core-regexp"))]
-    // Safety:
-    //
-    // Convert `pattern_bytes` to an owned byte vec to ensure the underlying
-    // `RString` is not garbage collected when yielding matches.
+    // SAFETY: `pattern_bytes` is converted to an owned byte vec to ensure the
+    // underlying `RString*` is not garbage collected when yielding matches.
     if let Ok(pattern_bytes) = unsafe { implicitly_convert_to_string(interp, &mut pattern) } {
         let pattern_bytes = pattern_bytes.to_vec();
 
@@ -1638,9 +1578,7 @@ pub fn setbyte(interp: &mut Artichoke, mut value: Value, index: Value, byte: Val
     let u8_byte = (i64_byte % 256)
         .try_into()
         .expect("taking mod 256 guarantees the resulting i64 is in range for u8");
-    // Safety:
-    //
-    // No need to repack, this is an in-place mutation.
+    // SAFETY: No need to repack, this is an in-place mutation.
     unsafe {
         let string_mut = s.as_inner_mut();
         let cell = string_mut.get_mut(index).ok_or_else(|| {
@@ -1741,11 +1679,8 @@ pub fn upcase(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> 
 
 pub fn upcase_bang(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
     let mut s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
-    // Safety:
-    //
-    // The string is reboxed before any intervening operations on the
-    // interpreter.
-    // The string is reboxed without any intervening mruby allocations.
+    // SAFETY: The string is repacked before any intervening uses of `interp`
+    // which means no mruby heap allocations can occur.
     unsafe {
         let string_mut = s.as_inner_mut();
         // `make_uppercase` might reallocate the string and invalidate the

--- a/artichoke-backend/src/extn/core/symbol/mod.rs
+++ b/artichoke-backend/src/extn/core/symbol/mod.rs
@@ -30,11 +30,9 @@ impl BoxUnboxVmValue for Symbol {
             return Err(TypeError::from(message).into());
         }
 
-        // Safety:
-        //
-        // The above check on the data type ensures the `value` union holds a
-        // `u32` in the `sym` variant.
         let value = value.inner();
+        // SAFETY: The above check on the data type ensures the `value` union
+        // holds a `u32` in the `sym` variant.
         let symbol_id = value.value.sym;
         Ok(UnboxedValueGuard::new(Immediate::new(symbol_id.into())))
     }

--- a/artichoke-backend/src/state/parser.rs
+++ b/artichoke-backend/src/state/parser.rs
@@ -136,11 +136,7 @@ pub struct Context {
 
 impl Default for Context {
     fn default() -> Self {
-        // Safety:
-        //
-        // - The `TOP_FILENAME` constant is controlled by this module.
-        // - The `TOP_FILENAME` constant does not contain NUL bytes.
-        // - This behavior is enforced by a test in this module.
+        // SAFETY: `TOP_FILENAME` has no NUL bytes (asserted by tests).
         unsafe { Self::new_unchecked(TOP_FILENAME) }
     }
 }

--- a/spinoso-string/src/buf/nul_terminated_vec.rs
+++ b/spinoso-string/src/buf/nul_terminated_vec.rs
@@ -89,8 +89,8 @@ impl Deref for Buf {
 impl DerefMut for Buf {
     #[inline]
     fn deref_mut(&mut self) -> &mut Self::Target {
-        // SAFETY: the mutable reference given out is a slice, NOT the underlying
-        // `Vec`, so the allocation cannot change size.
+        // SAFETY: the mutable reference given out is a slice, NOT the
+        // underlying `Vec`, so the allocation cannot change size.
         &mut *self.inner
     }
 }
@@ -141,7 +141,7 @@ impl Buf {
     #[inline]
     pub unsafe fn from_raw_parts(raw_parts: RawParts<u8>) -> Self {
         let mut inner = RawParts::into_vec(raw_parts);
-        // SAFETY: callers may have written into the spare capacity of the `Vec`
+        // SAFETY: Callers may have written into the spare capacity of the `Vec`
         // so we must ensure the NUL termination byte is still present.
         ensure_nul_terminated(&mut inner);
         Self { inner }

--- a/spinoso-string/src/enc/utf8/mod.rs
+++ b/spinoso-string/src/enc/utf8/mod.rs
@@ -146,10 +146,8 @@ impl Utf8String {
         } else {
             return bytes.len();
         };
-        // Safety:
-        //
-        // If `ByteSlice::find_non_ascii_byte` returns `Some(_)`, the index is
-        // guaranteed to be a valid index within `bytes`.
+        // SAFETY: `ByteSlice::find_non_ascii_byte` gurantees that the index is
+        // in range for slicing if `Some(_)` is returned.
         bytes = unsafe { bytes.get_unchecked(tail..) };
         if simdutf8::basic::from_utf8(bytes).is_ok() {
             return tail + bytecount::num_chars(bytes);

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -211,11 +211,7 @@ where
     writeln!(output, "{}", preamble(interp)?)?;
 
     interp.reset_parser()?;
-    // Safety:
-    //
-    // - `Context::new_unchecked` requires that its argument has no NUL bytes.
-    // - `REPL` is controlled by this crate.
-    // - A test asserts that `REPL` has no NUL bytes.
+    // SAFETY: `REPL` has no NUL bytes (asserted by tests).
     let context = unsafe { Context::new_unchecked(REPL.to_vec()) };
     interp.push_context(context)?;
     let mut parser = Parser::new(interp).ok_or_else(ParserAllocError::new)?;

--- a/src/ruby.rs
+++ b/src/ruby.rs
@@ -157,11 +157,7 @@ where
     W: io::Write + WriteColor,
 {
     interp.pop_context()?;
-    // Safety:
-    //
-    // - `Context::new_unchecked` requires that its argument has no NUL bytes.
-    // - `INLINE_EVAL_SWITCH` is controlled by this crate.
-    // - A test asserts that `INLINE_EVAL_SWITCH` has no NUL bytes.
+    // SAFETY: `INLINE_EVAL_SWITCH` has no NUL bytes (asserted by tests).
     let context = unsafe { Context::new_unchecked(INLINE_EVAL_SWITCH) };
     interp.push_context(context)?;
     if let Some(fixture) = fixture {


### PR DESCRIPTION
- Use consistent `// SAFETY: ...` style for inline safety comments on `unsafe` blocks.
- Rework safety justifications for clarity.
- Remove some obsolete safety comments.
- Move safety comments closer to unsafe code that they justify.

The `// SAFETY: ...` style (all caps, justification immediately following) seems to be preferred in the ecosystem. The rust-lang/rust repository vastly prefers this style and Rust-for-Linux uses this style. One other nice thing I noticed is that `rust-lang/rust.vim` highlights the `SAFETY` word in comment blocks.