### PR TITLE
Update embedded license descriptions for mruby and Oniguruma

### DIFF
--- a/generate-third-party/lib/generate_third_party/cargo_about/about.hbs
+++ b/generate-third-party/lib/generate_third_party/cargo_about/about.hbs
@@ -13,7 +13,7 @@ deps:
 {{/each}}
 {{/each}}
   - name: "mruby"
-    version: "3.0.0"
+    version: "3.1.0"
     url: "https://github.com/mruby/mruby"
     license: "MIT License"
     id: "MIT"
@@ -38,8 +38,8 @@ deps:
       FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
       DEALINGS IN THE SOFTWARE.
   - name: "oniguruma"
-    version: "6.9.7"
-    url: "https://github.com/kkos/oniguruma/tree/3bbb3d65c65350bfd941129592cb390aadedb25a"
+    version: "6.9.8"
+    url: "https://github.com/kkos/oniguruma/tree/08d36110c5670c815ad6d6f969e578049d209080"
     license: "2-Clause BSD License"
     id: "BSD-2-Clause"
     text: |


### PR DESCRIPTION
These update the `generate-third-party` gem with changes to C
dependencies from:

- https://github.com/artichoke/artichoke/pull/1755
- https://github.com/artichoke/artichoke/pull/2063