### PR TITLE
Add String#byteindex and String#byterindex

### DIFF
--- a/artichoke-backend/src/extn/core/string/mruby.rs
+++ b/artichoke-backend/src/extn/core/string/mruby.rs
@@ -23,6 +23,7 @@ pub fn init(interp: &mut Artichoke) -> InitializeResult<()> {
         .add_method("ascii_only?", string_ascii_only, sys::mrb_args_none())?
         .add_method("b", string_b, sys::mrb_args_none())?
         .add_method("byteindex", string_byteindex, sys::mrb_args_req_and_opt(1, 1))?
+        .add_method("byterindex", string_byterindex, sys::mrb_args_req_and_opt(1, 1))?
         .add_method("bytes", string_bytes, sys::mrb_args_none())? // This does not support the deprecated block form
         .add_method("bytesize", string_bytesize, sys::mrb_args_none())?
         .add_method("byteslice", string_byteslice, sys::mrb_args_req_and_opt(1, 1))?
@@ -193,6 +194,19 @@ unsafe extern "C" fn string_byteindex(mrb: *mut sys::mrb_state, slf: sys::mrb_va
     let substring = Value::from(substring);
     let offset = offset.map(Value::from);
     let result = trampoline::byteindex(&mut guard, value, substring, offset);
+    match result {
+        Ok(value) => value.inner(),
+        Err(exception) => error::raise(guard, exception),
+    }
+}
+
+unsafe extern "C" fn string_byterindex(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
+    let (substring, offset) = mrb_get_args!(mrb, required = 1, optional = 1);
+    unwrap_interpreter!(mrb, to => guard);
+    let value = Value::from(slf);
+    let substring = Value::from(substring);
+    let offset = offset.map(Value::from);
+    let result = trampoline::byterindex(&mut guard, value, substring, offset);
     match result {
         Ok(value) => value.inner(),
         Err(exception) => error::raise(guard, exception),

--- a/artichoke-backend/src/extn/core/string/trampoline.rs
+++ b/artichoke-backend/src/extn/core/string/trampoline.rs
@@ -601,7 +601,7 @@ pub fn byteindex(
     } else {
         None
     };
-    interp.try_convert(s.index(needle, offset))
+    interp.try_convert(s.byteindex(needle, offset))
 }
 
 pub fn byterindex(

--- a/artichoke-backend/src/extn/core/string/trampoline.rs
+++ b/artichoke-backend/src/extn/core/string/trampoline.rs
@@ -612,7 +612,7 @@ pub fn byterindex(
 ) -> Result<Value, Error> {
     #[cfg(feature = "core-regexp")]
     if let Ok(_pattern) = unsafe { Regexp::unbox_from_value(&mut substring, interp) } {
-        return Err(NotImplementedError::from("String#byteindex with Regexp pattern").into());
+        return Err(NotImplementedError::from("String#byterindex with Regexp pattern").into());
     }
     let s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
     let needle = unsafe { implicitly_convert_to_string(interp, &mut substring)? };

--- a/spinoso-string/src/lib.rs
+++ b/spinoso-string/src/lib.rs
@@ -2258,4 +2258,19 @@ mod tests {
         assert_eq!(ascii.byteindex(utf8_needle.clone(), None), Some(1));
         assert_eq!(binary.byteindex(utf8_needle.clone(), None), Some(1));
     }
+
+    #[test]
+    fn byteindex_support_specifiying_byte_position_to_start_search() {
+        let utf8 = String::utf8("a 💎 has 4 bytes".as_bytes().to_vec());
+
+        // Empty string as needle
+        let needle = String::utf8("a".as_bytes().to_vec());
+        assert_eq!(utf8.byteindex(needle.clone(), None), Some(0));
+        assert_eq!(utf8.byteindex(needle.clone(), Some(0)), Some(0));
+        assert_eq!(utf8.byteindex(needle.clone(), Some(1)), Some(8));
+        // In the middle of 💎
+        assert_eq!(utf8.byteindex(needle.clone(), Some(3)), Some(8));
+        assert_eq!(utf8.byteindex(needle.clone(), Some(8)), Some(8));
+        assert_eq!(utf8.byteindex(needle.clone(), Some(9)), None);
+    }
 }

--- a/spinoso-string/src/lib.rs
+++ b/spinoso-string/src/lib.rs
@@ -1727,7 +1727,7 @@ impl String {
     /// assert_eq!(s.byteindex("X", None), None);
     /// ```
     ///
-    /// [`String#index`]: https://ruby-doc.org/3.2.0/String.html#method-i-byteindex
+    /// [`String#byteindex`]: https://ruby-doc.org/3.2.0/String.html#method-i-byteindex
     #[inline]
     #[must_use]
     pub fn byteindex<T: AsRef<[u8]>>(&self, needle: T, offset: Option<usize>) -> Option<usize> {

--- a/spinoso-string/src/lib.rs
+++ b/spinoso-string/src/lib.rs
@@ -1622,11 +1622,11 @@ impl String {
         self.inner.chr()
     }
 
-    /// Returns the index of the first occurrence of the given substring in this
-    /// `String`.
+    /// Returns the char-based index of the first occurrence of the given
+    /// substring in this `String`.
     ///
     /// Returns [`None`] if not found. If the second parameter is present, it
-    /// specifies the position in the string to begin the search.
+    /// specifies the character position in the string to begin the search.
     ///
     /// This function can be used to implement [`String#index`].
     ///
@@ -1668,11 +1668,11 @@ impl String {
         inner(self.inner.as_slice(), needle, offset)
     }
 
-    /// Returns the index of the last occurrence of the given substring in this
-    /// `String`.
+    /// Returns the char-based index of the last occurrence of the given
+    /// substring in this `String`.
     ///
     /// Returns [`None`] if not found. If the second parameter is present, it
-    /// specifies the position in the string to begin the search.
+    /// specifies the character position in the string to begin the search.
     ///
     /// This function can be used to implement [`String#rindex`].
     ///
@@ -1705,11 +1705,11 @@ impl String {
         inner(self.inner.as_slice(), needle, offset)
     }
 
-    /// Returns the Integer byte-based index of the first occurrence of the
-    /// given substring.
+    /// Returns the byte-based index of the first occurrence of the given
+    /// substring in this `String`.
     ///
     /// Returns [`None`] if not found. If the second parameter is present, it
-    /// specifies the position in the string to begin the search.
+    /// specifies the byte position in the string to begin the search.
     ///
     /// This function can be used to implement [`String#byteindex`].
     ///
@@ -1751,11 +1751,11 @@ impl String {
         inner(self.inner.as_slice(), needle, offset)
     }
 
-    /// Returns the Integer byte-based index of the last occurrence of the
-    /// given substring.
+    /// Returns the byte-based index of the last occurrence of the given
+    /// substring in this `String`.
     ///
     /// Returns [`None`] if not found. If the second parameter is present, it
-    /// specifies the position in the string to begin the search.
+    /// specifies the byte position in the string to begin the search.
     ///
     /// This function can be used to implement [`String#rindex`].
     ///

--- a/spinoso-string/src/lib.rs
+++ b/spinoso-string/src/lib.rs
@@ -1705,6 +1705,89 @@ impl String {
         inner(self.inner.as_slice(), needle, offset)
     }
 
+    /// Returns the Integer byte-based index of the first occurrence of the
+    /// given substring.
+    ///
+    /// Returns [`None`] if not found. If the second parameter is present, it
+    /// specifies the position in the string to begin the search.
+    ///
+    /// This function can be used to implement [`String#byteindex`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use spinoso_string::String;
+    ///
+    /// let s = String::from("via 💎 v3.2.0");
+    /// assert_eq!(s.byteindex("a", None), Some(2));
+    /// assert_eq!(s.byteindex("a", Some(2)), Some(2));
+    /// assert_eq!(s.byteindex("a", Some(3)), None);
+    /// assert_eq!(s.byteindex("💎", None), Some(4));
+    /// assert_eq!(s.byteindex(".", None), Some(11));
+    /// assert_eq!(s.byteindex("X", None), None);
+    /// ```
+    ///
+    /// [`String#index`]: https://ruby-doc.org/3.2.0/String.html#method-i-byteindex
+    #[inline]
+    #[must_use]
+    pub fn byteindex<T: AsRef<[u8]>>(&self, needle: T, offset: Option<usize>) -> Option<usize> {
+        fn inner(buf: &[u8], needle: &[u8], offset: Option<usize>) -> Option<usize> {
+            if let Some(offset) = offset {
+                let buf = buf.get(offset..)?;
+                let index = buf.find(needle)?;
+                // This addition is guaranteed not to overflow because the result is
+                // a valid index of the underlying `Vec`.
+                //
+                // `self.buf.len() < isize::MAX` because `self.buf` is a `Vec` and
+                // `Vec` documents `isize::MAX` as its maximum allocation size.
+                Some(index + offset)
+            } else {
+                buf.find(needle)
+            }
+        }
+        // convert to a concrete type and delegate to a single `index` impl
+        // to minimize code duplication when monomorphizing.
+        let needle = needle.as_ref();
+        inner(self.inner.as_slice(), needle, offset)
+    }
+
+    /// Returns the Integer byte-based index of the last occurrence of the
+    /// given substring.
+    ///
+    /// Returns [`None`] if not found. If the second parameter is present, it
+    /// specifies the position in the string to begin the search.
+    ///
+    /// This function can be used to implement [`String#rindex`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use spinoso_string::String;
+    ///
+    /// let s = String::from("via 💎 v3.2.0");
+    /// assert_eq!(s.byterindex("v", None), Some(9));
+    /// assert_eq!(s.byterindex("a", None), Some(2));
+    /// ```
+    ///
+    /// [`String#byterindex`]: https://ruby-doc.org/3.2.0/String.html#method-i-byterindex
+    #[inline]
+    #[must_use]
+    pub fn byterindex<T: AsRef<[u8]>>(&self, needle: T, offset: Option<usize>) -> Option<usize> {
+        fn inner(buf: &[u8], needle: &[u8], offset: Option<usize>) -> Option<usize> {
+            if let Some(offset) = offset {
+                let end = buf.len().checked_sub(offset).unwrap_or_default();
+                let buf = buf.get(..end)?;
+                buf.rfind(needle)
+            } else {
+                buf.rfind(needle)
+            }
+        }
+        // convert to a concrete type and delegate to a single `rindex` impl
+        // to minimize code duplication when monomorphizing.
+        let needle = needle.as_ref();
+        inner(self.inner.as_slice(), needle, offset)
+    }
+
     /// Returns an iterator that yields a debug representation of the `String`.
     ///
     /// This iterator produces [`char`] sequences like `"spinoso"` and

--- a/spinoso-string/src/lib.rs
+++ b/spinoso-string/src/lib.rs
@@ -2221,4 +2221,41 @@ mod tests {
         assert_eq!(utf8, binary);
         assert_eq!(binary, ascii);
     }
+
+    #[test]
+    fn byteindex_supports_needle_and_haystack_of_different_encodings() {
+        // all encodings for the receiver
+        let utf8 = String::utf8("abc💎🔻".as_bytes().to_vec());
+        let ascii = String::ascii(b"abc\xFE\xFF".to_vec());
+        let binary = String::binary(b"abc\xFE\xFF".to_vec());
+
+        // Empty string as needle
+        assert_eq!(utf8.byteindex([], None), Some(0));
+        assert_eq!(ascii.byteindex([], None), Some(0));
+        assert_eq!(binary.byteindex([], None), Some(0));
+
+        // ASCII needles
+        let ascii_needle = String::ascii(b"b".to_vec());
+        assert_eq!(utf8.byteindex(ascii_needle.clone(), None), Some(1));
+        assert_eq!(ascii.byteindex(ascii_needle.clone(), None), Some(1));
+        assert_eq!(binary.byteindex(ascii_needle.clone(), None), Some(1));
+
+        // Binary needles
+        let binray_needle = String::binary(b"b".to_vec());
+        assert_eq!(utf8.byteindex(binray_needle.clone(), None), Some(1));
+        assert_eq!(ascii.byteindex(binray_needle.clone(), None), Some(1));
+        assert_eq!(binary.byteindex(binray_needle.clone(), None), Some(1));
+
+        // UTF-8 needles with multibyte chars
+        let utf8_needle = String::utf8("💎🔻".as_bytes().to_vec());
+        assert_eq!(utf8.byteindex(utf8_needle.clone(), None), Some(3));
+        assert_eq!(ascii.byteindex(utf8_needle.clone(), None), None);
+        assert_eq!(binary.byteindex(utf8_needle.clone(), None), None);
+
+        // UTF-8 encoded strings that have binary contents.
+        let utf8_needle = String::utf8([b'b', b'c'].to_vec());
+        assert_eq!(utf8.byteindex(utf8_needle.clone(), None), Some(1));
+        assert_eq!(ascii.byteindex(utf8_needle.clone(), None), Some(1));
+        assert_eq!(binary.byteindex(utf8_needle.clone(), None), Some(1));
+    }
 }

--- a/spinoso-string/src/lib.rs
+++ b/spinoso-string/src/lib.rs
@@ -2236,27 +2236,27 @@ mod tests {
 
         // ASCII needles
         let ascii_needle = String::ascii(b"b".to_vec());
-        assert_eq!(utf8.byteindex(ascii_needle.clone(), None), Some(1));
-        assert_eq!(ascii.byteindex(ascii_needle.clone(), None), Some(1));
-        assert_eq!(binary.byteindex(ascii_needle.clone(), None), Some(1));
+        assert_eq!(utf8.byteindex(&ascii_needle, None), Some(1));
+        assert_eq!(ascii.byteindex(&ascii_needle, None), Some(1));
+        assert_eq!(binary.byteindex(&ascii_needle, None), Some(1));
 
         // Binary needles
         let binray_needle = String::binary(b"b".to_vec());
-        assert_eq!(utf8.byteindex(binray_needle.clone(), None), Some(1));
-        assert_eq!(ascii.byteindex(binray_needle.clone(), None), Some(1));
-        assert_eq!(binary.byteindex(binray_needle.clone(), None), Some(1));
+        assert_eq!(utf8.byteindex(&binray_needle, None), Some(1));
+        assert_eq!(ascii.byteindex(&binray_needle, None), Some(1));
+        assert_eq!(binary.byteindex(&binray_needle, None), Some(1));
 
         // UTF-8 needles with multibyte chars
         let utf8_needle = String::utf8("💎🔻".as_bytes().to_vec());
-        assert_eq!(utf8.byteindex(utf8_needle.clone(), None), Some(3));
-        assert_eq!(ascii.byteindex(utf8_needle.clone(), None), None);
-        assert_eq!(binary.byteindex(utf8_needle.clone(), None), None);
+        assert_eq!(utf8.byteindex(&utf8_needle, None), Some(3));
+        assert_eq!(ascii.byteindex(&utf8_needle, None), None);
+        assert_eq!(binary.byteindex(&utf8_needle, None), None);
 
         // UTF-8 encoded strings that have binary contents.
         let utf8_needle = String::utf8([b'b', b'c'].to_vec());
-        assert_eq!(utf8.byteindex(utf8_needle.clone(), None), Some(1));
-        assert_eq!(ascii.byteindex(utf8_needle.clone(), None), Some(1));
-        assert_eq!(binary.byteindex(utf8_needle.clone(), None), Some(1));
+        assert_eq!(utf8.byteindex(&utf8_needle, None), Some(1));
+        assert_eq!(ascii.byteindex(&utf8_needle, None), Some(1));
+        assert_eq!(binary.byteindex(&utf8_needle, None), Some(1));
     }
 
     #[test]
@@ -2265,12 +2265,12 @@ mod tests {
 
         // Empty string as needle
         let needle = String::utf8("a".as_bytes().to_vec());
-        assert_eq!(utf8.byteindex(needle.clone(), None), Some(0));
-        assert_eq!(utf8.byteindex(needle.clone(), Some(0)), Some(0));
-        assert_eq!(utf8.byteindex(needle.clone(), Some(1)), Some(8));
+        assert_eq!(utf8.byteindex(&needle, None), Some(0));
+        assert_eq!(utf8.byteindex(&needle, Some(0)), Some(0));
+        assert_eq!(utf8.byteindex(&needle, Some(1)), Some(8));
         // In the middle of 💎
-        assert_eq!(utf8.byteindex(needle.clone(), Some(3)), Some(8));
-        assert_eq!(utf8.byteindex(needle.clone(), Some(8)), Some(8));
-        assert_eq!(utf8.byteindex(needle.clone(), Some(9)), None);
+        assert_eq!(utf8.byteindex(&needle, Some(3)), Some(8));
+        assert_eq!(utf8.byteindex(&needle, Some(8)), Some(8));
+        assert_eq!(utf8.byteindex(&needle, Some(9)), None);
     }
 }

--- a/spinoso-string/src/lib.rs
+++ b/spinoso-string/src/lib.rs
@@ -1635,7 +1635,7 @@ impl String {
     /// ```
     /// use spinoso_string::String;
     ///
-    /// let s = String::from("via 💎 v3.2.0");
+    /// let s = String::utf8("via 💎 v3.2.0".as_bytes().to_vec());
     /// assert_eq!(s.index("a", None), Some(2));
     /// assert_eq!(s.index("a", Some(2)), Some(2));
     /// assert_eq!(s.index("a", Some(3)), None);
@@ -1681,7 +1681,7 @@ impl String {
     /// ```
     /// use spinoso_string::String;
     ///
-    /// let s = String::from("via 💎 v3.2.0");
+    /// let s = String::utf8("via 💎 v3.2.0".as_bytes().to_vec());
     /// assert_eq!(s.rindex("v", None), Some(9)); // FIXME: Should be 5 (#2360)
     /// assert_eq!(s.rindex("a", None), Some(2));
     /// ```
@@ -1718,7 +1718,7 @@ impl String {
     /// ```
     /// use spinoso_string::String;
     ///
-    /// let s = String::from("via 💎 v3.2.0");
+    /// let s = String::utf8("via 💎 v3.2.0".as_bytes().to_vec());
     /// assert_eq!(s.byteindex("a", None), Some(2));
     /// assert_eq!(s.byteindex("a", Some(2)), Some(2));
     /// assert_eq!(s.byteindex("a", Some(3)), None);
@@ -1764,7 +1764,7 @@ impl String {
     /// ```
     /// use spinoso_string::String;
     ///
-    /// let s = String::from("via 💎 v3.2.0");
+    /// let s = String::utf8("via 💎 v3.2.0".as_bytes().to_vec());
     /// assert_eq!(s.byterindex("v", None), Some(9));
     /// assert_eq!(s.byterindex("a", None), Some(2));
     /// ```

--- a/spinoso-string/src/lib.rs
+++ b/spinoso-string/src/lib.rs
@@ -1635,11 +1635,13 @@ impl String {
     /// ```
     /// use spinoso_string::String;
     ///
-    /// let s = String::from("hello");
-    /// assert_eq!(s.index("e", None), Some(1));
-    /// assert_eq!(s.index("lo", None), Some(3));
-    /// assert_eq!(s.index("a", None), None);
-    /// assert_eq!(s.index("l", Some(3)), Some(3));
+    /// let s = String::from("via 💎 v3.2.0");
+    /// assert_eq!(s.index("a", None), Some(2));
+    /// assert_eq!(s.index("a", Some(2)), Some(2));
+    /// assert_eq!(s.index("a", Some(3)), None);
+    /// assert_eq!(s.index("💎", None), Some(4));
+    /// assert_eq!(s.index(".", None), Some(11)); // FIXME: Should be 8 (#2360)
+    /// assert_eq!(s.index("X", None), None);
     /// ```
     ///
     /// [`String#index`]: https://ruby-doc.org/core-3.1.2/String.html#method-i-index
@@ -1666,6 +1668,25 @@ impl String {
         inner(self.inner.as_slice(), needle, offset)
     }
 
+    /// Returns the index of the last occurrence of the given substring in this
+    /// `String`.
+    ///
+    /// Returns [`None`] if not found. If the second parameter is present, it
+    /// specifies the position in the string to begin the search.
+    ///
+    /// This function can be used to implement [`String#rindex`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use spinoso_string::String;
+    ///
+    /// let s = String::from("via 💎 v3.2.0");
+    /// assert_eq!(s.rindex("v", None), Some(9)); // FIXME: Should be 5 (#2360)
+    /// assert_eq!(s.rindex("a", None), Some(2));
+    /// ```
+    ///
+    /// [`String#rindex`]: https://ruby-doc.org/core-3.1.2/String.html#method-i-rindex
     #[inline]
     #[must_use]
     pub fn rindex<T: AsRef<[u8]>>(&self, needle: T, offset: Option<usize>) -> Option<usize> {


### PR DESCRIPTION
Fix #2361 

In this PR, `byteindex` and `byterindex` will become available for `String` just like `index` and `rindex`.

<img width="823" alt="image" src="https://user-images.githubusercontent.com/12410942/226643376-80f65298-4cfb-474f-a878-116a1e8a26bb.png">

The incorrect output of `index` and `rindex` is a separate bug that is tracked by #2360.

Please let me know if equivalent amount of doctest is preferred for all four methods. I was just a bit of worry about being too verbose, so there isn't too many test case for some of them.