### PR TITLE
Fix a daylight savings time breakage in spinoso-time doctests

### DIFF
--- a/spinoso-time/src/time/tzrs/timezone.rs
+++ b/spinoso-time/src/time/tzrs/timezone.rs
@@ -79,10 +79,9 @@ impl Time {
     /// ```
     /// # use spinoso_time::tzrs::{Time, TimeError};
     /// # fn example() -> Result<(), TimeError> {
-    /// let local_offset = Time::now()?.utc_offset();
     /// let now_utc = Time::utc(2022, 7, 8, 12, 34, 56, 0)?;
-    /// let now_local = now_utc.to_local()?;
-    /// assert_eq!(now_local.utc_offset(), local_offset);
+    /// let now_local = Time::local(2022, 7, 8, 12, 34, 56, 0)?;
+    /// assert_eq!(now_utc.to_local()?.utc_offset(), now_local.utc_offset());
     /// # Ok(())
     /// # }
     /// # example().unwrap()


### PR DESCRIPTION
Doc test examples for `Time::to_local` failed when the current user's local time has a different UTC offset than the 2022-07-08T12:34:56 timestamp used in the test.

For me, located in `America/Los_Angeles`, this test started failing as of 2am local time on 2022-11-06.

Fix the test by forcibly constructing the local time with the same date time instead of using `Time::now`.