### PR TITLE
Add clang-tidy runner and fix violations

### DIFF
--- a/artichoke-backend/build.rs
+++ b/artichoke-backend/build.rs
@@ -30,7 +30,7 @@ mod paths {
     }
 
     pub fn bindgen_header() -> PathBuf {
-        crate_root().join("cext").join("bindgen.h")
+        crate_root().join("cext").join("include").join("bindgen.h")
     }
 }
 

--- a/artichoke-backend/cext/include/bindgen.h
+++ b/artichoke-backend/cext/include/bindgen.h
@@ -7,6 +7,9 @@
  * These bindings are exported in the `artichoke_backend::sys` module.
  */
 
+#ifndef BINDGEN_H
+#define BINDGEN_H
+
 #include <mruby.h>
 #include <mruby/array.h>
 #include <mruby/boxing_no.h>
@@ -35,3 +38,5 @@
 
 #include <mrbsys/ext.h>
 #include <mrbsys/reexports.h>
+
+#endif  // BINDGEN_H

--- a/artichoke-backend/cext/mrbsys/include/mrbsys/ext.h
+++ b/artichoke-backend/cext/mrbsys/include/mrbsys/ext.h
@@ -6,6 +6,9 @@
  * initializers).
  */
 
+#ifndef MRBSYS_EXT_H
+#define MRBSYS_EXT_H
+
 #include <stdbool.h>
 
 #include <mruby.h>
@@ -146,3 +149,5 @@ MRB_API void mrb_sys_safe_gc_mark(mrb_state *mrb, mrb_value value);
 #ifdef __cplusplus
 } /* extern "C" { */
 #endif
+
+#endif  // MRBSYS_EXT_H

--- a/artichoke-backend/cext/mrbsys/include/mrbsys/reexports.h
+++ b/artichoke-backend/cext/mrbsys/include/mrbsys/reexports.h
@@ -1,3 +1,6 @@
+#ifndef MRBSYS_REEXPORTS_H
+#define MRBSYS_REEXPORTS_H
+
 #include <mruby.h>
 #include <mruby/common.h>
 
@@ -11,3 +14,5 @@ MRB_API void mrb_init_mrbgems(mrb_state *mrb);
 #ifdef __cplusplus
 } /* extern "C" { */
 #endif
+
+#endif  // MRBSYS_REEXPORTS_H

--- a/artichoke-backend/cext/mrbsys/src/ext.c
+++ b/artichoke-backend/cext/mrbsys/src/ext.c
@@ -374,6 +374,7 @@ mrb_obj_as_string(mrb_state *mrb, mrb_value obj)
     case MRB_TT_SYMBOL:
       return mrb_sym_str(mrb, mrb_symbol(obj));
     case MRB_TT_INTEGER:
+      // NOLINTNEXTLINE(readability-magic-numbers): print in base 10
       return mrb_integer_to_str(mrb, obj, 10);
     case MRB_TT_SCLASS:
     case MRB_TT_CLASS:

--- a/artichoke-backend/clang-tidy
+++ b/artichoke-backend/clang-tidy
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+unset CDPATH
+
+dir="$(cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+
+cd "$dir" || exit 1
+
+if command -v brew &>/dev/null; then
+  if llvm_prefix="$(brew --prefix llvm 2>/dev/null)"; then
+    PATH="${llvm_prefix}/bin:$PATH"
+    export PATH
+  fi
+fi
+
+exec clang-tidy `find cext -type f \( -name '*.h' -or -name '*.c' \)` \
+  '-checks=-*,
+  clang-analyzer-*,
+  concurrency-*,
+  google-*,
+  llvm-*,
+  -llvm-include-order,
+  misc-*,
+  modernize-*,
+  performance-*,
+  portability-*,
+  readability-*,
+  -readability-identifier-length' \
+  -- \
+  -I vendor/mruby/include \
+  -I cext/mrbsys/include \
+  -DARTICHOKE \
+  -DMRB_ARY_NO_EMBED \
+  -DMRB_GC_TURN_OFF_GENERATIONAL \
+  -DMRB_INT64 \
+  -DMRB_NO_BOXING \
+  -DMRB_NO_PRESYM \
+  -DMRB_NO_STDIO \
+  -DMRB_UTF8_STRING


### PR DESCRIPTION
Clean up clang-tidy violations in artichoke-backend `cext` code and bindings.