### PR TITLE
Remove Rust build caching from 'Crash' workflow

### DIFF
--- a/.github/workflows/crash.yaml
+++ b/.github/workflows/crash.yaml
@@ -34,11 +34,6 @@ jobs:
           cargo version --verbose
           echo "::endgroup::"
 
-      - uses: Swatinem/rust-cache@v1
-        with:
-          key: v3
-          working-directory: "spec-runner"
-
       - name: Compile debug
         run: cargo build --verbose --bin spec-runner
         working-directory: "spec-runner"


### PR DESCRIPTION
This workflow is non-blocking, so we can remove the cache, which contains both debug and release artifacts, to reduce some cache pressure to avoid thrashing the 10GB GitHub Actions cache limit.