### PR TITLE
Sync rustdoc workflow with current project-wide defaults

### DIFF
--- a/.github/workflows/rustdoc.yaml
+++ b/.github/workflows/rustdoc.yaml
@@ -23,33 +23,17 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Install nightly Rust toolchain
-        run: |
-          echo "::group::rustup toolchain install"
-          rustup toolchain install nightly --profile minimal
-          echo "::endgroup::"
-          echo "::group::set default toolchain"
-          rm -rf rust-toolchain
-          rustup default nightly
-          echo "::endgroup::"
-          echo "::group::rustup version"
-          rustup -Vv
-          echo "::endgroup::"
-          echo "::group::rustc version"
-          rustc -Vv
-          echo "::endgroup::"
-          echo "::group::cargo version"
-          cargo version --verbose
-          echo "::endgroup::"
+      - name: Install Rust toolchain
+        uses: artichoke/setup-rust/rustdoc@v1
 
-      - uses: Swatinem/rust-cache@v1
+      - name: Check docs with no default features
+        run: cargo doc --workspace --no-default-features
+
+      - name: Clean docs
+        run: cargo clean
 
       - name: Build Documentation
         run: cargo doc --workspace
-
-      # https://github.com/artichoke/artichoke/issues/1826
-      - name: Purge sources from out dir
-        run: find . -path './target/doc/*/target/debug/build/*' | xargs rm -rf
 
       - name: Copy static content
         run: cp --verbose .github/rustdoc/* target/doc/

--- a/artichoke-backend/src/load_path.rs
+++ b/artichoke-backend/src/load_path.rs
@@ -35,7 +35,8 @@ pub use native::Native;
 /// `RUBY_LOAD_PATH` is the default current working directory for
 /// [`Memory`] file systems.
 ///
-/// [`Hybrid`] file systems locate the path on a [`Memory`] file system.
+/// If the `load-path-native-file-system-loader` feature is enabled, the file
+/// system will locate the path on a [`Memory`] file system.
 #[cfg(not(windows))]
 pub const RUBY_LOAD_PATH: &str = "/artichoke/virtual_root/src/lib";
 

--- a/artichoke-backend/src/state/mod.rs
+++ b/artichoke-backend/src/state/mod.rs
@@ -46,8 +46,7 @@ impl State {
     /// - `Regexp` [global state][regexp-state].
     /// - [In-memory virtual file system].
     /// - [Ruby parser and file context].
-    /// - [Intepreter-level PRNG] (requires activating the `core-random`
-    ///   feature).
+    #[cfg_attr(feature = "core-random", doc = "- [Intepreter-level PRNG].")]
     /// - [IO capturing] strategy.
     ///
     /// # Errors
@@ -61,7 +60,7 @@ impl State {
     /// [regexp-state]: regexp::State
     /// [In-memory virtual file system]: load_path
     /// [Ruby parser and file context]: parser::State
-    /// [Intepreter-level PRNG]: Random
+    #[cfg_attr(feature = "core-random", doc = "[Intepreter-level PRNG]: Random")]
     /// [IO capturing]: output::Strategy
     pub fn new() -> Result<Self, InterpreterAllocError> {
         Ok(Self {

--- a/scolapasta-hex/src/lib.rs
+++ b/scolapasta-hex/src/lib.rs
@@ -28,8 +28,8 @@
 //!
 //! - Allocate and return a [`String`]: [`try_encode`].
 //! - Encode into an already allocated [`String`]: [`try_encode_into`].
-//! - Encode into a [`fmt::Write`]: [`format_into`].
-//! - Encode into a [`io::Write`]: [`write_into`].
+//! - Encode into a [`core::fmt::Write`]: [`format_into`].
+//! - Encode into a [`std::io::Write`]: [`write_into`].
 //!
 //! # Examples
 //!
@@ -76,8 +76,15 @@
 //! - **alloc** - Enables a dependency on the Rust [`alloc`] crate. Activating
 //!   this feature enables APIs that require [`alloc::string::String`].
 //!
+#![cfg_attr(
+    not(feature = "std"),
+    doc = "[`std::io::Write`]: https://doc.rust-lang.org/std/io/trait.Write.html"
+)]
+#![cfg_attr(
+    not(feature = "std"),
+    doc = "[`write_into`]: https://artichoke.github.io/artichoke/scolapasta_hex/fn.write_into.html"
+)]
 //! [Base 16 encoding]: https://tools.ietf.org/html/rfc4648#section-8
-//! [`io::Write`]: https://doc.rust-lang.org/std/io/trait.Write.html
 
 #![no_std]
 

--- a/spinoso-array/src/array/mod.rs
+++ b/spinoso-array/src/array/mod.rs
@@ -1,21 +1,21 @@
-//! Implementations of Ruby [`Array`], a growable vector.
-//!
-//! This module contains multiple implementations of a backing store for the
-//! Ruby `Array` core class. [`Array`](vec::Array) is based on the [`Vec`] type
-//! in `std`. [`SmallArray`](smallvec::SmallArray) is based on [`SmallVec`].
-//! [`TinyArray`](tinyvec::TinyArray) is based on [`TinyVec`].
-//!
-//! The smallvec backend uses small vector optimization to store
-//! [some elements][inline-capacity] inline without spilling to the heap.
-//!
-//! The `SmallArray` backend requires the `small-array` Cargo feature to be
-//! enabled.
-//!
-//! [`Array`]: https://ruby-doc.org/core-3.1.2/Array.html
-//! [`Vec`]: alloc::vec::Vec
-//! [`SmallVec`]: ::smallvec::SmallVec
-//! [`TinyVec`]: ::tinyvec::TinyVec
-//! [inline-capacity]: INLINE_CAPACITY
+// Implementations of Ruby [`Array`], a growable vector.
+//
+// This module contains multiple implementations of a backing store for the
+// Ruby `Array` core class. [`Array`](vec::Array) is based on the [`Vec`] type
+// in `std`. [`SmallArray`](smallvec::SmallArray) is based on [`SmallVec`].
+// [`TinyArray`](tinyvec::TinyArray) is based on [`TinyVec`].
+//
+// The smallvec backend uses small vector optimization to store
+// [some elements][inline-capacity] inline without spilling to the heap.
+//
+// The `SmallArray` backend requires the `small-array` Cargo feature to be
+// enabled.
+//
+// [`Array`]: https://ruby-doc.org/core-3.1.2/Array.html
+// [`Vec`]: alloc::vec::Vec
+// [`SmallVec`]: ::smallvec::SmallVec
+// [`TinyVec`]: ::tinyvec::TinyVec
+// [inline-capacity]: INLINE_CAPACITY
 
 #[cfg(feature = "small-array")]
 pub mod smallvec;

--- a/spinoso-array/src/lib.rs
+++ b/spinoso-array/src/lib.rs
@@ -33,12 +33,30 @@
 //!
 //! - [`Array`] is based on [`Vec`] from the Rust `alloc` crate and standard
 //!   library. This Spinoso array type is enabled by default.
-//! - [`SmallArray`] is based on [`SmallVec`] and implements the small vector
-//!   optimization – small arrays are stored inline without a heap allocation.
-//!   This Spinoso array type requires the **small-array** Cargo feature.
-//! - [`TinyArray`] is based on [`TinyVec`] and implements the small vector
-//!   optimization – small arrays are stored inline without a heap allocation.
-//!   This Spinoso array type requires the **tiny-array** Cargo feature.
+#![cfg_attr(
+    feature = "small-array",
+    doc = "- [`SmallArray`] is based on [`SmallVec`] and implements the small vector"
+)]
+#![cfg_attr(
+    feature = "small-array",
+    doc = "  optimization – small arrays are stored inline without a heap allocation."
+)]
+#![cfg_attr(
+    feature = "small-array",
+    doc = "  This Spinoso array type requires the **small-array** Cargo feature."
+)]
+#![cfg_attr(
+    feature = "tiny-array",
+    doc = "- [`TinyArray`] is based on [`TinyVec`] and implements the small vector"
+)]
+#![cfg_attr(
+    feature = "tiny-array",
+    doc = "  optimization – small arrays are stored inline without a heap allocation."
+)]
+#![cfg_attr(
+    feature = "tiny-array",
+    doc = "  This Spinoso array type requires the **tiny-array** Cargo feature."
+)]
 //!
 //!
 //! # `no_std`
@@ -118,8 +136,8 @@
 //! [collection of crates]: https://crates.io/keywords/spinoso
 //! [Artichoke Ruby]: https://www.artichokeruby.org/
 //! [`Vec`]: alloc::vec::Vec
-//! [`SmallVec`]: smallvec::SmallVec
-//! [`TinyVec`]: tinyvec::TinyVec
+#![cfg_attr(feature = "small-array", doc = "[`SmallVec`]: smallvec::SmallVec")]
+#![cfg_attr(feature = "tiny-array", doc = "[`TinyVec`]: tinyvec::TinyVec")]
 //! [`From`]: core::convert::From
 //! [`FromIterator`]: core::iter::FromIterator
 //! [`Index`]: core::ops::Index

--- a/spinoso-env/src/env/mod.rs
+++ b/spinoso-env/src/env/mod.rs
@@ -1,17 +1,17 @@
-//! ENV is a hash-like accessor for environment variables.
-//!
-//! This module contains implementations of an environ accessor and mutator.
-//!
-//! [`Memory`] is based on a Rust [`HashMap`] and offers a virtualized `ENV` API
-//! that cannot modify the host system.
-//!
-//! [`System`] is based on [`env::var_os`] and directly accesses and modifies
-//! the host system environ via platform-specific APIs.
-//!
-//! [`Memory`]: memory::Memory
-//! [`HashMap`]: std::collections::HashMap
-//! [`System`]: system::System
-//! [`env::var_os`]: std::env::var_os
+// ENV is a hash-like accessor for environment variables.
+//
+// This module contains implementations of an environ accessor and mutator.
+//
+// [`Memory`] is based on a Rust [`HashMap`] and offers a virtualized `ENV` API
+// that cannot modify the host system.
+//
+// [`System`] is based on [`env::var_os`] and directly accesses and modifies
+// the host system environ via platform-specific APIs.
+//
+// [`Memory`]: memory::Memory
+// [`HashMap`]: std::collections::HashMap
+// [`System`]: system::System
+// [`env::var_os`]: std::env::var_os
 
 pub mod memory;
 #[cfg(feature = "system-env")]

--- a/spinoso-env/src/lib.rs
+++ b/spinoso-env/src/lib.rs
@@ -89,6 +89,10 @@
 //! - **system-env** - Enable an `ENV` backend that accesses the host system's
 //!   environment variables via the [`std::env`] module.
 //!
+#![cfg_attr(
+    not(feature = "system-env"),
+    doc = "[`System`]: https://artichoke.github.io/artichoke/spinoso_env/struct.System.html"
+)]
 //! [`ENV`]: https://ruby-doc.org/core-3.1.2/ENV.html
 //! [`HashMap`]: std::collections::HashMap
 //! [Rust Standard Library]: std

--- a/spinoso-math/src/lib.rs
+++ b/spinoso-math/src/lib.rs
@@ -62,6 +62,7 @@
 //!   implementations in Rust [`core`]. Dropping this feature removes the
 //!   [`libm`] dependency.
 //!
+#![cfg_attr(not(feature = "full"), doc = "[`libm`]: https://docs.rs/libm/latest/libm/")]
 //! [`Float`]: https://ruby-doc.org/core-3.1.2/Float.html
 //! [`NaN`]: f64::NAN
 //! [`alloc`]: https://doc.rust-lang.org/alloc/

--- a/spinoso-random/src/lib.rs
+++ b/spinoso-random/src/lib.rs
@@ -82,10 +82,28 @@
 //!   this feature enables [`std::error::Error`] impls on error types in this
 //!   crate.
 //!
+#![cfg_attr(
+    not(feature = "std"),
+    doc = "[`std::error::Error`]: https://doc.rust-lang.org/std/error/trait.Error.html"
+)]
+#![cfg_attr(feature = "rand-traits", doc = "[`RngCore`]: rand_core::RngCore")]
+#![cfg_attr(
+    not(feature = "rand-traits"),
+    doc = "[`RngCore`]: https://docs.rs/rand_core/latest/rand_core/trait.RngCore.html"
+)]
+#![cfg_attr(feature = "rand-traits", doc = "[`rand_core`]: ::rand_core")]
+#![cfg_attr(
+    not(feature = "rand-traits"),
+    doc = "[`rand_core`]: https://docs.rs/rand_core/latest/rand_core/"
+)]
+#![cfg_attr(feature = "random-rand", doc = "[`rand`]: ::rand")]
+#![cfg_attr(not(feature = "random-rand"), doc = "[`rand`]: https://docs.rs/rand/latest/rand/")]
+#![cfg_attr(
+    not(feature = "random-rand"),
+    doc = "[`rand()`]: https://artichoke.github.io/artichoke/spinoso_random/fn.rand.html"
+)]
 //! [ruby-random]: https://ruby-doc.org/core-3.1.2/Random.html
 //! [`alloc`]: https://doc.rust-lang.org/alloc/
-//! [`rand`]: ::rand
-//! [`RngCore`]: rand_core::RngCore
 
 #![no_std]
 
@@ -125,7 +143,10 @@ pub use self::rand::{rand, Max, Rand};
 /// - Constraints for bounding random numbers are invalid.
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
 pub enum Error {
-    /// Error that indicates [`rand()`] was passed an invalid constraint.
+    #[cfg_attr(
+        feature = "random-rand",
+        doc = "Error that indicates [`rand()`] was passed an invalid constraint."
+    )]
     ///
     /// See [`ArgumentError`].
     Argument(ArgumentError),
@@ -391,8 +412,10 @@ impl error::Error for NewSeedError {}
 /// Error that indicates a random number could not be generated with the given
 /// bounds.
 ///
-/// This error is returned by [`rand()`]. See its documentation for more
-/// details.
+#[cfg_attr(
+    feature = "random-rand",
+    doc = "This error is returned by [`rand()`]. See its documentation for more details."
+)]
 ///
 /// This error corresponds to the [Ruby `ArgumentError` Exception class].
 ///
@@ -467,11 +490,16 @@ impl ArgumentError {
 
     /// Retrieve the exception message associated with this new seed error.
     ///
-    /// # Implementation notes
-    ///
-    /// Argument errors constructed with [`ArgumentError::with_rand_max`] return
-    /// an incomplete error message. Prefer to use the [`Display`] impl to
-    /// retrieve error messages from [`ArgumentError`].
+    #[cfg_attr(feature = "random-rand", doc = "# Implementation notes")]
+    #[cfg_attr(
+        feature = "random-rand",
+        doc = "Argument errors constructed with [`ArgumentError::with_rand_max`] return"
+    )]
+    #[cfg_attr(
+        feature = "random-rand",
+        doc = "an incomplete error message. Prefer to use the [`Display`] impl to"
+    )]
+    #[cfg_attr(feature = "random-rand", doc = "retrieve error messages from [`ArgumentError`].")]
     ///
     /// # Examples
     ///


### PR DESCRIPTION
- Build docs with no default features.
- Remove cache which will never be valid due to nightly compiler.
- Install and setup Rust toolchain using artichoke/setup-rust/rustdoc.

See:

- https://github.com/artichoke/project-infrastructure/issues/265
- https://github.com/artichoke/artichoke/pull/1813
- https://github.com/artichoke/project-infrastructure/pull/396

## Doc Changes

`spinoso-array` and the `State` struct in `artichoke-backend` heavily use conditional compilation and required changes. I used the same `#[cfg_attr(feature = "...", doc = "...")]` pattern used in https://github.com/artichoke/intaglio/pull/170.

## Testing

I rendered the docs and ensured:

- `cargo doc --workspace --no-default-features` completes without error.
- doc content appeared correctly when building with all features.
- intradoc links resolve correctly.