### PR TITLE
Ensure `Time#at` only takes symbol based subsec_types

### DIFF
--- a/artichoke-backend/src/extn/core/time/subsec.rs
+++ b/artichoke-backend/src/extn/core/time/subsec.rs
@@ -44,20 +44,21 @@ impl TryConvertMut<Option<Value>, SubsecMultiplier> for Artichoke {
     type Error = Error;
 
     fn try_convert_mut(&mut self, subsec_type: Option<Value>) -> Result<SubsecMultiplier, Self::Error> {
-        if let Some(mut subsec_type) = subsec_type {
-            let subsec_symbol = unsafe { Symbol::unbox_from_value(&mut subsec_type, self)? }.bytes(self);
-            match subsec_symbol {
-                b"milliseconds" => Ok(SubsecMultiplier::Millis),
-                b"usec" => Ok(SubsecMultiplier::Micros),
-                b"nsec" => Ok(SubsecMultiplier::Nanos),
-                _ => {
-                    let mut message = b"unexpected unit: ".to_vec();
-                    message.extend_from_slice(subsec_symbol);
-                    Err(ArgumentError::from(message).into())
-                }
+        let mut subsec_type = match subsec_type {
+            Some(t) => t,
+            None => return Ok(SubsecMultiplier::Micros),
+        };
+
+        let subsec_symbol = unsafe { Symbol::unbox_from_value(&mut subsec_type, self)? }.bytes(self);
+        match subsec_symbol {
+            b"milliseconds" => Ok(SubsecMultiplier::Millis),
+            b"usec" => Ok(SubsecMultiplier::Micros),
+            b"nsec" => Ok(SubsecMultiplier::Nanos),
+            _ => {
+                let mut message = b"unexpected unit: ".to_vec();
+                message.extend_from_slice(subsec_symbol);
+                Err(ArgumentError::from(message).into())
             }
-        } else {
-            Ok(SubsecMultiplier::Micros)
         }
     }
 }

--- a/artichoke-backend/src/extn/core/time/subsec.rs
+++ b/artichoke-backend/src/extn/core/time/subsec.rs
@@ -572,4 +572,43 @@ mod tests {
             b"unexpected unit: bad_unit".as_slice().as_bstr()
         );
     }
+
+    #[test]
+    fn subsec_unit_non_symbol() {
+        let mut interp = interpreter();
+
+        let err = subsec(&mut interp, (Some(b"1"), Some(b":bad_unit"))).unwrap_err();
+
+        assert_eq!(err.name(), "ArgumentError");
+        assert_eq!(
+            err.message().as_bstr(),
+            b"unexpected unit: bad_unit".as_slice().as_bstr()
+        );
+
+        let err = subsec(&mut interp, (Some(b"1"), Some(b"1"))).unwrap_err();
+
+        assert_eq!(err.name(), "ArgumentError");
+        assert_eq!(err.message().as_bstr(), b"unexpected unit: 1".as_slice().as_bstr());
+
+        let err = subsec(&mut interp, (Some(b"1"), Some(b"Object.new"))).unwrap_err();
+
+        assert_eq!(err.name(), "ArgumentError");
+        assert!(err
+            .message()
+            .as_bstr()
+            .starts_with(b"unexpected unit: #<Object:".as_slice().as_bstr()));
+    }
+
+    #[test]
+    fn subsec_unit_requires_explicit_symbol() {
+        let mut interp = interpreter();
+
+        let err = subsec(&mut interp, (Some(b"1"), Some(b"class A; def to_sym; :usec; end; end && A.new"))).unwrap_err();
+
+        assert_eq!(err.name(), "ArgumentError");
+        assert!(err
+            .message()
+            .as_bstr()
+            .starts_with(b"unexpected unit: #<A:".as_slice().as_bstr()));
+    }
 }


### PR DESCRIPTION
Fixes #2095 

This also implements the same match guard clauses as seen in #2217. Really easy to change to the other way.

I'm not entirely sure whether it makes sense to test that this fails, but the tests is there at least (e.g. I threw a test for `Object.new` which should be enough, so I think testing for this situation below isn't entirely necessary)

```console
[3.1.2] > class A; def to_sym; :usec; end; end
=> :to_sym
[3.1.2] > Time.at(1, 1, A.new)
<internal:timev>:274:in `at': unexpected unit: #<A:0x00007f66207eb430> (ArgumentError)
	from (irb):29:in `<main>'                                                          
	from /home/ben/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/irb-1.4.1/exe/irb:11:in `<top (required)>'
	from /home/ben/.rbenv/versions/3.1.2/bin/irb:25:in `load'                          
	from /home/ben/.rbenv/versions/3.1.2/bin/irb:25:in `<main>'  
```