### PR TITLE
Enable parsing of Time Args with 10 parameters

### DIFF
--- a/artichoke-backend/src/extn/core/time/args.rs
+++ b/artichoke-backend/src/extn/core/time/args.rs
@@ -58,7 +58,7 @@ impl TryConvertMut<&mut [Value], Args> for Artichoke {
             match i {
                 0 => {
                     let arg = to_int(self, arg)?;
-                    let arg: i64 = arg.try_convert_into::<Option<i64>>(self)?.unwrap();
+                    let arg: i64 = arg.try_convert_into(self)?;
 
                     result.year = i32::try_from(arg).map_err(|_| ArgumentError::with_message("year out of range"))?;
                 }
@@ -66,7 +66,7 @@ impl TryConvertMut<&mut [Value], Args> for Artichoke {
                     // TODO: This should support 3 letter month names
                     // as per the docs. https://ruby-doc.org/3.1.2/Time.html#method-c-new
                     let arg = to_int(self, arg)?;
-                    let arg: i64 = arg.try_convert_into::<Option<i64>>(self)?.unwrap();
+                    let arg: i64 = arg.try_convert_into(self)?;
 
                     result.month = match u8::try_from(arg) {
                         Ok(month @ 1..=12) => Ok(month),
@@ -75,7 +75,7 @@ impl TryConvertMut<&mut [Value], Args> for Artichoke {
                 }
                 2 => {
                     let arg = to_int(self, arg)?;
-                    let arg: i64 = arg.try_convert_into::<Option<i64>>(self)?.unwrap();
+                    let arg: i64 = arg.try_convert_into(self)?;
 
                     result.day = match u8::try_from(arg) {
                         Ok(day @ 1..=31) => Ok(day),
@@ -84,7 +84,7 @@ impl TryConvertMut<&mut [Value], Args> for Artichoke {
                 }
                 3 => {
                     let arg = to_int(self, arg)?;
-                    let arg: i64 = arg.try_convert_into::<Option<i64>>(self)?.unwrap();
+                    let arg: i64 = arg.try_convert_into(self)?;
 
                     result.hour = match u8::try_from(arg) {
                         Ok(hour @ 0..=59) => Ok(hour),
@@ -93,7 +93,7 @@ impl TryConvertMut<&mut [Value], Args> for Artichoke {
                 }
                 4 => {
                     let arg = to_int(self, arg)?;
-                    let arg: i64 = arg.try_convert_into::<Option<i64>>(self)?.unwrap();
+                    let arg: i64 = arg.try_convert_into(self)?;
 
                     result.minute = match u8::try_from(arg) {
                         Ok(minute @ 0..=59) => Ok(minute),
@@ -108,7 +108,7 @@ impl TryConvertMut<&mut [Value], Args> for Artichoke {
                     // => 0001-02-03 04:05:06 56294995342131/562949953421312 UTC
                     // ```
                     let arg = to_int(self, arg)?;
-                    let arg: i64 = arg.try_convert_into::<Option<i64>>(self)?.unwrap();
+                    let arg: i64 = arg.try_convert_into(self)?;
 
                     result.second = match u8::try_from(arg) {
                         Ok(second @ 0..=59) => Ok(second),
@@ -117,7 +117,7 @@ impl TryConvertMut<&mut [Value], Args> for Artichoke {
                 }
                 6 => {
                     let arg = to_int(self, arg)?;
-                    let arg: i64 = arg.try_convert_into::<Option<i64>>(self)?.unwrap();
+                    let arg: i64 = arg.try_convert_into(self)?;
 
                     // Args take a micros parameter, not a nanos value, and
                     // therefore we must multiply the value by 1_000. This is

--- a/artichoke-backend/src/extn/core/time/args.rs
+++ b/artichoke-backend/src/extn/core/time/args.rs
@@ -26,10 +26,10 @@ impl Default for Args {
     }
 }
 
-impl TryConvertMut<&[Value], Args> for Artichoke {
+impl TryConvertMut<&mut [Value], Args> for Artichoke {
     type Error = Error;
 
-    fn try_convert_mut(&mut self, args: &[Value]) -> Result<Args, Self::Error> {
+    fn try_convert_mut(&mut self, mut args: &mut [Value]) -> Result<Args, Self::Error> {
         // Time args should have a length of 1..=8 or 10. The error does not
         // give a hint that the 10 arg variant is supported however (this is
         // the same in MRI).
@@ -40,8 +40,6 @@ impl TryConvertMut<&[Value], Args> for Artichoke {
             return Err(ArgumentError::from(message).into());
         }
 
-        let mut args = args.to_vec();
-
         // Args are in order of year, month, day, hour, minute, second, micros.
         // This is unless there are 10 arguments provided (`Time#to_a` format),
         // at which points it is second, minute, hour, day, month, year.
@@ -51,7 +49,7 @@ impl TryConvertMut<&[Value], Args> for Artichoke {
             args.swap(2, 3);
             // All arguments after position 5 are ignored in the 10 argument
             // variant.
-            args.truncate(6);
+            args = &mut args[..6];
         }
 
         let mut result = Args::default();
@@ -162,9 +160,9 @@ mod tests {
     fn requires_at_least_one_param() {
         let mut interp = interpreter();
 
-        let args = vec![];
+        let mut args = vec![];
 
-        let result: Result<Args, Error> = interp.try_convert_mut(args.as_slice());
+        let result: Result<Args, Error> = interp.try_convert_mut(args.as_mut_slice());
         let error = result.unwrap_err();
 
         assert_eq!(error.name(), "ArgumentError");
@@ -179,8 +177,8 @@ mod tests {
         let mut interp = interpreter();
 
         let args = interp.eval(b"[2022, 2, 3, 4, 5, 6, 7, nil]").unwrap();
-        let ary_args: Vec<Value> = interp.try_convert_mut(args).unwrap();
-        let result: Args = interp.try_convert_mut(ary_args.as_slice()).unwrap();
+        let mut ary_args: Vec<Value> = interp.try_convert_mut(args).unwrap();
+        let result: Args = interp.try_convert_mut(ary_args.as_mut_slice()).unwrap();
         assert_eq!(2022, result.year);
         assert_eq!(2, result.month);
         assert_eq!(3, result.day);
@@ -195,8 +193,8 @@ mod tests {
         let mut interp = interpreter();
 
         let args = interp.eval(b"[2022, 2, 3, 4, 5, 6, 7]").unwrap();
-        let ary_args: Vec<Value> = interp.try_convert_mut(args).unwrap();
-        let result: Args = interp.try_convert_mut(ary_args.as_slice()).unwrap();
+        let mut ary_args: Vec<Value> = interp.try_convert_mut(args).unwrap();
+        let result: Args = interp.try_convert_mut(ary_args.as_mut_slice()).unwrap();
         assert_eq!(2022, result.year);
         assert_eq!(2, result.month);
         assert_eq!(3, result.day);
@@ -211,8 +209,8 @@ mod tests {
         let mut interp = interpreter();
 
         let args = interp.eval(b"[2022, 2, 3, 4, 5, 6]").unwrap();
-        let ary_args: Vec<Value> = interp.try_convert_mut(args).unwrap();
-        let result: Args = interp.try_convert_mut(ary_args.as_slice()).unwrap();
+        let mut ary_args: Vec<Value> = interp.try_convert_mut(args).unwrap();
+        let result: Args = interp.try_convert_mut(ary_args.as_mut_slice()).unwrap();
         assert_eq!(2022, result.year);
         assert_eq!(2, result.month);
         assert_eq!(3, result.day);
@@ -227,8 +225,8 @@ mod tests {
         let mut interp = interpreter();
 
         let args = interp.eval(b"[2022, 2, 3, 4, 5]").unwrap();
-        let ary_args: Vec<Value> = interp.try_convert_mut(args).unwrap();
-        let result: Args = interp.try_convert_mut(ary_args.as_slice()).unwrap();
+        let mut ary_args: Vec<Value> = interp.try_convert_mut(args).unwrap();
+        let result: Args = interp.try_convert_mut(ary_args.as_mut_slice()).unwrap();
         assert_eq!(2022, result.year);
         assert_eq!(2, result.month);
         assert_eq!(3, result.day);
@@ -243,8 +241,8 @@ mod tests {
         let mut interp = interpreter();
 
         let args = interp.eval(b"[2022, 2, 3, 4]").unwrap();
-        let ary_args: Vec<Value> = interp.try_convert_mut(args).unwrap();
-        let result: Args = interp.try_convert_mut(ary_args.as_slice()).unwrap();
+        let mut ary_args: Vec<Value> = interp.try_convert_mut(args).unwrap();
+        let result: Args = interp.try_convert_mut(ary_args.as_mut_slice()).unwrap();
         assert_eq!(2022, result.year);
         assert_eq!(2, result.month);
         assert_eq!(3, result.day);
@@ -259,8 +257,8 @@ mod tests {
         let mut interp = interpreter();
 
         let args = interp.eval(b"[2022, 2, 3]").unwrap();
-        let ary_args: Vec<Value> = interp.try_convert_mut(args).unwrap();
-        let result: Args = interp.try_convert_mut(ary_args.as_slice()).unwrap();
+        let mut ary_args: Vec<Value> = interp.try_convert_mut(args).unwrap();
+        let result: Args = interp.try_convert_mut(ary_args.as_mut_slice()).unwrap();
         assert_eq!(2022, result.year);
         assert_eq!(2, result.month);
         assert_eq!(3, result.day);
@@ -275,8 +273,8 @@ mod tests {
         let mut interp = interpreter();
 
         let args = interp.eval(b"[2022, 2]").unwrap();
-        let ary_args: Vec<Value> = interp.try_convert_mut(args).unwrap();
-        let result: Args = interp.try_convert_mut(ary_args.as_slice()).unwrap();
+        let mut ary_args: Vec<Value> = interp.try_convert_mut(args).unwrap();
+        let result: Args = interp.try_convert_mut(ary_args.as_mut_slice()).unwrap();
         assert_eq!(2022, result.year);
         assert_eq!(2, result.month);
         assert_eq!(1, result.day);
@@ -291,8 +289,8 @@ mod tests {
         let mut interp = interpreter();
 
         let args = interp.eval(b"[2022]").unwrap();
-        let ary_args: Vec<Value> = interp.try_convert_mut(args).unwrap();
-        let result: Args = interp.try_convert_mut(ary_args.as_slice()).unwrap();
+        let mut ary_args: Vec<Value> = interp.try_convert_mut(args).unwrap();
+        let result: Args = interp.try_convert_mut(ary_args.as_mut_slice()).unwrap();
         assert_eq!(2022, result.year);
         assert_eq!(1, result.month);
         assert_eq!(1, result.day);
@@ -307,14 +305,14 @@ mod tests {
         let mut interp = interpreter();
 
         let args = interp.eval(b"[2022, 1, 1, 0, 0, 0, 1]").unwrap();
-        let ary_args: Vec<Value> = interp.try_convert_mut(args).unwrap();
-        let result: Args = interp.try_convert_mut(ary_args.as_slice()).unwrap();
+        let mut ary_args: Vec<Value> = interp.try_convert_mut(args).unwrap();
+        let result: Args = interp.try_convert_mut(ary_args.as_mut_slice()).unwrap();
         let nanos = result.nanoseconds;
         assert_eq!(1000, nanos);
 
         let args = interp.eval(b"[2022, 1, 1, 0, 0, 0, 999_999]").unwrap();
-        let ary_args: Vec<Value> = interp.try_convert_mut(args).unwrap();
-        let result: Args = interp.try_convert_mut(ary_args.as_slice()).unwrap();
+        let mut ary_args: Vec<Value> = interp.try_convert_mut(args).unwrap();
+        let result: Args = interp.try_convert_mut(ary_args.as_mut_slice()).unwrap();
         let nanos = result.nanoseconds;
         assert_eq!(999_999_000, nanos);
     }
@@ -324,14 +322,14 @@ mod tests {
         let mut interp = interpreter();
 
         let args = interp.eval(b"[2022, 1, 1, 0, 0, 0, -1]").unwrap();
-        let ary_args: Vec<Value> = interp.try_convert_mut(args).unwrap();
-        let result: Result<Args, Error> = interp.try_convert_mut(ary_args.as_slice());
+        let mut ary_args: Vec<Value> = interp.try_convert_mut(args).unwrap();
+        let result: Result<Args, Error> = interp.try_convert_mut(ary_args.as_mut_slice());
         let error = result.unwrap_err();
         assert_eq!(error.message().as_bstr(), b"subsecx out of range".as_bstr());
 
         let args = interp.eval(b"[2022, 1, 1, 0, 0, 0, 1_000_000]").unwrap();
-        let ary_args: Vec<Value> = interp.try_convert_mut(args).unwrap();
-        let result: Result<Args, Error> = interp.try_convert_mut(ary_args.as_slice());
+        let mut ary_args: Vec<Value> = interp.try_convert_mut(args).unwrap();
+        let result: Result<Args, Error> = interp.try_convert_mut(ary_args.as_mut_slice());
         let error = result.unwrap_err();
         assert_eq!(error.message().as_bstr(), b"subsecx out of range".as_bstr());
     }
@@ -344,8 +342,8 @@ mod tests {
         let mut interp = interpreter();
 
         let args = interp.eval(b"[2022, 2, 3, 4, 5, 6, 7, nil, 0]").unwrap();
-        let ary_args: Vec<Value> = interp.try_convert_mut(args).unwrap();
-        let result: Result<Args, Error> = interp.try_convert_mut(ary_args.as_slice());
+        let mut ary_args: Vec<Value> = interp.try_convert_mut(args).unwrap();
+        let result: Result<Args, Error> = interp.try_convert_mut(ary_args.as_mut_slice());
         let error = result.unwrap_err();
 
         assert_eq!(
@@ -360,8 +358,8 @@ mod tests {
         let mut interp = interpreter();
 
         let args = interp.eval(b"[1, 2, 3, 4, 5, 2022, nil, nil, nil, nil]").unwrap();
-        let ary_args: Vec<Value> = interp.try_convert_mut(args).unwrap();
-        let result: Args = interp.try_convert_mut(ary_args.as_slice()).unwrap();
+        let mut ary_args: Vec<Value> = interp.try_convert_mut(args).unwrap();
+        let result: Args = interp.try_convert_mut(ary_args.as_mut_slice()).unwrap();
 
         assert_eq!(1, result.second);
         assert_eq!(2, result.minute);
@@ -376,8 +374,8 @@ mod tests {
         let mut interp = interpreter();
 
         let args = interp.eval(b"[2022, 2, 3, 4, 5, 6, 7, nil, 0, 0, 0]").unwrap();
-        let ary_args: Vec<Value> = interp.try_convert_mut(args).unwrap();
-        let result: Result<Args, Error> = interp.try_convert_mut(ary_args.as_slice());
+        let mut ary_args: Vec<Value> = interp.try_convert_mut(args).unwrap();
+        let result: Result<Args, Error> = interp.try_convert_mut(ary_args.as_mut_slice());
         let error = result.unwrap_err();
 
         assert_eq!(

--- a/artichoke-backend/src/extn/core/time/args.rs
+++ b/artichoke-backend/src/extn/core/time/args.rs
@@ -360,9 +360,6 @@ mod tests {
     fn ten_args_changes_unit_order() {}
 
     #[test]
-    fn ten_args_removes_micros() {}
-
-    #[test]
     fn eleven_args_is_too_many() {
         let mut interp = interpreter();
 

--- a/artichoke-backend/src/extn/core/time/mruby.rs
+++ b/artichoke-backend/src/extn/core/time/mruby.rs
@@ -130,8 +130,8 @@ unsafe extern "C" fn time_self_at(mrb: *mut sys::mrb_state, _slf: sys::mrb_value
 unsafe extern "C" fn time_self_mkutc(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {
     let args = mrb_get_args!(mrb, *args);
     unwrap_interpreter!(mrb, to => guard);
-    let args = args.iter().copied().map(Value::from).collect::<Vec<Value>>();
-    let result = trampoline::mkutc(&mut guard, &args);
+    let mut args = args.iter().copied().map(Value::from).collect::<Vec<Value>>();
+    let result = trampoline::mkutc(&mut guard, &mut args);
     match result {
         Ok(value) => value.inner(),
         Err(exception) => error::raise(guard, exception),
@@ -141,8 +141,8 @@ unsafe extern "C" fn time_self_mkutc(mrb: *mut sys::mrb_state, _slf: sys::mrb_va
 unsafe extern "C" fn time_self_mktime(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {
     let args = mrb_get_args!(mrb, *args);
     unwrap_interpreter!(mrb, to => guard);
-    let args = args.iter().copied().map(Value::from).collect::<Vec<Value>>();
-    let result = trampoline::mktime(&mut guard, &args);
+    let mut args = args.iter().copied().map(Value::from).collect::<Vec<Value>>();
+    let result = trampoline::mktime(&mut guard, &mut args);
     match result {
         Ok(value) => value.inner(),
         Err(exception) => error::raise(guard, exception),

--- a/artichoke-backend/src/extn/core/time/trampoline.rs
+++ b/artichoke-backend/src/extn/core/time/trampoline.rs
@@ -118,13 +118,13 @@ pub fn mkutc(interp: &mut Artichoke, args: &[Value]) -> Result<Value, Error> {
     let args: Args = interp.try_convert_mut(args)?;
 
     let time = Time::utc(
-        args.year()?,
-        args.month()?,
-        args.day()?,
-        args.hour()?,
-        args.minute()?,
-        args.second()?,
-        args.nanoseconds()?,
+        args.year,
+        args.month,
+        args.day,
+        args.hour,
+        args.minute,
+        args.second,
+        args.nanoseconds,
     )?;
 
     Time::alloc_value(time, interp)
@@ -134,13 +134,13 @@ pub fn mktime(interp: &mut Artichoke, args: &[Value]) -> Result<Value, Error> {
     let args: Args = interp.try_convert_mut(args)?;
 
     let time = Time::local(
-        args.year()?,
-        args.month()?,
-        args.day()?,
-        args.hour()?,
-        args.minute()?,
-        args.second()?,
-        args.nanoseconds()?,
+        args.year,
+        args.month,
+        args.day,
+        args.hour,
+        args.minute,
+        args.second,
+        args.nanoseconds,
     )?;
 
     Time::alloc_value(time, interp)

--- a/artichoke-backend/src/extn/core/time/trampoline.rs
+++ b/artichoke-backend/src/extn/core/time/trampoline.rs
@@ -114,7 +114,7 @@ pub fn at(
     Time::alloc_value(time, interp)
 }
 
-pub fn mkutc(interp: &mut Artichoke, args: &[Value]) -> Result<Value, Error> {
+pub fn mkutc(interp: &mut Artichoke, args: &mut [Value]) -> Result<Value, Error> {
     let args: Args = interp.try_convert_mut(args)?;
 
     let time = Time::utc(
@@ -130,7 +130,7 @@ pub fn mkutc(interp: &mut Artichoke, args: &[Value]) -> Result<Value, Error> {
     Time::alloc_value(time, interp)
 }
 
-pub fn mktime(interp: &mut Artichoke, args: &[Value]) -> Result<Value, Error> {
+pub fn mktime(interp: &mut Artichoke, args: &mut [Value]) -> Result<Value, Error> {
     let args: Args = interp.try_convert_mut(args)?;
 
     let time = Time::local(


### PR DESCRIPTION
Quick follow on from #2410 

Adds ten argument support (e.g. `Time.local(*Time.now.to_a)`)
Refactor the existing logic to do all type and range checking within the initial parsing. (See the commit details for some more info).

This solves a bunch of problems I had in my head about how to structure this code. It might be somewhat reusable for the likes of `Time::new`, but will have to see.

Related to: #2223 