### PR TITLE
More spec compliance work on `Kernel#Integer`

### DIFF
--- a/artichoke-backend/src/convert.rs
+++ b/artichoke-backend/src/convert.rs
@@ -16,12 +16,14 @@ mod boxing;
 mod bytes;
 mod fixnum;
 mod float;
+mod float_to_int;
 mod hash;
 mod implicit;
 mod nilable;
 mod string;
 
 pub use boxing::{BoxUnboxVmValue, HeapAllocated, HeapAllocatedData, Immediate, UnboxedValueGuard};
+pub use float_to_int::float_to_int;
 pub use implicit::{
     implicitly_convert_to_int, implicitly_convert_to_nilable_string, implicitly_convert_to_spinoso_string,
     implicitly_convert_to_string,

--- a/artichoke-backend/src/convert.rs
+++ b/artichoke-backend/src/convert.rs
@@ -19,6 +19,7 @@ mod float;
 mod float_to_int;
 mod hash;
 mod implicit;
+mod maybe_to_int;
 mod nilable;
 mod string;
 
@@ -28,6 +29,7 @@ pub use implicit::{
     implicitly_convert_to_int, implicitly_convert_to_nilable_string, implicitly_convert_to_spinoso_string,
     implicitly_convert_to_string,
 };
+pub use maybe_to_int::maybe_to_int;
 
 /// Provide a fallible converter for types that implement an infallible
 /// conversion.

--- a/artichoke-backend/src/convert/float_to_int.rs
+++ b/artichoke-backend/src/convert/float_to_int.rs
@@ -1,0 +1,113 @@
+use spinoso_exception::{FloatDomainError, RangeError};
+
+use crate::error::Error;
+
+/// Convert a [`f64`] to an [`i64`] by rounding toward zero.
+///
+/// # Errors
+///
+/// This function can return either a [`FloatDomainError`] or a [`RangeError`].
+///
+/// [`FloatDomainError`] is returned if the input is either [NaN] or infinite.
+///
+/// [`RangeError`] is returned if the input is finite but out of range of
+/// `i64::MIN..=i64::MAX`.
+///
+/// [NaN]: f64::NAN
+pub fn float_to_int(float: f64) -> Result<i64, Error> {
+    if float.is_nan() {
+        return Err(FloatDomainError::with_message("NaN").into());
+    }
+    if float.is_sign_negative() {
+        if float.is_infinite() {
+            return Err(FloatDomainError::with_message("-Infinity").into());
+        }
+        // ```
+        // [3.1.2] > Integer -10.9
+        // => -10
+        // [3.1.2] > Integer -10.5
+        // => -10
+        // [3.1.2] > Integer -10.2
+        // => -10
+        // ```
+        let float = float.ceil();
+        if float < i64::MIN as f64 {
+            return Err(RangeError::with_message("too small for int").into());
+        }
+        Ok(float as i64)
+    } else {
+        if float.is_infinite() {
+            return Err(FloatDomainError::with_message("Infinity").into());
+        }
+        // ```
+        // [3.1.2] > Integer 10.9
+        // => 10
+        // [3.1.2] > Integer 10.5
+        // => 10
+        // [3.1.2] > Integer 10.2
+        // => 10
+        // ```
+        let float = float.floor();
+        if float > i64::MAX as f64 {
+            return Err(RangeError::with_message("too big for int").into());
+        }
+        Ok(float as i64)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bstr::ByteSlice;
+
+    use super::float_to_int;
+    use crate::test::prelude::*;
+
+    #[test]
+    fn float_to_int_rounds_to_zero() {
+        let result = float_to_int(10.0).unwrap();
+        assert_eq!(result, 10);
+        let result = float_to_int(10.2).unwrap();
+        assert_eq!(result, 10);
+        let result = float_to_int(10.5).unwrap();
+        assert_eq!(result, 10);
+        let result = float_to_int(10.9).unwrap();
+        assert_eq!(result, 10);
+
+        let result = float_to_int(-10.0).unwrap();
+        assert_eq!(result, -10);
+        let result = float_to_int(-10.2).unwrap();
+        assert_eq!(result, -10);
+        let result = float_to_int(-10.5).unwrap();
+        assert_eq!(result, -10);
+        let result = float_to_int(-10.9).unwrap();
+        assert_eq!(result, -10);
+    }
+
+    #[test]
+    fn float_nan_is_domain_error() {
+        let err = float_to_int(f64::NAN).unwrap_err();
+        assert_eq!(&*err.message().as_bstr(), "NaN".as_bytes().as_bstr());
+        assert_eq!(&*err.name(), "FloatDomainError");
+    }
+
+    #[test]
+    fn float_infinities_are_domain_error() {
+        let err = float_to_int(f64::INFINITY).unwrap_err();
+        assert_eq!(&*err.message().as_bstr(), "Infinity".as_bytes().as_bstr());
+        assert_eq!(&*err.name(), "FloatDomainError");
+
+        let err = float_to_int(f64::NEG_INFINITY).unwrap_err();
+        assert_eq!(&*err.message().as_bstr(), "-Infinity".as_bytes().as_bstr());
+        assert_eq!(&*err.name(), "FloatDomainError");
+    }
+
+    // FIXME: MRI converts these to `BigNum`s.
+    #[test]
+    fn float_out_of_i64_range_is_range_error() {
+        let err = float_to_int(f64::MAX).unwrap_err();
+        assert_eq!(&*err.name(), "RangeError");
+
+        let err = float_to_int(f64::MIN).unwrap_err();
+        assert_eq!(&*err.name(), "RangeError");
+    }
+}

--- a/artichoke-backend/src/convert/float_to_int.rs
+++ b/artichoke-backend/src/convert/float_to_int.rs
@@ -8,12 +8,14 @@ use crate::error::Error;
 ///
 /// This function can return either a [`FloatDomainError`] or a [`RangeError`].
 ///
-/// [`FloatDomainError`] is returned if the input is either [NaN] or infinite.
+/// [`FloatDomainError`] is returned if the input is either [`NaN`] or infinite.
 ///
 /// [`RangeError`] is returned if the input is finite but out of range of
 /// `i64::MIN..=i64::MAX`.
 ///
-/// [NaN]: f64::NAN
+/// [`NaN`]: f64::NAN
+#[allow(clippy::cast_possible_truncation)]
+#[allow(clippy::cast_precision_loss)]
 pub fn float_to_int(float: f64) -> Result<i64, Error> {
     if float.is_nan() {
         return Err(FloatDomainError::with_message("NaN").into());

--- a/artichoke-backend/src/convert/maybe_to_int.rs
+++ b/artichoke-backend/src/convert/maybe_to_int.rs
@@ -1,0 +1,81 @@
+use artichoke_core::value::Value as _;
+
+use crate::error::Error;
+use crate::value::Value;
+use crate::Artichoke;
+
+/// Attempt a fallible conversion of the given value to `i64`.
+///
+/// Conversion steps:
+///
+/// - If the given value is an `Integer`, return its underlying [`i64`].
+/// - If the value does not have a `to_int` method, the conversion is not
+///   applicable so return [`None`].
+/// - If `value.to_int` raises, return the exception in `Err(_)`.
+/// - If the value returned by the conversion is an `Integer`, return its
+///   underlying [`i64`].
+/// - Else, the conversion is not applicable so return [`None`].
+pub fn maybe_to_int(interp: &mut Artichoke, value: Value) -> Result<Option<i64>, Error> {
+    if let Ok(int) = value.try_convert_into::<i64>(interp) {
+        return Ok(Some(int));
+    }
+    if !value.respond_to(interp, "to_int")? {
+        return Ok(None);
+    }
+    let value = value.funcall(interp, "to_int", &[], None)?;
+    if let Ok(int) = value.try_convert_into::<i64>(interp) {
+        return Ok(Some(int));
+    }
+    Ok(None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::maybe_to_int;
+    use crate::test::prelude::*;
+
+    #[test]
+    fn integer_is_returned() {
+        let mut interp = interpreter();
+        let int = interp.eval(b"5").unwrap();
+        assert_eq!(maybe_to_int(&mut interp, int).unwrap(), Some(5));
+        let int = interp.eval(b"-5").unwrap();
+        assert_eq!(maybe_to_int(&mut interp, int).unwrap(), Some(-5));
+    }
+
+    #[test]
+    fn object_is_is_not_applicable() {
+        let mut interp = interpreter();
+        let int = interp.eval(b"BasicObject.new").unwrap();
+        assert_eq!(maybe_to_int(&mut interp, int).unwrap(), None);
+        let int = interp.eval(b"Object.new").unwrap();
+        assert_eq!(maybe_to_int(&mut interp, int).unwrap(), None);
+        let int = interp.eval(b"[1, 2, 3]").unwrap();
+        assert_eq!(maybe_to_int(&mut interp, int).unwrap(), None);
+    }
+
+    #[test]
+    fn conversion_with_to_int_is_returned() {
+        let mut interp = interpreter();
+        let int = interp.eval(b"class A; def to_int; 99; end; end; A.new").unwrap();
+        assert_eq!(maybe_to_int(&mut interp, int).unwrap(), Some(99));
+    }
+
+    #[test]
+    fn conversion_with_raising_to_int_is_error() {
+        let mut interp = interpreter();
+        let int = interp
+            .eval(b"class A; def to_int; raise 'bonk'; end; end; A.new")
+            .unwrap();
+        maybe_to_int(&mut interp, int).unwrap_err();
+    }
+
+    #[test]
+    fn conversion_with_unapplicable_to_int_is_not_applicable() {
+        let mut interp = interpreter();
+        let int = interp.eval(b"class A; def to_int; [1, 2, 3]; end; end; A.new").unwrap();
+        assert_eq!(maybe_to_int(&mut interp, int).unwrap(), None);
+        let int = interp.eval(b"class B; def to_int; 'rip'; end; end; B.new").unwrap();
+        assert_eq!(maybe_to_int(&mut interp, int).unwrap(), None);
+    }
+}

--- a/artichoke-backend/src/extn/core/kernel/kernel.rb
+++ b/artichoke-backend/src/extn/core/kernel/kernel.rb
@@ -62,37 +62,7 @@ module Kernel
   end
 
   def Integer(arg, base = nil, exception: true) # rubocop:disable Naming/MethodName
-    raise ArgumentError, 'base specified for non string value' if base&.positive? && arg.is_a?(Numeric)
-
-    classname = arg.class
-    classname = arg.inspect if arg.nil? || arg.equal?(false) || arg.equal?(true)
-
-    raise TypeError, "can't convert #{classname} into Integer" if arg.nil?
-
-    if arg.respond_to?(:to_int)
-      ret = arg.to_int
-
-      # uncritically return the value of to_int even if it is not an Integer
-      return ret if ret.is_a?(Numeric)
-      return ret if !ret.nil? && ret.scan(/\D/)&.empty? && ret.to_i.nil?
-
-      if arg.respond_to?(:to_i)
-        ret = arg.to_i
-        return ret if ret.is_a?(Numeric)
-
-        raise TypeError, "can't convert #{classname} to Integer (#{arg.class}#to_i gives #{ret.class})"
-      end
-    elsif !arg.is_a?(String) && arg && arg.respond_to?(:to_i)
-      ret = arg.to_i
-
-      return ret if ret.is_a?(Numeric)
-
-      raise TypeError, "can't convert #{classname} to Integer (#{arg.class}#to_i gives #{ret.class})"
-    elsif arg.is_a?(String)
-      return ::Artichoke::Kernel::Integer(arg, base)
-    end
-
-    raise TypeError, "can't convert #{classname} to Integer"
+    ::Artichoke::Kernel.Integer(arg, base)
   rescue StandardError => e
     return nil if exception.equal?(false)
 

--- a/artichoke-backend/src/extn/core/kernel/kernel_test.rb
+++ b/artichoke-backend/src/extn/core/kernel/kernel_test.rb
@@ -4,6 +4,13 @@
 # https://ruby-doc.org/core-2.6.3/Kernel.html
 def spec
   throw_catch
+  kernel_integer_implicit_conversion
+  kernel_integer_float
+  kernel_integer_float_infinity
+  kernel_integer_float_neg_infinity
+  kernel_integer_float_nan
+  kernel_integer_integer
+  kernel_integer_nil
   kernel_p_no_args
   kernel_p_one_arg
   kernel_p_array_args
@@ -41,6 +48,477 @@ def throw_catch
     456
   end
   raise unless result == 123
+end
+
+class A
+  def to_int
+    16
+  end
+end
+
+class AA
+  def to_int
+    "16"
+  end
+end
+
+class B
+  def to_str
+    "55"
+  end
+end
+
+class C
+  def to_int
+    raise 'to int err'
+  end
+end
+
+class D
+  def to_str
+    raise 'to str err'
+  end
+end
+
+class AAA
+  def to_int
+    Object.new
+  end
+end
+
+class S < String; end
+
+class AAAA
+  def to_int
+    S.new
+  end
+end
+
+def kernel_integer_implicit_conversion
+  begin
+    Integer(10, A.new)
+    raise 'expected ArgumentError'
+  rescue ArgumentError => e
+    raise unless e.message == 'base specified for non string value'
+  end
+
+  begin
+    Integer(10.9, A.new)
+    raise 'expected ArgumentError'
+  rescue ArgumentError => e
+    raise "got message: #{e.message}" unless e.message == 'base specified for non string value'
+  end
+
+  raise unless Integer('10', A.new) == 16
+  raise unless Integer(10, AA.new) == 10
+  raise unless Integer(10.9, AA.new) == 10
+  raise unless Integer('10', AA.new) == 10
+  raise unless Integer(10, AAA.new) == 10
+  raise unless Integer(10.9, AAA.new) == 10
+  raise unless Integer('10', AAA.new) == 10
+  raise unless Integer(10, AAAA.new) == 10
+  raise unless Integer(10.9, AAAA.new) == 10
+  raise unless Integer('10', AAAA.new) == 10
+  raise unless Integer(10, B.new) == 10
+  raise unless Integer(10.9, B.new) == 10
+  raise unless Integer('10', B.new) == 10
+
+  begin
+    Integer(10, C.new)
+    raise 'expected RuntimeError'
+  rescue RuntimeError => e
+    raise "got message: #{e.message}" unless e.message == 'to int err'
+  end
+
+  begin
+    Integer(10.9, C.new)
+    raise 'expected RuntimeError'
+  rescue RuntimeError => e
+    raise "got message: #{e.message}" unless e.message == 'to int err'
+  end
+
+  begin
+    Integer('10', C.new)
+    raise 'expected RuntimeError'
+  rescue RuntimeError => e
+    raise "got message: #{e.message}" unless e.message == 'to int err'
+  end
+
+  raise unless Integer(10, D.new) == 10
+  raise unless Integer(10.9, D.new) == 10
+  raise unless Integer('10', D.new) == 10
+  raise unless Integer(10, [1, 2, 3]) == 10
+  raise unless Integer(10.9, [1, 2, 3]) == 10
+  raise unless Integer('10', [1, 2, 3]) == 10
+
+  raise unless Integer('555', '55') == 555
+  raise unless Integer('555', '10') == 555
+  raise unless Integer(A.new) == 16
+
+  begin
+    Integer(B.new)
+    raise "expected TypeError"
+  rescue TypeError => e
+    raise "got message: #{e.message}" unless e.message == "can't convert B into Integer"
+  end
+
+  begin
+    Integer(C.new)
+    raise "expected TypeError"
+  rescue TypeError => e
+    raise "got message: #{e.message}" unless e.message == "can't convert C into Integer"
+  end
+
+  begin
+    Integer(D.new)
+    raise "expected TypeError"
+  rescue TypeError => e
+    raise "got message: #{e.message}" unless e.message == "can't convert D into Integer"
+  end
+
+  begin
+    Integer(A.new, 10)
+    raise 'expected ArgumentError'
+  rescue ArgumentError => e
+    raise "got message: #{e.message}" unless e.message == 'base specified for non string value'
+  end
+
+  begin
+    Integer(A.new, A.new)
+    raise 'expected ArgumentError'
+  rescue ArgumentError => e
+    raise "got message: #{e.message}" unless e.message == 'base specified for non string value'
+  end
+
+  raise unless Integer(A.new, B.new) == 16
+
+  begin
+    Integer(A.new, C.new)
+    raise 'expected RuntimeError'
+  rescue RuntimeError => e
+    raise "got message: #{e.message}" unless e.message == 'to int err'
+  end
+
+  raise unless Integer(A.new, D.new) == 16
+  raise unless Integer(A.new, Object.new) == 16
+  raise unless Integer(A.new, BasicObject.new) == 16
+  raise unless Integer(A.new, [1, 2, 3]) == 16
+  raise unless Integer(A.new, AA.new) == 16
+  raise unless Integer(B.new, 10) == 55
+
+  begin
+    Integer(B.new, '10')
+    raise "expected TypeError"
+  rescue TypeError => e
+    raise "got message: #{e.message}" unless e.message == "can't convert B into Integer"
+  end
+
+  raise unless Integer(B.new, A.new) == 85
+
+  begin
+    Integer(B.new, AA.new)
+    raise "expected TypeError"
+  rescue TypeError => e
+    raise "got message: #{e.message}" unless e.message == "can't convert B into Integer"
+  end
+
+  begin
+    Integer(B.new, B.new)
+    raise "expected TypeError"
+  rescue TypeError => e
+    raise "got message: #{e.message}" unless e.message == "can't convert B into Integer"
+  end
+
+  begin
+    Integer(B.new, C.new)
+    raise 'expected RuntimeError'
+  rescue RuntimeError => e
+    raise "got message: #{e.message}" unless e.message == 'to int err'
+  end
+
+  begin
+    Integer(B.new, D.new)
+    raise "expected TypeError"
+  rescue TypeError => e
+    raise "got message: #{e.message}" unless e.message == "can't convert B into Integer"
+  end
+
+  begin
+    Integer(C.new, 10)
+    raise 'expected ArgumentError'
+  rescue ArgumentError => e
+    raise "got message: #{e.message}" unless e.message == 'base specified for non string value'
+  end
+
+  begin
+    Integer(C.new, A.new)
+    raise 'expected ArgumentError'
+  rescue ArgumentError => e
+    raise "got message: #{e.message}" unless e.message == 'base specified for non string value'
+  end
+
+  begin
+    Integer(C.new, AA.new)
+    raise 'expected ArgumentError'
+  rescue TypeError => e
+    raise "got message: #{e.message}" unless e.message == "can't convert C into Integer"
+  end
+
+  begin
+    Integer(C.new, B.new)
+    raise 'expected ArgumentError'
+  rescue TypeError => e
+    raise "got message: #{e.message}" unless e.message == "can't convert C into Integer"
+  end
+
+  begin
+    Integer(C.new, C.new)
+    raise 'expected RuntimeError'
+  rescue RuntimeError => e
+    raise "got message: #{e.message}" unless e.message == 'to int err'
+  end
+
+  begin
+    Integer(C.new, D.new)
+    raise 'expected ArgumentError'
+  rescue TypeError => e
+    raise "got message: #{e.message}" unless e.message == "can't convert C into Integer"
+  end
+
+  begin
+    Integer(D.new, 10)
+    raise 'expected RuntimeError'
+  rescue RuntimeError => e
+    raise "got message: #{e.message}" unless e.message == 'to str err'
+  end
+
+  begin
+    Integer(D.new, A.new)
+    raise 'expected RuntimeError'
+  rescue RuntimeError => e
+    raise "got message: #{e.message}" unless e.message == 'to str err'
+  end
+
+  begin
+    Integer(D.new, AA.new)
+    raise 'expected ArgumentError'
+  rescue TypeError => e
+    raise "got message: #{e.message}" unless e.message == "can't convert D into Integer"
+  end
+
+  begin
+    Integer(D.new, B.new)
+    raise 'expected ArgumentError'
+  rescue TypeError => e
+    raise "got message: #{e.message}" unless e.message == "can't convert D into Integer"
+  end
+
+  begin
+    Integer(D.new, C.new)
+    raise 'expected RuntimeError'
+  rescue RuntimeError => e
+    raise "got message: #{e.message}" unless e.message == 'to int err'
+  end
+
+  begin
+    Integer(D.new, D.new)
+    raise 'expected ArgumentError'
+  rescue TypeError => e
+    raise "got message: #{e.message}" unless e.message == "can't convert D into Integer"
+  end
+end
+
+def kernel_integer_float
+  raise unless Integer(10.2) == 10
+  raise unless Integer(10.5) == 10
+  raise unless Integer(10.9) == 10
+  raise unless Integer(-10.2) == -10
+  raise unless Integer(-10.5) == -10
+  raise unless Integer(-10.9) == -10
+  raise unless Integer(10.2, nil) == 10
+  raise unless Integer(10.5, nil) == 10
+  raise unless Integer(10.9, nil) == 10
+  raise unless Integer(-10.2, nil) == -10
+  raise unless Integer(-10.5, nil) == -10
+  raise unless Integer(-10.9, nil) == -10
+
+  begin
+    Integer(10.2, 10)
+    raise "expected ArgumentError"
+  rescue ArgumentError => e
+    raise "got message: #{e.message}" unless e.message == "base specified for non string value"
+  end
+
+  begin
+    Integer(10.2, 10)
+    raise "expected ArgumentError"
+  rescue ArgumentError => e
+    raise "got message: #{e.message}" unless e.message == "base specified for non string value"
+  end
+
+  begin
+    Integer(10.2, 10)
+    raise "expected ArgumentError"
+  rescue ArgumentError => e
+    raise "got message: #{e.message}" unless e.message == "base specified for non string value"
+  end
+end
+
+def kernel_integer_float_infinity
+  begin
+    Integer(Float::INFINITY)
+    raise "expected FloatDomainError"
+  rescue FloatDomainError => e
+    raise "got message: #{e.message}" unless e.message == "Infinity"
+  end
+
+  begin
+    Integer(Float::INFINITY, 10)
+    raise "expected ArgumentError"
+  rescue ArgumentError => e
+    raise "got message: #{e.message}" unless e.message == "base specified for non string value"
+  end
+
+  begin
+    Integer(Float::INFINITY, '10')
+    raise "expected FloatDomainError"
+  rescue FloatDomainError => e
+    raise "got message: #{e.message}" unless e.message == "Infinity"
+  end
+end
+
+def kernel_integer_float_neg_infinity
+  begin
+    Integer(-Float::INFINITY)
+    raise "expected FloatDomainError"
+  rescue FloatDomainError => e
+    raise "got message: #{e.message}" unless e.message == "-Infinity"
+  end
+
+  begin
+    Integer(-Float::INFINITY, 10)
+    raise "expected ArgumentError"
+  rescue ArgumentError => e
+    raise "got message: #{e.message}" unless e.message == "base specified for non string value"
+  end
+
+  begin
+    Integer(-Float::INFINITY, '10')
+    raise "expected FloatDomainError"
+  rescue FloatDomainError => e
+    raise "got message: #{e.message}" unless e.message == "-Infinity"
+  end
+end
+
+def kernel_integer_float_nan
+  begin
+    Integer(Float::NAN)
+    raise "expected FloatDomainError"
+  rescue FloatDomainError => e
+    raise "got message: #{e.message}" unless e.message == "NaN"
+  end
+
+  begin
+    Integer(Float::NAN, 10)
+    raise "expected ArgumentError"
+  rescue ArgumentError => e
+    raise "got message: #{e.message}" unless e.message == "base specified for non string value"
+  end
+
+  begin
+    Integer(Float::NAN, '10')
+    raise "expected FloatDomainError"
+  rescue FloatDomainError => e
+    raise "got message: #{e.message}" unless e.message == "NaN"
+  end
+end
+
+def kernel_integer_integer
+  raise unless Integer(16) == 16
+  raise unless Integer(-16) == -16
+
+  begin
+    Integer(16, 10)
+    raise "expected ArgumentError"
+  rescue ArgumentError => e
+    raise "got message: #{e.message}" unless e.message == "base specified for non string value"
+  end
+
+  raise unless Integer(16, '10') == 16
+  raise unless Integer(-16, '10') == -16
+end
+
+def kernel_integer_nil
+  begin
+    Integer(nil)
+    raise 'expected TypeError'
+  rescue TypeError => e
+    raise "got message: #{e.message}" unless e.message == "can't convert nil into Integer"
+  end
+
+  begin
+    Integer(nil, nil)
+    raise 'expected TypeError'
+  rescue TypeError => e
+    raise "got message: #{e.message}" unless e.message == "can't convert nil into Integer"
+  end
+
+  begin
+    Integer(nil, '10')
+    raise 'expected TypeError'
+  rescue TypeError => e
+    raise "got message: #{e.message}" unless e.message == "can't convert nil into Integer"
+  end
+
+  begin
+    Integer(nil, [1, 2, 3])
+    raise 'expected TypeError'
+  rescue TypeError => e
+    raise "got message: #{e.message}" unless e.message == "can't convert nil into Integer"
+  end
+
+  begin
+    Integer(nil, 10)
+    raise "expected ArgumentError"
+  rescue ArgumentError => e
+    raise "got message: #{e.message}" unless e.message == "base specified for non string value"
+  end
+
+  begin
+    Integer(nil, A.new)
+    raise "expected ArgumentError"
+  rescue ArgumentError => e
+    raise "got message: #{e.message}" unless e.message == "base specified for non string value"
+  end
+
+  begin
+    Integer(nil, AA.new)
+    raise 'expected TypeError'
+  rescue TypeError => e
+    raise "got message: #{e.message}" unless e.message == "can't convert nil into Integer"
+  end
+
+  begin
+    Integer(nil, B.new)
+    raise 'expected TypeError'
+  rescue TypeError => e
+    raise "got message: #{e.message}" unless e.message == "can't convert nil into Integer"
+  end
+
+  begin
+    Integer(nil, C.new)
+    raise 'expected RuntimeError'
+  rescue RuntimeError => e
+    raise "got message: #{e.message}" unless e.message == 'to int err'
+  end
+
+  begin
+    Integer(nil, D.new)
+    raise 'expected TypeError'
+  rescue TypeError => e
+    raise "got message: #{e.message}" unless e.message == "can't convert nil into Integer"
+  end
+
 end
 
 class Foo

--- a/artichoke-backend/src/extn/core/kernel/kernel_test.rb
+++ b/artichoke-backend/src/extn/core/kernel/kernel_test.rb
@@ -58,13 +58,13 @@ end
 
 class AA
   def to_int
-    "16"
+    '16'
   end
 end
 
 class B
   def to_str
-    "55"
+    '55'
   end
 end
 
@@ -157,21 +157,21 @@ def kernel_integer_implicit_conversion
 
   begin
     Integer(B.new)
-    raise "expected TypeError"
+    raise 'expected TypeError'
   rescue TypeError => e
     raise "got message: #{e.message}" unless e.message == "can't convert B into Integer"
   end
 
   begin
     Integer(C.new)
-    raise "expected TypeError"
+    raise 'expected TypeError'
   rescue TypeError => e
     raise "got message: #{e.message}" unless e.message == "can't convert C into Integer"
   end
 
   begin
     Integer(D.new)
-    raise "expected TypeError"
+    raise 'expected TypeError'
   rescue TypeError => e
     raise "got message: #{e.message}" unless e.message == "can't convert D into Integer"
   end
@@ -208,7 +208,7 @@ def kernel_integer_implicit_conversion
 
   begin
     Integer(B.new, '10')
-    raise "expected TypeError"
+    raise 'expected TypeError'
   rescue TypeError => e
     raise "got message: #{e.message}" unless e.message == "can't convert B into Integer"
   end
@@ -217,14 +217,14 @@ def kernel_integer_implicit_conversion
 
   begin
     Integer(B.new, AA.new)
-    raise "expected TypeError"
+    raise 'expected TypeError'
   rescue TypeError => e
     raise "got message: #{e.message}" unless e.message == "can't convert B into Integer"
   end
 
   begin
     Integer(B.new, B.new)
-    raise "expected TypeError"
+    raise 'expected TypeError'
   rescue TypeError => e
     raise "got message: #{e.message}" unless e.message == "can't convert B into Integer"
   end
@@ -238,7 +238,7 @@ def kernel_integer_implicit_conversion
 
   begin
     Integer(B.new, D.new)
-    raise "expected TypeError"
+    raise 'expected TypeError'
   rescue TypeError => e
     raise "got message: #{e.message}" unless e.message == "can't convert B into Integer"
   end
@@ -344,92 +344,92 @@ def kernel_integer_float
 
   begin
     Integer(10.2, 10)
-    raise "expected ArgumentError"
+    raise 'expected ArgumentError'
   rescue ArgumentError => e
-    raise "got message: #{e.message}" unless e.message == "base specified for non string value"
+    raise "got message: #{e.message}" unless e.message == 'base specified for non string value'
   end
 
   begin
     Integer(10.2, 10)
-    raise "expected ArgumentError"
+    raise 'expected ArgumentError'
   rescue ArgumentError => e
-    raise "got message: #{e.message}" unless e.message == "base specified for non string value"
+    raise "got message: #{e.message}" unless e.message == 'base specified for non string value'
   end
 
   begin
     Integer(10.2, 10)
-    raise "expected ArgumentError"
+    raise 'expected ArgumentError'
   rescue ArgumentError => e
-    raise "got message: #{e.message}" unless e.message == "base specified for non string value"
+    raise "got message: #{e.message}" unless e.message == 'base specified for non string value'
   end
 end
 
 def kernel_integer_float_infinity
   begin
     Integer(Float::INFINITY)
-    raise "expected FloatDomainError"
+    raise 'expected FloatDomainError'
   rescue FloatDomainError => e
-    raise "got message: #{e.message}" unless e.message == "Infinity"
+    raise "got message: #{e.message}" unless e.message == 'Infinity'
   end
 
   begin
     Integer(Float::INFINITY, 10)
-    raise "expected ArgumentError"
+    raise 'expected ArgumentError'
   rescue ArgumentError => e
-    raise "got message: #{e.message}" unless e.message == "base specified for non string value"
+    raise "got message: #{e.message}" unless e.message == 'base specified for non string value'
   end
 
   begin
     Integer(Float::INFINITY, '10')
-    raise "expected FloatDomainError"
+    raise 'expected FloatDomainError'
   rescue FloatDomainError => e
-    raise "got message: #{e.message}" unless e.message == "Infinity"
+    raise "got message: #{e.message}" unless e.message == 'Infinity'
   end
 end
 
 def kernel_integer_float_neg_infinity
   begin
     Integer(-Float::INFINITY)
-    raise "expected FloatDomainError"
+    raise 'expected FloatDomainError'
   rescue FloatDomainError => e
-    raise "got message: #{e.message}" unless e.message == "-Infinity"
+    raise "got message: #{e.message}" unless e.message == '-Infinity'
   end
 
   begin
     Integer(-Float::INFINITY, 10)
-    raise "expected ArgumentError"
+    raise 'expected ArgumentError'
   rescue ArgumentError => e
-    raise "got message: #{e.message}" unless e.message == "base specified for non string value"
+    raise "got message: #{e.message}" unless e.message == 'base specified for non string value'
   end
 
   begin
     Integer(-Float::INFINITY, '10')
-    raise "expected FloatDomainError"
+    raise 'expected FloatDomainError'
   rescue FloatDomainError => e
-    raise "got message: #{e.message}" unless e.message == "-Infinity"
+    raise "got message: #{e.message}" unless e.message == '-Infinity'
   end
 end
 
 def kernel_integer_float_nan
   begin
     Integer(Float::NAN)
-    raise "expected FloatDomainError"
+    raise 'expected FloatDomainError'
   rescue FloatDomainError => e
-    raise "got message: #{e.message}" unless e.message == "NaN"
+    raise "got message: #{e.message}" unless e.message == 'NaN'
   end
 
   begin
     Integer(Float::NAN, 10)
-    raise "expected ArgumentError"
+    raise 'expected ArgumentError'
   rescue ArgumentError => e
-    raise "got message: #{e.message}" unless e.message == "base specified for non string value"
+    raise "got message: #{e.message}" unless e.message == 'base specified for non string value'
   end
 
   begin
     Integer(Float::NAN, '10')
-    raise "expected FloatDomainError"
+    raise 'expected FloatDomainError'
   rescue FloatDomainError => e
-    raise "got message: #{e.message}" unless e.message == "NaN"
+    raise "got message: #{e.message}" unless e.message == 'NaN'
   end
 end
 
@@ -439,9 +439,9 @@ def kernel_integer_integer
 
   begin
     Integer(16, 10)
-    raise "expected ArgumentError"
+    raise 'expected ArgumentError'
   rescue ArgumentError => e
-    raise "got message: #{e.message}" unless e.message == "base specified for non string value"
+    raise "got message: #{e.message}" unless e.message == 'base specified for non string value'
   end
 
   raise unless Integer(16, '10') == 16
@@ -479,16 +479,16 @@ def kernel_integer_nil
 
   begin
     Integer(nil, 10)
-    raise "expected ArgumentError"
+    raise 'expected ArgumentError'
   rescue ArgumentError => e
-    raise "got message: #{e.message}" unless e.message == "base specified for non string value"
+    raise "got message: #{e.message}" unless e.message == 'base specified for non string value'
   end
 
   begin
     Integer(nil, A.new)
-    raise "expected ArgumentError"
+    raise 'expected ArgumentError'
   rescue ArgumentError => e
-    raise "got message: #{e.message}" unless e.message == "base specified for non string value"
+    raise "got message: #{e.message}" unless e.message == 'base specified for non string value'
   end
 
   begin
@@ -518,7 +518,6 @@ def kernel_integer_nil
   rescue TypeError => e
     raise "got message: #{e.message}" unless e.message == "can't convert nil into Integer"
   end
-
 end
 
 class Foo

--- a/artichoke-backend/src/extn/core/kernel/trampoline.rs
+++ b/artichoke-backend/src/extn/core/kernel/trampoline.rs
@@ -57,6 +57,8 @@ pub fn integer(interp: &mut Artichoke, mut subject: Value, base: Option<Value>) 
             if let Ok(s) = subject.try_convert_into_mut::<&[u8]>(interp) {
                 scolapasta_int_parse::parse(s, Some(base))?
             } else if subject.respond_to(interp, "to_str")? {
+                // SAFETY: the extracted byte slice is used and discarded before
+                // the interpreter is accessed again.
                 let s = unsafe { implicitly_convert_to_string(interp, &mut subject)? };
                 scolapasta_int_parse::parse(s, Some(base))?
             } else {

--- a/artichoke-backend/src/extn/core/kernel/trampoline.rs
+++ b/artichoke-backend/src/extn/core/kernel/trampoline.rs
@@ -1,4 +1,4 @@
-use crate::convert::implicitly_convert_to_string;
+use crate::convert::{float_to_int, implicitly_convert_to_int, implicitly_convert_to_string, maybe_to_int};
 use crate::extn::core::kernel;
 use crate::extn::core::kernel::require::RelativePath;
 use crate::extn::prelude::*;
@@ -30,48 +30,52 @@ use crate::extn::prelude::*;
 pub fn integer(interp: &mut Artichoke, mut subject: Value, base: Option<Value>) -> Result<Value, Error> {
     // Flatten explicit `nil` argument with missing argument
     let base = base.and_then(|base| interp.convert(base));
-    // SAFETY: Extract the `Copy` radix integer first since implicit conversions
-    // can trigger garbage collections.
-    let base = if let Some(base) = base {
-        Some(base.try_convert_into::<i64>(interp)?)
+
+    let result = if subject.is_nil() {
+        if let Some(base) = base {
+            if maybe_to_int(interp, base)?.is_some() {
+                return Err(ArgumentError::with_message("base specified for non string value").into());
+            }
+        }
+        return Err(TypeError::with_message("can't convert nil into Integer").into());
+    } else if let Ok(subject) = subject.try_convert_into_mut::<&[u8]>(interp) {
+        let base = if let Some(base) = base {
+            maybe_to_int(interp, base)?
+        } else {
+            None
+        };
+        scolapasta_int_parse::parse(subject, base)?
+    } else if let Ok(float) = subject.try_convert_into::<f64>(interp) {
+        if let Some(base) = base {
+            if maybe_to_int(interp, base)?.is_some() {
+                return Err(ArgumentError::with_message("base specified for non string value").into());
+            }
+        }
+        float_to_int(float)?
+    } else if let Some(base) = base {
+        if let Some(base) = maybe_to_int(interp, base)? {
+            if let Ok(s) = subject.try_convert_into_mut::<&[u8]>(interp) {
+                scolapasta_int_parse::parse(s, Some(base))?
+            } else if subject.respond_to(interp, "to_str")? {
+                let s = unsafe { implicitly_convert_to_string(interp, &mut subject)? };
+                scolapasta_int_parse::parse(s, Some(base))?
+            } else {
+                return Err(ArgumentError::with_message("base specified for non string value").into());
+            }
+        } else {
+            implicitly_convert_to_int(interp, subject).map_err(|_| {
+                let message = format!("can't convert {} into Integer", interp.class_name_for_value(subject));
+                TypeError::from(message)
+            })?
+        }
     } else {
-        None
+        implicitly_convert_to_int(interp, subject).map_err(|_| {
+            let message = format!("can't convert {} into Integer", interp.class_name_for_value(subject));
+            TypeError::from(message)
+        })?
     };
 
-    // Implicit conversions are only performed if a non-nil radix argument is
-    // given:
-    //
-    // ```
-    // [3.1.2] > class A; def to_str; "1234"; end; end
-    // => :to_str
-    // [3.1.2] > Integer(A.new)
-    // (irb):20:in `Integer': can't convert A into Integer (TypeError)
-    //         from (irb):20:in `<main>'
-    //         from /usr/local/var/rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/irb-1.4.1/exe/irb:11:in `<top (required)>'
-    //         from /usr/local/var/rbenv/versions/3.1.2/bin/irb:25:in `load'
-    //         from /usr/local/var/rbenv/versions/3.1.2/bin/irb:25:in `<main>'
-    // [3.1.2] > Integer(A.new, nil)
-    // (irb):2:in `Integer': can't convert A into Integer (TypeError)
-    //         from (irb):2:in `<main>'
-    //         from /usr/local/var/rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/irb-1.4.1/exe/irb:11:in `<top (required)>'
-    //         from /usr/local/var/rbenv/versions/3.1.2/bin/irb:25:in `load'
-    //         from /usr/local/var/rbenv/versions/3.1.2/bin/irb:25:in `<main>'
-    // [3.1.2] > Integer(A.new, 10)
-    // => 1234
-    // ```
-    let integer = if base.is_none() {
-        let subject = subject.try_convert_into_mut::<&[u8]>(interp)?;
-        scolapasta_int_parse::parse(subject, base)?
-    } else {
-        // SAFETY: no interpreter access occurs between extracting this slice
-        // and the slice going out of scope, so the buffer backing it will not
-        // be invalidated.
-        let subject = unsafe { implicitly_convert_to_string(interp, &mut subject)? };
-        // This line needs to appear in both branches because the lifetimes of
-        // `subject` differ.
-        scolapasta_int_parse::parse(subject, base)?
-    };
-    Ok(interp.convert(integer))
+    Ok(interp.convert(result))
 }
 
 pub fn load(interp: &mut Artichoke, path: Value) -> Result<Value, Error> {


### PR DESCRIPTION
Completely rewrite the trampoline to properly handle all combinations of string / integer / float / nil / other subject + nil / int / other base with full support for implicit conversions.

Add some new converter functions to help.

Add a boatload of tests.

https://github.com/artichoke/artichoke/pull/2070 was split out of this PR.

Fixes https://github.com/artichoke/artichoke/issues/2055.