### PR TITLE
Pin `dirs-sys` to v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,6 +77,7 @@ dependencies = [
  "bstr",
  "clap",
  "directories",
+ "dirs-sys",
  "log",
  "posix-space",
  "rustyline",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,12 @@ clap = { version = "4.2.4", optional = true }
 directories = { version = "5.0.0", optional = true }
 # XXX: load-bearing unused dependency.
 #
+# `dirs-sys` v4.0.1 includes an additional dependency, `option-ext`, which has
+# an MPL-2.0 license. MPL is a copyleft license, all of which are banned in
+# Artichoke.
+dirs-sys = { version = "=0.4.0", optional = true }
+# XXX: load-bearing unused dependency.
+#
 # `rustyline` improperly declares its minimum version on `log` as `0.4` despite
 # requiring `>=0.4.5` to compile. Link in at least the minimum version here so
 # cargo pulls in at least 0.4.5, e.g. when using `-Zminimal-versions`.
@@ -82,7 +88,16 @@ default = [
 ]
 # Enable a CLI frontend for Artichoke, including a `ruby`-equivalent CLI and
 # REPL.
-cli = ["backtrace", "dep:bstr", "dep:clap", "dep:directories", "dep:log", "dep:posix-space", "dep:rustyline"]
+cli = [
+  "backtrace",
+  "dep:bstr",
+  "dep:clap",
+  "dep:directories",
+  "dep:dirs-sys",
+  "dep:log",
+  "dep:posix-space",
+  "dep:rustyline",
+]
 # Enable a module for formtting backtraces from Ruby exceptions.
 backtrace = ["dep:termcolor"]
 # Enable all features of Ruby Core, Standard Library, and the underlying VM.


### PR DESCRIPTION
`dirs-sys` v0.4.1 brings in an additional dependency, `option-ext`. `option-ext` is licensed with MPL-2.0. MPL-2.0 is a vaguely copyleft license, all of which are banned in Artichoke by `cargo-deny` and `deny.toml`.

See:

- https://github.com/dirs-dev/dirs-sys-rs/issues/21
- https://github.com/dirs-dev/dirs-sys-rs/commit/e169da7af901eb621e5d244efe960f4da8ed150d