### PR TITLE
Break up long string literal on multiple lines

### DIFF
--- a/artichoke-backend/src/block.rs
+++ b/artichoke-backend/src/block.rs
@@ -144,7 +144,10 @@ impl Block {
 
     pub fn yield_arg(&self, interp: &mut Artichoke, arg: &Value) -> Result<Value, Error> {
         if arg.is_dead(interp) {
-            return Err(Fatal::from("Value yielded to block is dead. This indicates a bug in the mruby garbage collector. Please leave a comment at https://github.com/artichoke/artichoke/issues/1336.").into());
+            let message = "Value yielded to block is dead. \
+                           This indicates a bug in the mruby garbage collector. \
+                           Please leave a comment at https://github.com/artichoke/artichoke/issues/1336.";
+            return Err(Fatal::with_message(message).into());
         }
         let result = unsafe { interp.with_ffi_boundary(|mrb| protect::block_yield(mrb, self.inner(), arg.inner()))? };
         match result {

--- a/artichoke-backend/src/value.rs
+++ b/artichoke-backend/src/value.rs
@@ -141,7 +141,10 @@ impl ValueCore for Value {
         block: Option<Self::Block>,
     ) -> Result<Self::Value, Self::Error> {
         if self.is_dead(interp) {
-            return Err(Fatal::from("Value receiver for function call is dead. This indicates a bug in the mruby garbage collector. Please leave a comment at https://github.com/artichoke/artichoke/issues/1336.").into());
+            let message = "Value receiver for function call is dead. \
+                           This indicates a bug in the mruby garbage collector. \
+                           Please leave a comment at https://github.com/artichoke/artichoke/issues/1336.";
+            return Err(Fatal::with_message(message).into());
         }
         if let Ok(arg_count_error) = ArgCountError::try_from(args) {
             emit_fatal_warning!("Value::funcall invoked with too many arguments: {}", arg_count_error);


### PR DESCRIPTION
For fatal error message when calling functions and yielding blocks with dead values.