### PR TITLE
Improve correctness of `Kernel#Integer` and add more tests

### DIFF
--- a/artichoke-backend/src/extn/core/kernel/integer.rs
+++ b/artichoke-backend/src/extn/core/kernel/integer.rs
@@ -229,12 +229,12 @@ impl<'a> ParseState<'a> {
     fn collect_digit(self, digit: u8) -> Self {
         match self {
             Self::Initial(arg) => {
-                let mut digits = String::new();
+                let mut digits = String::with_capacity(10);
                 digits.push(char::from(digit));
                 Self::Accumulate(arg, digits)
             }
             Self::Sign(arg, sign) => {
-                let mut digits = String::new();
+                let mut digits = String::with_capacity(10);
                 if let Sign::Negative = sign {
                     digits.push('-');
                 }

--- a/artichoke-backend/src/extn/core/kernel/integer.rs
+++ b/artichoke-backend/src/extn/core/kernel/integer.rs
@@ -206,6 +206,7 @@ impl Default for Sign {
     }
 }
 
+#[must_use]
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 enum ParseState<'a> {
     Initial(IntegerString<'a>),

--- a/artichoke-backend/src/extn/core/kernel/integer.rs
+++ b/artichoke-backend/src/extn/core/kernel/integer.rs
@@ -461,6 +461,18 @@ mod tests {
     }
 
     #[test]
+    fn squeeze_leading_zeros_is_octal_when_octal_digits() {
+        let result = integer("000000000000000000000000000000000000000123".try_into().unwrap(), None);
+        assert_eq!(result.unwrap(), 83);
+    }
+
+    #[test]
+    fn squeeze_leading_is_invalid_when_non_octal_digits() {
+        let result = integer("000000000000000000000000000000000000000987".try_into().unwrap(), None);
+        result.unwrap_err();
+    }
+
+    #[test]
     fn squeeze_leading_zeros_enforces_no_double_underscore() {
         let result = integer("0x___11".try_into().unwrap(), Radix::new(16));
         result.unwrap_err();

--- a/artichoke-backend/src/extn/core/kernel/integer.rs
+++ b/artichoke-backend/src/extn/core/kernel/integer.rs
@@ -264,6 +264,7 @@ const fn radix_table() -> [u32; 256] {
         if idx >= table.len() {
             return table;
         }
+        #[allow(clippy::cast_possible_truncation)]
         let byte = idx as u8;
         if byte >= b'0' && byte <= b'9' {
             table[idx] = (byte - b'0' + 1) as u32;
@@ -284,7 +285,7 @@ pub fn method(arg: IntegerString<'_>, radix: Option<Radix>) -> Result<i64, Error
         .as_bytes()
         .iter()
         .copied()
-        .skip_while(|b| b.is_ascii_whitespace())
+        .skip_while(u8::is_ascii_whitespace)
         .peekable();
 
     match chars.peek() {
@@ -1030,7 +1031,7 @@ mod tests {
     fn nul_byte_is_err() {
         IntegerString::try_from("\0").unwrap_err();
         IntegerString::try_from("123\0").unwrap_err();
-        IntegerString::try_from("123\0456").unwrap_err();
+        IntegerString::try_from("123\x00456").unwrap_err();
     }
 
     #[test]

--- a/artichoke-backend/src/extn/core/kernel/integer.rs
+++ b/artichoke-backend/src/extn/core/kernel/integer.rs
@@ -524,6 +524,24 @@ mod tests {
     }
 
     #[test]
+    fn double_underscore_is_err() {
+        let result = integer("0x111__11".try_into().unwrap(), None);
+        assert_eq!(
+            result.unwrap_err().message().as_bstr(),
+            r#"invalid value for Integer(): "0x111__11""#.as_bytes().as_bstr()
+        );
+    }
+
+    #[test]
+    fn trailing_underscore_is_err() {
+        let result = integer("0x111_11_".try_into().unwrap(), None);
+        assert_eq!(
+            result.unwrap_err().message().as_bstr(),
+            r#"invalid value for Integer(): "0x111_11_""#.as_bytes().as_bstr()
+        );
+    }
+
+    #[test]
     fn all_spaces_is_err() {
         let result = integer("    ".try_into().unwrap(), None);
         assert_eq!(

--- a/artichoke-backend/src/extn/core/kernel/integer.rs
+++ b/artichoke-backend/src/extn/core/kernel/integer.rs
@@ -412,6 +412,20 @@ mod tests {
     }
 
     #[test]
+    fn parse_int_max() {
+        let result = integer("9_223_372_036_854_775_807".try_into().unwrap(), None);
+        assert_eq!(result.unwrap(), i64::MAX);
+        let result = integer("+9_223_372_036_854_775_807".try_into().unwrap(), None);
+        assert_eq!(result.unwrap(), i64::MAX);
+    }
+
+    #[test]
+    fn parse_int_min() {
+        let result = integer("-9_223_372_036_854_775_808".try_into().unwrap(), None);
+        assert_eq!(result.unwrap(), i64::MIN);
+    }
+
+    #[test]
     fn leading_zero_does_not_imply_octal_when_given_radix() {
         // ```
         // [3.1.2] > Integer('017', 12)


### PR DESCRIPTION
This fixes bugs related to:

- Squeezing leading zeros.
- Disallowing repeated underscores.
- Disallow trailing underscores.
- `-1` radix does not default to `10` it defaults to "no explicit radix given" to allow `0x...` and similar literals to parse.
- Turn a mismatched `0x`-style prefix and given radix into an error, e.g. `Integer("0xFF", 12)`.

The parser is changed to:

- Operate on byte slices after validating they are ASCII only.
- Eagerly determine the radix given the input string and optional radix argument.
- Decrease risk of error by marking the `ParserState` as `#[must_use]`.
- Return properly formatted `ArgumentError`s during error states.
- Avoid an `O(n)` copy if the string is a negative number by eagerly pushing `-` into the buffer.
- Short circuit with error if a given character/byte is not part of the radix range.