### PR TITLE
Parse user `inputrc` to detect preferred `editing-mode` (emacs or vi)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,9 +25,11 @@ name = "artichoke"
 version = "0.1.0-pre.0"
 dependencies = [
  "artichoke-backend",
+ "bstr",
  "clap",
  "directories",
  "log",
+ "posix-space",
  "rustyline",
  "scolapasta-path",
  "scolapasta-string-escape",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ documentation.workspace = true
 
 [dependencies]
 artichoke-backend = { version = "0.20.0", path = "artichoke-backend", default-features = false }
+bstr = { version = "1.2.0", optional = true, default-features = false }
 clap = { version = "4.1.0", optional = true }
 directories = { version = "4.0.1", optional = true }
 # XXX: load-bearing unused dependency.
@@ -33,6 +34,7 @@ directories = { version = "4.0.1", optional = true }
 #
 # See: https://github.com/kkawakam/rustyline/pull/583
 log = { version = "0.4.5", optional = true }
+posix-space = { version = "1.0.3", optional = true }
 rustyline = { version = "11.0.0", optional = true, default-features = false, features = ["with-file-history"] }
 scolapasta-path = { version = "0.5.0", path = "scolapasta-path" }
 scolapasta-string-escape = { version = "0.3.0", path = "scolapasta-string-escape", default-features = false }
@@ -95,7 +97,7 @@ default = [
 ]
 # Enable a CLI frontend for Artichoke, including a `ruby`-equivalent CLI and
 # REPL.
-cli = ["backtrace", "dep:clap", "dep:directories", "dep:log", "dep:rustyline"]
+cli = ["backtrace", "dep:bstr", "dep:clap", "dep:directories", "dep:log", "dep:posix-space", "dep:rustyline"]
 # Enable a module for formtting backtraces from Ruby exceptions.
 backtrace = ["dep:termcolor"]
 # Enable all features of Ruby Core, Standard Library, and the underlying VM.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,6 +100,8 @@ pub mod backtrace;
 mod filename;
 pub mod parser;
 #[cfg(feature = "cli")]
+mod readline_bind_mode;
+#[cfg(feature = "cli")]
 pub mod repl;
 #[cfg(feature = "cli")]
 pub mod ruby;

--- a/src/readline_bind_mode.rs
+++ b/src/readline_bind_mode.rs
@@ -1,0 +1,175 @@
+use std::env;
+use std::fs;
+
+use bstr::ByteSlice;
+use directories::BaseDirs;
+use rustyline::config::EditMode;
+
+/// Read inputc contents according to the GNU Readline hierarchy of config files.
+///
+/// This routine is ported from GNU Readline's `rl_read_init_file` function as
+/// of commit `7274faabe97ce53d6b464272d7e6ab6c1392837b`.
+///
+/// > Do key bindings from a file.  If FILENAME is NULL it defaults
+/// > to the first non-null filename from this list:
+/// >   1. the filename used for the previous call
+/// >   2. the value of the shell variable `INPUTRC'
+/// >   3. ~/.inputrc
+/// >   4. /etc/inputrc
+/// > If the file existed and could be opened and read, 0 is returned,
+/// > otherwise errno is returned. */
+pub fn rl_read_init_file() -> Option<Vec<u8>> {
+    if let Some(inputrc) = env::var_os("INPUTRC") {
+        return fs::read(inputrc).ok();
+    }
+    if let Some(base_dirs) = BaseDirs::new() {
+        let inputrc = base_dirs.home_dir().join(".inputrc");
+        if let Ok(content) = fs::read(inputrc) {
+            return Some(content);
+        }
+    }
+    if let Ok(content) = fs::read("/etc/inputrc") {
+        return Some(content);
+    }
+    if cfg!(windows) {
+        if let Some(base_dirs) = BaseDirs::new() {
+            let inputrc = base_dirs.home_dir().join("_inputrc");
+            if let Ok(content) = fs::read(inputrc) {
+                return Some(content);
+            }
+        }
+    }
+    None
+}
+
+/// Look for vi editing mode in inputrc, like this:
+///
+/// ```txt
+/// # Vi mode
+/// set editing-mode vi
+/// ```
+pub fn get_readline_edit_mode(contents: impl AsRef<[u8]>) -> Option<EditMode> {
+    let contents = contents.as_ref();
+
+    for line in contents.lines() {
+        // Skip leading whitespace.
+        let line = trim_whitespace_front(line);
+
+        // If the line is not a comment, then parse it.
+        if matches!(line.get(0), Some(b'#') | None) {
+            continue;
+        }
+
+        // If this is a command to set a variable, then do that.
+        if !line.starts_with_str("set") {
+            continue;
+        }
+        let line = &line[3..];
+        // Skip leading whitespace.
+        let line = trim_whitespace_front(line);
+
+        if !line.starts_with_str("editing-mode") {
+            continue;
+        }
+        let line = &line[12..];
+        // Skip leading whitespace.
+        let line = trim_whitespace_front(line);
+
+        match line {
+            b"vi" | br#""vi""# => return Some(EditMode::Vi),
+            b"emacs" | br#""emacs""# => return Some(EditMode::Emacs),
+            _ => return None,
+        }
+    }
+
+    None
+}
+
+/// Skip leading whitespace.
+fn trim_whitespace_front(mut s: &[u8]) -> &[u8] {
+    loop {
+        if let Some((&head, tail)) = s.split_first() {
+            if posix_space::is_space(head) {
+                s = tail;
+                continue;
+            }
+        }
+        break s;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rustyline::config::EditMode;
+
+    use super::get_readline_edit_mode;
+
+    #[test]
+    fn parse_empty() {
+        let test_cases = [
+            "",
+            "              ",
+            "\t\t\t",
+            "          \n              ",
+            "\n",
+            "\r\n",
+            "              \r\n           ",
+        ];
+        for contents in test_cases {
+            let result = get_readline_edit_mode(contents);
+            assert_eq!(result, None);
+        }
+    }
+
+    #[test]
+    fn integration_inputrc_vi() {
+        let test_case = "\
+# Vi mode
+set editing-mode vi
+set keymap vi
+
+# Ignore case on tab completion
+set completion-ignore-case On
+";
+        let result = get_readline_edit_mode(test_case);
+        assert_eq!(result, Some(EditMode::Vi));
+    }
+
+    #[test]
+    fn integration_inputrc_emacs() {
+        let test_case = "\
+# Ignore case on tab completion
+set completion-ignore-case On
+
+set editing-mode emacs
+";
+        let result = get_readline_edit_mode(test_case);
+        assert_eq!(result, Some(EditMode::Emacs));
+    }
+
+    #[test]
+    fn integration_inputrc_vi_quoted() {
+        let test_case = r#"\
+# Vi mode
+set editing-mode "vi"
+set keymap vi
+
+# Ignore case on tab completion
+set completion-ignore-case On
+"#;
+        let result = get_readline_edit_mode(test_case);
+        assert_eq!(result, Some(EditMode::Vi));
+    }
+
+    #[test]
+    fn integration_inputrc_emacs_quoted() {
+        let test_case = r#"\
+# Ignore case on tab completion
+set completion-ignore-case On
+
+set editing-mode "emacs"
+"#;
+        let result = get_readline_edit_mode(test_case);
+        assert_eq!(result, Some(EditMode::Emacs));
+    }
+}

--- a/src/readline_bind_mode.rs
+++ b/src/readline_bind_mode.rs
@@ -13,7 +13,7 @@ use rustyline::config::EditMode;
 /// > Do key bindings from a file.  If FILENAME is NULL it defaults
 /// > to the first non-null filename from this list:
 /// >   1. the filename used for the previous call
-/// >   2. the value of the shell variable `INPUTRC'
+/// >   2. the value of the shell variable `INPUTRC`
 /// >   3. ~/.inputrc
 /// >   4. /etc/inputrc
 /// > If the file existed and could be opened and read, 0 is returned,
@@ -56,7 +56,7 @@ pub fn get_readline_edit_mode(contents: impl AsRef<[u8]>) -> Option<EditMode> {
         let line = trim_whitespace_front(line);
 
         // If the line is not a comment, then parse it.
-        if matches!(line.get(0), Some(b'#') | None) {
+        if matches!(line.first(), Some(b'#') | None) {
             continue;
         }
 


### PR DESCRIPTION
Port routines for reading and parsing the `inputrc` file from GNU Readline to determine the user's preference for editing mode (either `emacs`, `vi`, or unset).

Use this parsed config to configure the rustyline editor.

This allows `airb` to use vi line editing movements if their configuration prefers that (as mine does). Specifically, detect the presence of the `set editing-mode` directive in `inputrc`.

`inputrc` config is loaded as per GNU Readline with the following cascade:

- From the file pointed to by the `INPUTRC` env variable.
- From `~/.inputrc` (which uses `directories` to detect the user's home directory).
- From `/etc/inputrc`.
- From `~/_inputrc` if on Windows.