### PR TITLE
Add `Time#strftime` in `spinoso-time`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -747,6 +747,7 @@ dependencies = [
  "chrono-tz",
  "once_cell",
  "regex",
+ "strftime-ruby",
  "tz-rs",
  "tzdb",
 ]
@@ -756,6 +757,12 @@ name = "str-buf"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e08d8363704e6c71fc928674353e6b7c23dcea9d82d7012c8faf2a3a025f8d0"
+
+[[package]]
+name = "strftime-ruby"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b02d24309580475dca1e01d10378f9a0d979aa95ee6c00bdbbf883f5315c905"
 
 [[package]]
 name = "strsim"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-time"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "chrono",
  "chrono-tz",

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -36,7 +36,7 @@ spinoso-regexp = { version = "0.4.0", path = "../spinoso-regexp", optional = tru
 spinoso-securerandom = { version = "0.2.0", path = "../spinoso-securerandom", optional = true }
 spinoso-string = { version = "0.20.0", path = "../spinoso-string", features = ["always-nul-terminated-c-string-compat"] }
 spinoso-symbol = { version = "0.3.0", path = "../spinoso-symbol" }
-spinoso-time = { version = "0.5.0", path = "../spinoso-time", features = ["chrono"], default-features = false, optional = true }
+spinoso-time = { version = "0.6.0", path = "../spinoso-time", features = ["chrono"], default-features = false, optional = true }
 
 [dev-dependencies]
 quickcheck = { version = "1.0.3", default-features = false }

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-time"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "chrono",
  "chrono-tz",

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-time"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "chrono",
  "chrono-tz",

--- a/spinoso-time/Cargo.toml
+++ b/spinoso-time/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spinoso-time"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2021"
 rust-version = "1.63.0"

--- a/spinoso-time/Cargo.toml
+++ b/spinoso-time/Cargo.toml
@@ -24,7 +24,7 @@ chrono = { version = "0.4.20", default-features = false, features = ["clock"], o
 chrono-tz = { version = "0.6.3", default-features = false, optional = true }
 once_cell = { version = "1.12.0", optional = true }
 regex =  { version = "1.5.5", default-features = false, features = ["std"], optional = true }
-strftime-ruby = { version = "1.0.0", default-features = false, optional = true }
+strftime-ruby = { version = "1.0.0", default-features = false, features = ["alloc"], optional = true }
 tz-rs = { version = "0.6.12", default-features = false, features = ["std"], optional = true }
 tzdb = { version = "0.4.0", default-features = false, optional = true }
 

--- a/spinoso-time/Cargo.toml
+++ b/spinoso-time/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["date-and-time"]
 [features]
 default = ["chrono", "tzrs", "tzrs-local"]
 chrono = ["dep:chrono", "dep:chrono-tz"]
-tzrs = ["dep:once_cell", "dep:regex", "dep:tz-rs", "dep:tzdb"]
+tzrs = ["dep:once_cell", "dep:regex", "dep:strftime-ruby", "dep:tz-rs", "dep:tzdb"]
 tzrs-local = ["tzrs", "tzdb?/local"]
 
 [dependencies]
@@ -24,6 +24,7 @@ chrono = { version = "0.4.20", default-features = false, features = ["clock"], o
 chrono-tz = { version = "0.6.3", default-features = false, optional = true }
 once_cell = { version = "1.12.0", optional = true }
 regex =  { version = "1.5.5", default-features = false, features = ["std"], optional = true }
+strftime-ruby = { version = "1.0.0", default-features = false, optional = true }
 tz-rs = { version = "0.6.12", default-features = false, features = ["std"], optional = true }
 tzdb = { version = "0.4.0", default-features = false, optional = true }
 

--- a/spinoso-time/README.md
+++ b/spinoso-time/README.md
@@ -38,7 +38,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-spinoso-time = { version = "0.4.0", features = ["chrono"] }
+spinoso-time = { version = "0.6.0", features = ["chrono"] }
 ```
 
 ## Examples

--- a/spinoso-time/src/lib.rs
+++ b/spinoso-time/src/lib.rs
@@ -72,6 +72,9 @@ mod readme {}
 
 use core::time::Duration;
 
+#[cfg(feature = "tzrs")]
+pub use strftime;
+
 mod time;
 
 #[cfg(feature = "chrono")]

--- a/spinoso-time/src/time/tzrs/convert.rs
+++ b/spinoso-time/src/time/tzrs/convert.rs
@@ -5,7 +5,7 @@ use super::{Time, ToA};
 impl fmt::Display for Time {
     /// Returns a canonical string representation of _time_.
     ///
-    /// `Display` uses the same format as [`Time::to_s`].
+    /// `Display` uses the same format as [`Time#to_s`].
     ///
     /// # Examples
     ///
@@ -19,10 +19,7 @@ impl fmt::Display for Time {
     /// # example().unwrap()
     /// ```
     ///
-    /// [`Time#asctime`]: https://ruby-doc.org/core-3.1.2/Time.html#method-i-asctime
-    /// [`Time#ctime`]: https://ruby-doc.org/core-3.1.2/Time.html#method-i-ctime
     /// [`Time#to_s`]: https://ruby-doc.org/core-3.1.2/Time.html#method-i-to_s
-    /// [`Time#inspect`]: https://ruby-doc.org/core-3.1.2/Time.html#method-i-inspect
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // https://github.com/ruby/ruby/blob/v3_1_2/time.c#L4007-L4017
         const UTC_FORMAT: &str = "%Y-%m-%d %H:%M:%S UTC";

--- a/spinoso-time/src/time/tzrs/convert.rs
+++ b/spinoso-time/src/time/tzrs/convert.rs
@@ -38,6 +38,56 @@ impl fmt::Display for Time {
 
 // Conversions
 impl Time {
+    /// Formats _time_ according to the directives in the given format string.
+    ///
+    /// Can be used to implement [`Time#strftime`]. The resulting string should be
+    /// treated as an ASCII-encoded string.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spinoso_time::tzrs::Time;
+    /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let now = Time::utc(2022, 05, 26, 13, 16, 22, 276)?;
+    /// assert_eq!(
+    ///     now.strftime("Today is %c 🎉".as_bytes())?,
+    ///     "Today is Thu May 26 13:16:22 2022 🎉".as_bytes(),
+    /// );
+    /// # Ok(())
+    /// # }
+    /// # example().unwrap()
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Can return [`strftime::Error`] if formatting fails. See
+    /// [`strftime::bytes::strftime`] for more details.
+    ///
+    /// [`Time#strftime`]: https://ruby-doc.org/core-3.1.2/Time.html#method-i-strftime
+    #[inline]
+    pub fn strftime(&self, format: &[u8]) -> Result<Vec<u8>, strftime::Error> {
+        // Requires ASCII-compatible encoding (which rules out things like
+        // UTF-16). ASCII, Binary, and UTF-8 are considered ASCII-compatible.
+        //
+        // ```
+        // [3.1.2] * Time.now.strftime("abc %c")
+        // => "abc Sat Aug 20 12:18:56 2022"
+        // [3.1.2] > Time.now.strftime("abc %c 📦")
+        // => "abc Sat Aug 20 12:19:04 2022 📦"
+        // [3.1.2] > Time.now.strftime("abc %c 📦 \xFF")
+        // => "abc Sat Aug 20 12:19:12 2022 📦 \xFF"
+        // [3.1.2] > Time.now.strftime("abc %c 📦 \xFF".encode(Encoding::UTF_16))
+        // (irb):5:in `encode': "\xFF" on UTF-8 (Encoding::InvalidByteSequenceError)
+        //         from (irb):5:in `<main>'
+        //         from /usr/local/var/rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/irb-1.4.1/exe/irb:11:in `<top (required)>'
+        //         from /usr/local/var/rbenv/versions/3.1.2/bin/irb:25:in `load'
+        //         from /usr/local/var/rbenv/versions/3.1.2/bin/irb:25:in `<main>'
+        // [3.1.2] > Time.now.strftime("abc %c 📦 \xFF".encode(Encoding::UTF_8))
+        // => "abc Sat Aug 20 12:20:10 2022 📦 \xFF"
+        // ```
+        strftime::bytes::strftime(self, format)
+    }
+
     /// Serialize a `Time` into its components as a [`ToA`].
     ///
     /// `ToA` stores a `Time` as a ten-element struct of time components: [sec,

--- a/spinoso-time/src/time/tzrs/convert.rs
+++ b/spinoso-time/src/time/tzrs/convert.rs
@@ -1,12 +1,11 @@
-use core::fmt::{Display, Formatter, Result};
+use core::fmt;
 
 use super::{Time, ToA};
 
-impl Display for Time {
+impl fmt::Display for Time {
     /// Returns a canonical string representation of _time_.
     ///
-    /// Can be used to implement the Ruby method [`Time#asctime`],
-    /// [`Time#ctime`], [`Time#to_s`], and [`Time#inspect`].
+    /// `Display` uses the same format as [`Time::to_s`].
     ///
     /// # Examples
     ///
@@ -24,40 +23,21 @@ impl Display for Time {
     /// [`Time#ctime`]: https://ruby-doc.org/core-3.1.2/Time.html#method-i-ctime
     /// [`Time#to_s`]: https://ruby-doc.org/core-3.1.2/Time.html#method-i-to_s
     /// [`Time#inspect`]: https://ruby-doc.org/core-3.1.2/Time.html#method-i-inspect
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        // TODO: future
-        //self.strftime("%Y-%m-%d %H:%M:%S %z")
-        write!(
-            f,
-            "{:0>4}-{:0>2}-{:0>2} {:0>2}:{:0>2}:{:0>2} {}",
-            self.year(),
-            self.month(),
-            self.day(),
-            self.hour(),
-            self.minute(),
-            self.second(),
-            self.time_zone()
-        )
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // https://github.com/ruby/ruby/blob/v3_1_2/time.c#L4007-L4017
+        const UTC_FORMAT: &str = "%Y-%m-%d %H:%M:%S UTC";
+        const FORMAT: &str = "%Y-%m-%d %H:%M:%S %z";
+
+        if self.is_utc() {
+            strftime::fmt::strftime(self, UTC_FORMAT, f).map_err(|_| fmt::Error)
+        } else {
+            strftime::fmt::strftime(self, FORMAT, f).map_err(|_| fmt::Error)
+        }
     }
 }
 
 // Conversions
 impl Time {
-    /// Formats _time_ according to the directives in the given format string.
-    ///
-    /// Can be used to implement [`Time#strftime`][ruby-time-strftime].
-    ///
-    /// # Panics
-    ///
-    /// Panics on every invocation. Functionality is not implemented.
-    ///
-    /// [ruby-time-strftime]: https://ruby-doc.org/core-3.1.2/Time.html#method-i-strftime
-    #[inline]
-    #[must_use]
-    pub fn strftime(_: Self, _format: &str) -> String {
-        todo!("Not implemented. See https://github.com/artichoke/artichoke/issues/1914")
-    }
-
     /// Serialize a `Time` into its components as a [`ToA`].
     ///
     /// `ToA` stores a `Time` as a ten-element struct of time components: [sec,

--- a/spinoso-time/src/time/tzrs/convert.rs
+++ b/spinoso-time/src/time/tzrs/convert.rs
@@ -46,8 +46,12 @@ impl Time {
     /// # Examples
     ///
     /// ```
-    /// # use spinoso_time::tzrs::Time;
-    /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// # use spinoso_time::tzrs::{TimeError, Time};
+    /// # #[derive(Debug)]
+    /// # enum Error { Time(TimeError), Strftime(strftime::Error) };
+    /// # impl From<TimeError> for Error { fn from(err: TimeError) -> Self { Self::Time(err) } }
+    /// # impl From<strftime::Error> for Error { fn from(err: strftime::Error) -> Self { Self::Strftime(err) } }
+    /// # fn example() -> Result<(), Error> {
     /// let now = Time::utc(2022, 05, 26, 13, 16, 22, 276)?;
     /// assert_eq!(
     ///     now.strftime("Today is %c 🎉".as_bytes())?,

--- a/spinoso-time/src/time/tzrs/mod.rs
+++ b/spinoso-time/src/time/tzrs/mod.rs
@@ -9,6 +9,7 @@ mod error;
 mod math;
 mod offset;
 mod parts;
+mod strftime;
 mod timezone;
 mod to_a;
 

--- a/spinoso-time/src/time/tzrs/strftime.rs
+++ b/spinoso-time/src/time/tzrs/strftime.rs
@@ -1,0 +1,55 @@
+use super::Time;
+
+impl strftime::Time for Time {
+    fn year(&self) -> i32 {
+        Time::year(self)
+    }
+
+    fn month(&self) -> u8 {
+        Time::month(self)
+    }
+
+    fn day(&self) -> u8 {
+        Time::day(self)
+    }
+
+    fn hour(&self) -> u8 {
+        Time::hour(self)
+    }
+
+    fn minute(&self) -> u8 {
+        Time::minute(self)
+    }
+
+    fn second(&self) -> u8 {
+        Time::second(self)
+    }
+
+    fn nanoseconds(&self) -> u32 {
+        Time::nanoseconds(self)
+    }
+
+    fn day_of_week(&self) -> u8 {
+        Time::day_of_week(self)
+    }
+
+    fn day_of_year(&self) -> u16 {
+        Time::day_of_year(self)
+    }
+
+    fn to_int(&self) -> i64 {
+        Time::to_int(self)
+    }
+
+    fn is_utc(&self) -> bool {
+        Time::is_utc(self)
+    }
+
+    fn utc_offset(&self) -> i32 {
+        Time::utc_offset(self)
+    }
+
+    fn time_zone(&self) -> &str {
+        Time::time_zone(self)
+    }
+}


### PR DESCRIPTION
Using the newly released `strftime-ruby` crate.

Fixes #1914.

cc @x-hgg-x this PR uses `strftime-ruby` in Artichoke.