### PR TITLE
Format code in rustdoc examples

### DIFF
--- a/artichoke-backend/src/convert/implicit.rs
+++ b/artichoke-backend/src/convert/implicit.rs
@@ -39,7 +39,10 @@ use crate::Artichoke;
 /// let integer = interp.convert(17);
 /// let a = interp.eval(b"class A; def to_int; 3; end; end; A.new")?;
 ///
-/// assert!(matches!(implicitly_convert_to_int(&mut interp, integer), Ok(17)));
+/// assert!(matches!(
+///     implicitly_convert_to_int(&mut interp, integer),
+///     Ok(17)
+/// ));
 /// assert!(matches!(implicitly_convert_to_int(&mut interp, a), Ok(3)));
 ///
 /// // failed conversions
@@ -48,7 +51,8 @@ use crate::Artichoke;
 /// let c = interp.eval(b"class C; def to_int; nil; end; end; C.new")?;
 /// let d = interp.eval(b"class D; def to_int; 'not an integer'; end; end; D.new")?;
 /// let e = interp.eval(b"class E; def to_int; 3.2; end; end; E.new")?;
-/// let f = interp.eval(b"class F; def to_int; raise ArgumentError, 'not an integer'; end; end; F.new")?;
+/// let f = interp
+///     .eval(b"class F; def to_int; raise ArgumentError, 'not an integer'; end; end; F.new")?;
 ///
 /// assert!(implicitly_convert_to_int(&mut interp, nil).is_err());
 /// assert!(implicitly_convert_to_int(&mut interp, b).is_err());

--- a/artichoke-backend/src/extn/core/symbol/ffi.rs
+++ b/artichoke-backend/src/extn/core/symbol/ffi.rs
@@ -8,7 +8,7 @@ use crate::extn::prelude::*;
 
 // ```c
 // MRB_API mrb_sym mrb_intern(mrb_state*,const char*,size_t);
-//
+// ```
 #[no_mangle]
 unsafe extern "C" fn mrb_intern(mrb: *mut sys::mrb_state, name: *const c_char, len: usize) -> sys::mrb_sym {
     let bytes = slice::from_raw_parts(name.cast::<u8>(), len);

--- a/artichoke-backend/src/extn/core/time/trampoline.rs
+++ b/artichoke-backend/src/extn/core/time/trampoline.rs
@@ -485,9 +485,9 @@ fn strftime_with_encoding(
         // [3.1.2]> Time.now.strftime("%")
         // (irb):1:in `strftime': invalid format: % (ArgumentError)
         //      from (irb):1:in `<main>'
-        //	    from /home/ben/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/irb-1.4.1/exe/irb:11:in `<top (required)>'
-        //	    from /home/ben/.rbenv/versions/3.1.2/bin/irb:25:in `load'
-        //	    from /home/ben/.rbenv/versions/3.1.2/bin/irb:25:in `<main>'
+        // 	    from /home/ben/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/irb-1.4.1/exe/irb:11:in `<top (required)>'
+        // 	    from /home/ben/.rbenv/versions/3.1.2/bin/irb:25:in `load'
+        // 	    from /home/ben/.rbenv/versions/3.1.2/bin/irb:25:in `<main>'
         // ```
         //
         // Note: The errors which are re-thrown as RuntimeError include (but is

--- a/artichoke-load-path/src/rubylib.rs
+++ b/artichoke-load-path/src/rubylib.rs
@@ -51,7 +51,7 @@ use same_file::Handle;
 /// // directory.
 /// let fixed_loader = Rubylib::with_rubylib_and_cwd(
 ///     OsStr::new("/home/artichoke/src:/usr/share/artichoke:./_lib"),
-///     Path::new("/home/artichoke")
+///     Path::new("/home/artichoke"),
 /// )?;
 /// # Some(())
 /// # }

--- a/mezzaluna-feature-loader/src/loaded_features/mod.rs
+++ b/mezzaluna-feature-loader/src/loaded_features/mod.rs
@@ -235,6 +235,7 @@ impl<S> LoadedFeatures<S> {
     ///
     /// ```
     /// use std::collections::hash_map::RandomState;
+    ///
     /// use mezzaluna_feature_loader::{Feature, LoadedFeatures};
     ///
     /// let s = RandomState::new();
@@ -267,6 +268,7 @@ impl<S> LoadedFeatures<S> {
     ///
     /// ```
     /// use std::collections::hash_map::RandomState;
+    ///
     /// use mezzaluna_feature_loader::{Feature, LoadedFeatures};
     ///
     /// let s = RandomState::new();
@@ -286,6 +288,7 @@ impl<S> LoadedFeatures<S> {
     ///
     /// ```
     /// use std::collections::hash_map::RandomState;
+    ///
     /// use mezzaluna_feature_loader::LoadedFeatures;
     ///
     /// let s = RandomState::new();
@@ -341,7 +344,9 @@ where
     /// use mezzaluna_feature_loader::LoadedFeatures;
     ///
     /// let mut features = LoadedFeatures::new();
-    /// features.try_reserve(10).expect("why is this OOMing on 10 features?");
+    /// features
+    ///     .try_reserve(10)
+    ///     .expect("why is this OOMing on 10 features?");
     /// assert!(features.capacity() >= 10);
     /// ```
     pub fn try_reserve(&mut self, additional: usize) -> Result<(), TryReserveError> {

--- a/mezzaluna-feature-loader/src/loaders/disk.rs
+++ b/mezzaluna-feature-loader/src/loaders/disk.rs
@@ -36,8 +36,12 @@ use scolapasta_path::is_explicit_relative;
 /// // The relative path `./_lib` is resolved relative to the given working
 /// // directory.
 /// let fixed_loader = Disk::with_load_path_and_cwd(
-///     vec![PathBuf::from("/home/artichoke/src"), PathBuf::from("/usr/share/artichoke"), PathBuf::from("_lib")],
-///     Path::new("/home/artichoke")
+///     vec![
+///         PathBuf::from("/home/artichoke/src"),
+///         PathBuf::from("/usr/share/artichoke"),
+///         PathBuf::from("_lib"),
+///     ],
+///     Path::new("/home/artichoke"),
 /// )?;
 /// # Some(())
 /// # }
@@ -201,12 +205,20 @@ impl Disk {
     /// # use mezzaluna_feature_loader::loaders::Disk;
     /// # fn example() -> Option<()> {
     /// let loader = Disk::with_load_path_and_cwd(
-    ///     vec![PathBuf::from("/home/artichoke/src"), PathBuf::from("/usr/share/artichoke"), PathBuf::from("_lib")],
+    ///     vec![
+    ///         PathBuf::from("/home/artichoke/src"),
+    ///         PathBuf::from("/usr/share/artichoke"),
+    ///         PathBuf::from("_lib"),
+    ///     ],
     ///     Path::new("/home/artichoke"),
     /// )?;
     /// assert_eq!(
     ///     loader.load_path(),
-    ///     &[Path::new("/home/artichoke/src"), Path::new("/usr/share/artichoke"), Path::new("/home/artichoke/_lib")]
+    ///     &[
+    ///         Path::new("/home/artichoke/src"),
+    ///         Path::new("/usr/share/artichoke"),
+    ///         Path::new("/home/artichoke/_lib")
+    ///     ]
     /// );
     /// # Some(())
     /// # }
@@ -230,21 +242,31 @@ impl Disk {
     /// # use mezzaluna_feature_loader::loaders::Disk;
     /// # fn example() -> Option<()> {
     /// let mut loader = Disk::with_load_path_and_cwd(
-    ///     vec![PathBuf::from("/home/artichoke/src"), PathBuf::from("/usr/share/artichoke"), PathBuf::from("_lib")],
+    ///     vec![
+    ///         PathBuf::from("/home/artichoke/src"),
+    ///         PathBuf::from("/usr/share/artichoke"),
+    ///         PathBuf::from("_lib"),
+    ///     ],
     ///     Path::new("/home/artichoke"),
     /// )?;
     /// assert_eq!(
     ///     loader.load_path(),
-    ///     &[Path::new("/home/artichoke/src"), Path::new("/usr/share/artichoke"), Path::new("/home/artichoke/_lib")]
+    ///     &[
+    ///         Path::new("/home/artichoke/src"),
+    ///         Path::new("/usr/share/artichoke"),
+    ///         Path::new("/home/artichoke/_lib")
+    ///     ]
     /// );
     ///
-    /// let old_load_path = loader.set_load_path(
-    ///     vec![PathBuf::from("libpath")],
-    ///     Path::new("/home/app"),
-    /// );
+    /// let old_load_path =
+    ///     loader.set_load_path(vec![PathBuf::from("libpath")], Path::new("/home/app"));
     /// assert_eq!(
     ///     old_load_path,
-    ///     &[Path::new("/home/artichoke/src"), Path::new("/usr/share/artichoke"), Path::new("/home/artichoke/_lib")]
+    ///     &[
+    ///         Path::new("/home/artichoke/src"),
+    ///         Path::new("/usr/share/artichoke"),
+    ///         Path::new("/home/artichoke/_lib")
+    ///     ]
     /// );
     /// assert_eq!(loader.load_path(), [Path::new("/home/app/libpath")]);
     /// # Some(())

--- a/mezzaluna-feature-loader/src/loaders/memory.rs
+++ b/mezzaluna-feature-loader/src/loaders/memory.rs
@@ -114,7 +114,10 @@ impl Memory {
     /// # use mezzaluna_feature_loader::loaders::Memory;
     /// # fn example() -> Option<()> {
     /// let mut loader = Memory::new();
-    /// loader.put_file_bytes(PathBuf::from("strscan.rb"), b"class StringScanner; end".to_vec());
+    /// loader.put_file_bytes(
+    ///     PathBuf::from("strscan.rb"),
+    ///     b"class StringScanner; end".to_vec(),
+    /// );
     /// let content = loader.resolve_file(Path::new("strscan.rb"));
     /// assert_eq!(content, Some("class StringScanner; end".as_bytes()));
     /// # Some(())
@@ -201,7 +204,10 @@ impl Memory {
     /// # fn example() -> Option<()> {
     /// let loader = Memory::new();
     /// # #[cfg(not(windows))]
-    /// assert_eq!(loader.load_path(), Path::new("/artichoke/virtual_root/src/lib"));
+    /// assert_eq!(
+    ///     loader.load_path(),
+    ///     Path::new("/artichoke/virtual_root/src/lib")
+    /// );
     /// # Some(())
     /// # }
     /// # example().unwrap();
@@ -216,7 +222,10 @@ impl Memory {
     /// # fn example() -> Option<()> {
     /// let loader = Memory::new();
     /// # #[cfg(windows)]
-    /// assert_eq!(loader.load_path(), Path::new("c://artichoke/virtual_root/src/lib"));
+    /// assert_eq!(
+    ///     loader.load_path(),
+    ///     Path::new("c://artichoke/virtual_root/src/lib")
+    /// );
     /// # Some(())
     /// # }
     /// # example().unwrap();

--- a/mezzaluna-feature-loader/src/loaders/rubylib.rs
+++ b/mezzaluna-feature-loader/src/loaders/rubylib.rs
@@ -48,7 +48,7 @@ use same_file::Handle;
 /// // directory.
 /// let fixed_loader = Rubylib::with_rubylib_and_cwd(
 ///     OsStr::new("/home/artichoke/src:/usr/share/artichoke:./_lib"),
-///     Path::new("/home/artichoke")
+///     Path::new("/home/artichoke"),
 /// )?;
 /// # Some(())
 /// # }

--- a/scolapasta-path/src/paths.rs
+++ b/scolapasta-path/src/paths.rs
@@ -35,7 +35,10 @@ use windows as imp;
 /// # use std::path::Path;
 /// # use scolapasta_path::memory_loader_ruby_load_path;
 /// # #[cfg(windows)]
-/// assert_eq!(memory_loader_ruby_load_path(), Path::new("c:/artichoke/virtual_root/src/lib"));
+/// assert_eq!(
+///     memory_loader_ruby_load_path(),
+///     Path::new("c:/artichoke/virtual_root/src/lib")
+/// );
 /// ```
 ///
 /// On non-Windows systems:
@@ -44,7 +47,10 @@ use windows as imp;
 /// # use std::path::Path;
 /// # use scolapasta_path::memory_loader_ruby_load_path;
 /// # #[cfg(not(windows))]
-/// assert_eq!(memory_loader_ruby_load_path(), Path::new("/artichoke/virtual_root/src/lib"));
+/// assert_eq!(
+///     memory_loader_ruby_load_path(),
+///     Path::new("/artichoke/virtual_root/src/lib")
+/// );
 /// ```
 #[must_use]
 pub fn memory_loader_ruby_load_path() -> &'static Path {

--- a/scolapasta-path/src/platform_string.rs
+++ b/scolapasta-path/src/platform_string.rs
@@ -102,7 +102,10 @@ pub fn os_str_to_bytes(os_str: &OsStr) -> Result<&[u8], ConvertBytesError> {
 /// # use std::ffi::OsString;
 /// # use scolapasta_path::os_string_to_bytes;
 /// let platform_string: OsString = OsString::from("/etc/passwd");
-/// assert_eq!(os_string_to_bytes(platform_string), Ok(b"/etc/passwd".to_vec()));
+/// assert_eq!(
+///     os_string_to_bytes(platform_string),
+///     Ok(b"/etc/passwd".to_vec())
+/// );
 /// ```
 ///
 /// # Errors
@@ -140,7 +143,10 @@ impl ConvertBytesError {
     /// ```
     /// # use scolapasta_path::ConvertBytesError;
     /// const ERR: ConvertBytesError = ConvertBytesError::new();
-    /// assert_eq!(ERR.message(), "Could not convert between bytes and platform string");
+    /// assert_eq!(
+    ///     ERR.message(),
+    ///     "Could not convert between bytes and platform string"
+    /// );
     /// ```
     #[inline]
     #[must_use]
@@ -155,7 +161,10 @@ impl ConvertBytesError {
     /// ```
     /// # use scolapasta_path::ConvertBytesError;
     /// let err = ConvertBytesError::new();
-    /// assert_eq!(err.message(), "Could not convert between bytes and platform string");
+    /// assert_eq!(
+    ///     err.message(),
+    ///     "Could not convert between bytes and platform string"
+    /// );
     /// ```
     #[inline]
     #[must_use]

--- a/scolapasta-string-escape/src/literal.rs
+++ b/scolapasta-string-escape/src/literal.rs
@@ -394,7 +394,10 @@ impl ByteSequenceTooLongError {
     /// ```
     /// # use scolapasta_string_escape::ByteSequenceTooLongError;
     /// let err = ByteSequenceTooLongError::new();
-    /// assert_eq!(err.message(), "Invalid UTF-8 byte literal sequences can be at most three bytes long");
+    /// assert_eq!(
+    ///     err.message(),
+    ///     "Invalid UTF-8 byte literal sequences can be at most three bytes long"
+    /// );
     /// ```
     #[inline]
     #[must_use]

--- a/spinoso-array/src/array/smallvec/mod.rs
+++ b/spinoso-array/src/array/smallvec/mod.rs
@@ -94,7 +94,7 @@ impl<T> SmallArray<T> {
     /// # Examples
     ///
     /// ```
-    /// use spinoso_array::{INLINE_CAPACITY, SmallArray};
+    /// use spinoso_array::{SmallArray, INLINE_CAPACITY};
     /// let ary: SmallArray<i32> = SmallArray::new();
     /// assert!(ary.is_empty());
     /// assert_eq!(ary.capacity(), INLINE_CAPACITY);
@@ -143,7 +143,7 @@ impl<T> SmallArray<T> {
     /// # Examples
     ///
     /// ```
-    /// use spinoso_array::{INLINE_CAPACITY, SmallArray};
+    /// use spinoso_array::{SmallArray, INLINE_CAPACITY};
     /// let ary = SmallArray::assoc(0, 100);
     /// assert_eq!(ary.capacity(), INLINE_CAPACITY);
     /// assert_eq!(ary.len(), 2);
@@ -313,7 +313,7 @@ impl<T> SmallArray<T> {
     ///
     /// ```
     /// # use smallvec::SmallVec;
-    /// use spinoso_array::{INLINE_CAPACITY, SmallArray};
+    /// use spinoso_array::{SmallArray, INLINE_CAPACITY};
     /// let ary = SmallArray::from(&[1, 2, 4]);
     /// let vec: SmallVec<[i32; INLINE_CAPACITY]> = ary.into_inner();
     /// ```
@@ -370,7 +370,7 @@ impl<T> SmallArray<T> {
     /// # Examples
     ///
     /// ```
-    /// use spinoso_array::{INLINE_CAPACITY, SmallArray};
+    /// use spinoso_array::{SmallArray, INLINE_CAPACITY};
     /// let ary: SmallArray<i32> = SmallArray::with_capacity(1);
     /// assert_eq!(ary.capacity(), INLINE_CAPACITY);
     ///
@@ -997,7 +997,7 @@ where
     ///
     /// ```
     /// # use spinoso_array::SmallArray;
-    /// let mut ary = SmallArray::from(&[1, 2 ,4]);
+    /// let mut ary = SmallArray::from(&[1, 2, 4]);
     /// ary.set(1, 11);
     /// assert_eq!(ary, &[1, 11, 4]);
     /// ary.set(5, 263);

--- a/spinoso-array/src/array/tinyvec/mod.rs
+++ b/spinoso-array/src/array/tinyvec/mod.rs
@@ -102,7 +102,7 @@ where
     /// # Examples
     ///
     /// ```
-    /// use spinoso_array::{INLINE_CAPACITY, TinyArray};
+    /// use spinoso_array::{TinyArray, INLINE_CAPACITY};
     /// let ary: TinyArray<i32> = TinyArray::new();
     /// assert!(ary.is_empty());
     /// assert_eq!(ary.capacity(), INLINE_CAPACITY);
@@ -151,7 +151,7 @@ where
     /// # Examples
     ///
     /// ```
-    /// use spinoso_array::{INLINE_CAPACITY, TinyArray};
+    /// use spinoso_array::{TinyArray, INLINE_CAPACITY};
     /// let ary = TinyArray::assoc(0, 100);
     /// assert_eq!(ary.capacity(), INLINE_CAPACITY);
     /// assert_eq!(ary.len(), 2);
@@ -298,7 +298,7 @@ where
     ///
     /// ```
     /// # use tinyvec::TinyVec;
-    /// use spinoso_array::{INLINE_CAPACITY, TinyArray};
+    /// use spinoso_array::{TinyArray, INLINE_CAPACITY};
     /// let ary = TinyArray::from(&[1, 2, 4]);
     /// let vec: TinyVec<[i32; INLINE_CAPACITY]> = ary.into_inner();
     /// ```
@@ -365,7 +365,7 @@ where
     /// # Examples
     ///
     /// ```
-    /// use spinoso_array::{INLINE_CAPACITY, TinyArray};
+    /// use spinoso_array::{TinyArray, INLINE_CAPACITY};
     /// let ary: TinyArray<i32> = TinyArray::with_capacity(1);
     /// assert_eq!(ary.capacity(), INLINE_CAPACITY);
     ///
@@ -1001,7 +1001,7 @@ where
     ///
     /// ```
     /// # use spinoso_array::TinyArray;
-    /// let mut ary = TinyArray::from(&[1, 2 ,4]);
+    /// let mut ary = TinyArray::from(&[1, 2, 4]);
     /// ary.set(1, 11);
     /// assert_eq!(ary, &[1, 11, 4]);
     /// ary.set(5, 263);

--- a/spinoso-array/src/array/vec/mod.rs
+++ b/spinoso-array/src/array/vec/mod.rs
@@ -1028,7 +1028,7 @@ where
     ///
     /// ```
     /// # use spinoso_array::Array;
-    /// let mut ary = Array::from(&[1, 2 ,4]);
+    /// let mut ary = Array::from(&[1, 2, 4]);
     /// ary.set(1, 11);
     /// assert_eq!(ary, &[1, 11, 4]);
     /// ary.set(5, 263);

--- a/spinoso-env/src/env/memory.rs
+++ b/spinoso-env/src/env/memory.rs
@@ -33,7 +33,10 @@ type Bytes = Vec<u8>;
 /// # fn example() -> Result<(), spinoso_env::Error> {
 /// let mut env = Memory::new();
 /// env.put(b"ENV_BACKEND", Some(b"spinoso_env::Memory"))?;
-/// assert_eq!(env.get(b"ENV_BACKEND")?.as_deref(), Some(&b"spinoso_env::Memory"[..]));
+/// assert_eq!(
+///     env.get(b"ENV_BACKEND")?.as_deref(),
+///     Some(&b"spinoso_env::Memory"[..])
+/// );
 /// # Ok(())
 /// # }
 /// # example().unwrap()

--- a/spinoso-env/src/env/system.rs
+++ b/spinoso-env/src/env/system.rs
@@ -40,7 +40,10 @@ type Bytes = Vec<u8>;
 /// const ENV: System = System::new();
 /// # fn example() -> Result<(), spinoso_env::Error> {
 /// ENV.put(b"ENV_BACKEND", Some(b"spinoso_env::System"))?;
-/// assert_eq!(std::env::var("ENV_BACKEND").as_deref(), Ok("spinoso_env::System"));
+/// assert_eq!(
+///     std::env::var("ENV_BACKEND").as_deref(),
+///     Ok("spinoso_env::System")
+/// );
 /// # Ok(())
 /// # }
 /// # example().unwrap()

--- a/spinoso-env/src/lib.rs
+++ b/spinoso-env/src/lib.rs
@@ -195,10 +195,11 @@ impl error::Error for Error {
 /// let err = ArgumentError::new();
 /// assert_eq!(err.message(), "ArgumentError");
 ///
-/// let err = ArgumentError::with_message(
+/// let err = ArgumentError::with_message("bad environment variable name: contains null byte");
+/// assert_eq!(
+///     err.message(),
 ///     "bad environment variable name: contains null byte"
 /// );
-/// assert_eq!(err.message(), "bad environment variable name: contains null byte");
 /// ```
 ///
 /// [Ruby `ArgumentError` Exception class]: https://ruby-doc.org/core-3.1.2/ArgumentError.html
@@ -257,10 +258,12 @@ impl ArgumentError {
     ///
     /// ```
     /// # use spinoso_env::ArgumentError;
-    /// const ERR: ArgumentError = ArgumentError::with_message(
+    /// const ERR: ArgumentError =
+    ///     ArgumentError::with_message("bad environment variable name: contains null byte");
+    /// assert_eq!(
+    ///     ERR.message(),
     ///     "bad environment variable name: contains null byte"
     /// );
-    /// assert_eq!(ERR.message(), "bad environment variable name: contains null byte");
     /// ```
     #[inline]
     #[must_use]
@@ -277,10 +280,11 @@ impl ArgumentError {
     /// let err = ArgumentError::new();
     /// assert_eq!(err.message(), "ArgumentError");
     ///
-    /// let err = ArgumentError::with_message(
+    /// let err = ArgumentError::with_message("bad environment variable name: contains null byte");
+    /// assert_eq!(
+    ///     err.message(),
     ///     "bad environment variable name: contains null byte"
     /// );
-    /// assert_eq!(err.message(), "bad environment variable name: contains null byte");
     /// ```
     #[inline]
     #[must_use]

--- a/spinoso-math/src/lib.rs
+++ b/spinoso-math/src/lib.rs
@@ -148,9 +148,12 @@ impl Error {
     /// assert_eq!(err.message(), "Math::DomainError");
     ///
     /// let err = Error::from(NotImplementedError::with_message(
-    ///     "Artichoke was not built with Math::erf support"
+    ///     "Artichoke was not built with Math::erf support",
     /// ));
-    /// assert_eq!(err.message(), "Artichoke was not built with Math::erf support");
+    /// assert_eq!(
+    ///     err.message(),
+    ///     "Artichoke was not built with Math::erf support"
+    /// );
     /// ```
     #[inline]
     #[must_use]
@@ -207,10 +210,11 @@ impl error::Error for Error {
 /// let err = DomainError::new();
 /// assert_eq!(err.message(), "Math::DomainError");
 ///
-/// let err = DomainError::with_message(
-///     r#"Numerical argument is out of domain - "acos""#,
+/// let err = DomainError::with_message(r#"Numerical argument is out of domain - "acos""#);
+/// assert_eq!(
+///     err.message(),
+///     r#"Numerical argument is out of domain - "acos""#
 /// );
-/// assert_eq!(err.message(), r#"Numerical argument is out of domain - "acos""#);
 /// ```
 ///
 /// [Ruby `Math::DomainError` Exception class]: https://ruby-doc.org/core-3.1.2/Math/DomainError.html
@@ -250,10 +254,12 @@ impl DomainError {
     ///
     /// ```
     /// # use spinoso_math::DomainError;
-    /// const ERR: DomainError = DomainError::with_message(
-    ///     r#"Numerical argument is out of domain - "acos""#,
+    /// const ERR: DomainError =
+    ///     DomainError::with_message(r#"Numerical argument is out of domain - "acos""#);
+    /// assert_eq!(
+    ///     ERR.message(),
+    ///     r#"Numerical argument is out of domain - "acos""#
     /// );
-    /// assert_eq!(ERR.message(), r#"Numerical argument is out of domain - "acos""#);
     /// ```
     #[inline]
     #[must_use]
@@ -270,10 +276,11 @@ impl DomainError {
     /// let err = DomainError::new();
     /// assert_eq!(err.message(), "Math::DomainError");
     ///
-    /// let err = DomainError::with_message(
-    ///     r#"Numerical argument is out of domain - "acos""#,
+    /// let err = DomainError::with_message(r#"Numerical argument is out of domain - "acos""#);
+    /// assert_eq!(
+    ///     err.message(),
+    ///     r#"Numerical argument is out of domain - "acos""#
     /// );
-    /// assert_eq!(err.message(), r#"Numerical argument is out of domain - "acos""#);
     /// ```
     #[inline]
     #[must_use]
@@ -308,10 +315,11 @@ impl error::Error for DomainError {}
 /// let err = NotImplementedError::new();
 /// assert_eq!(err.message(), "NotImplementedError");
 ///
-/// let err = NotImplementedError::with_message(
+/// let err = NotImplementedError::with_message("Artichoke was not built with Math::erf support");
+/// assert_eq!(
+///     err.message(),
 ///     "Artichoke was not built with Math::erf support"
 /// );
-/// assert_eq!(err.message(), "Artichoke was not built with Math::erf support");
 /// ```
 ///
 /// [Rust core library]: https://doc.rust-lang.org/std/primitive.f64.html
@@ -342,10 +350,12 @@ impl NotImplementedError {
     ///
     /// ```
     /// # use spinoso_math::NotImplementedError;
-    /// const ERR: NotImplementedError = NotImplementedError::with_message(
+    /// const ERR: NotImplementedError =
+    ///     NotImplementedError::with_message("Artichoke was not built with Math::erf support");
+    /// assert_eq!(
+    ///     ERR.message(),
     ///     "Artichoke was not built with Math::erf support"
     /// );
-    /// assert_eq!(ERR.message(), "Artichoke was not built with Math::erf support");
     /// ```
     #[inline]
     #[must_use]
@@ -363,10 +373,11 @@ impl NotImplementedError {
     /// let err = NotImplementedError::new();
     /// assert_eq!(err.message(), "NotImplementedError");
     ///
-    /// let err = NotImplementedError::with_message(
+    /// let err = NotImplementedError::with_message("Artichoke was not built with Math::erf support");
+    /// assert_eq!(
+    ///     err.message(),
     ///     "Artichoke was not built with Math::erf support"
     /// );
-    /// assert_eq!(err.message(), "Artichoke was not built with Math::erf support");
     /// ```
     #[inline]
     #[must_use]

--- a/spinoso-math/src/math.rs
+++ b/spinoso-math/src/math.rs
@@ -180,9 +180,17 @@ pub fn atan(value: f64) -> f64 {
 /// assert!((math::atan2(1.0, -1.0) - 2.356194490192345).abs() < f64::EPSILON);
 /// assert!((math::atan2(0.0, -1.0) - 3.141592653589793).abs() < f64::EPSILON);
 /// assert!((math::atan2(f64::INFINITY, f64::INFINITY) - 0.7853981633974483).abs() < f64::EPSILON);
-/// assert!((math::atan2(f64::INFINITY, f64::NEG_INFINITY) - 2.356194490192345).abs() < f64::EPSILON);
-/// assert!((math::atan2(f64::NEG_INFINITY, f64::INFINITY) - (-0.7853981633974483)).abs() < f64::EPSILON);
-/// assert!((math::atan2(f64::NEG_INFINITY, f64::NEG_INFINITY) - (-2.356194490192345)).abs() < f64::EPSILON);
+/// assert!(
+///     (math::atan2(f64::INFINITY, f64::NEG_INFINITY) - 2.356194490192345).abs() < f64::EPSILON
+/// );
+/// assert!(
+///     (math::atan2(f64::NEG_INFINITY, f64::INFINITY) - (-0.7853981633974483)).abs()
+///         < f64::EPSILON
+/// );
+/// assert!(
+///     (math::atan2(f64::NEG_INFINITY, f64::NEG_INFINITY) - (-2.356194490192345)).abs()
+///         < f64::EPSILON
+/// );
 /// ```
 #[inline]
 #[must_use]

--- a/spinoso-regexp/src/lib.rs
+++ b/spinoso-regexp/src/lib.rs
@@ -355,6 +355,7 @@ impl Config {
 ///
 /// ```
 /// use core::num::NonZeroUsize;
+///
 /// use spinoso_regexp::nth_match_group;
 ///
 /// # fn example() -> Option<()> {
@@ -418,6 +419,7 @@ pub fn nth_match_group(group: NonZeroUsize) -> Cow<'static, str> {
 ///
 /// ```
 /// use core::num::NonZeroUsize;
+///
 /// use spinoso_regexp::nth_match_group_bytes;
 ///
 /// # fn example() -> Option<()> {

--- a/spinoso-securerandom/src/lib.rs
+++ b/spinoso-securerandom/src/lib.rs
@@ -244,7 +244,8 @@ impl ArgumentError {
     ///
     /// ```
     /// # use spinoso_securerandom::ArgumentError;
-    /// const ERR: ArgumentError = ArgumentError::with_message("negative string size (or size too big)");
+    /// const ERR: ArgumentError =
+    ///     ArgumentError::with_message("negative string size (or size too big)");
     /// assert_eq!(ERR.message(), "negative string size (or size too big)");
     /// ```
     #[inline]

--- a/spinoso-string/src/center.rs
+++ b/spinoso-string/src/center.rs
@@ -84,8 +84,14 @@ impl std::error::Error for CenterError {}
 /// let s = String::from("hello");
 ///
 /// assert_eq!(s.center(4, None)?.collect::<Vec<_>>(), b"hello");
-/// assert_eq!(s.center(20, None)?.collect::<Vec<_>>(), b"       hello        ");
-/// assert_eq!(s.center(20, Some(&b"123"[..]))?.collect::<Vec<_>>(), b"1231231hello12312312");
+/// assert_eq!(
+///     s.center(20, None)?.collect::<Vec<_>>(),
+///     b"       hello        "
+/// );
+/// assert_eq!(
+///     s.center(20, Some(&b"123"[..]))?.collect::<Vec<_>>(),
+///     b"1231231hello12312312"
+/// );
 /// # Ok(())
 /// # }
 /// # example().unwrap();

--- a/spinoso-string/src/codepoints.rs
+++ b/spinoso-string/src/codepoints.rs
@@ -152,13 +152,22 @@ impl std::error::Error for InvalidCodepointError {}
 /// # fn example() -> Result<(), CodepointsError> {
 /// let s = String::from("hello");
 ///
-/// assert_eq!(s.codepoints()?.collect::<Vec<_>>(), [104, 101, 108, 108, 111]);
+/// assert_eq!(
+///     s.codepoints()?.collect::<Vec<_>>(),
+///     [104, 101, 108, 108, 111]
+/// );
 ///
 /// let s = String::utf8(b"abc\xFFxyz".to_vec());
-/// assert!(matches!(s.codepoints(), Err(CodepointsError::InvalidUtf8Codepoint)));
+/// assert!(matches!(
+///     s.codepoints(),
+///     Err(CodepointsError::InvalidUtf8Codepoint)
+/// ));
 ///
 /// let s = String::binary(b"abc\xFFxyz".to_vec());
-/// assert_eq!(s.codepoints()?.collect::<Vec<_>>(), [97, 98, 99, 255, 120, 121, 122]);
+/// assert_eq!(
+///     s.codepoints()?.collect::<Vec<_>>(),
+///     [97, 98, 99, 255, 120, 121, 122]
+/// );
 /// # Ok(())
 /// # }
 /// # example().unwrap();

--- a/spinoso-string/src/encoding.rs
+++ b/spinoso-string/src/encoding.rs
@@ -28,7 +28,10 @@ const BINARY_NAMES: &[&str] = &["ASCII-8BIT", "BINARY"];
 ///
 /// ```
 /// # use spinoso_string::{Encoding, InvalidEncodingError};
-/// assert_eq!(Encoding::try_from_flag(255), Err(InvalidEncodingError::new()));
+/// assert_eq!(
+///     Encoding::try_from_flag(255),
+///     Err(InvalidEncodingError::new())
+/// );
 /// assert_eq!(Encoding::try_from(255), Err(InvalidEncodingError::new()));
 /// ```
 ///
@@ -200,8 +203,14 @@ impl Encoding {
     /// assert_eq!(Encoding::try_from_flag(2), Ok(Encoding::Utf8));
     /// assert_eq!(Encoding::try_from_flag(4), Ok(Encoding::Ascii));
     /// assert_eq!(Encoding::try_from_flag(8), Ok(Encoding::Binary));
-    /// assert_eq!(Encoding::try_from_flag(2 | 4), Err(InvalidEncodingError::new()));
-    /// assert_eq!(Encoding::try_from_flag(255), Err(InvalidEncodingError::new()));
+    /// assert_eq!(
+    ///     Encoding::try_from_flag(2 | 4),
+    ///     Err(InvalidEncodingError::new())
+    /// );
+    /// assert_eq!(
+    ///     Encoding::try_from_flag(255),
+    ///     Err(InvalidEncodingError::new())
+    /// );
     /// ```
     ///
     /// [`to_flag`]: Self::to_flag
@@ -307,7 +316,10 @@ impl Encoding {
     /// ```
     /// # use spinoso_string::Encoding;
     /// assert_eq!(Encoding::Utf8.names(), ["UTF-8", "CP65001"]);
-    /// assert_eq!(Encoding::Ascii.names(), ["US-ASCII", "ASCII", "ANSI_X3.4-1968", "646"]);
+    /// assert_eq!(
+    ///     Encoding::Ascii.names(),
+    ///     ["US-ASCII", "ASCII", "ANSI_X3.4-1968", "646"]
+    /// );
     /// assert_eq!(Encoding::Binary.names(), ["ASCII-8BIT", "BINARY"]);
     /// ```
     ///

--- a/spinoso-string/src/lib.rs
+++ b/spinoso-string/src/lib.rs
@@ -1402,8 +1402,14 @@ impl String {
     /// let s = String::from("hello");
     ///
     /// assert_eq!(s.center(4, None)?.collect::<Vec<_>>(), b"hello");
-    /// assert_eq!(s.center(20, None)?.collect::<Vec<_>>(), b"       hello        ");
-    /// assert_eq!(s.center(20, Some(&b"123"[..]))?.collect::<Vec<_>>(), b"1231231hello12312312");
+    /// assert_eq!(
+    ///     s.center(20, None)?.collect::<Vec<_>>(),
+    ///     b"       hello        "
+    /// );
+    /// assert_eq!(
+    ///     s.center(20, Some(&b"123"[..]))?.collect::<Vec<_>>(),
+    ///     b"1231231hello12312312"
+    /// );
     /// # Ok(())
     /// # }
     /// # example().unwrap();
@@ -1730,6 +1736,7 @@ impl String {
     ///
     /// ```
     /// use core::str;
+    ///
     /// use spinoso_string::String;
     ///
     /// let s = String::utf8(b"ab\xF0\x9F\x92\x8E\xFF".to_vec());
@@ -1793,7 +1800,10 @@ impl String {
     ///
     /// # fn example() -> Result<(), spinoso_string::CodepointsError> {
     /// let s = String::utf8(b"ab\xF0\x9F\x92\x8E\xFF".to_vec());
-    /// assert!(matches!(s.codepoints(), Err(CodepointsError::InvalidUtf8Codepoint)));
+    /// assert!(matches!(
+    ///     s.codepoints(),
+    ///     Err(CodepointsError::InvalidUtf8Codepoint)
+    /// ));
     ///
     /// let s = String::utf8("💎".as_bytes().to_vec());
     /// let mut codepoints = s.codepoints()?;

--- a/spinoso-string/src/ord.rs
+++ b/spinoso-string/src/ord.rs
@@ -69,7 +69,10 @@ impl OrdError {
     /// ```
     /// # use spinoso_string::OrdError;
     ///
-    /// assert_eq!(OrdError::invalid_utf8_byte_sequence().message(), "invalid byte sequence in UTF-8");
+    /// assert_eq!(
+    ///     OrdError::invalid_utf8_byte_sequence().message(),
+    ///     "invalid byte sequence in UTF-8"
+    /// );
     /// assert_eq!(OrdError::empty_string().message(), "empty string");
     /// ```
     ///

--- a/spinoso-symbol/src/all_symbols.rs
+++ b/spinoso-symbol/src/all_symbols.rs
@@ -23,6 +23,7 @@ use crate::Symbol;
 /// # extern crate alloc;
 /// use alloc::borrow::Cow;
 /// use alloc::boxed::Box;
+///
 /// use artichoke_core::intern::Intern;
 /// use spinoso_symbol::{InternerAllSymbols, Symbol};
 ///
@@ -36,7 +37,7 @@ use crate::Symbol;
 ///
 ///     fn intern_bytes<T>(&mut self, symbol: T) -> Result<Self::Symbol, Self::Error>
 ///     where
-///         T: Into<Cow<'static, [u8]>>
+///         T: Into<Cow<'static, [u8]>>,
 ///     {
 ///         let boxed = Box::<[u8]>::from(symbol.into());
 ///         Box::leak(boxed);

--- a/spinoso-symbol/src/ident.rs
+++ b/spinoso-symbol/src/ident.rs
@@ -9,33 +9,60 @@
 //!
 //! ```
 //! # use spinoso_symbol::IdentifierType;
-//! assert_eq!("spinoso".parse::<IdentifierType>(), Ok(IdentifierType::Local));
-//! assert_eq!("spinoso_symbol_features".parse::<IdentifierType>(), Ok(IdentifierType::Local));
+//! assert_eq!(
+//!     "spinoso".parse::<IdentifierType>(),
+//!     Ok(IdentifierType::Local)
+//! );
+//! assert_eq!(
+//!     "spinoso_symbol_features".parse::<IdentifierType>(),
+//!     Ok(IdentifierType::Local)
+//! );
 //! ```
 //!
 //! # Examples – constant
 //!
 //! ```
 //! # use spinoso_symbol::IdentifierType;
-//! assert_eq!("Spinoso".parse::<IdentifierType>(), Ok(IdentifierType::Constant));
-//! assert_eq!("SpinosoSymbol".parse::<IdentifierType>(), Ok(IdentifierType::Constant));
-//! assert_eq!("SPINOSO_SYMBOL_FEATURES".parse::<IdentifierType>(), Ok(IdentifierType::Constant));
+//! assert_eq!(
+//!     "Spinoso".parse::<IdentifierType>(),
+//!     Ok(IdentifierType::Constant)
+//! );
+//! assert_eq!(
+//!     "SpinosoSymbol".parse::<IdentifierType>(),
+//!     Ok(IdentifierType::Constant)
+//! );
+//! assert_eq!(
+//!     "SPINOSO_SYMBOL_FEATURES".parse::<IdentifierType>(),
+//!     Ok(IdentifierType::Constant)
+//! );
 //! ```
 //!
 //! # Examples – global
 //!
 //! ```
 //! # use spinoso_symbol::IdentifierType;
-//! assert_eq!("$use_spinoso_symbol".parse::<IdentifierType>(), Ok(IdentifierType::Global));
-//! assert_eq!("$USE_SPINOSO_SYMBOL".parse::<IdentifierType>(), Ok(IdentifierType::Global));
+//! assert_eq!(
+//!     "$use_spinoso_symbol".parse::<IdentifierType>(),
+//!     Ok(IdentifierType::Global)
+//! );
+//! assert_eq!(
+//!     "$USE_SPINOSO_SYMBOL".parse::<IdentifierType>(),
+//!     Ok(IdentifierType::Global)
+//! );
 //! ```
 //!
 //! # Examples – instance and class variables
 //!
 //! ```
 //! # use spinoso_symbol::IdentifierType;
-//! assert_eq!("@artichoke".parse::<IdentifierType>(), Ok(IdentifierType::Instance));
-//! assert_eq!("@@rumble".parse::<IdentifierType>(), Ok(IdentifierType::Class));
+//! assert_eq!(
+//!     "@artichoke".parse::<IdentifierType>(),
+//!     Ok(IdentifierType::Instance)
+//! );
+//! assert_eq!(
+//!     "@@rumble".parse::<IdentifierType>(),
+//!     Ok(IdentifierType::Class)
+//! );
 //! ```
 //!
 //! # Example – attribute setter
@@ -44,8 +71,14 @@
 //!
 //! ```
 //! # use spinoso_symbol::IdentifierType;
-//! assert_eq!("artichoke=".parse::<IdentifierType>(), Ok(IdentifierType::AttrSet));
-//! assert_eq!("spinoso_symbol=".parse::<IdentifierType>(), Ok(IdentifierType::AttrSet));
+//! assert_eq!(
+//!     "artichoke=".parse::<IdentifierType>(),
+//!     Ok(IdentifierType::AttrSet)
+//! );
+//! assert_eq!(
+//!     "spinoso_symbol=".parse::<IdentifierType>(),
+//!     Ok(IdentifierType::AttrSet)
+//! );
 //! ```
 
 use core::fmt;
@@ -69,33 +102,60 @@ use bstr::ByteSlice;
 ///
 /// ```
 /// # use spinoso_symbol::IdentifierType;
-/// assert_eq!("spinoso".parse::<IdentifierType>(), Ok(IdentifierType::Local));
-/// assert_eq!("spinoso_symbol_features".parse::<IdentifierType>(), Ok(IdentifierType::Local));
+/// assert_eq!(
+///     "spinoso".parse::<IdentifierType>(),
+///     Ok(IdentifierType::Local)
+/// );
+/// assert_eq!(
+///     "spinoso_symbol_features".parse::<IdentifierType>(),
+///     Ok(IdentifierType::Local)
+/// );
 /// ```
 ///
 /// # Examples – constant
 ///
 /// ```
 /// # use spinoso_symbol::IdentifierType;
-/// assert_eq!("Spinoso".parse::<IdentifierType>(), Ok(IdentifierType::Constant));
-/// assert_eq!("SpinosoSymbol".parse::<IdentifierType>(), Ok(IdentifierType::Constant));
-/// assert_eq!("SPINOSO_SYMBOL_FEATURES".parse::<IdentifierType>(), Ok(IdentifierType::Constant));
+/// assert_eq!(
+///     "Spinoso".parse::<IdentifierType>(),
+///     Ok(IdentifierType::Constant)
+/// );
+/// assert_eq!(
+///     "SpinosoSymbol".parse::<IdentifierType>(),
+///     Ok(IdentifierType::Constant)
+/// );
+/// assert_eq!(
+///     "SPINOSO_SYMBOL_FEATURES".parse::<IdentifierType>(),
+///     Ok(IdentifierType::Constant)
+/// );
 /// ```
 ///
 /// # Examples – global
 ///
 /// ```
 /// # use spinoso_symbol::IdentifierType;
-/// assert_eq!("$use_spinoso_symbol".parse::<IdentifierType>(), Ok(IdentifierType::Global));
-/// assert_eq!("$USE_SPINOSO_SYMBOL".parse::<IdentifierType>(), Ok(IdentifierType::Global));
+/// assert_eq!(
+///     "$use_spinoso_symbol".parse::<IdentifierType>(),
+///     Ok(IdentifierType::Global)
+/// );
+/// assert_eq!(
+///     "$USE_SPINOSO_SYMBOL".parse::<IdentifierType>(),
+///     Ok(IdentifierType::Global)
+/// );
 /// ```
 ///
 /// # Examples – instance and class variables
 ///
 /// ```
 /// # use spinoso_symbol::IdentifierType;
-/// assert_eq!("@artichoke".parse::<IdentifierType>(), Ok(IdentifierType::Instance));
-/// assert_eq!("@@rumble".parse::<IdentifierType>(), Ok(IdentifierType::Class));
+/// assert_eq!(
+///     "@artichoke".parse::<IdentifierType>(),
+///     Ok(IdentifierType::Instance)
+/// );
+/// assert_eq!(
+///     "@@rumble".parse::<IdentifierType>(),
+///     Ok(IdentifierType::Class)
+/// );
 /// ```
 ///
 /// # Example – attribute setter
@@ -104,8 +164,14 @@ use bstr::ByteSlice;
 ///
 /// ```
 /// # use spinoso_symbol::IdentifierType;
-/// assert_eq!("artichoke=".parse::<IdentifierType>(), Ok(IdentifierType::AttrSet));
-/// assert_eq!("spinoso_symbol=".parse::<IdentifierType>(), Ok(IdentifierType::AttrSet));
+/// assert_eq!(
+///     "artichoke=".parse::<IdentifierType>(),
+///     Ok(IdentifierType::AttrSet)
+/// );
+/// assert_eq!(
+///     "spinoso_symbol=".parse::<IdentifierType>(),
+///     Ok(IdentifierType::AttrSet)
+/// );
 /// ```
 ///
 /// [`Inspect`]: crate::Inspect
@@ -122,7 +188,10 @@ pub enum IdentifierType {
     /// ```
     /// # use spinoso_symbol::IdentifierType;
     /// assert_eq!("empty?".parse::<IdentifierType>(), Ok(IdentifierType::Junk));
-    /// assert_eq!("flatten!".parse::<IdentifierType>(), Ok(IdentifierType::Junk));
+    /// assert_eq!(
+    ///     "flatten!".parse::<IdentifierType>(),
+    ///     Ok(IdentifierType::Junk)
+    /// );
     /// assert_eq!("<=>".parse::<IdentifierType>(), Ok(IdentifierType::Junk));
     /// assert_eq!("!~".parse::<IdentifierType>(), Ok(IdentifierType::Junk));
     /// assert_eq!("[]".parse::<IdentifierType>(), Ok(IdentifierType::Junk));
@@ -145,14 +214,23 @@ pub enum IdentifierType {
     ///
     /// ```
     /// # use spinoso_symbol::{IdentifierType, ParseIdentifierError};
-    /// assert_eq!("$".parse::<IdentifierType>(), Err(ParseIdentifierError::new()));
+    /// assert_eq!(
+    ///     "$".parse::<IdentifierType>(),
+    ///     Err(ParseIdentifierError::new())
+    /// );
     /// assert_eq!("$foo".parse::<IdentifierType>(), Ok(IdentifierType::Global));
-    /// assert_eq!("$@foo".parse::<IdentifierType>(), Err(ParseIdentifierError::new()));
+    /// assert_eq!(
+    ///     "$@foo".parse::<IdentifierType>(),
+    ///     Err(ParseIdentifierError::new())
+    /// );
     /// assert_eq!("$0".parse::<IdentifierType>(), Ok(IdentifierType::Global));
     /// assert_eq!("$1".parse::<IdentifierType>(), Ok(IdentifierType::Global));
     /// assert_eq!("$9".parse::<IdentifierType>(), Ok(IdentifierType::Global));
     /// assert_eq!("$-w".parse::<IdentifierType>(), Ok(IdentifierType::Global));
-    /// assert_eq!("$-www".parse::<IdentifierType>(), Err(ParseIdentifierError::new()));
+    /// assert_eq!(
+    ///     "$-www".parse::<IdentifierType>(),
+    ///     Err(ParseIdentifierError::new())
+    /// );
     /// ```
     Global,
     /// Identifier that is an instance variable name.
@@ -164,17 +242,50 @@ pub enum IdentifierType {
     ///
     /// ```
     /// # use spinoso_symbol::{IdentifierType, ParseIdentifierError};
-    /// assert_eq!("@".parse::<IdentifierType>(), Err(ParseIdentifierError::new()));
-    /// assert_eq!("@foo".parse::<IdentifierType>(), Ok(IdentifierType::Instance));
-    /// assert_eq!("@Foo".parse::<IdentifierType>(), Ok(IdentifierType::Instance));
-    /// assert_eq!("@FOO".parse::<IdentifierType>(), Ok(IdentifierType::Instance));
-    /// assert_eq!("@foo_bar".parse::<IdentifierType>(), Ok(IdentifierType::Instance));
-    /// assert_eq!("@FooBar".parse::<IdentifierType>(), Ok(IdentifierType::Instance));
-    /// assert_eq!("@FOO_BAR".parse::<IdentifierType>(), Ok(IdentifierType::Instance));
-    /// assert_eq!("@$foo".parse::<IdentifierType>(), Err(ParseIdentifierError::new()));
-    /// assert_eq!("@0".parse::<IdentifierType>(), Err(ParseIdentifierError::new()));
-    /// assert_eq!("@1".parse::<IdentifierType>(), Err(ParseIdentifierError::new()));
-    /// assert_eq!("@9".parse::<IdentifierType>(), Err(ParseIdentifierError::new()));
+    /// assert_eq!(
+    ///     "@".parse::<IdentifierType>(),
+    ///     Err(ParseIdentifierError::new())
+    /// );
+    /// assert_eq!(
+    ///     "@foo".parse::<IdentifierType>(),
+    ///     Ok(IdentifierType::Instance)
+    /// );
+    /// assert_eq!(
+    ///     "@Foo".parse::<IdentifierType>(),
+    ///     Ok(IdentifierType::Instance)
+    /// );
+    /// assert_eq!(
+    ///     "@FOO".parse::<IdentifierType>(),
+    ///     Ok(IdentifierType::Instance)
+    /// );
+    /// assert_eq!(
+    ///     "@foo_bar".parse::<IdentifierType>(),
+    ///     Ok(IdentifierType::Instance)
+    /// );
+    /// assert_eq!(
+    ///     "@FooBar".parse::<IdentifierType>(),
+    ///     Ok(IdentifierType::Instance)
+    /// );
+    /// assert_eq!(
+    ///     "@FOO_BAR".parse::<IdentifierType>(),
+    ///     Ok(IdentifierType::Instance)
+    /// );
+    /// assert_eq!(
+    ///     "@$foo".parse::<IdentifierType>(),
+    ///     Err(ParseIdentifierError::new())
+    /// );
+    /// assert_eq!(
+    ///     "@0".parse::<IdentifierType>(),
+    ///     Err(ParseIdentifierError::new())
+    /// );
+    /// assert_eq!(
+    ///     "@1".parse::<IdentifierType>(),
+    ///     Err(ParseIdentifierError::new())
+    /// );
+    /// assert_eq!(
+    ///     "@9".parse::<IdentifierType>(),
+    ///     Err(ParseIdentifierError::new())
+    /// );
     /// ```
     ///
     /// [`Constant`]: Self::Constant
@@ -189,17 +300,41 @@ pub enum IdentifierType {
     ///
     /// ```
     /// # use spinoso_symbol::{IdentifierType, ParseIdentifierError};
-    /// assert_eq!("@@".parse::<IdentifierType>(), Err(ParseIdentifierError::new()));
+    /// assert_eq!(
+    ///     "@@".parse::<IdentifierType>(),
+    ///     Err(ParseIdentifierError::new())
+    /// );
     /// assert_eq!("@@foo".parse::<IdentifierType>(), Ok(IdentifierType::Class));
     /// assert_eq!("@@Foo".parse::<IdentifierType>(), Ok(IdentifierType::Class));
     /// assert_eq!("@@FOO".parse::<IdentifierType>(), Ok(IdentifierType::Class));
-    /// assert_eq!("@@foo_bar".parse::<IdentifierType>(), Ok(IdentifierType::Class));
-    /// assert_eq!("@@FooBar".parse::<IdentifierType>(), Ok(IdentifierType::Class));
-    /// assert_eq!("@@FOO_BAR".parse::<IdentifierType>(), Ok(IdentifierType::Class));
-    /// assert_eq!("@@$foo".parse::<IdentifierType>(), Err(ParseIdentifierError::new()));
-    /// assert_eq!("@@0".parse::<IdentifierType>(), Err(ParseIdentifierError::new()));
-    /// assert_eq!("@@1".parse::<IdentifierType>(), Err(ParseIdentifierError::new()));
-    /// assert_eq!("@@9".parse::<IdentifierType>(), Err(ParseIdentifierError::new()));
+    /// assert_eq!(
+    ///     "@@foo_bar".parse::<IdentifierType>(),
+    ///     Ok(IdentifierType::Class)
+    /// );
+    /// assert_eq!(
+    ///     "@@FooBar".parse::<IdentifierType>(),
+    ///     Ok(IdentifierType::Class)
+    /// );
+    /// assert_eq!(
+    ///     "@@FOO_BAR".parse::<IdentifierType>(),
+    ///     Ok(IdentifierType::Class)
+    /// );
+    /// assert_eq!(
+    ///     "@@$foo".parse::<IdentifierType>(),
+    ///     Err(ParseIdentifierError::new())
+    /// );
+    /// assert_eq!(
+    ///     "@@0".parse::<IdentifierType>(),
+    ///     Err(ParseIdentifierError::new())
+    /// );
+    /// assert_eq!(
+    ///     "@@1".parse::<IdentifierType>(),
+    ///     Err(ParseIdentifierError::new())
+    /// );
+    /// assert_eq!(
+    ///     "@@9".parse::<IdentifierType>(),
+    ///     Err(ParseIdentifierError::new())
+    /// );
     /// ```
     ///
     /// [`Constant`]: Self::Constant
@@ -215,10 +350,22 @@ pub enum IdentifierType {
     ///
     /// ```
     /// # use spinoso_symbol::{IdentifierType, ParseIdentifierError};
-    /// assert_eq!("Foo=".parse::<IdentifierType>(), Ok(IdentifierType::AttrSet));
-    /// assert_eq!("foo=".parse::<IdentifierType>(), Ok(IdentifierType::AttrSet));
-    /// assert_eq!("foo_bar=".parse::<IdentifierType>(), Ok(IdentifierType::AttrSet));
-    /// assert_eq!("foo_bar?=".parse::<IdentifierType>(), Err(ParseIdentifierError::new()));
+    /// assert_eq!(
+    ///     "Foo=".parse::<IdentifierType>(),
+    ///     Ok(IdentifierType::AttrSet)
+    /// );
+    /// assert_eq!(
+    ///     "foo=".parse::<IdentifierType>(),
+    ///     Ok(IdentifierType::AttrSet)
+    /// );
+    /// assert_eq!(
+    ///     "foo_bar=".parse::<IdentifierType>(),
+    ///     Ok(IdentifierType::AttrSet)
+    /// );
+    /// assert_eq!(
+    ///     "foo_bar?=".parse::<IdentifierType>(),
+    ///     Err(ParseIdentifierError::new())
+    /// );
     /// assert_eq!("ω=".parse::<IdentifierType>(), Ok(IdentifierType::AttrSet));
     /// ```
     ///
@@ -234,10 +381,22 @@ pub enum IdentifierType {
     ///
     /// ```
     /// # use spinoso_symbol::{IdentifierType, ParseIdentifierError};
-    /// assert_eq!("Foo".parse::<IdentifierType>(), Ok(IdentifierType::Constant));
-    /// assert_eq!("FOO".parse::<IdentifierType>(), Ok(IdentifierType::Constant));
-    /// assert_eq!("FooBar".parse::<IdentifierType>(), Ok(IdentifierType::Constant));
-    /// assert_eq!("FOO_BAR".parse::<IdentifierType>(), Ok(IdentifierType::Constant));
+    /// assert_eq!(
+    ///     "Foo".parse::<IdentifierType>(),
+    ///     Ok(IdentifierType::Constant)
+    /// );
+    /// assert_eq!(
+    ///     "FOO".parse::<IdentifierType>(),
+    ///     Ok(IdentifierType::Constant)
+    /// );
+    /// assert_eq!(
+    ///     "FooBar".parse::<IdentifierType>(),
+    ///     Ok(IdentifierType::Constant)
+    /// );
+    /// assert_eq!(
+    ///     "FOO_BAR".parse::<IdentifierType>(),
+    ///     Ok(IdentifierType::Constant)
+    /// );
     /// assert_eq!("Ω".parse::<IdentifierType>(), Ok(IdentifierType::Constant));
     /// ```
     Constant,
@@ -252,8 +411,14 @@ pub enum IdentifierType {
     /// # use spinoso_symbol::{IdentifierType, ParseIdentifierError};
     /// assert_eq!("foo".parse::<IdentifierType>(), Ok(IdentifierType::Local));
     /// assert_eq!("fOO".parse::<IdentifierType>(), Ok(IdentifierType::Local));
-    /// assert_eq!("fooBar".parse::<IdentifierType>(), Ok(IdentifierType::Local));
-    /// assert_eq!("foo_bar".parse::<IdentifierType>(), Ok(IdentifierType::Local));
+    /// assert_eq!(
+    ///     "fooBar".parse::<IdentifierType>(),
+    ///     Ok(IdentifierType::Local)
+    /// );
+    /// assert_eq!(
+    ///     "foo_bar".parse::<IdentifierType>(),
+    ///     Ok(IdentifierType::Local)
+    /// );
     /// assert_eq!("ω".parse::<IdentifierType>(), Ok(IdentifierType::Local));
     /// ```
     Local,

--- a/spinoso-time/src/time/tzrs/parts.rs
+++ b/spinoso-time/src/time/tzrs/parts.rs
@@ -245,7 +245,8 @@ impl Time {
     ///
     /// Can be used to implement [`Time#utc?`] and [`Time#gmt?`].
     ///
-    //// # Examples
+    /// # Examples
+    ///
     /// ```
     /// # use spinoso_time::tzrs::{Time, TimeError};
     /// # fn example() -> Result<(), TimeError> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,12 @@
 //! # fn example() -> Result<(), Error> {
 //! let mut interp = artichoke::interpreter()?;
 //! let s = interp.try_convert_mut("💎")?;
-//! let codepoint = s.funcall(&mut interp, "ord", &[] /* args */, None /* block */)?;
+//! let codepoint = s.funcall(
+//!     &mut interp,
+//!     "ord",
+//!     &[],  /* args */
+//!     None, /* block */
+//! )?;
 //! let codepoint = codepoint.try_convert_into::<u32>(&interp)?;
 //! assert_eq!(128142, codepoint);
 //! # interp.close();


### PR DESCRIPTION
Use the nightly-only rustdoc option `format_code_in_doc_comments`: https://rust-lang.github.io/rustfmt/?version=v1.5.1&search=format_code_in_doc_comments#format_code_in_doc_comments

Don't check this option into `rustfmt.toml` because it has some bugs with how it formats comments. See:

- https://github.com/rust-lang/rustfmt/issues/5568