### PR TITLE
Remove unneeded `From<...>` impls for `Error`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "artichoke-backend"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "artichoke-core",
  "artichoke-load-path",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ rustyline = { version = "10.0.0", optional = true, default-features = false }
 termcolor = { version = "1.1.0", optional = true }
 
 [dependencies.artichoke-backend]
-version = "0.16.0"
+version = "0.17.0"
 path = "artichoke-backend"
 default-features = false
 

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "artichoke-backend"
-version = "0.16.0"
+version = "0.17.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2021"
 rust-version = "1.63.0"

--- a/artichoke-backend/src/block.rs
+++ b/artichoke-backend/src/block.rs
@@ -45,25 +45,8 @@ impl RubyException for NoBlockGiven {
 
 impl From<NoBlockGiven> for Error {
     fn from(exception: NoBlockGiven) -> Self {
-        Self::from(Box::<dyn RubyException>::from(exception))
-    }
-}
-
-impl From<Box<NoBlockGiven>> for Error {
-    fn from(exception: Box<NoBlockGiven>) -> Self {
-        Self::from(Box::<dyn RubyException>::from(exception))
-    }
-}
-
-impl From<NoBlockGiven> for Box<dyn RubyException> {
-    fn from(exception: NoBlockGiven) -> Box<dyn RubyException> {
-        Box::new(exception)
-    }
-}
-
-impl From<Box<NoBlockGiven>> for Box<dyn RubyException> {
-    fn from(exception: Box<NoBlockGiven>) -> Box<dyn RubyException> {
-        exception
+        let err: Box<dyn RubyException> = Box::new(exception);
+        Self::from(err)
     }
 }
 

--- a/artichoke-backend/src/convert.rs
+++ b/artichoke-backend/src/convert.rs
@@ -116,25 +116,8 @@ impl RubyException for UnboxRubyError {
 
 impl From<UnboxRubyError> for Error {
     fn from(exception: UnboxRubyError) -> Self {
-        Self::from(Box::<dyn RubyException>::from(exception))
-    }
-}
-
-impl From<Box<UnboxRubyError>> for Error {
-    fn from(exception: Box<UnboxRubyError>) -> Self {
-        Self::from(Box::<dyn RubyException>::from(exception))
-    }
-}
-
-impl From<UnboxRubyError> for Box<dyn RubyException> {
-    fn from(exception: UnboxRubyError) -> Box<dyn RubyException> {
-        Box::new(exception)
-    }
-}
-
-impl From<Box<UnboxRubyError>> for Box<dyn RubyException> {
-    fn from(exception: Box<UnboxRubyError>) -> Box<dyn RubyException> {
-        exception
+        let err: Box<dyn RubyException> = Box::new(exception);
+        Self::from(err)
     }
 }
 
@@ -184,24 +167,7 @@ impl RubyException for BoxIntoRubyError {
 
 impl From<BoxIntoRubyError> for Error {
     fn from(exception: BoxIntoRubyError) -> Self {
-        Self::from(Box::<dyn RubyException>::from(exception))
-    }
-}
-
-impl From<Box<BoxIntoRubyError>> for Error {
-    fn from(exception: Box<BoxIntoRubyError>) -> Self {
-        Self::from(Box::<dyn RubyException>::from(exception))
-    }
-}
-
-impl From<BoxIntoRubyError> for Box<dyn RubyException> {
-    fn from(exception: BoxIntoRubyError) -> Box<dyn RubyException> {
-        Box::new(exception)
-    }
-}
-
-impl From<Box<BoxIntoRubyError>> for Box<dyn RubyException> {
-    fn from(exception: Box<BoxIntoRubyError>) -> Box<dyn RubyException> {
-        exception
+        let err: Box<dyn RubyException> = Box::new(exception);
+        Self::from(err)
     }
 }

--- a/artichoke-backend/src/def.rs
+++ b/artichoke-backend/src/def.rs
@@ -287,25 +287,8 @@ impl RubyException for ConstantNameError {
 
 impl From<ConstantNameError> for Error {
     fn from(exception: ConstantNameError) -> Self {
-        Self::from(Box::<dyn RubyException>::from(exception))
-    }
-}
-
-impl From<Box<ConstantNameError>> for Error {
-    fn from(exception: Box<ConstantNameError>) -> Self {
-        Self::from(Box::<dyn RubyException>::from(exception))
-    }
-}
-
-impl From<ConstantNameError> for Box<dyn RubyException> {
-    fn from(exception: ConstantNameError) -> Box<dyn RubyException> {
-        Box::new(exception)
-    }
-}
-
-impl From<Box<ConstantNameError>> for Box<dyn RubyException> {
-    fn from(exception: Box<ConstantNameError>) -> Box<dyn RubyException> {
-        exception
+        let err: Box<dyn RubyException> = Box::new(exception);
+        Self::from(err)
     }
 }
 
@@ -446,25 +429,8 @@ impl RubyException for NotDefinedError {
 
 impl From<NotDefinedError> for Error {
     fn from(exception: NotDefinedError) -> Self {
-        Self::from(Box::<dyn RubyException>::from(exception))
-    }
-}
-
-impl From<Box<NotDefinedError>> for Error {
-    fn from(exception: Box<NotDefinedError>) -> Self {
-        Self::from(Box::<dyn RubyException>::from(exception))
-    }
-}
-
-impl From<NotDefinedError> for Box<dyn RubyException> {
-    fn from(exception: NotDefinedError) -> Box<dyn RubyException> {
-        Box::new(exception)
-    }
-}
-
-impl From<Box<NotDefinedError>> for Box<dyn RubyException> {
-    fn from(exception: Box<NotDefinedError>) -> Box<dyn RubyException> {
-        exception
+        let err: Box<dyn RubyException> = Box::new(exception);
+        Self::from(err)
     }
 }
 

--- a/artichoke-backend/src/extn/core/exception/mod.rs
+++ b/artichoke-backend/src/extn/core/exception/mod.rs
@@ -42,25 +42,8 @@ macro_rules! ruby_exception_impl {
     ($exc:ident) => {
         impl From<$exc> for Error {
             fn from(exception: $exc) -> Error {
-                Error::from(Box::<dyn RubyException>::from(exception))
-            }
-        }
-
-        impl From<Box<$exc>> for Error {
-            fn from(exception: Box<$exc>) -> Error {
-                Error::from(Box::<dyn RubyException>::from(exception))
-            }
-        }
-
-        impl From<$exc> for Box<dyn RubyException> {
-            fn from(exception: $exc) -> Box<dyn RubyException> {
-                Box::new(exception)
-            }
-        }
-
-        impl From<Box<$exc>> for Box<dyn RubyException> {
-            fn from(exception: Box<$exc>) -> Box<dyn RubyException> {
-                exception
+                let err: Box<dyn RubyException> = Box::new(exception);
+                Self::from(err)
             }
         }
 

--- a/artichoke-backend/src/extn/core/math/mod.rs
+++ b/artichoke-backend/src/extn/core/math/mod.rs
@@ -52,25 +52,8 @@ impl RubyException for DomainError {
 
 impl From<DomainError> for Error {
     fn from(exception: DomainError) -> Self {
-        Self::from(Box::<dyn RubyException>::from(exception))
-    }
-}
-
-impl From<Box<DomainError>> for Error {
-    fn from(exception: Box<DomainError>) -> Self {
-        Self::from(Box::<dyn RubyException>::from(exception))
-    }
-}
-
-impl From<DomainError> for Box<dyn RubyException> {
-    fn from(exception: DomainError) -> Box<dyn RubyException> {
-        Box::new(exception)
-    }
-}
-
-impl From<Box<DomainError>> for Box<dyn RubyException> {
-    fn from(exception: Box<DomainError>) -> Box<dyn RubyException> {
-        exception
+        let err: Box<dyn RubyException> = Box::new(exception);
+        Self::from(err)
     }
 }
 

--- a/artichoke-backend/src/ffi.rs
+++ b/artichoke-backend/src/ffi.rs
@@ -97,25 +97,8 @@ impl RubyException for InterpreterExtractError {
 
 impl From<InterpreterExtractError> for Error {
     fn from(exception: InterpreterExtractError) -> Self {
-        Self::from(Box::<dyn RubyException>::from(exception))
-    }
-}
-
-impl From<Box<InterpreterExtractError>> for Error {
-    fn from(exception: Box<InterpreterExtractError>) -> Self {
-        Self::from(Box::<dyn RubyException>::from(exception))
-    }
-}
-
-impl From<InterpreterExtractError> for Box<dyn RubyException> {
-    fn from(exception: InterpreterExtractError) -> Box<dyn RubyException> {
-        Box::new(exception)
-    }
-}
-
-impl From<Box<InterpreterExtractError>> for Box<dyn RubyException> {
-    fn from(exception: Box<InterpreterExtractError>) -> Box<dyn RubyException> {
-        exception
+        let err: Box<dyn RubyException> = Box::new(exception);
+        Self::from(err)
     }
 }
 

--- a/artichoke-backend/src/gc/arena.rs
+++ b/artichoke-backend/src/gc/arena.rs
@@ -59,25 +59,8 @@ impl RubyException for ArenaSavepointError {
 
 impl From<ArenaSavepointError> for Error {
     fn from(exception: ArenaSavepointError) -> Self {
-        Self::from(Box::<dyn RubyException>::from(exception))
-    }
-}
-
-impl From<Box<ArenaSavepointError>> for Error {
-    fn from(exception: Box<ArenaSavepointError>) -> Self {
-        Self::from(Box::<dyn RubyException>::from(exception))
-    }
-}
-
-impl From<ArenaSavepointError> for Box<dyn RubyException> {
-    fn from(exception: ArenaSavepointError) -> Box<dyn RubyException> {
-        Box::new(exception)
-    }
-}
-
-impl From<Box<ArenaSavepointError>> for Box<dyn RubyException> {
-    fn from(exception: Box<ArenaSavepointError>) -> Box<dyn RubyException> {
-        exception
+        let err: Box<dyn RubyException> = Box::new(exception);
+        Self::from(err)
     }
 }
 

--- a/artichoke-backend/src/intern.rs
+++ b/artichoke-backend/src/intern.rs
@@ -147,27 +147,7 @@ impl RubyException for SymbolOverflowError {
 impl From<SymbolOverflowError> for Error {
     #[inline]
     fn from(exception: SymbolOverflowError) -> Self {
-        Self::from(Box::<dyn RubyException>::from(exception))
-    }
-}
-
-impl From<Box<SymbolOverflowError>> for Error {
-    #[inline]
-    fn from(exception: Box<SymbolOverflowError>) -> Self {
-        Self::from(Box::<dyn RubyException>::from(exception))
-    }
-}
-
-impl From<SymbolOverflowError> for Box<dyn RubyException> {
-    #[inline]
-    fn from(exception: SymbolOverflowError) -> Box<dyn RubyException> {
-        Box::new(exception)
-    }
-}
-
-impl From<Box<SymbolOverflowError>> for Box<dyn RubyException> {
-    #[inline]
-    fn from(exception: Box<SymbolOverflowError>) -> Box<dyn RubyException> {
-        exception
+        let err: Box<dyn RubyException> = Box::new(exception);
+        Self::from(err)
     }
 }

--- a/artichoke-backend/src/interpreter.rs
+++ b/artichoke-backend/src/interpreter.rs
@@ -120,25 +120,8 @@ impl RubyException for InterpreterAllocError {
 
 impl From<InterpreterAllocError> for Error {
     fn from(exception: InterpreterAllocError) -> Self {
-        Self::from(Box::<dyn RubyException>::from(exception))
-    }
-}
-
-impl From<Box<InterpreterAllocError>> for Error {
-    fn from(exception: Box<InterpreterAllocError>) -> Self {
-        Self::from(Box::<dyn RubyException>::from(exception))
-    }
-}
-
-impl From<InterpreterAllocError> for Box<dyn RubyException> {
-    fn from(exception: InterpreterAllocError) -> Box<dyn RubyException> {
-        Box::new(exception)
-    }
-}
-
-impl From<Box<InterpreterAllocError>> for Box<dyn RubyException> {
-    fn from(exception: Box<InterpreterAllocError>) -> Box<dyn RubyException> {
-        exception
+        let err: Box<dyn RubyException> = Box::new(exception);
+        Self::from(err)
     }
 }
 

--- a/artichoke-backend/src/io.rs
+++ b/artichoke-backend/src/io.rs
@@ -94,24 +94,7 @@ impl RubyException for IoError {
 
 impl From<IoError> for Error {
     fn from(exception: IoError) -> Self {
-        Self::from(Box::<dyn RubyException>::from(exception))
-    }
-}
-
-impl From<Box<IoError>> for Error {
-    fn from(exception: Box<IoError>) -> Self {
-        Self::from(Box::<dyn RubyException>::from(exception))
-    }
-}
-
-impl From<IoError> for Box<dyn RubyException> {
-    fn from(exception: IoError) -> Box<dyn RubyException> {
-        Box::new(exception)
-    }
-}
-
-impl From<Box<IoError>> for Box<dyn RubyException> {
-    fn from(exception: Box<IoError>) -> Box<dyn RubyException> {
-        exception
+        let err: Box<dyn RubyException> = Box::new(exception);
+        Self::from(err)
     }
 }

--- a/artichoke-backend/src/parser.rs
+++ b/artichoke-backend/src/parser.rs
@@ -81,24 +81,7 @@ impl RubyException for IncrementLinenoError {
 
 impl From<IncrementLinenoError> for Error {
     fn from(exception: IncrementLinenoError) -> Self {
-        Self::from(Box::<dyn RubyException>::from(exception))
-    }
-}
-
-impl From<Box<IncrementLinenoError>> for Error {
-    fn from(exception: Box<IncrementLinenoError>) -> Self {
-        Self::from(Box::<dyn RubyException>::from(exception))
-    }
-}
-
-impl From<IncrementLinenoError> for Box<dyn RubyException> {
-    fn from(exception: IncrementLinenoError) -> Box<dyn RubyException> {
-        Box::new(exception)
-    }
-}
-
-impl From<Box<IncrementLinenoError>> for Box<dyn RubyException> {
-    fn from(exception: Box<IncrementLinenoError>) -> Box<dyn RubyException> {
-        exception
+        let err: Box<dyn RubyException> = Box::new(exception);
+        Self::from(err)
     }
 }

--- a/artichoke-backend/src/platform_string/impls.rs
+++ b/artichoke-backend/src/platform_string/impls.rs
@@ -32,25 +32,8 @@ impl RubyException for ConvertBytesError {
 
 impl From<ConvertBytesError> for Error {
     fn from(exception: ConvertBytesError) -> Self {
-        Self::from(Box::<dyn RubyException>::from(exception))
-    }
-}
-
-impl From<Box<ConvertBytesError>> for Error {
-    fn from(exception: Box<ConvertBytesError>) -> Self {
-        Self::from(*exception)
-    }
-}
-
-impl From<ConvertBytesError> for Box<dyn RubyException> {
-    fn from(exception: ConvertBytesError) -> Box<dyn RubyException> {
-        Box::new(exception)
-    }
-}
-
-impl From<Box<ConvertBytesError>> for Box<dyn RubyException> {
-    fn from(exception: Box<ConvertBytesError>) -> Box<dyn RubyException> {
-        exception
+        let err: Box<dyn RubyException> = Box::new(exception);
+        Self::from(err)
     }
 }
 

--- a/artichoke-backend/src/value.rs
+++ b/artichoke-backend/src/value.rs
@@ -358,25 +358,8 @@ impl RubyException for ArgCountError {
 
 impl From<ArgCountError> for Error {
     fn from(exception: ArgCountError) -> Self {
-        Self::from(Box::<dyn RubyException>::from(exception))
-    }
-}
-
-impl From<Box<ArgCountError>> for Error {
-    fn from(exception: Box<ArgCountError>) -> Self {
-        Self::from(Box::<dyn RubyException>::from(exception))
-    }
-}
-
-impl From<ArgCountError> for Box<dyn RubyException> {
-    fn from(exception: ArgCountError) -> Box<dyn RubyException> {
-        Box::new(exception)
-    }
-}
-
-impl From<Box<ArgCountError>> for Box<dyn RubyException> {
-    fn from(exception: Box<ArgCountError>) -> Box<dyn RubyException> {
-        exception
+        let err: Box<dyn RubyException> = Box::new(exception);
+        Self::from(err)
     }
 }
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "artichoke-backend"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "artichoke-core",
  "artichoke-load-path",

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "artichoke-backend"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "artichoke-core",
  "artichoke-load-path",


### PR DESCRIPTION
Every error and exception type in artichoke-backend impls `From<...> for Error` and `From<...> for Box<dyn RubyException>` for all combinations of:

- Error type
- Boxed error type

Almost none of these trait impls are used. Remove them to improve compile times.

Bump `artichoke-backend` to 0.17.0 due to the breaking change of removing these trait impls.

This approach was first tried in https://github.com/artichoke/artichoke/pull/2107#issuecomment-1229358173.