### PR TITLE
Upgrade rustyline to 11.0.0, rework REPL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,6 +26,7 @@ version = "0.1.0-pre.0"
 dependencies = [
  "artichoke-backend",
  "clap",
+ "directories",
  "log",
  "rustyline",
  "scolapasta-path",
@@ -222,6 +223,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "directories"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f51c5d4ddabd36886dd3e1438cb358cdcb0d7c499cb99cb4ac2e38e18b5cb210"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
 ]
 
 [[package]]
@@ -531,6 +552,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1e22ce49f28be0887a992cf42172c8c75facdb74e3e1a7eb0f459cf2fcc95d7"
 
 [[package]]
+name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+dependencies = [
+ "getrandom",
+ "redox_syscall",
+ "thiserror",
+]
+
+[[package]]
 name = "regex"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -790,6 +831,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,12 +77,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "autocfg"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
-
-[[package]]
 name = "base64"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -262,17 +256,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fd-lock"
-version = "3.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ef1a30ae415c3a691a4f41afddc2dbcd6d70baf338368d85ebc1e8ed92cedb9"
-dependencies = [
- "cfg-if",
- "rustix",
- "windows-sys",
-]
-
-[[package]]
 name = "focaccia"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -417,14 +400,14 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.25.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f346ff70e7dbfd675fe90590b92d59ef2de15a8779ae305ebcbfd3f0caf59be4"
+checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
 dependencies = [
- "autocfg",
  "bitflags",
  "cfg-if",
  "libc",
+ "static_assertions",
 ]
 
 [[package]]
@@ -569,14 +552,13 @@ dependencies = [
 
 [[package]]
 name = "rustyline"
-version = "10.1.1"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e83c32c3f3c33b08496e0d1df9ea8c64d39adb8eb36a1ebb1440c690697aef"
+checksum = "5dfc8644681285d1fb67a467fb3021bfea306b99b4146b166a1fe3ada965eece"
 dependencies = [
  "bitflags",
  "cfg-if",
  "clipboard-win",
- "fd-lock",
  "libc",
  "log",
  "memchr",
@@ -753,6 +735,12 @@ dependencies = [
  "tz-rs",
  "tzdb",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "str-buf"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,6 +256,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fd-lock"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ef1a30ae415c3a691a4f41afddc2dbcd6d70baf338368d85ebc1e8ed92cedb9"
+dependencies = [
+ "cfg-if",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "focaccia"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -559,6 +570,7 @@ dependencies = [
  "bitflags",
  "cfg-if",
  "clipboard-win",
+ "fd-lock",
  "libc",
  "log",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ documentation.workspace = true
 
 [dependencies]
 clap = { version = "4.1.0", optional = true }
-directories = "4.0.1"
+directories = { version = "4.0.1", optional = true }
 # XXX: load-bearing unused dependency.
 #
 # `rustyline` improperly declares its minimum version on `log` as `0.4` despite
@@ -99,7 +99,7 @@ default = [
 ]
 # Enable a CLI frontend for Artichoke, including a `ruby`-equivalent CLI and
 # REPL.
-cli = ["backtrace", "dep:clap", "dep:log", "dep:rustyline"]
+cli = ["backtrace", "dep:clap", "dep:directories", "dep:log", "dep:rustyline"]
 # Enable a module for formtting backtraces from Ruby exceptions.
 backtrace = ["dep:termcolor"]
 # Enable all features of Ruby Core, Standard Library, and the underlying VM.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ documentation.workspace = true
 
 [dependencies]
 clap = { version = "4.1.0", optional = true }
+directories = "4.0.1"
 # XXX: load-bearing unused dependency.
 #
 # `rustyline` improperly declares its minimum version on `log` as `0.4` despite

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ clap = { version = "4.1.0", optional = true }
 log = { version = "0.4.5", optional = true }
 scolapasta-path = { version = "0.5.0", path = "scolapasta-path" }
 scolapasta-string-escape = { version = "0.3.0", path = "scolapasta-string-escape", default-features = false }
-rustyline = { version = "10.0.0", optional = true, default-features = false }
+rustyline = { version = "11.0.0", optional = true, default-features = false }
 termcolor = { version = "1.1.0", optional = true }
 
 [dependencies.artichoke-backend]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ clap = { version = "4.1.0", optional = true }
 log = { version = "0.4.5", optional = true }
 scolapasta-path = { version = "0.5.0", path = "scolapasta-path" }
 scolapasta-string-escape = { version = "0.3.0", path = "scolapasta-string-escape", default-features = false }
-rustyline = { version = "11.0.0", optional = true, default-features = false }
+rustyline = { version = "11.0.0", optional = true, default-features = false, features = ["with-file-history"] }
 termcolor = { version = "1.1.0", optional = true }
 
 [dependencies.artichoke-backend]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 #![warn(clippy::cargo)]
 #![allow(unknown_lints)]
 #![allow(clippy::manual_let_else)]
+#![allow(clippy::module_name_repetitions)]
 #![warn(missing_docs)]
 #![warn(missing_debug_implementations)]
 #![warn(missing_copy_implementations)]

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -6,6 +6,7 @@
 
 use std::error;
 use std::fmt;
+use std::fs;
 use std::io;
 use std::path::PathBuf;
 
@@ -172,8 +173,14 @@ fn preamble(interp: &mut Artichoke) -> Result<String, Error> {
 
 fn repl_history_file() -> Option<PathBuf> {
     let dirs = ProjectDirs::from("org", "artichokeruby", "airb")?;
-    let data = dirs.data_dir();
-    Some(data.join("history"))
+
+    let data_dir = dirs.data_dir();
+    // Ensure the data directory exists but ignore failures (e.g. the dir
+    // already exists) because all operations on the history file are best
+    // effort and non-blocking.
+    let _ignored = fs::create_dir(data_dir);
+
+    Some(data_dir.join("history"))
 }
 
 /// Run a REPL for the mruby interpreter exposed by the `mruby` crate.

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -257,6 +257,8 @@ where
         let readline = rl.readline(config.simple);
         match readline {
             Ok(input) if input.is_empty() => {}
+            // simulate `Kernel#exit`.
+            Ok(input) if input == "exit" || input == "exit()" => break,
             Ok(input) => {
                 let mut lock = parser.inner.lock().unwrap_or_else(PoisonError::into_inner);
                 let interp = lock.interp();

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -9,7 +9,7 @@ use std::fmt;
 use std::io;
 
 use rustyline::error::ReadlineError;
-use rustyline::Editor;
+use rustyline::DefaultEditor;
 use termcolor::WriteColor;
 
 use crate::backend::state::parser::Context;
@@ -216,7 +216,7 @@ where
     interp.push_context(context)?;
     let mut parser = Parser::new(interp).ok_or_else(ParserAllocError::new)?;
 
-    let mut rl = Editor::<()>::new().map_err(UnhandledReadlineError)?;
+    let mut rl = DefaultEditor::new().map_err(UnhandledReadlineError)?;
     // If a code block is open, accumulate code from multiple read lines in this
     // mutable `String` buffer.
     let mut buf = String::new();
@@ -260,7 +260,7 @@ where
                     Err(ref exc) => backtrace::format_repl_trace_into(&mut error, interp, exc)?,
                 }
                 for line in buf.lines() {
-                    rl.add_history_entry(line);
+                    rl.add_history_entry(line)?;
                     interp.add_fetch_lineno(1).map_err(|_| ParserLineCountError::new())?;
                 }
                 // Eval successful, so reset the REPL state for the next

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -193,13 +193,17 @@ where
     Werr: io::Write + WriteColor,
 {
     let mut interp = crate::interpreter()?;
-    let result = repl_loop(&mut interp, output, error, &config.unwrap_or_default());
+    let mut rl = DefaultEditor::new().map_err(UnhandledReadlineError)?;
+
+    let result = repl_loop(&mut interp, &mut rl, output, error, &config.unwrap_or_default());
+
     interp.close();
     result
 }
 
 fn repl_loop<Wout, Werr>(
     interp: &mut Artichoke,
+    rl: &mut DefaultEditor,
     mut output: Wout,
     mut error: Werr,
     config: &PromptConfig<'_, '_, '_>,
@@ -216,7 +220,6 @@ where
     interp.push_context(context)?;
     let mut parser = Parser::new(interp).ok_or_else(ParserAllocError::new)?;
 
-    let mut rl = DefaultEditor::new().map_err(UnhandledReadlineError)?;
     // If a code block is open, accumulate code from multiple read lines in this
     // mutable `String` buffer.
     let mut buf = String::new();


### PR DESCRIPTION
Upgrade rustyline to 11.0.0 and make the following improvements to the REPL:

- Persist REPL history to a history file.
- Store the history file in the OS-conventional data directory using the `directories` crate.
- Implement rustyline-native multiline editing by adapting `artichoke::Parser` into a rustyline `Validator` and `Helper`.
- Store multiline input as single entries in the history file.
- Remove manual buffer collecting multiline input in REPL loop.
- Simulate support for `Kernel#exit` by allowing the strings `exit` and `exit()` to terminate the REPL.