### PR TITLE
Close interpreter if there are errors during init

### DIFF
--- a/src/ruby.rs
+++ b/src/ruby.rs
@@ -109,7 +109,13 @@ where
     W: io::Write + WriteColor,
 {
     let mut interp = crate::interpreter()?;
+    // All operations using the interpreter must occur behind a function
+    // boundary so we can catch all errors and ensure we call `interp.close()`.
+    //
+    // Allowing the `?` operator to be used in the containing `run` function
+    // would result in a memory leak of the interpreter and its heap.
     let result = entrypoint(&mut interp, args, input, error);
+    // Cleanup and deallocate.
     interp.close();
     result
 }


### PR DESCRIPTION
This updates the REPL and interpreter boot to prevent memory leaks if there are errors or exceptions during interpreer boot and initialization.

This commit follows the same approach in:

- https://github.com/artichoke/artichoke/pull/1032

The REPL regressed in:

- https://github.com/artichoke/artichoke/pull/2423

As far as I can tell, interpreter boot in `artichoke-backend` has always had these leak problems on error.