### PR TITLE
Implement Array#push in Rust

### DIFF
--- a/artichoke-backend/src/extn/core/array/array.rb
+++ b/artichoke-backend/src/extn/core/array/array.rb
@@ -918,13 +918,6 @@ class Array
     raise NotImplementedError
   end
 
-  def push(*args)
-    raise FrozenError, "can't modify frozen Array" if frozen?
-
-    concat(args)
-    self
-  end
-
   def rassoc(obj)
     idx = 0
     len = length

--- a/artichoke-backend/src/extn/core/array/array_functional_test.rb
+++ b/artichoke-backend/src/extn/core/array/array_functional_test.rb
@@ -339,7 +339,7 @@ def push
   a = []
   b = [1, 2]
   a.push b
-  raise unless a == [[1,2]]
+  raise unless a == [[1, 2]]
 end
 
 def concat

--- a/artichoke-backend/src/extn/core/array/array_functional_test.rb
+++ b/artichoke-backend/src/extn/core/array/array_functional_test.rb
@@ -337,7 +337,7 @@ def push
   raise unless a == [[]]
 
   a = []
-  b = [1,2]
+  b = [1, 2]
   a.push b
   raise unless a == [[1,2]]
 end

--- a/artichoke-backend/src/extn/core/array/array_functional_test.rb
+++ b/artichoke-backend/src/extn/core/array/array_functional_test.rb
@@ -20,6 +20,8 @@ def spec
   inline_set_slice
   dynamic_set_slice
 
+  push
+
   concat
 
   inline_pop
@@ -311,6 +313,18 @@ def dynamic_set_slice
   a = (1..25).map.to_a
   a[0, 25] = %w[a]
   raise unless a == ['a']
+end
+
+def push
+  a = [1, 2]
+  b = [[3], [4]]
+  a.push b
+  raise unless a == [1, 2, [[3], [4]]]
+
+  a = [1, 2]
+  b = 3
+  a.push b
+  raise unless a == [1, 2, 3]
 end
 
 def concat

--- a/artichoke-backend/src/extn/core/array/array_functional_test.rb
+++ b/artichoke-backend/src/extn/core/array/array_functional_test.rb
@@ -325,6 +325,21 @@ def push
   b = 3
   a.push b
   raise unless a == [1, 2, 3]
+
+  a = [1, 2]
+  b = [3, 4]
+  a.push b
+  raise unless a == [1, 2, [3, 4]]
+
+  a = []
+  b = []
+  a.push b
+  raise unless a == [[]]
+
+  a = []
+  b = [1,2]
+  a.push b
+  raise unless a == [[1,2]]
 end
 
 def concat

--- a/artichoke-backend/src/extn/core/array/trampoline.rs
+++ b/artichoke-backend/src/extn/core/array/trampoline.rs
@@ -151,11 +151,17 @@ where
         return Err(FrozenError::with_message("can't modify frozen Array").into());
     }
 
+    let mut array = unsafe { Array::unbox_from_value(&mut ary, interp)? };
+
+    let array_mut = unsafe { array.as_inner_mut() };
+
     for value in others {
-        match push_single(interp, ary, value) {
-            Ok(new_ary) => ary = new_ary,
-            Err(e) => return Err(e),
-        }
+        array_mut.push(value);
+    }
+
+    unsafe {
+        let inner = array.take();
+        Array::box_into_value(inner, ary, interp)?;
     }
 
     Ok(ary)

--- a/artichoke-backend/src/extn/core/array/trampoline.rs
+++ b/artichoke-backend/src/extn/core/array/trampoline.rs
@@ -142,6 +142,25 @@ pub fn clear(interp: &mut Artichoke, mut ary: Value) -> Result<Value, Error> {
     Ok(ary)
 }
 
+pub fn push<I>(interp: &mut Artichoke, mut ary: Value, others: I) -> Result<Value, Error>
+where
+    I: IntoIterator<Item = Value>,
+    I::IntoIter: Clone,
+{
+    if ary.is_frozen(interp) {
+        return Err(FrozenError::with_message("can't modify frozen Array").into());
+    }
+
+    for value in others {
+        match push_single(interp, ary, value) {
+            Ok(new_ary) => ary = new_ary,
+            Err(e) => return Err(e),
+        }
+    }
+
+    Ok(ary)
+}
+
 pub fn concat<I>(interp: &mut Artichoke, mut ary: Value, others: I) -> Result<Value, Error>
 where
     I: IntoIterator<Item = Value>,

--- a/artichoke-backend/src/extn/core/array/trampoline.rs
+++ b/artichoke-backend/src/extn/core/array/trampoline.rs
@@ -153,11 +153,11 @@ where
 
     let mut array = unsafe { Array::unbox_from_value(&mut ary, interp)? };
 
+    // SAFETY: The array is repacked without any intervening interpreter heap
+    // allocations.
     let array_mut = unsafe { array.as_inner_mut() };
 
-    for value in others {
-        array_mut.push(value);
-    }
+    array_mut.extend(others);
 
     unsafe {
         let inner = array.take();


### PR DESCRIPTION
Related to the thread in #2115 regarding implementing `Array#push` in Rust.

My understanding in the thread was that the existing implementation is actually
correct, but this operation would ideally be implemented in Rust.

I'm far from a Rust expert so I had some trouble getting types to line up when
trying to replicate the approach of calling into `concat` directly. Regardless,
I took an initial stab at this out of interest and am resorting to calling
`push_single` a bunch of times. Not sure if this is actually a bad approach so
open to feedback.

Also, am a fan of both languages so thank you for making this project which
piqued my interest enough to attempt an OSS PR for the first time :).
