### PR TITLE
Remove some allocations from spinoso-env

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -593,7 +593,7 @@ jobs:
           node-version: 16
 
       - name: Install npm
-        run: npm i -f npm@8.16.0
+        run: npm i -f -g npm@8.16.0
 
       - name: Lint and check formatting with clang-format
         run: npx github:artichoke/clang-format --check

--- a/artichoke-backend/src/extn/core/integer/mod.rs
+++ b/artichoke-backend/src/extn/core/integer/mod.rs
@@ -101,7 +101,7 @@ impl Integer {
         if let Some(encoding) = encoding {
             let mut message = b"encoding parameter of Integer#chr (given ".to_vec();
             message.extend(encoding.inspect(interp));
-            message.extend(b") not supported");
+            message.extend_from_slice(b") not supported");
             Err(NotImplementedError::from(message).into())
         } else {
             // When no encoding is supplied, MRI assumes the encoding is

--- a/artichoke-backend/src/extn/core/regexp/pattern.rs
+++ b/artichoke-backend/src/extn/core/regexp/pattern.rs
@@ -37,8 +37,8 @@ where
     let hint = iter.size_hint();
     let modifiers = options.as_inline_modifier();
     let mut parsed = Vec::with_capacity(2 + modifiers.len() + 2 + hint.1.unwrap_or(hint.0));
-    parsed.extend(b"(?");
-    parsed.extend(modifiers.as_bytes());
+    parsed.extend_from_slice(b"(?");
+    parsed.extend_from_slice(modifiers.as_bytes());
     parsed.push(b':');
     parsed.extend(iter);
     parsed.push(b')');

--- a/spinoso-env/src/env/memory.rs
+++ b/spinoso-env/src/env/memory.rs
@@ -155,7 +155,7 @@ impl Memory {
             }
             if name.find_byte(b'=').is_some() {
                 let mut message = b"Invalid argument - setenv(".to_vec();
-                message.extend(name.to_vec());
+                message.extend_from_slice(name);
                 message.push(b')');
                 return Err(InvalidError::from(message).into());
             }

--- a/spinoso-env/src/env/system.rs
+++ b/spinoso-env/src/env/system.rs
@@ -195,7 +195,7 @@ impl System {
             }
             if name.find_byte(b'=').is_some() {
                 let mut message = b"Invalid argument - setenv(".to_vec();
-                message.extend(name.to_vec());
+                message.extend_from_slice(name);
                 message.push(b')');
                 return Err(InvalidError::from(message).into());
             }


### PR DESCRIPTION
Two error messages build a byte vec and have an unnecessary allocation when copying the name given to setenv.