### PR TITLE
Refactor `tzrs` offset parsing code for clarity

### DIFF
--- a/spinoso-time/Cargo.toml
+++ b/spinoso-time/Cargo.toml
@@ -23,7 +23,7 @@ tzrs-local = ["tzrs", "tzdb?/local"]
 chrono = { version = "0.4.19", default-features = false, features = ["clock"], optional = true }
 chrono-tz = { version = "0.6.0", default-features = false, optional = true }
 once_cell = { version = "1.12.0", optional = true }
-regex =  { version = "1.5.5", default-features = false, features = ["std", "unicode-perl"], optional = true }
+regex =  { version = "1.5.5", default-features = false, features = ["std"], optional = true }
 tz-rs = { version = "0.6.10", default-features = false, optional = true }
 tzdb = { version = "0.2.4", default-features = false, optional = true }
 

--- a/spinoso-time/src/time/tzrs/offset.rs
+++ b/spinoso-time/src/time/tzrs/offset.rs
@@ -249,12 +249,15 @@ impl TryFrom<&str> for Offset {
                 let hours = caps[2].parse::<i32>().expect("Two ASCII digits fit in i32");
                 let minutes = caps[3].parse::<i32>().expect("Two ASCII digits fit in i32");
 
-                if hours > 23 || minutes > 59 {
-                    return Err(TzOutOfRangeError::new().into());
+                // Check that the parsed offset is in range, which goes from:
+                // - `00:00` to `00:59`
+                // - `00:00` to `23:59`
+                if (0..=23).contains(&hours) && (0..=59).contains(&minutes) {
+                    let offset_seconds: i32 = sign * ((hours * SECONDS_IN_HOUR) + (minutes * SECONDS_IN_MINUTE));
+                    Ok(Self::fixed(offset_seconds)?)
+                } else {
+                    Err(TzOutOfRangeError::new().into())
                 }
-
-                let offset_seconds: i32 = sign * ((hours * SECONDS_IN_HOUR) + (minutes * SECONDS_IN_MINUTE));
-                Ok(Self::fixed(offset_seconds)?)
             }
         }
     }


### PR DESCRIPTION
- Use `(n..=m).contains(...)` to enforce range bounds on minutes and hours components of the offset for clarity and to prevent accidentally allowing negative offset parts.
- Remove `unicode-perl` feature from `regex` dependency in `spinoso-time` since #1988 removed use of the `\d` character class.