### PR TITLE
Rework visibility, docs, and prelude in artichoke-backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,7 +36,7 @@ dependencies = [
 
 [[package]]
 name = "artichoke-backend"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "artichoke-core",
  "artichoke-load-path",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ rustyline = { version = "10.0.0", optional = true, default-features = false }
 termcolor = { version = "1.1.0", optional = true }
 
 [dependencies.artichoke-backend]
-version = "0.18.0"
+version = "0.19.0"
 path = "artichoke-backend"
 default-features = false
 

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "artichoke-backend"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2021"
 rust-version = "1.63.0"

--- a/artichoke-backend/src/block.rs
+++ b/artichoke-backend/src/block.rs
@@ -2,10 +2,11 @@ use std::borrow::Cow;
 use std::error;
 use std::fmt;
 
+use spinoso_exception::{Fatal, TypeError};
+
 use crate::core::{ClassRegistry, TryConvertMut, Value as _};
 use crate::error::{Error, RubyException};
 use crate::exception_handler;
-use crate::extn::core::exception::{Fatal, TypeError};
 use crate::sys::{self, protect};
 use crate::types::{self, Ruby};
 use crate::value::Value;

--- a/artichoke-backend/src/class.rs
+++ b/artichoke-backend/src/class.rs
@@ -292,7 +292,8 @@ impl PartialEq for Spec {
 
 #[cfg(test)]
 mod tests {
-    use crate::extn::core::exception::StandardError;
+    use spinoso_exception::StandardError;
+
     use crate::extn::core::kernel::Kernel;
     use crate::test::prelude::*;
 

--- a/artichoke-backend/src/convert.rs
+++ b/artichoke-backend/src/convert.rs
@@ -2,9 +2,10 @@ use std::borrow::Cow;
 use std::error;
 use std::fmt;
 
+use spinoso_exception::TypeError;
+
 use crate::core::{ClassRegistry, Convert, ConvertMut, TryConvert, TryConvertMut, Value as _};
 use crate::error::{Error, RubyException};
-use crate::extn::core::exception::TypeError;
 use crate::sys;
 use crate::types::{Ruby, Rust};
 use crate::value::Value;

--- a/artichoke-backend/src/convert/boxing.rs
+++ b/artichoke-backend/src/convert/boxing.rs
@@ -5,10 +5,11 @@ use std::mem::ManuallyDrop;
 use std::ops::{Deref, DerefMut};
 use std::ptr;
 
+use spinoso_exception::TypeError;
+
 use crate::core::Value as _;
 use crate::def::NotDefinedError;
 use crate::error::Error;
-use crate::extn::core::exception::TypeError;
 use crate::ffi::InterpreterExtractError;
 use crate::sys;
 use crate::types::Ruby;

--- a/artichoke-backend/src/def.rs
+++ b/artichoke-backend/src/def.rs
@@ -5,11 +5,12 @@ use std::fmt;
 use std::io::{self, Write as _};
 use std::ptr::NonNull;
 
+use spinoso_exception::{NameError, ScriptError};
+
 use crate::class;
 use crate::convert::BoxUnboxVmValue;
 use crate::core::{ClassRegistry, TryConvertMut};
 use crate::error::{Error, RubyException};
-use crate::extn::core::exception::{NameError, ScriptError};
 use crate::module;
 use crate::sys;
 use crate::Artichoke;

--- a/artichoke-backend/src/error.rs
+++ b/artichoke-backend/src/error.rs
@@ -1,3 +1,10 @@
+//! Error types for Ruby exceptions and unwinding support.
+//!
+//! This module contains the boxed trait object and underlying trait that
+//! unifies all error types in this crate as a Ruby `Exception`.
+//!
+//! [`raise`] can convert any [`RubyException`] into an unwinding action.
+
 use std::borrow::Cow;
 use std::error;
 use std::ffi::CStr;
@@ -7,6 +14,17 @@ use std::hint;
 use crate::sys;
 use crate::{Artichoke, Guard};
 
+/// The `Error` type, a wrapper around a dynamic exception type.
+///
+/// `Error` works a lot like `Box<dyn std::error::Error>`, but with these
+/// differences:
+///
+/// - `Error` requires that the error is `'static`.
+/// - `Error` requires that the error implement [`RubyException`].
+/// - `Error` can convert itself to a backtrace on the underlying Ruby VM.
+///
+/// All types that implement [`RubyException`] are able to be converted to
+/// `Error`.
 #[derive(Debug)]
 pub struct Error(Box<dyn RubyException>);
 

--- a/artichoke-backend/src/eval.rs
+++ b/artichoke-backend/src/eval.rs
@@ -2,11 +2,11 @@ use std::ffi::OsStr;
 use std::path::Path;
 
 use scolapasta_path::os_str_to_bytes;
+use spinoso_exception::{ArgumentError, Fatal};
 
 use crate::core::{Eval, LoadSources, Parser};
 use crate::error::Error;
 use crate::exception_handler;
-use crate::extn::core::exception::{ArgumentError, Fatal};
 use crate::ffi::InterpreterExtractError;
 use crate::state::parser::Context;
 use crate::sys;

--- a/artichoke-backend/src/extn/core/array/array.rb
+++ b/artichoke-backend/src/extn/core/array/array.rb
@@ -99,10 +99,6 @@ class Array
     array
   end
 
-  def <<(obj)
-    push(obj)
-  end
-
   def <=>(other)
     return nil unless other.is_a?(Array)
 

--- a/artichoke-backend/src/extn/core/array/mod.rs
+++ b/artichoke-backend/src/extn/core/array/mod.rs
@@ -9,7 +9,7 @@ use crate::fmt::WriteError;
 pub mod args;
 mod ffi;
 pub(crate) mod mruby;
-pub mod trampoline;
+pub(super) mod trampoline;
 mod wrapper;
 
 #[doc(inline)]

--- a/artichoke-backend/src/extn/core/array/mod.rs
+++ b/artichoke-backend/src/extn/core/array/mod.rs
@@ -8,7 +8,7 @@ use crate::fmt::WriteError;
 
 pub mod args;
 mod ffi;
-pub(crate) mod mruby;
+pub(in crate::extn) mod mruby;
 pub(super) mod trampoline;
 mod wrapper;
 

--- a/artichoke-backend/src/extn/core/array/mod.rs
+++ b/artichoke-backend/src/extn/core/array/mod.rs
@@ -8,7 +8,7 @@ use crate::fmt::WriteError;
 
 pub mod args;
 mod ffi;
-pub mod mruby;
+pub(crate) mod mruby;
 pub mod trampoline;
 mod wrapper;
 

--- a/artichoke-backend/src/extn/core/env/mod.rs
+++ b/artichoke-backend/src/extn/core/env/mod.rs
@@ -26,7 +26,7 @@ use spinoso_env::{ArgumentError as EnvArgumentError, Error as EnvError, InvalidE
 use crate::extn::prelude::*;
 
 pub(crate) mod mruby;
-pub mod trampoline;
+pub(super) mod trampoline;
 
 #[cfg(not(feature = "core-env-system"))]
 type Backend = spinoso_env::Memory;

--- a/artichoke-backend/src/extn/core/env/mod.rs
+++ b/artichoke-backend/src/extn/core/env/mod.rs
@@ -25,7 +25,7 @@ use spinoso_env::{ArgumentError as EnvArgumentError, Error as EnvError, InvalidE
 
 use crate::extn::prelude::*;
 
-pub(crate) mod mruby;
+pub(in crate::extn) mod mruby;
 pub(super) mod trampoline;
 
 #[cfg(not(feature = "core-env-system"))]

--- a/artichoke-backend/src/extn/core/env/mod.rs
+++ b/artichoke-backend/src/extn/core/env/mod.rs
@@ -25,7 +25,7 @@ use spinoso_env::{ArgumentError as EnvArgumentError, Error as EnvError, InvalidE
 
 use crate::extn::prelude::*;
 
-pub mod mruby;
+pub(crate) mod mruby;
 pub mod trampoline;
 
 #[cfg(not(feature = "core-env-system"))]

--- a/artichoke-backend/src/extn/core/exception/mod.rs
+++ b/artichoke-backend/src/extn/core/exception/mod.rs
@@ -27,7 +27,7 @@ pub use spinoso_exception::core::*;
 
 use crate::extn::prelude::*;
 
-pub(crate) mod mruby;
+pub(in crate::extn) mod mruby;
 
 /// Implement traits to convert Spinoso exceptions to artichoke-backend error
 /// types.

--- a/artichoke-backend/src/extn/core/exception/mod.rs
+++ b/artichoke-backend/src/extn/core/exception/mod.rs
@@ -27,7 +27,7 @@ pub use spinoso_exception::core::*;
 
 use crate::extn::prelude::*;
 
-pub mod mruby;
+pub(crate) mod mruby;
 
 /// Implement traits to convert Spinoso exceptions to artichoke-backend error
 /// types.

--- a/artichoke-backend/src/extn/core/float/mod.rs
+++ b/artichoke-backend/src/extn/core/float/mod.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use crate::extn::core::numeric::{self, Coercion, Outcome};
 use crate::extn::prelude::*;
 
-pub mod mruby;
+pub(crate) mod mruby;
 
 #[repr(transparent)]
 #[derive(Default, Clone, Copy, PartialEq, PartialOrd)]

--- a/artichoke-backend/src/extn/core/float/mod.rs
+++ b/artichoke-backend/src/extn/core/float/mod.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use crate::extn::core::numeric::{self, Coercion, Outcome};
 use crate::extn::prelude::*;
 
-pub(crate) mod mruby;
+pub(in crate::extn) mod mruby;
 
 #[repr(transparent)]
 #[derive(Default, Clone, Copy, PartialEq, PartialOrd)]

--- a/artichoke-backend/src/extn/core/integer/mod.rs
+++ b/artichoke-backend/src/extn/core/integer/mod.rs
@@ -5,7 +5,7 @@ use crate::extn::core::numeric::{self, Coercion, Outcome};
 use crate::extn::prelude::*;
 use crate::fmt::WriteError;
 
-pub mod mruby;
+pub(crate) mod mruby;
 pub mod trampoline;
 
 #[repr(transparent)]

--- a/artichoke-backend/src/extn/core/integer/mod.rs
+++ b/artichoke-backend/src/extn/core/integer/mod.rs
@@ -146,11 +146,11 @@ impl Integer {
     }
 
     #[inline]
-    pub fn bit(self, bit: i64) -> Result<Self, Error> {
+    pub fn bit(self, bit: i64) -> Self {
         if let Ok(bit) = u32::try_from(bit) {
-            Ok(self.as_i64().checked_shr(bit).map_or(0, |v| v & 1).into())
+            self.as_i64().checked_shr(bit).map_or(0, |v| v & 1).into()
         } else {
-            Ok(Self(0))
+            Self(0)
         }
     }
 

--- a/artichoke-backend/src/extn/core/integer/mod.rs
+++ b/artichoke-backend/src/extn/core/integer/mod.rs
@@ -5,7 +5,7 @@ use crate::extn::core::numeric::{self, Coercion, Outcome};
 use crate::extn::prelude::*;
 use crate::fmt::WriteError;
 
-pub(crate) mod mruby;
+pub(in crate::extn) mod mruby;
 pub(super) mod trampoline;
 
 #[repr(transparent)]

--- a/artichoke-backend/src/extn/core/integer/mod.rs
+++ b/artichoke-backend/src/extn/core/integer/mod.rs
@@ -6,7 +6,7 @@ use crate::extn::prelude::*;
 use crate::fmt::WriteError;
 
 pub(crate) mod mruby;
-pub mod trampoline;
+pub(super) mod trampoline;
 
 #[repr(transparent)]
 #[derive(Default, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]

--- a/artichoke-backend/src/extn/core/integer/trampoline.rs
+++ b/artichoke-backend/src/extn/core/integer/trampoline.rs
@@ -11,7 +11,7 @@ pub fn chr(interp: &mut Artichoke, value: Value, encoding: Option<Value>) -> Res
 pub fn element_reference(interp: &mut Artichoke, value: Value, bit: Value) -> Result<Value, Error> {
     let value = value.try_convert_into::<Integer>(interp)?;
     let bit = implicitly_convert_to_int(interp, bit)?;
-    let bit = value.bit(bit)?;
+    let bit = value.bit(bit);
     Ok(interp.convert(bit))
 }
 
@@ -42,6 +42,7 @@ pub fn is_nobits(interp: &mut Artichoke, value: Value, mask: Value) -> Result<Va
     Ok(interp.convert(result))
 }
 
+#[allow(clippy::unnecessary_wraps)]
 pub fn size(interp: &Artichoke) -> Result<Value, Error> {
     qed::const_assert!(Integer::size() < i8::MAX as usize);
     const SIZE: i64 = Integer::size() as i64;

--- a/artichoke-backend/src/extn/core/kernel/mod.rs
+++ b/artichoke-backend/src/extn/core/kernel/mod.rs
@@ -1,5 +1,5 @@
 pub mod integer;
-pub mod mruby;
+pub(crate) mod mruby;
 pub mod require;
 pub mod trampoline;
 

--- a/artichoke-backend/src/extn/core/kernel/mod.rs
+++ b/artichoke-backend/src/extn/core/kernel/mod.rs
@@ -1,7 +1,7 @@
 pub mod integer;
 pub(crate) mod mruby;
 pub mod require;
-pub mod trampoline;
+pub(super) mod trampoline;
 
 #[derive(Debug, Clone, Copy)]
 pub struct Kernel;

--- a/artichoke-backend/src/extn/core/kernel/mod.rs
+++ b/artichoke-backend/src/extn/core/kernel/mod.rs
@@ -1,5 +1,5 @@
 pub mod integer;
-pub(crate) mod mruby;
+pub(in crate::extn) mod mruby;
 pub mod require;
 pub(super) mod trampoline;
 

--- a/artichoke-backend/src/extn/core/matchdata/mod.rs
+++ b/artichoke-backend/src/extn/core/matchdata/mod.rs
@@ -25,7 +25,7 @@ use crate::extn::prelude::*;
 use crate::fmt::WriteError;
 
 mod boxing;
-pub mod mruby;
+pub(crate) mod mruby;
 pub mod trampoline;
 
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]

--- a/artichoke-backend/src/extn/core/matchdata/mod.rs
+++ b/artichoke-backend/src/extn/core/matchdata/mod.rs
@@ -26,7 +26,7 @@ use crate::fmt::WriteError;
 
 mod boxing;
 pub(crate) mod mruby;
-pub mod trampoline;
+pub(super) mod trampoline;
 
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
 pub struct Region {

--- a/artichoke-backend/src/extn/core/matchdata/mod.rs
+++ b/artichoke-backend/src/extn/core/matchdata/mod.rs
@@ -256,11 +256,6 @@ impl MatchData {
         }
     }
 
-    #[must_use]
-    pub fn is_empty(&self) -> bool {
-        self.len().unwrap_or_default() > 0
-    }
-
     #[inline]
     pub fn len(&self) -> Result<usize, Error> {
         let haystack = self.matched_region();
@@ -348,11 +343,6 @@ impl MatchData {
     #[must_use]
     pub fn regexp(&self) -> &Regexp {
         &self.regexp
-    }
-
-    #[inline]
-    pub fn regexp_mut(&mut self) -> &mut Regexp {
-        &mut self.regexp
     }
 
     #[inline]

--- a/artichoke-backend/src/extn/core/matchdata/mod.rs
+++ b/artichoke-backend/src/extn/core/matchdata/mod.rs
@@ -25,7 +25,7 @@ use crate::extn::prelude::*;
 use crate::fmt::WriteError;
 
 mod boxing;
-pub(crate) mod mruby;
+pub(in crate::extn) mod mruby;
 pub(super) mod trampoline;
 
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]

--- a/artichoke-backend/src/extn/core/math/mod.rs
+++ b/artichoke-backend/src/extn/core/math/mod.rs
@@ -22,7 +22,7 @@ use std::borrow::Cow;
 use crate::extn::prelude::*;
 
 pub(crate) mod mruby;
-pub mod trampoline;
+pub(super) mod trampoline;
 
 #[doc(inline)]
 pub use spinoso_math::{DomainError, Math, E, PI};

--- a/artichoke-backend/src/extn/core/math/mod.rs
+++ b/artichoke-backend/src/extn/core/math/mod.rs
@@ -21,7 +21,7 @@ use std::borrow::Cow;
 
 use crate::extn::prelude::*;
 
-pub(crate) mod mruby;
+pub(in crate::extn) mod mruby;
 pub(super) mod trampoline;
 
 #[doc(inline)]

--- a/artichoke-backend/src/extn/core/math/mod.rs
+++ b/artichoke-backend/src/extn/core/math/mod.rs
@@ -21,7 +21,7 @@ use std::borrow::Cow;
 
 use crate::extn::prelude::*;
 
-pub mod mruby;
+pub(crate) mod mruby;
 pub mod trampoline;
 
 #[doc(inline)]

--- a/artichoke-backend/src/extn/core/mod.rs
+++ b/artichoke-backend/src/extn/core/mod.rs
@@ -2,42 +2,42 @@
 
 use crate::extn::prelude::*;
 
-pub mod array;
-pub mod artichoke;
-pub mod basicobject;
-pub mod comparable;
-pub mod enumerable;
-pub mod enumerator;
+pub(crate) mod array;
+pub(crate) mod artichoke;
+pub(crate) mod basicobject;
+pub(crate) mod comparable;
+pub(crate) mod enumerable;
+pub(crate) mod enumerator;
 #[cfg(feature = "core-env")]
-pub mod env;
-pub mod exception;
-pub mod falseclass;
-pub mod float;
-pub mod hash;
-pub mod integer;
-pub mod kernel;
+pub(crate) mod env;
+pub(crate) mod exception;
+pub(crate) mod falseclass;
+pub(crate) mod float;
+pub(crate) mod hash;
+pub(crate) mod integer;
+pub(crate) mod kernel;
 #[cfg(feature = "core-regexp")]
-pub mod matchdata;
+pub(crate) mod matchdata;
 #[cfg(feature = "core-math")]
-pub mod math;
-pub mod method;
-pub mod module;
-pub mod nilclass;
-pub mod numeric;
-pub mod object;
-pub mod proc;
+pub(crate) mod math;
+pub(crate) mod method;
+pub(crate) mod module;
+pub(crate) mod nilclass;
+pub(crate) mod numeric;
+pub(crate) mod object;
+pub(crate) mod proc;
 #[cfg(feature = "core-random")]
-pub mod random;
-pub mod range;
+pub(crate) mod random;
+pub(crate) mod range;
 #[cfg(feature = "core-regexp")]
-pub mod regexp;
-pub mod string;
-pub mod symbol;
-pub mod thread;
+pub(crate) mod regexp;
+pub(crate) mod string;
+pub(crate) mod symbol;
+pub(crate) mod thread;
 #[cfg(feature = "core-time")]
-pub mod time;
-pub mod trueclass;
-pub mod warning;
+pub(crate) mod time;
+pub(crate) mod trueclass;
+pub(crate) mod warning;
 
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
     // These core classes are ordered according to the dependency DAG between

--- a/artichoke-backend/src/extn/core/numeric/mod.rs
+++ b/artichoke-backend/src/extn/core/numeric/mod.rs
@@ -1,7 +1,7 @@
 use crate::extn::core::integer::Integer;
 use crate::extn::prelude::*;
 
-pub mod mruby;
+pub(crate) mod mruby;
 
 #[derive(Debug, Clone, Copy)]
 pub struct Numeric;

--- a/artichoke-backend/src/extn/core/numeric/mod.rs
+++ b/artichoke-backend/src/extn/core/numeric/mod.rs
@@ -1,7 +1,7 @@
 use crate::extn::core::integer::Integer;
 use crate::extn::prelude::*;
 
-pub(crate) mod mruby;
+pub(in crate::extn) mod mruby;
 
 #[derive(Debug, Clone, Copy)]
 pub struct Numeric;

--- a/artichoke-backend/src/extn/core/numeric/mod.rs
+++ b/artichoke-backend/src/extn/core/numeric/mod.rs
@@ -45,27 +45,6 @@ pub enum Coercion {
 /// Artichoke represents the `[y, x]` tuple Array as the [`Coercion`] enum, which
 /// orders its values `Coercion::Integer(x, y)`.
 ///
-/// # Examples
-///
-/// ```
-/// # use artichoke_backend::prelude::*;
-/// # use artichoke_backend::extn::core::numeric::{self, Coercion};
-/// # fn example() -> Result<(), Box<dyn std::error::Error>> {
-/// # let mut interp = artichoke_backend::interpreter()?;
-/// let x = interp.convert(1_i64);
-/// let y = interp.convert_mut(2.5_f64);
-/// assert_eq!(Coercion::Float(1.0, 2.5), numeric::coerce(&mut interp, x, y)?);
-/// let x = interp.convert_mut(1.2_f64);
-/// let y = interp.convert(3_i64);
-/// assert_eq!(Coercion::Float(1.2, 3.0), numeric::coerce(&mut interp, x, y)?);
-/// let x = interp.convert(1_i64);
-/// let y = interp.convert(2_i64);
-/// assert_eq!(Coercion::Integer(1, 2), numeric::coerce(&mut interp, x, y)?);
-/// # Ok(())
-/// # }
-/// # example().unwrap();
-/// ```
-///
 /// [numeric]: https://ruby-doc.org/core-3.1.2/Numeric.html#method-i-coerce
 pub fn coerce(interp: &mut Artichoke, x: Value, y: Value) -> Result<Coercion, Error> {
     fn do_coerce(interp: &mut Artichoke, x: Value, y: Value, depth: u8) -> Result<Coercion, Error> {
@@ -128,4 +107,42 @@ pub fn coerce(interp: &mut Artichoke, x: Value, y: Value) -> Result<Coercion, Er
         }
     }
     do_coerce(interp, x, y, 0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Coercion;
+    use crate::test::prelude::*;
+
+    #[test]
+    fn coerce_int_to_float() {
+        let mut interp = interpreter();
+        let x = interp.convert(1_i64);
+        let y = interp.convert_mut(2.5_f64);
+        assert_eq!(Coercion::Float(1.0, 2.5), super::coerce(&mut interp, x, y).unwrap());
+    }
+
+    #[test]
+    fn coerce_float_to_int() {
+        let mut interp = interpreter();
+        let x = interp.convert_mut(1.2_f64);
+        let y = interp.convert(3_i64);
+        assert_eq!(Coercion::Float(1.2, 3.0), super::coerce(&mut interp, x, y).unwrap());
+    }
+
+    #[test]
+    fn coerce_int_to_int() {
+        let mut interp = interpreter();
+        let x = interp.convert(1_i64);
+        let y = interp.convert(2_i64);
+        assert_eq!(Coercion::Integer(1, 2), super::coerce(&mut interp, x, y).unwrap());
+    }
+
+    #[test]
+    fn coerce_float_to_float() {
+        let mut interp = interpreter();
+        let x = interp.convert_mut(1.2_f64);
+        let y = interp.convert_mut(2.5_f64);
+        assert_eq!(Coercion::Float(1.2, 2.5), super::coerce(&mut interp, x, y).unwrap());
+    }
 }

--- a/artichoke-backend/src/extn/core/random/mod.rs
+++ b/artichoke-backend/src/extn/core/random/mod.rs
@@ -29,7 +29,7 @@ use crate::convert::{implicitly_convert_to_int, HeapAllocatedData};
 use crate::extn::prelude::*;
 
 pub(crate) mod mruby;
-pub mod trampoline;
+pub(super) mod trampoline;
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 enum Rng {

--- a/artichoke-backend/src/extn/core/random/mod.rs
+++ b/artichoke-backend/src/extn/core/random/mod.rs
@@ -28,7 +28,7 @@ pub use spinoso_random::{Max, Rand, Random};
 use crate::convert::{implicitly_convert_to_int, HeapAllocatedData};
 use crate::extn::prelude::*;
 
-pub mod mruby;
+pub(crate) mod mruby;
 pub mod trampoline;
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]

--- a/artichoke-backend/src/extn/core/random/mod.rs
+++ b/artichoke-backend/src/extn/core/random/mod.rs
@@ -28,7 +28,7 @@ pub use spinoso_random::{Max, Rand, Random};
 use crate::convert::{implicitly_convert_to_int, HeapAllocatedData};
 use crate::extn::prelude::*;
 
-pub(crate) mod mruby;
+pub(in crate::extn) mod mruby;
 pub(super) mod trampoline;
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]

--- a/artichoke-backend/src/extn/core/regexp/mod.rs
+++ b/artichoke-backend/src/extn/core/regexp/mod.rs
@@ -30,7 +30,7 @@ pub(crate) mod mruby;
 pub mod opts;
 pub mod pattern;
 pub mod syntax;
-pub mod trampoline;
+pub(super) mod trampoline;
 
 #[cfg(feature = "core-regexp-oniguruma")]
 use backend::onig::Onig;

--- a/artichoke-backend/src/extn/core/regexp/mod.rs
+++ b/artichoke-backend/src/extn/core/regexp/mod.rs
@@ -26,7 +26,7 @@ use crate::extn::prelude::*;
 pub mod backend;
 mod boxing;
 pub mod enc;
-pub mod mruby;
+pub(crate) mod mruby;
 pub mod opts;
 pub mod pattern;
 pub mod syntax;

--- a/artichoke-backend/src/extn/core/regexp/mod.rs
+++ b/artichoke-backend/src/extn/core/regexp/mod.rs
@@ -26,7 +26,7 @@ use crate::extn::prelude::*;
 pub mod backend;
 mod boxing;
 pub mod enc;
-pub(crate) mod mruby;
+pub(in crate::extn) mod mruby;
 pub mod opts;
 pub mod pattern;
 pub mod syntax;

--- a/artichoke-backend/src/extn/core/regexp/pattern.rs
+++ b/artichoke-backend/src/extn/core/regexp/pattern.rs
@@ -14,21 +14,6 @@ pub struct Pattern {
 }
 
 impl Pattern {
-    /// Construct a new, empty pattern.
-    #[must_use]
-    pub const fn new() -> Self {
-        Self {
-            pattern: Vec::new(),
-            options: Options::new(),
-        }
-    }
-
-    /// Return the pattern as a byte slice.
-    #[must_use]
-    pub fn pattern(&self) -> &[u8] {
-        self.pattern.as_slice()
-    }
-
     /// Consume self and return the inner pattern byte vector.
     #[must_use]
     pub fn into_pattern(self) -> Vec<u8> {

--- a/artichoke-backend/src/extn/core/string/mod.rs
+++ b/artichoke-backend/src/extn/core/string/mod.rs
@@ -15,7 +15,7 @@ use crate::value::Value;
 use crate::Artichoke;
 
 mod ffi;
-pub mod mruby;
+pub(crate) mod mruby;
 pub mod trampoline;
 
 const ENCODING_FLAG_BITPOS: usize = 5;

--- a/artichoke-backend/src/extn/core/string/mod.rs
+++ b/artichoke-backend/src/extn/core/string/mod.rs
@@ -15,7 +15,7 @@ use crate::value::Value;
 use crate::Artichoke;
 
 mod ffi;
-pub(crate) mod mruby;
+pub(in crate::extn) mod mruby;
 pub(super) mod trampoline;
 
 const ENCODING_FLAG_BITPOS: usize = 5;

--- a/artichoke-backend/src/extn/core/string/mod.rs
+++ b/artichoke-backend/src/extn/core/string/mod.rs
@@ -16,7 +16,7 @@ use crate::Artichoke;
 
 mod ffi;
 pub(crate) mod mruby;
-pub mod trampoline;
+pub(super) mod trampoline;
 
 const ENCODING_FLAG_BITPOS: usize = 5;
 

--- a/artichoke-backend/src/extn/core/symbol/mod.rs
+++ b/artichoke-backend/src/extn/core/symbol/mod.rs
@@ -4,7 +4,7 @@ use crate::convert::{Immediate, UnboxedValueGuard};
 use crate::extn::prelude::*;
 
 pub mod ffi;
-pub mod mruby;
+pub(crate) mod mruby;
 pub mod trampoline;
 
 #[doc(inline)]

--- a/artichoke-backend/src/extn/core/symbol/mod.rs
+++ b/artichoke-backend/src/extn/core/symbol/mod.rs
@@ -5,7 +5,7 @@ use crate::extn::prelude::*;
 
 pub mod ffi;
 pub(crate) mod mruby;
-pub mod trampoline;
+pub(super) mod trampoline;
 
 #[doc(inline)]
 pub use spinoso_symbol::Symbol;

--- a/artichoke-backend/src/extn/core/symbol/mod.rs
+++ b/artichoke-backend/src/extn/core/symbol/mod.rs
@@ -4,7 +4,7 @@ use crate::convert::{Immediate, UnboxedValueGuard};
 use crate::extn::prelude::*;
 
 pub mod ffi;
-pub(crate) mod mruby;
+pub(in crate::extn) mod mruby;
 pub(super) mod trampoline;
 
 #[doc(inline)]

--- a/artichoke-backend/src/extn/core/time/mod.rs
+++ b/artichoke-backend/src/extn/core/time/mod.rs
@@ -23,7 +23,7 @@
 use crate::convert::HeapAllocatedData;
 use crate::extn::prelude::*;
 
-pub(crate) mod mruby;
+pub(in crate::extn) mod mruby;
 pub mod offset;
 pub mod subsec;
 pub(super) mod trampoline;

--- a/artichoke-backend/src/extn/core/time/mod.rs
+++ b/artichoke-backend/src/extn/core/time/mod.rs
@@ -26,7 +26,7 @@ use crate::extn::prelude::*;
 pub(crate) mod mruby;
 pub mod offset;
 pub mod subsec;
-pub mod trampoline;
+pub(super) mod trampoline;
 
 #[doc(inline)]
 pub use spinoso_time::tzrs::*;

--- a/artichoke-backend/src/extn/core/time/mod.rs
+++ b/artichoke-backend/src/extn/core/time/mod.rs
@@ -23,7 +23,7 @@
 use crate::convert::HeapAllocatedData;
 use crate::extn::prelude::*;
 
-pub mod mruby;
+pub(crate) mod mruby;
 pub mod offset;
 pub mod subsec;
 pub mod trampoline;

--- a/artichoke-backend/src/extn/core/time/subsec.rs
+++ b/artichoke-backend/src/extn/core/time/subsec.rs
@@ -82,7 +82,7 @@ impl Subsec {
     /// various accuracies, and can overflow. e.g. 1001 milliseconds, is 1
     /// second, and `1_000_000` nanoseconds.
     #[must_use]
-    pub fn to_tuple(&self) -> (i64, u32) {
+    pub fn to_tuple(self) -> (i64, u32) {
         (self.secs, self.nanos)
     }
 }

--- a/artichoke-backend/src/extn/prelude.rs
+++ b/artichoke-backend/src/extn/prelude.rs
@@ -14,18 +14,38 @@
 //!
 //! The prelude may grow over time as additional items see ubiquitous use.
 
+pub use artichoke_core::class_registry::ClassRegistry as _;
+pub use artichoke_core::coerce_to_numeric::CoerceToNumeric;
+pub use artichoke_core::constant::DefineConstant as _;
+pub use artichoke_core::convert::{Convert, ConvertMut, TryConvert, TryConvertMut};
+pub use artichoke_core::debug::Debug as _;
+pub use artichoke_core::eval::Eval as _;
+pub use artichoke_core::file::File;
+pub use artichoke_core::globals::Globals as _;
+pub use artichoke_core::intern::Intern as _;
+pub use artichoke_core::io::Io as _;
+pub use artichoke_core::load::LoadSources as _;
+pub use artichoke_core::module_registry::ModuleRegistry as _;
+pub use artichoke_core::parser::Parser as _;
+pub use artichoke_core::prng::Prng as _;
+pub use artichoke_core::regexp::Regexp as _;
+pub use artichoke_core::types::Ruby;
+pub use artichoke_core::value::Value as _;
+pub use artichoke_core::warn::Warn as _;
 pub use scolapasta_aref as aref;
+pub use spinoso_exception::core::*;
 
 pub use crate::block::Block;
 pub use crate::class;
 pub use crate::convert::{BoxUnboxVmValue, HeapAllocatedData};
-pub use crate::core::{Regexp as _, Value as _, *};
 pub use crate::def::{self, EnclosingRubyScope, NotDefinedError};
+pub use crate::error::{self, Error, RubyException};
 pub use crate::ffi::InterpreterExtractError;
+pub use crate::gc::MrbGarbageCollection as _;
 pub use crate::module;
-pub use crate::prelude::*;
 pub use crate::sys;
 pub use crate::value::Value;
+pub use crate::{Artichoke, Guard};
 
 /// Type alias for errors returned from `init` functions in
 /// [`extn`](crate::extn).

--- a/artichoke-backend/src/extn/stdlib/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/mod.rs
@@ -1,33 +1,33 @@
 use crate::extn::prelude::*;
 
 #[cfg(feature = "stdlib-abbrev")]
-pub mod abbrev;
+pub(in crate::extn) mod abbrev;
 #[cfg(feature = "stdlib-base64")]
-pub mod base64;
+pub(in crate::extn) mod base64;
 #[cfg(feature = "stdlib-cmath")]
-pub mod cmath;
+pub(in crate::extn) mod cmath;
 #[cfg(feature = "stdlib-delegate")]
-pub mod delegate;
+pub(in crate::extn) mod delegate;
 #[cfg(feature = "stdlib-forwardable")]
-pub mod forwardable;
+pub(in crate::extn) mod forwardable;
 #[cfg(feature = "stdlib-json")]
-pub mod json;
+pub(in crate::extn) mod json;
 #[cfg(feature = "stdlib-monitor")]
-pub mod monitor;
+pub(in crate::extn) mod monitor;
 #[cfg(feature = "stdlib-ostruct")]
-pub mod ostruct;
+pub(in crate::extn) mod ostruct;
 #[cfg(feature = "stdlib-securerandom")]
-pub mod securerandom;
+pub(in crate::extn) mod securerandom;
 #[cfg(feature = "stdlib-set")]
-pub mod set;
+pub(in crate::extn) mod set;
 #[cfg(feature = "stdlib-shellwords")]
-pub mod shellwords;
+pub(in crate::extn) mod shellwords;
 #[cfg(feature = "stdlib-strscan")]
-pub mod strscan;
+pub(in crate::extn) mod strscan;
 #[cfg(feature = "stdlib-time")]
-pub mod time;
+pub(in crate::extn) mod time;
 #[cfg(feature = "stdlib-uri")]
-pub mod uri;
+pub(in crate::extn) mod uri;
 
 #[allow(unused_variables)]
 pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {

--- a/artichoke-backend/src/extn/stdlib/securerandom/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/securerandom/mod.rs
@@ -20,7 +20,7 @@ use crate::convert::implicitly_convert_to_int;
 use crate::extn::core::exception as exc;
 use crate::extn::prelude::*;
 
-pub mod mruby;
+pub(crate) mod mruby;
 pub mod trampoline;
 
 #[doc(inline)]

--- a/artichoke-backend/src/extn/stdlib/securerandom/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/securerandom/mod.rs
@@ -21,7 +21,7 @@ use crate::extn::core::exception as exc;
 use crate::extn::prelude::*;
 
 pub(crate) mod mruby;
-pub mod trampoline;
+pub(super) mod trampoline;
 
 #[doc(inline)]
 pub use spinoso_securerandom::{

--- a/artichoke-backend/src/extn/stdlib/securerandom/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/securerandom/mod.rs
@@ -17,7 +17,6 @@
 //! [`getrandom`]: https://crates.io/crates/getrandom
 
 use crate::convert::implicitly_convert_to_int;
-use crate::extn::core::exception as exc;
 use crate::extn::prelude::*;
 
 pub(in crate::extn) mod mruby;
@@ -42,7 +41,7 @@ impl From<SecureRandomError> for Error {
 
 impl From<ArgumentError> for Error {
     fn from(err: ArgumentError) -> Self {
-        exc::ArgumentError::from(err.message()).into()
+        spinoso_exception::ArgumentError::from(err.message()).into()
     }
 }
 
@@ -86,7 +85,7 @@ impl TryConvertMut<Option<Value>, Max> for Artichoke {
                     let max = implicitly_convert_to_int(self, max).map_err(|_| {
                         let mut message = b"invalid argument - ".to_vec();
                         message.extend_from_slice(max.inspect(self).as_slice());
-                        exc::ArgumentError::from(message)
+                        spinoso_exception::ArgumentError::from(message)
                     })?;
                     Ok(Max::Integer(max))
                 }

--- a/artichoke-backend/src/extn/stdlib/securerandom/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/securerandom/mod.rs
@@ -20,7 +20,7 @@ use crate::convert::implicitly_convert_to_int;
 use crate::extn::core::exception as exc;
 use crate::extn::prelude::*;
 
-pub(crate) mod mruby;
+pub(in crate::extn) mod mruby;
 pub(super) mod trampoline;
 
 #[doc(inline)]

--- a/artichoke-backend/src/fmt.rs
+++ b/artichoke-backend/src/fmt.rs
@@ -23,6 +23,7 @@ use crate::Artichoke;
 /// use std::fmt::Write;
 /// # use artichoke_backend::Error;;
 /// # use artichoke_backend::fmt::WriteError;
+///
 /// fn task() -> Result<String, Error> {
 ///     let mut buf = String::new();
 ///     write!(&mut buf, "success!").map_err(WriteError::from)?;

--- a/artichoke-backend/src/fmt.rs
+++ b/artichoke-backend/src/fmt.rs
@@ -4,9 +4,10 @@ use std::borrow::Cow;
 use std::error;
 use std::fmt;
 
+use spinoso_exception::Fatal;
+
 use crate::core::{ClassRegistry, TryConvertMut};
 use crate::error::{Error, RubyException};
-use crate::extn::core::exception::Fatal;
 use crate::sys;
 use crate::Artichoke;
 

--- a/artichoke-backend/src/gc/arena.rs
+++ b/artichoke-backend/src/gc/arena.rs
@@ -5,9 +5,10 @@ use std::error;
 use std::fmt;
 use std::ops::{Deref, DerefMut};
 
+use spinoso_exception::Fatal;
+
 use crate::core::{ClassRegistry, TryConvertMut};
 use crate::error::{Error, RubyException};
-use crate::extn::core::exception::Fatal;
 use crate::sys;
 use crate::Artichoke;
 

--- a/artichoke-backend/src/intern.rs
+++ b/artichoke-backend/src/intern.rs
@@ -1,7 +1,6 @@
 use std::borrow::Cow;
 
 use intaglio::SymbolOverflowError;
-
 use spinoso_exception::Fatal;
 
 use crate::core::{ClassRegistry, Intern, TryConvertMut};

--- a/artichoke-backend/src/intern.rs
+++ b/artichoke-backend/src/intern.rs
@@ -2,9 +2,10 @@ use std::borrow::Cow;
 
 use intaglio::SymbolOverflowError;
 
+use spinoso_exception::Fatal;
+
 use crate::core::{ClassRegistry, Intern, TryConvertMut};
 use crate::error::{Error, RubyException};
-use crate::extn::core::exception::Fatal;
 use crate::ffi::InterpreterExtractError;
 use crate::sys;
 use crate::Artichoke;

--- a/artichoke-backend/src/interpreter.rs
+++ b/artichoke-backend/src/interpreter.rs
@@ -3,10 +3,11 @@ use std::error;
 use std::ffi::c_void;
 use std::fmt;
 
+use spinoso_exception::Fatal;
+
 use crate::core::{ClassRegistry, Eval, TryConvertMut};
 use crate::error::{Error, RubyException};
 use crate::extn;
-use crate::extn::core::exception::Fatal;
 use crate::ffi;
 use crate::gc::{MrbGarbageCollection, State as GcState};
 use crate::release_metadata::ReleaseMetadata;

--- a/artichoke-backend/src/io.rs
+++ b/artichoke-backend/src/io.rs
@@ -5,7 +5,6 @@ use std::io;
 
 use crate::core::{ClassRegistry, Io, TryConvertMut};
 use crate::error::{Error, RubyException};
-use crate::extn::core::exception;
 use crate::ffi::InterpreterExtractError;
 use crate::state::output::Output;
 use crate::sys;
@@ -87,7 +86,10 @@ impl RubyException for IoError {
 
     fn as_mrb_value(&self, interp: &mut Artichoke) -> Option<sys::mrb_value> {
         let message = interp.try_convert_mut(self.message()).ok()?;
-        let value = interp.new_instance::<exception::IOError>(&[message]).ok().flatten()?;
+        let value = interp
+            .new_instance::<spinoso_exception::IOError>(&[message])
+            .ok()
+            .flatten()?;
         Some(value.inner())
     }
 }

--- a/artichoke-backend/src/lib.rs
+++ b/artichoke-backend/src/lib.rs
@@ -171,7 +171,7 @@ pub use crate::interpreter::{interpreter, interpreter_with_config};
 /// The prelude may grow over time as additional items see ubiquitous use.
 pub mod prelude {
     pub use artichoke_core::prelude::*;
-    pub use spinoso_exception::*;
+    pub use spinoso_exception::core::*;
 
     pub use crate::error::{self, Error, RubyException};
     pub use crate::gc::MrbGarbageCollection;

--- a/artichoke-backend/src/lib.rs
+++ b/artichoke-backend/src/lib.rs
@@ -171,9 +171,9 @@ pub use crate::interpreter::{interpreter, interpreter_with_config};
 /// The prelude may grow over time as additional items see ubiquitous use.
 pub mod prelude {
     pub use artichoke_core::prelude::*;
+    pub use spinoso_exception::*;
 
     pub use crate::error::{self, Error, RubyException};
-    pub use crate::extn::core::exception::*;
     pub use crate::gc::MrbGarbageCollection;
     pub use crate::release_metadata::ReleaseMetadata;
     pub use crate::{Artichoke, Guard};

--- a/artichoke-backend/src/load_path/memory.rs
+++ b/artichoke-backend/src/load_path/memory.rs
@@ -222,12 +222,13 @@ impl Entry {
 /// - Optional hook to a Rust function to be executed on `require` (similar to a
 ///   MRI C extension rubygem).
 ///
-/// Sources in `Memory` are only writable via the
-/// [`LoadSources`](crate::core::LoadSources) trait. Sources can only be
-/// completely replaced.
+/// Sources in `Memory` are only writable via the [`LoadSources`] trait. Sources
+/// can only be completely replaced.
 ///
 /// These APIs are consumed primarily by the `Kernel::require` implementation in
-/// [`extn::core::kernel::require`](crate::extn::core::kernel::require).
+/// `extn::core::kernel::require`.
+///
+/// [`LoadSources`]: artichoke_core::load::LoadSources
 #[derive(Debug)]
 pub struct Memory {
     fs: HashMap<BString, Entry>,
@@ -253,9 +254,11 @@ impl Memory {
     ///
     /// Sets the current working directory of the virtual file system to
     /// [`RUBY_LOAD_PATH`] for storing Ruby source files. This path is searched
-    /// by [`Kernel::require`, `Kernel::require_relative`, and `Kernel::load`].
+    /// by [`Kernel::require`], [`Kernel::require_relative`], and [`Kernel::load`].
     ///
-    /// [`Kernel::require`, `Kernel::require_relative`, and `Kernel::load`]: crate::extn::core::kernel::require
+    /// [`Kernel::require`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-require
+    /// [`Kernel::require_relative`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-require_relative
+    /// [`Kernel::load`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-load
     #[must_use]
     pub fn new() -> Self {
         Self::default()

--- a/artichoke-backend/src/parser.rs
+++ b/artichoke-backend/src/parser.rs
@@ -1,8 +1,9 @@
 use std::borrow::Cow;
 
+use spinoso_exception::ScriptError;
+
 use crate::core::{ClassRegistry, IncrementLinenoError, Parser, TryConvertMut};
 use crate::error::{Error, RubyException};
-use crate::extn::core::exception::ScriptError;
 use crate::ffi::InterpreterExtractError;
 use crate::state::parser::Context;
 use crate::sys;

--- a/artichoke-backend/src/release_metadata.rs
+++ b/artichoke-backend/src/release_metadata.rs
@@ -1,16 +1,120 @@
-use crate::core;
+//! Information about an Artichoke build.
+//!
+//! Release metadata allows populating Ruby constants that describe the build,
+//! like `RUBY_COPYRIGHT` for copyright information or `RUBY_PLATFORM` for
+//! target architecture.
 
+use artichoke_core::release_metadata;
+
+/// Information about an Artichoke build.
+///
+/// This build information is injected into `artichoke-backend` by the
+/// `artichoke` crate at interpreter initialization time.
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ReleaseMetadata<'a> {
+    /// Copyright information.
+    ///
+    /// This value will populate the `RUBY_COPYRIGHT` constant.
+    ///
+    /// # Examples
+    ///
+    /// ```text
+    /// artichoke - Copyright (c) 2019-2020 Ryan Lopopolo \<rjl@hyperbo.la\>
+    /// ```
     pub copyright: &'a str,
+    /// A description of the current build.
+    ///
+    /// This value will populate the `RUBY_DESCRIPTION` constant.
+    ///
+    /// # Examples
+    ///
+    /// ```text
+    /// artichoke 0.1.0-pre.0 (2021-01-12 revision 4009) [x86_64-apple-darwin]
+    /// ```
     pub description: &'a str,
+    /// The engine, or VM, used in the current build.
+    ///
+    /// This value will populate the `RUBY_ENGINE` constant.
+    ///
+    /// # Examples
+    ///
+    /// ```text
+    /// artichoke-mruby
+    /// ```
     pub engine: &'a str,
+    /// The version of the engine, or VM, used in the current build.
+    ///
+    /// This value will populate the `RUBY_ENGINE_VERSION` constant.
+    ///
+    /// # Examples
+    ///
+    /// ```text
+    /// 0.1.0-pre.0
+    /// ```
     pub engine_version: &'a str,
+    /// The patch level the current build.
+    ///
+    /// This value will populate the `RUBY_PATCHLEVEL` constant.
+    ///
+    /// # Examples
+    ///
+    /// ```text
+    /// 0
+    /// ```
     pub patchlevel: &'a str,
+    /// The target triple of the platform this build targets.
+    ///
+    /// The platform will be a [Rust or LLVM target triple][triple].
+    ///
+    /// This value will populate the `RUBY_PLATFORM` constant.
+    ///
+    /// # Examples
+    ///
+    /// ```text
+    /// x86_64-apple-darwin
+    /// ```
+    ///
+    /// [triple]: https://forge.rust-lang.org/release/platform-support.html
     pub platform: &'a str,
+    /// The build date of this release.
+    ///
+    /// This value will populate the `RUBY_RELEASE_DATE` constant.
+    ///
+    /// # Examples
+    ///
+    /// ```text
+    /// 2021-01-12
+    /// ```
     pub release_date: &'a str,
+    /// The target MRI Ruby version for this build.
+    ///
+    /// This value will populate the `RUBY_VERSION` constant.
+    ///
+    /// # Examples
+    ///
+    /// ```text
+    /// 3.1.2
+    /// ```
     pub revision: &'a str,
+    /// The target MRI Ruby version for this build.
+    ///
+    /// This value will populate the `RUBY_VERSION` constant.
+    ///
+    /// # Examples
+    ///
+    /// ```text
+    /// 3.1.2
+    /// ```
     pub ruby_version: &'a str,
+    /// A description of the compiler used to build Artichoke.
+    ///
+    /// This value will populate the `ARTICHOKE_COMPILER_VERSION` constant.
+    ///
+    /// # Examples
+    ///
+    /// ```text
+    /// rustc 1.49.0 (e1884a8e3 2020-12-29) on x86_64-apple-darwin
+    /// ```
     pub compiler_version: Option<&'a str>,
 }
 
@@ -20,7 +124,7 @@ impl<'a> Default for ReleaseMetadata<'a> {
     }
 }
 
-impl<'a> core::ReleaseMetadata for ReleaseMetadata<'a> {
+impl<'a> release_metadata::ReleaseMetadata for ReleaseMetadata<'a> {
     fn ruby_copyright(&self) -> &str {
         self.copyright
     }
@@ -79,111 +183,299 @@ impl<'a> ReleaseMetadata<'a> {
         }
     }
 
+    /// Set copyright information.
+    ///
+    /// This value will populate the `RUBY_COPYRIGHT` constant.
+    ///
+    /// # Examples
+    ///
+    /// ```text
+    /// artichoke - Copyright (c) 2019-2020 Ryan Lopopolo \<rjl@hyperbo.la\>
+    /// ```
     #[must_use]
     pub fn with_ruby_copyright(mut self, copyright: &'a str) -> Self {
         self.copyright = copyright;
         self
     }
 
+    /// Set a description of the current build.
+    ///
+    /// This value will populate the `RUBY_DESCRIPTION` constant.
+    ///
+    /// # Examples
+    ///
+    /// ```text
+    /// artichoke 0.1.0-pre.0 (2021-01-12 revision 4009) [x86_64-apple-darwin]
+    /// ```
     #[must_use]
     pub fn with_ruby_description(mut self, description: &'a str) -> Self {
         self.description = description;
         self
     }
 
+    /// Set the engine, or VM, used in the current build.
+    ///
+    /// This value will populate the `RUBY_ENGINE` constant.
+    ///
+    /// # Examples
+    ///
+    /// ```text
+    /// artichoke-mruby
+    /// ```
     #[must_use]
     pub fn with_ruby_engine(mut self, engine: &'a str) -> Self {
         self.engine = engine;
         self
     }
 
+    /// Set the version of the engine, or VM, used in the current build.
+    ///
+    /// This value will populate the `RUBY_ENGINE_VERSION` constant.
+    ///
+    /// # Examples
+    ///
+    /// ```text
+    /// 0.1.0-pre.0
+    /// ```
     #[must_use]
     pub fn with_ruby_engine_version(mut self, engine_version: &'a str) -> Self {
         self.engine_version = engine_version;
         self
     }
 
+    /// Set the patch level the current build.
+    ///
+    /// This value will populate the `RUBY_PATCHLEVEL` constant.
+    ///
+    /// # Examples
+    ///
+    /// ```text
+    /// 0
+    /// ```
     #[must_use]
     pub fn with_ruby_patchlevel(mut self, patchlevel: &'a str) -> Self {
         self.patchlevel = patchlevel;
         self
     }
 
+    /// Set the target triple of the platform this build targets.
+    ///
+    /// The platform will be a [Rust or LLVM target triple][triple].
+    ///
+    /// This value will populate the `RUBY_PLATFORM` constant.
+    ///
+    /// # Examples
+    ///
+    /// ```text
+    /// x86_64-apple-darwin
+    /// ```
+    ///
+    /// [triple]: https://forge.rust-lang.org/release/platform-support.html
     #[must_use]
     pub fn with_ruby_platform(mut self, platform: &'a str) -> Self {
         self.platform = platform;
         self
     }
 
+    /// Set the build date of this release.
+    ///
+    /// This value will populate the `RUBY_RELEASE_DATE` constant.
+    ///
+    /// # Examples
+    ///
+    /// ```text
+    /// 2021-01-12
+    /// ```
     #[must_use]
     pub fn with_ruby_release_date(mut self, release_date: &'a str) -> Self {
         self.release_date = release_date;
         self
     }
 
+    /// Set the target MRI Ruby version for this build.
+    ///
+    /// This value will populate the `RUBY_VERSION` constant.
+    ///
+    /// # Examples
+    ///
+    /// ```text
+    /// 3.1.2
+    /// ```
     #[must_use]
     pub fn with_ruby_revision(mut self, revision: &'a str) -> Self {
         self.revision = revision;
         self
     }
 
+    /// Set the target MRI Ruby version for this build.
+    ///
+    /// This value will populate the `RUBY_VERSION` constant.
+    ///
+    /// # Examples
+    ///
+    /// ```text
+    /// 3.1.2
+    /// ```
     #[must_use]
     pub fn with_ruby_version(mut self, ruby_version: &'a str) -> Self {
         self.ruby_version = ruby_version;
         self
     }
 
+    /// Set a description of the compiler used to build Artichoke.
+    ///
+    /// This value will populate the `ARTICHOKE_COMPILER_VERSION` constant.
+    ///
+    /// # Examples
+    ///
+    /// ```text
+    /// rustc 1.49.0 (e1884a8e3 2020-12-29) on x86_64-apple-darwin
+    /// ```
     #[must_use]
     pub fn with_artichoke_compiler_version(mut self, compiler_version: Option<&'a str>) -> Self {
         self.compiler_version = compiler_version;
         self
     }
 
+    /// Copyright information.
+    ///
+    /// This value will populate the `RUBY_COPYRIGHT` constant.
+    ///
+    /// # Examples
+    ///
+    /// ```text
+    /// artichoke - Copyright (c) 2019-2020 Ryan Lopopolo \<rjl@hyperbo.la\>
+    /// ```
     #[must_use]
     pub const fn ruby_copyright(&self) -> &str {
         self.copyright
     }
 
+    /// A description of the current build.
+    ///
+    /// This value will populate the `RUBY_DESCRIPTION` constant.
+    ///
+    /// # Examples
+    ///
+    /// ```text
+    /// artichoke 0.1.0-pre.0 (2021-01-12 revision 4009) [x86_64-apple-darwin]
+    /// ```
     #[must_use]
     pub const fn ruby_description(&self) -> &str {
         self.description
     }
 
+    /// The engine, or VM, used in the current build.
+    ///
+    /// This value will populate the `RUBY_ENGINE` constant.
+    ///
+    /// # Examples
+    ///
+    /// ```text
+    /// artichoke-mruby
+    /// ```
     #[must_use]
     pub const fn ruby_engine(&self) -> &str {
         self.engine
     }
 
+    /// The version of the engine, or VM, used in the current build.
+    ///
+    /// This value will populate the `RUBY_ENGINE_VERSION` constant.
+    ///
+    /// # Examples
+    ///
+    /// ```text
+    /// 0.1.0-pre.0
+    /// ```
     #[must_use]
     pub const fn ruby_engine_version(&self) -> &str {
         self.engine_version
     }
 
+    /// The patch level the current build.
+    ///
+    /// This value will populate the `RUBY_PATCHLEVEL` constant.
+    ///
+    /// # Examples
+    ///
+    /// ```text
+    /// 0
+    /// ```
     #[must_use]
     pub const fn ruby_patchlevel(&self) -> &str {
         self.patchlevel
     }
 
+    /// The target triple of the platform this build targets.
+    ///
+    /// The platform will be a [Rust or LLVM target triple][triple].
+    ///
+    /// This value will populate the `RUBY_PLATFORM` constant.
+    ///
+    /// # Examples
+    ///
+    /// ```text
+    /// x86_64-apple-darwin
+    /// ```
+    ///
+    /// [triple]: https://forge.rust-lang.org/release/platform-support.html
     #[must_use]
     pub const fn ruby_platform(&self) -> &str {
         self.platform
     }
 
+    /// The build date of this release.
+    ///
+    /// This value will populate the `RUBY_RELEASE_DATE` constant.
+    ///
+    /// # Examples
+    ///
+    /// ```text
+    /// 2021-01-12
+    /// ```
     #[must_use]
     pub const fn ruby_release_date(&self) -> &str {
         self.release_date
     }
 
+    /// The target MRI Ruby version for this build.
+    ///
+    /// This value will populate the `RUBY_VERSION` constant.
+    ///
+    /// # Examples
+    ///
+    /// ```text
+    /// 3.1.2
+    /// ```
     #[must_use]
     pub const fn ruby_revision(&self) -> &str {
         self.revision
     }
 
+    /// The target MRI Ruby version for this build.
+    ///
+    /// This value will populate the `RUBY_VERSION` constant.
+    ///
+    /// # Examples
+    ///
+    /// ```text
+    /// 3.1.2
+    /// ```
     #[must_use]
     pub const fn ruby_version(&self) -> &str {
         self.ruby_version
     }
 
+    /// A description of the compiler used to build Artichoke.
+    ///
+    /// This value will populate the `ARTICHOKE_COMPILER_VERSION` constant.
+    ///
+    /// # Examples
+    ///
+    /// ```text
+    /// rustc 1.49.0 (e1884a8e3 2020-12-29) on x86_64-apple-darwin
+    /// ```
     #[must_use]
     pub const fn artichoke_compiler_version(&self) -> Option<&str> {
         self.compiler_version

--- a/artichoke-backend/src/value.rs
+++ b/artichoke-backend/src/value.rs
@@ -8,11 +8,11 @@ use std::ptr;
 use artichoke_core::convert::{Convert, ConvertMut, TryConvertMut};
 use artichoke_core::intern::Intern;
 use artichoke_core::value::Value as ValueCore;
+use spinoso_exception::{ArgumentError, Fatal};
 
 use crate::core::ClassRegistry;
 use crate::error::{Error, RubyException};
 use crate::exception_handler;
-use crate::extn::core::exception::{ArgumentError, Fatal};
 use crate::gc::MrbGarbageCollection;
 use crate::sys::{self, protect};
 use crate::types::{self, Ruby};

--- a/artichoke-backend/src/value.rs
+++ b/artichoke-backend/src/value.rs
@@ -1,3 +1,5 @@
+//! Boxed values on the Ruby interpreter heap.
+
 use std::borrow::Cow;
 use std::error;
 use std::fmt;

--- a/artichoke-backend/src/warn.rs
+++ b/artichoke-backend/src/warn.rs
@@ -1,9 +1,10 @@
 use std::fmt::Write;
 
+use spinoso_exception::IOError;
+
 use crate::core::{ModuleRegistry, TryConvertMut, Value as _, Warn};
 use crate::def::NotDefinedError;
 use crate::error::Error;
-use crate::extn::core::exception::IOError;
 use crate::extn::core::warning::Warning;
 use crate::ffi::InterpreterExtractError;
 use crate::fmt::WriteError;

--- a/artichoke-core/src/release_metadata.rs
+++ b/artichoke-core/src/release_metadata.rs
@@ -15,7 +15,9 @@ pub trait ReleaseMetadata {
     ///
     /// # Examples
     ///
-    /// > artichoke - Copyright (c) 2019-2020 Ryan Lopopolo \<rjl@hyperbo.la\>
+    /// ```text
+    /// artichoke - Copyright (c) 2019-2020 Ryan Lopopolo \<rjl@hyperbo.la\>
+    /// ```
     fn ruby_copyright(&self) -> &str;
 
     /// A description of the current build.
@@ -24,7 +26,9 @@ pub trait ReleaseMetadata {
     ///
     /// # Examples
     ///
-    /// > artichoke 0.1.0-pre.0 (2021-01-12 revision 4009) [x86_64-apple-darwin]
+    /// ```text
+    /// artichoke 0.1.0-pre.0 (2021-01-12 revision 4009) [x86_64-apple-darwin]
+    /// ```
     fn ruby_description(&self) -> &str;
 
     /// The engine, or VM, used in the current build.
@@ -33,7 +37,9 @@ pub trait ReleaseMetadata {
     ///
     /// # Examples
     ///
-    /// > artichoke-mruby
+    /// ```text
+    /// artichoke-mruby
+    /// ```
     fn ruby_engine(&self) -> &str;
 
     /// The version of the engine, or VM, used in the current build.
@@ -42,7 +48,9 @@ pub trait ReleaseMetadata {
     ///
     /// # Examples
     ///
-    /// > 0.1.0-pre.0
+    /// ```text
+    /// 0.1.0-pre.0
+    /// ```
     fn ruby_engine_version(&self) -> &str;
 
     /// The patch level the current build.
@@ -51,7 +59,9 @@ pub trait ReleaseMetadata {
     ///
     /// # Examples
     ///
-    /// > 0
+    /// ```text
+    /// 0
+    /// ```
     fn ruby_patchlevel(&self) -> &str;
 
     /// The target triple of the platform this build targets.
@@ -62,7 +72,9 @@ pub trait ReleaseMetadata {
     ///
     /// # Examples
     ///
-    /// > x86_64-apple-darwin
+    /// ```text
+    /// x86_64-apple-darwin
+    /// ```
     ///
     /// [triple]: https://forge.rust-lang.org/release/platform-support.html
     fn ruby_platform(&self) -> &str;
@@ -73,7 +85,9 @@ pub trait ReleaseMetadata {
     ///
     /// # Examples
     ///
-    /// > 2021-01-12
+    /// ```text
+    /// 2021-01-12
+    /// ```
     fn ruby_release_date(&self) -> &str;
 
     /// The revision count of the Artichoke git repository used for this build.
@@ -82,7 +96,9 @@ pub trait ReleaseMetadata {
     ///
     /// # Examples
     ///
-    /// > 4009
+    /// ```text
+    /// 4009
+    /// ```
     fn ruby_revision(&self) -> &str;
 
     /// The target MRI Ruby version for this build.
@@ -91,7 +107,9 @@ pub trait ReleaseMetadata {
     ///
     /// # Examples
     ///
-    /// > 3.1.2
+    /// ```text
+    /// 3.1.2
+    /// ```
     fn ruby_version(&self) -> &str;
 
     /// A description of the compiler used to build Artichoke.
@@ -100,6 +118,8 @@ pub trait ReleaseMetadata {
     ///
     /// # Examples
     ///
-    /// > rustc 1.49.0 (e1884a8e3 2020-12-29) on x86_64-apple-darwin
+    /// ```text
+    /// rustc 1.49.0 (e1884a8e3 2020-12-29) on x86_64-apple-darwin
+    /// ```
     fn artichoke_compiler_version(&self) -> Option<&str>;
 }

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -29,7 +29,7 @@ dependencies = [
 
 [[package]]
 name = "artichoke-backend"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "artichoke-core",
  "artichoke-load-path",

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "artichoke-backend"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "artichoke-core",
  "artichoke-load-path",

--- a/src/ruby.rs
+++ b/src/ruby.rs
@@ -86,6 +86,9 @@ impl Args {
 
 /// Main entry point for Artichoke's version of the `ruby` CLI.
 ///
+/// This entry point handles allocating, intitializing, and closing an Artichoke
+/// interpreter.
+///
 /// # Errors
 ///
 /// If an exception is raised on the interpreter, then an error is returned.
@@ -100,12 +103,7 @@ where
     result
 }
 
-/// Main entry point for Artichoke's version of the `ruby` CLI.
-///
-/// # Errors
-///
-/// If an exception is raised on the interpreter, then an error is returned.
-pub fn entrypoint<R, W>(
+fn entrypoint<R, W>(
     interp: &mut Artichoke,
     args: Args,
     mut input: R,


### PR DESCRIPTION
- `extn` internals (trampolines, mruby glue) are private, which mirrors static linkage in MRI and mruby.
- Add crate-level docs for several modules.
- Add docs for `Error`.
- Implement `Array#<<`. Fixes https://github.com/artichoke/artichoke/issues/2114.
- Add docs to `release_metadata` module, types, and methods in `artichoke-backend`.
- Rework preludes in `artichoke-backend` to avoid glob re-exports.