### PR TITLE
Upgrade `libm` to 0.2.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -335,9 +335,9 @@ checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
 name = "libm"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33a33a362ce288760ec6a508b94caaec573ae7d3bbbd91b87aa0bad4456839db"
+checksum = "da83a57f3f5ba3680950aa3cbc806fc297bc0b289d42e8942ed528ace71b8145"
 
 [[package]]
 name = "linux-raw-sys"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -197,9 +197,9 @@ dependencies = [
 
 [[package]]
 name = "libm"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33a33a362ce288760ec6a508b94caaec573ae7d3bbbd91b87aa0bad4456839db"
+checksum = "da83a57f3f5ba3680950aa3cbc806fc297bc0b289d42e8942ed528ace71b8145"
 
 [[package]]
 name = "memchr"

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -248,9 +248,9 @@ checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
 name = "libm"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33a33a362ce288760ec6a508b94caaec573ae7d3bbbd91b87aa0bad4456839db"
+checksum = "da83a57f3f5ba3680950aa3cbc806fc297bc0b289d42e8942ed528ace71b8145"
 
 [[package]]
 name = "memchr"

--- a/spinoso-math/Cargo.toml
+++ b/spinoso-math/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["libm", "math", "no_std", "spinoso"]
 categories = ["algorithms", "no-std"]
 
 [dependencies]
-libm = { version = "0.2.2", optional = true }
+libm = { version = "0.2.3", optional = true }
 
 [features]
 default = ["full"]

--- a/spinoso-random/Cargo.toml
+++ b/spinoso-random/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["algorithms", "no-std"]
 
 [dependencies]
 getrandom = { version = "0.2.0", default-features = false }
-libm = "0.2.2"
+libm = "0.2.3"
 rand = { version = "0.8.0", optional = true, default-features = false }
 # 0.6.1 is vulnerable to underfilling a buffer.
 #


### PR DESCRIPTION
Pulls in a fix to remove panics from `libm::tgamma`, which is used by
`spinoso-math`:

- https://github.com/rust-lang/libm/pull/264

This commit obsoletes these @dependabot PRs:

- #2003
- #2011
- #2012