### PR TITLE
Time Args support for month string values

### DIFF
--- a/artichoke-backend/src/extn/core/kernel/mod.rs
+++ b/artichoke-backend/src/extn/core/kernel/mod.rs
@@ -3,6 +3,8 @@ pub(in crate::extn) mod mruby;
 pub mod require;
 pub(super) mod trampoline;
 
+pub use trampoline::integer;
+
 #[derive(Debug, Clone, Copy)]
 pub struct Kernel;
 

--- a/artichoke-backend/src/extn/core/time/args.rs
+++ b/artichoke-backend/src/extn/core/time/args.rs
@@ -339,18 +339,19 @@ mod tests {
         let mut interp = interpreter();
 
         let table = [
-            (b"[2022, \"jan\"]", 1),
-            (b"[2022, \"feb\"]", 2),
-            (b"[2022, \"mar\"]", 3),
-            (b"[2022, \"apr\"]", 4),
-            (b"[2022, \"may\"]", 5),
-            (b"[2022, \"jun\"]", 6),
-            (b"[2022, \"jul\"]", 7),
-            (b"[2022, \"aug\"]", 8),
-            (b"[2022, \"sep\"]", 9),
-            (b"[2022, \"oct\"]", 10),
-            (b"[2022, \"nov\"]", 11),
-            (b"[2022, \"dec\"]", 12),
+            (b"[2022, 'jan']", 1),
+            (b"[2022, 'feb']", 2),
+            (b"[2022, 'mar']", 3),
+            (b"[2022, 'apr']", 4),
+            (b"[2022, 'may']", 5),
+            (b"[2022, 'jun']", 6),
+            (b"[2022, 'jul']", 7),
+            (b"[2022, 'aug']", 8),
+            (b"[2022, 'sep']", 9),
+            (b"[2022, 'oct']", 10),
+            (b"[2022, 'nov']", 11),
+            (b"[2022, 'dec']", 12),
+        ];
         ];
 
         for (input, expected_month) in table {
@@ -367,7 +368,7 @@ mod tests {
         let mut interp = interpreter();
 
         let args = interp
-            .eval(b"class A; def to_str; \"feb\"; end; end; [2022, A.new]")
+            .eval(b"class A; def to_str; 'feb'; end; end; [2022, A.new]")
             .unwrap();
         let mut ary_args: Vec<Value> = interp.try_convert_mut(args).unwrap();
         let result: Args = interp.try_convert_mut(ary_args.as_mut_slice()).unwrap();
@@ -391,7 +392,7 @@ mod tests {
         let mut interp = interpreter();
 
         let args = interp
-            .eval(b"class A; def to_str; \"aaa\"; end; end; [2022, A.new]")
+            .eval(b"class A; def to_str; 'aaa'; end; end; [2022, A.new]")
             .unwrap();
         let mut ary_args: Vec<Value> = interp.try_convert_mut(args).unwrap();
         let result: Result<Args, Error> = interp.try_convert_mut(ary_args.as_mut_slice());

--- a/artichoke-backend/src/extn/core/time/args.rs
+++ b/artichoke-backend/src/extn/core/time/args.rs
@@ -399,6 +399,7 @@ mod tests {
             let result: Args = interp.try_convert_mut(ary_args.as_mut_slice()).unwrap();
 
             assert_eq!(expected_month, result.month);
+            assert_eq!(2022, result.year);
         }
     }
 

--- a/artichoke-backend/src/extn/core/time/args.rs
+++ b/artichoke-backend/src/extn/core/time/args.rs
@@ -352,6 +352,28 @@ mod tests {
             (b"[2022, 'nov']", 11),
             (b"[2022, 'dec']", 12),
         ];
+
+        for (input, expected_month) in table {
+            let args = interp.eval(input).unwrap();
+            let mut ary_args: Vec<Value> = interp.try_convert_mut(args).unwrap();
+            let result: Args = interp.try_convert_mut(ary_args.as_mut_slice()).unwrap();
+
+            assert_eq!(expected_month, result.month);
+        }
+    }
+
+    #[test]
+    fn month_strings_are_case_insensitive() {
+        let mut interp = interpreter();
+
+        let table = [
+            (b"[2022, 'Feb']", 2),
+            (b"[2022, 'fEb']", 2),
+            (b"[2022, 'feB']", 2),
+            (b"[2022, 'FEb']", 2),
+            (b"[2022, 'FeB']", 2),
+            (b"[2022, 'fEB']", 2),
+            (b"[2022, 'FEB']", 2),
         ];
 
         for (input, expected_month) in table {
@@ -381,6 +403,17 @@ mod tests {
         let mut interp = interpreter();
 
         let args = interp.eval(b"class A; def to_int; 2; end; end; [2022, A.new]").unwrap();
+        let mut ary_args: Vec<Value> = interp.try_convert_mut(args).unwrap();
+        let result: Args = interp.try_convert_mut(ary_args.as_mut_slice()).unwrap();
+
+        assert_eq!(2, result.month);
+    }
+
+    #[test]
+    fn month_string_can_be_integer_strings() {
+        let mut interp = interpreter();
+
+        let args = interp.eval(b"class A; def to_str; '2'; end; end; [2022, A.new]").unwrap();
         let mut ary_args: Vec<Value> = interp.try_convert_mut(args).unwrap();
         let result: Args = interp.try_convert_mut(ary_args.as_mut_slice()).unwrap();
 


### PR DESCRIPTION
Another follow on from #2410 and #2411.
Related to #2223

`Time#utc`, `Time#local`, and friends all support specifying a month value from the shortened 3 character english names for the month.

Ref: https://ruby-doc.org/3.1.2/Time.html#method-c-utc