### PR TITLE
Strip binaries in release mode with Cargo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ members = [
 [profile.release]
 codegen-units = 1
 lto = true
+strip = true
 
 [features]
 default = [


### PR DESCRIPTION
https://doc.rust-lang.org/cargo/reference/profiles.html#strip

Support for this landed in Rust toolchain version 1.59.0, but was not enabled at the time:

- https://github.com/artichoke/artichoke/pull/1753