### PR TITLE
Use trailing NUL byte in `mrb_intern_check_cstr`

### DIFF
--- a/artichoke-backend/src/extn/core/symbol/ffi.rs
+++ b/artichoke-backend/src/extn/core/symbol/ffi.rs
@@ -82,9 +82,9 @@ unsafe extern "C" fn mrb_intern_check(mrb: *mut sys::mrb_state, name: *const c_c
 #[no_mangle]
 unsafe extern "C" fn mrb_intern_check_cstr(mrb: *mut sys::mrb_state, name: *const c_char) -> sys::mrb_sym {
     let string = CStr::from_ptr(name);
-    let bytes = string.to_bytes();
+    let bytes = string.to_bytes_with_nul();
     unwrap_interpreter!(mrb, to => guard, or_else = 0);
-    if let Ok(Some(sym)) = guard.check_interned_bytes(bytes) {
+    if let Ok(Some(sym)) = guard.check_interned_bytes_with_trailing_nul(bytes) {
         sym
     } else {
         0


### PR DESCRIPTION
Previously this function was implemented with `CStr::to_bytes` which does not include the trailing NUL. Artichoke has a fast, non-allocating pathway through the interner if the trailing NUL can be included.

This change eliminates ~1.5% of all allocations when running the spec runner, as profiled by DHAT following the guide at: https://docs.rs/dhat/0.3.0/dhat/index.html

This change eliminates ~1.5% of all allocations when running the spec runner, as profiled by DHAT.

Benchmarking this change against `trunk` shows a ~2% speedup:

```console
$ hyperfine --warmup 1 './target/release/spec-runner-trunk -q all-core-specs.toml' './target/release/spec-runner-new -q all-core-specs.toml'
Benchmark 1: ./target/release/spec-runner-trunk -q all-core-specs.toml
  Time (mean ± σ):      4.593 s ±  0.042 s    [User: 4.374 s, System: 0.214 s]
  Range (min … max):    4.554 s …  4.680 s    10 runs

Benchmark 2: ./target/release/spec-runner-new -q all-core-specs.toml
  Time (mean ± σ):      4.525 s ±  0.053 s    [User: 4.308 s, System: 0.211 s]
  Range (min … max):    4.456 s …  4.633 s    10 runs

Summary
  './target/release/spec-runner-new -q all-core-specs.toml' ran
    1.02 ± 0.02 times faster than './target/release/spec-runner-trunk -q all-core-specs.toml'
```

I was inspired to try out DHAT by this tweet: https://twitter.com/fitzgen/status/1552066808428969984.

I'll follow up with a separate PR that adds DHAT glue to the spec runner.