### PR TITLE
Remove errant doc cfg callout in mezzaluna-feature-loader

### DIFF
--- a/mezzaluna-feature-loader/src/loaders/memory.rs
+++ b/mezzaluna-feature-loader/src/loaders/memory.rs
@@ -25,7 +25,6 @@ use std::path::{Path, PathBuf};
 ///
 /// [load path]: Self::load_path
 #[derive(Default, Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(docsrs, doc(cfg(feature = "disk")))]
 pub struct Memory {
     sources: HashMap<PathBuf, Cow<'static, [u8]>>,
 }


### PR DESCRIPTION
Memory loader was tagged as requiring the disk feature. This loader is available with no features enabled.