### PR TITLE
Fix Regexp#initialize to raise FrozenError instead of FrozenError on reinitializing literal Regexp in Ruby 3

### DIFF
--- a/artichoke-backend/src/extn/core/regexp/regexp_test.rb
+++ b/artichoke-backend/src/extn/core/regexp/regexp_test.rb
@@ -44,6 +44,22 @@ def regexp_initialize_already_init_compiled
   rescue TypeError => e
     raise "got message: #{e.message}" unless e.message == 'already initialized regexp'
   end
+
+  r = Regexp.compile('abc', 'i', 'n')
+  begin
+    r.send(:initialize, '/xyz/')
+    raise 'expected TypeError'
+  rescue TypeError => e
+    raise "got message: #{e.message}" unless e.message == 'already initialized regexp'
+  end
+
+  r = Regexp.compile('abc', 'i', 'n')
+  begin
+    r.send(:initialize, Regexp.compile('xyz'))
+    raise 'expected TypeError'
+  rescue TypeError => e
+    raise "got message: #{e.message}" unless e.message == 'already initialized regexp'
+  end
 end
 
 # Since Ruby 3.0, Regexp literals are frozen by default.

--- a/artichoke-backend/src/extn/core/regexp/trampoline.rs
+++ b/artichoke-backend/src/extn/core/regexp/trampoline.rs
@@ -12,14 +12,21 @@ pub fn initialize(
 ) -> Result<Value, Error> {
     if let Ok(existing) = unsafe { Regexp::unbox_from_value(&mut into, interp) } {
         if existing.is_literal() {
-            // NOTE: In Ruby 3.0.0+, this branch should return a `FrozenError`.
-            return Err(SecurityError::with_message("can't modify literal regexp").into());
+            return Err(FrozenError::with_message("can't modify literal regexp").into());
         }
         return Err(TypeError::with_message("already initialized regexp").into());
     }
     let (options, encoding) = interp.try_convert_mut((options, encoding))?;
     let regexp = Regexp::initialize(interp, pattern, options, encoding)?;
-    Regexp::box_into_value(regexp, into, interp)
+    let result = Regexp::box_into_value(regexp, into, interp);
+    if let Some(options) = options {
+        if options.is_literal() {
+            let mut value = result?;
+            value.freeze(interp)?;
+            return Ok(value);
+        }
+    }
+    result
 }
 
 pub fn escape(interp: &mut Artichoke, mut pattern: Value) -> Result<Value, Error> {
@@ -168,4 +175,24 @@ pub fn to_s(interp: &mut Artichoke, mut regexp: Value) -> Result<Value, Error> {
     let regexp = unsafe { Regexp::unbox_from_value(&mut regexp, interp)? };
     let s = regexp.string();
     interp.try_convert_mut(s)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test::prelude::*;
+
+    #[test]
+    fn should_raise_frozen_error() {
+        let mut interp = interpreter();
+        let pattern = interp.try_convert_mut("xyz").unwrap();
+        let options = None;
+        let encoding = None;
+        let slf = interp.eval(b"/abc/").unwrap();
+        let result = initialize(&mut interp, pattern, options, encoding, slf);
+        assert_eq!(
+            "FrozenError (can't modify literal regexp)",
+            result.unwrap_err().to_string()
+        );
+    }
 }

--- a/artichoke-backend/src/extn/core/regexp/trampoline.rs
+++ b/artichoke-backend/src/extn/core/regexp/trampoline.rs
@@ -18,15 +18,11 @@ pub fn initialize(
     }
     let (options, encoding) = interp.try_convert_mut((options, encoding))?;
     let regexp = Regexp::initialize(interp, pattern, options, encoding)?;
-    let result = Regexp::box_into_value(regexp, into, interp);
-    if let Some(options) = options {
-        if options.is_literal() {
-            let mut value = result?;
-            value.freeze(interp)?;
-            return Ok(value);
-        }
+    let mut value = Regexp::box_into_value(regexp, into, interp)?;
+    if matches!(options, Some(options) if options.is_literal()) {
+        value.freeze(interp)?;
     }
-    result
+    Ok(value)
 }
 
 pub fn escape(interp: &mut Artichoke, mut pattern: Value) -> Result<Value, Error> {


### PR DESCRIPTION
Since Ruby 3.0, Regexp literals are frozen by default, this PR changes the type of the error returned when one tries to re-initialize Regexp literals from `SecurityError` to `FrozenError`. 

```bash
$ RBENV_VERSION=2.7.6 ruby -ve 'p(/abc/.frozen?)'
ruby 2.7.6p219 (2022-04-12 revision c9c2245c0a) [arm64-darwin21]
false

$ RBENV_VERSION=3.1.2 ruby -ve 'p(/abc/.frozen?)'
ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [arm64-darwin21]
true

$ RBENV_VERSION=2.7.6 ruby -ve '/abc/.send(:initialize, /xyz/)'
ruby 2.7.6p219 (2022-04-12 revision c9c2245c0a) [arm64-darwin21]
Traceback (most recent call last):
	1: from -e:1:in `<main>'
-e:1:in `initialize': can't modify literal regexp (SecurityError)

$ RBENV_VERSION=3.1.2 ruby -ve '/abc/.send(:initialize, /xyz/)'
ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [arm64-darwin21]
-e:1:in `initialize': can't modify frozen Regexp: /abc/ (FrozenError)
	from -e:1:in `<main>'
```

This PR updates the following tests and implementations of `Regexp`:

1. Add a test to ensure that Regexp literals are frozen by default.
1. Add a test to ensure that re-initializing Regexp literals raises `FrozenError`.
1. Update the initializer of the `Regexp` backend so that 
    - `Regexp` literals are frozen upon creation.
    - `FrozenError` is raised when one tries to re-initialize `Regexp` literals.

With these modifications, the following behaviors are changed:

```diff
$ cargo run --bin artichoke -q -- -e 'p(/abc/.frozen?)' 
- false
+ true
```

```diff
$ cargo run --bin artichoke -q -- -e 'p(/abc/.send(:initialize, "xyz"))'
Traceback (most recent call last):
        2: from -e:1
- -e:1:in initialize: can't modify literal regexp (SecurityError)
+ -e:1:in initialize: can't modify literal regexp (FrozenError)
```

Fixes #1985.