### PR TITLE
Relax the type bounds on Default and Debug impls in mezzaluna-type-registry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -497,7 +497,7 @@ dependencies = [
 
 [[package]]
 name = "mezzaluna-type-registry"
-version = "1.0.0"
+version = "1.0.1"
 
 [[package]]
 name = "nix"

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -18,7 +18,7 @@ artichoke-core = { version = "0.12.0", path = "../artichoke-core" }
 artichoke-load-path = { version = "0.1.0", path = "../artichoke-load-path", default-features = false }
 bstr = { version = "1.2.0", default-features = false, features = ["alloc"] }
 intaglio = { version = "1.7.0", default-features = false, features = ["bytes"] }
-mezzaluna-type-registry = { version = "1.0.0", path = "../mezzaluna-type-registry" }
+mezzaluna-type-registry = { version = "1.0.1", path = "../mezzaluna-type-registry" }
 once_cell = "1.12.0"
 onig = { version = "6.4.0", optional = true, default-features = false }
 posix-space = "1.0.0"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -316,7 +316,7 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "mezzaluna-type-registry"
-version = "1.0.0"
+version = "1.0.1"
 
 [[package]]
 name = "once_cell"

--- a/mezzaluna-type-registry/Cargo.toml
+++ b/mezzaluna-type-registry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mezzaluna-type-registry"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 description = "Registry for associating static config with Rust types"
 keywords = ["any", "registry", "static", "typemap"]

--- a/mezzaluna-type-registry/README.md
+++ b/mezzaluna-type-registry/README.md
@@ -22,7 +22,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-mezzaluna-type-registry = "1.0.0"
+mezzaluna-type-registry = "1.0.1"
 ```
 
 And store "specs" for Rust types like this:

--- a/mezzaluna-type-registry/src/lib.rs
+++ b/mezzaluna-type-registry/src/lib.rs
@@ -120,8 +120,25 @@ impl<'a, T> Iterator for TypeSpecs<'a, T> {
 /// assert_eq!(reg.get::<Vec<u8>>(), Some(&"String"));
 /// assert_eq!(reg.get::<f64>(), None);
 /// ```
-#[derive(Default, Debug)]
 pub struct Registry<T, S = RandomState>(HashMap<TypeId, Box<T>, S>);
+
+impl<T, S> Default for Registry<T, S>
+where
+    S: Default,
+{
+    fn default() -> Self {
+        Self(HashMap::default())
+    }
+}
+
+impl<T, S> fmt::Debug for Registry<T, S>
+where
+    T: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_map().entries(self.0.iter()).finish()
+    }
+}
 
 impl<T, S> PartialEq for Registry<T, S>
 where

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -567,7 +567,7 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "mezzaluna-type-registry"
-version = "1.0.0"
+version = "1.0.1"
 
 [[package]]
 name = "miniz_oxide"


### PR DESCRIPTION
The impls previously required either `T` or `S` to impl a trait when the bound was not required.