### PR TITLE
Raise Ruby LoadError instead of Rust IoError when fail to load a program file

### DIFF
--- a/artichoke-backend/src/eval.rs
+++ b/artichoke-backend/src/eval.rs
@@ -1,6 +1,7 @@
 use std::ffi::OsStr;
 use std::path::Path;
 
+use bstr::ByteSlice;
 use scolapasta_path::os_str_to_bytes;
 use spinoso_exception::{ArgumentError, Fatal, LoadError};
 
@@ -13,7 +14,6 @@ use crate::sys::protect;
 use crate::value::Value;
 use crate::Artichoke;
 use crate::{exception_handler, RubyException};
-use bstr::ByteSlice;
 
 impl Eval for Artichoke {
     type Value = Value;

--- a/artichoke-backend/src/eval.rs
+++ b/artichoke-backend/src/eval.rs
@@ -60,7 +60,7 @@ impl Eval for Artichoke {
         let code = self
             .read_source_file_contents(file)
             .map_err(|err| {
-                let message = format!("ruby: {} -- {}", err.message().as_bstr(), file.to_string_lossy());
+                let message = format!("ruby: {} -- {}", err.message().as_bstr(), file.display());
                 LoadError::from(message)
             })?
             .into_owned();

--- a/artichoke-backend/src/eval.rs
+++ b/artichoke-backend/src/eval.rs
@@ -72,8 +72,11 @@ impl Eval for Artichoke {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(unix)]
+    use std::ffi::OsStr;
+    #[cfg(unix)]
     use std::os::unix::ffi::OsStrExt;
-    use std::{ffi::OsStr, path::Path};
+    use std::path::Path;
 
     use bstr::ByteSlice;
 
@@ -243,6 +246,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
     fn eval_file_error_invalid_path() {
         let mut interp = interpreter();
         let err = interp

--- a/artichoke-backend/src/eval.rs
+++ b/artichoke-backend/src/eval.rs
@@ -72,7 +72,8 @@ impl Eval for Artichoke {
 
 #[cfg(test)]
 mod tests {
-    use std::path::Path;
+    use std::os::unix::ffi::OsStrExt;
+    use std::{ffi::OsStr, path::Path};
 
     use bstr::ByteSlice;
 
@@ -237,6 +238,19 @@ mod tests {
         assert_eq!("LoadError", err.name().as_ref());
         assert_eq!(
             "ruby: file not found in virtual file system -- no/such/file.rb",
+            err.message().as_ref().as_bstr()
+        );
+    }
+
+    #[test]
+    fn eval_file_error_invalid_path() {
+        let mut interp = interpreter();
+        let err = interp
+            .eval_file(Path::new(OsStr::from_bytes(b"not/valid/utf8/\xff.rb")))
+            .unwrap_err();
+        assert_eq!("LoadError", err.name().as_ref());
+        assert_eq!(
+            "ruby: file not found in virtual file system -- not/valid/utf8/�.rb",
             err.message().as_ref().as_bstr()
         );
     }


### PR DESCRIPTION
Fixes #1579

Demo:
![](https://user-images.githubusercontent.com/12410942/210594586-a59ab20f-840d-45fb-8f56-90633cad3f72.png)

The current implementation is still a little different from MRI in the `(os error 2)` or `(os error 12)`. I'm not sure if the `(os error x)` is part of the default behavior of underlying OS error because I can't really find related code in Artichoke codebase. If that's the case, would we still want to remove the `(os error x)` part with something like `.replace()`?