### PR TITLE
Enable `cc` crate to build C sources in parallel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,6 +118,9 @@ name = "cc"
 version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
+dependencies = [
+ "jobserver",
+]
 
 [[package]]
 name = "cfg-if"
@@ -314,6 +317,15 @@ name = "io-lifetimes"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24c3f4eff5495aee4c0399d7b6a0dc2b6e81be84242ffbfcf253ebacccc1d0cb"
+
+[[package]]
+name = "jobserver"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af25a77299a7f711a01975c35a6a424eb6862092cc2d6c72c4ed6cbc56dfc1fa"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "js-sys"

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -43,7 +43,7 @@ spinoso-time = { version = "0.6.0", path = "../spinoso-time", features = ["tzrs"
 quickcheck = { version = "1.0.3", default-features = false }
 
 [build-dependencies]
-cc = "1.0.72"
+cc = { version = "1.0.72", features = ["parallel"] }
 
 [features]
 default = [

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -107,6 +107,9 @@ name = "cc"
 version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
+dependencies = [
+ "jobserver",
+]
 
 [[package]]
 name = "cfg-if"
@@ -142,6 +145,15 @@ name = "intaglio"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd49aef5b63b46af0844b99cea402c3063d9a052249265d322657d83cf464211"
+
+[[package]]
+name = "jobserver"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af25a77299a7f711a01975c35a6a424eb6862092cc2d6c72c4ed6cbc56dfc1fa"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "libc"

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -138,6 +138,9 @@ name = "cc"
 version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
+dependencies = [
+ "jobserver",
+]
 
 [[package]]
 name = "cfg-if"
@@ -275,6 +278,15 @@ name = "itoa"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
+
+[[package]]
+name = "jobserver"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af25a77299a7f711a01975c35a6a424eb6862092cc2d6c72c4ed6cbc56dfc1fa"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "lazy_static"


### PR DESCRIPTION
Enable the `parallel` feature on `cc` in artichoke-backend's build dependencies. This feature pulls in the `jobserver` crate and allows `cc` to drive parallelism by integrating with `cargo`'s jobserver.

This change reduces two long poles of the build:

- `onig_sys` build script: 5.8s -> 1.9s
- `artichoke-backend` build script: 6.9s -> 2.1s

After this change, neither of these crates are the long pole. After this change the next two longest poles are:

- Deep dependency tree from `onig_sys` build script -> `onig_sys` -> `onig` -> `spinoso-regexp`.
- `tzdb` (5.4s) -> `spinoso-time`.

`artichoke-backend` itself also is a chunky crate, taking 6.5s to compile.

Followup to #2117 with some more goodness from `cargo build --timings`.