### PR TITLE
Remove Rust build caching from 'spec-state' workflow

### DIFF
--- a/.github/workflows/spec-state.yaml
+++ b/.github/workflows/spec-state.yaml
@@ -38,11 +38,6 @@ jobs:
           cargo version --verbose
           echo "::endgroup::"
 
-      - uses: Swatinem/rust-cache@v1
-        with:
-          key: v3
-          working-directory: "artichoke/spec-runner"
-
       - name: Compile spec-runner
         run: cargo build --release --verbose --bin spec-runner
         working-directory: "artichoke/spec-runner"


### PR DESCRIPTION
This workflow only runs on the trunk branch post-merge, so we can remove the cache to reduce some cache pressure to avoid thrashing the 10GB GitHub Actions cache limit.