### PR TITLE
Add inline comments to explain the parsing steps of a time offset

### DIFF
--- a/spinoso-time/src/time/tzrs/offset.rs
+++ b/spinoso-time/src/time/tzrs/offset.rs
@@ -323,7 +323,15 @@ impl TryFrom<&str> for Offset {
 
                 let caps = HH_MM_MATCHER.captures(input).ok_or_else(TzStringError::new)?;
 
+                // Special handling of the +/- sign is required because `-00:30`
+                // must parse to a negative offset and `i32::from_str_radix`
+                // cannot preserve the `-` sign when parsing zero.
                 let sign = if &caps[1] == "+" { 1 } else { -1 };
+
+                // Both of these calls to `parse::<i32>()` ultimately boil down
+                // to `i32::from_str_radix(s, 10)`. This function strips leading
+                // zero padding as is present when parsing offsets like `+00:30`
+                // or `-08:00`.
                 let hours = caps[2].parse::<i32>().expect("Two ASCII digits fit in i32");
                 let minutes = caps[3].parse::<i32>().expect("Two ASCII digits fit in i32");
 


### PR DESCRIPTION
Include a justification why the sign must be parsed separately from the
hour offset: `-00:30` needs to preserve the `-` sign. `parse::<i32>()`
ultimately boils down to `i32::from_str_radix(s, 10)` and although this
handles a leading `+` or `-` and squeezing leading zeros, the `-` sign
is lost when parsing `0`.