### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,8 +31,6 @@ updates:
     directory: "/fuzz"
     schedule:
       interval: monthly
-    allow:
-      - dependency-type: "all"
     open-pull-requests-limit: 10
     assignees:
       - lopopolo


### PR DESCRIPTION
missed a "all" section for the fuzz workspace.

Followup to #2547.