### PR TITLE
Add docs to spec-runner README for heap profiling mode

### DIFF
--- a/spec-runner/README.md
+++ b/spec-runner/README.md
@@ -6,9 +6,15 @@
 
 `spec-runner` is the [ruby/spec][ruby-spec] runner for Artichoke.
 
+[ruby-spec]: https://github.com/ruby/spec
+
 `spec-runner` is a wrapper around [`MSpec`][mspec-sources] and [vendored
 ruby/spec sources][ruby-spec-sources] that works with the Artichoke virtual file
 system. `spec-runner` runs the specs declared in a [manifest file].
+
+[mspec-sources]: vendor/mspec
+[ruby-spec-sources]: vendor/spec
+[manifest file]: enforced-specs.toml
 
 ## Spec Manifest
 
@@ -41,21 +47,52 @@ skip = ["parse"]
 
 ```console
 $ cargo run -q -p spec-runner -- --help
-spec-runner 0.3.0
+spec-runner 0.6.0
 ruby/spec runner for Artichoke.
 
 USAGE:
-    spec-runner <config>
-
-FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+    spec-runner [OPTIONS] [config]
 
 ARGS:
     <config>    Path to TOML config file
+
+OPTIONS:
+    -f, --format <formatter>    Choose an output formatter [default: artichoke] [possible values:
+                                artichoke, summary, tagger, yaml]
+    -h, --help                  Print help information
+    -q, --quiet                 Suppress spec failures when exiting
+    -V, --version               Print version information
 ```
 
-[ruby-spec]: https://github.com/ruby/spec
-[mspec-sources]: vendor/mspec
-[ruby-spec-sources]: vendor/spec
-[manifest file]: enforced-specs.toml
+## Profiling
+
+The `spec-runner` can be used as a profiling harness for Articoke Ruby using a
+combination of Cargo features and a customized spec manifest file.
+
+### Heap Profiling
+
+Heap profiling with the Rust [`dhat`] crate was added in
+[artichoke/artichoke#2042].
+
+[`dhat`]: https://docs.rs/dhat/0.3.0/dhat/index.html
+[artichoke/artichoke#2042]: https://github.com/artichoke/artichoke/pull/2042
+
+To run a heap profile:
+
+1. Create a spec manifest. If you'd like a general purpose workload, you can use
+   [`all-core-specs.toml`].
+2. Run `spec-runner` with Cargo:
+
+   ```console
+   $ cargo run --release --bin spec-runner -q --features dhat-heap -- --quiet path/to/spec-manifest.toml
+   ```
+
+3. If this worked, you'll see `dhat` print some summary statistics and output a
+   file called `dhat-heap.json` to your shell's current working directory.
+4. Navigate to the [online DHAT viewer] and click the `Load...` button to load
+   the generated `dhat-heap.json` file. The `dhat` crate documentation has an
+   explainer on [how to use this viewer].
+
+[`all-core-specs.toml`]: all-core-specs.toml
+[online dhat viewer]: https://nnethercote.github.io/dh_view/dh_view.html
+[how to use this viewer]: https://docs.rs/dhat/0.3.0/dhat/index.html#viewing


### PR DESCRIPTION
Followup to #2042 and #2041.

Update _Usage_ section in README for spec-runner 0.6.0.