### PR TITLE
Add Rust implementation of start_with? and end_with?

### DIFF
--- a/artichoke-backend/src/extn/core/string/mod.rs
+++ b/artichoke-backend/src/extn/core/string/mod.rs
@@ -179,6 +179,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "core-regexp")]
     fn start_with_regex() {
         let mut interp = interpreter();
         // Test that regexp matching using start_with? clear the relevant regexp globals

--- a/artichoke-backend/src/extn/core/string/mod.rs
+++ b/artichoke-backend/src/extn/core/string/mod.rs
@@ -183,11 +183,11 @@ mod tests {
         let mut interp = interpreter();
         // Test that regexp matching using start_with? clear the relevant regexp globals
         // This is not tested in the vendored MRI version hence why it is tested here
-        let test = "
-            raise 'start_with? gives incorrect result' unless 'abcd test-123'.start_with?(/test-(\\d+)/) == false;
+        let test = r#"
+            raise 'start_with? gives incorrect result' unless 'abcd test-123'.start_with?(/test-(\d+)/) == false;
             raise 'start_with? should clear Regexp.last_match' unless Regexp.last_match == nil
             raise 'start_with? should clear $1' unless $1 == nil
-        ";
+        "#;
         let result = interp.eval(test.as_bytes());
         unwrap_or_panic_with_backtrace(&mut interp, SUBJECT, result);
     }

--- a/artichoke-backend/src/extn/core/string/mod.rs
+++ b/artichoke-backend/src/extn/core/string/mod.rs
@@ -177,4 +177,18 @@ mod tests {
         let result = interp.eval(test.as_bytes());
         unwrap_or_panic_with_backtrace(&mut interp, SUBJECT, result);
     }
+
+    #[test]
+    fn start_with_regex() {
+        let mut interp = interpreter();
+        // Test that regexp matching using start_with? clear the relevant regexp globals
+        // This is not tested in the vendored MRI version hence why it is tested here
+        let test = "
+            raise 'start_with? gives incorrect result' unless 'abcd test-123'.start_with?(/test-(\\d+)/) == false;
+            raise 'start_with? should clear Regexp.last_match' unless Regexp.last_match == nil
+            raise 'start_with? should clear $1' unless $1 == nil
+        ";
+        let result = interp.eval(test.as_bytes());
+        unwrap_or_panic_with_backtrace(&mut interp, SUBJECT, result);
+    }
 }

--- a/artichoke-backend/src/extn/core/string/mruby.rs
+++ b/artichoke-backend/src/extn/core/string/mruby.rs
@@ -448,7 +448,7 @@ unsafe extern "C" fn string_end_with(mrb: *mut sys::mrb_state, slf: sys::mrb_val
     let suffixes = suffixes.iter().map(|&other| Value::from(other));
     let result = trampoline::end_with(&mut guard, value, suffixes);
     match result {
-        Ok(result) => return result.inner(),
+        Ok(result) => result.inner(),
         Err(exception) => error::raise(guard, exception),
     }
 }
@@ -682,7 +682,7 @@ unsafe extern "C" fn string_start_with(mrb: *mut sys::mrb_state, slf: sys::mrb_v
     let prefixes = prefixes.iter().map(|&other| Value::from(other));
     let result = trampoline::start_with(&mut guard, value, prefixes);
     match result {
-        Ok(result) => return result.inner(),
+        Ok(result) => result.inner(),
         Err(exception) => error::raise(guard, exception),
     }
 }

--- a/artichoke-backend/src/extn/core/string/mruby.rs
+++ b/artichoke-backend/src/extn/core/string/mruby.rs
@@ -442,18 +442,14 @@ unsafe extern "C" fn string_empty(mrb: *mut sys::mrb_state, slf: sys::mrb_value)
 }
 
 unsafe extern "C" fn string_end_with(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
-    let prefixes = mrb_get_args!(mrb, *args);
+    let suffixes = mrb_get_args!(mrb, *args);
     unwrap_interpreter!(mrb, to => guard);
     let value = Value::from(slf);
-
-    for prefix in prefixes.iter().map(|&other| Value::from(other)) {
-        match trampoline::end_with(&mut guard, value, prefix) {
-            Ok(true) => return guard.convert(true).inner(),
-            Ok(false) => {}
-            Err(exception) => error::raise(guard, exception),
-        }
+    let suffixes = suffixes.iter().map(|&other| Value::from(other));
+    match trampoline::end_with(&mut guard, value, suffixes) {
+        Ok(result) => return result.inner(),
+        Err(exception) => error::raise(guard, exception),
     }
-    guard.convert(false).inner()
 }
 
 unsafe extern "C" fn string_eql(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
@@ -682,15 +678,11 @@ unsafe extern "C" fn string_start_with(mrb: *mut sys::mrb_state, slf: sys::mrb_v
     let prefixes = mrb_get_args!(mrb, *args);
     unwrap_interpreter!(mrb, to => guard);
     let value = Value::from(slf);
-
-    for prefix in prefixes.iter().map(|&other| Value::from(other)) {
-        match trampoline::start_with(&mut guard, value, prefix) {
-            Ok(true) => return guard.convert(true).inner(),
-            Ok(false) => {}
-            Err(exception) => error::raise(guard, exception),
-        }
+    let prefixes = prefixes.iter().map(|&other| Value::from(other));
+    match trampoline::start_with(&mut guard, value, prefixes) {
+        Ok(result) => return result.inner(),
+        Err(exception) => error::raise(guard, exception),
     }
-    guard.convert(false).inner()
 }
 
 unsafe extern "C" fn string_to_f(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {

--- a/artichoke-backend/src/extn/core/string/mruby.rs
+++ b/artichoke-backend/src/extn/core/string/mruby.rs
@@ -447,7 +447,7 @@ unsafe extern "C" fn string_end_with(mrb: *mut sys::mrb_state, slf: sys::mrb_val
     let value = Value::from(slf);
     let suffixes = suffixes.iter().map(|&other| Value::from(other));
     match trampoline::end_with(&mut guard, value, suffixes) {
-        Ok(result) => return result.inner(),
+        Ok(result) => result.inner(),
         Err(exception) => error::raise(guard, exception),
     }
 }
@@ -680,7 +680,7 @@ unsafe extern "C" fn string_start_with(mrb: *mut sys::mrb_state, slf: sys::mrb_v
     let value = Value::from(slf);
     let prefixes = prefixes.iter().map(|&other| Value::from(other));
     match trampoline::start_with(&mut guard, value, prefixes) {
-        Ok(result) => return result.inner(),
+        Ok(result) => result.inner(),
         Err(exception) => error::raise(guard, exception),
     }
 }

--- a/artichoke-backend/src/extn/core/string/mruby.rs
+++ b/artichoke-backend/src/extn/core/string/mruby.rs
@@ -446,8 +446,9 @@ unsafe extern "C" fn string_end_with(mrb: *mut sys::mrb_state, slf: sys::mrb_val
     unwrap_interpreter!(mrb, to => guard);
     let value = Value::from(slf);
     let suffixes = suffixes.iter().map(|&other| Value::from(other));
-    match trampoline::end_with(&mut guard, value, suffixes) {
-        Ok(result) => result.inner(),
+    let result = trampoline::end_with(&mut guard, value, suffixes);
+    match result {
+        Ok(result) => return result.inner(),
         Err(exception) => error::raise(guard, exception),
     }
 }
@@ -679,8 +680,9 @@ unsafe extern "C" fn string_start_with(mrb: *mut sys::mrb_state, slf: sys::mrb_v
     unwrap_interpreter!(mrb, to => guard);
     let value = Value::from(slf);
     let prefixes = prefixes.iter().map(|&other| Value::from(other));
-    match trampoline::start_with(&mut guard, value, prefixes) {
-        Ok(result) => result.inner(),
+    let result = trampoline::start_with(&mut guard, value, prefixes);
+    match result {
+        Ok(result) => return result.inner(),
         Err(exception) => error::raise(guard, exception),
     }
 }

--- a/artichoke-backend/src/extn/core/string/string.rb
+++ b/artichoke-backend/src/extn/core/string/string.rb
@@ -574,25 +574,10 @@ class String
   end
 
   # https://ruby-doc.org/core-3.0.2/String.html#method-i-end_with-3F
-  def end_with?(*suffixes)
-    suffixes.each do |suffix|
-      case suffix
-      when String
-        return true if suffix.empty?
-        return true if self[-suffix.length..-1] == suffix
-      when Regexp
-        m = suffix.match(self)
-        next if m.nil?
-
-        return true if m.end(0) == length
-      else
-        suffix = Artichoke::String.implicit_conversion(suffix)
-        return true if suffix.empty?
-        return true if self[-suffix.length..-1] == suffix
-      end
-    end
-    false
-  end
+  #
+  # NOTE: Implemented in native code.
+  #
+  # def end_with?; end
 
   # https://ruby-doc.org/core-3.0.2/String.html#method-i-eql-3F
   #
@@ -1036,23 +1021,10 @@ class String
   end
 
   # https://ruby-doc.org/core-3.0.2/String.html#method-i-start_with-3F
-  def start_with?(*prefixes)
-    prefixes.each do |prefix|
-      case prefix
-      when String
-        return true if self[0...prefix.length] == prefix
-      when Regexp
-        m = prefix.match(self)
-        next if m.nil?
-
-        return true if m.begin(0).zero?
-      else
-        prefix = Artichoke::String.implicit_conversion(prefix)
-        return true if self[0...prefix.length] == prefix
-      end
-    end
-    false
-  end
+  #
+  # NOTE: Implemented in native code.
+  #
+  # def start_with?; end
 
   # https://ruby-doc.org/core-3.0.2/String.html#method-i-strip
   def strip

--- a/artichoke-backend/src/extn/core/string/string_test.rb
+++ b/artichoke-backend/src/extn/core/string/string_test.rb
@@ -10,6 +10,7 @@ def spec
   string_unary_minus
   string_reverse
   string_tr
+  string_end_with
 
   true
 end
@@ -180,6 +181,23 @@ end
 
 def string_tr
   raise unless 'abcd'.tr('a-z', 'xxx') == 'xxxx'
+end
+
+def string_end_with
+  def assert_raise_type_error
+    begin
+      yield
+    rescue TypeError
+      return
+    else
+      raise
+    end
+  end
+
+  assert_raise_type_error { "abc".end_with?(/c/) }
+  assert_raise_type_error { "abc".end_with?('e', 'xyz', /c/) }
+
+  "abc".end_with?('e', 'bc', /c/)
 end
 
 spec if $PROGRAM_NAME == __FILE__

--- a/artichoke-backend/src/extn/core/string/string_test.rb
+++ b/artichoke-backend/src/extn/core/string/string_test.rb
@@ -185,19 +185,17 @@ end
 
 def string_end_with
   def assert_raise_type_error
-    begin
-      yield
-    rescue TypeError
-      return
-    else
-      raise
-    end
+    yield
+  rescue TypeError
+    nil
+  else
+    raise
   end
 
-  assert_raise_type_error { "abc".end_with?(/c/) }
-  assert_raise_type_error { "abc".end_with?('e', 'xyz', /c/) }
+  assert_raise_type_error { 'abc'.end_with?(/c/) }
+  assert_raise_type_error { 'abc'.end_with?('e', 'xyz', /c/) }
 
-  "abc".end_with?('e', 'bc', /c/)
+  'abc'.end_with?('e', 'bc', /c/)
 end
 
 spec if $PROGRAM_NAME == __FILE__

--- a/artichoke-backend/src/extn/core/string/string_test.rb
+++ b/artichoke-backend/src/extn/core/string/string_test.rb
@@ -183,15 +183,15 @@ def string_tr
   raise unless 'abcd'.tr('a-z', 'xxx') == 'xxxx'
 end
 
-def string_end_with
-  def assert_raise_type_error
-    yield
-  rescue TypeError
-    nil
-  else
-    raise
-  end
+def assert_raise_type_error
+  yield
+rescue TypeError
+  nil
+else
+  raise
+end
 
+def string_end_with
   assert_raise_type_error { 'abc'.end_with?(/c/) }
   assert_raise_type_error { 'abc'.end_with?('e', 'xyz', /c/) }
 

--- a/artichoke-backend/src/extn/core/string/trampoline.rs
+++ b/artichoke-backend/src/extn/core/string/trampoline.rs
@@ -1063,7 +1063,7 @@ pub fn end_with<T>(interp: &mut Artichoke, mut value: Value, suffixes: T) -> Res
 where
     T: IntoIterator<Item = Value>,
 {
-    for mut suffix in suffixes.into_iter() {
+    for mut suffix in suffixes {
         let s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
         // SAFETY: `s` used and discarded immediately  before any intervening operations on the VM.
         // This ensures there are no intervening garbage collections which may free the `RString*` that backs this value.
@@ -1494,7 +1494,7 @@ where
 {
     let s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
 
-    for mut prefix in prefixes.into_iter() {
+    for mut prefix in prefixes {
         if prefix.ruby_type() == Ruby::String {
             let needle = unsafe { super::String::unbox_from_value(&mut prefix, interp)? };
             if s.starts_with(needle.as_inner_ref()) {

--- a/artichoke-backend/src/extn/core/string/trampoline.rs
+++ b/artichoke-backend/src/extn/core/string/trampoline.rs
@@ -1059,12 +1059,20 @@ pub fn is_empty(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error
     Ok(interp.convert(s.is_empty()))
 }
 
-pub fn end_with(interp: &mut Artichoke, mut value: Value, mut prefix: Value) -> Result<bool, Error> {
-    let s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
-    // SAFETY: `s` used and discarded immediately  before any intervening operations on the VM.
-    // This ensures there are no intervening garbage collections which may free the `RString*` that backs this value.
-    let needle = unsafe { implicitly_convert_to_string(interp, &mut prefix)? };
-    Ok(s.ends_with(needle))
+pub fn end_with<T>(interp: &mut Artichoke, mut value: Value, suffixes: T) -> Result<Value, Error>
+where
+    T: IntoIterator<Item = Value>,
+{
+    for mut suffix in suffixes.into_iter() {
+        let s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
+        // SAFETY: `s` used and discarded immediately  before any intervening operations on the VM.
+        // This ensures there are no intervening garbage collections which may free the `RString*` that backs this value.
+        let needle = unsafe { implicitly_convert_to_string(interp, &mut suffix)? };
+        if s.ends_with(needle) {
+            return Ok(interp.convert(true));
+        }
+    }
+    Ok(interp.convert(false))
 }
 
 pub fn eql(interp: &mut Artichoke, mut value: Value, mut other: Value) -> Result<Value, Error> {
@@ -1480,36 +1488,48 @@ pub fn split(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
     Err(NotImplementedError::new().into())
 }
 
-pub fn start_with(interp: &mut Artichoke, mut value: Value, mut prefix: Value) -> Result<bool, Error> {
+pub fn start_with<T>(interp: &mut Artichoke, mut value: Value, prefixes: T) -> Result<Value, Error>
+where
+    T: IntoIterator<Item = Value>,
+{
     let s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
-    if prefix.ruby_type() == Ruby::String {
-        let needle = unsafe { super::String::unbox_from_value(&mut prefix, interp)? };
-        Ok(s.starts_with(needle.as_inner_ref()))
-    } else {
-        #[cfg(feature = "core-regexp")]
-        if let Ok(regexp) = unsafe { Regexp::unbox_from_value(&mut prefix, interp) } {
-            let mut inner = regexp.inner().match_(interp, &s, None, None)?;
-            if inner.is_nil() {
-                return Ok(false);
+
+    for mut prefix in prefixes.into_iter() {
+        if prefix.ruby_type() == Ruby::String {
+            let needle = unsafe { super::String::unbox_from_value(&mut prefix, interp)? };
+            if s.starts_with(needle.as_inner_ref()) {
+                return Ok(interp.convert(true));
+            }
+        } else {
+            #[cfg(feature = "core-regexp")]
+            if let Ok(regexp) = unsafe { Regexp::unbox_from_value(&mut prefix, interp) } {
+                let mut inner = regexp.inner().match_(interp, &s, None, None)?;
+                if inner.is_nil() {
+                    continue;
+                }
+
+                let match_data = unsafe { MatchData::unbox_from_value(&mut inner, interp)? };
+                if match_data.begin(matchdata::Capture::GroupIndex(0))? == Some(0) {
+                    return Ok(interp.convert(true));
+                }
+
+                regexp::clear_capture_globals(interp)?;
+                interp.unset_global_variable(regexp::LAST_MATCH)?;
+                interp.unset_global_variable(regexp::STRING_LEFT_OF_MATCH)?;
+                interp.unset_global_variable(regexp::STRING_RIGHT_OF_MATCH)?;
+                continue;
             }
 
-            let match_data = unsafe { MatchData::unbox_from_value(&mut inner, interp)? };
-            if match_data.begin(matchdata::Capture::GroupIndex(0))? == Some(0) {
-                return Ok(true);
+            // SAFETY: `s` used and discarded immediately  before any intervening operations on the VM.
+            // This ensures there are no intervening garbage collections which may free the `RString*` that backs this value.
+            let needle = unsafe { implicitly_convert_to_string(interp, &mut prefix)? };
+            if s.starts_with(needle) {
+                return Ok(interp.convert(true));
             }
-
-            regexp::clear_capture_globals(interp)?;
-            interp.unset_global_variable(regexp::LAST_MATCH)?;
-            interp.unset_global_variable(regexp::STRING_LEFT_OF_MATCH)?;
-            interp.unset_global_variable(regexp::STRING_RIGHT_OF_MATCH)?;
-            return Ok(false);
         }
-
-        // SAFETY: `s` used and discarded immediately  before any intervening operations on the VM.
-        // This ensures there are no intervening garbage collections which may free the `RString*` that backs this value.
-        let needle = unsafe { implicitly_convert_to_string(interp, &mut prefix)? };
-        Ok(s.starts_with(needle))
     }
+
+    Ok(interp.convert(false))
 }
 
 pub fn to_f(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {

--- a/artichoke-backend/src/extn/core/string/trampoline.rs
+++ b/artichoke-backend/src/extn/core/string/trampoline.rs
@@ -1066,7 +1066,7 @@ where
     let s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
 
     for mut suffix in suffixes {
-        // SAFETY: `s` used and discarded immediately  before any intervening operations on the VM.
+        // SAFETY: `s` used and discarded immediately before any intervening operations on the VM.
         // This ensures there are no intervening garbage collections which may free the `RString*` that backs this value.
         let needle = unsafe { implicitly_convert_to_string(interp, &mut suffix)? };
         if s.ends_with(needle) {
@@ -1521,7 +1521,7 @@ where
                 continue;
             }
 
-            // SAFETY: `s` used and discarded immediately  before any intervening operations on the VM.
+            // SAFETY: `s` used and discarded immediately before any intervening operations on the VM.
             // This ensures there are no intervening garbage collections which may free the `RString*` that backs this value.
             let needle = unsafe { implicitly_convert_to_string(interp, &mut prefix)? };
             if s.starts_with(needle) {

--- a/artichoke-backend/src/extn/core/string/trampoline.rs
+++ b/artichoke-backend/src/extn/core/string/trampoline.rs
@@ -1063,8 +1063,9 @@ pub fn end_with<T>(interp: &mut Artichoke, mut value: Value, suffixes: T) -> Res
 where
     T: IntoIterator<Item = Value>,
 {
+    let s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
+
     for mut suffix in suffixes {
-        let s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
         // SAFETY: `s` used and discarded immediately  before any intervening operations on the VM.
         // This ensures there are no intervening garbage collections which may free the `RString*` that backs this value.
         let needle = unsafe { implicitly_convert_to_string(interp, &mut suffix)? };

--- a/artichoke-backend/src/extn/core/string/trampoline.rs
+++ b/artichoke-backend/src/extn/core/string/trampoline.rs
@@ -1492,16 +1492,17 @@ pub fn start_with(interp: &mut Artichoke, mut value: Value, mut prefix: Value) -
             if inner.is_nil() {
                 return Ok(false);
             }
+
             let match_data = unsafe { MatchData::unbox_from_value(&mut inner, interp)? };
-            if match_data.begin(matchdata::Capture::GroupIndex(0))? != Some(0) {
-                regexp::clear_capture_globals(interp)?;
-                interp.unset_global_variable(regexp::LAST_MATCH)?;
-                interp.unset_global_variable(regexp::STRING_LEFT_OF_MATCH)?;
-                interp.unset_global_variable(regexp::STRING_RIGHT_OF_MATCH)?;
-                return Ok(false);
-            } else {
+            if match_data.begin(matchdata::Capture::GroupIndex(0))? == Some(0) {
                 return Ok(true);
             }
+
+            regexp::clear_capture_globals(interp)?;
+            interp.unset_global_variable(regexp::LAST_MATCH)?;
+            interp.unset_global_variable(regexp::STRING_LEFT_OF_MATCH)?;
+            interp.unset_global_variable(regexp::STRING_RIGHT_OF_MATCH)?;
+            return Ok(false);
         }
 
         // SAFETY: `s` used and discarded immediately  before any intervening operations on the VM.


### PR DESCRIPTION
Adds Rust implementations for `String#start_with?` and `String#end_with?`

Also corrects some differences to MRI 3.1.2
 - `start_with?` clears regexp globals when it fails to match
 - `end_with?` doesn't understand regexp matching

Closes #2186