### PR TITLE
Implement `Value::respond_to` with mruby VM method table lookups

### DIFF
--- a/artichoke-backend/cext/mrbsys/include/mrbsys/ext.h
+++ b/artichoke-backend/cext/mrbsys/include/mrbsys/ext.h
@@ -21,6 +21,10 @@
 extern "C" {
 #endif
 
+// VM method table twiddling
+
+MRB_API bool mrb_sys_value_has_method(mrb_state *mrb, mrb_value value, mrb_sym method);
+
 // Check whether `mrb_value` is nil, false, or true
 
 MRB_API bool mrb_sys_value_is_nil(mrb_value value);

--- a/artichoke-backend/cext/mrbsys/src/ext.c
+++ b/artichoke-backend/cext/mrbsys/src/ext.c
@@ -14,6 +14,16 @@ const uint8_t mrblib_irep[] = {0};
 
 const char mrb_digitmap[] = "0123456789abcdefghijklmnopqrstuvwxyz";
 
+// VM method table twiddling
+
+MRB_API bool
+mrb_sys_value_has_method(mrb_state *mrb, mrb_value value, mrb_sym method)
+{
+  struct RClass *class_pointer = mrb_sys_class_of_value(mrb, value);
+  mrb_method_t m = mrb_method_search_vm(mrb, &class_pointer, method);
+  return !MRB_METHOD_UNDEF_P(m);
+}
+
 // Check whether `mrb_value` is nil, false, or true
 
 MRB_API bool


### PR DESCRIPTION
This avoids routing through `Object#respond_to?` which means
`Value::respond_to` works with `BasicObject` and is not subject to
malicious classes overriding `#respond_to?`.

This commit also reworks the `&str` to symbol conversion to avoid an
allocation in the common case.