### PR TITLE
Remove `pub` from trait impl-only modules in artichoke-backend

### DIFF
--- a/artichoke-backend/src/lib.rs
+++ b/artichoke-backend/src/lib.rs
@@ -113,7 +113,7 @@ pub mod macros;
 mod artichoke;
 pub mod block;
 pub mod class;
-pub mod class_registry;
+mod class_registry;
 mod coerce_to_numeric;
 mod constant;
 pub mod convert;
@@ -135,7 +135,7 @@ mod load;
 pub mod load_path;
 pub mod method;
 pub mod module;
-pub mod module_registry;
+mod module_registry;
 mod parser;
 pub mod platform_string;
 #[cfg(feature = "core-random")]


### PR DESCRIPTION
`artichoke_backend::class_registry` and `artichoke_backend::module_registry` only contain trait implementations of traits from `artichoke_core`.

These modules do not export any types, functions, or constants, so remove `pub mod` from their declarations in `lib.rs`.