### PR TITLE
Ensure whitespace is trimmed when parsing radixes in `Kernel#Integer`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -609,7 +609,7 @@ version = "0.2.0"
 
 [[package]]
 name = "scolapasta-int-parse"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "scolapasta-string-escape",
 ]

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -25,7 +25,7 @@ qed = "1.3.0"
 # See: CVE-2022-24713
 # https://github.com/artichoke/artichoke/pull/1729
 regex = "1.5.5"
-scolapasta-int-parse = { version = "0.2.1", path = "../scolapasta-int-parse", default-features = false }
+scolapasta-int-parse = { version = "0.2.2", path = "../scolapasta-int-parse", default-features = false }
 scolapasta-string-escape = { version = "0.3.0", path = "../scolapasta-string-escape", default-features = false }
 spinoso-array = { version = "0.9.0", path = "../spinoso-array", default-features = false }
 spinoso-env = { version = "0.2.0", path = "../spinoso-env", optional = true, default-features = false }

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -437,7 +437,7 @@ version = "0.2.0"
 
 [[package]]
 name = "scolapasta-int-parse"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "scolapasta-string-escape",
 ]

--- a/scolapasta-int-parse/Cargo.toml
+++ b/scolapasta-int-parse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scolapasta-int-parse"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2021"
 rust-version = "1.63.0"

--- a/scolapasta-int-parse/README.md
+++ b/scolapasta-int-parse/README.md
@@ -24,7 +24,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-scolapasta-int-parse = "0.2.1"
+scolapasta-int-parse = "0.2.2"
 ```
 
 Parse strings into integers like:

--- a/scolapasta-int-parse/src/lib.rs
+++ b/scolapasta-int-parse/src/lib.rs
@@ -50,6 +50,7 @@ mod error;
 mod parser;
 mod radix;
 mod subject;
+mod whitespace;
 
 pub use error::{ArgumentError, Error, InvalidRadixError, InvalidRadixExceptionKind};
 use parser::{Sign, State as ParseState};

--- a/scolapasta-int-parse/src/lib.rs
+++ b/scolapasta-int-parse/src/lib.rs
@@ -945,4 +945,14 @@ mod tests {
         let result = parse("                  0x123", Some(-6));
         assert_eq!(result.unwrap(), 291);
     }
+
+    #[test]
+    fn trim_vertical_tab() {
+        // ```
+        // [3.1.2] > Integer "    \x0B 27"
+        // => 27
+        // ```
+        let result = parse(b"    \x0B 27", None);
+        assert_eq!(result.unwrap(), 27);
+    }
 }

--- a/scolapasta-int-parse/src/lib.rs
+++ b/scolapasta-int-parse/src/lib.rs
@@ -931,4 +931,18 @@ mod tests {
         let result = parse("\u{000D} 93 \u{000D}", None);
         assert_eq!(result.unwrap(), 93);
     }
+
+    #[test]
+    fn negative_radix_leading_whitespace() {
+        // ```
+        // [3.1.2] > Integer "                  0123", -6
+        // => 83
+        // [3.1.2] > Integer "                  0x123", -6
+        // => 291
+        // ```
+        let result = parse("                  0123", Some(-6));
+        assert_eq!(result.unwrap(), 83);
+        let result = parse("                  0x123", Some(-6));
+        assert_eq!(result.unwrap(), 291);
+    }
 }

--- a/scolapasta-int-parse/src/lib.rs
+++ b/scolapasta-int-parse/src/lib.rs
@@ -168,7 +168,7 @@ fn parse_inner(subject: &[u8], radix: Option<i64>) -> Result<i64, Error<'_>> {
     let mut state = ParseState::new(subject);
 
     // Phase 3: Trim leading and trailing whitespace.
-    let mut chars = trim_whitespace(subject.as_bytes()).iter().copied().peekable();
+    let mut chars = whitespace::trim(subject.as_bytes()).iter().copied().peekable();
 
     // Phase 4: Set sign.
     match chars.peek() {
@@ -267,28 +267,6 @@ fn parse_inner(subject: &[u8], radix: Option<i64>) -> Result<i64, Error<'_>> {
     // Phase 8: Parse (signed) ASCII alphanumeric string to an `i64`.
     let src = state.into_numeric_string()?;
     i64::from_str_radix(&*src, radix).map_err(|_| subject.into())
-}
-
-fn trim_whitespace(mut bytes: &[u8]) -> &[u8] {
-    loop {
-        if let Some((first, remaining)) = bytes.split_first() {
-            if first.is_ascii_whitespace() {
-                bytes = remaining;
-                continue;
-            }
-        }
-        break;
-    }
-    loop {
-        if let Some((last, remaining)) = bytes.split_last() {
-            if last.is_ascii_whitespace() {
-                bytes = remaining;
-                continue;
-            }
-        }
-        break;
-    }
-    bytes
 }
 
 #[cfg(test)]

--- a/scolapasta-int-parse/src/radix.rs
+++ b/scolapasta-int-parse/src/radix.rs
@@ -2,6 +2,7 @@ use core::num::NonZeroU32;
 
 use crate::error::{InvalidRadixError, InvalidRadixErrorKind};
 use crate::subject::IntegerString;
+use crate::whitespace;
 
 // Create a lookup table from each byte value (of which the ASCII range is
 // relevant) to the maximum minimum radix the character is valid for.
@@ -166,7 +167,9 @@ impl Radix {
             //         from /usr/local/var/rbenv/versions/3.1.2/bin/irb:25:in `load'
             //         from /usr/local/var/rbenv/versions/3.1.2/bin/irb:25:in `<main>'
             // ```
-            Ok(_) if num < 0 && matches!(subject.as_bytes().first(), Some(&b'0')) => Ok(None),
+            Ok(_) if num < 0 && matches!(whitespace::trim_leading(subject.as_bytes()).first(), Some(&b'0')) => {
+                Ok(None)
+            }
             // ```
             // [3.1.2] > Integer "123", -(2 ** 31)
             // (irb):63:in `Integer': invalid radix -2147483648 (ArgumentError)

--- a/scolapasta-int-parse/src/radix.rs
+++ b/scolapasta-int-parse/src/radix.rs
@@ -589,4 +589,19 @@ mod tests {
         assert_eq!(&*buf, "integer -4294967297 too small to convert to `int'");
         assert_eq!(err.exception_kind(), InvalidRadixExceptionKind::RangeError);
     }
+
+    #[test]
+    fn negative_radix_with_inline_base_and_leading_spaces_ignores() {
+        // [3.1.2] > Integer "                  0123", -6
+        // => 83
+        // [3.1.2] > Integer "                  0x123", -6
+        // => 291
+        let subject = "                  0123".try_into().unwrap();
+        let radix = Radix::try_base_from_str_and_i64(subject, -6).unwrap();
+        assert_eq!(radix, None);
+
+        let subject = "                  0x123".try_into().unwrap();
+        let radix = Radix::try_base_from_str_and_i64(subject, -6).unwrap();
+        assert_eq!(radix, None);
+    }
 }

--- a/scolapasta-int-parse/src/whitespace.rs
+++ b/scolapasta-int-parse/src/whitespace.rs
@@ -7,7 +7,8 @@ fn is_posix_ascii_whitespace(b: u8) -> bool {
     // > POSIX > locale includes U+000B VERTICAL TAB as well as all the above
     // > characters [...]
     //
-    // Ruby uses the POSIX standards.
+    // Ruby uses the POSIX standards:
+    // https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap07.html
     b.is_ascii_whitespace() || matches!(b, b'\x0B')
 }
 

--- a/scolapasta-int-parse/src/whitespace.rs
+++ b/scolapasta-int-parse/src/whitespace.rs
@@ -1,0 +1,105 @@
+pub fn trim_leading(bytes: &[u8]) -> &[u8] {
+    if let Some(idx) = bytes.iter().position(|&b| !b.is_ascii_whitespace()) {
+        &bytes[idx..]
+    } else {
+        bytes
+    }
+}
+
+pub fn trim_trailing(bytes: &[u8]) -> &[u8] {
+    if let Some(idx) = bytes.iter().rev().position(|&b| !b.is_ascii_whitespace()) {
+        &bytes[..bytes.len() - idx]
+    } else {
+        bytes
+    }
+}
+
+pub fn trim(bytes: &[u8]) -> &[u8] {
+    let bytes = trim_leading(bytes);
+    trim_trailing(bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trim_leading_trims_leading_whitespace() {
+        assert_eq!(trim_leading(b"abc"), b"abc");
+        assert_eq!(trim_leading(b" abc"), b"abc");
+        assert_eq!(trim_leading(b"      abc"), b"abc");
+        assert_eq!(trim_leading(b"\tabc"), b"abc");
+        assert_eq!(trim_leading(b"\nabc"), b"abc");
+        assert_eq!(trim_leading(b"\x0Aabc"), b"abc");
+        assert_eq!(trim_leading(b"\x0Cabc"), b"abc");
+        assert_eq!(trim_leading(b" \t\n\x0A\x0Cabc"), b"abc");
+        assert_eq!(
+            trim_leading(b" \t\n\x0A\x0C \t\n\x0A\x0C \t\n\x0A\x0C \t\n\x0A\x0Cabc"),
+            b"abc"
+        );
+    }
+
+    #[test]
+    fn trim_leading_preserves_trailing_whitespace() {
+        assert_eq!(trim_leading(b"abc "), b"abc ");
+        assert_eq!(trim_leading(b" abc "), b"abc ");
+        assert_eq!(trim_leading(b"      abc      "), b"abc      ");
+        assert_eq!(trim_leading(b"\tabc\t"), b"abc\t");
+        assert_eq!(trim_leading(b"\nabc\n"), b"abc\n");
+        assert_eq!(trim_leading(b"\x0Aabc\x0A"), b"abc\x0A");
+        assert_eq!(trim_leading(b"\x0Cabc\x0C"), b"abc\x0C");
+        assert_eq!(trim_leading(b" \t\n\x0A\x0Cabc \t\n\x0A\x0C"), b"abc \t\n\x0A\x0C");
+        assert_eq!(
+            trim_leading(b" \t\n\x0A\x0C \t\n\x0A\x0C \t\n\x0A\x0C \t\n\x0A\x0Cabc \t\n\x0A\x0C \t\n\x0A\x0C \t\n\x0A\x0C \t\n\x0A\x0C"),
+            b"abc \t\n\x0A\x0C \t\n\x0A\x0C \t\n\x0A\x0C \t\n\x0A\x0C"
+        );
+    }
+
+    #[test]
+    fn trim_trailing_trims_trailing_whitespace() {
+        assert_eq!(trim_trailing(b"abc"), b"abc");
+        assert_eq!(trim_trailing(b"abc "), b"abc");
+        assert_eq!(trim_trailing(b"abc      "), b"abc");
+        assert_eq!(trim_trailing(b"abc\t"), b"abc");
+        assert_eq!(trim_trailing(b"abc\n"), b"abc");
+        assert_eq!(trim_trailing(b"abc\x0A"), b"abc");
+        assert_eq!(trim_trailing(b"abc\x0C"), b"abc");
+        assert_eq!(trim_trailing(b"abc \t\n\x0A\x0C"), b"abc");
+        assert_eq!(
+            trim_trailing(b"abc \t\n\x0A\x0C \t\n\x0A\x0C \t\n\x0A\x0C \t\n\x0A\x0C"),
+            b"abc"
+        );
+    }
+
+    #[test]
+    fn trim_leading_preserves_leading_whitespace() {
+        assert_eq!(trim_trailing(b" abc"), b" abc");
+        assert_eq!(trim_trailing(b" abc "), b" abc");
+        assert_eq!(trim_trailing(b"      abc      "), b"      abc");
+        assert_eq!(trim_trailing(b"\tabc\t"), b"\tabc");
+        assert_eq!(trim_trailing(b"\nabc\n"), b"\nabc");
+        assert_eq!(trim_trailing(b"\x0Aabc\x0A"), b"\x0Aabc");
+        assert_eq!(trim_trailing(b"\x0Cabc\x0C"), b"\x0Cabc");
+        assert_eq!(trim_trailing(b" \t\n\x0A\x0Cabc \t\n\x0A\x0C"), b" \t\n\x0A\x0Cabc");
+        assert_eq!(
+            trim_trailing(b" \t\n\x0A\x0C \t\n\x0A\x0C \t\n\x0A\x0C \t\n\x0A\x0Cabc \t\n\x0A\x0C \t\n\x0A\x0C \t\n\x0A\x0C \t\n\x0A\x0C"),
+            b" \t\n\x0A\x0C \t\n\x0A\x0C \t\n\x0A\x0C \t\n\x0A\x0Cabc"
+        );
+    }
+
+    #[test]
+    fn trim_trims_all_whitespace() {
+        assert_eq!(trim(b" abc "), b"abc");
+        assert_eq!(trim(b" abc "), b"abc");
+        assert_eq!(trim(b"      abc      "), b"abc");
+        assert_eq!(trim(b"\tabc\t"), b"abc");
+        assert_eq!(trim(b"\nabc\n"), b"abc");
+        assert_eq!(trim(b"\x0Aabc\x0A"), b"abc");
+        assert_eq!(trim(b"\x0Cabc\x0C"), b"abc");
+        assert_eq!(trim(b" \t\n\x0A\x0Cabc \t\n\x0A\x0C"), b"abc");
+        assert_eq!(
+            trim(b" \t\n\x0A\x0C \t\n\x0A\x0C \t\n\x0A\x0C \t\n\x0A\x0Cabc \t\n\x0A\x0C \t\n\x0A\x0C \t\n\x0A\x0C \t\n\x0A\x0C"),
+            b"abc"
+        );
+    }
+}

--- a/scolapasta-int-parse/src/whitespace.rs
+++ b/scolapasta-int-parse/src/whitespace.rs
@@ -1,4 +1,4 @@
-fn is_ascii_whitespace(b: u8) -> bool {
+fn is_posix_ascii_whitespace(b: u8) -> bool {
     // From the docs for `u8::is_ascii_whitespace`:
     // https://doc.rust-lang.org/std/primitive.u8.html#method.is_ascii_whitespace
     //
@@ -12,7 +12,7 @@ fn is_ascii_whitespace(b: u8) -> bool {
 }
 
 pub fn trim_leading(bytes: &[u8]) -> &[u8] {
-    if let Some(idx) = bytes.iter().position(|&b| !is_ascii_whitespace(b)) {
+    if let Some(idx) = bytes.iter().position(|&b| !is_posix_ascii_whitespace(b)) {
         &bytes[idx..]
     } else {
         bytes
@@ -20,7 +20,7 @@ pub fn trim_leading(bytes: &[u8]) -> &[u8] {
 }
 
 pub fn trim_trailing(bytes: &[u8]) -> &[u8] {
-    if let Some(idx) = bytes.iter().rposition(|&b| !is_ascii_whitespace(b)) {
+    if let Some(idx) = bytes.iter().rposition(|&b| !is_posix_ascii_whitespace(b)) {
         &bytes[..=idx]
     } else {
         bytes
@@ -61,7 +61,7 @@ mod tests {
         // ```
         const WHITESPACE_BYTES: &[u8] = &[9, 10, 11, 12, 13, 32];
         for b in u8::MIN..=u8::MAX {
-            assert_eq!(is_ascii_whitespace(b), WHITESPACE_BYTES.contains(&b));
+            assert_eq!(is_posix_ascii_whitespace(b), WHITESPACE_BYTES.contains(&b));
         }
     }
 

--- a/scolapasta-int-parse/src/whitespace.rs
+++ b/scolapasta-int-parse/src/whitespace.rs
@@ -1,5 +1,5 @@
 pub fn trim_leading(bytes: &[u8]) -> &[u8] {
-    if let Some(idx) = bytes.iter().position(|&b| !b.is_ascii_whitespace()) {
+    if let Some(idx) = bytes.iter().position(|b| !b.is_ascii_whitespace()) {
         &bytes[idx..]
     } else {
         bytes
@@ -7,7 +7,7 @@ pub fn trim_leading(bytes: &[u8]) -> &[u8] {
 }
 
 pub fn trim_trailing(bytes: &[u8]) -> &[u8] {
-    if let Some(idx) = bytes.iter().rev().position(|&b| !b.is_ascii_whitespace()) {
+    if let Some(idx) = bytes.iter().rev().position(|b| !b.is_ascii_whitespace()) {
         &bytes[..bytes.len() - idx]
     } else {
         bytes

--- a/scolapasta-int-parse/src/whitespace.rs
+++ b/scolapasta-int-parse/src/whitespace.rs
@@ -1,4 +1,4 @@
-fn is_ascii_whitespace(b: &u8) -> bool {
+fn is_ascii_whitespace(b: u8) -> bool {
     // From the docs for `u8::is_ascii_whitespace`:
     // https://doc.rust-lang.org/std/primitive.u8.html#method.is_ascii_whitespace
     //
@@ -12,7 +12,7 @@ fn is_ascii_whitespace(b: &u8) -> bool {
 }
 
 pub fn trim_leading(bytes: &[u8]) -> &[u8] {
-    if let Some(idx) = bytes.iter().position(|b| !is_ascii_whitespace(b)) {
+    if let Some(idx) = bytes.iter().position(|&b| !is_ascii_whitespace(b)) {
         &bytes[idx..]
     } else {
         bytes
@@ -20,7 +20,7 @@ pub fn trim_leading(bytes: &[u8]) -> &[u8] {
 }
 
 pub fn trim_trailing(bytes: &[u8]) -> &[u8] {
-    if let Some(idx) = bytes.iter().rposition(|b| !is_ascii_whitespace(b)) {
+    if let Some(idx) = bytes.iter().rposition(|&b| !is_ascii_whitespace(b)) {
         &bytes[..=idx]
     } else {
         bytes
@@ -61,7 +61,7 @@ mod tests {
         // ```
         const WHITESPACE_BYTES: &[u8] = &[9, 10, 11, 12, 13, 32];
         for b in u8::MIN..=u8::MAX {
-            assert_eq!(is_ascii_whitespace(&b), WHITESPACE_BYTES.contains(&b));
+            assert_eq!(is_ascii_whitespace(b), WHITESPACE_BYTES.contains(&b));
         }
     }
 

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -685,7 +685,7 @@ version = "0.2.0"
 
 [[package]]
 name = "scolapasta-int-parse"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "scolapasta-string-escape",
 ]


### PR DESCRIPTION
Add a new module to `scolapasta-int-parse` for whitespace trimming. Ensure that the POSIX definition of ASCII whitespace is used.