### PR TITLE
Implement `spinoso-securerandom` with `getrandom`

### DIFF
--- a/spinoso-securerandom/Cargo.toml
+++ b/spinoso-securerandom/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["algorithms"]
 
 [dependencies]
 base64 = { version = "0.13.0", default-features = false, features = ["alloc"] }
-rand = "0.8.0"
+rand = { version = "0.8.0", default-features = false, features = ["getrandom"] }
 scolapasta-hex = { version = "0.2.0", path = "../scolapasta-hex", default-features = false, features = ["alloc"] }
 
 [package.metadata.docs.rs]

--- a/spinoso-securerandom/src/lib.rs
+++ b/spinoso-securerandom/src/lib.rs
@@ -96,7 +96,8 @@ use std::collections::TryReserveError;
 use std::error;
 
 use rand::distributions::Alphanumeric;
-use rand::{self, CryptoRng, Rng, RngCore};
+use rand::rngs::OsRng;
+use rand::{CryptoRng, Rng, RngCore};
 use scolapasta_hex as hex;
 
 mod uuid;
@@ -456,7 +457,7 @@ pub fn random_bytes(len: Option<i64>) -> Result<Vec<u8>, Error> {
     let mut bytes = Vec::new();
     bytes.try_reserve(len)?;
     bytes.resize(len, 0);
-    get_random_bytes(rand::thread_rng(), &mut bytes)?;
+    get_random_bytes(OsRng, &mut bytes)?;
     Ok(bytes)
 }
 
@@ -578,7 +579,7 @@ pub fn random_number(max: Max) -> Result<Rand, DomainError> {
         }
     }
 
-    get_random_number(rand::thread_rng(), max)
+    get_random_number(OsRng, max)
 }
 
 /// Generate a hex-encoded [`String`] of random bytes.
@@ -725,7 +726,7 @@ pub fn alphanumeric(len: Option<i64>) -> Result<Vec<u8>, Error> {
         None => DEFAULT_REQUESTED_BYTES,
     };
 
-    let string = get_alphanumeric(rand::thread_rng(), len)?;
+    let string = get_alphanumeric(OsRng, len)?;
     Ok(string)
 }
 

--- a/spinoso-securerandom/src/uuid.rs
+++ b/spinoso-securerandom/src/uuid.rs
@@ -4,6 +4,7 @@
 //!
 //! [RFC 4122]: https://tools.ietf.org/html/rfc4122#section-4.4
 
+use rand::rngs::OsRng;
 use rand::{CryptoRng, RngCore};
 use scolapasta_hex as hex;
 
@@ -30,7 +31,7 @@ pub fn v4() -> Result<String, Error> {
     }
 
     let mut bytes = [0; OCTETS];
-    get_random_bytes(rand::thread_rng(), &mut bytes)?;
+    get_random_bytes(OsRng, &mut bytes)?;
 
     // Per RFC 4122, Section 4.4, set bits for version and `clock_seq_hi_and_reserved`.
     bytes[6] = (bytes[6] & 0x0f) | 0x40;


### PR DESCRIPTION
In MRI Ruby, `SecureRandom` is implemented with `Random::urandom` which itself is implemented with an OS-provided cryptographically secure random number source.

This commit removes an intermediate CSPRNG and instead delegates directly to the host operating system for random bytes by using the `getrandom` crate-backed `OsRng` from `rand`.

This allows deactivating a bunch of features in `rand` which will hopefully drop some deps if https://github.com/rust-phf/rust-phf/pull/263 is accepted and Artichoke upgrades to `pfh` 0.11.0+.