### PR TITLE
Fix `Kernel#Integer` failing specs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -609,7 +609,7 @@ version = "0.2.0"
 
 [[package]]
 name = "scolapasta-int-parse"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "scolapasta-string-escape",
 ]

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -25,7 +25,7 @@ qed = "1.3.0"
 # See: CVE-2022-24713
 # https://github.com/artichoke/artichoke/pull/1729
 regex = "1.5.5"
-scolapasta-int-parse = { version = "0.2.0", path = "../scolapasta-int-parse", default-features = false }
+scolapasta-int-parse = { version = "0.2.1", path = "../scolapasta-int-parse", default-features = false }
 scolapasta-string-escape = { version = "0.3.0", path = "../scolapasta-string-escape", default-features = false }
 spinoso-array = { version = "0.9.0", path = "../spinoso-array", default-features = false }
 spinoso-env = { version = "0.2.0", path = "../spinoso-env", optional = true, default-features = false }

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -437,7 +437,7 @@ version = "0.2.0"
 
 [[package]]
 name = "scolapasta-int-parse"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "scolapasta-string-escape",
 ]

--- a/scolapasta-int-parse/Cargo.toml
+++ b/scolapasta-int-parse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scolapasta-int-parse"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2021"
 rust-version = "1.62.0"

--- a/scolapasta-int-parse/README.md
+++ b/scolapasta-int-parse/README.md
@@ -24,7 +24,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-scolapasta-int-parse = "0.2.0"
+scolapasta-int-parse = "0.2.1"
 ```
 
 Parse strings into integers like:

--- a/scolapasta-int-parse/src/lib.rs
+++ b/scolapasta-int-parse/src/lib.rs
@@ -167,25 +167,7 @@ fn parse_inner(subject: &[u8], radix: Option<i64>) -> Result<i64, Error<'_>> {
     let mut state = ParseState::new(subject);
 
     // Phase 3: Trim leading and trailing whitespace.
-    let mut chars = {
-        let mut bytes = subject.as_bytes();
-        loop {
-            if let Some((first, tail)) = bytes.split_first() {
-                if first.is_ascii_whitespace() {
-                    bytes = tail;
-                    continue;
-                }
-            }
-            if let Some((last, head)) = bytes.split_last() {
-                if last.is_ascii_whitespace() {
-                    bytes = head;
-                    continue;
-                }
-            }
-            break;
-        }
-        bytes.iter().copied().peekable()
-    };
+    let mut chars = trim_whitespace(subject.as_bytes()).iter().copied().peekable();
 
     // Phase 4: Set sign.
     match chars.peek() {
@@ -284,6 +266,28 @@ fn parse_inner(subject: &[u8], radix: Option<i64>) -> Result<i64, Error<'_>> {
     // Phase 8: Parse (signed) ASCII alphanumeric string to an `i64`.
     let src = state.into_numeric_string()?;
     i64::from_str_radix(&*src, radix).map_err(|_| subject.into())
+}
+
+fn trim_whitespace(mut bytes: &[u8]) -> &[u8] {
+    loop {
+        if let Some((first, remaining)) = bytes.split_first() {
+            if first.is_ascii_whitespace() {
+                bytes = remaining;
+                continue;
+            }
+        }
+        break;
+    }
+    loop {
+        if let Some((last, remaining)) = bytes.split_last() {
+            if last.is_ascii_whitespace() {
+                bytes = remaining;
+                continue;
+            }
+        }
+        break;
+    }
+    bytes
 }
 
 #[cfg(test)]

--- a/scolapasta-int-parse/src/lib.rs
+++ b/scolapasta-int-parse/src/lib.rs
@@ -240,8 +240,9 @@ fn parse_inner(subject: &[u8], radix: Option<i64>) -> Result<i64, Error<'_>> {
                     16
                 }
                 (Some(b'b' | b'B' | b'o' | b'O' | b'd' | b'D' | b'x' | b'X'), Some(_)) => return Err(subject.into()),
-                (Some(_) | None, None) => 8,
-                (Some(_) | None, Some(radix)) => radix,
+                (None, _) => return Ok(0),
+                (Some(_), None) => 8,
+                (Some(_), Some(radix)) => radix,
             }
         }
         Some(_) => radix.unwrap_or(10),
@@ -838,6 +839,32 @@ mod tests {
     #[test]
     fn int_min_radix_does_not_panic() {
         parse("111", Some(i64::MIN)).unwrap_err();
+    }
+
+    #[test]
+    fn decimal_zero() {
+        let result = parse("0", None);
+        assert_eq!(result.unwrap(), 0);
+        let result = parse("0", Some(2));
+        assert_eq!(result.unwrap(), 0);
+        let result = parse("0", Some(8));
+        assert_eq!(result.unwrap(), 0);
+        let result = parse("0", Some(10));
+        assert_eq!(result.unwrap(), 0);
+        let result = parse("0", Some(16));
+        assert_eq!(result.unwrap(), 0);
+        let result = parse("0", Some(36));
+        assert_eq!(result.unwrap(), 0);
+    }
+
+    #[test]
+    fn decimal_zero_whitespace() {
+        let result = parse("0 ", None);
+        assert_eq!(result.unwrap(), 0);
+        let result = parse(" 0", None);
+        assert_eq!(result.unwrap(), 0);
+        let result = parse(" 0 ", None);
+        assert_eq!(result.unwrap(), 0);
     }
 
     #[test]

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -685,7 +685,7 @@ version = "0.2.0"
 
 [[package]]
 name = "scolapasta-int-parse"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "scolapasta-string-escape",
 ]


### PR DESCRIPTION
- Trim leading _and_ trailing ASCII whitespace.
- Trim _any_ ASCII whitespace, not just spaces (` `).
- Treat a single (potentially whitespace padded) `0` as parsing to `0`.

Fixes https://github.com/artichoke/artichoke/issues/2067.

Thanks for the report @b-n.