### PR TITLE
Update spec-runner binary to clap v4

### DIFF
--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -78,6 +78,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -152,22 +163,22 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "3.2.20"
+version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b71c3ce99b7611011217b366d923f1d0a7e07a92bb2dbf1e84508c673ca3bd"
+checksum = "31c9484ccdc4cb8e7b117cbd0eb150c7c0f04464854e4679aeb50ef03b32d003"
 dependencies = [
+ "atty",
  "bitflags",
  "clap_lex",
- "indexmap",
  "strsim",
- "textwrap",
+ "termcolor",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.2.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
 dependencies = [
  "os_str_bytes",
 ]
@@ -245,19 +256,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d"
 
 [[package]]
-name = "hashbrown"
-version = "0.12.3"
+name = "hermit-abi"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
-name = "indexmap"
-version = "1.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
- "autocfg",
- "hashbrown",
+ "libc",
 ]
 
 [[package]]
@@ -791,12 +795,6 @@ checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
 ]
-
-[[package]]
-name = "textwrap"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thousands"

--- a/spec-runner/Cargo.toml
+++ b/spec-runner/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["development-tools::testing"]
 
 [dependencies]
 artichoke = { version = "0.1.0-pre.0", path = "..", default-features = false, features = ["backtrace", "kitchen-sink"] }
-clap = { version = "3.2.5", default-features = false, features = ["std", "suggestions"] }
+clap = "4.0.2"
 dhat = { version = "0.3.0", optional = true }
 rust-embed = "6.3.0"
 serde = { version = "1.0.136", features = ["derive"] }

--- a/spec-runner/README.md
+++ b/spec-runner/README.md
@@ -46,22 +46,19 @@ skip = ["parse"]
 ## Usage
 
 ```console
-$ cargo run -q -p spec-runner -- --help
-spec-runner 0.6.1
+$ cargo run -q -- --help
 ruby/spec runner for Artichoke.
 
-USAGE:
-    spec-runner [OPTIONS] [config]
+Usage: spec-runner [OPTIONS] [config]
 
-ARGS:
-    <config>    Path to TOML config file
+Arguments:
+  [config]  Path to TOML config file
 
-OPTIONS:
-    -f, --format <formatter>    Choose an output formatter [default: artichoke] [possible values:
-                                artichoke, summary, tagger, yaml]
-    -h, --help                  Print help information
-    -q, --quiet                 Suppress spec failures when exiting
-    -V, --version               Print version information
+Options:
+  -f, --format <formatter>  Choose an output formatter [default: artichoke] [possible values: artichoke, summary, tagger, yaml]
+  -q, --quiet               Suppress spec failures when exiting
+  -h, --help                Print help information
+  -V, --version             Print version information
 ```
 
 ## Profiling

--- a/spec-runner/src/mspec.rs
+++ b/spec-runner/src/mspec.rs
@@ -5,6 +5,7 @@ use std::str::FromStr;
 
 use artichoke::backend::load_path::RUBY_LOAD_PATH;
 use artichoke::prelude::*;
+use rust_embed::RustEmbed;
 
 /// Load `MSpec` sources into the Artichoke virtual file system.
 ///

--- a/spec-runner/src/rubyspec.rs
+++ b/spec-runner/src/rubyspec.rs
@@ -1,6 +1,7 @@
 //! Embedded copy of ruby/spec suites.
 
 use artichoke::prelude::*;
+use rust_embed::RustEmbed;
 
 /// Load ruby/spec sources into the Artichoke virtual file system.
 ///


### PR DESCRIPTION
https://epage.github.io/blog/2022/09/clap4/