### PR TITLE
Install bindgen from `bindgen-cli` package

### DIFF
--- a/artichoke-backend/build.rs
+++ b/artichoke-backend/build.rs
@@ -246,11 +246,22 @@ mod libs {
             .arg("--root")
             .arg(&bindgen_install_dir)
             .arg("--version")
-            .arg("0.60.1")
-            .arg("bindgen")
+            .arg("0.61.0")
+            .arg("--locked")
+            .arg("bindgen-cli")
             .status()
             .unwrap();
         assert!(status.success(), "cargo install bindgen failed");
+
+        // NOTE: this extensionless binary name also works on Windows even though
+        // `bindgen` is installed with an `.exe` extension:
+        //
+        // ```
+        // PS artichoke> .\target\debug\build\artichoke-backend-10a84ed92b73d6ee\out\bindgen\bin\bindgen.exe --version
+        // bindgen 0.61.0
+        // PS artichoke> .\target\debug\build\artichoke-backend-10a84ed92b73d6ee\out\bindgen\bin\bindgen --version
+        // bindgen 0.61.0
+        // ```
         bindgen_install_dir.join("bin").join("bindgen")
     }
 


### PR DESCRIPTION
Update bindgen to v0.61.0.

See:

- https://github.com/rust-lang/rust-bindgen/pull/2284
- https://github.com/artichoke/docker-artichoke-nightly/pull/127