### PR TITLE
Add fuzzer for `scolapasta-int-parse`

### DIFF
--- a/.github/workflows/fuzz.yaml
+++ b/.github/workflows/fuzz.yaml
@@ -46,6 +46,53 @@ jobs:
         if: github.event_name == 'schedule'
         run: cargo fuzz run eval -- -max_total_time=1800 # 30 minutes
 
+  fuzz-kernel-integer:
+    name: Fuzz Kernel#Integer
+    runs-on: ubuntu-latest
+    env:
+      RUST_BACKTRACE: 1
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install nightly Rust toolchain
+        run: |
+          echo "::group::rustup toolchain install"
+          rustup toolchain install nightly --profile minimal
+          echo "::endgroup::"
+          echo "::group::set default toolchain"
+          rm -rf rust-toolchain
+          rustup default nightly
+          echo "::endgroup::"
+          echo "::group::rustup version"
+          rustup -Vv
+          echo "::endgroup::"
+          echo "::group::rustc version"
+          rustc -Vv
+          echo "::endgroup::"
+          echo "::group::cargo version"
+          cargo version --verbose
+          echo "::endgroup::"
+
+      - name: Install cargo-fuzz
+        run: cargo install cargo-fuzz
+
+      - name: Build fuzz targets
+        run: cargo fuzz build
+
+      - name: Fuzz Kernel#Integer with binary input
+        if: github.event_name == 'schedule'
+        run: cargo fuzz run kernel-integer-bytes -- -max_total_time=600 # 10 minutes
+
+      - name: Fuzz Kernel#Integer with numeric input
+        if: github.event_name == 'schedule'
+        run: cargo fuzz run kernel-integer-int -- -max_total_time=600 # 10 minutes
+
+      - name: Fuzz Kernel#Integer with UTF-8 input
+        if: github.event_name == 'schedule'
+        run: cargo fuzz run kernel-integer-str -- -max_total_time=600 # 10 minutes
+
   leak-san:
     name: Compile and test with LeakSanitizer
     runs-on: ubuntu-latest

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -62,6 +62,7 @@ version = "0.0.0"
 dependencies = [
  "artichoke",
  "libfuzzer-sys",
+ "scolapasta-int-parse",
 ]
 
 [[package]]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -13,6 +13,7 @@ cargo-fuzz = true
 [dependencies]
 artichoke = { version = "0.1.0-pre.0", path = "..", default-features = false, features = ["kitchen-sink"] }
 libfuzzer-sys = "0.4.3"
+scolapasta-int-parse = { version = "0.2.0", path = "../scolapasta-int-parse", default-features = false }
 
 # Prevent this from interfering with workspaces
 [workspace]
@@ -21,3 +22,15 @@ members = ["."]
 [[bin]]
 name = "eval"
 path = "fuzz_targets/eval.rs"
+
+[[bin]]
+name = "kernel-integer-bytes"
+path = "fuzz_targets/kernel_integer_bytes.rs"
+
+[[bin]]
+name = "kernel-integer-int"
+path = "fuzz_targets/kernel_integer_int.rs"
+
+[[bin]]
+name = "kernel-integer-str"
+path = "fuzz_targets/kernel_integer_str.rs"

--- a/fuzz/fuzz_targets/kernel_integer_bytes.rs
+++ b/fuzz/fuzz_targets/kernel_integer_bytes.rs
@@ -1,0 +1,16 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+use scolapasta_int_parse::parse;
+
+fuzz_target!(|data: &[u8]| {
+    // We're looking for panics, not correctness, so drop the results.
+    drop(parse(data, None));
+    for radix in -500..500 {
+        drop(parse(data, Some(radix)));
+    }
+    drop(parse(data, Some(i32::MAX.into())));
+    drop(parse(data, Some(i32::MIN.into())));
+    drop(parse(data, Some(i64::MAX)));
+    drop(parse(data, Some(i64::MAX)));
+});

--- a/fuzz/fuzz_targets/kernel_integer_int.rs
+++ b/fuzz/fuzz_targets/kernel_integer_int.rs
@@ -1,0 +1,17 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+use scolapasta_int_parse::parse;
+
+fuzz_target!(|data: i64| {
+    let data = data.to_string();
+    // We're looking for panics, not correctness, so drop the results.
+    drop(parse(&data, None));
+    for radix in -500..500 {
+        drop(parse(&data, Some(radix)));
+    }
+    drop(parse(&data, Some(i32::MAX.into())));
+    drop(parse(&data, Some(i32::MIN.into())));
+    drop(parse(&data, Some(i64::MAX)));
+    drop(parse(&data, Some(i64::MAX)));
+});

--- a/fuzz/fuzz_targets/kernel_integer_str.rs
+++ b/fuzz/fuzz_targets/kernel_integer_str.rs
@@ -1,0 +1,16 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+use scolapasta_int_parse::parse;
+
+fuzz_target!(|data: &str| {
+    // We're looking for panics, not correctness, so drop the results.
+    drop(parse(data, None));
+    for radix in -500..500 {
+        drop(parse(data, Some(radix)));
+    }
+    drop(parse(data, Some(i32::MAX.into())));
+    drop(parse(data, Some(i32::MIN.into())));
+    drop(parse(data, Some(i64::MAX)));
+    drop(parse(data, Some(i64::MAX)));
+});


### PR DESCRIPTION
Add fuzzers for binary input, UTF-8 input, and numeric input for a variety of radixes.

Followup to https://github.com/artichoke/artichoke/pull/2053.