### PR TITLE
Refactor String#chop to use String#ends_with directly

### DIFF
--- a/spinoso-string/src/lib.rs
+++ b/spinoso-string/src/lib.rs
@@ -1544,7 +1544,7 @@ impl String {
         if self.is_empty() {
             return false;
         }
-        let bytes_to_remove = if self.inner.as_slice().ends_with(b"\r\n") {
+        let bytes_to_remove = if self.inner.ends_with(b"\r\n") {
             2
         } else if let Encoding::Utf8 = self.encoding() {
             let (ch, size) = bstr::decode_last_utf8(&self.as_slice());


### PR DESCRIPTION
Close #1721


The original discussion in https://github.com/artichoke/artichoke/pull/1678#discussion_r816221491 seems like `String#ends_with` was not exist back then, but it actually [does exist here](https://github.com/b-n/artichoke/blob/b5ca546d817081cc3e1087322b3f98317ac7f78f/spinoso-string/src/enc/mod.rs#L503-L511). Please let me know if I misunderstand #1721.