### PR TITLE
Add `RB_FIXABLE` macro impl in a new crate

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -296,6 +296,14 @@ jobs:
         run: cargo check --verbose --all-features --all-targets --profile=test
         working-directory: "scolapasta-aref"
 
+      - name: Compile scolapasta-fixable with no default features
+        run: cargo check --verbose --no-default-features --all-targets --profile=test
+        working-directory: "scolapasta-fixable"
+
+      - name: Compile scolapasta-fixable with all features
+        run: cargo check --verbose --all-features --all-targets --profile=test
+        working-directory: "scolapasta-fixable"
+
       - name: Compile scolapasta-hex with no default features
         run: cargo check --verbose --no-default-features --all-targets --profile=test
         working-directory: "scolapasta-hex"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -639,6 +639,10 @@ name = "scolapasta-aref"
 version = "0.1.0"
 
 [[package]]
+name = "scolapasta-fixable"
+version = "0.1.0"
+
+[[package]]
 name = "scolapasta-hex"
 version = "0.2.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,25 +55,10 @@ required-features = ["cli"]
 
 [workspace]
 members = [
-  "artichoke-backend",
-  "artichoke-core",
-  "artichoke-load-path",
-  "mezzaluna-feature-loader",
-  "scolapasta-aref",
-  "scolapasta-hex",
-  "scolapasta-int-parse",
-  "scolapasta-path",
-  "scolapasta-string-escape",
-  "spinoso-array",
-  "spinoso-env",
-  "spinoso-exception",
-  "spinoso-math",
-  "spinoso-random",
-  "spinoso-regexp",
-  "spinoso-securerandom",
-  "spinoso-string",
-  "spinoso-symbol",
-  "spinoso-time",
+  "artichoke-*",
+  "mezzaluna-*",
+  "scolapasta-*",
+  "spinoso-*",
 ]
 
 [workspace.package]

--- a/scolapasta-aref/src/lib.rs
+++ b/scolapasta-aref/src/lib.rs
@@ -37,6 +37,11 @@
 
 #![no_std]
 
+// Ensure code blocks in `README.md` compile
+#[cfg(doctest)]
+#[doc = include_str!("../README.md")]
+mod readme {}
+
 /// Convert a signed aref offset to a `usize` index into the underlying container.
 ///
 /// Negative indexes are interpreted as indexing from the end of the container

--- a/scolapasta-fixable/Cargo.toml
+++ b/scolapasta-fixable/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "scolapasta-fixable"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/scolapasta-fixable/Cargo.toml
+++ b/scolapasta-fixable/Cargo.toml
@@ -1,8 +1,24 @@
 [package]
 name = "scolapasta-fixable"
 version = "0.1.0"
-edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
+description = """
+Converters from numeric types to a Ruby Integer, or Fixnum, immediate.
+"""
+keywords = ["conversion", "fixnum", "integer", "no_std", "numeric-tower"]
+categories = ["encoding", "no-std", "rust-patterns"]
+readme = "README.md"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+documentation.workspace = true
 
 [dependencies]
+
+[features]
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/scolapasta-fixable/LICENSE
+++ b/scolapasta-fixable/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2019 Ryan Lopopolo <rjl@hyperbo.la>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/scolapasta-fixable/README.md
+++ b/scolapasta-fixable/README.md
@@ -1,0 +1,24 @@
+# scolapasta-fixable
+
+[![GitHub Actions](https://github.com/artichoke/artichoke/workflows/CI/badge.svg)](https://github.com/artichoke/artichoke/actions)
+[![Discord](https://img.shields.io/discord/607683947496734760)](https://discord.gg/QCe2tp2)
+[![Twitter](https://img.shields.io/twitter/follow/artichokeruby?label=Follow&style=social)](https://twitter.com/artichokeruby)
+<br>
+[![Crate](https://img.shields.io/crates/v/scolapasta-fixable.svg)](https://crates.io/crates/scolapasta-fixable)
+[![API](https://docs.rs/scolapasta-fixable/badge.svg)](https://docs.rs/scolapasta-fixable)
+[![API trunk](https://img.shields.io/badge/docs-trunk-blue.svg)](https://artichoke.github.io/artichoke/scolapasta_fixable/)
+
+Functions for converting numeric immediates to integer or "fixnum" immediates.
+
+_Scolapasta_ refers to a specialized colander used to drain pasta. The utilities
+defined in the `scolapasta` family of crates are the kitchen tools for preparing
+Artichoke Ruby.
+
+## Usage
+
+Add this to your `Cargo.toml`:
+
+```toml
+[dependencies]
+scolapasta-fixable = "0.1.0"
+```

--- a/scolapasta-fixable/README.md
+++ b/scolapasta-fixable/README.md
@@ -63,8 +63,8 @@ use scolapasta_fixable::Fixable;
 assert_eq!(u64::MAX.to_fix(), None);
 assert_eq!(i128::MIN.to_fix(), None);
 assert_eq!(4_611_686_018_427_387_904.0_f64.to_fix(), None);
-assert_eq!(f64::INFINITY, None);
-assert_eq!(f64::NAN, None);
+assert_eq!(f64::INFINITY.to_fix(), None);
+assert_eq!(f64::NAN.to_fix(), None);
 ```
 
 For non-integer fixable types, the fractional part is discarded when converting

--- a/scolapasta-fixable/README.md
+++ b/scolapasta-fixable/README.md
@@ -22,3 +22,7 @@ Add this to your `Cargo.toml`:
 [dependencies]
 scolapasta-fixable = "0.1.0"
 ```
+
+## License
+
+`scolapasta-fixable` is licensed under the [MIT License](LICENSE) (c) Ryan Lopopolo.

--- a/scolapasta-fixable/README.md
+++ b/scolapasta-fixable/README.md
@@ -26,3 +26,13 @@ scolapasta-fixable = "0.1.0"
 ## License
 
 `scolapasta-fixable` is licensed under the [MIT License](LICENSE) (c) Ryan Lopopolo.
+
+This repository includes a vendored copy of the arithmetic headers from Ruby
+3.2.0, which is licensed under the [Ruby license] or [BSD 2-clause license]. See
+[`vendor/README.md`] for more details. These sources are not distributed on
+[crates.io].
+
+[ruby license]: vendor/ruby-3.2.0/COPYING
+[bsd 2-clause license]: vendor/ruby-3.2.0/BSDL
+[`vendor/readme.md`]: vendor/README.md
+[crates.io]: https://crates.io/

--- a/scolapasta-fixable/src/lib.rs
+++ b/scolapasta-fixable/src/lib.rs
@@ -1,0 +1,14 @@
+pub fn add(left: usize, right: usize) -> usize {
+    left + right
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        let result = add(2, 2);
+        assert_eq!(result, 4);
+    }
+}

--- a/scolapasta-fixable/src/lib.rs
+++ b/scolapasta-fixable/src/lib.rs
@@ -139,6 +139,10 @@ impl Fixable for i128 {
         let x = i64::try_from(self).ok()?;
         x.to_fix()
     }
+
+    fn is_fixable(self) -> bool {
+        (RUBY_FIXNUM_MIN.into()..=RUBY_FIXNUM_MAX.into()).contains(&self)
+    }
 }
 
 impl Fixable for u8 {
@@ -180,6 +184,12 @@ impl Fixable for u64 {
         // no need to check the min bound since `u64::MIN` is zero.
         Some(x)
     }
+
+    fn is_fixable(self) -> bool {
+        const MAX: u64 = RUBY_FIXNUM_MAX as u64;
+
+        (..=MAX).contains(&self)
+    }
 }
 
 impl Fixable for u128 {
@@ -190,6 +200,12 @@ impl Fixable for u128 {
         }
         // no need to check the min bound since `u128::MIN` is zero.
         Some(x)
+    }
+
+    fn is_fixable(self) -> bool {
+        const MAX: u128 = RUBY_FIXNUM_MAX as u128;
+
+        (..=MAX).contains(&self)
     }
 }
 
@@ -455,6 +471,9 @@ mod tests {
         let test_cases = [
             (i128::MIN, None),
             (i64::MIN.into(), None),
+            (i128::from(RUBY_FIXNUM_MIN) - 1, None),
+            (i128::from(RUBY_FIXNUM_MIN), Some(RUBY_FIXNUM_MIN)),
+            (i128::from(RUBY_FIXNUM_MIN) + 1, Some(RUBY_FIXNUM_MIN + 1)),
             // ```
             // >>> (-(2 ** 63 - 1)) >> 1
             // -4611686018427387904
@@ -476,6 +495,9 @@ mod tests {
             (4_611_686_018_427_387_903 - 1, Some(4_611_686_018_427_387_902)),
             (4_611_686_018_427_387_903, Some(4_611_686_018_427_387_903)),
             (4_611_686_018_427_387_903 + 1, None),
+            (i128::from(RUBY_FIXNUM_MAX) - 1, Some(RUBY_FIXNUM_MAX - 1)),
+            (i128::from(RUBY_FIXNUM_MAX), Some(RUBY_FIXNUM_MAX)),
+            (i128::from(RUBY_FIXNUM_MAX) + 1, None),
             (i64::MAX.into(), None),
             (i128::MAX, None),
         ];
@@ -646,6 +668,9 @@ mod tests {
             (4_611_686_018_427_387_903 - 1, Some(4_611_686_018_427_387_902)),
             (4_611_686_018_427_387_903, Some(4_611_686_018_427_387_903)),
             (4_611_686_018_427_387_903 + 1, None),
+            (u64::try_from(RUBY_FIXNUM_MAX).unwrap() - 1, Some(RUBY_FIXNUM_MAX - 1)),
+            (u64::try_from(RUBY_FIXNUM_MAX).unwrap(), Some(RUBY_FIXNUM_MAX)),
+            (u64::try_from(RUBY_FIXNUM_MAX).unwrap() + 1, None),
             (i64::MAX.try_into().unwrap(), None),
             (u64::MAX, None),
         ];
@@ -671,6 +696,9 @@ mod tests {
             (4_611_686_018_427_387_903 - 1, Some(4_611_686_018_427_387_902)),
             (4_611_686_018_427_387_903, Some(4_611_686_018_427_387_903)),
             (4_611_686_018_427_387_903 + 1, None),
+            (u128::try_from(RUBY_FIXNUM_MAX).unwrap() - 1, Some(RUBY_FIXNUM_MAX - 1)),
+            (u128::try_from(RUBY_FIXNUM_MAX).unwrap(), Some(RUBY_FIXNUM_MAX)),
+            (u128::try_from(RUBY_FIXNUM_MAX).unwrap() + 1, None),
             (i64::MAX.try_into().unwrap(), None),
             (u128::MAX, None),
         ];

--- a/scolapasta-fixable/src/lib.rs
+++ b/scolapasta-fixable/src/lib.rs
@@ -189,21 +189,33 @@ impl Fixable for u128 {
 
 impl Fixable for f32 {
     fn to_fix(self) -> Option<i64> {
-        let d = Duration::try_from_secs_f32(self)
-            .or_else(|_| Duration::try_from_secs_f32(-self))
-            .ok()?;
-        let x = d.as_secs();
-        x.to_fix()
+        if let Ok(d) = Duration::try_from_secs_f32(self) {
+            let x = d.as_secs();
+            return x.to_fix();
+        }
+        if let Ok(d) = Duration::try_from_secs_f32(-self) {
+            let x = d.as_secs();
+            let x = i64::try_from(x).ok()?;
+            let x = x.checked_neg()?;
+            return x.to_fix();
+        }
+        None
     }
 }
 
 impl Fixable for f64 {
     fn to_fix(self) -> Option<i64> {
-        let d = Duration::try_from_secs_f64(self)
-            .or_else(|_| Duration::try_from_secs_f64(-self))
-            .ok()?;
-        let x = d.as_secs();
-        x.to_fix()
+        if let Ok(d) = Duration::try_from_secs_f64(self) {
+            let x = d.as_secs();
+            return x.to_fix();
+        }
+        if let Ok(d) = Duration::try_from_secs_f64(-self) {
+            let x = d.as_secs();
+            let x = i64::try_from(x).ok()?;
+            let x = x.checked_neg()?;
+            return x.to_fix();
+        }
+        None
     }
 }
 
@@ -400,6 +412,7 @@ mod tests {
     fn i128_to_fix() {
         let test_cases = [
             (i128::MIN, None),
+            (i64::MIN.into(), None),
             // ```
             // >>> (-(2 ** 63 - 1)) >> 1
             // -4611686018427387904
@@ -421,6 +434,7 @@ mod tests {
             (4_611_686_018_427_387_903 - 1, Some(4_611_686_018_427_387_902)),
             (4_611_686_018_427_387_903, Some(4_611_686_018_427_387_903)),
             (4_611_686_018_427_387_903 + 1, None),
+            (i64::MAX.into(), None),
             (i128::MAX, None),
         ];
         for (x, fixed) in test_cases {
@@ -478,6 +492,7 @@ mod tests {
             (4_611_686_018_427_387_903 - 1, Some(4_611_686_018_427_387_902)),
             (4_611_686_018_427_387_903, Some(4_611_686_018_427_387_903)),
             (4_611_686_018_427_387_903 + 1, None),
+            (i64::MAX.try_into().unwrap(), None),
             (u64::MAX, None),
         ];
         for (x, fixed) in test_cases {
@@ -502,6 +517,7 @@ mod tests {
             (4_611_686_018_427_387_903 - 1, Some(4_611_686_018_427_387_902)),
             (4_611_686_018_427_387_903, Some(4_611_686_018_427_387_903)),
             (4_611_686_018_427_387_903 + 1, None),
+            (i64::MAX.try_into().unwrap(), None),
             (u128::MAX, None),
         ];
         for (x, fixed) in test_cases {
@@ -516,6 +532,8 @@ mod tests {
         let test_cases = [
             (f32::NEG_INFINITY, None),
             (f32::MIN, None),
+            (i64::MIN as _, None),
+            (-4_612_686_018_427_388_000.0, None),
             (-1024.0, Some(-1024)),
             (-10.0, Some(-10)),
             (-1.9, Some(-1)),
@@ -534,6 +552,8 @@ mod tests {
             (1.9, Some(1)),
             (10.0, Some(10)),
             (1024.0, Some(1024)),
+            (4_611_686_018_427_387_904.0, None),
+            (i64::MAX as _, None),
             (f32::MAX, None),
             (f32::INFINITY, None),
             (f32::MIN_POSITIVE, Some(0)),
@@ -552,7 +572,8 @@ mod tests {
         let test_cases = [
             (f64::NEG_INFINITY, None),
             (f64::MIN, None),
-            (-4_611_686_018_427_387_904.0, None),
+            (i64::MIN as _, None),
+            (-4_612_686_018_427_388_000.0, None),
             (-1024.0, Some(-1024)),
             (-10.0, Some(-10)),
             (-1.9, Some(-1)),
@@ -572,6 +593,7 @@ mod tests {
             (10.0, Some(10)),
             (1024.0, Some(1024)),
             (4_611_686_018_427_387_904.0, None),
+            (i64::MAX as _, None),
             (f64::MAX, None),
             (f64::INFINITY, None),
             (f64::MIN_POSITIVE, Some(0)),

--- a/scolapasta-fixable/src/lib.rs
+++ b/scolapasta-fixable/src/lib.rs
@@ -350,22 +350,114 @@ mod tests {
     }
 
     #[test]
-    fn all_neg_i32_fix_to_self() {
-        for x in i32::MIN..0 {
+    fn all_i32_fix_to_self_shard_0() {
+        const N: i32 = 0;
+        const LOWER: i32 = i32::MIN + N * (1 << 29);
+        const UPPER: i32 = LOWER + (1 << 29);
+
+        let mut c = 0;
+        for x in LOWER..UPPER {
             assert_eq!(x.to_fix(), Some(x.into()), "{x} should be its own fixnum");
+            c += 1;
         }
+        assert_eq!(c, 1 << 29);
     }
 
     #[test]
-    fn zero_i32_fixes_to_self() {
-        assert_eq!(0_i32.to_fix(), Some(0), "0 should be its own fixnum");
+    fn all_i32_fix_to_self_shard_1() {
+        const N: i32 = 1;
+        const LOWER: i32 = i32::MIN + N * (1 << 29);
+        const UPPER: i32 = LOWER + (1 << 29);
+
+        let mut c = 0;
+        for x in LOWER..UPPER {
+            assert_eq!(x.to_fix(), Some(x.into()), "{x} should be its own fixnum");
+            c += 1;
+        }
+        assert_eq!(c, 1 << 29);
     }
 
     #[test]
-    fn all_pos_i32_fix_to_self() {
-        for x in 1..=i32::MAX {
+    fn all_i32_fix_to_self_shard_2() {
+        const N: i32 = 2;
+        const LOWER: i32 = i32::MIN + N * (1 << 29);
+        const UPPER: i32 = LOWER + (1 << 29);
+
+        let mut c = 0;
+        for x in LOWER..UPPER {
             assert_eq!(x.to_fix(), Some(x.into()), "{x} should be its own fixnum");
+            c += 1;
         }
+        assert_eq!(c, 1 << 29);
+    }
+
+    #[test]
+    fn all_i32_fix_to_self_shard_3() {
+        const N: i32 = 3;
+        const LOWER: i32 = i32::MIN + N * (1 << 29);
+        const UPPER: i32 = LOWER + (1 << 29);
+
+        let mut c = 0;
+        for x in LOWER..UPPER {
+            assert_eq!(x.to_fix(), Some(x.into()), "{x} should be its own fixnum");
+            c += 1;
+        }
+        assert_eq!(c, 1 << 29);
+    }
+
+    #[test]
+    fn all_i32_fix_to_self_shard_4() {
+        const N: i32 = 0;
+        const LOWER: i32 = N * (1 << 29);
+        const UPPER: i32 = LOWER + (1 << 29);
+
+        let mut c = 0;
+        for x in LOWER..UPPER {
+            assert_eq!(x.to_fix(), Some(x.into()), "{x} should be its own fixnum");
+            c += 1;
+        }
+        assert_eq!(c, 1 << 29);
+    }
+
+    #[test]
+    fn all_i32_fix_to_self_shard_5() {
+        const N: i32 = 1;
+        const LOWER: i32 = N * (1 << 29);
+        const UPPER: i32 = LOWER + (1 << 29);
+
+        let mut c = 0;
+        for x in LOWER..UPPER {
+            assert_eq!(x.to_fix(), Some(x.into()), "{x} should be its own fixnum");
+            c += 1;
+        }
+        assert_eq!(c, 1 << 29);
+    }
+
+    #[test]
+    fn all_i32_fix_to_self_shard_6() {
+        const N: i32 = 2;
+        const LOWER: i32 = N * (1 << 29);
+        const UPPER: i32 = LOWER + (1 << 29);
+
+        let mut c = 0;
+        for x in LOWER..UPPER {
+            assert_eq!(x.to_fix(), Some(x.into()), "{x} should be its own fixnum");
+            c += 1;
+        }
+        assert_eq!(c, 1 << 29);
+    }
+
+    #[test]
+    fn all_i32_fix_to_self_shard_7() {
+        const N: i32 = 3;
+        const LOWER: i32 = N * (1 << 29);
+
+        let mut c = 0;
+        for x in LOWER..=i32::MAX {
+            assert_eq!(x.to_fix(), Some(x.into()), "{x} should be its own fixnum");
+            c += 1;
+        }
+        assert_eq!(c, 1 << 29);
     }
 
     #[test]
@@ -459,22 +551,114 @@ mod tests {
     }
 
     #[test]
-    fn all_neg_u32_fix_to_self() {
-        for x in u32::MIN..0 {
+    fn all_u32_fix_to_self_shard_0() {
+        const N: u32 = 0;
+        const LOWER: u32 = N * (1 << 29);
+        const UPPER: u32 = LOWER + (1 << 29);
+
+        let mut c = 0;
+        for x in LOWER..UPPER {
             assert_eq!(x.to_fix(), Some(x.into()), "{x} should be its own fixnum");
+            c += 1;
         }
+        assert_eq!(c, 1 << 29);
     }
 
     #[test]
-    fn zero_u32_fixes_to_self() {
-        assert_eq!(0_u32.to_fix(), Some(0), "0 should be its own fixnum");
+    fn all_u32_fix_to_self_shard_1() {
+        const N: u32 = 1;
+        const LOWER: u32 = N * (1 << 29);
+        const UPPER: u32 = LOWER + (1 << 29);
+
+        let mut c = 0;
+        for x in LOWER..UPPER {
+            assert_eq!(x.to_fix(), Some(x.into()), "{x} should be its own fixnum");
+            c += 1;
+        }
+        assert_eq!(c, 1 << 29);
     }
 
     #[test]
-    fn all_pos_u32_fix_to_self() {
-        for x in 1..=u32::MAX {
+    fn all_u32_fix_to_self_shard_2() {
+        const N: u32 = 2;
+        const LOWER: u32 = N * (1 << 29);
+        const UPPER: u32 = LOWER + (1 << 29);
+
+        let mut c = 0;
+        for x in LOWER..UPPER {
             assert_eq!(x.to_fix(), Some(x.into()), "{x} should be its own fixnum");
+            c += 1;
         }
+        assert_eq!(c, 1 << 29);
+    }
+
+    #[test]
+    fn all_u32_fix_to_self_shard_3() {
+        const N: u32 = 3;
+        const LOWER: u32 = N * (1 << 29);
+        const UPPER: u32 = LOWER + (1 << 29);
+
+        let mut c = 0;
+        for x in LOWER..UPPER {
+            assert_eq!(x.to_fix(), Some(x.into()), "{x} should be its own fixnum");
+            c += 1;
+        }
+        assert_eq!(c, 1 << 29);
+    }
+
+    #[test]
+    fn all_u32_fix_to_self_shard_4() {
+        const N: u32 = 4;
+        const LOWER: u32 = N * (1 << 29);
+        const UPPER: u32 = LOWER + (1 << 29);
+
+        let mut c = 0;
+        for x in LOWER..UPPER {
+            assert_eq!(x.to_fix(), Some(x.into()), "{x} should be its own fixnum");
+            c += 1;
+        }
+        assert_eq!(c, 1 << 29);
+    }
+
+    #[test]
+    fn all_u32_fix_to_self_shard_5() {
+        const N: u32 = 5;
+        const LOWER: u32 = N * (1 << 29);
+        const UPPER: u32 = LOWER + (1 << 29);
+
+        let mut c = 0;
+        for x in LOWER..UPPER {
+            assert_eq!(x.to_fix(), Some(x.into()), "{x} should be its own fixnum");
+            c += 1;
+        }
+        assert_eq!(c, 1 << 29);
+    }
+
+    #[test]
+    fn all_u32_fix_to_self_shard_6() {
+        const N: u32 = 6;
+        const LOWER: u32 = N * (1 << 29);
+        const UPPER: u32 = LOWER + (1 << 29);
+
+        let mut c = 0;
+        for x in LOWER..UPPER {
+            assert_eq!(x.to_fix(), Some(x.into()), "{x} should be its own fixnum");
+            c += 1;
+        }
+        assert_eq!(c, 1 << 29);
+    }
+
+    #[test]
+    fn all_u32_fix_to_self_shard_7() {
+        const N: u32 = 7;
+        const LOWER: u32 = N * (1 << 29);
+
+        let mut c = 0;
+        for x in LOWER..=u32::MAX {
+            assert_eq!(x.to_fix(), Some(x.into()), "{x} should be its own fixnum");
+            c += 1;
+        }
+        assert_eq!(c, 1 << 29);
     }
 
     #[test]

--- a/scolapasta-fixable/src/lib.rs
+++ b/scolapasta-fixable/src/lib.rs
@@ -276,81 +276,7 @@ mod tests {
     }
 
     #[test]
-    fn all_neg_i32_are_fixable() {
-        for x in i32::MIN..0 {
-            assert!(x.is_fixable(), "{x} should be fixable");
-            assert!(RB_FIXABLE(x), "{x} should be fixable");
-        }
-    }
-
-    #[test]
-    fn zero_i32_is_fixable() {
-        assert!(0_i32.is_fixable(), "0 should be fixable");
-        assert!(RB_FIXABLE(0_i32), "0 should be fixable");
-    }
-
-    #[test]
-    fn all_pos_i32_are_fixable() {
-        for x in 1..=i32::MAX {
-            assert!(x.is_fixable(), "{x} should be fixable");
-            assert!(RB_FIXABLE(x), "{x} should be fixable");
-        }
-    }
-
-    #[test]
-    fn all_u8_are_fixable() {
-        for x in u8::MIN..=u8::MAX {
-            assert!(x.is_fixable(), "{x} should be fixable");
-            assert!(RB_FIXABLE(x), "{x} should be fixable");
-        }
-    }
-
-    #[test]
-    fn all_u16_are_fixable() {
-        for x in u16::MIN..=u16::MAX {
-            assert!(x.is_fixable(), "{x} should be fixable");
-            assert!(RB_FIXABLE(x), "{x} should be fixable");
-        }
-    }
-
-    #[test]
-    fn all_neg_u32_are_fixable() {
-        for x in u32::MIN..0 {
-            assert!(x.is_fixable(), "{x} should be fixable");
-            assert!(RB_FIXABLE(x), "{x} should be fixable");
-        }
-    }
-
-    #[test]
-    fn zero_u32_is_fixable() {
-        assert!(0_u32.is_fixable(), "0 should be fixable");
-        assert!(RB_FIXABLE(0_u32), "0 should be fixable");
-    }
-
-    #[test]
-    fn all_pos_u32_are_fixable() {
-        for x in 1..=u32::MAX {
-            assert!(x.is_fixable(), "{x} should be fixable");
-            assert!(RB_FIXABLE(x), "{x} should be fixable");
-        }
-    }
-
-    #[test]
-    fn all_i8_fix_to_self() {
-        for x in i8::MIN..=i8::MAX {
-            assert_eq!(x.to_fix(), Some(x.into()), "{x} should be its own fixnum");
-        }
-    }
-
-    #[test]
-    fn all_i16_fix_to_self() {
-        for x in i16::MIN..=i16::MAX {
-            assert_eq!(x.to_fix(), Some(x.into()), "{x} should be its own fixnum");
-        }
-    }
-
-    #[test]
-    fn all_i32_fix_to_self_shard_0() {
+    fn all_i32_are_fixable_shard_0() {
         const N: i32 = 0;
         const LOWER: i32 = i32::MIN + N * (1 << 29);
         const UPPER: i32 = LOWER + (1 << 29);
@@ -358,13 +284,15 @@ mod tests {
         let mut c = 0;
         for x in LOWER..UPPER {
             assert_eq!(x.to_fix(), Some(x.into()), "{x} should be its own fixnum");
+            assert!(x.is_fixable(), "{x} should be fixable");
+            assert!(RB_FIXABLE(x), "{x} should be fixable");
             c += 1;
         }
         assert_eq!(c, 1 << 29);
     }
 
     #[test]
-    fn all_i32_fix_to_self_shard_1() {
+    fn all_i32_are_fixable_shard_1() {
         const N: i32 = 1;
         const LOWER: i32 = i32::MIN + N * (1 << 29);
         const UPPER: i32 = LOWER + (1 << 29);
@@ -372,13 +300,15 @@ mod tests {
         let mut c = 0;
         for x in LOWER..UPPER {
             assert_eq!(x.to_fix(), Some(x.into()), "{x} should be its own fixnum");
+            assert!(x.is_fixable(), "{x} should be fixable");
+            assert!(RB_FIXABLE(x), "{x} should be fixable");
             c += 1;
         }
         assert_eq!(c, 1 << 29);
     }
 
     #[test]
-    fn all_i32_fix_to_self_shard_2() {
+    fn all_i32_are_fixable_shard_2() {
         const N: i32 = 2;
         const LOWER: i32 = i32::MIN + N * (1 << 29);
         const UPPER: i32 = LOWER + (1 << 29);
@@ -386,13 +316,15 @@ mod tests {
         let mut c = 0;
         for x in LOWER..UPPER {
             assert_eq!(x.to_fix(), Some(x.into()), "{x} should be its own fixnum");
+            assert!(x.is_fixable(), "{x} should be fixable");
+            assert!(RB_FIXABLE(x), "{x} should be fixable");
             c += 1;
         }
         assert_eq!(c, 1 << 29);
     }
 
     #[test]
-    fn all_i32_fix_to_self_shard_3() {
+    fn all_i32_are_fixable_shard_3() {
         const N: i32 = 3;
         const LOWER: i32 = i32::MIN + N * (1 << 29);
         const UPPER: i32 = LOWER + (1 << 29);
@@ -400,13 +332,15 @@ mod tests {
         let mut c = 0;
         for x in LOWER..UPPER {
             assert_eq!(x.to_fix(), Some(x.into()), "{x} should be its own fixnum");
+            assert!(x.is_fixable(), "{x} should be fixable");
+            assert!(RB_FIXABLE(x), "{x} should be fixable");
             c += 1;
         }
         assert_eq!(c, 1 << 29);
     }
 
     #[test]
-    fn all_i32_fix_to_self_shard_4() {
+    fn all_i32_are_fixable_shard_4() {
         const N: i32 = 0;
         const LOWER: i32 = N * (1 << 29);
         const UPPER: i32 = LOWER + (1 << 29);
@@ -414,13 +348,15 @@ mod tests {
         let mut c = 0;
         for x in LOWER..UPPER {
             assert_eq!(x.to_fix(), Some(x.into()), "{x} should be its own fixnum");
+            assert!(x.is_fixable(), "{x} should be fixable");
+            assert!(RB_FIXABLE(x), "{x} should be fixable");
             c += 1;
         }
         assert_eq!(c, 1 << 29);
     }
 
     #[test]
-    fn all_i32_fix_to_self_shard_5() {
+    fn all_i32_are_fixable_shard_5() {
         const N: i32 = 1;
         const LOWER: i32 = N * (1 << 29);
         const UPPER: i32 = LOWER + (1 << 29);
@@ -428,13 +364,15 @@ mod tests {
         let mut c = 0;
         for x in LOWER..UPPER {
             assert_eq!(x.to_fix(), Some(x.into()), "{x} should be its own fixnum");
+            assert!(x.is_fixable(), "{x} should be fixable");
+            assert!(RB_FIXABLE(x), "{x} should be fixable");
             c += 1;
         }
         assert_eq!(c, 1 << 29);
     }
 
     #[test]
-    fn all_i32_fix_to_self_shard_6() {
+    fn all_i32_are_fixable_shard_6() {
         const N: i32 = 2;
         const LOWER: i32 = N * (1 << 29);
         const UPPER: i32 = LOWER + (1 << 29);
@@ -442,26 +380,30 @@ mod tests {
         let mut c = 0;
         for x in LOWER..UPPER {
             assert_eq!(x.to_fix(), Some(x.into()), "{x} should be its own fixnum");
+            assert!(x.is_fixable(), "{x} should be fixable");
+            assert!(RB_FIXABLE(x), "{x} should be fixable");
             c += 1;
         }
         assert_eq!(c, 1 << 29);
     }
 
     #[test]
-    fn all_i32_fix_to_self_shard_7() {
+    fn all_i32_are_fixable_shard_7() {
         const N: i32 = 3;
         const LOWER: i32 = N * (1 << 29);
 
         let mut c = 0;
         for x in LOWER..=i32::MAX {
             assert_eq!(x.to_fix(), Some(x.into()), "{x} should be its own fixnum");
+            assert!(x.is_fixable(), "{x} should be fixable");
+            assert!(RB_FIXABLE(x), "{x} should be fixable");
             c += 1;
         }
         assert_eq!(c, 1 << 29);
     }
 
     #[test]
-    fn i64_to_fix() {
+    fn i64_are_fixable() {
         let test_cases = [
             (i64::MIN, None),
             (RUBY_FIXNUM_MIN - 1, None),
@@ -501,7 +443,7 @@ mod tests {
     }
 
     #[test]
-    fn i128_to_fix() {
+    fn i128_are_fixable() {
         let test_cases = [
             (i128::MIN, None),
             (i64::MIN.into(), None),
@@ -537,21 +479,25 @@ mod tests {
     }
 
     #[test]
-    fn all_u8_fix_to_self() {
+    fn all_u8_are_fixable() {
         for x in u8::MIN..=u8::MAX {
             assert_eq!(x.to_fix(), Some(x.into()), "{x} should be its own fixnum");
+            assert!(x.is_fixable(), "{x} should be fixable");
+            assert!(RB_FIXABLE(x), "{x} should be fixable");
         }
     }
 
     #[test]
-    fn all_u16_fix_to_self() {
+    fn all_u16_are_fixable() {
         for x in u16::MIN..=u16::MAX {
             assert_eq!(x.to_fix(), Some(x.into()), "{x} should be its own fixnum");
+            assert!(x.is_fixable(), "{x} should be fixable");
+            assert!(RB_FIXABLE(x), "{x} should be fixable");
         }
     }
 
     #[test]
-    fn all_u32_fix_to_self_shard_0() {
+    fn all_u32_are_fixable_shard_0() {
         const N: u32 = 0;
         const LOWER: u32 = N * (1 << 29);
         const UPPER: u32 = LOWER + (1 << 29);
@@ -559,13 +505,15 @@ mod tests {
         let mut c = 0;
         for x in LOWER..UPPER {
             assert_eq!(x.to_fix(), Some(x.into()), "{x} should be its own fixnum");
+            assert!(x.is_fixable(), "{x} should be fixable");
+            assert!(RB_FIXABLE(x), "{x} should be fixable");
             c += 1;
         }
         assert_eq!(c, 1 << 29);
     }
 
     #[test]
-    fn all_u32_fix_to_self_shard_1() {
+    fn all_u32_are_fixable_shard_1() {
         const N: u32 = 1;
         const LOWER: u32 = N * (1 << 29);
         const UPPER: u32 = LOWER + (1 << 29);
@@ -573,13 +521,15 @@ mod tests {
         let mut c = 0;
         for x in LOWER..UPPER {
             assert_eq!(x.to_fix(), Some(x.into()), "{x} should be its own fixnum");
+            assert!(x.is_fixable(), "{x} should be fixable");
+            assert!(RB_FIXABLE(x), "{x} should be fixable");
             c += 1;
         }
         assert_eq!(c, 1 << 29);
     }
 
     #[test]
-    fn all_u32_fix_to_self_shard_2() {
+    fn all_u32_are_fixable_shard_2() {
         const N: u32 = 2;
         const LOWER: u32 = N * (1 << 29);
         const UPPER: u32 = LOWER + (1 << 29);
@@ -587,13 +537,15 @@ mod tests {
         let mut c = 0;
         for x in LOWER..UPPER {
             assert_eq!(x.to_fix(), Some(x.into()), "{x} should be its own fixnum");
+            assert!(x.is_fixable(), "{x} should be fixable");
+            assert!(RB_FIXABLE(x), "{x} should be fixable");
             c += 1;
         }
         assert_eq!(c, 1 << 29);
     }
 
     #[test]
-    fn all_u32_fix_to_self_shard_3() {
+    fn all_u32_are_fixable_shard_3() {
         const N: u32 = 3;
         const LOWER: u32 = N * (1 << 29);
         const UPPER: u32 = LOWER + (1 << 29);
@@ -601,13 +553,15 @@ mod tests {
         let mut c = 0;
         for x in LOWER..UPPER {
             assert_eq!(x.to_fix(), Some(x.into()), "{x} should be its own fixnum");
+            assert!(x.is_fixable(), "{x} should be fixable");
+            assert!(RB_FIXABLE(x), "{x} should be fixable");
             c += 1;
         }
         assert_eq!(c, 1 << 29);
     }
 
     #[test]
-    fn all_u32_fix_to_self_shard_4() {
+    fn all_u32_are_fixable_shard_4() {
         const N: u32 = 4;
         const LOWER: u32 = N * (1 << 29);
         const UPPER: u32 = LOWER + (1 << 29);
@@ -615,13 +569,15 @@ mod tests {
         let mut c = 0;
         for x in LOWER..UPPER {
             assert_eq!(x.to_fix(), Some(x.into()), "{x} should be its own fixnum");
+            assert!(x.is_fixable(), "{x} should be fixable");
+            assert!(RB_FIXABLE(x), "{x} should be fixable");
             c += 1;
         }
         assert_eq!(c, 1 << 29);
     }
 
     #[test]
-    fn all_u32_fix_to_self_shard_5() {
+    fn all_u32_are_fixable_shard_5() {
         const N: u32 = 5;
         const LOWER: u32 = N * (1 << 29);
         const UPPER: u32 = LOWER + (1 << 29);
@@ -629,13 +585,15 @@ mod tests {
         let mut c = 0;
         for x in LOWER..UPPER {
             assert_eq!(x.to_fix(), Some(x.into()), "{x} should be its own fixnum");
+            assert!(x.is_fixable(), "{x} should be fixable");
+            assert!(RB_FIXABLE(x), "{x} should be fixable");
             c += 1;
         }
         assert_eq!(c, 1 << 29);
     }
 
     #[test]
-    fn all_u32_fix_to_self_shard_6() {
+    fn all_u32_are_fixable_shard_6() {
         const N: u32 = 6;
         const LOWER: u32 = N * (1 << 29);
         const UPPER: u32 = LOWER + (1 << 29);
@@ -643,26 +601,30 @@ mod tests {
         let mut c = 0;
         for x in LOWER..UPPER {
             assert_eq!(x.to_fix(), Some(x.into()), "{x} should be its own fixnum");
+            assert!(x.is_fixable(), "{x} should be fixable");
+            assert!(RB_FIXABLE(x), "{x} should be fixable");
             c += 1;
         }
         assert_eq!(c, 1 << 29);
     }
 
     #[test]
-    fn all_u32_fix_to_self_shard_7() {
+    fn all_u32_are_fixable_shard_7() {
         const N: u32 = 7;
         const LOWER: u32 = N * (1 << 29);
 
         let mut c = 0;
         for x in LOWER..=u32::MAX {
             assert_eq!(x.to_fix(), Some(x.into()), "{x} should be its own fixnum");
+            assert!(x.is_fixable(), "{x} should be fixable");
+            assert!(RB_FIXABLE(x), "{x} should be fixable");
             c += 1;
         }
         assert_eq!(c, 1 << 29);
     }
 
     #[test]
-    fn u64_to_fix() {
+    fn u64_are_fixable() {
         let test_cases = [
             (u64::MIN, Some(0)),
             (0_u64, Some(0)),
@@ -687,7 +649,7 @@ mod tests {
     }
 
     #[test]
-    fn u128_to_fix() {
+    fn u128_are_fixable() {
         let test_cases = [
             (u128::MIN, Some(0)),
             (0_u128, Some(0)),
@@ -712,7 +674,7 @@ mod tests {
     }
 
     #[test]
-    fn f32_to_fix() {
+    fn f32_are_fixable() {
         let test_cases = [
             (f32::NEG_INFINITY, None),
             (f32::MIN, None),
@@ -752,7 +714,7 @@ mod tests {
     }
 
     #[test]
-    fn f64_to_fix() {
+    fn f64_are_fixable() {
         let test_cases = [
             (f64::NEG_INFINITY, None),
             (f64::MIN, None),

--- a/scolapasta-fixable/src/lib.rs
+++ b/scolapasta-fixable/src/lib.rs
@@ -24,8 +24,124 @@
 
 #![no_std]
 
-pub fn add(left: usize, right: usize) -> usize {
-    left + right
+/// The maximum possible value that a fixnum can represent, 63 bits of an
+/// [`i64`].
+///
+/// # C Declaration
+/// ```c
+/// /** Maximum possible value that a fixnum can represent. */
+/// #define RUBY_FIXNUM_MAX  (LONG_MAX / 2)
+/// ```
+pub const RUBY_FIXNUM_MAX: i64 = i64::MAX / 2;
+
+/// The minimum possible value that a fixnum can represent, 63 bits of an
+/// [`i64`].
+///
+/// ```c
+/// /** Minimum possible value that a fixnum can represent. */
+/// #define RUBY_FIXNUM_MIN  (LONG_MIN / 2)
+/// ```
+pub const RUBY_FIXNUM_MIN: i64 = i64::MIN / 2;
+
+mod private {
+    pub trait Sealed {}
+
+    impl Sealed for i8 {}
+    impl Sealed for i16 {}
+    impl Sealed for i32 {}
+
+    impl Sealed for u8 {}
+    impl Sealed for u16 {}
+    impl Sealed for u32 {}
+}
+
+/// Marker trait for numeric values which can be converted to a "fixnum", or
+/// Integer, representation.
+///
+/// A numeric value is fixable if its integral portion can fit within 63 bits of
+/// an [`i64`].
+///
+/// See [`RUBY_FIXNUM_MIN`] and [`RUBY_FIXNUM_MAX`] for more details on the range
+/// of values yielded by implementers of this trait.
+///
+/// This trait is sealed and cannot be implmented outside of this crate.
+pub trait Fixable: private::Sealed {
+    /// Convert a fixable numeric value to its integral part.
+    ///
+    /// This method returns [`None`] if `self` is out of range.
+    fn to_fix(self) -> Option<i64>;
+}
+
+impl Fixable for i8 {
+    fn to_fix(self) -> Option<i64> {
+        Some(self.into())
+    }
+}
+
+impl Fixable for i16 {
+    fn to_fix(self) -> Option<i64> {
+        Some(self.into())
+    }
+}
+
+impl Fixable for i32 {
+    fn to_fix(self) -> Option<i64> {
+        Some(self.into())
+    }
+}
+
+impl Fixable for u8 {
+    fn to_fix(self) -> Option<i64> {
+        Some(self.into())
+    }
+}
+
+impl Fixable for u16 {
+    fn to_fix(self) -> Option<i64> {
+        Some(self.into())
+    }
+}
+
+impl Fixable for u32 {
+    fn to_fix(self) -> Option<i64> {
+        Some(self.into())
+    }
+}
+
+/// Check whether the given numeric is in the range of fixnum.
+///
+/// FIXABLE can be applied to any numeric type. See the implementersof the
+/// [`Fixable`] trait for more details on which numeric types are fixable.
+///
+/// # C Declaration
+///
+/// ```c
+/// /**
+///  * Checks if the passed value is in  range of fixnum, assuming it is a positive
+///  * number.  Can sometimes be useful for C's unsigned integer types.
+///  *
+///  * @internal
+///  *
+///  * FIXABLE can be applied to anything, from double to intmax_t.  The problem is
+///  * double.   On a  64bit system  RUBY_FIXNUM_MAX is  4,611,686,018,427,387,903,
+///  * which is not representable by a double.  The nearest value that a double can
+///  * represent  is   4,611,686,018,427,387,904,  which   is  not   fixable.   The
+///  * seemingly-strange "< FIXNUM_MAX + 1" expression below is due to this.
+///  */
+/// #define RB_POSFIXABLE(_) ((_) <  RUBY_FIXNUM_MAX + 1)
+///
+/// /**
+///  * Checks if the passed value is in  range of fixnum, assuming it is a negative
+///  * number.  This is an implementation of #RB_FIXABLE.  Rarely used stand alone.
+///  */
+/// #define RB_NEGFIXABLE(_) ((_) >= RUBY_FIXNUM_MIN)
+///
+/// /** Checks if the passed value is in  range of fixnum */
+/// #define RB_FIXABLE(_)    (RB_POSFIXABLE(_) && RB_NEGFIXABLE(_))
+/// ```
+#[allow(non_snake_case)] // match MRI macro name
+pub fn RB_FIXABLE<T: Fixable>(x: T) -> bool {
+    x.to_fix().is_some()
 }
 
 #[cfg(test)]
@@ -33,8 +149,68 @@ mod tests {
     use super::*;
 
     #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
+    fn all_i8_are_fixable() {
+        for x in i8::MIN..=i8::MAX {
+            assert!(RB_FIXABLE(x), "{x} should be fixable");
+        }
+    }
+
+    #[test]
+    fn all_i16_are_fixable() {
+        for x in i16::MIN..=i16::MAX {
+            assert!(RB_FIXABLE(x), "{x} should be fixable");
+        }
+    }
+
+    #[test]
+    fn all_neg_i32_are_fixable() {
+        for x in i32::MIN..0 {
+            assert!(RB_FIXABLE(x), "{x} should be fixable");
+        }
+    }
+
+    #[test]
+    fn zero_i32_is_fixable() {
+        assert!(RB_FIXABLE(0_i32), "0 should be fixable");
+    }
+
+    #[test]
+    fn all_pos_i32_are_fixable() {
+        for x in 1..=i32::MAX {
+            assert!(RB_FIXABLE(x), "{x} should be fixable");
+        }
+    }
+
+    #[test]
+    fn all_u8_are_fixable() {
+        for x in u8::MIN..=u8::MAX {
+            assert!(RB_FIXABLE(x), "{x} should be fixable");
+        }
+    }
+
+    #[test]
+    fn all_u16_are_fixable() {
+        for x in u16::MIN..=u16::MAX {
+            assert!(RB_FIXABLE(x), "{x} should be fixable");
+        }
+    }
+
+    #[test]
+    fn all_neg_u32_are_fixable() {
+        for x in u32::MIN..0 {
+            assert!(RB_FIXABLE(x), "{x} should be fixable");
+        }
+    }
+
+    #[test]
+    fn zero_u32_is_fixable() {
+        assert!(RB_FIXABLE(0_u32), "0 should be fixable");
+    }
+
+    #[test]
+    fn all_pos_u32_are_fixable() {
+        for x in 1..=u32::MAX {
+            assert!(RB_FIXABLE(x), "{x} should be fixable");
+        }
     }
 }

--- a/scolapasta-fixable/src/lib.rs
+++ b/scolapasta-fixable/src/lib.rs
@@ -53,8 +53,8 @@
 //!
 //! assert!(23_u8.is_fixable());
 //! assert_eq!(23_u8.to_fix(), Some(23_i64));
-//! assert!(-9000.27_f64.is_fixable());
-//! assert_eq!(-9000.27_f64.to_fix(), Some(-9000_i64));
+//! assert!((-9000.27_f64).is_fixable());
+//! assert_eq!((-9000.27_f64).to_fix(), Some(-9000_i64));
 //! ```
 //!
 //! Some numeric types, such as [`u64`], [`i128`], and [`f64`] have values that
@@ -67,8 +67,8 @@
 //! assert_eq!(u64::MAX.to_fix(), None);
 //! assert_eq!(i128::MIN.to_fix(), None);
 //! assert_eq!(4_611_686_018_427_387_904.0_f64.to_fix(), None);
-//! assert_eq!(f64::INFINITY, None);
-//! assert_eq!(f64::NAN, None);
+//! assert_eq!(f64::INFINITY.to_fix(), None);
+//! assert_eq!(f64::NAN.to_fix(), None);
 //! ```
 //!
 //! For non-integer fixable types, the fractional part is discarded when converting

--- a/scolapasta-fixable/src/lib.rs
+++ b/scolapasta-fixable/src/lib.rs
@@ -83,9 +83,11 @@ pub trait Fixable: private::Sealed + Sized {
     /// Convert a fixable numeric value to its integral part.
     ///
     /// This method returns [`None`] if `self` is out of range.
+    #[must_use]
     fn to_fix(self) -> Option<i64>;
 
     /// Test whether a fixable numeric value is in range.
+    #[must_use]
     fn is_fixable(self) -> bool {
         self.to_fix().is_some()
     }
@@ -271,6 +273,7 @@ impl Fixable for f64 {
 /// /** Checks if the passed value is in  range of fixnum */
 /// #define RB_FIXABLE(_)    (RB_POSFIXABLE(_) && RB_NEGFIXABLE(_))
 /// ```
+#[must_use]
 #[allow(non_snake_case)] // match MRI macro name
 pub fn RB_FIXABLE<T: Fixable>(x: T) -> bool {
     x.is_fixable()

--- a/scolapasta-fixable/src/lib.rs
+++ b/scolapasta-fixable/src/lib.rs
@@ -264,6 +264,7 @@ mod tests {
     #[test]
     fn all_i8_are_fixable() {
         for x in i8::MIN..=i8::MAX {
+            assert_eq!(x.to_fix(), Some(x.into()), "{x} should be its own fixnum");
             assert!(x.is_fixable(), "{x} should be fixable");
             assert!(RB_FIXABLE(x), "{x} should be fixable");
         }
@@ -272,6 +273,7 @@ mod tests {
     #[test]
     fn all_i16_are_fixable() {
         for x in i16::MIN..=i16::MAX {
+            assert_eq!(x.to_fix(), Some(x.into()), "{x} should be its own fixnum");
             assert!(x.is_fixable(), "{x} should be fixable");
             assert!(RB_FIXABLE(x), "{x} should be fixable");
         }

--- a/scolapasta-fixable/src/lib.rs
+++ b/scolapasta-fixable/src/lib.rs
@@ -128,6 +128,10 @@ impl Fixable for i64 {
         }
         Some(self)
     }
+
+    fn is_fixable(self) -> bool {
+        (RUBY_FIXNUM_MIN..=RUBY_FIXNUM_MAX).contains(&self)
+    }
 }
 
 impl Fixable for i128 {

--- a/scolapasta-fixable/src/lib.rs
+++ b/scolapasta-fixable/src/lib.rs
@@ -393,7 +393,7 @@ impl Fixable for f32 {
     ///
     /// This function discards the fractional part of the float, i.e. truncates.
     ///
-    /// [NaN](f32::NAN) and infinities return [`None`].
+    /// [`NaN`](f32::NAN) and infinities return [`None`].
     ///
     /// # Implementation Notes
     ///
@@ -426,7 +426,7 @@ impl Fixable for f64 {
     ///
     /// This function discards the fractional part of the float, i.e. truncates.
     ///
-    /// [NaN](f64::NAN) and infinities return [`None`].
+    /// [`NaN`](f64::NAN) and infinities return [`None`].
     ///
     /// # Implementation Notes
     ///
@@ -936,6 +936,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::cast_precision_loss)]
     fn f32_are_fixable() {
         let test_cases = [
             (f32::NEG_INFINITY, None),
@@ -976,6 +977,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::cast_precision_loss)]
     fn f64_are_fixable() {
         let test_cases = [
             (f64::NEG_INFINITY, None),

--- a/scolapasta-fixable/src/lib.rs
+++ b/scolapasta-fixable/src/lib.rs
@@ -225,6 +225,7 @@ mod tests {
     #[test]
     fn all_i8_are_fixable() {
         for x in i8::MIN..=i8::MAX {
+            assert!(x.is_fixable(), "{x} should be fixable");
             assert!(RB_FIXABLE(x), "{x} should be fixable");
         }
     }
@@ -232,6 +233,7 @@ mod tests {
     #[test]
     fn all_i16_are_fixable() {
         for x in i16::MIN..=i16::MAX {
+            assert!(x.is_fixable(), "{x} should be fixable");
             assert!(RB_FIXABLE(x), "{x} should be fixable");
         }
     }
@@ -239,18 +241,21 @@ mod tests {
     #[test]
     fn all_neg_i32_are_fixable() {
         for x in i32::MIN..0 {
+            assert!(x.is_fixable(), "{x} should be fixable");
             assert!(RB_FIXABLE(x), "{x} should be fixable");
         }
     }
 
     #[test]
     fn zero_i32_is_fixable() {
+        assert!(0_i32.is_fixable(), "0 should be fixable");
         assert!(RB_FIXABLE(0_i32), "0 should be fixable");
     }
 
     #[test]
     fn all_pos_i32_are_fixable() {
         for x in 1..=i32::MAX {
+            assert!(x.is_fixable(), "{x} should be fixable");
             assert!(RB_FIXABLE(x), "{x} should be fixable");
         }
     }
@@ -258,6 +263,7 @@ mod tests {
     #[test]
     fn all_u8_are_fixable() {
         for x in u8::MIN..=u8::MAX {
+            assert!(x.is_fixable(), "{x} should be fixable");
             assert!(RB_FIXABLE(x), "{x} should be fixable");
         }
     }
@@ -265,6 +271,7 @@ mod tests {
     #[test]
     fn all_u16_are_fixable() {
         for x in u16::MIN..=u16::MAX {
+            assert!(x.is_fixable(), "{x} should be fixable");
             assert!(RB_FIXABLE(x), "{x} should be fixable");
         }
     }
@@ -272,18 +279,21 @@ mod tests {
     #[test]
     fn all_neg_u32_are_fixable() {
         for x in u32::MIN..0 {
+            assert!(x.is_fixable(), "{x} should be fixable");
             assert!(RB_FIXABLE(x), "{x} should be fixable");
         }
     }
 
     #[test]
     fn zero_u32_is_fixable() {
+        assert!(0_u32.is_fixable(), "0 should be fixable");
         assert!(RB_FIXABLE(0_u32), "0 should be fixable");
     }
 
     #[test]
     fn all_pos_u32_are_fixable() {
         for x in 1..=u32::MAX {
+            assert!(x.is_fixable(), "{x} should be fixable");
             assert!(RB_FIXABLE(x), "{x} should be fixable");
         }
     }
@@ -357,6 +367,7 @@ mod tests {
         for (x, fixed) in test_cases {
             assert_eq!(x.to_fix(), fixed, "{x} did not fix correctly");
             assert_eq!(x.is_fixable(), fixed.is_some(), "{x} did not is_fixable correctly");
+            assert_eq!(RB_FIXABLE(x), fixed.is_some(), "{x} did not RB_FIXABLE correctly");
         }
     }
 
@@ -390,6 +401,7 @@ mod tests {
         for (x, fixed) in test_cases {
             assert_eq!(x.to_fix(), fixed, "{x} did not fix correctly");
             assert_eq!(x.is_fixable(), fixed.is_some(), "{x} did not is_fixable correctly");
+            assert_eq!(RB_FIXABLE(x), fixed.is_some(), "{x} did not RB_FIXABLE correctly");
         }
     }
 
@@ -446,6 +458,7 @@ mod tests {
         for (x, fixed) in test_cases {
             assert_eq!(x.to_fix(), fixed, "{x} did not fix correctly");
             assert_eq!(x.is_fixable(), fixed.is_some(), "{x} did not is_fixable correctly");
+            assert_eq!(RB_FIXABLE(x), fixed.is_some(), "{x} did not RB_FIXABLE correctly");
         }
     }
 
@@ -469,6 +482,7 @@ mod tests {
         for (x, fixed) in test_cases {
             assert_eq!(x.to_fix(), fixed, "{x} did not fix correctly");
             assert_eq!(x.is_fixable(), fixed.is_some(), "{x} did not is_fixable correctly");
+            assert_eq!(RB_FIXABLE(x), fixed.is_some(), "{x} did not RB_FIXABLE correctly");
         }
     }
 }

--- a/scolapasta-fixable/src/lib.rs
+++ b/scolapasta-fixable/src/lib.rs
@@ -38,6 +38,9 @@ use core::time::Duration;
 /// ```
 pub const RUBY_FIXNUM_MAX: i64 = i64::MAX / 2;
 
+pub(crate) const RUBY_FIXNUM_MAX_U64: u64 = RUBY_FIXNUM_MAX as u64;
+pub(crate) const RUBY_FIXNUM_MAX_U128: u128 = RUBY_FIXNUM_MAX as u128;
+
 /// The minimum possible value that a fixnum can represent, 63 bits of an
 /// [`i64`].
 ///
@@ -186,9 +189,7 @@ impl Fixable for u64 {
     }
 
     fn is_fixable(self) -> bool {
-        const MAX: u64 = RUBY_FIXNUM_MAX as u64;
-
-        (..=MAX).contains(&self)
+        (..=RUBY_FIXNUM_MAX_U64).contains(&self)
     }
 }
 
@@ -203,9 +204,7 @@ impl Fixable for u128 {
     }
 
     fn is_fixable(self) -> bool {
-        const MAX: u128 = RUBY_FIXNUM_MAX as u128;
-
-        (..=MAX).contains(&self)
+        (..=RUBY_FIXNUM_MAX_U128).contains(&self)
     }
 }
 
@@ -787,5 +786,11 @@ mod tests {
             assert_eq!(x.is_fixable(), fixed.is_some(), "{x} did not is_fixable correctly");
             assert_eq!(RB_FIXABLE(x), fixed.is_some(), "{x} did not RB_FIXABLE correctly");
         }
+    }
+
+    #[test]
+    fn casts_in_const_context_are_safe() {
+        assert_eq!(RUBY_FIXNUM_MAX_U64, u64::try_from(RUBY_FIXNUM_MAX).unwrap());
+        assert_eq!(RUBY_FIXNUM_MAX_U128, u128::try_from(RUBY_FIXNUM_MAX).unwrap());
     }
 }

--- a/scolapasta-fixable/src/lib.rs
+++ b/scolapasta-fixable/src/lib.rs
@@ -92,6 +92,7 @@ use core::time::Duration;
 /// [`i64`].
 ///
 /// # C Declaration
+///
 /// ```c
 /// /** Maximum possible value that a fixnum can represent. */
 /// #define RUBY_FIXNUM_MAX  (LONG_MAX / 2)
@@ -103,6 +104,8 @@ pub(crate) const RUBY_FIXNUM_MAX_U128: u128 = RUBY_FIXNUM_MAX as u128;
 
 /// The minimum possible value that a fixnum can represent, 63 bits of an
 /// [`i64`].
+///
+/// # C Declaration
 ///
 /// ```c
 /// /** Minimum possible value that a fixnum can represent. */
@@ -209,11 +212,11 @@ impl Fixable for i32 {
 
 impl Fixable for i64 {
     /// Convert an [`i64`] to a fixnum if it is less than or equal to
-    /// [`RB_FIXNUM_MAX`] and greater than or equal to [`RB_FIXNUM_MIN`] in
+    /// [`RUBY_FIXNUM_MAX`] and greater than or equal to [`RUBY_FIXNUM_MIN`] in
     /// magnitude.
     ///
-    /// This method returns [`None`] if the receiver is greater [`RB_FIXNUM_MAX`]
-    /// or less than [`RB_FIXNUM_MIN`].
+    /// This method returns [`None`] if the receiver is greater than
+    /// [`RUBY_FIXNUM_MAX`] or less than [`RUBY_FIXNUM_MIN`].
     fn to_fix(self) -> Option<i64> {
         if self > RUBY_FIXNUM_MAX {
             return None;
@@ -226,8 +229,8 @@ impl Fixable for i64 {
 
     /// Test whether an [`i64`] value is in range of fixnum.
     ///
-    /// This method returns `false` if the receiver is greater [`RB_FIXNUM_MAX`]
-    /// or less than [`RB_FIXNUM_MAX`].
+    /// This method returns `false` if the receiver is greater than
+    /// [`RUBY_FIXNUM_MAX`] or less than [`RUBY_FIXNUM_MAX`].
     fn is_fixable(self) -> bool {
         (RUBY_FIXNUM_MIN..=RUBY_FIXNUM_MAX).contains(&self)
     }
@@ -235,11 +238,11 @@ impl Fixable for i64 {
 
 impl Fixable for i128 {
     /// Convert an [`i128`] to a fixnum if it is less than or equal to
-    /// [`RB_FIXNUM_MAX`] and greater than or equal to [`RB_FIXNUM_MIN`] in
+    /// [`RUBY_FIXNUM_MAX`] and greater than or equal to [`RUBY_FIXNUM_MIN`] in
     /// magnitude.
     ///
-    /// This method returns [`None`] if the receiver is greater [`RB_FIXNUM_MAX`]
-    /// or less than [`RB_FIXNUM_MIN`].
+    /// This method returns [`None`] if the receiver is greater than
+    /// [`RUBY_FIXNUM_MAX`] or less than [`RUBY_FIXNUM_MIN`].
     fn to_fix(self) -> Option<i64> {
         let x = i64::try_from(self).ok()?;
         x.to_fix()
@@ -247,8 +250,8 @@ impl Fixable for i128 {
 
     /// Test whether an [`i128`] value is in range of fixnum.
     ///
-    /// This method returns `false` if the receiver is greater [`RB_FIXNUM_MAX`]
-    /// or less than [`RB_FIXNUM_MAX`].
+    /// This method returns `false` if the receiver is greater than
+    /// [`RUBY_FIXNUM_MAX`] or less than [`RUBY_FIXNUM_MAX`].
     fn is_fixable(self) -> bool {
         (RUBY_FIXNUM_MIN.into()..=RUBY_FIXNUM_MAX.into()).contains(&self)
     }
@@ -310,9 +313,10 @@ impl Fixable for u32 {
 
 impl Fixable for u64 {
     /// Convert a [`u64`] to a fixnum if it is less than or equal to
-    /// [`RB_FIXNUM_MAX`] in magnitude.
+    /// [`RUBY_FIXNUM_MAX`] in magnitude.
     ///
-    /// This method returns [`None`] if the receiver is greater [`RB_FIXNUM_MAX`].
+    /// This method returns [`None`] if the receiver is greater than
+    /// [`RUBY_FIXNUM_MAX`].
     fn to_fix(self) -> Option<i64> {
         let x = i64::try_from(self).ok()?;
         if x > RUBY_FIXNUM_MAX {
@@ -324,7 +328,8 @@ impl Fixable for u64 {
 
     /// Test whether a [`u64`] value is in range of fixnum.
     ///
-    /// This method returns `false` if the receiver is greater [`RB_FIXNUM_MAX`].
+    /// This method returns `false` if the receiver is greater than
+    /// [`RUBY_FIXNUM_MAX`].
     fn is_fixable(self) -> bool {
         (..=RUBY_FIXNUM_MAX_U64).contains(&self)
     }
@@ -332,9 +337,10 @@ impl Fixable for u64 {
 
 impl Fixable for u128 {
     /// Convert a [`u128`] to a fixnum if it is less than or equal to
-    /// [`RB_FIXNUM_MAX`] in magnitude.
+    /// [`RUBY_FIXNUM_MAX`] in magnitude.
     ///
-    /// This method returns [`None`] if the receiver is greater [`RB_FIXNUM_MAX`].
+    /// This method returns [`None`] if the receiver is greater than
+    /// [`RUBY_FIXNUM_MAX`].
     fn to_fix(self) -> Option<i64> {
         let x = i64::try_from(self).ok()?;
         if x > RUBY_FIXNUM_MAX {
@@ -346,7 +352,8 @@ impl Fixable for u128 {
 
     /// Test whether a [`u128`] value is in range of fixnum.
     ///
-    /// This method returns `false` if the receiver is greater [`RB_FIXNUM_MAX`].
+    /// This method returns `false` if the receiver is greater than
+    /// [`RUBY_FIXNUM_MAX`].
     fn is_fixable(self) -> bool {
         (..=RUBY_FIXNUM_MAX_U128).contains(&self)
     }
@@ -354,11 +361,11 @@ impl Fixable for u128 {
 
 impl Fixable for f32 {
     /// Convert an [`f32`] to a fixnum if it is less than or equal to
-    /// [`RB_FIXNUM_MAX`] and greater than or equal to [`RB_FIXNUM_MIN`] in
+    /// [`RUBY_FIXNUM_MAX`] and greater than or equal to [`RUBY_FIXNUM_MIN`] in
     /// magnitude.
     ///
-    /// This method returns [`None`] if the receiver is greater [`RB_FIXNUM_MAX`]
-    /// or less than [`RB_FIXNUM_MIN`].
+    /// This method returns [`None`] if the receiver is greater than
+    /// [`RUBY_FIXNUM_MAX`] or less than [`RUBY_FIXNUM_MIN`].
     ///
     /// This function discards the fractional part of the float, i.e. truncates.
     ///
@@ -387,11 +394,11 @@ impl Fixable for f32 {
 
 impl Fixable for f64 {
     /// Convert an [`f64`] to a fixnum if it is less than or equal to
-    /// [`RB_FIXNUM_MAX`] and greater than or equal to [`RB_FIXNUM_MIN`] in
+    /// [`RUBY_FIXNUM_MAX`] and greater than or equal to [`RUBY_FIXNUM_MIN`] in
     /// magnitude.
     ///
-    /// This method returns [`None`] if the receiver is greater [`RB_FIXNUM_MAX`]
-    /// or less than [`RB_FIXNUM_MIN`].
+    /// This method returns [`None`] if the receiver is greater than
+    /// [`RUBY_FIXNUM_MAX`] or less than [`RUBY_FIXNUM_MIN`].
     ///
     /// This function discards the fractional part of the float, i.e. truncates.
     ///

--- a/scolapasta-fixable/src/lib.rs
+++ b/scolapasta-fixable/src/lib.rs
@@ -65,16 +65,25 @@ mod private {
 /// of values yielded by implementers of this trait.
 ///
 /// This trait is sealed and cannot be implmented outside of this crate.
-pub trait Fixable: private::Sealed {
+pub trait Fixable: private::Sealed + Sized {
     /// Convert a fixable numeric value to its integral part.
     ///
     /// This method returns [`None`] if `self` is out of range.
     fn to_fix(self) -> Option<i64>;
+
+    /// Test whether a fixable numeric value is in range.
+    fn is_fixable(self) -> bool {
+        self.to_fix().is_some()
+    }
 }
 
 impl Fixable for i8 {
     fn to_fix(self) -> Option<i64> {
         Some(self.into())
+    }
+
+    fn is_fixable(self) -> bool {
+        true
     }
 }
 
@@ -82,11 +91,19 @@ impl Fixable for i16 {
     fn to_fix(self) -> Option<i64> {
         Some(self.into())
     }
+
+    fn is_fixable(self) -> bool {
+        true
+    }
 }
 
 impl Fixable for i32 {
     fn to_fix(self) -> Option<i64> {
         Some(self.into())
+    }
+
+    fn is_fixable(self) -> bool {
+        true
     }
 }
 
@@ -94,17 +111,29 @@ impl Fixable for u8 {
     fn to_fix(self) -> Option<i64> {
         Some(self.into())
     }
+
+    fn is_fixable(self) -> bool {
+        true
+    }
 }
 
 impl Fixable for u16 {
     fn to_fix(self) -> Option<i64> {
         Some(self.into())
     }
+
+    fn is_fixable(self) -> bool {
+        true
+    }
 }
 
 impl Fixable for u32 {
     fn to_fix(self) -> Option<i64> {
         Some(self.into())
+    }
+
+    fn is_fixable(self) -> bool {
+        true
     }
 }
 
@@ -141,7 +170,7 @@ impl Fixable for u32 {
 /// ```
 #[allow(non_snake_case)] // match MRI macro name
 pub fn RB_FIXABLE<T: Fixable>(x: T) -> bool {
-    x.to_fix().is_some()
+    x.is_fixable()
 }
 
 #[cfg(test)]
@@ -211,6 +240,72 @@ mod tests {
     fn all_pos_u32_are_fixable() {
         for x in 1..=u32::MAX {
             assert!(RB_FIXABLE(x), "{x} should be fixable");
+        }
+    }
+
+    #[test]
+    fn all_i8_fix_to_self() {
+        for x in i8::MIN..=i8::MAX {
+            assert_eq!(x.to_fix(), Some(x.into()), "{x} should be its own fixnum");
+        }
+    }
+
+    #[test]
+    fn all_i16_fix_to_self() {
+        for x in i16::MIN..=i16::MAX {
+            assert_eq!(x.to_fix(), Some(x.into()), "{x} should be its own fixnum");
+        }
+    }
+
+    #[test]
+    fn all_neg_i32_fix_to_self() {
+        for x in i32::MIN..0 {
+            assert_eq!(x.to_fix(), Some(x.into()), "{x} should be its own fixnum");
+        }
+    }
+
+    #[test]
+    fn zero_i32_fixes_to_self() {
+        assert_eq!(0_i32.to_fix(), Some(0), "0 should be its own fixnum");
+    }
+
+    #[test]
+    fn all_pos_i32_fix_to_self() {
+        for x in 1..=i32::MAX {
+            assert_eq!(x.to_fix(), Some(x.into()), "{x} should be its own fixnum");
+        }
+    }
+
+    #[test]
+    fn all_u8_fix_to_self() {
+        for x in u8::MIN..=u8::MAX {
+            assert_eq!(x.to_fix(), Some(x.into()), "{x} should be its own fixnum");
+        }
+    }
+
+    #[test]
+    fn all_u16_fix_to_self() {
+        for x in u16::MIN..=u16::MAX {
+            assert_eq!(x.to_fix(), Some(x.into()), "{x} should be its own fixnum");
+        }
+    }
+
+    #[test]
+    fn all_neg_u32_fix_to_self() {
+        for x in u32::MIN..0 {
+            assert_eq!(x.to_fix(), Some(x.into()), "{x} should be its own fixnum");
+        }
+    }
+
+    #[test]
+    fn zero_u32_fixes_to_self() {
+        assert_eq!(0_u32.to_fix(), Some(0), "0 should be its own fixnum");
+    }
+
+    #[test]
+    fn all_pos_u32_fix_to_self() {
+        for x in 1..=u32::MAX {
+            assert_eq!(x.to_fix(), Some(x.into()), "{x} should be its own fixnum");
         }
     }
 }

--- a/scolapasta-fixable/src/lib.rs
+++ b/scolapasta-fixable/src/lib.rs
@@ -1,3 +1,29 @@
+#![warn(clippy::all)]
+#![warn(clippy::pedantic)]
+#![warn(clippy::cargo)]
+#![allow(unknown_lints)]
+#![allow(clippy::manual_let_else)]
+#![warn(missing_docs)]
+#![warn(missing_debug_implementations)]
+#![warn(missing_copy_implementations)]
+#![warn(rust_2018_idioms)]
+#![warn(rust_2021_compatibility)]
+#![warn(trivial_casts, trivial_numeric_casts)]
+#![warn(unused_qualifications)]
+#![warn(variant_size_differences)]
+#![forbid(unsafe_code)]
+// Enable feature callouts in generated documentation:
+// https://doc.rust-lang.org/beta/unstable-book/language-features/doc-cfg.html
+//
+// This approach is borrowed from tokio.
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_alias))]
+
+//! Functions for converting numeric immediates to integer or "fixnum"
+//! immediates.
+
+#![no_std]
+
 pub fn add(left: usize, right: usize) -> usize {
     left + right
 }

--- a/scolapasta-fixable/src/lib.rs
+++ b/scolapasta-fixable/src/lib.rs
@@ -3,6 +3,8 @@
 #![warn(clippy::cargo)]
 #![allow(unknown_lints)]
 #![allow(clippy::manual_let_else)]
+// to use value receivers for primitives like `f64::is_nan` does in `std`.
+#![allow(clippy::wrong_self_convention)]
 #![warn(missing_docs)]
 #![warn(missing_debug_implementations)]
 #![warn(missing_copy_implementations)]

--- a/scolapasta-fixable/vendor/README.md
+++ b/scolapasta-fixable/vendor/README.md
@@ -1,0 +1,20 @@
+# scolapasta-fixable Vendored Dependencies
+
+## Ruby arithmetic headers
+
+[Ruby] (MRI Ruby or CRuby) is the reference Ruby implementation.
+
+[ruby]: https://github.com/ruby/ruby
+
+The [`arithmetic.h`] and [`arithmetic`] headers are vendored here as the reference
+implementation whose behavior this crate seeks to match.
+
+[`arithmetic.h`]: ruby-3.2.0/include/ruby/internal/arithmetic.h
+[`arithmetic`]: ruby-3.2.0/include/ruby/internal/arithmetic/
+
+This source file is from [MRI Ruby 3.2.0], which is licensed under the [Ruby
+license] or [BSD 2-clause license].
+
+[mri ruby 3.2.0]: https://github.com/ruby/ruby/tree/v3_2_0
+[ruby license]: ruby-3.2.0/COPYING
+[bsd 2-clause license]: ruby-3.2.0/BSDL

--- a/scolapasta-fixable/vendor/README.md
+++ b/scolapasta-fixable/vendor/README.md
@@ -6,8 +6,8 @@
 
 [ruby]: https://github.com/ruby/ruby
 
-The [`arithmetic.h`] and [`arithmetic`] headers are vendored here as the reference
-implementation whose behavior this crate seeks to match.
+The [`arithmetic.h`] and [`arithmetic`] headers are vendored here as the
+reference implementation whose behavior this crate seeks to match.
 
 [`arithmetic.h`]: ruby-3.2.0/include/ruby/internal/arithmetic.h
 [`arithmetic`]: ruby-3.2.0/include/ruby/internal/arithmetic/

--- a/scolapasta-fixable/vendor/ruby-3.2.0/BSDL
+++ b/scolapasta-fixable/vendor/ruby-3.2.0/BSDL
@@ -1,0 +1,22 @@
+Copyright (C) 1993-2013 Yukihiro Matsumoto. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.

--- a/scolapasta-fixable/vendor/ruby-3.2.0/COPYING
+++ b/scolapasta-fixable/vendor/ruby-3.2.0/COPYING
@@ -1,0 +1,56 @@
+Ruby is copyrighted free software by Yukihiro Matsumoto <matz@netlab.jp>.
+You can redistribute it and/or modify it under either the terms of the
+2-clause BSDL (see the file BSDL), or the conditions below:
+
+1. You may make and give away verbatim copies of the source form of the
+   software without restriction, provided that you duplicate all of the
+   original copyright notices and associated disclaimers.
+
+2. You may modify your copy of the software in any way, provided that
+   you do at least ONE of the following:
+
+   a. place your modifications in the Public Domain or otherwise
+      make them Freely Available, such as by posting said
+      modifications to Usenet or an equivalent medium, or by allowing
+      the author to include your modifications in the software.
+
+   b. use the modified software only within your corporation or
+      organization.
+
+   c. give non-standard binaries non-standard names, with
+      instructions on where to get the original software distribution.
+
+   d. make other distribution arrangements with the author.
+
+3. You may distribute the software in object code or binary form,
+   provided that you do at least ONE of the following:
+
+   a. distribute the binaries and library files of the software,
+      together with instructions (in the manual page or equivalent)
+      on where to get the original distribution.
+
+   b. accompany the distribution with the machine-readable source of
+      the software.
+
+   c. give non-standard binaries non-standard names, with
+      instructions on where to get the original software distribution.
+
+   d. make other distribution arrangements with the author.
+
+4. You may modify and include the part of the software into any other
+   software (possibly commercial).  But some files in the distribution
+   are not written by the author, so that they are not under these terms.
+
+   For the list of those files and their copying conditions, see the
+   file LEGAL.
+
+5. The scripts and library files supplied as input to or produced as
+   output from the software do not automatically fall under the
+   copyright of the software, but belong to whomever generated them,
+   and may be sold commercially, and may be aggregated with this
+   software.
+
+6. THIS SOFTWARE IS PROVIDED "AS IS" AND WITHOUT ANY EXPRESS OR
+   IMPLIED WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED
+   WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+   PURPOSE.

--- a/scolapasta-fixable/vendor/ruby-3.2.0/include/ruby/backward/2/limits.h
+++ b/scolapasta-fixable/vendor/ruby-3.2.0/include/ruby/backward/2/limits.h
@@ -1,0 +1,99 @@
+#ifndef RUBY_BACKWARD2_LIMITS_H                      /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY_BACKWARD2_LIMITS_H
+/**
+ * @author     Ruby developers <ruby-core@ruby-lang.org>
+ * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
+ *             Permission  is hereby  granted,  to  either redistribute  and/or
+ *             modify this file, provided that  the conditions mentioned in the
+ *             file COPYING are met.  Consult the file for details.
+ * @warning    Symbols   prefixed  with   either  `RBIMPL`   or  `rbimpl`   are
+ *             implementation details.   Don't take  them as canon.  They could
+ *             rapidly appear then vanish.  The name (path) of this header file
+ *             is also an  implementation detail.  Do not expect  it to persist
+ *             at the place it is now.  Developers are free to move it anywhere
+ *             anytime at will.
+ * @note       To  ruby-core:  remember  that   this  header  can  be  possibly
+ *             recursively included  from extension  libraries written  in C++.
+ *             Do not  expect for  instance `__VA_ARGS__` is  always available.
+ *             We assume C99  for ruby itself but we don't  assume languages of
+ *             extension libraries.  They could be written in C++98.
+ * @brief      Historical shim for `<limits.h>`.
+ *
+ * The macros in this header file are obsolescent.  Does anyone really need our
+ * own definition of `CHAR_BIT` today?
+ */
+#include "ruby/internal/config.h"
+
+#ifdef HAVE_LIMITS_H
+# include <limits.h>
+#endif
+
+#include "ruby/backward/2/long_long.h"
+
+#ifndef LONG_MAX
+# /* assuming 32bit(2's complement) long */
+# define LONG_MAX 2147483647L
+#endif
+
+#ifndef LONG_MIN
+# define LONG_MIN (-LONG_MAX-1)
+#endif
+
+#ifndef CHAR_BIT
+# define CHAR_BIT 8
+#endif
+
+#ifdef LLONG_MAX
+# /* Take that. */
+#elif defined(LONG_LONG_MAX)
+# define LLONG_MAX  LONG_LONG_MAX
+#elif defined(_I64_MAX)
+# define LLONG_MAX _I64_MAX
+#else
+# /* assuming 64bit(2's complement) long long */
+# define LLONG_MAX 9223372036854775807LL
+#endif
+
+#ifdef LLONG_MIN
+# /* Take that. */
+#elif defined(LONG_LONG_MIN)
+# define LLONG_MIN  LONG_LONG_MIN
+#elif defined(_I64_MAX)
+# define LLONG_MIN _I64_MIN
+#else
+# define LLONG_MIN (-LLONG_MAX-1)
+#endif
+
+#ifdef SIZE_MAX
+# /* Take that. */
+#elif SIZEOF_SIZE_T == SIZEOF_LONG_LONG
+# define SIZE_MAX ULLONG_MAX
+# define SIZE_MIN ULLONG_MIN
+#elif SIZEOF_SIZE_T == SIZEOF_LONG
+# define SIZE_MAX ULONG_MAX
+# define SIZE_MIN ULONG_MIN
+#elif SIZEOF_SIZE_T == SIZEOF_INT
+# define SIZE_MAX UINT_MAX
+# define SIZE_MIN UINT_MIN
+#else
+# define SIZE_MAX USHRT_MAX
+# define SIZE_MIN USHRT_MIN
+#endif
+
+#ifdef SSIZE_MAX
+# /* Take that. */
+#elif SIZEOF_SIZE_T == SIZEOF_LONG_LONG
+# define SSIZE_MAX LLONG_MAX
+# define SSIZE_MIN LLONG_MIN
+#elif SIZEOF_SIZE_T == SIZEOF_LONG
+# define SSIZE_MAX LONG_MAX
+# define SSIZE_MIN LONG_MIN
+#elif SIZEOF_SIZE_T == SIZEOF_INT
+# define SSIZE_MAX INT_MAX
+# define SSIZE_MIN INT_MIN
+#else
+# define SSIZE_MAX SHRT_MAX
+# define SSIZE_MIN SHRT_MIN
+#endif
+
+#endif /* RUBY_BACKWARD2_LIMITS_H */

--- a/scolapasta-fixable/vendor/ruby-3.2.0/include/ruby/backward/2/long_long.h
+++ b/scolapasta-fixable/vendor/ruby-3.2.0/include/ruby/backward/2/long_long.h
@@ -1,0 +1,73 @@
+#ifndef RUBY_BACKWARD2_LONG_LONG_H                   /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY_BACKWARD2_LONG_LONG_H
+/**
+ * @file
+ * @author     Ruby developers <ruby-core@ruby-lang.org>
+ * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
+ *             Permission  is hereby  granted,  to  either redistribute  and/or
+ *             modify this file, provided that  the conditions mentioned in the
+ *             file COPYING are met.  Consult the file for details.
+ * @warning    Symbols   prefixed  with   either  `RBIMPL`   or  `rbimpl`   are
+ *             implementation details.   Don't take  them as canon.  They could
+ *             rapidly appear then vanish.  The name (path) of this header file
+ *             is also an  implementation detail.  Do not expect  it to persist
+ *             at the place it is now.  Developers are free to move it anywhere
+ *             anytime at will.
+ * @note       To  ruby-core:  remember  that   this  header  can  be  possibly
+ *             recursively included  from extension  libraries written  in C++.
+ *             Do not  expect for  instance `__VA_ARGS__` is  always available.
+ *             We assume C99  for ruby itself but we don't  assume languages of
+ *             extension libraries.  They could be written in C++98.
+ * @brief      Defines old #LONG_LONG
+ *
+ * No  known  compiler   that  can  compile  today's  ruby   lacks  long  long.
+ * Historically MSVC was  one of such compiler, but it  implemented long long a
+ * while  ago  (some  time  back  in  2013).   The  macros  are  for  backwards
+ * compatibility only.
+ */
+#include "ruby/internal/config.h"
+#include "ruby/internal/has/warning.h"
+#include "ruby/internal/warning_push.h"
+
+#if defined(__DOXYGEN__)
+# /** @cond INTERNAL_MACRO */
+# define HAVE_LONG_LONG 1
+# define HAVE_TRUE_LONG_LONG 1
+# /** @endcond */
+# /** @deprecated  Just use `long long` directly. */
+# define LONG_LONG long long.
+
+#elif RBIMPL_HAS_WARNING("-Wc++11-long-long")
+# define HAVE_TRUE_LONG_LONG 1
+# define LONG_LONG                           \
+    RBIMPL_WARNING_PUSH()                     \
+    RBIMPL_WARNING_IGNORED(-Wc++11-long-long) \
+    long long                                \
+    RBIMPL_WARNING_POP()
+
+#elif RBIMPL_HAS_WARNING("-Wlong-long")
+# define HAVE_TRUE_LONG_LONG 1
+# define LONG_LONG                     \
+    RBIMPL_WARNING_PUSH()               \
+    RBIMPL_WARNING_IGNORED(-Wlong-long) \
+    long long                          \
+    RBIMPL_WARNING_POP()
+
+#elif defined(HAVE_LONG_LONG)
+# define HAVE_TRUE_LONG_LONG 1
+# define LONG_LONG long long
+
+#elif SIZEOF___INT64 > 0
+# define HAVE_LONG_LONG 1
+# define LONG_LONG __int64
+# undef SIZEOF_LONG_LONG
+# define SIZEOF_LONG_LONG SIZEOF___INT64
+
+#else
+# error Hello!  Ruby developers believe this message must not happen.
+# error If you encounter this message, can you file a bug report?
+# error Remember to attach a detailed description of your environment.
+# error Thank you!
+#endif
+
+#endif /* RBIMPL_BACKWARD2_LONG_LONG_H */

--- a/scolapasta-fixable/vendor/ruby-3.2.0/include/ruby/internal/arithmetic.h
+++ b/scolapasta-fixable/vendor/ruby-3.2.0/include/ruby/internal/arithmetic.h
@@ -1,0 +1,39 @@
+#ifndef RBIMPL_ARITHMETIC_H                          /*-*-C++-*-vi:se ft=cpp:*/
+#define RBIMPL_ARITHMETIC_H
+/**
+ * @file
+ * @author     Ruby developers <ruby-core@ruby-lang.org>
+ * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
+ *             Permission  is hereby  granted,  to  either redistribute  and/or
+ *             modify this file, provided that  the conditions mentioned in the
+ *             file COPYING are met.  Consult the file for details.
+ * @warning    Symbols   prefixed  with   either  `RBIMPL`   or  `rbimpl`   are
+ *             implementation details.   Don't take  them as canon.  They could
+ *             rapidly appear then vanish.  The name (path) of this header file
+ *             is also an  implementation detail.  Do not expect  it to persist
+ *             at the place it is now.  Developers are free to move it anywhere
+ *             anytime at will.
+ * @note       To  ruby-core:  remember  that   this  header  can  be  possibly
+ *             recursively included  from extension  libraries written  in C++.
+ *             Do not  expect for  instance `__VA_ARGS__` is  always available.
+ *             We assume C99  for ruby itself but we don't  assume languages of
+ *             extension libraries.  They could be written in C++98.
+ * @brief      Conversion  between  C's arithmetic  types  and  Ruby's  numeric
+ *             types.
+ */
+#include "ruby/internal/arithmetic/char.h"
+#include "ruby/internal/arithmetic/double.h"
+#include "ruby/internal/arithmetic/fixnum.h"
+#include "ruby/internal/arithmetic/gid_t.h"
+#include "ruby/internal/arithmetic/int.h"
+#include "ruby/internal/arithmetic/intptr_t.h"
+#include "ruby/internal/arithmetic/long.h"
+#include "ruby/internal/arithmetic/long_long.h"
+#include "ruby/internal/arithmetic/mode_t.h"
+#include "ruby/internal/arithmetic/off_t.h"
+#include "ruby/internal/arithmetic/pid_t.h"
+#include "ruby/internal/arithmetic/short.h"
+#include "ruby/internal/arithmetic/size_t.h"
+#include "ruby/internal/arithmetic/st_data_t.h"
+#include "ruby/internal/arithmetic/uid_t.h"
+#endif /* RBIMPL_ARITHMETIC_H */

--- a/scolapasta-fixable/vendor/ruby-3.2.0/include/ruby/internal/arithmetic/char.h
+++ b/scolapasta-fixable/vendor/ruby-3.2.0/include/ruby/internal/arithmetic/char.h
@@ -1,0 +1,81 @@
+#ifndef RBIMPL_ARITHMETIC_CHAR_H                     /*-*-C++-*-vi:se ft=cpp:*/
+#define RBIMPL_ARITHMETIC_CHAR_H
+/**
+ * @file
+ * @author     Ruby developers <ruby-core@ruby-lang.org>
+ * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
+ *             Permission  is hereby  granted,  to  either redistribute  and/or
+ *             modify this file, provided that  the conditions mentioned in the
+ *             file COPYING are met.  Consult the file for details.
+ * @warning    Symbols   prefixed  with   either  `RBIMPL`   or  `rbimpl`   are
+ *             implementation details.   Don't take  them as canon.  They could
+ *             rapidly appear then vanish.  The name (path) of this header file
+ *             is also an  implementation detail.  Do not expect  it to persist
+ *             at the place it is now.  Developers are free to move it anywhere
+ *             anytime at will.
+ * @note       To  ruby-core:  remember  that   this  header  can  be  possibly
+ *             recursively included  from extension  libraries written  in C++.
+ *             Do not  expect for  instance `__VA_ARGS__` is  always available.
+ *             We assume C99  for ruby itself but we don't  assume languages of
+ *             extension libraries.  They could be written in C++98.
+ * @brief      Arithmetic conversion between C's `char` and Ruby's.
+ */
+#include "ruby/internal/arithmetic/int.h"  /* NUM2INT is here, but */
+#include "ruby/internal/arithmetic/long.h" /* INT2FIX is here.*/
+#include "ruby/internal/attr/artificial.h"
+#include "ruby/internal/attr/const.h"
+#include "ruby/internal/attr/constexpr.h"
+#include "ruby/internal/cast.h"
+#include "ruby/internal/core/rstring.h"
+#include "ruby/internal/value_type.h"
+
+#define RB_NUM2CHR rb_num2char_inline /**< @alias{rb_num2char_inline} */
+#define NUM2CHR    RB_NUM2CHR         /**< @old{RB_NUM2CHR} */
+#define CHR2FIX    RB_CHR2FIX         /**< @old{RB_CHR2FIX} */
+
+/** @cond INTERNAL_MACRO */
+#define RB_CHR2FIX RB_CHR2FIX
+/** @endcond */
+
+RBIMPL_ATTR_CONST_UNLESS_DEBUG()
+RBIMPL_ATTR_CONSTEXPR_UNLESS_DEBUG(CXX14)
+RBIMPL_ATTR_ARTIFICIAL()
+/**
+ * Converts a C's `unsigned char` into an instance of ::rb_cInteger.
+ *
+ * @param[in]  c  Arbitrary `unsigned char` value.
+ * @return     An instance of ::rb_cInteger.
+ *
+ * @internal
+ *
+ * Nobody explicitly states this but in  Ruby, a char means an unsigned integer
+ * value of  range 0..255.   This is  a general principle.   AFAIK there  is no
+ * single line of code where char is signed.
+ */
+static inline VALUE
+RB_CHR2FIX(unsigned char c)
+{
+    return RB_INT2FIX(c);
+}
+
+/**
+ * Converts an instance of ::rb_cNumeric into  C's `char`.  At the same time it
+ * accepts a String of more than one character, and returns its first byte.  In
+ * the  early days  there  was a  Ruby level  "character"  literal `?c`,  which
+ * roughly worked this way.
+ *
+ * @param[in]  x               Either a string or a numeric.
+ * @exception  rb_eTypeError   `x` is not a numeric.
+ * @exception  rb_eRangeError  `x` is out of range of `unsigned int`.
+ * @return     The passed value converted into C's `char`.
+ */
+static inline char
+rb_num2char_inline(VALUE x)
+{
+    if (RB_TYPE_P(x, RUBY_T_STRING) && (RSTRING_LEN(x)>=1))
+        return RSTRING_PTR(x)[0];
+    else
+        return RBIMPL_CAST((char)RB_NUM2INT(x));
+}
+
+#endif /* RBIMPL_ARITHMETIC_CHAR_H */

--- a/scolapasta-fixable/vendor/ruby-3.2.0/include/ruby/internal/arithmetic/double.h
+++ b/scolapasta-fixable/vendor/ruby-3.2.0/include/ruby/internal/arithmetic/double.h
@@ -1,0 +1,72 @@
+#ifndef RBIMPL_ARITHMETIC_DOUBLE_H                   /*-*-C++-*-vi:se ft=cpp:*/
+#define RBIMPL_ARITHMETIC_DOUBLE_H
+/**
+ * @file
+ * @author     Ruby developers <ruby-core@ruby-lang.org>
+ * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
+ *             Permission  is hereby  granted,  to  either redistribute  and/or
+ *             modify this file, provided that  the conditions mentioned in the
+ *             file COPYING are met.  Consult the file for details.
+ * @warning    Symbols   prefixed  with   either  `RBIMPL`   or  `rbimpl`   are
+ *             implementation details.   Don't take  them as canon.  They could
+ *             rapidly appear then vanish.  The name (path) of this header file
+ *             is also an  implementation detail.  Do not expect  it to persist
+ *             at the place it is now.  Developers are free to move it anywhere
+ *             anytime at will.
+ * @note       To  ruby-core:  remember  that   this  header  can  be  possibly
+ *             recursively included  from extension  libraries written  in C++.
+ *             Do not  expect for  instance `__VA_ARGS__` is  always available.
+ *             We assume C99  for ruby itself but we don't  assume languages of
+ *             extension libraries.  They could be written in C++98.
+ * @brief      Arithmetic conversion between C's `double` and Ruby's.
+ */
+#include "ruby/internal/attr/pure.h"
+#include "ruby/internal/dllexport.h"
+#include "ruby/internal/value.h"
+
+#define NUM2DBL      rb_num2dbl       /**< @old{rb_num2dbl} */
+#define RFLOAT_VALUE rb_float_value   /**< @old{rb_float_value} */
+#define DBL2NUM      rb_float_new     /**< @old{rb_float_new} */
+
+RBIMPL_SYMBOL_EXPORT_BEGIN()
+/**
+ * Converts an instance of ::rb_cNumeric into C's `double`.
+ *
+ * @param[in]  num             Something numeric.
+ * @exception  rb_eTypeError   `num` is not a numeric.
+ * @return     The passed value converted into C's `double`.
+ */
+double rb_num2dbl(VALUE num);
+
+RBIMPL_ATTR_PURE()
+/**
+ * Extracts its double value from an instance of ::rb_cFloat.
+ *
+ * @param[in]  num  An instance of ::rb_cFloat.
+ * @pre        Must not pass anything other than a Fixnum.
+ * @return     The passed value converted into C's `double`.
+ */
+double rb_float_value(VALUE num);
+
+/**
+ * Converts a C's `double` into an instance of ::rb_cFloat.
+ *
+ * @param[in]  d  Arbitrary `double` value.
+ * @return     An instance of ::rb_cFloat.
+ */
+VALUE rb_float_new(double d);
+
+/**
+ * Identical to rb_float_new(), except it does not generate Flonums.
+ *
+ * @param[in]  d  Arbitrary `double` value.
+ * @return     An instance of ::rb_cFloat.
+ *
+ * @internal
+ *
+ * @shyouhei has no idea why it is here.
+ */
+VALUE rb_float_new_in_heap(double d);
+RBIMPL_SYMBOL_EXPORT_END()
+
+#endif /* RBIMPL_ARITHMETIC_DOUBLE_H */

--- a/scolapasta-fixable/vendor/ruby-3.2.0/include/ruby/internal/arithmetic/fixnum.h
+++ b/scolapasta-fixable/vendor/ruby-3.2.0/include/ruby/internal/arithmetic/fixnum.h
@@ -1,0 +1,60 @@
+#ifndef RBIMPL_ARITHMETIC_FIXNUM_H                   /*-*-C++-*-vi:se ft=cpp:*/
+#define RBIMPL_ARITHMETIC_FIXNUM_H
+/**
+ * @file
+ * @author     Ruby developers <ruby-core@ruby-lang.org>
+ * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
+ *             Permission  is hereby  granted,  to  either redistribute  and/or
+ *             modify this file, provided that  the conditions mentioned in the
+ *             file COPYING are met.  Consult the file for details.
+ * @warning    Symbols   prefixed  with   either  `RBIMPL`   or  `rbimpl`   are
+ *             implementation details.   Don't take  them as canon.  They could
+ *             rapidly appear then vanish.  The name (path) of this header file
+ *             is also an  implementation detail.  Do not expect  it to persist
+ *             at the place it is now.  Developers are free to move it anywhere
+ *             anytime at will.
+ * @note       To  ruby-core:  remember  that   this  header  can  be  possibly
+ *             recursively included  from extension  libraries written  in C++.
+ *             Do not  expect for  instance `__VA_ARGS__` is  always available.
+ *             We assume C99  for ruby itself but we don't  assume languages of
+ *             extension libraries.  They could be written in C++98.
+ * @brief      Handling of integers formerly known as Fixnums.
+ */
+#include "ruby/backward/2/limits.h"
+
+#define FIXABLE    RB_FIXABLE      /**< @old{RB_FIXABLE} */
+#define FIXNUM_MAX RUBY_FIXNUM_MAX /**< @old{RUBY_FIXNUM_MAX} */
+#define FIXNUM_MIN RUBY_FIXNUM_MIN /**< @old{RUBY_FIXNUM_MIN} */
+#define NEGFIXABLE RB_NEGFIXABLE   /**< @old{RB_NEGFIXABLE} */
+#define POSFIXABLE RB_POSFIXABLE   /**< @old{RB_POSFIXABLE} */
+
+/**
+ * Checks if the passed value is in  range of fixnum, assuming it is a positive
+ * number.  Can sometimes be useful for C's unsigned integer types.
+ *
+ * @internal
+ *
+ * FIXABLE can be applied to anything, from double to intmax_t.  The problem is
+ * double.   On a  64bit system  RUBY_FIXNUM_MAX is  4,611,686,018,427,387,903,
+ * which is not representable by a double.  The nearest value that a double can
+ * represent  is   4,611,686,018,427,387,904,  which   is  not   fixable.   The
+ * seemingly-strange "< FIXNUM_MAX + 1" expression below is due to this.
+ */
+#define RB_POSFIXABLE(_) ((_) <  RUBY_FIXNUM_MAX + 1)
+
+/**
+ * Checks if the passed value is in  range of fixnum, assuming it is a negative
+ * number.  This is an implementation of #RB_FIXABLE.  Rarely used stand alone.
+ */
+#define RB_NEGFIXABLE(_) ((_) >= RUBY_FIXNUM_MIN)
+
+/** Checks if the passed value is in  range of fixnum */
+#define RB_FIXABLE(_)    (RB_POSFIXABLE(_) && RB_NEGFIXABLE(_))
+
+/** Maximum possible value that a fixnum can represent. */
+#define RUBY_FIXNUM_MAX  (LONG_MAX / 2)
+
+/** Minimum possible value that a fixnum can represent. */
+#define RUBY_FIXNUM_MIN  (LONG_MIN / 2)
+
+#endif /* RBIMPL_ARITHMETIC_FIXNUM_H */

--- a/scolapasta-fixable/vendor/ruby-3.2.0/include/ruby/internal/arithmetic/gid_t.h
+++ b/scolapasta-fixable/vendor/ruby-3.2.0/include/ruby/internal/arithmetic/gid_t.h
@@ -1,0 +1,41 @@
+#ifndef RBIMPL_ARITHMETIC_GID_T_H                    /*-*-C++-*-vi:se ft=cpp:*/
+#define RBIMPL_ARITHMETIC_GID_T_H
+/**
+ * @file
+ * @author     Ruby developers <ruby-core@ruby-lang.org>
+ * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
+ *             Permission  is hereby  granted,  to  either redistribute  and/or
+ *             modify this file, provided that  the conditions mentioned in the
+ *             file COPYING are met.  Consult the file for details.
+ * @warning    Symbols   prefixed  with   either  `RBIMPL`   or  `rbimpl`   are
+ *             implementation details.   Don't take  them as canon.  They could
+ *             rapidly appear then vanish.  The name (path) of this header file
+ *             is also an  implementation detail.  Do not expect  it to persist
+ *             at the place it is now.  Developers are free to move it anywhere
+ *             anytime at will.
+ * @note       To  ruby-core:  remember  that   this  header  can  be  possibly
+ *             recursively included  from extension  libraries written  in C++.
+ *             Do not  expect for  instance `__VA_ARGS__` is  always available.
+ *             We assume C99  for ruby itself but we don't  assume languages of
+ *             extension libraries.  They could be written in C++98.
+ * @brief      Arithmetic conversion between C's `gid_t` and Ruby's.
+ */
+#include "ruby/internal/config.h"
+#include "ruby/internal/arithmetic/long.h"
+
+/** Converts a C's `gid_t` into an instance of ::rb_cInteger. */
+#ifndef GIDT2NUM
+# define GIDT2NUM RB_LONG2NUM
+#endif
+
+/** Converts an instance of ::rb_cNumeric into C's `gid_t`. */
+#ifndef NUM2GIDT
+# define NUM2GIDT RB_NUM2LONG
+#endif
+
+/** A rb_sprintf() format prefix to be used for a `gid_t` parameter. */
+#ifndef PRI_GIDT_PREFIX
+# define PRI_GIDT_PREFIX PRI_LONG_PREFIX
+#endif
+
+#endif /* RBIMPL_ARITHMETIC_GID_T_H */

--- a/scolapasta-fixable/vendor/ruby-3.2.0/include/ruby/internal/arithmetic/int.h
+++ b/scolapasta-fixable/vendor/ruby-3.2.0/include/ruby/internal/arithmetic/int.h
@@ -1,0 +1,264 @@
+#ifndef RBIMPL_ARITHMETIC_INT_H                      /*-*-C++-*-vi:se ft=cpp:*/
+#define RBIMPL_ARITHMETIC_INT_H
+/**
+ * @file
+ * @author     Ruby developers <ruby-core@ruby-lang.org>
+ * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
+ *             Permission  is hereby  granted,  to  either redistribute  and/or
+ *             modify this file, provided that  the conditions mentioned in the
+ *             file COPYING are met.  Consult the file for details.
+ * @warning    Symbols   prefixed  with   either  `RBIMPL`   or  `rbimpl`   are
+ *             implementation details.   Don't take  them as canon.  They could
+ *             rapidly appear then vanish.  The name (path) of this header file
+ *             is also an  implementation detail.  Do not expect  it to persist
+ *             at the place it is now.  Developers are free to move it anywhere
+ *             anytime at will.
+ * @note       To  ruby-core:  remember  that   this  header  can  be  possibly
+ *             recursively included  from extension  libraries written  in C++.
+ *             Do not  expect for  instance `__VA_ARGS__` is  always available.
+ *             We assume C99  for ruby itself but we don't  assume languages of
+ *             extension libraries.  They could be written in C++98.
+ * @brief      Arithmetic conversion between C's `int` and Ruby's.
+ */
+#include "ruby/internal/config.h"
+#include "ruby/internal/arithmetic/fixnum.h"
+#include "ruby/internal/arithmetic/intptr_t.h"
+#include "ruby/internal/arithmetic/long.h"
+#include "ruby/internal/attr/artificial.h"
+#include "ruby/internal/attr/const.h"
+#include "ruby/internal/attr/constexpr.h"
+#include "ruby/internal/compiler_is.h"
+#include "ruby/internal/dllexport.h"
+#include "ruby/internal/special_consts.h"
+#include "ruby/internal/value.h"
+#include "ruby/internal/warning_push.h"
+#include "ruby/assert.h"
+
+#define RB_INT2NUM  rb_int2num_inline  /**< @alias{rb_int2num_inline} */
+#define RB_NUM2INT  rb_num2int_inline  /**< @alias{rb_num2int_inline} */
+#define RB_UINT2NUM rb_uint2num_inline /**< @alias{rb_uint2num_inline} */
+
+#define FIX2INT    RB_FIX2INT          /**< @old{RB_FIX2INT} */
+#define FIX2UINT   RB_FIX2UINT         /**< @old{RB_FIX2UINT} */
+#define INT2NUM    RB_INT2NUM          /**< @old{RB_INT2NUM} */
+#define NUM2INT    RB_NUM2INT          /**< @old{RB_NUM2INT} */
+#define NUM2UINT   RB_NUM2UINT         /**< @old{RB_NUM2UINT} */
+#define UINT2NUM   RB_UINT2NUM         /**< @old{RB_UINT2NUM} */
+
+/** @cond INTERNAL_MACRO */
+#define RB_FIX2INT  RB_FIX2INT
+#define RB_NUM2UINT RB_NUM2UINT
+#define RB_FIX2UINT RB_FIX2UINT
+/** @endcond */
+
+RBIMPL_SYMBOL_EXPORT_BEGIN()
+
+/**
+ * Converts an instance of ::rb_cNumeric into C's `long`.
+ *
+ * @param[in]  num             Something numeric.
+ * @exception  rb_eTypeError   `num` is not a numeric.
+ * @exception  rb_eRangeError  `num` is out of range of `int`.
+ * @return     The passed value converted into C's `long`.
+ *
+ * @internal
+ *
+ * Yes, the  API is  really strange.   It returns `long`,  but raises  when the
+ * value is out of `int`.  This seems to  be due to the fact that Matz favoured
+ * K&R before, and his machine at that moment was an ILP32 architecture.
+ */
+long rb_num2int(VALUE num);
+
+/**
+ * Identical to rb_num2int().
+ *
+ * @param[in]  num             Something numeric.
+ * @exception  rb_eTypeError   `num` is not a numeric.
+ * @exception  rb_eRangeError  `num` is out of range of `int`.
+ * @return     The passed value converted into C's `long`.
+ *
+ * @internal
+ *
+ * This function seems to be a complete  waste of disk space.  @shyouhei has no
+ * idea why this is a different thing from rb_num2short().
+ */
+long rb_fix2int(VALUE num);
+
+/**
+ * Converts an instance of ::rb_cNumeric into C's `unsigned long`.
+ *
+ * @param[in]  num             Something numeric.
+ * @exception  rb_eTypeError   `num` is not a numeric.
+ * @exception  rb_eRangeError  `num` is out of range of `unsigned int`.
+ * @return     The passed value converted into C's `unsigned long`.
+ *
+ * @internal
+ *
+ * Yes, the API is really strange.  It returns `unsigned long`, but raises when
+ * the value is out  of `unsigned int`.  This seems to be due  to the fact that
+ * Matz  favoured K&R  before, and  his  machine at  that moment  was an  ILP32
+ * architecture.
+ */
+unsigned long rb_num2uint(VALUE num);
+
+/**
+ * Identical to rb_num2uint().
+ *
+ * @param[in]  num             Something numeric.
+ * @exception  rb_eTypeError   `num` is not a numeric.
+ * @exception  rb_eRangeError  `num` is out of range of `unsigned int`.
+ * @return     The passed value converted into C's `unsigned long`.
+ *
+ * @internal
+ *
+ * This function seems to be a complete  waste of disk space.  @shyouhei has no
+ * idea why this is a different thing from rb_num2short().
+ */
+unsigned long rb_fix2uint(VALUE num);
+RBIMPL_SYMBOL_EXPORT_END()
+
+RBIMPL_ATTR_ARTIFICIAL()
+/**
+ * Converts a Fixnum into C's `int`.
+ *
+ * @param[in]  x  Some Fixnum.
+ * @pre        Must not pass anything other than a Fixnum.
+ * @return     The passed value converted into C's `int`.
+ */
+static inline int
+RB_FIX2INT(VALUE x)
+{
+    /* "FIX2INT raises a  TypeError if passed nil", says rubyspec.  Not sure if
+     * that is a desired behaviour but just preserve backwards compatilibily.
+     */
+#if 0
+    RBIMPL_ASSERT_OR_ASSUME(RB_FIXNUM_P(x));
+#endif
+    long ret;
+
+    if /* constexpr */ (sizeof(int) < sizeof(long)) {
+        ret = rb_fix2int(x);
+    }
+    else {
+        ret = RB_FIX2LONG(x);
+    }
+
+    return RBIMPL_CAST((int)ret);
+}
+
+/**
+ * Converts an instance of ::rb_cNumeric into C's `int`.
+ *
+ * @param[in]  x               Something numeric.
+ * @exception  rb_eTypeError   `x` is not a numeric.
+ * @exception  rb_eRangeError  `x` is out of range of `int`.
+ * @return     The passed value converted into C's `int`.
+ */
+static inline int
+rb_num2int_inline(VALUE x)
+{
+    long ret;
+
+    if /* constexpr */ (sizeof(int) == sizeof(long)) {
+        ret = RB_NUM2LONG(x);
+    }
+    else if (RB_FIXNUM_P(x)) {
+        ret = rb_fix2int(x);
+    }
+    else {
+        ret = rb_num2int(x);
+    }
+
+    return RBIMPL_CAST((int)ret);
+}
+
+/**
+ * Converts an instance of ::rb_cNumeric into C's `unsigned int`.
+ *
+ * @param[in]  x               Something numeric.
+ * @exception  rb_eTypeError   `x` is not a numeric.
+ * @exception  rb_eRangeError  `x` is out of range of `unsigned int`.
+ * @return     The passed value converted into C's `unsigned int`.
+ */
+RBIMPL_ATTR_ARTIFICIAL()
+static inline unsigned int
+RB_NUM2UINT(VALUE x)
+{
+    unsigned long ret;
+
+    if /* constexpr */ (sizeof(int) < sizeof(long)) {
+        ret = rb_num2uint(x);
+    }
+    else {
+        ret = RB_NUM2ULONG(x);
+    }
+
+    return RBIMPL_CAST((unsigned int)ret);
+}
+
+RBIMPL_ATTR_ARTIFICIAL()
+/**
+ * Converts a Fixnum into C's `int`.
+ *
+ * @param[in]  x  Some Fixnum.
+ * @pre        Must not pass anything other than a Fixnum.
+ * @return     The passed value converted into C's `int`.
+ */
+static inline unsigned int
+RB_FIX2UINT(VALUE x)
+{
+#if 0 /* Ditto for RB_FIX2INT. */
+    RBIMPL_ASSERT_OR_ASSUME(RB_FIXNUM_P(x));
+#endif
+    unsigned long ret;
+
+    if /* constexpr */ (sizeof(int) < sizeof(long)) {
+        ret = rb_fix2uint(x);
+    }
+    else {
+        ret = RB_FIX2ULONG(x);
+    }
+
+    return RBIMPL_CAST((unsigned int)ret);
+}
+
+RBIMPL_WARNING_PUSH()
+#if RBIMPL_COMPILER_IS(GCC)
+RBIMPL_WARNING_IGNORED(-Wtype-limits) /* We can ignore them here. */
+#elif RBIMPL_HAS_WARNING("-Wtautological-constant-out-of-range-compare")
+RBIMPL_WARNING_IGNORED(-Wtautological-constant-out-of-range-compare)
+#endif
+
+/**
+ * Converts a C's `int` into an instance of ::rb_cInteger.
+ *
+ * @param[in]  v  Arbitrary `int` value.
+ * @return     An instance of ::rb_cInteger.
+ */
+static inline VALUE
+rb_int2num_inline(int v)
+{
+    if (RB_FIXABLE(v))
+        return RB_INT2FIX(v);
+    else
+        return rb_int2big(v);
+}
+
+/**
+ * Converts a C's `unsigned int` into an instance of ::rb_cInteger.
+ *
+ * @param[in]  v  Arbitrary `unsigned int` value.
+ * @return     An instance of ::rb_cInteger.
+ */
+static inline VALUE
+rb_uint2num_inline(unsigned int v)
+{
+    if (RB_POSFIXABLE(v))
+        return RB_LONG2FIX(v);
+    else
+        return rb_uint2big(v);
+}
+
+RBIMPL_WARNING_POP()
+
+#endif /* RBIMPL_ARITHMETIC_INT_H */

--- a/scolapasta-fixable/vendor/ruby-3.2.0/include/ruby/internal/arithmetic/intptr_t.h
+++ b/scolapasta-fixable/vendor/ruby-3.2.0/include/ruby/internal/arithmetic/intptr_t.h
@@ -1,0 +1,74 @@
+#ifndef RBIMPL_ARITHMETIC_INTPTR_T_H                 /*-*-C++-*-vi:se ft=cpp:*/
+#define RBIMPL_ARITHMETIC_INTPTR_T_H
+/**
+ * @file
+ * @author     Ruby developers <ruby-core@ruby-lang.org>
+ * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
+ *             Permission  is hereby  granted,  to  either redistribute  and/or
+ *             modify this file, provided that  the conditions mentioned in the
+ *             file COPYING are met.  Consult the file for details.
+ * @warning    Symbols   prefixed  with   either  `RBIMPL`   or  `rbimpl`   are
+ *             implementation details.   Don't take  them as canon.  They could
+ *             rapidly appear then vanish.  The name (path) of this header file
+ *             is also an  implementation detail.  Do not expect  it to persist
+ *             at the place it is now.  Developers are free to move it anywhere
+ *             anytime at will.
+ * @note       To  ruby-core:  remember  that   this  header  can  be  possibly
+ *             recursively included  from extension  libraries written  in C++.
+ *             Do not  expect for  instance `__VA_ARGS__` is  always available.
+ *             We assume C99  for ruby itself but we don't  assume languages of
+ *             extension libraries.  They could be written in C++98.
+ * @brief      Arithmetic conversion between C's `intptr_t` and Ruby's.
+ */
+#include "ruby/internal/config.h"
+
+#ifdef HAVE_STDINT_H
+# include <stdint.h>
+#endif
+
+#include "ruby/internal/value.h"
+#include "ruby/internal/dllexport.h"
+
+#define rb_int_new  rb_int2inum  /**< @alias{rb_int2inum} */
+#define rb_uint_new rb_uint2inum /**< @alias{rb_uint2inum} */
+
+RBIMPL_SYMBOL_EXPORT_BEGIN()
+
+/**
+ * Converts a C's `intptr_t` into an instance of ::rb_cInteger.
+ *
+ * @param[in]  i  Arbitrary `intptr_t` value.
+ * @return     An instance of ::rb_cInteger.
+ * @note       This function always allocates Bignums, even if the given number
+ *             is small enough to fit into a Fixnum.
+ */
+VALUE rb_int2big(intptr_t i);
+
+/**
+ * Converts a C's `intptr_t` into an instance of ::rb_cInteger.
+ *
+ * @param[in]  i  Arbitrary `intptr_t` value.
+ * @return     An instance of ::rb_cInteger.
+ */
+VALUE rb_int2inum(intptr_t i);
+
+/**
+ * Converts a C's `intptr_t` into an instance of ::rb_cInteger.
+ *
+ * @param[in]  i  Arbitrary `intptr_t` value.
+ * @return     An instance of ::rb_cInteger.
+ * @note       This function always allocates Bignums, even if the given number
+ *             is small enough to fit into a Fixnum.
+ */
+VALUE rb_uint2big(uintptr_t i);
+
+/**
+ * Converts a C's `uintptr_t` into an instance of ::rb_cInteger.
+ *
+ * @param[in]  i  Arbitrary `uintptr_t` value.
+ * @return     An instance of ::rb_cInteger.
+ */
+VALUE rb_uint2inum(uintptr_t i);
+RBIMPL_SYMBOL_EXPORT_END()
+
+#endif /* RBIMPL_ARITHMETIC_INTPTR_T_H */

--- a/scolapasta-fixable/vendor/ruby-3.2.0/include/ruby/internal/arithmetic/long.h
+++ b/scolapasta-fixable/vendor/ruby-3.2.0/include/ruby/internal/arithmetic/long.h
@@ -1,0 +1,356 @@
+#ifndef RBIMPL_ARITHMETIC_LONG_H                     /*-*-C++-*-vi:se ft=cpp:*/
+#define RBIMPL_ARITHMETIC_LONG_H
+/**
+ * @file
+ * @author     Ruby developers <ruby-core@ruby-lang.org>
+ * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
+ *             Permission  is hereby  granted,  to  either redistribute  and/or
+ *             modify this file, provided that  the conditions mentioned in the
+ *             file COPYING are met.  Consult the file for details.
+ * @warning    Symbols   prefixed  with   either  `RBIMPL`   or  `rbimpl`   are
+ *             implementation details.   Don't take  them as canon.  They could
+ *             rapidly appear then vanish.  The name (path) of this header file
+ *             is also an  implementation detail.  Do not expect  it to persist
+ *             at the place it is now.  Developers are free to move it anywhere
+ *             anytime at will.
+ * @note       To  ruby-core:  remember  that   this  header  can  be  possibly
+ *             recursively included  from extension  libraries written  in C++.
+ *             Do not  expect for  instance `__VA_ARGS__` is  always available.
+ *             We assume C99  for ruby itself but we don't  assume languages of
+ *             extension libraries.  They could be written in C++98.
+ * @brief      Arithmetic conversion between C's `long` and Ruby's.
+ *
+ * ### Q&A ###
+ *
+ * - Q: Why are INT2FIX etc. here, not in `int.h`?
+ *
+ * - A: Because they  are in fact  handling `long`.   It seems someone  did not
+ *      understand the difference of `int`  and `long` when they designed those
+ *      macros.
+ */
+#include "ruby/internal/config.h"
+#include "ruby/internal/arithmetic/fixnum.h"   /* FIXABLE */
+#include "ruby/internal/arithmetic/intptr_t.h" /* rb_int2big etc.*/
+#include "ruby/internal/assume.h"
+#include "ruby/internal/attr/artificial.h"
+#include "ruby/internal/attr/cold.h"
+#include "ruby/internal/attr/const.h"
+#include "ruby/internal/attr/constexpr.h"
+#include "ruby/internal/attr/noreturn.h"
+#include "ruby/internal/cast.h"
+#include "ruby/internal/dllexport.h"
+#include "ruby/internal/special_consts.h"      /* FIXNUM_FLAG */
+#include "ruby/internal/value.h"
+#include "ruby/assert.h"
+
+#define FIX2LONG     RB_FIX2LONG          /**< @old{RB_FIX2LONG} */
+#define FIX2ULONG    RB_FIX2ULONG         /**< @old{RB_FIX2ULONG} */
+#define INT2FIX      RB_INT2FIX           /**< @old{RB_INT2FIX} */
+#define LONG2FIX     RB_INT2FIX           /**< @old{RB_INT2FIX} */
+#define LONG2NUM     RB_LONG2NUM          /**< @old{RB_LONG2NUM} */
+#define NUM2LONG     RB_NUM2LONG          /**< @old{RB_NUM2LONG} */
+#define NUM2ULONG    RB_NUM2ULONG         /**< @old{RB_NUM2ULONG} */
+#define RB_FIX2LONG  rb_fix2long          /**< @alias{rb_fix2long} */
+#define RB_FIX2ULONG rb_fix2ulong         /**< @alias{rb_fix2ulong} */
+#define RB_LONG2FIX  RB_INT2FIX           /**< @alias{RB_INT2FIX} */
+#define RB_LONG2NUM  rb_long2num_inline   /**< @alias{rb_long2num_inline} */
+#define RB_NUM2LONG  rb_num2long_inline   /**< @alias{rb_num2long_inline} */
+#define RB_NUM2ULONG rb_num2ulong_inline  /**< @alias{rb_num2ulong_inline} */
+#define RB_ULONG2NUM rb_ulong2num_inline  /**< @alias{rb_ulong2num_inline} */
+#define ULONG2NUM    RB_ULONG2NUM         /**< @old{RB_ULONG2NUM} */
+#define rb_fix_new   RB_INT2FIX           /**< @alias{RB_INT2FIX} */
+#define rb_long2int  rb_long2int_inline   /**< @alias{rb_long2int_inline} */
+
+/** @cond INTERNAL_MACRO */
+#define RB_INT2FIX RB_INT2FIX
+/** @endcond */
+
+RBIMPL_SYMBOL_EXPORT_BEGIN()
+
+RBIMPL_ATTR_NORETURN()
+RBIMPL_ATTR_COLD()
+/**
+ * This is an utility function to raise an ::rb_eRangeError.
+ *
+ * @param[in]  num             A signed value about to overflow.
+ * @exception  rb_eRangeError  `num` is out of range of `int`.
+ */
+void rb_out_of_int(SIGNED_VALUE num);
+
+/**
+ * Converts an instance of ::rb_cNumeric into C's `long`.
+ *
+ * @param[in]  num             Something numeric.
+ * @exception  rb_eTypeError   `num` is not a numeric.
+ * @exception  rb_eRangeError  `num` is out of range of `long`.
+ * @return     The passed value converted into C's `long`.
+ */
+long rb_num2long(VALUE num);
+
+/**
+ * Converts an instance of ::rb_cNumeric into C's `unsigned long`.
+ *
+ * @param[in]  num             Something numeric.
+ * @exception  rb_eTypeError   `num` is not a numeric.
+ * @exception  rb_eRangeError  `num` is out of range of `unsigned long`.
+ * @return     The passed value converted into C's `unsigned long`.
+ */
+unsigned long rb_num2ulong(VALUE num);
+RBIMPL_SYMBOL_EXPORT_END()
+
+RBIMPL_ATTR_CONST_UNLESS_DEBUG()
+RBIMPL_ATTR_CONSTEXPR_UNLESS_DEBUG(CXX14)
+RBIMPL_ATTR_ARTIFICIAL()
+/**
+ * Converts a C's `long` into an instance of ::rb_cInteger.
+ *
+ * @param[in]  i  Arbitrary `long` value.
+ * @return     An instance of ::rb_cInteger.
+ */
+static inline VALUE
+RB_INT2FIX(long i)
+{
+    RBIMPL_ASSERT_OR_ASSUME(RB_FIXABLE(i));
+
+    /* :NOTE: VALUE can be wider than long.  As j being unsigned, 2j+1 is fully
+     * defined. Also it can be compiled into a single LEA instruction. */
+    const unsigned long j = i;
+    const unsigned long k = (j << 1) + RUBY_FIXNUM_FLAG;
+    const long          l = k;
+    const SIGNED_VALUE  m = l; /* Sign extend */
+    const VALUE         n = m;
+
+    RBIMPL_ASSERT_OR_ASSUME(RB_FIXNUM_P(n));
+    return n;
+}
+
+/**
+ * Checks if `int` can hold the given integer.
+ *
+ * @param[in]  n               Arbitrary `long` value.
+ * @exception  rb_eRangeError  `n` is out of range of `int`.
+ * @return     Identical value of type `int`
+ */
+static inline int
+rb_long2int_inline(long n)
+{
+    int i = RBIMPL_CAST((int)n);
+
+    if /* constexpr */ (sizeof(long) <= sizeof(int)) {
+        RBIMPL_ASSUME(i == n);
+    }
+
+    if (i != n)
+        rb_out_of_int(n);
+
+    return i;
+}
+
+RBIMPL_ATTR_CONST_UNLESS_DEBUG()
+RBIMPL_ATTR_CONSTEXPR_UNLESS_DEBUG(CXX14)
+/**
+ * @private
+ *
+ * This  is an  implementation detail  of rb_fix2long().   People don't  use it
+ * directly.
+ *
+ * @param[in]  x  A Fixnum.
+ * @return     Identical value of type `long`
+ * @pre        Must not pass anything other than a Fixnum.
+ */
+static inline long
+rbimpl_fix2long_by_idiv(VALUE x)
+{
+    RBIMPL_ASSERT_OR_ASSUME(RB_FIXNUM_P(x));
+
+    /* :NOTE: VALUE  can be wider  than long.  (x-1)/2 never  overflows because
+     * RB_FIXNUM_P(x)  holds.   Also it  has  no  portability issue  like  y>>1
+     * below. */
+    const SIGNED_VALUE y = x - RUBY_FIXNUM_FLAG;
+    const SIGNED_VALUE z = y / 2;
+    const long         w = RBIMPL_CAST((long)z);
+
+    RBIMPL_ASSERT_OR_ASSUME(RB_FIXABLE(w));
+    return w;
+}
+
+RBIMPL_ATTR_CONST_UNLESS_DEBUG()
+RBIMPL_ATTR_CONSTEXPR_UNLESS_DEBUG(CXX14)
+/**
+ * @private
+ *
+ * This  is an  implementation detail  of rb_fix2long().   People don't  use it
+ * directly.
+ *
+ * @param[in]  x  A Fixnum.
+ * @return     Identical value of type `long`
+ * @pre        Must not pass anything other than a Fixnum.
+ */
+static inline long
+rbimpl_fix2long_by_shift(VALUE x)
+{
+    RBIMPL_ASSERT_OR_ASSUME(RB_FIXNUM_P(x));
+
+    /* :NOTE: VALUE can be wider than long.  If right shift is arithmetic, this
+     * is noticeably faster than above. */
+    const SIGNED_VALUE y = x;
+    const SIGNED_VALUE z = y >> 1;
+    const long         w = RBIMPL_CAST((long)z);
+
+    RBIMPL_ASSERT_OR_ASSUME(RB_FIXABLE(w));
+    return w;
+}
+
+RBIMPL_ATTR_CONST()
+RBIMPL_ATTR_CONSTEXPR(CXX11)
+/**
+ * @private
+ *
+ * This  is an  implementation detail  of rb_fix2long().   People don't  use it
+ * directly.
+ *
+ * @retval  true   This C compiler's right shift operator is arithmetic.
+ * @retval  false  This C compiler's right shift operator is logical.
+ */
+static inline bool
+rbimpl_right_shift_is_arithmetic_p(void)
+{
+    return (-1 >> 1) == -1;
+}
+
+RBIMPL_ATTR_CONST_UNLESS_DEBUG()
+RBIMPL_ATTR_CONSTEXPR_UNLESS_DEBUG(CXX14)
+/**
+ * Converts a Fixnum into C's `long`.
+ *
+ * @param[in]  x  Some Fixnum.
+ * @pre        Must not pass anything other than a Fixnum.
+ * @return     The passed value converted into C's `long`.
+ */
+static inline long
+rb_fix2long(VALUE x)
+{
+    if /* constexpr */ (rbimpl_right_shift_is_arithmetic_p()) {
+        return rbimpl_fix2long_by_shift(x);
+    }
+    else {
+        return rbimpl_fix2long_by_idiv(x);
+    }
+}
+
+RBIMPL_ATTR_CONST_UNLESS_DEBUG()
+RBIMPL_ATTR_CONSTEXPR_UNLESS_DEBUG(CXX14)
+/**
+ * Converts a Fixnum into C's `unsigned long`.
+ *
+ * @param[in]  x  Some Fixnum.
+ * @pre        Must not pass anything other than a Fixnum.
+ * @return     The passed value converted into C's `unsigned long`.
+ * @note       Negative fixnums will be converted into large unsigned longs.
+ */
+static inline unsigned long
+rb_fix2ulong(VALUE x)
+{
+    RBIMPL_ASSERT_OR_ASSUME(RB_FIXNUM_P(x));
+    return rb_fix2long(x);
+}
+
+/**
+ * Converts an instance of ::rb_cNumeric into C's `long`.
+ *
+ * @param[in]  x               Something numeric.
+ * @exception  rb_eTypeError   `x` is not a numeric.
+ * @exception  rb_eRangeError  `x` is out of range of `long`.
+ * @return     The passed value converted into C's `long`.
+ */
+static inline long
+rb_num2long_inline(VALUE x)
+{
+    if (RB_FIXNUM_P(x))
+        return RB_FIX2LONG(x);
+    else
+        return rb_num2long(x);
+}
+
+/**
+ * Converts an instance of ::rb_cNumeric into C's `unsigned long`.
+ *
+ * @param[in]  x               Something numeric.
+ * @exception  rb_eTypeError   `x` is not a numeric.
+ * @exception  rb_eRangeError  `x` is out of range of `unsigned long`.
+ * @return     The passed value converted into C's `unsigned long`.
+ *
+ * @internal
+ *
+ * This  (negative fixnum  would become  a large  unsigned long  while negative
+ * bignum  is an  exception)  has been  THE behaviour  of  NUM2ULONG since  the
+ * beginning.  It is strange, but we can  no longer change how it works at this
+ * moment.  We have to get by with it.
+ *
+ * @see https://bugs.ruby-lang.org/issues/9089
+ */
+static inline unsigned long
+rb_num2ulong_inline(VALUE x)
+{
+    if (RB_FIXNUM_P(x))
+        return RB_FIX2ULONG(x);
+    else
+        return rb_num2ulong(x);
+}
+
+/**
+ * Converts a C's `long` into an instance of ::rb_cInteger.
+ *
+ * @param[in]  v  Arbitrary `long` value.
+ * @return     An instance of ::rb_cInteger.
+ */
+static inline VALUE
+rb_long2num_inline(long v)
+{
+    if (RB_FIXABLE(v))
+        return RB_LONG2FIX(v);
+    else
+        return rb_int2big(v);
+}
+
+/**
+ * Converts a C's `unsigned long` into an instance of ::rb_cInteger.
+ *
+ * @param[in]  v  Arbitrary `unsigned long` value.
+ * @return     An instance of ::rb_cInteger.
+ */
+static inline VALUE
+rb_ulong2num_inline(unsigned long v)
+{
+    if (RB_POSFIXABLE(v))
+        return RB_LONG2FIX(v);
+    else
+        return rb_uint2big(v);
+}
+
+/**
+ * @cond INTERNAL_MACRO
+ *
+ * Following overload is necessary because sometimes  INT2FIX is used as a enum
+ * value (e.g. `enum {  FOO = INT2FIX(0) };`).  THIS IS NG  in theory because a
+ * VALUE does not fit into an enum (which must be a signed int).  But we cannot
+ * break existing codes.
+ */
+#if RBIMPL_HAS_ATTR_CONSTEXPR_CXX14
+# /* C++ can write constexpr as enum values. */
+
+#elif ! defined(HAVE_BUILTIN___BUILTIN_CHOOSE_EXPR_CONSTANT_P)
+# undef INT2FIX
+# define INT2FIX(i) (RBIMPL_CAST((VALUE)(i)) << 1 | RUBY_FIXNUM_FLAG)
+
+#else
+# undef INT2FIX
+# define INT2FIX(i)                                     \
+    __builtin_choose_expr(                              \
+        __builtin_constant_p(i),                        \
+        RBIMPL_CAST((VALUE)(i)) << 1 | RUBY_FIXNUM_FLAG, \
+        RB_INT2FIX(i))
+#endif
+/** @endcond */
+
+#endif /* RBIMPL_ARITHMETIC_LONG_H */

--- a/scolapasta-fixable/vendor/ruby-3.2.0/include/ruby/internal/arithmetic/long_long.h
+++ b/scolapasta-fixable/vendor/ruby-3.2.0/include/ruby/internal/arithmetic/long_long.h
@@ -1,0 +1,135 @@
+#ifndef RBIMPL_ARITHMETIC_LONG_LONG_H                /*-*-C++-*-vi:se ft=cpp:*/
+#define RBIMPL_ARITHMETIC_LONG_LONG_H
+/**
+ * @file
+ * @author     Ruby developers <ruby-core@ruby-lang.org>
+ * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
+ *             Permission  is hereby  granted,  to  either redistribute  and/or
+ *             modify this file, provided that  the conditions mentioned in the
+ *             file COPYING are met.  Consult the file for details.
+ * @warning    Symbols   prefixed  with   either  `RBIMPL`   or  `rbimpl`   are
+ *             implementation details.   Don't take  them as canon.  They could
+ *             rapidly appear then vanish.  The name (path) of this header file
+ *             is also an  implementation detail.  Do not expect  it to persist
+ *             at the place it is now.  Developers are free to move it anywhere
+ *             anytime at will.
+ * @note       To  ruby-core:  remember  that   this  header  can  be  possibly
+ *             recursively included  from extension  libraries written  in C++.
+ *             Do not  expect for  instance `__VA_ARGS__` is  always available.
+ *             We assume C99  for ruby itself but we don't  assume languages of
+ *             extension libraries.  They could be written in C++98.
+ * @brief      Arithmetic conversion between C's `long long` and Ruby's.
+ */
+#include "ruby/internal/value.h"
+#include "ruby/internal/dllexport.h"
+#include "ruby/internal/special_consts.h"
+#include "ruby/backward/2/long_long.h"
+
+#define RB_LL2NUM  rb_ll2num_inline   /**< @alias{rb_ll2num_inline} */
+#define RB_ULL2NUM rb_ull2num_inline  /**< @alias{rb_ull2num_inline} */
+#define LL2NUM     RB_LL2NUM          /**< @old{RB_LL2NUM} */
+#define ULL2NUM    RB_ULL2NUM         /**< @old{RB_ULL2NUM} */
+#define RB_NUM2LL  rb_num2ll_inline   /**< @alias{rb_num2ll_inline} */
+#define RB_NUM2ULL rb_num2ull_inline  /**< @alias{rb_num2ull_inline} */
+#define NUM2LL     RB_NUM2LL          /**< @old{RB_NUM2LL} */
+#define NUM2ULL    RB_NUM2ULL         /**< @old{RB_NUM2ULL} */
+
+RBIMPL_SYMBOL_EXPORT_BEGIN()
+/**
+ * Converts a C's `long long` into an instance of ::rb_cInteger.
+ *
+ * @param[in]  num  Arbitrary `long long` value.
+ * @return     An instance of ::rb_cInteger.
+ */
+VALUE rb_ll2inum(LONG_LONG num);
+
+/**
+ * Converts a C's `unsigned long long` into an instance of ::rb_cInteger.
+ *
+ * @param[in]  num  Arbitrary `unsigned long long` value.
+ * @return     An instance of ::rb_cInteger.
+ */
+VALUE rb_ull2inum(unsigned LONG_LONG num);
+
+/**
+ * Converts an instance of ::rb_cNumeric into C's `long long`.
+ *
+ * @param[in]  num             Something numeric.
+ * @exception  rb_eTypeError   `num` is not a numeric.
+ * @exception  rb_eRangeError  `num` is out of range of `long long`.
+ * @return     The passed value converted into C's `long long`.
+ */
+LONG_LONG rb_num2ll(VALUE num);
+
+/**
+ * Converts an instance of ::rb_cNumeric into C's `unsigned long long`.
+ *
+ * @param[in]  num             Something numeric.
+ * @exception  rb_eTypeError   `num` is not a numeric.
+ * @exception  rb_eRangeError  `num` is out of range of `unsigned long long`.
+ * @return     The passed value converted into C's `unsigned long long`.
+ */
+unsigned LONG_LONG rb_num2ull(VALUE num);
+RBIMPL_SYMBOL_EXPORT_END()
+
+/**
+ * Converts a C's `long long` into an instance of ::rb_cInteger.
+ *
+ * @param[in]  n  Arbitrary `long long` value.
+ * @return     An instance of ::rb_cInteger
+ */
+static inline VALUE
+rb_ll2num_inline(LONG_LONG n)
+{
+    if (FIXABLE(n)) return LONG2FIX((long)n);
+    return rb_ll2inum(n);
+}
+
+/**
+ * Converts a C's `unsigned long long` into an instance of ::rb_cInteger.
+ *
+ * @param[in]  n  Arbitrary `unsigned long long` value.
+ * @return     An instance of ::rb_cInteger
+ */
+static inline VALUE
+rb_ull2num_inline(unsigned LONG_LONG n)
+{
+    if (POSFIXABLE(n)) return LONG2FIX((long)n);
+    return rb_ull2inum(n);
+}
+
+/**
+ * Converts an instance of ::rb_cNumeric into C's `long long`.
+ *
+ * @param[in]  x               Something numeric.
+ * @exception  rb_eTypeError   `x` is not a numeric.
+ * @exception  rb_eRangeError  `x` is out of range of `long long`.
+ * @return     The passed value converted into C's `long long`.
+ */
+static inline LONG_LONG
+rb_num2ll_inline(VALUE x)
+{
+    if (RB_FIXNUM_P(x))
+        return RB_FIX2LONG(x);
+    else
+        return rb_num2ll(x);
+}
+
+/**
+ * Converts an instance of ::rb_cNumeric into C's `unsigned long long`.
+ *
+ * @param[in]  x               Something numeric.
+ * @exception  rb_eTypeError   `x` is not a numeric.
+ * @exception  rb_eRangeError  `x` is out of range of `unsigned long long`.
+ * @return     The passed value converted into C's `unsigned long long`.
+ */
+static inline unsigned LONG_LONG
+rb_num2ull_inline(VALUE x)
+{
+    if (RB_FIXNUM_P(x))
+        return RB_FIX2LONG(x);
+    else
+        return rb_num2ull(x);
+}
+
+#endif /* RBIMPL_ARITHMETIC_LONG_LONG_H */

--- a/scolapasta-fixable/vendor/ruby-3.2.0/include/ruby/internal/arithmetic/mode_t.h
+++ b/scolapasta-fixable/vendor/ruby-3.2.0/include/ruby/internal/arithmetic/mode_t.h
@@ -1,0 +1,41 @@
+#ifndef RBIMPL_ARITHMETIC_MODE_T_H                   /*-*-C++-*-vi:se ft=cpp:*/
+#define RBIMPL_ARITHMETIC_MODE_T_H
+/**
+ * @file
+ * @author     Ruby developers <ruby-core@ruby-lang.org>
+ * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
+ *             Permission  is hereby  granted,  to  either redistribute  and/or
+ *             modify this file, provided that  the conditions mentioned in the
+ *             file COPYING are met.  Consult the file for details.
+ * @warning    Symbols   prefixed  with   either  `RBIMPL`   or  `rbimpl`   are
+ *             implementation details.   Don't take  them as canon.  They could
+ *             rapidly appear then vanish.  The name (path) of this header file
+ *             is also an  implementation detail.  Do not expect  it to persist
+ *             at the place it is now.  Developers are free to move it anywhere
+ *             anytime at will.
+ * @note       To  ruby-core:  remember  that   this  header  can  be  possibly
+ *             recursively included  from extension  libraries written  in C++.
+ *             Do not  expect for  instance `__VA_ARGS__` is  always available.
+ *             We assume C99  for ruby itself but we don't  assume languages of
+ *             extension libraries.  They could be written in C++98.
+ * @brief      Arithmetic conversion between C's `mode_t` and Ruby's.
+ */
+#include "ruby/internal/config.h"
+#include "ruby/internal/arithmetic/int.h"
+
+/** Converts a C's `mode_t` into an instance of ::rb_cInteger. */
+#ifndef NUM2MODET
+# define NUM2MODET RB_NUM2INT
+#endif
+
+/** Converts an instance of ::rb_cNumeric into C's `mode_t`. */
+#ifndef MODET2NUM
+# define MODET2NUM RB_INT2NUM
+#endif
+
+/** A rb_sprintf() format prefix to be used for a `mode_t` parameter. */
+#ifndef PRI_MODET_PREFIX
+# define PRI_MODET_PREFIX PRI_INT_PREFIX
+#endif
+
+#endif /* RBIMPL_ARITHMETIC_MODE_T_H */

--- a/scolapasta-fixable/vendor/ruby-3.2.0/include/ruby/internal/arithmetic/off_t.h
+++ b/scolapasta-fixable/vendor/ruby-3.2.0/include/ruby/internal/arithmetic/off_t.h
@@ -1,0 +1,62 @@
+#ifndef RBIMPL_ARITHMETIC_OFF_T_H                    /*-*-C++-*-vi:se ft=cpp:*/
+#define RBIMPL_ARITHMETIC_OFF_T_H
+/**
+ * @file
+ * @author     Ruby developers <ruby-core@ruby-lang.org>
+ * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
+ *             Permission  is hereby  granted,  to  either redistribute  and/or
+ *             modify this file, provided that  the conditions mentioned in the
+ *             file COPYING are met.  Consult the file for details.
+ * @warning    Symbols   prefixed  with   either  `RBIMPL`   or  `rbimpl`   are
+ *             implementation details.   Don't take  them as canon.  They could
+ *             rapidly appear then vanish.  The name (path) of this header file
+ *             is also an  implementation detail.  Do not expect  it to persist
+ *             at the place it is now.  Developers are free to move it anywhere
+ *             anytime at will.
+ * @note       To  ruby-core:  remember  that   this  header  can  be  possibly
+ *             recursively included  from extension  libraries written  in C++.
+ *             Do not  expect for  instance `__VA_ARGS__` is  always available.
+ *             We assume C99  for ruby itself but we don't  assume languages of
+ *             extension libraries.  They could be written in C++98.
+ * @brief      Arithmetic conversion between C's `off_t` and Ruby's.
+ */
+#include "ruby/internal/config.h"
+#include "ruby/internal/arithmetic/int.h"
+#include "ruby/internal/arithmetic/long.h"
+#include "ruby/internal/arithmetic/long_long.h"
+#include "ruby/backward/2/long_long.h"
+
+/** Converts a C's `off_t` into an instance of ::rb_cInteger. */
+#ifdef OFFT2NUM
+# /* take that. */
+#elif SIZEOF_OFF_T == SIZEOF_LONG_LONG
+# define OFFT2NUM RB_LL2NUM
+#elif SIZEOF_OFF_T == SIZEOF_LONG
+# define OFFT2NUM RB_LONG2NUM
+#else
+# define OFFT2NUM RB_INT2NUM
+#endif
+
+/** Converts an instance of ::rb_cNumeric into C's `off_t`. */
+#ifdef NUM2OFFT
+# /* take that. */
+#elif SIZEOF_OFF_T == SIZEOF_LONG_LONG
+# define NUM2OFFT RB_NUM2LL
+#elif SIZEOF_OFF_T == SIZEOF_LONG
+# define NUM2OFFT RB_NUM2LONG
+#else
+# define NUM2OFFT RB_NUM2INT
+#endif
+
+/** A rb_sprintf() format prefix to be used for an `off_t` parameter. */
+#ifdef PRI_OFFT_PREFIX
+# /* take that. */
+#elif SIZEOF_OFF_T == SIZEOF_LONG_LONG
+# define PRI_OFFT_PREFIX PRI_LL_PREFIX
+#elif SIZEOF_OFF_T == SIZEOF_LONG
+# define PRI_OFFT_PREFIX PRI_LONG_PREFIX
+#else
+# define PRI_OFFT_PREFIX PRI_INT_PREFIX
+#endif
+
+#endif /* RBIMPL_ARITHMETIC_OFF_T_H */

--- a/scolapasta-fixable/vendor/ruby-3.2.0/include/ruby/internal/arithmetic/pid_t.h
+++ b/scolapasta-fixable/vendor/ruby-3.2.0/include/ruby/internal/arithmetic/pid_t.h
@@ -1,0 +1,41 @@
+#ifndef RBIMPL_ARITHMETIC_PID_T_H                    /*-*-C++-*-vi:se ft=cpp:*/
+#define RBIMPL_ARITHMETIC_PID_T_H
+/**
+ * @file
+ * @author     Ruby developers <ruby-core@ruby-lang.org>
+ * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
+ *             Permission  is hereby  granted,  to  either redistribute  and/or
+ *             modify this file, provided that  the conditions mentioned in the
+ *             file COPYING are met.  Consult the file for details.
+ * @warning    Symbols   prefixed  with   either  `RBIMPL`   or  `rbimpl`   are
+ *             implementation details.   Don't take  them as canon.  They could
+ *             rapidly appear then vanish.  The name (path) of this header file
+ *             is also an  implementation detail.  Do not expect  it to persist
+ *             at the place it is now.  Developers are free to move it anywhere
+ *             anytime at will.
+ * @note       To  ruby-core:  remember  that   this  header  can  be  possibly
+ *             recursively included  from extension  libraries written  in C++.
+ *             Do not  expect for  instance `__VA_ARGS__` is  always available.
+ *             We assume C99  for ruby itself but we don't  assume languages of
+ *             extension libraries.  They could be written in C++98.
+ * @brief      Arithmetic conversion between C's `pid_t` and Ruby's.
+ */
+#include "ruby/internal/config.h"
+#include "ruby/internal/arithmetic/long.h"
+
+/** Converts a C's `pid_t` into an instance of ::rb_cInteger. */
+#ifndef PIDT2NUM
+# define PIDT2NUM RB_LONG2NUM
+#endif
+
+/** Converts an instance of ::rb_cNumeric into C's `pid_t`. */
+#ifndef NUM2PIDT
+# define NUM2PIDT RB_NUM2LONG
+#endif
+
+/** A rb_sprintf() format prefix to be used for a `pid_t` parameter. */
+#ifndef PRI_PIDT_PREFIX
+# define PRI_PIDT_PREFIX PRI_LONG_PREFIX
+#endif
+
+#endif /* RBIMPL_ARITHMETIC_PID_T_H */

--- a/scolapasta-fixable/vendor/ruby-3.2.0/include/ruby/internal/arithmetic/short.h
+++ b/scolapasta-fixable/vendor/ruby-3.2.0/include/ruby/internal/arithmetic/short.h
@@ -1,0 +1,113 @@
+#ifndef RBIMPL_ARITHMETIC_SHORT_H                    /*-*-C++-*-vi:se ft=cpp:*/
+#define RBIMPL_ARITHMETIC_SHORT_H
+/**
+ * @file
+ * @author     Ruby developers <ruby-core@ruby-lang.org>
+ * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
+ *             Permission  is hereby  granted,  to  either redistribute  and/or
+ *             modify this file, provided that  the conditions mentioned in the
+ *             file COPYING are met.  Consult the file for details.
+ * @warning    Symbols   prefixed  with   either  `RBIMPL`   or  `rbimpl`   are
+ *             implementation details.   Don't take  them as canon.  They could
+ *             rapidly appear then vanish.  The name (path) of this header file
+ *             is also an  implementation detail.  Do not expect  it to persist
+ *             at the place it is now.  Developers are free to move it anywhere
+ *             anytime at will.
+ * @note       To  ruby-core:  remember  that   this  header  can  be  possibly
+ *             recursively included  from extension  libraries written  in C++.
+ *             Do not  expect for  instance `__VA_ARGS__` is  always available.
+ *             We assume C99  for ruby itself but we don't  assume languages of
+ *             extension libraries.  They could be written in C++98.
+ * @brief      Arithmetic conversion between C's `short` and Ruby's.
+ *
+ * Shyouhei  wonders:  why  there  is   no  SHORT2NUM,  given  there  are  both
+ * #USHORT2NUM and #CHR2FIX?
+ */
+#include "ruby/internal/value.h"
+#include "ruby/internal/dllexport.h"
+#include "ruby/internal/special_consts.h"
+
+#define RB_NUM2SHORT  rb_num2short_inline /**< @alias{rb_num2short_inline} */
+#define RB_NUM2USHORT rb_num2ushort       /**< @alias{rb_num2ushort} */
+#define NUM2SHORT     RB_NUM2SHORT        /**< @old{RB_NUM2SHORT} */
+#define NUM2USHORT    RB_NUM2USHORT       /**< @old{RB_NUM2USHORT} */
+#define USHORT2NUM    RB_INT2FIX          /**< @old{RB_INT2FIX} */
+#define RB_FIX2SHORT  rb_fix2short        /**< @alias{rb_fix2ushort} */
+#define FIX2SHORT     RB_FIX2SHORT        /**< @old{RB_FIX2SHORT} */
+
+RBIMPL_SYMBOL_EXPORT_BEGIN()
+
+/**
+ * Converts an instance of ::rb_cNumeric into C's `short`.
+ *
+ * @param[in]  num             Something numeric.
+ * @exception  rb_eTypeError   `num` is not a numeric.
+ * @exception  rb_eRangeError  `num` is out of range of `short`.
+ * @return     The passed value converted into C's `short`.
+ */
+short rb_num2short(VALUE num);
+
+/**
+ * Converts an instance of ::rb_cNumeric into C's `unsigned short`.
+ *
+ * @param[in]  num             Something numeric.
+ * @exception  rb_eTypeError   `num` is not a numeric.
+ * @exception  rb_eRangeError  `num` is out of range of `unsigned short`.
+ * @return     The passed value converted into C's `unsigned short`.
+ */
+unsigned short rb_num2ushort(VALUE num);
+
+/**
+ * Identical to rb_num2short().
+ *
+ * @param[in]  num             Something numeric.
+ * @exception  rb_eTypeError   `num` is not a numeric.
+ * @exception  rb_eRangeError  `num` is out of range of `short`.
+ * @return     The passed value converted into C's `short`.
+ *
+ * @internal
+ *
+ * This function seems to be a complete  waste of disk space.  @shyouhei has no
+ * idea why this is a different thing from rb_num2short().
+ */
+short rb_fix2short(VALUE num);
+
+/**
+ * Identical to rb_num2ushort().
+ *
+ * @param[in]  num             Something numeric.
+ * @exception  rb_eTypeError   `num` is not a numeric.
+ * @exception  rb_eRangeError  `num` is out of range of `unsigned short`.
+ * @return     The passed value converted into C's `unsigned short`.
+ *
+ * @internal
+ *
+ * This function seems to be a complete  waste of disk space.  @shyouhei has no
+ * idea why this is a different thing from rb_num2ushort().
+ */
+unsigned short rb_fix2ushort(VALUE num);
+RBIMPL_SYMBOL_EXPORT_END()
+
+/**
+ * Identical to rb_num2short().
+ *
+ * @param[in]  x               Something numeric.
+ * @exception  rb_eTypeError   `x` is not a numeric.
+ * @exception  rb_eRangeError  `x` is out of range of `short`.
+ * @return     The passed value converted into C's `short`.
+ *
+ * @internal
+ *
+ * This function seems to  be a complete waste of time.   @shyouhei has no idea
+ * why this is a different thing from rb_num2short().
+ */
+static inline short
+rb_num2short_inline(VALUE x)
+{
+    if (RB_FIXNUM_P(x))
+        return rb_fix2short(x);
+    else
+        return rb_num2short(x);
+}
+
+#endif /* RBIMPL_ARITHMETIC_SHORT_H */

--- a/scolapasta-fixable/vendor/ruby-3.2.0/include/ruby/internal/arithmetic/size_t.h
+++ b/scolapasta-fixable/vendor/ruby-3.2.0/include/ruby/internal/arithmetic/size_t.h
@@ -1,0 +1,66 @@
+#ifndef RBIMPL_ARITHMETIC_SIZE_T_H                   /*-*-C++-*-vi:se ft=cpp:*/
+#define RBIMPL_ARITHMETIC_SIZE_T_H
+/**
+ * @file
+ * @author     Ruby developers <ruby-core@ruby-lang.org>
+ * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
+ *             Permission  is hereby  granted,  to  either redistribute  and/or
+ *             modify this file, provided that  the conditions mentioned in the
+ *             file COPYING are met.  Consult the file for details.
+ * @warning    Symbols   prefixed  with   either  `RBIMPL`   or  `rbimpl`   are
+ *             implementation details.   Don't take  them as canon.  They could
+ *             rapidly appear then vanish.  The name (path) of this header file
+ *             is also an  implementation detail.  Do not expect  it to persist
+ *             at the place it is now.  Developers are free to move it anywhere
+ *             anytime at will.
+ * @note       To  ruby-core:  remember  that   this  header  can  be  possibly
+ *             recursively included  from extension  libraries written  in C++.
+ *             Do not  expect for  instance `__VA_ARGS__` is  always available.
+ *             We assume C99  for ruby itself but we don't  assume languages of
+ *             extension libraries.  They could be written in C++98.
+ * @brief      Arithmetic conversion between C's `size_t` and Ruby's.
+ */
+#include "ruby/internal/config.h"
+#include "ruby/internal/arithmetic/int.h"
+#include "ruby/internal/arithmetic/long.h"
+#include "ruby/internal/arithmetic/long_long.h"
+#include "ruby/backward/2/long_long.h"
+
+#if defined(__DOXYGEN__)
+# /** Converts a C's `size_t` into an instance of ::rb_cInteger. */
+# define RB_SIZE2NUM RB_ULONG2NUM
+# /** Converts a C's `ssize_t` into an instance of ::rb_cInteger. */
+# define RB_SSIZE2NUM RB_LONG2NUM
+#elif SIZEOF_SIZE_T == SIZEOF_LONG_LONG
+# define RB_SIZE2NUM RB_ULL2NUM
+# define RB_SSIZE2NUM RB_LL2NUM
+#elif SIZEOF_SIZE_T == SIZEOF_LONG
+# define RB_SIZE2NUM RB_ULONG2NUM
+# define RB_SSIZE2NUM RB_LONG2NUM
+#else
+# define RB_SIZE2NUM RB_UINT2NUM
+# define RB_SSIZE2NUM RB_INT2NUM
+#endif
+
+#if defined(__DOXYGEN__)
+# /** Converts an instance of ::rb_cInteger into C's `size_t`. */
+# define RB_NUM2SIZE RB_NUM2ULONG
+# /** Converts an instance of ::rb_cInteger into C's `ssize_t`. */
+# define RB_NUM2SSIZE RB_NUM2LONG
+#elif SIZEOF_SIZE_T == SIZEOF_LONG_LONG
+# define RB_NUM2SIZE RB_NUM2ULL
+# define RB_NUM2SSIZE RB_NUM2LL
+#elif SIZEOF_SIZE_T == SIZEOF_LONG
+# define RB_NUM2SIZE RB_NUM2ULONG
+# define RB_NUM2SSIZE RB_NUM2LONG
+#else
+# define RB_NUM2SIZE RB_NUM2UINT
+# define RB_NUM2SSIZE RB_NUM2INT
+#endif
+
+#define NUM2SIZET RB_NUM2SIZE   /**< @old{RB_NUM2SIZE} */
+#define SIZET2NUM RB_SIZE2NUM   /**< @old{RB_SIZE2NUM} */
+#define NUM2SSIZET RB_NUM2SSIZE /**< @old{RB_NUM2SSIZE} */
+#define SSIZET2NUM RB_SSIZE2NUM /**< @old{RB_SSIZE2NUM} */
+
+#endif /* RBIMPL_ARITHMETIC_SIZE_T_H */

--- a/scolapasta-fixable/vendor/ruby-3.2.0/include/ruby/internal/arithmetic/st_data_t.h
+++ b/scolapasta-fixable/vendor/ruby-3.2.0/include/ruby/internal/arithmetic/st_data_t.h
@@ -1,0 +1,75 @@
+#ifndef RBIMPL_ARITHMERIC_ST_DATA_T_H                /*-*-C++-*-vi:se ft=cpp:*/
+#define RBIMPL_ARITHMERIC_ST_DATA_T_H
+/**
+ * @file
+ * @author     Ruby developers <ruby-core@ruby-lang.org>
+ * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
+ *             Permission  is hereby  granted,  to  either redistribute  and/or
+ *             modify this file, provided that  the conditions mentioned in the
+ *             file COPYING are met.  Consult the file for details.
+ * @warning    Symbols   prefixed  with   either  `RBIMPL`   or  `rbimpl`   are
+ *             implementation details.   Don't take  them as canon.  They could
+ *             rapidly appear then vanish.  The name (path) of this header file
+ *             is also an  implementation detail.  Do not expect  it to persist
+ *             at the place it is now.  Developers are free to move it anywhere
+ *             anytime at will.
+ * @note       To  ruby-core:  remember  that   this  header  can  be  possibly
+ *             recursively included  from extension  libraries written  in C++.
+ *             Do not  expect for  instance `__VA_ARGS__` is  always available.
+ *             We assume C99  for ruby itself but we don't  assume languages of
+ *             extension libraries.  They could be written in C++98.
+ * @brief      Arithmetic conversion between C's `st_data_t` and Ruby's.
+ */
+#include "ruby/internal/arithmetic/fixnum.h"
+#include "ruby/internal/arithmetic/long.h"
+#include "ruby/internal/attr/artificial.h"
+#include "ruby/internal/attr/const.h"
+#include "ruby/internal/attr/constexpr.h"
+#include "ruby/internal/cast.h"
+#include "ruby/internal/value.h"
+#include "ruby/assert.h"
+#include "ruby/st.h"
+
+#define ST2FIX    RB_ST2FIX     /**< @old{RB_ST2FIX} */
+/** @cond INTERNAL_MACRO */
+#define RB_ST2FIX RB_ST2FIX
+/** @endcond */
+
+RBIMPL_ATTR_CONST_UNLESS_DEBUG()
+RBIMPL_ATTR_CONSTEXPR_UNLESS_DEBUG(CXX14)
+RBIMPL_ATTR_ARTIFICIAL()
+/**
+ * Converts a C's `st_data_t` into an instance of ::rb_cInteger.
+ *
+ * @param[in]  i  The data in question.
+ * @return     A converted result
+ * @warning    THIS CONVERSION LOSES DATA!  Be warned.
+ * @see        https://bugs.ruby-lang.org/issues/13877
+ * @see        https://bugs.ruby-lang.org/issues/14218
+ *
+ * @internal
+ *
+ * This  is   needed  because  of   hash  functions.   Hash   functions  return
+ * `st_data_t`,  which could  theoretically  be bigger  than Fixnums.   However
+ * allocating Bignums for them every time  we calculate hash values is just too
+ * heavy.  To avoid  penalty we need to  ignore some upper bit(s)  and stick to
+ * Fixnums.  This function is used for that purpose.
+ */
+static inline VALUE
+RB_ST2FIX(st_data_t i)
+{
+    SIGNED_VALUE x = i;
+
+    if (x >= 0) {
+        x &= RUBY_FIXNUM_MAX;
+    }
+    else {
+        x |= RUBY_FIXNUM_MIN;
+    }
+
+    RBIMPL_ASSERT_OR_ASSUME(RB_FIXABLE(x));
+    unsigned long y = RBIMPL_CAST((unsigned long)x);
+    return RB_LONG2FIX(y);
+}
+
+#endif /* RBIMPL_ARITHMETIC_ST_DATA_T_H */

--- a/scolapasta-fixable/vendor/ruby-3.2.0/include/ruby/internal/arithmetic/uid_t.h
+++ b/scolapasta-fixable/vendor/ruby-3.2.0/include/ruby/internal/arithmetic/uid_t.h
@@ -1,0 +1,41 @@
+#ifndef RBIMPL_ARITHMETIC_UID_T_H                    /*-*-C++-*-vi:se ft=cpp:*/
+#define RBIMPL_ARITHMETIC_UID_T_H
+/**
+ * @file
+ * @author     Ruby developers <ruby-core@ruby-lang.org>
+ * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
+ *             Permission  is hereby  granted,  to  either redistribute  and/or
+ *             modify this file, provided that  the conditions mentioned in the
+ *             file COPYING are met.  Consult the file for details.
+ * @warning    Symbols   prefixed  with   either  `RBIMPL`   or  `rbimpl`   are
+ *             implementation details.   Don't take  them as canon.  They could
+ *             rapidly appear then vanish.  The name (path) of this header file
+ *             is also an  implementation detail.  Do not expect  it to persist
+ *             at the place it is now.  Developers are free to move it anywhere
+ *             anytime at will.
+ * @note       To  ruby-core:  remember  that   this  header  can  be  possibly
+ *             recursively included  from extension  libraries written  in C++.
+ *             Do not  expect for  instance `__VA_ARGS__` is  always available.
+ *             We assume C99  for ruby itself but we don't  assume languages of
+ *             extension libraries.  They could be written in C++98.
+ * @brief      Arithmetic conversion between C's `uid_t` and Ruby's.
+ */
+#include "ruby/internal/config.h"
+#include "ruby/internal/arithmetic/long.h"
+
+/** Converts a C's `uid_t` into an instance of ::rb_cInteger. */
+#ifndef UIDT2NUM
+# define UIDT2NUM RB_LONG2NUM
+#endif
+
+/** Converts an instance of ::rb_cNumeric into C's `uid_t`. */
+#ifndef NUM2UIDT
+# define NUM2UIDT RB_NUM2LONG
+#endif
+
+/** A rb_sprintf() format prefix to be used for a `uid_t` parameter. */
+#ifndef PRI_UIDT_PREFIX
+# define PRI_UIDT_PREFIX PRI_LONG_PREFIX
+#endif
+
+#endif /* RBIMPL_ARITHMETIC_UID_T_H */

--- a/scolapasta-int-parse/README.md
+++ b/scolapasta-int-parse/README.md
@@ -30,16 +30,16 @@ scolapasta-int-parse = "0.2.2"
 Parse strings into integers like:
 
 ```rust
-use scolapasta_int_parse::{parse, ArgumentError, Radix};
+use scolapasta_int_parse::{parse, Error};
 
-fn example() -> Result<(), ArgumentError<'static>> {
+fn example() -> Result<(), Error<'static>> {
     let int_max = parse("9_223_372_036_854_775_807", None)?;
     assert_eq!(int_max, i64::MAX);
 
     let deadbeef = parse("                       0x000000000deadbeef", None)?;
     assert_eq!(deadbeef, 3_735_928_559);
 
-    let num = parse("32xyz", Radix::new(36))?;
+    let num = parse("32xyz", Some(36))?;
     assert_eq!(num, 5_176_187);
 
     Ok(())

--- a/scolapasta-int-parse/src/lib.rs
+++ b/scolapasta-int-parse/src/lib.rs
@@ -42,6 +42,11 @@
 
 #![no_std]
 
+// Ensure code blocks in `README.md` compile
+#[cfg(doctest)]
+#[doc = include_str!("../README.md")]
+mod readme {}
+
 extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;

--- a/scolapasta-path/src/lib.rs
+++ b/scolapasta-path/src/lib.rs
@@ -32,6 +32,11 @@
 //! assert!(!is_explicit_relative("/artichoke/src/json/pure"));
 //! ```
 
+// Ensure code blocks in `README.md` compile
+#[cfg(doctest)]
+#[doc = include_str!("../README.md")]
+mod readme {}
+
 mod paths;
 mod platform_string;
 


### PR DESCRIPTION
Add a new crate, `scolapasta-fixable` which can test and convert integers to "fixable" range.

Closes #2311.

This PR also includes some opportunistic fixes to tests and READMEs in other crates that were discovered while working on this branch.