### PR TITLE
Update CI workflow to use artichoke/setup-rust

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,28 +25,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Rust toolchain
-        shell: bash
-        run: |
-          echo "::group::rustup toolchain install"
-          rustup toolchain install 1.65.0 --profile minimal
-          echo "::endgroup::"
-          echo "::group::set default toolchain"
-          rm -rf rust-toolchain
-          rustup default 1.65.0
-          echo "::endgroup::"
-          echo "::group::rustup version"
-          rustup -Vv
-          echo "::endgroup::"
-          echo "::group::rustc version"
-          rustc -Vv
-          echo "::endgroup::"
-          echo "::group::cargo version"
-          cargo version --verbose
-          echo "::endgroup::"
-
-      - uses: Swatinem/rust-cache@v1
+        uses: artichoke/setup-rust/build-and-test@v1
         with:
-          key: v3
+          toolchain: "1.65.0"
 
       - name: Compile
         run: cargo build --workspace --verbose
@@ -68,46 +49,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Rust toolchain
-        run: |
-          echo "::group::rustup toolchain install"
-          rustup toolchain install 1.65.0 --profile minimal --component clippy
-          echo "::endgroup::"
-          echo "::group::set default toolchain"
-          rm -rf rust-toolchain
-          rustup default 1.65.0
-          echo "::endgroup::"
-          echo "::group::rustup version"
-          rustup -Vv
-          echo "::endgroup::"
-          echo "::group::rustc version"
-          rustc -Vv
-          echo "::endgroup::"
-          echo "::group::cargo version"
-          cargo version --verbose
-          echo "::endgroup::"
-          echo "::group::clippy version"
-          cargo clippy --version
-          echo "::endgroup::"
-
-      - name: Install nightly Rust toolchain
-        run: |
-          echo "::group::rustup toolchain install"
-          rustup toolchain install nightly --profile minimal --component rustfmt
-          echo "::endgroup::"
-          echo "::group::rustup version"
-          rustup -Vv
-          echo "::endgroup::"
-          echo "::group::rustc version"
-          rustc +nightly -Vv
-          echo "::endgroup::"
-          echo "::group::cargo version"
-          cargo +nightly version --verbose
-          echo "::endgroup::"
-          echo "::group::rustfmt version"
-          rustfmt +nightly -Vv
-          echo "::endgroup::"
-
-      - uses: Swatinem/rust-cache@v1
+        uses: artichoke/setup-rust/lint-and-format@v1
+        with:
+          toolchain: "1.65.0"
 
       - name: Check artichoke formatting
         run: cargo +nightly fmt --check
@@ -138,27 +82,13 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Rust toolchain
-        run: |
-          echo "::group::rustup toolchain install"
-          rustup toolchain install 1.65.0 --profile minimal
-          echo "::endgroup::"
-          echo "::group::set default toolchain"
-          rm -rf rust-toolchain
-          rustup default 1.65.0
-          echo "::endgroup::"
-          echo "::group::rustup version"
-          rustup -Vv
-          echo "::endgroup::"
-          echo "::group::rustc version"
-          rustc -Vv
-          echo "::endgroup::"
-          echo "::group::cargo version"
-          cargo version --verbose
-          echo "::endgroup::"
-
-      - uses: Swatinem/rust-cache@v1
+        uses: artichoke/setup-rust/lint-and-format@v1
         with:
-          working-directory: "fuzz"
+          toolchain: "1.65.0"
+
+      - name: Check fuzz formatting
+        run: cargo +nightly fmt --check
+        working-directory: "fuzz"
 
       - name: Check fuzz with locked Cargo.lock
         run: cargo check --locked --all-targets --profile=test
@@ -175,48 +105,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Rust toolchain
-        run: |
-          echo "::group::rustup toolchain install"
-          rustup toolchain install 1.65.0 --profile minimal --component clippy
-          echo "::endgroup::"
-          echo "::group::set default toolchain"
-          rm -rf rust-toolchain
-          rustup default 1.65.0
-          echo "::endgroup::"
-          echo "::group::rustup version"
-          rustup -Vv
-          echo "::endgroup::"
-          echo "::group::rustc version"
-          rustc -Vv
-          echo "::endgroup::"
-          echo "::group::cargo version"
-          cargo version --verbose
-          echo "::endgroup::"
-          echo "::group::clippy version"
-          cargo clippy --version
-          echo "::endgroup::"
-
-      - name: Install nightly Rust toolchain
-        run: |
-          echo "::group::rustup toolchain install"
-          rustup toolchain install nightly --profile minimal --component rustfmt
-          echo "::endgroup::"
-          echo "::group::rustup version"
-          rustup -Vv
-          echo "::endgroup::"
-          echo "::group::rustc version"
-          rustc +nightly -Vv
-          echo "::endgroup::"
-          echo "::group::cargo version"
-          cargo +nightly version --verbose
-          echo "::endgroup::"
-          echo "::group::rustfmt version"
-          rustfmt +nightly -Vv
-          echo "::endgroup::"
-
-      - uses: Swatinem/rust-cache@v1
+        uses: artichoke/setup-rust/lint-and-format@v1
         with:
-          working-directory: "spec-runner"
+          toolchain: "1.65.0"
 
       - name: Check spec-runner formatting
         run: cargo +nightly fmt --check
@@ -245,52 +136,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Rust toolchain
-        run: |
-          echo "::group::rustup toolchain install"
-          rustup toolchain install 1.65.0 --profile minimal --component clippy
-          echo "::endgroup::"
-          echo "::group::set default toolchain"
-          rm -rf rust-toolchain
-          rustup default 1.65.0
-          echo "::endgroup::"
-          echo "::group::rustup version"
-          rustup -Vv
-          echo "::endgroup::"
-          echo "::group::rustc version"
-          rustc -Vv
-          echo "::endgroup::"
-          echo "::group::cargo version"
-          cargo version --verbose
-          echo "::endgroup::"
-          echo "::group::clippy version"
-          cargo clippy --version
-          echo "::endgroup::"
-
-      - name: Install nightly Rust toolchain
-        run: |
-          echo "::group::rustup toolchain install"
-          rustup toolchain install nightly --profile minimal --component rustfmt
-          echo "::endgroup::"
-          echo "::group::rustup version"
-          rustup -Vv
-          echo "::endgroup::"
-          echo "::group::rustc version"
-          rustc +nightly -Vv
-          echo "::endgroup::"
-          echo "::group::cargo version"
-          cargo +nightly version --verbose
-          echo "::endgroup::"
-          echo "::group::rustfmt version"
-          rustfmt +nightly -Vv
-          echo "::endgroup::"
-
-      - uses: Swatinem/rust-cache@v1
+        uses: artichoke/setup-rust/lint-and-format@v1
         with:
-          working-directory: "."
-
-      - uses: Swatinem/rust-cache@v1
-        with:
-          working-directory: "ui-tests"
+          toolchain: "1.65.0"
 
       - name: Check ui-tests formatting
         run: cargo +nightly fmt --check
@@ -326,25 +174,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Rust toolchain
-        run: |
-          echo "::group::rustup toolchain install"
-          rustup toolchain install 1.65.0 --profile minimal
-          echo "::endgroup::"
-          echo "::group::set default toolchain"
-          rm -rf rust-toolchain
-          rustup default 1.65.0
-          echo "::endgroup::"
-          echo "::group::rustup version"
-          rustup -Vv
-          echo "::endgroup::"
-          echo "::group::rustc version"
-          rustc -Vv
-          echo "::endgroup::"
-          echo "::group::cargo version"
-          cargo version --verbose
-          echo "::endgroup::"
-
-      - uses: Swatinem/rust-cache@v1
+        uses: artichoke/setup-rust/build-and-test@v1
+        with:
+          toolchain: "1.65.0"
 
       - name: Check artichoke-load-path with no default features
         run: cargo check --verbose --no-default-features --all-targets --profile=test
@@ -513,55 +345,22 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Rust toolchain
-        run: |
-          echo "::group::rustup toolchain install"
-          rustup toolchain install 1.65.0 --profile minimal
-          echo "::endgroup::"
-          echo "::group::set default toolchain"
-          rm -rf rust-toolchain
-          rustup default 1.65.0
-          echo "::endgroup::"
-          echo "::group::rustup version"
-          rustup -Vv
-          echo "::endgroup::"
-          echo "::group::rustc version"
-          rustc -Vv
-          echo "::endgroup::"
-          echo "::group::cargo version"
-          cargo version --verbose
-          echo "::endgroup::"
-
-      - name: Install nightly Rust toolchain
-        run: |
-          echo "::group::rustup toolchain install"
-          rustup toolchain install nightly --profile minimal
-          echo "::endgroup::"
-          echo "::group::rustup version"
-          rustup -Vv
-          echo "::endgroup::"
-          echo "::group::rustc version"
-          rustc +nightly -Vv
-          echo "::endgroup::"
-          echo "::group::cargo version"
-          cargo +nightly version --verbose
-          echo "::endgroup::"
-
-      - uses: Swatinem/rust-cache@v1
-
-      - uses: Swatinem/rust-cache@v1
+        uses: artichoke/setup-rust/check-minimal-versions@v1
         with:
-          working-directory: "spec-runner"
-          key: spec-runner
+          toolchain: "1.65.0"
 
-      - name: Check artichoke with minimal versions
-        run: |
-          cargo +nightly generate-lockfile -Z minimal-versions
-          cargo check --workspace --all-targets --profile=test
+      - name: Generate minimal versions lockfile in root workspace
+        run: cargo +nightly generate-lockfile -Z minimal-versions
 
-      - name: Check spec-runner with minimal versions
-        run: |
-          cargo +nightly generate-lockfile -Z minimal-versions
-          cargo check --workspace --all-targets --profile=test
+      - name: Check with minimal versions in root workspace
+        run: cargo check --all-targets --profile=test
+
+      - name: Generate minimal versions lockfile in spec-runner workspace
+        run: cargo +nightly generate-lockfile -Z minimal-versions
+        working-directory: "spec-runner"
+
+      - name: Check with minimal versions in spec-runner workspace
+        run: cargo check --all-targets --profile=test
         working-directory: "spec-runner"
 
   ruby:

--- a/fuzz/fuzz_targets/eval.rs
+++ b/fuzz/fuzz_targets/eval.rs
@@ -1,7 +1,6 @@
 #![no_main]
-use libfuzzer_sys::fuzz_target;
-
 use artichoke::prelude::*;
+use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|data: &[u8]| {
     let mut interp = artichoke::interpreter().unwrap();

--- a/fuzz/fuzz_targets/kernel_integer_bytes.rs
+++ b/fuzz/fuzz_targets/kernel_integer_bytes.rs
@@ -1,6 +1,5 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
-
 use scolapasta_int_parse::parse;
 
 fuzz_target!(|data: &[u8]| {

--- a/fuzz/fuzz_targets/kernel_integer_int.rs
+++ b/fuzz/fuzz_targets/kernel_integer_int.rs
@@ -1,6 +1,5 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
-
 use scolapasta_int_parse::parse;
 
 fuzz_target!(|data: i64| {

--- a/fuzz/fuzz_targets/kernel_integer_str.rs
+++ b/fuzz/fuzz_targets/kernel_integer_str.rs
@@ -1,6 +1,5 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
-
 use scolapasta_int_parse::parse;
 
 fuzz_target!(|data: &str| {


### PR DESCRIPTION
This removes all direct uses of Swatinem/rust-cache, which obsoletes #2273 and should remove several uses of the cache which will relieve thrash against the 10GB limit for GitHub Actions caches.

Add a missing lint step to check formatting in the fuzz workspace.

Separate the minimum versions lockfile generation and cargo check step for both root and spec-runner workspaces.

See:

- https://github.com/artichoke/artichoke/pull/1813
- https://github.com/artichoke/project-infrastructure/issues/265