### PR TITLE
TimeArgs seconds should support 0..=60

### DIFF
--- a/artichoke-backend/src/extn/core/time/args.rs
+++ b/artichoke-backend/src/extn/core/time/args.rs
@@ -169,7 +169,7 @@ impl TryConvertMut<&mut [Value], Args> for Artichoke {
                     let arg: i64 = arg.try_convert_into(self)?;
 
                     result.second = match u8::try_from(arg) {
-                        Ok(second @ 0..=59) => second,
+                        Ok(second @ 0..=60) => second,
                         _ => return Err(ArgumentError::with_message("sec out of range").into()),
                     };
                 }


### PR DESCRIPTION
Occurred in #2411 when copy/pasting code blocks for `sec`.