### PR TITLE
Add Unicode-DFS-2016 as acceptable 3p license

### DIFF
--- a/generate-third-party/lib/generate_third_party/all_targets/about.toml
+++ b/generate-third-party/lib/generate_third_party/all_targets/about.toml
@@ -3,6 +3,7 @@ accepted = [
   "Apache-2.0",
   "Apache-2.0 WITH LLVM-exception",
   "BSL-1.0",
+  "Unicode-DFS-2016",
 ]
 targets = [
   "x86_64-unknown-linux-gnu",

--- a/generate-third-party/lib/generate_third_party/cargo_about.rb
+++ b/generate-third-party/lib/generate_third_party/cargo_about.rb
@@ -30,9 +30,10 @@ module Artichoke
           command = ['cargo', 'about', 'generate', @template, '--manifest-path', manifest_path, '--config', @config]
           out, err, status = Open3.capture3(command.shelljoin)
 
+          warn err unless err.strip.empty?
+
           unless status.success?
             warn 'Generate failed'
-            warn err
             exit 1
           end
 

--- a/generate-third-party/lib/generate_third_party/one_target/aarch64-apple-darwin/about.toml
+++ b/generate-third-party/lib/generate_third_party/one_target/aarch64-apple-darwin/about.toml
@@ -3,6 +3,7 @@ accepted = [
   "Apache-2.0",
   "Apache-2.0 WITH LLVM-exception",
   "BSL-1.0",
+  "Unicode-DFS-2016",
 ]
 targets = [
   "aarch64-apple-darwin",

--- a/generate-third-party/lib/generate_third_party/one_target/x86_64-apple-darwin/about.toml
+++ b/generate-third-party/lib/generate_third_party/one_target/x86_64-apple-darwin/about.toml
@@ -3,6 +3,7 @@ accepted = [
   "Apache-2.0",
   "Apache-2.0 WITH LLVM-exception",
   "BSL-1.0",
+  "Unicode-DFS-2016",
 ]
 targets = [
   "x86_64-apple-darwin",

--- a/generate-third-party/lib/generate_third_party/one_target/x86_64-pc-windows-msvc/about.toml
+++ b/generate-third-party/lib/generate_third_party/one_target/x86_64-pc-windows-msvc/about.toml
@@ -3,6 +3,7 @@ accepted = [
   "Apache-2.0",
   "Apache-2.0 WITH LLVM-exception",
   "BSL-1.0",
+  "Unicode-DFS-2016",
 ]
 targets = [
   "x86_64-pc-windows-msvc",

--- a/generate-third-party/lib/generate_third_party/one_target/x86_64-unknown-linux-gnu/about.toml
+++ b/generate-third-party/lib/generate_third_party/one_target/x86_64-unknown-linux-gnu/about.toml
@@ -3,6 +3,7 @@ accepted = [
   "Apache-2.0",
   "Apache-2.0 WITH LLVM-exception",
   "BSL-1.0",
+  "Unicode-DFS-2016",
 ]
 targets = [
   "x86_64-unknown-linux-gnu",

--- a/generate-third-party/lib/generate_third_party/one_target/x86_64-unknown-linux-musl/about.toml
+++ b/generate-third-party/lib/generate_third_party/one_target/x86_64-unknown-linux-musl/about.toml
@@ -3,6 +3,7 @@ accepted = [
   "Apache-2.0",
   "Apache-2.0 WITH LLVM-exception",
   "BSL-1.0",
+  "Unicode-DFS-2016",
 ]
 targets = [
   "x86_64-unknown-linux-musl",


### PR DESCRIPTION
The local `generate-third-party` gem invokes `cargo-about` to print license information. The `cargo-about` config requires an enumeration of acceptable licenses. This change was missed when upgrading focaccia to 1.2.0 in: 61fd5649c2a2c15f496fef7aaf7b8a8fe342828a.

Fixes CI failures in the nightly Docker builder: https://github.com/artichoke/docker-artichoke-nightly/runs/8165703828?check_suite_focus=true.