### PR TITLE
Upgrade `tz-rs` to 0.6.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -847,9 +847,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tz-rs"
-version = "0.6.11"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb454313e3d79601e2116bb6c7a93ec0eda1dbb52f9204f831f897204182c5f"
+checksum = "5b3d23fda22515e0e3f4f903e159ad4fd32e37dc94d63522a091df70a247fbb0"
 dependencies = [
  "const_fn",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ path = "artichoke-backend"
 default-features = false
 
 [build-dependencies]
-tz-rs = { version = "0.6.9", default-features = false }
+tz-rs = { version = "0.6.12", default-features = false, features = ["std"] }
 
 [[bin]]
 name = "airb"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -508,9 +508,9 @@ dependencies = [
 
 [[package]]
 name = "tz-rs"
-version = "0.6.11"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb454313e3d79601e2116bb6c7a93ec0eda1dbb52f9204f831f897204182c5f"
+checksum = "5b3d23fda22515e0e3f4f903e159ad4fd32e37dc94d63522a091df70a247fbb0"
 
 [[package]]
 name = "uncased"

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -710,9 +710,9 @@ checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
 name = "tz-rs"
-version = "0.6.11"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb454313e3d79601e2116bb6c7a93ec0eda1dbb52f9204f831f897204182c5f"
+checksum = "5b3d23fda22515e0e3f4f903e159ad4fd32e37dc94d63522a091df70a247fbb0"
 
 [[package]]
 name = "uncased"

--- a/spinoso-time/Cargo.toml
+++ b/spinoso-time/Cargo.toml
@@ -24,7 +24,7 @@ chrono = { version = "0.4.19", default-features = false, features = ["clock"], o
 chrono-tz = { version = "0.6.0", default-features = false, optional = true }
 once_cell = { version = "1.12.0", optional = true }
 regex =  { version = "1.5.5", default-features = false, features = ["std"], optional = true }
-tz-rs = { version = "0.6.10", default-features = false, optional = true }
+tz-rs = { version = "0.6.12", default-features = false, features = ["std"], optional = true }
 tzdb = { version = "0.2.4", default-features = false, optional = true }
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
`tz-rs` 0.6.12 added a new `std` default feature which gates access to
APIs that were previously available with `default-features = false`:

https://github.com/x-hgg-x/tz-rs/commit/3eae3eb663ef7d9098ebb5dc6cc9ca7f2d2dc068

Update dependency constraints across the workspace to 0.6.12 and add the
new `std` feature.

This commit obsoletes these @dependabot PRs:

- #1998