### PR TITLE
Pass whether a `Regexp` is a `/.../` literal from mruby codegen to Artichoke

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -696,7 +696,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-regexp"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "bitflags",
  "bstr",

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -32,7 +32,7 @@ spinoso-env = { version = "0.2.0", path = "../spinoso-env", optional = true, def
 spinoso-exception = { version = "0.1.0", path = "../spinoso-exception" }
 spinoso-math = { version = "0.3.0", path = "../spinoso-math", optional = true, default-features = false }
 spinoso-random = { version = "0.3.0", path = "../spinoso-random", optional = true }
-spinoso-regexp = { version = "0.3.0", path = "../spinoso-regexp", optional = true, default-features = false }
+spinoso-regexp = { version = "0.4.0", path = "../spinoso-regexp", optional = true, default-features = false }
 spinoso-securerandom = { version = "0.2.0", path = "../spinoso-securerandom", optional = true }
 spinoso-string = { version = "0.20.0", path = "../spinoso-string", features = ["always-nul-terminated-c-string-compat"] }
 spinoso-symbol = { version = "0.3.0", path = "../spinoso-symbol" }

--- a/artichoke-backend/src/extn/core/regexp/mod.rs
+++ b/artichoke-backend/src/extn/core/regexp/mod.rs
@@ -301,6 +301,12 @@ impl Regexp {
 
     #[inline]
     #[must_use]
+    pub fn is_literal(&self) -> bool {
+        self.0.source().options().is_literal()
+    }
+
+    #[inline]
+    #[must_use]
     pub fn options(&self) -> i64 {
         let options = self.0.source().options().flags();
         let encoding = self.0.encoding().flags();

--- a/artichoke-backend/src/extn/core/regexp/mod.rs
+++ b/artichoke-backend/src/extn/core/regexp/mod.rs
@@ -361,3 +361,20 @@ impl TryConvertMut<(Option<Value>, Option<Value>), (Option<Options>, Option<Enco
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::test::prelude::*;
+
+    const SUBJECT: &str = "Regexp";
+    const FUNCTIONAL_TEST: &[u8] = include_bytes!("regexp_test.rb");
+
+    #[test]
+    fn functional() {
+        let mut interp = interpreter();
+        let result = interp.eval(FUNCTIONAL_TEST);
+        unwrap_or_panic_with_backtrace(&mut interp, SUBJECT, result);
+        let result = interp.eval(b"spec");
+        unwrap_or_panic_with_backtrace(&mut interp, SUBJECT, result);
+    }
+}

--- a/artichoke-backend/src/extn/core/regexp/mruby.rs
+++ b/artichoke-backend/src/extn/core/regexp/mruby.rs
@@ -55,7 +55,7 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
 }
 
 unsafe extern "C" fn initialize(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
-    let (pattern, options, encoding) = mrb_get_args!(mrb, required = 1, optional = 2);
+    let (pattern, options, encoding, _block) = mrb_get_args!(mrb, required = 1, optional = 2, &block);
     unwrap_interpreter!(mrb, to => guard);
     let slf = Value::from(slf);
     let pattern = Value::from(pattern);

--- a/artichoke-backend/src/extn/core/regexp/regexp_test.rb
+++ b/artichoke-backend/src/extn/core/regexp/regexp_test.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# Tests from Kernel core docs in Ruby 2.6.3
+# https://ruby-doc.org/core-2.6.3/Kernel.html
+def spec
+  regexp_initialize_already_init_literal
+  regexp_initialize_already_init_compiled
+
+  true
+end
+
+def regexp_initialize_already_init_literal
+  r = /abc/in
+  begin
+    r.send(:initialize, 'xyz')
+    raise 'expected SecurityError'
+  rescue SecurityError => e
+    raise "got message: #{e.message}" unless e.message == "can't modify literal regexp"
+  end
+end
+
+def regexp_initialize_already_init_compiled
+  r = Regexp.compile('abc', 'i', 'n')
+  begin
+    r.send(:initialize, 'xyz')
+    raise 'expected TypeError'
+  rescue TypeError => e
+    raise "got message: #{e.message}" unless e.message == 'already initialized regexp'
+  end
+end
+
+spec if $PROGRAM_NAME == __FILE__

--- a/artichoke-backend/src/extn/core/regexp/trampoline.rs
+++ b/artichoke-backend/src/extn/core/regexp/trampoline.rs
@@ -1,5 +1,5 @@
 use crate::convert::{implicitly_convert_to_int, implicitly_convert_to_nilable_string, implicitly_convert_to_string};
-use crate::extn::core::regexp::{Options, Regexp};
+use crate::extn::core::regexp::Regexp;
 use crate::extn::core::symbol::Symbol;
 use crate::extn::prelude::*;
 
@@ -11,8 +11,7 @@ pub fn initialize(
     mut into: Value,
 ) -> Result<Value, Error> {
     if let Ok(existing) = unsafe { Regexp::unbox_from_value(&mut into, interp) } {
-        let options = Options::from(existing.options());
-        if options.is_literal() {
+        if existing.is_literal() {
             // NOTE: In Ruby 3.0.0+, this branch should return a `FrozenError`.
             return Err(SecurityError::with_message("can't modify literal regexp").into());
         }

--- a/artichoke-backend/vendor/mruby/mrbgems/mruby-compiler/core/parse.y
+++ b/artichoke-backend/vendor/mruby/mrbgems/mruby-compiler/core/parse.y
@@ -5028,7 +5028,7 @@ parse_string(parser_state *p)
     int f = 0;
     int re_opt;
     char *s = strndup(tok(p), toklen(p));
-    char flags[3];
+    char flags[4];
     char *flag = flags;
     char enc = '\0';
     char *encp;
@@ -5068,6 +5068,7 @@ parse_string(parser_state *p)
       if (f & 4) *flag++ = 'm';
       if (f & 16) enc = 'u';
       if (f & 32) enc = 'n';
+      if (f & 128) *flag++ = 'l';
     }
     if (flag > flags) {
       dup = strndup(flags, (size_t)(flag - flags));

--- a/artichoke-backend/vendor/mruby/mrbgems/mruby-compiler/core/y.tab.c
+++ b/artichoke-backend/vendor/mruby/mrbgems/mruby-compiler/core/y.tab.c
@@ -11635,7 +11635,7 @@ parse_string(parser_state *p)
     int f = 0;
     int re_opt;
     char *s = strndup(tok(p), toklen(p));
-    char flags[3];
+    char flags[4];
     char *flag = flags;
     char enc = '\0';
     char *encp;
@@ -11675,6 +11675,7 @@ parse_string(parser_state *p)
       if (f & 4) *flag++ = 'm';
       if (f & 16) enc = 'u';
       if (f & 32) enc = 'n';
+      if (f & 128) *flag++ = 'l';
     }
     if (flag > flags) {
       dup = strndup(flags, (size_t)(flag - flags));

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -510,7 +510,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-regexp"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "bitflags",
  "bstr",

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -828,7 +828,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-regexp"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "bitflags",
  "bstr",

--- a/spinoso-regexp/Cargo.toml
+++ b/spinoso-regexp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spinoso-regexp"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2021"
 rust-version = "1.63.0"

--- a/spinoso-regexp/README.md
+++ b/spinoso-regexp/README.md
@@ -31,7 +31,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-spinoso-regexp = "0.3.0"
+spinoso-regexp = "0.4.0"
 ```
 
 ## Crate features

--- a/spinoso-regexp/src/encoding.rs
+++ b/spinoso-regexp/src/encoding.rs
@@ -135,7 +135,7 @@ impl TryFrom<&[u8]> for Encoding {
             match flag {
                 b'u' | b's' | b'e' if enc.is_none() => enc = Some(Encoding::Fixed),
                 b'n' if enc.is_none() => enc = Some(Encoding::No),
-                b'i' | b'm' | b'x' | b'o' => continue,
+                b'i' | b'm' | b'x' | b'o' | b'l' => continue,
                 _ => return Err(InvalidEncodingError::new()),
             }
         }

--- a/spinoso-regexp/src/lib.rs
+++ b/spinoso-regexp/src/lib.rs
@@ -240,7 +240,7 @@ pub struct Config {
 
 impl fmt::Debug for Config {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Source")
+        f.debug_struct("Config")
             .field("pattern", &self.pattern.as_bstr())
             .field("options", &self.options)
             .finish()

--- a/spinoso-regexp/src/options.rs
+++ b/spinoso-regexp/src/options.rs
@@ -198,8 +198,10 @@ impl Options {
     ///
     /// Alias for the corresponding `Into<Flags>` implementation.
     #[must_use]
-    pub const fn flags(self) -> Flags {
-        self.flags
+    pub fn flags(self) -> Flags {
+        let mut flags = self.flags;
+        flags.remove(Flags::LITERAL);
+        flags
     }
 
     /// Convert an `Options` to its bit representation.

--- a/spinoso-regexp/src/options.rs
+++ b/spinoso-regexp/src/options.rs
@@ -97,7 +97,7 @@ impl From<Options> for i64 {
 
 impl From<Flags> for Options {
     fn from(mut flags: Flags) -> Self {
-        flags.remove(Flags::FIXEDENCODING | Flags::NOENCODING | Flags::LITERAL);
+        flags.remove(Flags::FIXEDENCODING | Flags::NOENCODING);
         Self { flags }
     }
 }
@@ -133,11 +133,7 @@ impl From<Option<bool>> for Options {
 
 impl From<&str> for Options {
     fn from(options: &str) -> Self {
-        let mut flags = Flags::empty();
-        flags.set(Flags::MULTILINE, options.contains('m'));
-        flags.set(Flags::IGNORECASE, options.contains('i'));
-        flags.set(Flags::EXTENDED, options.contains('x'));
-        Self { flags }
+        Self::from(options.as_bytes())
     }
 }
 
@@ -147,6 +143,7 @@ impl From<&[u8]> for Options {
         flags.set(Flags::MULTILINE, options.find_byte(b'm').is_some());
         flags.set(Flags::IGNORECASE, options.find_byte(b'i').is_some());
         flags.set(Flags::EXTENDED, options.find_byte(b'x').is_some());
+        flags.set(Flags::LITERAL, options.find_byte(b'l').is_some());
         Self { flags }
     }
 }

--- a/spinoso-regexp/src/options.rs
+++ b/spinoso-regexp/src/options.rs
@@ -311,7 +311,10 @@ mod tests {
 
     #[test]
     fn from_all_flags_ignores_encoding_and_literal() {
-        assert_eq!(Options::from(Flags::all()), Options::from(Flags::ALL_REGEXP_OPTS));
+        assert_eq!(
+            Options::from(Flags::all()),
+            Options::from(Flags::ALL_REGEXP_OPTS | Flags::LITERAL)
+        );
     }
 
     // If options is an `Integer`, it should be one or more of the constants
@@ -564,10 +567,13 @@ mod tests {
         assert_ne!(Options::from(Flags::EXTENDED | Flags::IGNORECASE), opts);
         assert_ne!(Options::from(Flags::MULTILINE | Flags::IGNORECASE), opts);
         assert_eq!(
-            Options::from(Flags::EXTENDED | Flags::IGNORECASE | Flags::MULTILINE),
+            Options::from(Flags::EXTENDED | Flags::IGNORECASE | Flags::MULTILINE | Flags::LITERAL),
             opts
         );
-        assert_eq!(Options::from(Flags::ALL_REGEXP_OPTS), opts);
+
+        let mut flags = opts.flags;
+        flags.remove(Flags::LITERAL);
+        assert_eq!(Options::from(Flags::ALL_REGEXP_OPTS).flags, flags);
         assert_eq!(opts.ignore_case(), RegexpOption::Enabled);
         assert_eq!(opts.extended(), RegexpOption::Enabled);
         assert_eq!(opts.multiline(), RegexpOption::Enabled);


### PR DESCRIPTION
With these changes:

```console
$ cargo run --bin airb -q
artichoke 0.1.0-pre.0 (2022-08-11 revision 6046) [x86_64-apple-darwin]
[rustc 1.63.0 (4b91a6ea7 2022-08-08) on x86_64-apple-darwin]
>>> /airb/in

[artichoke-backend/src/extn/core/regexp/enc.rs:13] encoding = [
    110,
]
[artichoke-backend/src/extn/core/regexp/opts.rs:18] options = [
    105,
    108,
]
[artichoke-backend/src/extn/core/regexp/trampoline.rs:22] options = Some(
    Options {
        flags: IGNORECASE | LITERAL,
    },
)
=> /airb/in
```

And the exceptions:

```console
$ cargo run --bin airb -q
artichoke 0.1.0-pre.0 (2022-08-11 revision 6046) [x86_64-apple-darwin]
[rustc 1.63.0 (4b91a6ea7 2022-08-08) on x86_64-apple-darwin]
>>> /abc/in
=> /abc/in
>>> /abc/in.send(:initialize, "xyz")
Traceback (most recent call last):
        2: from (airb):2
        1: from (airb):2:in initialize
SecurityError (can't modify literal regexp)
>>> Regexp.compile('jkl')
=> /jkl/
>>> Regexp.compile('jkl').send(:initialize, "qwerty")
Traceback (most recent call last):
        2: from (airb):4
        1: from (airb):4:in initialize
TypeError (already initialized regexp)
```