### PR TITLE
Limit downcasing work for `String` Time month args

### DIFF
--- a/artichoke-backend/src/extn/core/time/args.rs
+++ b/artichoke-backend/src/extn/core/time/args.rs
@@ -466,6 +466,19 @@ mod tests {
     }
 
     #[test]
+    fn month_downcase_shortcut_does_not_limit_call_to_integer() {
+        let mut interp = interpreter();
+
+        let args = interp
+            .eval(b"class I; def to_str; '0000000002'; end; end; [2022, I.new]")
+            .unwrap();
+        let mut ary_args: Vec<Value> = interp.try_convert_mut(args).unwrap();
+        let result: Args = interp.try_convert_mut(ary_args.as_mut_slice()).unwrap();
+
+        assert_eq!(2, result.month);
+    }
+
+    #[test]
     fn subsec_is_valid_micros_not_nanos() {
         let mut interp = interpreter();
 

--- a/artichoke-backend/src/extn/core/time/args.rs
+++ b/artichoke-backend/src/extn/core/time/args.rs
@@ -93,8 +93,15 @@ impl TryConvertMut<&mut [Value], Args> for Artichoke {
                     // ```
                     let month: i64 = if let Ok(arg) = to_str(self, arg) {
                         let mut month_str: Vec<u8> = arg.try_convert_into_mut(self)?;
+
+                        // Valid month string args are always 3 bytes long (or 3
+                        // ASCII characters). only downcase the first 3 bytes to
+                        // avoid excessive resource consumption if given a long
+                        // string.
+                        let month_str = month_str.get_mut(..3).unwrap_or_default();
                         month_str.make_ascii_lowercase();
-                        match month_str.as_slice() {
+
+                        match &*month_str {
                             b"jan" => 1,
                             b"feb" => 2,
                             b"mar" => 3,


### PR DESCRIPTION
All valid string arguments to `Time.new` for the month are 3 ASCII characters. In the event that a very long string is passed, the existing implementation will do a lot of work downcasing the string that is ultimately discarded.

Short circuit this by extracting the first 3 bytes from the captured `Vec` and only downcasing those.

Followup to #2413.