### PR TITLE
Replace `bstr/std` with `scolapasta-path` in `spinoso-env`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -688,6 +688,7 @@ name = "spinoso-env"
 version = "0.2.0"
 dependencies = [
  "bstr",
+ "scolapasta-path",
  "scolapasta-string-escape",
 ]
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -339,6 +339,7 @@ name = "spinoso-env"
 version = "0.2.0"
 dependencies = [
  "bstr",
+ "scolapasta-path",
  "scolapasta-string-escape",
 ]
 

--- a/scolapasta-path/Cargo.toml
+++ b/scolapasta-path/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/artichoke/artichoke"
 readme = "README.md"
 license = "MIT"
 keywords = ["filesystem", "path"]
-categories = ["filesystem"]
+categories = ["filesystem", "wasm"]
 
 [dependencies]
 

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -675,6 +675,7 @@ name = "spinoso-env"
 version = "0.2.0"
 dependencies = [
  "bstr",
+ "scolapasta-path",
  "scolapasta-string-escape",
 ]
 

--- a/spinoso-env/Cargo.toml
+++ b/spinoso-env/Cargo.toml
@@ -15,13 +15,14 @@ categories = ["os", "wasm"]
 
 [dependencies]
 bstr = { version = "1.0.0", default-features = false }
+scolapasta-path = { version = "0.3.0", path = "../scolapasta-path", optional = true }
 scolapasta-string-escape = { version = "0.3.0", path = "../scolapasta-string-escape", default-features = false }
 
 [features]
 default = ["system-env"]
 # Enable an `ENV` implementation that access the system environment via
 # `std::env::var_os`. These APIs enable Ruby to manipulate the host system.
-system-env = ["bstr/std"]
+system-env = ["dep:scolapasta-path"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/spinoso-env/src/lib.rs
+++ b/spinoso-env/src/lib.rs
@@ -66,13 +66,17 @@
 //! process:
 //!
 //! ```
+//! # #[cfg(feature = "system-env")]
 //! # use spinoso_env::System;
+//! # #[cfg(feature = "system-env")]
 //! const ENV: System = System::new();
+//! # #[cfg(feature = "system-env")]
 //! # fn example() -> Result<(), spinoso_env::Error> {
 //! ENV.put(b"RUBY", Some(b"Artichoke"))?;
 //! assert!(ENV.get(b"PATH")?.is_some());
 //! # Ok(())
 //! # }
+//! # #[cfg(feature = "system-env")]
 //! # example().unwrap()
 //! ```
 //!
@@ -91,7 +95,7 @@
 //! [`std::env`]: module@std::env
 
 // Ensure code blocks in `README.md` compile
-#[cfg(doctest)]
+#[cfg(all(doctest, feature = "system-env"))]
 #[doc = include_str!("../README.md")]
 mod readme {}
 
@@ -99,6 +103,8 @@ use core::fmt;
 use std::borrow::Cow;
 use std::error;
 
+#[cfg(feature = "system-env")]
+use scolapasta_path::ConvertBytesError;
 use scolapasta_string_escape::format_debug_escape_into;
 
 mod env;
@@ -136,6 +142,13 @@ pub enum Error {
     ///
     /// See [`InvalidError`].
     Invalid(InvalidError),
+}
+
+#[cfg(feature = "system-env")]
+impl From<ConvertBytesError> for Error {
+    fn from(err: ConvertBytesError) -> Self {
+        Self::Argument(err.into())
+    }
 }
 
 impl From<ArgumentError> for Error {
@@ -196,6 +209,13 @@ impl From<&'static str> for ArgumentError {
     #[inline]
     fn from(message: &'static str) -> Self {
         Self::with_message(message)
+    }
+}
+
+#[cfg(feature = "system-env")]
+impl From<ConvertBytesError> for ArgumentError {
+    fn from(_err: ConvertBytesError) -> Self {
+        Self::with_message("bytes could not be converted to a platform string")
     }
 }
 


### PR DESCRIPTION
The "system env" backend requires converting between bytes and platform strings. Previously this was done with routines which require the `bstr/std` feature. This feature is a bit heavy though ans the `OsString` specific bits are available in `scolapasta-path`.

This commit also includes changes to get `spinoso-env` to build and test with no default features.

Followup to https://github.com/artichoke/artichoke/pull/2173.