### PR TITLE
Reduce scope of ignore list for markdown URLs

### DIFF
--- a/.github/markdown-link-check.json
+++ b/.github/markdown-link-check.json
@@ -4,7 +4,28 @@
       "pattern": "img.shields.io"
     },
     {
-      "pattern": "^https://docs.rs/.*"
+      "pattern": "^https://crates.io/crates/artichoke.*"
+    },
+    {
+      "pattern": "^https://crates.io/crates/mezzaluna.*"
+    },
+    {
+      "pattern": "^https://crates.io/crates/scolapasta.*"
+    },
+    {
+      "pattern": "^https://crates.io/crates/spinoso.*"
+    },
+    {
+      "pattern": "^https://docs.rs/artichoke.*"
+    },
+    {
+      "pattern": "^https://docs.rs/mezzaluna.*"
+    },
+    {
+      "pattern": "^https://docs.rs/scolapasta.*"
+    },
+    {
+      "pattern": "^https://docs.rs/spinoso.*"
     }
   ],
   "replacementPatterns": [],


### PR DESCRIPTION
Restrict ignore list for markdown URLs in markdown-link-check config to only ignore workspace crates in docs.rs and crates.io. All workspace crates have 'artichoke', 'mezzaluna', 'scolapasta', or 'spinoso' prefixes.