### PR TITLE
Add `to_i` fallback to `Kernel#Integer`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "artichoke-backend"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "artichoke-core",
  "artichoke-load-path",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ rustyline = { version = "10.0.0", optional = true, default-features = false }
 termcolor = { version = "1.1.0", optional = true }
 
 [dependencies.artichoke-backend]
-version = "0.13.0"
+version = "0.14.0"
 path = "artichoke-backend"
 default-features = false
 

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "artichoke-backend"
-version = "0.13.0"
+version = "0.14.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2021"
 rust-version = "1.63.0"

--- a/artichoke-backend/src/convert.rs
+++ b/artichoke-backend/src/convert.rs
@@ -29,7 +29,7 @@ pub use implicit::{
     implicitly_convert_to_int, implicitly_convert_to_nilable_string, implicitly_convert_to_spinoso_string,
     implicitly_convert_to_string,
 };
-pub use maybe_to_int::maybe_to_int;
+pub use maybe_to_int::{maybe_to_int, MaybeToInt};
 
 /// Provide a fallible converter for types that implement an infallible
 /// conversion.

--- a/artichoke-backend/src/convert/maybe_to_int.rs
+++ b/artichoke-backend/src/convert/maybe_to_int.rs
@@ -1,8 +1,18 @@
+use artichoke_core::debug::Debug as _;
 use artichoke_core::value::Value as _;
+use spinoso_exception::TypeError;
 
 use crate::error::Error;
 use crate::value::Value;
 use crate::Artichoke;
+
+#[derive(Debug)]
+pub enum MaybeToInt {
+    Int(i64),
+    NotApplicable,
+    Err(TypeError),
+    UncriticalReturn(Value),
+}
 
 /// Attempt a fallible conversion of the given value to `i64`.
 ///
@@ -15,50 +25,102 @@ use crate::Artichoke;
 /// - If the value returned by the conversion is an `Integer`, return its
 ///   underlying [`i64`].
 /// - Else, the conversion is not applicable so return [`None`].
-pub fn maybe_to_int(interp: &mut Artichoke, value: Value) -> Result<Option<i64>, Error> {
+pub fn maybe_to_int(interp: &mut Artichoke, value: Value) -> Result<MaybeToInt, Error> {
     if let Ok(int) = value.try_convert_into::<i64>(interp) {
-        return Ok(Some(int));
+        return Ok(MaybeToInt::Int(int));
     }
-    if !value.respond_to(interp, "to_int")? {
-        return Ok(None);
+    if value.respond_to(interp, "to_int")? {
+        let to_int = value.funcall(interp, "to_int", &[], None)?;
+        if let Ok(int) = to_int.try_convert_into::<i64>(interp) {
+            return Ok(MaybeToInt::Int(int));
+        }
     }
-    let value = value.funcall(interp, "to_int", &[], None)?;
-    if let Ok(int) = value.try_convert_into::<i64>(interp) {
-        return Ok(Some(int));
+    if !value.respond_to(interp, "to_i")? {
+        return Ok(MaybeToInt::NotApplicable);
     }
-    Ok(None)
+    let to_i = value.funcall(interp, "to_i", &[], None)?;
+    if to_i.is_nil() {
+        let message = format!(
+            "can't convert {class} to Integer ({class}#to_i gives NilClass)",
+            class = interp.class_name_for_value(value)
+        );
+        return Ok(MaybeToInt::Err(TypeError::from(message)));
+    }
+    // Uncritically return the result of `#to_i`.
+    Ok(MaybeToInt::UncriticalReturn(to_i))
 }
 
 #[cfg(test)]
 mod tests {
-    use super::maybe_to_int;
+    use super::{maybe_to_int, MaybeToInt};
     use crate::test::prelude::*;
 
     #[test]
     fn integer_is_returned() {
         let mut interp = interpreter();
         let int = interp.eval(b"5").unwrap();
-        assert_eq!(maybe_to_int(&mut interp, int).unwrap(), Some(5));
+        assert!(matches!(maybe_to_int(&mut interp, int).unwrap(), MaybeToInt::Int(5)));
         let int = interp.eval(b"-5").unwrap();
-        assert_eq!(maybe_to_int(&mut interp, int).unwrap(), Some(-5));
+        assert!(matches!(maybe_to_int(&mut interp, int).unwrap(), MaybeToInt::Int(-5)));
     }
 
     #[test]
     fn object_is_is_not_applicable() {
         let mut interp = interpreter();
         let int = interp.eval(b"BasicObject.new").unwrap();
-        assert_eq!(maybe_to_int(&mut interp, int).unwrap(), None);
+        assert!(matches!(
+            maybe_to_int(&mut interp, int).unwrap(),
+            MaybeToInt::NotApplicable
+        ));
         let int = interp.eval(b"Object.new").unwrap();
-        assert_eq!(maybe_to_int(&mut interp, int).unwrap(), None);
+        assert!(matches!(
+            maybe_to_int(&mut interp, int).unwrap(),
+            MaybeToInt::NotApplicable
+        ));
         let int = interp.eval(b"[1, 2, 3]").unwrap();
-        assert_eq!(maybe_to_int(&mut interp, int).unwrap(), None);
+        assert!(matches!(
+            maybe_to_int(&mut interp, int).unwrap(),
+            MaybeToInt::NotApplicable
+        ));
+    }
+
+    #[test]
+    fn conversion_with_to_int_not_applicable_to_i_nil_is_err() {
+        let mut interp = interpreter();
+        let int = interp
+            .eval(b"class A; def to_int; Object.new; end; def to_i; nil; end; end; A.new")
+            .unwrap();
+        assert!(matches!(
+            maybe_to_int(&mut interp, int).unwrap(),
+            MaybeToInt::Err(err) if err.message() == b"can't convert A to Integer (A#to_i gives NilClass)"
+        ));
+    }
+
+    #[test]
+    fn conversion_without_to_to_i_is_nil_is_err() {
+        let mut interp = interpreter();
+        let int = interp.eval(b"class A; def to_i; nil; end; end; A.new").unwrap();
+        assert!(matches!(
+            maybe_to_int(&mut interp, int).unwrap(),
+            MaybeToInt::Err(err) if err.message() == b"can't convert A to Integer (A#to_i gives NilClass)"
+        ));
+    }
+
+    #[test]
+    fn conversion_without_to_to_i_non_nil_is_uncritically_returned() {
+        let mut interp = interpreter();
+        let int = interp.eval(b"class A; def to_i; Object.new; end; end; A.new").unwrap();
+        assert!(matches!(
+            maybe_to_int(&mut interp, int).unwrap(),
+            MaybeToInt::UncriticalReturn(..)
+        ));
     }
 
     #[test]
     fn conversion_with_to_int_is_returned() {
         let mut interp = interpreter();
         let int = interp.eval(b"class A; def to_int; 99; end; end; A.new").unwrap();
-        assert_eq!(maybe_to_int(&mut interp, int).unwrap(), Some(99));
+        assert!(matches!(maybe_to_int(&mut interp, int).unwrap(), MaybeToInt::Int(99)));
     }
 
     #[test]
@@ -74,8 +136,14 @@ mod tests {
     fn conversion_with_unapplicable_to_int_is_not_applicable() {
         let mut interp = interpreter();
         let int = interp.eval(b"class A; def to_int; [1, 2, 3]; end; end; A.new").unwrap();
-        assert_eq!(maybe_to_int(&mut interp, int).unwrap(), None);
+        assert!(matches!(
+            maybe_to_int(&mut interp, int).unwrap(),
+            MaybeToInt::NotApplicable
+        ));
         let int = interp.eval(b"class B; def to_int; 'rip'; end; end; B.new").unwrap();
-        assert_eq!(maybe_to_int(&mut interp, int).unwrap(), None);
+        assert!(matches!(
+            maybe_to_int(&mut interp, int).unwrap(),
+            MaybeToInt::NotApplicable
+        ));
     }
 }

--- a/artichoke-backend/src/extn/core/kernel/kernel_test.rb
+++ b/artichoke-backend/src/extn/core/kernel/kernel_test.rb
@@ -97,7 +97,7 @@ end
 
 class R
   def to_int
-    "xys"
+    'xys'
   end
 
   def to_i
@@ -107,25 +107,25 @@ end
 
 class W
   def to_int
-    "nine"
+    'nine'
   end
 end
 
 class X
   def to_int
-    "9"
+    '9'
   end
 end
 
 class Y
   def to_i
-    "nine"
+    'nine'
   end
 end
 
 class Z
   def to_i
-    "9"
+    '9'
   end
 end
 

--- a/artichoke-backend/src/extn/core/kernel/kernel_test.rb
+++ b/artichoke-backend/src/extn/core/kernel/kernel_test.rb
@@ -11,6 +11,7 @@ def spec
   kernel_integer_float_nan
   kernel_integer_integer
   kernel_integer_nil
+  kernel_integer_maybe_to_int
   kernel_p_no_args
   kernel_p_one_arg
   kernel_p_array_args
@@ -91,6 +92,40 @@ class S < String; end
 class AAAA
   def to_int
     S.new
+  end
+end
+
+class R
+  def to_int
+    "xys"
+  end
+
+  def to_i
+    nil
+  end
+end
+
+class W
+  def to_int
+    "nine"
+  end
+end
+
+class X
+  def to_int
+    "9"
+  end
+end
+
+class Y
+  def to_i
+    "nine"
+  end
+end
+
+class Z
+  def to_i
+    "9"
   end
 end
 
@@ -517,6 +552,50 @@ def kernel_integer_nil
     raise 'expected TypeError'
   rescue TypeError => e
     raise "got message: #{e.message}" unless e.message == "can't convert nil into Integer"
+  end
+end
+
+def kernel_integer_maybe_to_int
+  begin
+    Integer(Y.new)
+    raise 'expected TypeError'
+  rescue TypeError => e
+    raise "got message: #{e.message}" unless e.message == "can't convert Y to Integer (Y#to_i gives String)"
+  end
+
+  begin
+    Integer(Z.new)
+    raise 'expected TypeError'
+  rescue TypeError => e
+    raise "got message: #{e.message}" unless e.message == "can't convert Z to Integer (Z#to_i gives String)"
+  end
+
+  begin
+    Integer(W.new)
+    raise 'expected TypeError'
+  rescue TypeError => e
+    raise "got message: #{e.message}" unless e.message == "can't convert W into Integer"
+  end
+
+  begin
+    Integer(X.new)
+    raise 'expected TypeError'
+  rescue TypeError => e
+    raise "got message: #{e.message}" unless e.message == "can't convert X into Integer"
+  end
+
+  begin
+    Integer(R.new)
+    raise 'expected TypeError'
+  rescue TypeError => e
+    raise "got message: #{e.message}" unless e.message == "can't convert R to Integer (R#to_i gives NilClass)"
+  end
+
+  begin
+    Integer('abc', R.new)
+    raise 'expected ArgumentError'
+  rescue ArgumentError => e
+    raise "got message: #{e.message}" unless e.message == 'invalid value for Integer(): "abc"'
   end
 end
 

--- a/artichoke-backend/src/extn/core/kernel/trampoline.rs
+++ b/artichoke-backend/src/extn/core/kernel/trampoline.rs
@@ -84,10 +84,6 @@ pub fn integer(interp: &mut Artichoke, mut subject: Value, base: Option<Value>) 
     } else {
         match maybe_to_int(interp, subject) {
             Ok(MaybeToInt::Int(int)) => int,
-            Ok(MaybeToInt::NotApplicable) => {
-                let message = format!("can't convert {} into Integer", interp.class_name_for_value(subject));
-                return Err(TypeError::from(message).into());
-            }
             Ok(MaybeToInt::Err(err)) => return Err(err.into()),
             Ok(MaybeToInt::UncriticalReturn(result)) => {
                 let class = interp.class_name_for_value(subject).to_owned();
@@ -95,7 +91,7 @@ pub fn integer(interp: &mut Artichoke, mut subject: Value, base: Option<Value>) 
                 let message = format!("can't convert {class} to Integer ({class}#to_i gives {result})");
                 return Err(TypeError::from(message).into());
             }
-            Err(_) => {
+            Ok(MaybeToInt::NotApplicable) | Err(_) => {
                 let message = format!("can't convert {} into Integer", interp.class_name_for_value(subject));
                 return Err(TypeError::from(message).into());
             }

--- a/artichoke-backend/src/extn/core/kernel/trampoline.rs
+++ b/artichoke-backend/src/extn/core/kernel/trampoline.rs
@@ -1,4 +1,6 @@
-use crate::convert::{float_to_int, implicitly_convert_to_int, implicitly_convert_to_string, maybe_to_int};
+use crate::convert::{
+    float_to_int, implicitly_convert_to_int, implicitly_convert_to_string, maybe_to_int, MaybeToInt,
+};
 use crate::extn::core::kernel;
 use crate::extn::core::kernel::require::RelativePath;
 use crate::extn::prelude::*;
@@ -33,27 +35,36 @@ pub fn integer(interp: &mut Artichoke, mut subject: Value, base: Option<Value>) 
 
     let result = if subject.is_nil() {
         if let Some(base) = base {
-            if maybe_to_int(interp, base)?.is_some() {
+            if matches!(maybe_to_int(interp, base)?, MaybeToInt::Int(..)) {
                 return Err(ArgumentError::with_message("base specified for non string value").into());
             }
         }
         return Err(TypeError::with_message("can't convert nil into Integer").into());
     } else if let Ok(subject) = subject.try_convert_into_mut::<&[u8]>(interp) {
         let base = if let Some(base) = base {
-            maybe_to_int(interp, base)?
+            if let MaybeToInt::Int(int) = maybe_to_int(interp, base)? {
+                Some(int)
+            } else {
+                None
+            }
         } else {
             None
         };
         scolapasta_int_parse::parse(subject, base)?
     } else if let Ok(float) = subject.try_convert_into::<f64>(interp) {
         if let Some(base) = base {
-            if maybe_to_int(interp, base)?.is_some() {
+            if matches!(maybe_to_int(interp, base)?, MaybeToInt::Int(..)) {
                 return Err(ArgumentError::with_message("base specified for non string value").into());
             }
         }
         float_to_int(float)?
     } else if let Some(base) = base {
-        if let Some(base) = maybe_to_int(interp, base)? {
+        let base = if let MaybeToInt::Int(int) = maybe_to_int(interp, base)? {
+            Some(int)
+        } else {
+            None
+        };
+        if let Some(base) = base {
             if let Ok(s) = subject.try_convert_into_mut::<&[u8]>(interp) {
                 scolapasta_int_parse::parse(s, Some(base))?
             } else if subject.respond_to(interp, "to_str")? {
@@ -71,10 +82,24 @@ pub fn integer(interp: &mut Artichoke, mut subject: Value, base: Option<Value>) 
             })?
         }
     } else {
-        implicitly_convert_to_int(interp, subject).map_err(|_| {
-            let message = format!("can't convert {} into Integer", interp.class_name_for_value(subject));
-            TypeError::from(message)
-        })?
+        match maybe_to_int(interp, subject) {
+            Ok(MaybeToInt::Int(int)) => int,
+            Ok(MaybeToInt::NotApplicable) => {
+                let message = format!("can't convert {} into Integer", interp.class_name_for_value(subject));
+                return Err(TypeError::from(message).into());
+            }
+            Ok(MaybeToInt::Err(err)) => return Err(err.into()),
+            Ok(MaybeToInt::UncriticalReturn(result)) => {
+                let class = interp.class_name_for_value(subject).to_owned();
+                let result = interp.class_name_for_value(result);
+                let message = format!("can't convert {class} to Integer ({class}#to_i gives {result})");
+                return Err(TypeError::from(message).into());
+            }
+            Err(_) => {
+                let message = format!("can't convert {} into Integer", interp.class_name_for_value(subject));
+                return Err(TypeError::from(message).into());
+            }
+        }
     };
 
     Ok(interp.convert(result))

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "artichoke-backend"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "artichoke-core",
  "artichoke-load-path",

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "artichoke-backend"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "artichoke-core",
  "artichoke-load-path",


### PR DESCRIPTION
There is one remaining spec failure which is due to differences between Ruby 2.6 (where the specs are vendored from) to Ruby 3.1.x (which Artichoke claims it is compatible with):

```
Passed 1888, skipped 247, not implemented 92, failed 1 specs.

An exception occurred during: kernel_integer
TypeError: can't convert  into Integer

(eval):65:in Integer
(eval):65:in Integer
/artichoke/virtual_root/src/lib/core/kernel/Integer_spec.rb:20:in protect
(eval):165:in all?
/artichoke/virtual_root/src/lib/core/kernel/Integer_spec.rb:159
(eval):590:in each
/artichoke/virtual_root/src/lib/spec_runner.rb:74:in run_specs
(eval):1

Passed 1888, skipped 247, not implemented 92, failed 1 specs.
```

Running `kernel_test.rb` under MRI 3.1.2 passes, as it does in the kernel functional tests.

Fixes #2078.