### PR TITLE
Remove `TryConvertMut` fully-qualified turbofishes

### DIFF
--- a/artichoke-backend/src/convert/string.rs
+++ b/artichoke-backend/src/convert/string.rs
@@ -43,7 +43,11 @@ impl TryConvertMut<Value, String> for Artichoke {
     type Error = Error;
 
     fn try_convert_mut(&mut self, value: Value) -> Result<String, Self::Error> {
-        TryConvertMut::<_, &str>::try_convert_mut(self, value).map(String::from)
+        let bytes = self.try_convert_mut(value)?;
+        // This converter requires that the bytes be valid UTF-8 data. If the
+        // `Value` contains binary data, use the `Vec<u8>` or `&[u8]` converter.
+        let string = String::from_utf8(bytes).map_err(|_| UnboxRubyError::new(&value, Rust::String))?;
+        Ok(string)
     }
 }
 

--- a/artichoke-backend/src/extn/core/string/trampoline.rs
+++ b/artichoke-backend/src/extn/core/string/trampoline.rs
@@ -321,7 +321,7 @@ pub fn equals_equals(interp: &mut Artichoke, mut value: Value, mut other: Value)
     if value.respond_to(interp, "to_str")? {
         let result = other.funcall(interp, "==", &[value], None)?;
         // any falsy returned value yields `false`, otherwise `true`.
-        if let Ok(result) = TryConvert::<_, Option<bool>>::try_convert(interp, result) {
+        if let Ok(result) = result.try_convert_into::<Option<bool>>(interp) {
             let result = result.unwrap_or_default();
             Ok(interp.convert(result))
         } else {


### PR DESCRIPTION
- Simplify a trampoline by using `Value::try_convert_into` in an `if let` condition.
- Reimplement `TryConvertMut<Value, String>` to go through the `Vec<u8>` owned impl, instead of the `&str` -> `&[u8]` borrowed impl. This saves a stack frame and uses a direct clone of the underlying `Vec<u8>`.

Thanks for poking me about this and getting me to look at this old cold again @b-n!