### PR TITLE
Upgrade to bstr 1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,11 +95,12 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bstr"
-version = "0.2.17"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
+checksum = "11aee792a41973cf54c837d6f344e35a03076328831b01ef30a14d965d47bfbc"
 dependencies = [
  "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -648,6 +649,12 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "serde"
+version = "1.0.144"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f747710de3dcd43b88c9168773254e809d8ddbdf9653b84e2554ab219f17860"
 
 [[package]]
 name = "simdutf8"

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["api-bindings"]
 [dependencies]
 artichoke-core = { version = "0.12.0", path = "../artichoke-core" }
 artichoke-load-path = { version = "0.1.0", path = "../artichoke-load-path", default-features = false }
-bstr = { version = "1.0.0", default-features = false, features = ["std"] }
+bstr = { version = "1.0.0", default-features = false, features = ["alloc"] }
 intaglio = { version = "1.7.0", default-features = false, features = ["bytes"] }
 once_cell = "1.12.0"
 onig = { version = "6.4.0", optional = true, default-features = false }

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["api-bindings"]
 [dependencies]
 artichoke-core = { version = "0.12.0", path = "../artichoke-core" }
 artichoke-load-path = { version = "0.1.0", path = "../artichoke-load-path", default-features = false }
-bstr = { version = "0.2.9", default-features = false, features = ["std"] }
+bstr = { version = "1.0.0", default-features = false, features = ["std"] }
 intaglio = { version = "1.7.0", default-features = false, features = ["bytes"] }
 once_cell = "1.12.0"
 onig = { version = "6.4.0", optional = true, default-features = false }

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -90,11 +90,12 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bstr"
-version = "0.2.17"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
+checksum = "11aee792a41973cf54c837d6f344e35a03076328831b01ef30a14d965d47bfbc"
 dependencies = [
  "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -313,6 +314,12 @@ version = "0.3.0"
 dependencies = [
  "bstr",
 ]
+
+[[package]]
+name = "serde"
+version = "1.0.144"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f747710de3dcd43b88c9168773254e809d8ddbdf9653b84e2554ab219f17860"
 
 [[package]]
 name = "simdutf8"

--- a/scolapasta-string-escape/Cargo.toml
+++ b/scolapasta-string-escape/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["artichoke", "escape", "no_std", "ruby"]
 categories = ["encoding", "no-std", "parser-implementations"]
 
 [dependencies]
-bstr = { version = "0.2.9", default-features = false }
+bstr = { version = "1.0.0", default-features = false }
 
 [features]
 default = ["std"]

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -121,11 +121,12 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "0.2.17"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
+checksum = "11aee792a41973cf54c837d6f344e35a03076328831b01ef30a14d965d47bfbc"
 dependencies = [
  "memchr",
+ "serde",
 ]
 
 [[package]]

--- a/spec-runner/Cargo.toml
+++ b/spec-runner/Cargo.toml
@@ -21,7 +21,7 @@ termcolor = "1.1.0"
 toml = { version = "0.5.8", default-features = false }
 
 [dev-dependencies]
-bstr = { version = "0.2.9", default-features = false }
+bstr = { version = "1.0.0", default-features = false }
 
 # `spec-runner` is a regression testing tool
 # Remove it from the main artichoke workspace.

--- a/spinoso-env/Cargo.toml
+++ b/spinoso-env/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["artichoke", "env", "environ", "spinoso"]
 categories = ["os", "wasm"]
 
 [dependencies]
-bstr = { version = "0.2.9", default-features = false }
+bstr = { version = "1.0.0", default-features = false }
 scolapasta-string-escape = { version = "0.3.0", path = "../scolapasta-string-escape", default-features = false }
 
 [features]

--- a/spinoso-regexp/Cargo.toml
+++ b/spinoso-regexp/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["data-structures", "parser-implementations"]
 
 [dependencies]
 bitflags = "1.3.0"
-bstr = { version = "1.0.0", default-features = false, features = ["std"] } # TODO: use `alloc` feature
+bstr = { version = "1.0.0", default-features = false, features = ["alloc"] }
 onig = { version = "6.4.0", optional = true, default-features = false }
 posix-space = "1.0.2"
 # Ensure the `regex` minimum version is at least 1.5.5 to pull in a fix for a

--- a/spinoso-regexp/Cargo.toml
+++ b/spinoso-regexp/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["data-structures", "parser-implementations"]
 
 [dependencies]
 bitflags = "1.3.0"
-bstr = { version = "0.2.9", default-features = false, features = ["std"] } # TODO: use `alloc` feature
+bstr = { version = "1.0.0", default-features = false, features = ["std"] } # TODO: use `alloc` feature
 onig = { version = "6.4.0", optional = true, default-features = false }
 posix-space = "1.0.2"
 # Ensure the `regex` minimum version is at least 1.5.5 to pull in a fix for a

--- a/spinoso-string/Cargo.toml
+++ b/spinoso-string/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["encoding", "no_std", "spinoso", "string", "utf8"]
 categories = ["data-structures", "encoding", "no-std"]
 
 [dependencies]
-bstr = { version = "0.2.9", default-features = false, features = ["std"] }
+bstr = { version = "1.0.0", default-features = false, features = ["std"] }
 bytecount = "0.6.2"
 focaccia = { version = "1.2.0", optional = true, default-features = false }
 raw-parts = "1.1.2"

--- a/spinoso-string/Cargo.toml
+++ b/spinoso-string/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["encoding", "no_std", "spinoso", "string", "utf8"]
 categories = ["data-structures", "encoding", "no-std"]
 
 [dependencies]
-bstr = { version = "1.0.0", default-features = false, features = ["std"] }
+bstr = { version = "1.0.0", default-features = false, features = ["alloc"] }
 bytecount = "0.6.2"
 focaccia = { version = "1.2.0", optional = true, default-features = false }
 raw-parts = "1.1.2"

--- a/spinoso-symbol/Cargo.toml
+++ b/spinoso-symbol/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["data-structures", "no-std", "parser-implementations"]
 
 [dependencies]
 artichoke-core = { version = "0.12.0", path = "../artichoke-core", optional = true, default-features = false }
-bstr = { version = "0.2.9", optional = true, default-features = false }
+bstr = { version = "1.0.0", optional = true, default-features = false }
 focaccia = { version = "1.2.0", optional = true, default-features = false }
 qed = "1.3.0"
 scolapasta-string-escape = { version = "0.3.0", path = "../scolapasta-string-escape", optional = true, default-features = false }

--- a/ui-tests/Cargo.lock
+++ b/ui-tests/Cargo.lock
@@ -4,11 +4,12 @@ version = 3
 
 [[package]]
 name = "bstr"
-version = "0.2.17"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
+checksum = "11aee792a41973cf54c837d6f344e35a03076328831b01ef30a14d965d47bfbc"
 dependencies = [
  "memchr",
+ "serde",
 ]
 
 [[package]]

--- a/ui-tests/Cargo.toml
+++ b/ui-tests/Cargo.toml
@@ -8,7 +8,7 @@ rust-version = "1.63.0"
 license = "MIT"
 
 [dependencies]
-bstr = { version = "1.0.0", default-features = false, features = ["std"] }
+bstr = { version = "1.0.0", default-features = false, features = ["alloc"] }
 insta = { version = "1.19.0", features = ["toml"] }
 serde = "1.0.132"
 

--- a/ui-tests/Cargo.toml
+++ b/ui-tests/Cargo.toml
@@ -8,7 +8,7 @@ rust-version = "1.63.0"
 license = "MIT"
 
 [dependencies]
-bstr = { version = "0.2.17", default-features = false, features = ["std"] }
+bstr = { version = "1.0.0", default-features = false, features = ["std"] }
 insta = { version = "1.19.0", features = ["toml"] }
 serde = "1.0.132"
 


### PR DESCRIPTION
See:

- https://blog.burntsushi.net/bstr/#other-crates-that-support-byte-strings
- https://twitter.com/artichokeruby/status/1567691439609638915

`serde` appears in the lockfile despite being unused and not being built due to:

- https://github.com/BurntSushi/bstr/issues/130
- https://github.com/rust-lang/cargo/issues/10801

I am expecting to send a followup PR that drops the `std` feature from `bstr` dep in `spinoso-env` in favor of replacing it with `scolapasta-path`.