### PR TITLE
Pin node and npm toolchain in `clang-format` CI job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -563,6 +563,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      - name: Setup Node.js runtime
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
+      - name: Install npm
+        run: npm i -f npm@8.16.0
+
       - name: Lint and check formatting with clang-format
         run: npx github:artichoke/clang-format --check
 


### PR DESCRIPTION
The GitHub Actions runner contains a version of `npx` that is bugged:

- https://github.com/npm/cli/issues/5132

```
npm WARN exec The following package was not found and will be installed: @artichokeruby/clang-format@0.10.0
npm ERR! code E404
npm ERR! 404 Not Found - GET https://registry.npmjs.org/@artichokeruby%2fclang-format - Not found
npm ERR! 404
npm ERR! 404  '@artichokeruby/clang-format@0.10.0' is not in this registry.
npm ERR! 404
npm ERR! 404 Note that you can also install from a
npm ERR! 404 tarball, folder, http url, or git url.
```

Work around this by pinning the node and npm versions.