### PR TITLE
Ensure airb history file can be saved on Windows

### DIFF
--- a/src/repl.rs
+++ b/src/repl.rs
@@ -196,7 +196,16 @@ fn repl_history_file() -> Option<PathBuf> {
     // Ensure the data directory exists but ignore failures (e.g. the dir
     // already exists) because all operations on the history file are best
     // effort and non-blocking.
-    let _ignored = fs::create_dir(data_dir);
+    //
+    // On Windows, the data dir is a path like:
+    //
+    // ```
+    // C:\Users\rjl\AppData\Roaming\artichokeruby\airb\data
+    // ```
+    //
+    // When this path doesn't exist, it contains several directories that
+    // must be created, so we must use `fs::create_dir_all`.
+    let _ignored = fs::create_dir_all(data_dir);
 
     Some(data_dir.join("history"))
 }


### PR DESCRIPTION
In general, the data directory for the org.artichoke.airb app is not guaranteed to exist, including all of its ancestors.

This is the case on Windows, which I have been able to reproduce. Changing the history file resolution to create all ancestor dirs resolves this breakage and allows history to be saved and loaded on Windows.

## Reproducer

```console
> cargo run --bin airb -q
artichoke 0.1.0-pre.0 (2023-04-21 revision 6692) [x86_64-pc-windows-msvc]
[rustc 1.69.0 (84c898d65 2023-04-16) on x86_64-pc-windows-msvc]
[src\repl.rs:199] fs::create_dir(data_dir) = Err(
    Os {
        code: 3,
        kind: NotFound,
        message: "The system cannot find the path specified.",
    },
)
[src\repl.rs:277] hist_file.display() = "C:\\Users\\rjl\\AppData\\Roaming\\artichokeruby\\airb\\data\\history"
[src\repl.rs:280] rl.load_history(hist_file) = Err(
    Io(
        Os {
            code: 3,
            kind: NotFound,
            message: "The system cannot find the path specified.",
        },
    ),
)
>>>
[src\repl.rs:288] hist_file.display() = "C:\\Users\\rjl\\AppData\\Roaming\\artichokeruby\\airb\\data\\history"
[src\repl.rs:291] rl.save_history(hist_file) = Ok(
    (),
)
```

## Fixed

```console
> cargo run --bin airb -q
artichoke 0.1.0-pre.0 (2023-04-21 revision 6692) [x86_64-pc-windows-msvc]
[rustc 1.69.0 (84c898d65 2023-04-16) on x86_64-pc-windows-msvc]
[src\repl.rs:208] fs::create_dir_all(data_dir) = Ok(
    (),
)
[src\repl.rs:286] hist_file.display() = "C:\\Users\\rjl\\AppData\\Roaming\\artichokeruby\\airb\\data\\history"
[src\repl.rs:289] rl.load_history(hist_file) = Err(
    Io(
        Os {
            code: 2,
            kind: NotFound,
            message: "The system cannot find the file specified.",
        },
    ),
)
>>> puts RUBY_DESCRIPTION
artichoke 0.1.0-pre.0 (2023-04-21 revision 6692) [x86_64-pc-windows-msvc]
=> nil
>>>
[src\repl.rs:297] hist_file.display() = "C:\\Users\\rjl\\AppData\\Roaming\\artichokeruby\\airb\\data\\history"
[src\repl.rs:300] rl.save_history(hist_file) = Ok(
    (),
)
> cargo run --bin airb -q
artichoke 0.1.0-pre.0 (2023-04-21 revision 6692) [x86_64-pc-windows-msvc]
[rustc 1.69.0 (84c898d65 2023-04-16) on x86_64-pc-windows-msvc]
[src\repl.rs:208] fs::create_dir_all(data_dir) = Ok(
    (),
)
[src\repl.rs:286] hist_file.display() = "C:\\Users\\rjl\\AppData\\Roaming\\artichokeruby\\airb\\data\\history"
[src\repl.rs:289] rl.load_history(hist_file) = Ok(
    (),
)
>>> puts RUBY_DESCRIPTION # 👈 this line loaded with a ⬆️ keypress
artichoke 0.1.0-pre.0 (2023-04-21 revision 6692) [x86_64-pc-windows-msvc]
=> nil
>>>
[src\repl.rs:297] hist_file.display() = "C:\\Users\\rjl\\AppData\\Roaming\\artichokeruby\\airb\\data\\history"
[src\repl.rs:300] rl.save_history(hist_file) = Ok(
    (),
)
```