### PR TITLE
Upgrade `rustyline` to 10.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,12 +208,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
-name = "endian-type"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
-
-[[package]]
 name = "errno"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -361,15 +355,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
-name = "memoffset"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "mezzaluna-feature-loader"
 version = "0.5.0"
 dependencies = [
@@ -377,25 +362,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "nibble_vec"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
-dependencies = [
- "smallvec",
-]
-
-[[package]]
 name = "nix"
-version = "0.23.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f866317acbd3a240710c63f065ffb1e4fd466259045ccb504130b7f668f35c6"
+checksum = "195cdbc1741b8134346d515b3a56a1c94b0912758009cfd53f99ea0f57b065fc"
 dependencies = [
  "bitflags",
- "cc",
  "cfg-if",
  "libc",
- "memoffset",
 ]
 
 [[package]]
@@ -545,16 +519,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "radix_trie"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
-dependencies = [
- "endian-type",
- "nibble_vec",
-]
-
-[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -629,9 +593,9 @@ dependencies = [
 
 [[package]]
 name = "rustyline"
-version = "9.1.2"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db7826789c0e25614b03e5a54a0717a86f9ff6e6e5247f92b369472869320039"
+checksum = "1d1cd5ae51d3f7bf65d7969d579d502168ef578f289452bd8ccc91de28fda20e"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -641,9 +605,7 @@ dependencies = [
  "log",
  "memchr",
  "nix",
- "radix_trie",
  "scopeguard",
- "smallvec",
  "unicode-segmentation",
  "unicode-width",
  "utf8parse",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ clap = { version = "3.2.5", optional = true, default-features = false, features 
 #
 # See: https://github.com/kkawakam/rustyline/pull/583
 log = { version = "0.4.5", optional = true }
-rustyline = { version = "9.1.2", optional = true, default-features = false }
+rustyline = { version = "10.0.0", optional = true, default-features = false }
 termcolor = { version = "1.1.0", optional = true }
 
 [dependencies.artichoke-backend]

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -216,7 +216,7 @@ where
     interp.push_context(context)?;
     let mut parser = Parser::new(interp).ok_or_else(ParserAllocError::new)?;
 
-    let mut rl = Editor::<()>::new();
+    let mut rl = Editor::<()>::new().map_err(UnhandledReadlineError)?;
     // If a code block is open, accumulate code from multiple read lines in this
     // mutable `String` buffer.
     let mut buf = String::new();


### PR DESCRIPTION
`rustyline` 10.0.0 includes a breaking change where `Editor::new` now
returns result. The REPL propagates this error as an unhandled readline
error, which will exit the REPL with an error message.

This is a handcrafted version of @dependabot's PR in #1999 to address
this breaking change.

`rustyline` 10.0.0 includes several commits (a few of which I authored)
that reduce the number of deps pulled in a bunch:

- https://github.com/kkawakam/rustyline/pull/613
- https://github.com/kkawakam/rustyline/pull/614
- https://github.com/kkawakam/rustyline/pull/615
- https://github.com/kkawakam/rustyline/pull/623