### PR TITLE
Fix panics on `f64` outside `i64` range for checked `Time` float ops

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -748,7 +748,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-time"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "once_cell",
  "regex",

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -36,7 +36,7 @@ spinoso-regexp = { version = "0.4.0", path = "../spinoso-regexp", optional = tru
 spinoso-securerandom = { version = "0.2.0", path = "../spinoso-securerandom", optional = true }
 spinoso-string = { version = "0.20.0", path = "../spinoso-string", features = ["always-nul-terminated-c-string-compat"] }
 spinoso-symbol = { version = "0.3.0", path = "../spinoso-symbol" }
-spinoso-time = { version = "0.7.0", path = "../spinoso-time", features = ["tzrs"], default-features = false, optional = true }
+spinoso-time = { version = "0.7.1", path = "../spinoso-time", features = ["tzrs"], default-features = false, optional = true }
 
 [dev-dependencies]
 quickcheck = { version = "1.0.3", default-features = false }

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -566,7 +566,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-time"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "once_cell",
  "regex",

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -952,7 +952,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-time"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "once_cell",
  "regex",

--- a/spinoso-time/Cargo.toml
+++ b/spinoso-time/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spinoso-time"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 description = """
 Datetime handling for Artichoke Ruby

--- a/spinoso-time/README.md
+++ b/spinoso-time/README.md
@@ -37,7 +37,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-spinoso-time = { version = "0.7.0", features = ["tzrs"] }
+spinoso-time = { version = "0.7.1", features = ["tzrs"] }
 ```
 
 ## Examples

--- a/spinoso-time/src/time/tzrs/error.rs
+++ b/spinoso-time/src/time/tzrs/error.rs
@@ -2,6 +2,7 @@
 
 use core::fmt;
 use core::num::TryFromIntError;
+use core::time::TryFromFloatSecsError;
 use std::error;
 use std::str::Utf8Error;
 
@@ -150,8 +151,14 @@ impl From<TzOutOfRangeError> for TimeError {
 }
 
 impl From<IntOverflowError> for TimeError {
-    fn from(error: IntOverflowError) -> Self {
-        Self::IntOverflowError(error)
+    fn from(err: IntOverflowError) -> Self {
+        Self::IntOverflowError(err)
+    }
+}
+
+impl From<TryFromFloatSecsError> for TimeError {
+    fn from(err: TryFromFloatSecsError) -> Self {
+        Self::TzOutOfRangeError(err.into())
     }
 }
 
@@ -206,6 +213,12 @@ impl TzOutOfRangeError {
     // This error is not to be constructed outside of this crate.
     pub(crate) const fn new() -> Self {
         Self { _private: () }
+    }
+}
+
+impl From<TryFromFloatSecsError> for TzOutOfRangeError {
+    fn from(_err: TryFromFloatSecsError) -> Self {
+        Self::new()
     }
 }
 

--- a/spinoso-time/src/time/tzrs/math.rs
+++ b/spinoso-time/src/time/tzrs/math.rs
@@ -161,9 +161,9 @@ impl Time {
         }
 
         if seconds.is_sign_positive() {
-            self.checked_add(Duration::from_secs_f64(seconds))
+            self.checked_add(Duration::try_from_secs_f64(seconds)?)
         } else {
-            self.checked_sub(Duration::from_secs_f64(-seconds))
+            self.checked_sub(Duration::try_from_secs_f64(-seconds)?)
         }
     }
 }
@@ -242,9 +242,9 @@ impl Time {
         }
 
         if seconds.is_sign_positive() {
-            self.checked_sub(Duration::from_secs_f64(seconds))
+            self.checked_sub(Duration::try_from_secs_f64(seconds)?)
         } else {
-            self.checked_add(Duration::from_secs_f64(-seconds))
+            self.checked_add(Duration::try_from_secs_f64(-seconds)?)
         }
     }
 }
@@ -302,6 +302,15 @@ mod tests {
         } else {
             assert!(500_000_000 - succ.nanoseconds() < 50);
         }
+    }
+
+    #[test]
+    fn add_out_of_fixnum_range_float_sec() {
+        let dt = datetime();
+        dt.checked_add_f64(f64::MAX).unwrap_err();
+
+        let dt = datetime();
+        dt.checked_add_f64(f64::MIN).unwrap_err();
     }
 
     #[test]
@@ -391,6 +400,15 @@ mod tests {
         } else {
             assert!(500_000_000 - succ.nanoseconds() < 50);
         }
+    }
+
+    #[test]
+    fn sub_out_of_fixnum_range_float_sec() {
+        let dt = datetime();
+        dt.checked_sub_f64(f64::MAX).unwrap_err();
+
+        let dt = datetime();
+        dt.checked_sub_f64(f64::MIN).unwrap_err();
     }
 
     #[test]


### PR DESCRIPTION
In Rust 1.66, `Duration::try_from_secs_{f32, f64}` were stabilized which ensures that `Duration`s are only constructed from floats which fit in its inner int representation.

Previously, passing too large or too small `f64` to `Time::checked_add_f64` and `Time::checked_sub_f64` would panic.

Additional tests have been added.

`spinoso-time` is bumped to 0.7.1 to reflect the bug fix.

Fixes #2194.