### PR TITLE
Fixup typos and improve docs in `scolapasta-int-parse`

### DIFF
--- a/scolapasta-int-parse/src/error.rs
+++ b/scolapasta-int-parse/src/error.rs
@@ -57,7 +57,7 @@ impl<'a> fmt::Display for Error<'a> {
 #[cfg(feature = "std")]
 impl<'a> std::error::Error for Error<'a> {}
 
-/// Error that indicates the input to [`parse`] was invalid.
+/// Error that indicates the byte string input to [`parse`] was invalid.
 ///
 /// This error can be returned in the following circumstances:
 ///
@@ -140,14 +140,15 @@ pub enum InvalidRadixErrorKind {
     Invalid(i64),
 }
 
-/// An enum describing which type of Ruby `Exception` and [`InvalidRadixError`]
+/// An enum describing which type of Ruby `Exception` an [`InvalidRadixError`]
 /// should be mapped to.
 ///
 /// If the given radix falls outside the range of an [`i32`], the error should
 /// be mapped to a [`RangeError`].
 ///
 /// If the given radix falls within the range of an [`i32`], but outside the
-/// range of `2..=36`, the error should be mapped to an [`ArgumentError`].
+/// range of `2..=36` (or `-36..=-2` in some cases), the error should be mapped
+/// to an [`ArgumentError`].
 ///
 /// The error message for these Ruby exceptions should be derived from the
 /// [`fmt::Display`] implementation of [`InvalidRadixError`].
@@ -157,7 +158,8 @@ pub enum InvalidRadixErrorKind {
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum InvalidRadixExceptionKind {
     /// If the given radix falls within the range of an [`i32`], but outside the
-    /// range of `2..=36`, the error should be mapped to an [`ArgumentError`]:
+    /// range of `2..=36` (or -36..=-2 in some cases), the error should be
+    /// mapped to an [`ArgumentError`]:
     ///
     /// ```console
     /// [3.1.2] > begin; Integer "123", 49; rescue => e; p e; end
@@ -217,7 +219,7 @@ impl From<InvalidRadixErrorKind> for InvalidRadixError {
 }
 
 impl InvalidRadixError {
-    /// Map an invalid radix error to the kind of Ruby Exception it should be
+    /// Map an invalid radix error to the kind of Ruby `Exception` it should be
     /// raised as.
     ///
     /// See [`InvalidRadixExceptionKind`] for more details.

--- a/scolapasta-int-parse/src/lib.rs
+++ b/scolapasta-int-parse/src/lib.rs
@@ -24,6 +24,8 @@
 //! input byte string:
 //!
 //! - Assert the byte string is ASCII and does not contain NUL bytes.
+//! - Parse the radix to ensure it is in range and valid for the given input
+//!   byte string.
 //! - Trim leading whitespace.
 //! - Accept a single, optional `+` or `-` sign byte.
 //! - Parse a literal radix out of the string from one of `0b`, `0B`, `0o`,

--- a/scolapasta-int-parse/src/radix.rs
+++ b/scolapasta-int-parse/src/radix.rs
@@ -34,13 +34,29 @@ pub static RADIX_TABLE: [u32; 256] = radix_table();
 /// This type enforces that its value is in the range 2 and 36 inclusive, which
 /// is required by [`i64::from_str_radix`].
 ///
-/// See [`parse`] for more details on how to use this type.
+/// This type is not part of the public API for [`parse`] but can be used on its
+/// own.
 ///
 /// [`parse`]: crate::parse
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Radix(NonZeroU32);
 
 impl Default for Radix {
+    /// The default radix is `10`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use scolapasta_int_parse::Radix;
+    /// # fn example() -> Option<()> {
+    /// let default = Radix::default();
+    /// let base10 = Radix::new(10)?;
+    /// assert_eq!(default, base10);
+    /// assert_eq!(default.as_u32(), 10);
+    /// # Some(())
+    /// # }
+    /// # example().unwrap();
+    /// ```
     fn default() -> Self {
         // SAFETY: Constant `10` is non-zero and between 2 and 36.
         unsafe { Self::new_unchecked(10) }
@@ -266,6 +282,7 @@ mod tests {
         let default = Radix::default();
         let base10 = Radix::new(10).unwrap();
         assert_eq!(default, base10);
+        assert_eq!(default.as_u32(), 10);
     }
 
     #[test]


### PR DESCRIPTION
Also add docs for `Radix::default` and an extra test that `Radix::default` gives `u32` radix as `10`.

Followup to https://github.com/artichoke/artichoke/pull/2053.