### PR TITLE
Fixup static offset parsing for tzrs times

### DIFF
--- a/spinoso-time/src/time/tzrs/offset.rs
+++ b/spinoso-time/src/time/tzrs/offset.rs
@@ -437,6 +437,22 @@ mod tests {
     }
 
     #[test]
+    fn from_str_fixed_strings_with_newlines() {
+        assert!(matches!(
+            offset_seconds_from_fixed_offset("+10:00\n+11:00").unwrap_err(),
+            TimeError::TzStringError(_)
+        ));
+        assert!(matches!(
+            offset_seconds_from_fixed_offset("+10:00\n").unwrap_err(),
+            TimeError::TzStringError(_)
+        ));
+        assert!(matches!(
+            offset_seconds_from_fixed_offset("\n+10:00").unwrap_err(),
+            TimeError::TzStringError(_)
+        ));
+    }
+
+    #[test]
     fn fixed_time_zone_designation() {
         assert_eq!("+0000", fixed_offset_name(0).unwrap());
         assert_eq!("+0000", fixed_offset_name(59).unwrap());

--- a/spinoso-time/src/time/tzrs/offset.rs
+++ b/spinoso-time/src/time/tzrs/offset.rs
@@ -235,8 +235,9 @@ impl TryFrom<&str> for Offset {
                 // See:
                 // - https://docs.rs/regex/latest/regex/#perl-character-classes-unicode-friendly
                 // - https://docs.rs/regex/latest/regex/#ascii-character-classes
-                static HH_MM_MATCHER: Lazy<Regex> =
-                    Lazy::new(|| Regex::new(r"^([\-\+]{1})([[:digit:]]{2}):?([[:digit:]]{2})$").unwrap());
+                static HH_MM_MATCHER: Lazy<Regex> = Lazy::new(|| {
+                    Regex::new(r"^([\-\+]{1})([[:digit:]]{2}):?([[:digit:]]{2})$").expect("regex must compile")
+                });
 
                 if let Some(caps) = HH_MM_MATCHER.captures(input) {
                     let sign = if &caps[1] == "+" { 1 } else { -1 };

--- a/spinoso-time/src/time/tzrs/offset.rs
+++ b/spinoso-time/src/time/tzrs/offset.rs
@@ -239,20 +239,18 @@ impl TryFrom<&str> for Offset {
                     Regex::new(r"^([\-\+]{1})([[:digit:]]{2}):?([[:digit:]]{2})$").expect("regex must compile")
                 });
 
-                if let Some(caps) = HH_MM_MATCHER.captures(input) {
-                    let sign = if &caps[1] == "+" { 1 } else { -1 };
-                    let hours = caps[2].parse::<i32>().expect("Two ASCII digits fit in i32");
-                    let minutes = caps[3].parse::<i32>().expect("Two ASCII digits fit in i32");
+                let caps = HH_MM_MATCHER.captures(input).ok_or_else(TzStringError::new)?;
 
-                    if hours > 23 || minutes > 59 {
-                        return Err(TzOutOfRangeError::new().into());
-                    }
+                let sign = if &caps[1] == "+" { 1 } else { -1 };
+                let hours = caps[2].parse::<i32>().expect("Two ASCII digits fit in i32");
+                let minutes = caps[3].parse::<i32>().expect("Two ASCII digits fit in i32");
 
-                    let offset_seconds: i32 = sign * ((hours * SECONDS_IN_HOUR) + (minutes * SECONDS_IN_MINUTE));
-                    Ok(Self::fixed(offset_seconds)?)
-                } else {
-                    Err(TzStringError::new().into())
+                if hours > 23 || minutes > 59 {
+                    return Err(TzOutOfRangeError::new().into());
                 }
+
+                let offset_seconds: i32 = sign * ((hours * SECONDS_IN_HOUR) + (minutes * SECONDS_IN_MINUTE));
+                Ok(Self::fixed(offset_seconds)?)
             }
         }
     }

--- a/spinoso-time/src/time/tzrs/offset.rs
+++ b/spinoso-time/src/time/tzrs/offset.rs
@@ -224,14 +224,24 @@ impl TryFrom<&str> for Offset {
             // ```
             "Z" | "UTC" => Ok(Self::utc()),
             _ => {
+                // With `Regex`, `\d` is a "Unicode friendly" Perl character
+                // class which matches Unicode property `Nd`. The `Nd` property
+                // includes all sorts of numerals, including Devanagari and
+                // Kannada, which don't parse into an `i32` using `FromStr`.
+                //
+                // `[[:digit:]]` is documented to be an ASCII character class
+                // for only digits 0-9.
+                //
+                // See:
+                // - https://docs.rs/regex/latest/regex/#perl-character-classes-unicode-friendly
+                // - https://docs.rs/regex/latest/regex/#ascii-character-classes
                 static HH_MM_MATCHER: Lazy<Regex> =
-                    Lazy::new(|| Regex::new(r"^([\-\+]{1})(\d{2}):?(\d{2})$").unwrap());
-                if HH_MM_MATCHER.is_match(input) {
-                    let caps = HH_MM_MATCHER.captures(input).unwrap();
+                    Lazy::new(|| Regex::new(r"^([\-\+]{1})([[:digit:]]{2}):?([[:digit:]]{2})$").unwrap());
 
-                    let sign = if caps.get(1).unwrap().as_str() == "+" { 1 } else { -1 };
-                    let hours = caps.get(2).unwrap().as_str().parse::<i32>().unwrap();
-                    let minutes = caps.get(3).unwrap().as_str().parse::<i32>().unwrap();
+                if let Some(caps) = HH_MM_MATCHER.captures(input) {
+                    let sign = if &caps[1] == "+" { 1 } else { -1 };
+                    let hours = caps[2].parse::<i32>().expect("Two ASCII digits fit in i32");
+                    let minutes = caps[3].parse::<i32>().expect("Two ASCII digits fit in i32");
 
                     if hours > 23 || minutes > 59 {
                         return Err(TzOutOfRangeError::new().into());
@@ -406,6 +416,23 @@ mod tests {
                 invalid_string,
             );
         }
+    }
+
+    #[test]
+    fn from_str_non_ascii_numeral_fixed_strings() {
+        // This offset string is constructed out of non-ASCII numerals in the
+        // Unicode Nd character class. The sequence contains `+`, Devanagari 1,
+        // Devanagari 0, Kannada 3, and Kannada 6.
+        //
+        // See:
+        //
+        // - https://en.wikipedia.org/wiki/Devanagari_numerals#Table
+        // - https://en.wikipedia.org/wiki/Kannada_script#Numerals
+        let offset = "+१०:೩೬";
+        assert!(matches!(
+            offset_seconds_from_fixed_offset(offset).unwrap_err(),
+            TimeError::TzStringError(_)
+        ));
     }
 
     #[test]


### PR DESCRIPTION
- Rather than check `Regex::is_match` and unwrapping `Regex::captures`, just call `Regex::captures` and pattern match on the returned `Option`.
- Use slice indexing on `Captures` since we know the groups are not optional and will be present in the match. This makes the code a bit easier to read by hiding the unwraps and `str` casting.
- Ensure only ASCII digits can match in the parsing `Regex`, add a test which failed previously.