### PR TITLE
`String#index` and `String#rindex` should return character offsets instead of byte offsets

### DIFF
--- a/spinoso-string/src/enc/ascii/mod.rs
+++ b/spinoso-string/src/enc/ascii/mod.rs
@@ -356,7 +356,8 @@ impl AsciiString {
     #[inline]
     #[must_use]
     pub fn rindex(&self, needle: &[u8], offset: usize) -> Option<usize> {
-        let buf = self.get(..=offset)?;
+        let search_until = (offset + 1).min(self.len());
+        let buf = self.get(..search_until)?;
         let index = buf.rfind(needle)?;
         Some(index)
     }
@@ -596,6 +597,7 @@ mod tests {
     #[test]
     fn rindex_with_different_offset() {
         let s = AsciiString::from(b"foo");
+        assert_eq!(s.rindex("o".as_bytes(), 3), Some(2));
         assert_eq!(s.rindex("o".as_bytes(), 2), Some(2));
         assert_eq!(s.rindex("o".as_bytes(), 1), Some(1));
         assert_eq!(s.rindex("o".as_bytes(), 0), None);

--- a/spinoso-string/src/enc/ascii/mod.rs
+++ b/spinoso-string/src/enc/ascii/mod.rs
@@ -343,6 +343,25 @@ impl AsciiString {
     }
 }
 
+// Index
+impl AsciiString {
+    #[inline]
+    #[must_use]
+    pub fn index(&self, needle: &[u8], offset: usize) -> Option<usize> {
+        let buf = self.get(offset..)?;
+        let index = buf.find(needle)?;
+        Some(index + offset)
+    }
+
+    #[inline]
+    #[must_use]
+    pub fn rindex(&self, needle: &[u8], offset: usize) -> Option<usize> {
+        let buf = self.get(..=offset)?;
+        let index = buf.rfind(needle)?;
+        Some(index)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use alloc::string::String;
@@ -546,5 +565,39 @@ mod tests {
         assert_eq!(s.get_char_slice(4..1), None);
         assert_eq!(s.get_char_slice(3..1), Some(&b""[..]));
         assert_eq!(s.get_char_slice(2..1), Some(&b""[..]));
+    }
+
+    #[test]
+    fn index_with_default_offset() {
+        let s = AsciiString::from(b"foo");
+        assert_eq!(s.index("f".as_bytes(), 0), Some(0));
+        assert_eq!(s.index("o".as_bytes(), 0), Some(1));
+        assert_eq!(s.index("oo".as_bytes(), 0), Some(1));
+        assert_eq!(s.index("ooo".as_bytes(), 0), None);
+    }
+
+    #[test]
+    fn index_with_different_offset() {
+        let s = AsciiString::from(b"foo");
+        assert_eq!(s.index("o".as_bytes(), 1), Some(1));
+        assert_eq!(s.index("o".as_bytes(), 2), Some(2));
+        assert_eq!(s.index("o".as_bytes(), 3), None);
+    }
+
+    #[test]
+    fn rindex_with_default_offset() {
+        let s = AsciiString::from(b"foo");
+        assert_eq!(s.rindex("f".as_bytes(), 2), Some(0));
+        assert_eq!(s.rindex("o".as_bytes(), 2), Some(2));
+        assert_eq!(s.rindex("oo".as_bytes(), 2), Some(1));
+        assert_eq!(s.rindex("ooo".as_bytes(), 2), None);
+    }
+
+    #[test]
+    fn rindex_with_different_offset() {
+        let s = AsciiString::from(b"foo");
+        assert_eq!(s.rindex("o".as_bytes(), 2), Some(2));
+        assert_eq!(s.rindex("o".as_bytes(), 1), Some(1));
+        assert_eq!(s.rindex("o".as_bytes(), 0), None);
     }
 }

--- a/spinoso-string/src/enc/binary/mod.rs
+++ b/spinoso-string/src/enc/binary/mod.rs
@@ -347,7 +347,8 @@ impl BinaryString {
     #[inline]
     #[must_use]
     pub fn rindex(&self, needle: &[u8], offset: usize) -> Option<usize> {
-        let buf = self.get(..=offset)?;
+        let search_until = (offset + 1).min(self.len());
+        let buf = self.get(..search_until)?;
         let index = buf.rfind(needle)?;
         Some(index)
     }
@@ -580,6 +581,7 @@ mod tests {
     #[test]
     fn rindex_with_different_offset() {
         let s = BinaryString::from(b"foo");
+        assert_eq!(s.rindex("o".as_bytes(), 3), Some(2));
         assert_eq!(s.rindex("o".as_bytes(), 2), Some(2));
         assert_eq!(s.rindex("o".as_bytes(), 1), Some(1));
         assert_eq!(s.rindex("o".as_bytes(), 0), None);

--- a/spinoso-string/src/enc/binary/mod.rs
+++ b/spinoso-string/src/enc/binary/mod.rs
@@ -334,6 +334,25 @@ impl BinaryString {
     }
 }
 
+// Index
+impl BinaryString {
+    #[inline]
+    #[must_use]
+    pub fn index(&self, needle: &[u8], offset: usize) -> Option<usize> {
+        let buf = self.get(offset..)?;
+        let index = buf.find(needle)?;
+        Some(index + offset)
+    }
+
+    #[inline]
+    #[must_use]
+    pub fn rindex(&self, needle: &[u8], offset: usize) -> Option<usize> {
+        let buf = self.get(..=offset)?;
+        let index = buf.rfind(needle)?;
+        Some(index)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use alloc::string::String;
@@ -530,5 +549,39 @@ mod tests {
         assert_eq!(s.get_char_slice(4..1), None);
         assert_eq!(s.get_char_slice(3..1), Some(&b""[..]));
         assert_eq!(s.get_char_slice(2..1), Some(&b""[..]));
+    }
+
+    #[test]
+    fn index_with_default_offset() {
+        let s = BinaryString::from(b"foo");
+        assert_eq!(s.index("f".as_bytes(), 0), Some(0));
+        assert_eq!(s.index("o".as_bytes(), 0), Some(1));
+        assert_eq!(s.index("oo".as_bytes(), 0), Some(1));
+        assert_eq!(s.index("ooo".as_bytes(), 0), None);
+    }
+
+    #[test]
+    fn index_with_different_offset() {
+        let s = BinaryString::from(b"foo");
+        assert_eq!(s.index("o".as_bytes(), 1), Some(1));
+        assert_eq!(s.index("o".as_bytes(), 2), Some(2));
+        assert_eq!(s.index("o".as_bytes(), 3), None);
+    }
+
+    #[test]
+    fn rindex_with_default_offset() {
+        let s = BinaryString::from(b"foo");
+        assert_eq!(s.rindex("f".as_bytes(), 2), Some(0));
+        assert_eq!(s.rindex("o".as_bytes(), 2), Some(2));
+        assert_eq!(s.rindex("oo".as_bytes(), 2), Some(1));
+        assert_eq!(s.rindex("ooo".as_bytes(), 2), None);
+    }
+
+    #[test]
+    fn rindex_with_different_offset() {
+        let s = BinaryString::from(b"foo");
+        assert_eq!(s.rindex("o".as_bytes(), 2), Some(2));
+        assert_eq!(s.rindex("o".as_bytes(), 1), Some(1));
+        assert_eq!(s.rindex("o".as_bytes(), 0), None);
     }
 }

--- a/spinoso-string/src/enc/mod.rs
+++ b/spinoso-string/src/enc/mod.rs
@@ -599,4 +599,22 @@ impl EncodedString {
             EncodedString::Utf8(inner) => inner.reverse(),
         }
     }
+
+    #[inline]
+    pub fn index(&self, needle: &[u8], offset: usize) -> Option<usize> {
+        match self {
+            EncodedString::Ascii(inner) => inner.index(needle, offset),
+            EncodedString::Binary(inner) => inner.index(needle, offset),
+            EncodedString::Utf8(inner) => inner.index(needle, offset),
+        }
+    }
+
+    #[inline]
+    pub fn rindex(&self, needle: &[u8], offset: usize) -> Option<usize> {
+        match self {
+            EncodedString::Ascii(inner) => inner.rindex(needle, offset),
+            EncodedString::Binary(inner) => inner.rindex(needle, offset),
+            EncodedString::Utf8(inner) => inner.rindex(needle, offset),
+        }
+    }
 }

--- a/spinoso-string/src/enc/utf8/mod.rs
+++ b/spinoso-string/src/enc/utf8/mod.rs
@@ -1274,6 +1274,7 @@ mod tests {
     #[test]
     fn rindex_with_different_offset() {
         let s = Utf8String::from("f💎oo");
+        assert_eq!(s.rindex("o".as_bytes(), 4), Some(3));
         assert_eq!(s.rindex("o".as_bytes(), 3), Some(3));
         assert_eq!(s.rindex("o".as_bytes(), 2), Some(2));
         assert_eq!(s.rindex("o".as_bytes(), 1), None);

--- a/spinoso-string/src/enc/utf8/mod.rs
+++ b/spinoso-string/src/enc/utf8/mod.rs
@@ -1280,4 +1280,28 @@ mod tests {
         assert_eq!(s.rindex("o".as_bytes(), 1), None);
         assert_eq!(s.rindex("o".as_bytes(), 0), None);
     }
+
+    #[test]
+    fn index_and_rindex_support_invalid_utf8_in_needle() {
+        // Invalid UTF-8 in needle
+        let needle = &"💎".as_bytes()[..3];
+
+        println!("{:?} rfinx {:?}", "f💎oo".as_bytes(), needle);
+
+        assert_eq!(Utf8String::from("f💎oo").index(needle, 0), None); // FIXME: Currently `Some(1)`
+        assert_eq!(Utf8String::from("f💎oo").rindex(needle, 3), None); // FIXME: Currently `Some(1)`
+    }
+
+    #[test]
+    fn index_and_rindex_support_invalid_utf8_in_haystack() {
+        // Invalid UTF-8 in haystack
+        let mut haystack = Vec::new();
+        haystack.extend_from_slice(b"f");
+        haystack.extend_from_slice(&"💎".as_bytes()[..2]);
+        haystack.extend_from_slice(b"oo");
+        let haystack = Utf8String::from(haystack);
+
+        assert_eq!(haystack.index("💎".as_bytes(), 0), None);
+        assert_eq!(haystack.rindex("💎".as_bytes(), 3), None);
+    }
 }

--- a/spinoso-string/src/enc/utf8/mod.rs
+++ b/spinoso-string/src/enc/utf8/mod.rs
@@ -804,6 +804,33 @@ impl Utf8String {
     }
 }
 
+// Index
+impl Utf8String {
+    #[inline]
+    #[must_use]
+    pub fn index(&self, needle: &[u8], offset: usize) -> Option<usize> {
+        for byte_pos in self.find_iter(needle) {
+            let char_pos = self[..byte_pos].chars().count();
+            if char_pos >= offset {
+                return Some(char_pos);
+            }
+        }
+        None
+    }
+
+    #[inline]
+    #[must_use]
+    pub fn rindex(&self, needle: &[u8], offset: usize) -> Option<usize> {
+        for byte_pos in self.inner.rfind_iter(needle) {
+            let char_pos = self[..byte_pos].chars().count();
+            if char_pos <= offset {
+                return Some(char_pos);
+            }
+        }
+        None
+    }
+}
+
 #[cfg(test)]
 #[allow(clippy::invisible_characters)]
 mod tests {
@@ -1215,5 +1242,41 @@ mod tests {
         assert_eq!(s.get_char_slice(10..8), None);
         assert_eq!(s.get_char_slice(10..5), None);
         assert_eq!(s.get_char_slice(10..2), None);
+    }
+
+    #[test]
+    fn index_with_default_offset() {
+        let s = Utf8String::from("f💎oo");
+        assert_eq!(s.index("f".as_bytes(), 0), Some(0));
+        assert_eq!(s.index("o".as_bytes(), 0), Some(2));
+        assert_eq!(s.index("oo".as_bytes(), 0), Some(2));
+        assert_eq!(s.index("ooo".as_bytes(), 0), None);
+    }
+
+    #[test]
+    fn index_with_different_offset() {
+        let s = Utf8String::from("f💎oo");
+        assert_eq!(s.index("o".as_bytes(), 1), Some(2));
+        assert_eq!(s.index("o".as_bytes(), 2), Some(2));
+        assert_eq!(s.index("o".as_bytes(), 3), Some(3));
+        assert_eq!(s.index("o".as_bytes(), 4), None);
+    }
+
+    #[test]
+    fn rindex_with_default_offset() {
+        let s = Utf8String::from("f💎oo");
+        assert_eq!(s.rindex("f".as_bytes(), 3), Some(0));
+        assert_eq!(s.rindex("o".as_bytes(), 3), Some(3));
+        assert_eq!(s.rindex("oo".as_bytes(), 3), Some(2));
+        assert_eq!(s.rindex("ooo".as_bytes(), 3), None);
+    }
+
+    #[test]
+    fn rindex_with_different_offset() {
+        let s = Utf8String::from("f💎oo");
+        assert_eq!(s.rindex("o".as_bytes(), 3), Some(3));
+        assert_eq!(s.rindex("o".as_bytes(), 2), Some(2));
+        assert_eq!(s.rindex("o".as_bytes(), 1), None);
+        assert_eq!(s.rindex("o".as_bytes(), 0), None);
     }
 }

--- a/spinoso-string/src/enc/utf8/mod.rs
+++ b/spinoso-string/src/enc/utf8/mod.rs
@@ -809,10 +809,37 @@ impl Utf8String {
     #[inline]
     #[must_use]
     pub fn index(&self, needle: &[u8], offset: usize) -> Option<usize> {
-        for byte_pos in self.find_iter(needle) {
-            let char_pos = self[..byte_pos].chars().count();
-            if char_pos >= offset {
-                return Some(char_pos);
+        // Decode needle
+        let needle_chars = match must_decode_utf8(needle) {
+            Some(chars) => chars,
+            // Needle containing any invalid UTF-8 should never match in MRI
+            None => return None,
+        };
+
+        // Decode haystack, and check against needle along the way whenever possible
+        let mut curr = 0;
+        let mut haystack_chars = Vec::new();
+        let mut bytes = &self.inner[..];
+        while !bytes.is_empty() {
+            if curr < offset {
+                curr += 1;
+                continue;
+            }
+
+            let (ch, size) = bstr::decode_utf8(bytes);
+            bytes = &bytes[size..];
+            haystack_chars.push(ch.unwrap_or('\u{FFFD}'));
+
+            if let Some(maybe_match) = haystack_chars.get(curr..) {
+                if needle_chars.len() > maybe_match.len() {
+                    continue; // decode more haystack before checking
+                }
+
+                if needle_chars == maybe_match {
+                    return Some(curr); // Found!
+                }
+
+                curr += 1;
             }
         }
         None
@@ -821,14 +848,52 @@ impl Utf8String {
     #[inline]
     #[must_use]
     pub fn rindex(&self, needle: &[u8], offset: usize) -> Option<usize> {
-        for byte_pos in self.inner.rfind_iter(needle) {
-            let char_pos = self[..byte_pos].chars().count();
-            if char_pos <= offset {
-                return Some(char_pos);
+        // Decode needle
+        let needle_chars = match must_decode_utf8(needle) {
+            Some(chars) => chars,
+            // Needle containing any invalid UTF-8 should never match in MRI
+            None => return None,
+        };
+
+        // Decode haystack
+        // We need to decode from the right side to tell the rightmost match, as well as
+        // from the left side to calculate the index of the match. Therefore we need to
+        // decode the entier haystack anyway.
+        let haystack_chars: Vec<char> = self.chars().collect();
+
+        // Compare from the right
+        let mut curr = offset.min(haystack_chars.len() - 1);
+        loop {
+            if let Some(maybe_match) = haystack_chars[curr..].get(0..needle_chars.len()) {
+                if needle_chars == maybe_match {
+                    return Some(curr); // Found!
+                }
+            }
+
+            if curr > 0 {
+                curr -= 1;
+            } else {
+                return None;
             }
         }
-        None
     }
+}
+
+// Decode UTF-8 bytes. Return None if any invalid UTF-8 bytes is encountered (instead of using
+// replacement codepoint, for example)
+fn must_decode_utf8(maybe_utf8_bytes: &[u8]) -> Option<Vec<char>> {
+    let mut chars = Vec::new();
+    let mut bytes = maybe_utf8_bytes;
+    while !bytes.is_empty() {
+        if let (Some(char), size) = bstr::decode_utf8(bytes) {
+            bytes = &bytes[size..];
+            chars.push(char);
+        } else {
+            // needle containing invalid UTF-8 should never match
+            return None;
+        }
+    }
+    Some(chars)
 }
 
 #[cfg(test)]
@@ -1285,8 +1350,6 @@ mod tests {
     fn index_and_rindex_support_invalid_utf8_in_needle() {
         // Invalid UTF-8 in needle
         let needle = &"💎".as_bytes()[..3];
-
-        println!("{:?} rfinx {:?}", "f💎oo".as_bytes(), needle);
 
         assert_eq!(Utf8String::from("f💎oo").index(needle, 0), None); // FIXME: Currently `Some(1)`
         assert_eq!(Utf8String::from("f💎oo").rindex(needle, 3), None); // FIXME: Currently `Some(1)`

--- a/spinoso-string/src/lib.rs
+++ b/spinoso-string/src/lib.rs
@@ -1646,8 +1646,6 @@ impl String {
     /// assert_eq!(s.index("X", None), None);
     /// ```
     ///
-    /// Related: String#rindex.
-    ///
     /// [`String#index`]: https://ruby-doc.org/core-3.1.2/String.html#method-i-index
     #[inline]
     #[must_use]

--- a/spinoso-string/src/lib.rs
+++ b/spinoso-string/src/lib.rs
@@ -2254,4 +2254,17 @@ mod tests {
         assert_eq!(utf8.byteindex(&needle, Some(8)), Some(8));
         assert_eq!(utf8.byteindex(&needle, Some(9)), None);
     }
+
+    #[test]
+    fn rindex_support_empty_string_and_empty_needle() {
+        // Empty needle
+        assert_eq!(String::ascii(b"foo".to_vec()).rindex("", None), Some(3));
+
+        // Empty haystack
+        assert_eq!(String::ascii(b"".to_vec()).rindex("foo", None), None);
+
+        // Empty haystack and needle
+        // FIXME: This currently return None instead of Some(0)
+        assert_eq!(String::ascii(b"".to_vec()).rindex("", None), Some(0));
+    }
 }

--- a/spinoso-string/src/lib.rs
+++ b/spinoso-string/src/lib.rs
@@ -1678,11 +1678,7 @@ impl String {
     #[inline]
     #[must_use]
     pub fn rindex<T: AsRef<[u8]>>(&self, needle: T, offset: Option<usize>) -> Option<usize> {
-        let default_max_offset = self.inner.char_len() - 1;
-        let mut offset = offset.unwrap_or(default_max_offset);
-        if offset > default_max_offset {
-            offset = default_max_offset;
-        }
+        let offset = offset.unwrap_or_else(|| self.inner.char_len().checked_sub(1).unwrap_or_default());
         self.inner.rindex(needle.as_ref(), offset)
     }
 
@@ -2264,7 +2260,6 @@ mod tests {
         assert_eq!(String::ascii(b"".to_vec()).rindex("foo", None), None);
 
         // Empty haystack and needle
-        // FIXME: This currently return None instead of Some(0)
         assert_eq!(String::ascii(b"".to_vec()).rindex("", None), Some(0));
     }
 }


### PR DESCRIPTION
Close #2360 
Close https://github.com/artichoke/artichoke/issues/323

~The branch of this PR is based on #2361 to avoid conflict.~

