### PR TITLE
Enable String#to_i spec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,6 +45,7 @@ dependencies = [
  "intaglio",
  "once_cell",
  "onig",
+ "posix-space",
  "qed",
  "quickcheck",
  "regex",

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -21,6 +21,7 @@ intaglio = { version = "1.7.0", default-features = false, features = ["bytes"] }
 once_cell = "1.12.0"
 onig = { version = "6.4.0", optional = true, default-features = false }
 qed = "1.3.0"
+posix-space = "1.0.0"
 # Ensure the `regex` minimum version is at least 1.5.5 to pull in a fix for a
 # DoS vulnerability.
 #

--- a/artichoke-backend/src/extn/core/string/string_test.rb
+++ b/artichoke-backend/src/extn/core/string/string_test.rb
@@ -11,6 +11,7 @@ def spec
   string_reverse
   string_tr
   string_end_with
+  string_to_i
 
   true
 end
@@ -196,6 +197,14 @@ def string_end_with
   assert_raise_type_error { 'abc'.end_with?('e', 'xyz', /c/) }
 
   'abc'.end_with?('e', 'bc', /c/)
+end
+
+def string_to_i
+  # All POSIX whitespace should get trimmed
+  raise unless "\x0B\n\r\t\x0C 123".to_i == 123
+
+  # Only single underscores are valid
+  raise unless '1__23'.to_i == 1
 end
 
 spec if $PROGRAM_NAME == __FILE__

--- a/artichoke-backend/src/extn/core/string/trampoline.rs
+++ b/artichoke-backend/src/extn/core/string/trampoline.rs
@@ -1554,7 +1554,7 @@ pub fn to_i(interp: &mut Artichoke, mut value: Value, base: Option<Value>) -> Re
     //  '_' is invalid because they are stripped out elsewhere in the string, but cannot start a number
     //  '+' and '-' invalid because we already have the sign prior to the prefix, but they are accepted
     //  at the begining of a string by str_from_radix, and double sign doesn't make sense
-    if slice.first() == Some(&b'_') || slice.first() == Some(&b'+') || slice.first() == Some(&b'-') {
+    if matches!(slice.first(), Some(&b'_' | &b'+' | &b'-')) {
         return Ok(interp.convert(0));
     }
 

--- a/artichoke-backend/src/extn/core/string/trampoline.rs
+++ b/artichoke-backend/src/extn/core/string/trampoline.rs
@@ -1619,6 +1619,12 @@ pub fn to_i(interp: &mut Artichoke, mut value: Value, base: Option<Value>) -> Re
         return Ok(interp.convert(0));
     }
 
+    // Double underscores are not valid, and we should stop parsing the string if we encounter one
+    if let Some(double_underscore) = slice.find(&"__") {
+        slice = &slice[..double_underscore];
+    }
+
+    // Single underscores should be ignored
     let mut slice = std::borrow::Cow::from(slice);
     if slice.find(&"_").is_some() {
         slice.to_mut().retain(|&c| c != b'_');

--- a/artichoke-backend/src/extn/core/string/trampoline.rs
+++ b/artichoke-backend/src/extn/core/string/trampoline.rs
@@ -1542,7 +1542,7 @@ pub fn to_i(interp: &mut Artichoke, mut value: Value, base: Option<Value>) -> Re
     let s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
     let mut slice = s.as_slice();
     // ignore preceding whitespace
-    if let Some(start) = slice.iter().position(|c| !c.is_ascii_whitespace()) {
+    if let Some(start) = slice.iter().position(|&c| !posix_space::is_space(c)) {
         slice = &slice[start..];
     } else {
         // All whitespace, but we cant return early because we need to ensure the base is valid too

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -38,6 +38,7 @@ dependencies = [
  "intaglio",
  "once_cell",
  "onig",
+ "posix-space",
  "qed",
  "regex",
  "scolapasta-aref",

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -48,6 +48,7 @@ dependencies = [
  "intaglio",
  "once_cell",
  "onig",
+ "posix-space",
  "qed",
  "regex",
  "scolapasta-aref",

--- a/spec-runner/enforced-specs.toml
+++ b/spec-runner/enforced-specs.toml
@@ -150,6 +150,7 @@ specs = [
   "setbyte",
   "size",
   "start_with",
+  "to_i",
   "tr",
   "tr_s",
 ]


### PR DESCRIPTION
Relates to #1912

Currently `String#to_i` isn't in the enforced specs, and there deviations from MRI because of this.
This PR makes `to_i` spec compliant, asides from the cases where a `Bignum` is needed which now throw a `NotImplemented` error instead.

While doing this work I did attempt to use the `scolapasta-int-parse` implementation, however as `to_i` parses as much as possible before failure and scolapasta either passes or returns an error I would have had to make more changes that I felt comfortable with in that library to make the specs pass. This has lead to a duplication of logic, but there is already an issue to fix this (#2075) 