### PR TITLE
spec-runner: .txt fixtures are not require/load paths

### DIFF
--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -630,7 +630,7 @@ checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
 
 [[package]]
 name = "spec-runner"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "artichoke",
  "bstr",

--- a/spec-runner/Cargo.toml
+++ b/spec-runner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spec-runner"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2021"
 rust-version = "1.63.0"

--- a/spec-runner/README.md
+++ b/spec-runner/README.md
@@ -47,7 +47,7 @@ skip = ["parse"]
 
 ```console
 $ cargo run -q -p spec-runner -- --help
-spec-runner 0.6.0
+spec-runner 0.6.1
 ruby/spec runner for Artichoke.
 
 USAGE:


### PR DESCRIPTION
Fixes these fatal errors arising from `SyntaxError`s in the `ARGF`
specs:

```
fatal: Value receiver for function call is dead. This indicates a bug in the mruby garbage collector. Please leave a comment at https://github.com/artichoke/artichoke/issues/1336.
fatal: Value receiver for function call is dead. This indicates a bug in the mruby garbage collector. Please leave a comment at https://github.com/artichoke/artichoke/issues/1336.
fatal: Value receiver for function call is dead. This indicates a bug in the mruby garbage collector. Please leave a comment at https://github.com/artichoke/artichoke/issues/1336.
```

Relates to:

- https://github.com/artichoke/artichoke/issues/1965