### PR TITLE
Remove Apache-2.0 WITH LLVM-exception license from cargo deny allowlist

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -8,7 +8,6 @@ ignore = []
 unlicensed = "deny"
 allow = [
   "Apache-2.0",
-  "Apache-2.0 WITH LLVM-exception",
   "BSL-1.0",
   "MIT",
   "Unicode-DFS-2016",


### PR DESCRIPTION
The _Apache-2.0 WITH LLVM-exception_ license is not used for any crates in `Cargo.lock` since `target-lexicon` was removed as a dependency in PR #1841.