### PR TITLE
Experiment with including CC version in `ARTICHOKE_COMPILER_VERSION`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ scolapasta-string-escape = { version = "0.3.0", path = "scolapasta-string-escape
 termcolor = { version = "1.1.0", optional = true }
 
 [build-dependencies]
+artichoke-backend = { version = "0.21.0", path = "artichoke-backend", default-features = false }
 tz-rs = { version = "0.6.12", default-features = false, features = ["std"] }
 
 [[bin]]

--- a/artichoke-backend/build.rs
+++ b/artichoke-backend/build.rs
@@ -222,6 +222,16 @@ mod libs {
             None => {}
         }
 
+        // try to resolve CC version
+        let cc = build.get_compiler().to_command().get_program().to_owned();
+        if let Ok(version) = Command::new(cc).arg("--version").output() {
+            if let Ok(version) = String::from_utf8(version.stdout) {
+                let env = "ARTICHOKE_CC_COMPILER";
+                let value = version.trim();
+                println!("cargo:rustc-env={env}={value}");
+            }
+        }
+
         build.compile(name);
     }
 

--- a/artichoke-backend/src/sys/mod.rs
+++ b/artichoke-backend/src/sys/mod.rs
@@ -30,6 +30,9 @@ pub(crate) mod protect;
 pub use self::args::*;
 pub use self::ffi::*;
 
+/// Version string from C compiler used to build the mruby-sys bindings.
+pub const CC_VERSION: Option<&str> = option_env!("ARTICHOKE_CC_COMPILER");
+
 impl Default for mrb_value {
     fn default() -> Self {
         unsafe { mrb_sys_nil_value() }

--- a/build.rs
+++ b/build.rs
@@ -149,6 +149,10 @@ fn compiler_version() -> Option<String> {
     let compiler_version = Command::new(cmd).arg("-V").output().ok()?;
     let compiler_version = String::from_utf8(compiler_version.stdout).ok()?;
     let mut compiler_version = compiler_version.trim().to_owned();
+    if let Some(cc) = artichoke_backend::sys::CC_VERSION {
+        compiler_version.push_str(" / ");
+        compiler_version.push_str(cc);
+    }
     if let Ok(compiler_host) = env::var("HOST") {
         compiler_version.push_str(" on ");
         compiler_version.push_str(&compiler_host);


### PR DESCRIPTION
Output looks like this:

```console
$ cargo run --quiet --bin artichoke -- -e 'puts ARTICHOKE_COMPILER_VERSION'
rustc 1.68.2 (9eb3afe9e 2023-03-27) / Apple clang version 14.0.3 (clang-1403.0.22.14.1) on x86_64-apple-darwin
```