### PR TITLE
Implement `String#byteindex`

### DIFF
--- a/artichoke-backend/src/convert/nilable.rs
+++ b/artichoke-backend/src/convert/nilable.rs
@@ -23,6 +23,18 @@ impl Convert<Option<i64>, Value> for Artichoke {
     }
 }
 
+impl TryConvert<Option<usize>, Value> for Artichoke {
+    type Error = Error;
+
+    fn try_convert(&self, value: Option<usize>) -> Result<Value, Self::Error> {
+        if let Some(value) = value {
+            self.try_convert(value)
+        } else {
+            Ok(Value::nil())
+        }
+    }
+}
+
 impl TryConvertMut<Option<Vec<u8>>, Value> for Artichoke {
     type Error = Error;
 

--- a/artichoke-backend/src/extn/core/string/mruby.rs
+++ b/artichoke-backend/src/extn/core/string/mruby.rs
@@ -22,6 +22,7 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
         .add_method("[]=", string_aset, sys::mrb_args_any())?
         .add_method("ascii_only?", string_ascii_only, sys::mrb_args_none())?
         .add_method("b", string_b, sys::mrb_args_none())?
+        .add_method("byteindex", string_byteindex, sys::mrb_args_req_and_opt(1, 1))?
         .add_method("bytes", string_bytes, sys::mrb_args_none())? // This does not support the deprecated block form
         .add_method("bytesize", string_bytesize, sys::mrb_args_none())?
         .add_method("byteslice", string_byteslice, sys::mrb_args_req_and_opt(1, 1))?
@@ -179,6 +180,19 @@ unsafe extern "C" fn string_b(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> 
     unwrap_interpreter!(mrb, to => guard);
     let value = Value::from(slf);
     let result = trampoline::b(&mut guard, value);
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => error::raise(guard, exception),
+    }
+}
+
+unsafe extern "C" fn string_byteindex(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
+    let (substring, offset) = mrb_get_args!(mrb, required = 1, optional = 1);
+    unwrap_interpreter!(mrb, to => guard);
+    let value = Value::from(slf);
+    let substring = Value::from(substring);
+    let offset = offset.map(Value::from);
+    let result = trampoline::byteindex(&mut guard, value, substring, offset);
     match result {
         Ok(value) => value.inner(),
         Err(exception) => error::raise(guard, exception),

--- a/artichoke-backend/src/extn/core/string/trampoline.rs
+++ b/artichoke-backend/src/extn/core/string/trampoline.rs
@@ -579,6 +579,31 @@ pub fn b(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
     super::String::alloc_value(s.to_binary(), interp)
 }
 
+pub fn byteindex(
+    interp: &mut Artichoke,
+    mut value: Value,
+    mut substring: Value,
+    offset: Option<Value>,
+) -> Result<Value, Error> {
+    #[cfg(feature = "core-regexp")]
+    if let Ok(_pattern) = unsafe { Regexp::unbox_from_value(&mut substring, interp) } {
+        return Err(NotImplementedError::from("String#byteindex with Regexp pattern").into());
+    }
+    let s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
+    let needle = unsafe { implicitly_convert_to_string(interp, &mut substring)? };
+    let offset = if let Some(offset) = offset {
+        let offset = implicitly_convert_to_int(interp, offset)?;
+        match aref::offset_to_index(offset, s.len()) {
+            None => return Ok(Value::nil()),
+            Some(offset) if offset > s.len() => return Ok(Value::nil()),
+            Some(offset) => Some(offset),
+        }
+    } else {
+        None
+    };
+    interp.try_convert(s.index(needle, offset))
+}
+
 pub fn bytes(interp: &mut Artichoke, mut value: Value) -> Result<Value, Error> {
     let s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
     let bytes = s


### PR DESCRIPTION
Only for `String` needles. `Regexp` needles raise `NotImplementedError`.

This PR was extracted from:

- https://github.com/artichoke/artichoke/pull/2355

I believe this is a new API in Ruby 3.2.0: https://ruby-doc.org/3.2.0/String.html#method-i-byteindex.