### PR TITLE
Cleanup readline parser validator implementation

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -6,22 +6,12 @@
 use std::ffi::CStr;
 use std::os::raw::c_char;
 use std::ptr::NonNull;
-#[cfg(feature = "cli")]
-use std::sync::{Arc, Mutex, PoisonError};
-
-#[cfg(feature = "cli")]
-use rustyline::{
-    completion::Completer,
-    error::ReadlineError,
-    highlight::Highlighter,
-    hint::Hinter,
-    line_buffer::LineBuffer,
-    validate::{ValidationContext, ValidationResult, Validator},
-    Changeset, Helper,
-};
 
 use crate::backend::sys;
 use crate::backend::{Artichoke, Error};
+
+#[cfg(feature = "cli")]
+pub(crate) mod repl;
 
 /// State shows whether artichoke can parse some code or why it cannot.
 ///
@@ -231,69 +221,5 @@ impl<'a> Drop for Parser<'a> {
         }
         // There is no need to free `context` since it is owned by the
         // Artichoke state.
-    }
-}
-
-/// A rustyline validator that checks whether REPL input parses as valid Ruby
-/// code.
-#[cfg(feature = "cli")]
-#[derive(Debug, Clone)]
-pub struct ParserValidator<'a> {
-    pub(crate) inner: Arc<Mutex<Parser<'a>>>,
-}
-
-#[cfg(feature = "cli")]
-impl<'a> ParserValidator<'a> {
-    /// Create a new parser validator from an interpreter instance.
-    ///
-    /// A parser validator wraps a [`Parser`] and adapts it to [`rustyline`]'s
-    /// [`Validator`] trait.
-    pub fn new(interp: &'a mut Artichoke) -> Option<Self> {
-        let inner = Parser::new(interp)?;
-        let inner = Arc::new(Mutex::new(inner));
-        Some(Self { inner })
-    }
-}
-
-#[cfg(feature = "cli")]
-impl<'a> Helper for ParserValidator<'a> {}
-
-#[cfg(feature = "cli")]
-impl<'a> Completer for ParserValidator<'a> {
-    type Candidate = String;
-
-    fn update(&self, _line: &mut LineBuffer, _start: usize, _elected: &str, _cl: &mut Changeset) {
-        unreachable!();
-    }
-}
-
-#[cfg(feature = "cli")]
-impl<'a> Hinter for ParserValidator<'a> {
-    type Hint = String;
-}
-
-#[cfg(feature = "cli")]
-impl<'a> Highlighter for ParserValidator<'a> {}
-
-#[cfg(feature = "cli")]
-impl<'a> Validator for ParserValidator<'a> {
-    fn validate(&self, ctx: &mut ValidationContext<'_>) -> Result<ValidationResult, ReadlineError> {
-        let mut parser = self.inner.lock().unwrap_or_else(PoisonError::into_inner);
-        let state = if let Ok(state) = parser.parse(ctx.input().as_bytes()) {
-            state
-        } else {
-            return Ok(ValidationResult::Invalid(None));
-        };
-
-        if state.is_code_block_open() {
-            return Ok(ValidationResult::Incomplete);
-        }
-        if state.is_fatal() {
-            return Ok(ValidationResult::Invalid(Some("fatal parsing error".into())));
-        }
-        if state.is_recoverable_error() {
-            return Ok(ValidationResult::Invalid(Some("could not parse input".into())));
-        }
-        Ok(ValidationResult::Valid(None))
     }
 }

--- a/src/parser/repl.rs
+++ b/src/parser/repl.rs
@@ -1,0 +1,76 @@
+use std::sync::{Mutex, PoisonError};
+
+use rustyline::{
+    completion::Completer,
+    error::ReadlineError,
+    highlight::Highlighter,
+    hint::Hinter,
+    line_buffer::LineBuffer,
+    validate::{ValidationContext, ValidationResult, Validator},
+    Changeset, Helper,
+};
+
+use crate::Artichoke;
+
+/// A rustyline validator that checks whether REPL input parses as valid Ruby
+/// code.
+#[derive(Debug)]
+pub struct Parser<'a> {
+    /// Inner [`Parser`], which contains a reference to an [`Artichoke`]
+    /// interpreter.
+    ///
+    /// [`Artichoke`]: crate::Artichoke
+    pub inner: Mutex<super::Parser<'a>>,
+}
+
+impl<'a> Parser<'a> {
+    /// Create a new parser validator from an interpreter instance.
+    ///
+    /// A parser validator wraps a [`Parser`] and adapts it to [`rustyline`]'s
+    /// [`Validator`] trait.
+    pub fn new(interp: &'a mut Artichoke) -> Option<Self> {
+        let inner = super::Parser::new(interp)?;
+        let inner = Mutex::new(inner);
+        Some(Self { inner })
+    }
+}
+
+impl<'a> Helper for Parser<'a> {}
+
+impl<'a> Completer for Parser<'a> {
+    type Candidate = String;
+
+    fn update(&self, _line: &mut LineBuffer, _start: usize, _elected: &str, _cl: &mut Changeset) {
+        unreachable!();
+    }
+}
+
+impl<'a> Hinter for Parser<'a> {
+    type Hint = String;
+}
+
+impl<'a> Highlighter for Parser<'a> {}
+
+impl<'a> Validator for Parser<'a> {
+    fn validate(&self, ctx: &mut ValidationContext<'_>) -> Result<ValidationResult, ReadlineError> {
+        let mut parser = self.inner.lock().unwrap_or_else(PoisonError::into_inner);
+
+        let state = if let Ok(state) = parser.parse(ctx.input().as_bytes()) {
+            state
+        } else {
+            return Ok(ValidationResult::Invalid(None));
+        };
+
+        if state.is_code_block_open() {
+            return Ok(ValidationResult::Incomplete);
+        }
+        if state.is_fatal() {
+            return Ok(ValidationResult::Invalid(Some("fatal parsing error".into())));
+        }
+        if state.is_recoverable_error() {
+            return Ok(ValidationResult::Invalid(Some("could not parse input".into())));
+        }
+
+        Ok(ValidationResult::Valid(None))
+    }
+}


### PR DESCRIPTION
Move the `ParserValidator` type to its own module in `artichoke::repl::parser`. This allows the `cfg`s to be added in only one spot and to simplify the type names.

Additionally, using the `Editor::get_helper` API, cloning the parser validator and wrapping in `Arc` is no longer necessary, although drop order becomes more important to the structure of the code.

Additionally, interpreter init and preamble printing is split out into a separate `init` routine and readline editor setup is moved into the `run` function. This means `artichoke::repl::run` imperatively prepares the REPL environment. Then `artichoke::repl::repl_loop` only implements the REPL loop itself.

Additionally, `exit` is now added to the readline history.

All internal functions to the `artichoke::repl` module are now documented.