### PR TITLE
Add `artichoke-repl-history` crate, remove `directories` and `dirs-sys` dependencies

### DIFF
--- a/.config/artichoke.dic
+++ b/.config/artichoke.dic
@@ -36,6 +36,7 @@ POSIX
 PRNG/MS
 README/MS
 REPL
+REPL's
 RNG/MS
 RTL
 SipHash
@@ -48,6 +49,7 @@ VM/MS
 VMware
 Wasm
 WebAssembly
+XDG
 ZST
 absolutized
 accessor/MS

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,7 +56,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -66,7 +66,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
 dependencies = [
  "anstyle",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -78,8 +78,6 @@ dependencies = [
  "artichoke-repl-history",
  "bstr",
  "clap",
- "directories",
- "dirs-sys",
  "log",
  "posix-space",
  "rustyline",
@@ -299,26 +297,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
-name = "directories"
-version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74be3be809c18e089de43bdc504652bb2bc473fca8756131f8689db8cf079ba9"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04414300db88f70d74c5ff54e50f9e1d1737d9a5b90f53fcf2e95ca2a9ab554b"
-dependencies = [
- "libc",
- "redox_users",
- "windows-sys 0.45.0",
-]
-
-[[package]]
 name = "errno"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -326,7 +304,7 @@ checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -357,7 +335,7 @@ checksum = "39ae6b3d9530211fb3b12a95374b8b0823be812f53d09e18c5675c0146b09642"
 dependencies = [
  "cfg-if",
  "rustix",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -426,7 +404,7 @@ checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -438,7 +416,7 @@ dependencies = [
  "hermit-abi",
  "io-lifetimes",
  "rustix",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -465,7 +443,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2336c5e342caba9cf3eac97c82970fa2a4a87d0e8671ec711425b67651bbdda"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -683,26 +661,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1e22ce49f28be0887a992cf42172c8c75facdb74e3e1a7eb0f459cf2fcc95d7"
 
 [[package]]
-name = "redox_syscall"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
-dependencies = [
- "getrandom",
- "redox_syscall",
- "thiserror",
-]
-
-[[package]]
 name = "regex"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -736,7 +694,7 @@ dependencies = [
  "io-lifetimes",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -981,26 +939,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "thiserror"
-version = "1.0.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "tinyvec"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1155,16 +1093,7 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
 dependencies = [
- "windows-targets 0.48.0",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1173,22 +1102,7 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets 0.48.0",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1197,20 +1111,14 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
 dependencies = [
- "windows_aarch64_gnullvm 0.48.0",
- "windows_aarch64_msvc 0.48.0",
- "windows_i686_gnu 0.48.0",
- "windows_i686_msvc 0.48.0",
- "windows_x86_64_gnu 0.48.0",
- "windows_x86_64_gnullvm 0.48.0",
- "windows_x86_64_msvc 0.48.0",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -1220,21 +1128,9 @@ checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1244,21 +1140,9 @@ checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1268,21 +1152,9 @@ checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,6 +143,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "artichoke-repl-history"
+version = "1.0.0"
+dependencies = [
+ "known-folders",
+ "sysdir",
+]
+
+[[package]]
 name = "base64"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -955,6 +963,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "sysdir"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "454c7b64faf012c0649e91bc0de7ab05a5597a1382974cb7c98d3a61501a0891"
 
 [[package]]
 name = "termcolor"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,6 +75,7 @@ version = "0.1.0-pre.0"
 dependencies = [
  "artichoke-backend",
  "artichoke-readline",
+ "artichoke-repl-history",
  "bstr",
  "clap",
  "directories",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ documentation.workspace = true
 [dependencies]
 artichoke-backend = { version = "0.23.0", path = "artichoke-backend", default-features = false }
 artichoke-readline = { version = "1.0.0", path = "artichoke-readline", optional = true }
+artichoke-repl-history = { version = "1.0.0", path = "artichoke-repl-history", optional = true }
 bstr = { version = "1.2.0", optional = true, default-features = false }
 clap = { version = "4.2.4", optional = true }
 directories = { version = "5.0.0", optional = true }
@@ -92,6 +93,7 @@ default = [
 cli = [
   "backtrace",
   "dep:artichoke-readline",
+  "dep:artichoke-repl-history",
   "dep:bstr",
   "dep:clap",
   "dep:directories",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,13 +24,6 @@ artichoke-readline = { version = "1.0.0", path = "artichoke-readline", optional 
 artichoke-repl-history = { version = "1.0.0", path = "artichoke-repl-history", optional = true }
 bstr = { version = "1.2.0", optional = true, default-features = false }
 clap = { version = "4.2.4", optional = true }
-directories = { version = "5.0.0", optional = true }
-# XXX: load-bearing unused dependency.
-#
-# `dirs-sys` v4.0.1 includes an additional dependency, `option-ext`, which has
-# an MPL-2.0 license. MPL is a copyleft license, all of which are banned in
-# Artichoke.
-dirs-sys = { version = "=0.4.0", optional = true }
 # XXX: load-bearing unused dependency.
 #
 # `rustyline` improperly declares its minimum version on `log` as `0.4` despite
@@ -96,8 +89,6 @@ cli = [
   "dep:artichoke-repl-history",
   "dep:bstr",
   "dep:clap",
-  "dep:directories",
-  "dep:dirs-sys",
   "dep:log",
   "dep:posix-space",
   "dep:rustyline",

--- a/artichoke-repl-history/Cargo.toml
+++ b/artichoke-repl-history/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "artichoke-repl-history"
+version = "1.0.0"
+authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
+description = "Helpers for working with REPL history files"
+keywords = ["artichoke", "artichoke-ruby", "history", "repl"]
+categories = ["command-line-utilities"]
+readme = "README.md"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+documentation.workspace = true
+
+[dependencies]
+
+[target.'cfg(target_os = "macos")'.dependencies]
+sysdir = "1.0.0"
+
+[target.'cfg(windows)'.dependencies]
+known-folders = "1.0.0"
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/artichoke-repl-history/LICENSE
+++ b/artichoke-repl-history/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2019 Ryan Lopopolo <rjl@hyperbo.la>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/artichoke-repl-history/README.md
+++ b/artichoke-repl-history/README.md
@@ -10,7 +10,7 @@
 
 Helpers for persisting Artichoke `airb` REPL history to disk.
 
-This crate provides platform support for resolving the Aritchoke Ruby airb
+This crate provides platform support for resolving the Artichoke Ruby `airb`
 REPL's application data folder and path to a history file within it.
 
 ## Platform Support
@@ -21,7 +21,7 @@ directory.
 On Windows, the history file is located in the current user's `LocalAppData`
 known folder.
 
-On Linux and other non-macOS unix targets, the history file is located in the
+On Linux and other non-macOS Unix targets, the history file is located in the
 `XDG_STATE_DIR` according to the [XDG Base Directory Specification], with the
 specified fallback if the environment variable is not set.
 

--- a/artichoke-repl-history/README.md
+++ b/artichoke-repl-history/README.md
@@ -22,7 +22,7 @@ On Windows, the history file is located in the current user's `LocalAppData`
 known folder.
 
 On Linux and other non-macOS Unix targets, the history file is located in the
-`XDG_STATE_DIR` according to the [XDG Base Directory Specification], with the
+`XDG_STATE_HOME` according to the [XDG Base Directory Specification], with the
 specified fallback if the environment variable is not set.
 
 [xdg base directory specification]:

--- a/artichoke-repl-history/README.md
+++ b/artichoke-repl-history/README.md
@@ -1,0 +1,53 @@
+# artichoke-repl-history
+
+[![GitHub Actions](https://github.com/artichoke/artichoke/workflows/CI/badge.svg)](https://github.com/artichoke/artichoke/actions)
+[![Discord](https://img.shields.io/discord/607683947496734760)](https://discord.gg/QCe2tp2)
+[![Twitter](https://img.shields.io/twitter/follow/artichokeruby?label=Follow&style=social)](https://twitter.com/artichokeruby)
+<br>
+[![Crate](https://img.shields.io/crates/v/artichoke-repl-history.svg)](https://crates.io/crates/artichoke-repl-history)
+[![API](https://docs.rs/artichoke-repl-history/badge.svg)](https://docs.rs/artichoke-repl-history)
+[![API trunk](https://img.shields.io/badge/docs-trunk-blue.svg)](https://artichoke.github.io/artichoke/artichoke_repl_history/)
+
+Helpers for persisting Artichoke `airb` REPL history to disk.
+
+This crate provides platform support for resolving the Aritchoke Ruby airb
+REPL's application data folder and path to a history file within it.
+
+## Platform Support
+
+On macOS, the history file is located in the current user's Application Support
+directory.
+
+On Windows, the history file is located in the current user's `LocalAppData`
+known folder.
+
+On Linux and other non-macOS unix targets, the history file is located in the
+`XDG_STATE_DIR` according to the [XDG Base Directory Specification], with the
+specified fallback if the environment variable is not set.
+
+[xdg base directory specification]:
+  https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
+
+## Usage
+
+Add this to your `Cargo.toml`:
+
+```toml
+[dependencies]
+artichoke-repl-history = "1.0.0"
+```
+
+And parse Readline editing mode like this:
+
+```rust
+use artichoke_repl_history::repl_history_file;
+
+if let Some(hist_file) = repl_history_file() {
+    // load history ...
+}
+```
+
+## License
+
+`artichoke-repl-history` is licensed with the [MIT License](LICENSE) (c) Ryan
+Lopopolo.

--- a/artichoke-repl-history/src/lib.rs
+++ b/artichoke-repl-history/src/lib.rs
@@ -126,8 +126,8 @@ pub fn repl_history_file() -> Option<PathBuf> {
 #[must_use]
 #[cfg(target_os = "macos")]
 fn repl_history_dir() -> Option<PathBuf> {
-    use std::ffi::{c_char, CStr, OsStr, OsString};
-    use std::os::unix::ffi::{OsStrExt, OsStringExt};
+    use std::ffi::{c_char, CStr, OsString};
+    use std::os::unix::ffi::OsStringExt;
 
     use sysdir::{
         sysdir_get_next_search_path_enumeration, sysdir_search_path_directory_t, sysdir_start_search_path_enumeration,
@@ -183,7 +183,12 @@ fn repl_history_dir() -> Option<PathBuf> {
 
             OsString::from_vec(home).into()
         }
-        path => OsStr::from_bytes(path).to_owned().into(),
+        path => {
+            let mut buf = vec![];
+            buf.try_reserve_exact(path.len()).ok()?;
+            buf.extend_from_slice(path);
+            OsString::from_vec(buf).into()
+        }
     };
     Some(application_support.join("org.artichokeruby.airb"))
 }

--- a/artichoke-repl-history/src/lib.rs
+++ b/artichoke-repl-history/src/lib.rs
@@ -134,6 +134,20 @@ fn repl_history_dir() -> Option<PathBuf> {
         PATH_MAX, SYSDIR_DOMAIN_MASK_USER,
     };
 
+    // Use macOS Standard Directories as retrieved by `sysdir(3)` APIs:
+    //
+    // https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/FileSystemProgrammingGuide/FileSystemOverview/FileSystemOverview.html#//apple_ref/doc/uid/TP40010672-CH2-SW6
+    //
+    // Per Apple:
+    //
+    // > The Library Directory Stores App-Specific Files.
+    // >
+    // > Application Support: Use this directory to store all app data files
+    // > except those associated with the user's documents. For example, you
+    // > might use this directory to store app-created data files, configuration
+    // > files, templates, or other fixed or modifiable resources that are
+    // > managed by the app.
+
     let mut path = [0; PATH_MAX as usize];
 
     let dir = sysdir_search_path_directory_t::SYSDIR_DIRECTORY_APPLICATION_SUPPORT;
@@ -190,6 +204,9 @@ fn repl_history_dir() -> Option<PathBuf> {
             OsString::from_vec(buf).into()
         }
     };
+    // Per Apple docs: All content in this directory should be placed in a
+    // custom subdirectory whose name is that of your app’s bundle identifier
+    // or your company.
     Some(application_support.join("org.artichokeruby.airb"))
 }
 

--- a/artichoke-repl-history/src/lib.rs
+++ b/artichoke-repl-history/src/lib.rs
@@ -33,7 +33,7 @@
 //! known folder.
 //!
 //! On Linux and other non-macOS Unix targets, the history file is located in
-//! the `XDG_STATE_DIR` according to the [XDG Base Directory Specification],
+//! the `XDG_STATE_HOME` according to the [XDG Base Directory Specification],
 //! with the specified fallback if the environment variable is not set.
 //!
 //! # Examples
@@ -361,7 +361,7 @@ mod tests {
 
         let _guard = ENV_LOCK.lock();
 
-        env::remove_var("XDG_STATE_DIR");
+        env::remove_var("XDG_STATE_HOME");
 
         let dir = repl_history_dir().unwrap();
         let mut components = dir.components();
@@ -382,7 +382,7 @@ mod tests {
 
         let _guard = ENV_LOCK.lock();
 
-        env::remove_var("XDG_STATE_DIR");
+        env::remove_var("XDG_STATE_HOME");
 
         let file = repl_history_file().unwrap();
         let mut components = file.components();
@@ -404,8 +404,8 @@ mod tests {
 
         let _guard = ENV_LOCK.lock();
 
-        env::remove_var("XDG_STATE_DIR");
-        env::set_var("XDG_STATE_DIR", "");
+        env::remove_var("XDG_STATE_HOME");
+        env::set_var("XDG_STATE_HOME", "");
 
         let dir = repl_history_dir().unwrap();
         let mut components = dir.components();
@@ -426,8 +426,8 @@ mod tests {
 
         let _guard = ENV_LOCK.lock();
 
-        env::remove_var("XDG_STATE_DIR");
-        env::set_var("XDG_STATE_DIR", "");
+        env::remove_var("XDG_STATE_HOME");
+        env::set_var("XDG_STATE_HOME", "");
 
         let file = repl_history_file().unwrap();
         let mut components = file.components();
@@ -449,8 +449,8 @@ mod tests {
 
         let _guard = ENV_LOCK.lock();
 
-        env::remove_var("XDG_STATE_DIR");
-        env::set_var("XDG_STATE_DIR", "/opt/artichoke/state");
+        env::remove_var("XDG_STATE_HOME");
+        env::set_var("XDG_STATE_HOME", "/opt/artichoke/state");
 
         let dir = repl_history_dir().unwrap();
         let mut components = dir.components();
@@ -470,8 +470,8 @@ mod tests {
 
         let _guard = ENV_LOCK.lock();
 
-        env::remove_var("XDG_STATE_DIR");
-        env::set_var("XDG_STATE_DIR", "/opt/artichoke/state");
+        env::remove_var("XDG_STATE_HOME");
+        env::set_var("XDG_STATE_HOME", "/opt/artichoke/state");
 
         let file = repl_history_file().unwrap();
         let mut components = file.components();

--- a/artichoke-repl-history/src/lib.rs
+++ b/artichoke-repl-history/src/lib.rs
@@ -68,13 +68,15 @@ use std::path::PathBuf;
 /// # Platform Notes
 ///
 /// The file is stored in the application data directory for the host operating
-/// system. For example, on macOS, the history file is located at:
+/// system.
+///
+/// On macOS, the history file is located at a path like:
 ///
 /// ```text
 /// /Users/username/Library/Application Support/org.artichokeruby.airb/history
 /// ```
 ///
-/// On Windows, the history file is located at:
+/// On Windows, the history file is located at a path like:
 ///
 /// ```text
 /// C:\Users\username\AppData\Local\Artichoke Ruby\airb\data\history.txt

--- a/artichoke-repl-history/src/lib.rs
+++ b/artichoke-repl-history/src/lib.rs
@@ -21,7 +21,7 @@
 
 //! Helpers for persisting Artichoke `airb` REPL history to disk.
 //!
-//! This crate provides platform support for resolving the Aritchoke Ruby airb
+//! This crate provides platform support for resolving the Artichoke Ruby `airb`
 //! REPL's application data folder and path to a history file within it.
 //!
 //! # Platform Support
@@ -32,7 +32,7 @@
 //! On Windows, the history file is located in the current user's `LocalAppData`
 //! known folder.
 //!
-//! On Linux and other non-macOS unix targets, the history file is located in
+//! On Linux and other non-macOS Unix targets, the history file is located in
 //! the `XDG_STATE_DIR` according to the [XDG Base Directory Specification],
 //! with the specified fallback if the environment variable is not set.
 //!
@@ -81,7 +81,7 @@ use std::path::PathBuf;
 /// C:\Users\username\AppData\Local\Artichoke Ruby\airb\data\history.txt
 /// ```
 ///
-/// On Linux and other unix platforms excluding macOS, the history file is
+/// On Linux and other Unix platforms excluding macOS, the history file is
 /// located in the XDG state home following the [XDG Base Directory
 /// Specification]. By default, the history file is located at:
 ///
@@ -255,7 +255,7 @@ fn repl_history_dir() -> Option<PathBuf> {
 ///
 /// - On Windows, this function returns `history.txt`.
 /// - On macOS, this function returns `history`.
-/// - On non-macOS unix targets, this function returns `airb_history`.
+/// - On non-macOSUUnix targets, this function returns `airb_history`.
 #[must_use]
 fn history_file_basename() -> &'static str {
     if cfg!(windows) {
@@ -277,7 +277,7 @@ mod tests {
 
     use super::*;
 
-    // Lock for coordinating access to system env for unix target tests.
+    // Lock for coordinating access to system env for Unix target tests.
     #[cfg(all(unix, not(target_os = "macos")))]
     static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 

--- a/artichoke-repl-history/src/lib.rs
+++ b/artichoke-repl-history/src/lib.rs
@@ -492,7 +492,7 @@ mod tests {
         let mut components = dir.components();
 
         let _skip_prefix = components.next().unwrap();
-        assert_eq!(components.next().unwrap().as_os_str(), OsStr::new("/"));
+        assert_eq!(components.next().unwrap().as_os_str(), OsStr::new(r"\"));
         assert_eq!(components.next().unwrap().as_os_str(), OsStr::new("Users"));
         let _skip_user_dir = components.next().unwrap();
         assert_eq!(components.next().unwrap().as_os_str(), OsStr::new("AppData"));
@@ -510,7 +510,7 @@ mod tests {
         let mut components = file.components();
 
         let _skip_prefix = components.next().unwrap();
-        assert_eq!(components.next().unwrap().as_os_str(), OsStr::new("/"));
+        assert_eq!(components.next().unwrap().as_os_str(), OsStr::new(r"\"));
         assert_eq!(components.next().unwrap().as_os_str(), OsStr::new("Users"));
         let _skip_user_dir = components.next().unwrap();
         assert_eq!(components.next().unwrap().as_os_str(), OsStr::new("AppData"));

--- a/artichoke-repl-history/src/lib.rs
+++ b/artichoke-repl-history/src/lib.rs
@@ -1,0 +1,499 @@
+#![warn(clippy::all)]
+#![warn(clippy::pedantic)]
+#![warn(clippy::cargo)]
+#![allow(clippy::manual_let_else)]
+#![allow(clippy::question_mark)] // https://github.com/rust-lang/rust-clippy/issues/8281
+#![allow(unknown_lints)]
+#![warn(missing_docs)]
+#![warn(missing_debug_implementations)]
+#![warn(missing_copy_implementations)]
+#![warn(rust_2018_idioms)]
+#![warn(rust_2021_compatibility)]
+#![warn(trivial_casts, trivial_numeric_casts)]
+#![warn(unused_qualifications)]
+#![warn(variant_size_differences)]
+// Enable feature callouts in generated documentation:
+// https://doc.rust-lang.org/beta/unstable-book/language-features/doc-cfg.html
+//
+// This approach is borrowed from tokio.
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_alias))]
+
+//! Helpers for persisting Artichoke `airb` REPL history to disk.
+//!
+//! This crate provides platform support for resolving the Aritchoke Ruby airb
+//! REPL's application data folder and path to a history file within it.
+//!
+//! # Platform Support
+//!
+//! On macOS, the history file is located in the current user's Application
+//! Support directory.
+//!
+//! On Windows, the history file is located in the current user's `LocalAppData`
+//! known folder.
+//!
+//! On Linux and other non-macOS unix targets, the history file is located in
+//! the `XDG_STATE_DIR` according to the [XDG Base Directory Specification],
+//! with the specified fallback if the environment variable is not set.
+//!
+//! # Examples
+//!
+//! ```
+//! use artichoke_repl_history::repl_history_file;
+//!
+//! if let Some(hist_file) = repl_history_file() {
+//!     // load history ...
+//! }
+//! ```
+//!
+//! [XDG Base Directory Specification]: https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
+
+// Ensure code blocks in `README.md` compile
+#[cfg(doctest)]
+#[doc = include_str!("../README.md")]
+mod readme {}
+
+use std::env;
+use std::path::PathBuf;
+
+/// Retrieve the path to the REPL history file.
+///
+/// This function will attempt to create all parent directories of the returned
+/// path. If creating parent directories fails, the error is ignored.
+///
+/// Callers should call this function once at startup and retain the returned
+/// value for later use. Some platforms depend on ambient global state in the
+/// environment, so subsequent calls may return different results.
+///
+/// # Platform Notes
+///
+/// The file is stored in the application data directory for the host operating
+/// system. For example, on macOS, the history file is located at:
+///
+/// ```text
+/// /Users/username/Library/Application Support/org.artichokeruby.airb/history
+/// ```
+///
+/// On Windows, the history file is located at:
+///
+/// ```text
+/// C:\Users\username\AppData\Local\Artichoke Ruby\airb\data\history.txt
+/// ```
+///
+/// On Linux and other unix platforms excluding macOS, the history file is
+/// located in the XDG state home following the [XDG Base Directory
+/// Specification]. By default, the history file is located at:
+///
+/// ```txt
+/// $HOME/.local/state/artichokeruby/airb_history
+/// ```
+///
+/// # Examples
+///
+/// ```
+/// use artichoke_repl_history::repl_history_file;
+///
+/// if let Some(hist_file) = repl_history_file() {
+///     // load history ...
+/// }
+/// ```
+///
+/// [XDG Base Directory Specification]: https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
+#[must_use]
+pub fn repl_history_file() -> Option<PathBuf> {
+    let data_dir = repl_history_dir()?;
+
+    // Ensure the data directory exists but ignore failures (e.g. the dir
+    // already exists) because all operations on the history file are best
+    // effort and non-blocking.
+    //
+    // On Windows, the data dir is a path like:
+    //
+    // ```
+    // C:\Users\username\AppData\Local\Artichoke Ruby\airb\data
+    // ```
+    //
+    // When this path doesn't exist, it contains several directories that
+    // must be created, so we must use `fs::create_dir_all`.
+    #[cfg(not(any(test, doctest, miri)))] // don't create side effects in tests
+    let _ignored = std::fs::create_dir_all(&data_dir);
+
+    Some(data_dir.join(history_file_basename()))
+}
+
+#[must_use]
+#[cfg(target_os = "macos")]
+fn repl_history_dir() -> Option<PathBuf> {
+    use std::ffi::{c_char, CStr, OsStr, OsString};
+    use std::os::unix::ffi::{OsStrExt, OsStringExt};
+
+    use sysdir::{
+        sysdir_get_next_search_path_enumeration, sysdir_search_path_directory_t, sysdir_start_search_path_enumeration,
+        PATH_MAX, SYSDIR_DOMAIN_MASK_USER,
+    };
+
+    let mut path = [0; PATH_MAX as usize];
+
+    let dir = sysdir_search_path_directory_t::SYSDIR_DIRECTORY_APPLICATION_SUPPORT;
+    let domain_mask = SYSDIR_DOMAIN_MASK_USER;
+    let application_support_bytes = unsafe {
+        // We don't need to loop here, just take the first result.
+        let mut state = sysdir_start_search_path_enumeration(dir, domain_mask);
+        let path = path.as_mut_ptr().cast::<c_char>();
+        state = sysdir_get_next_search_path_enumeration(state, path);
+        if state.is_finished() {
+            return None;
+        }
+        let path = CStr::from_ptr(path);
+        path.to_bytes()
+    };
+
+    // `std::env::home_dir` does not have problematic behavior on `unix`
+    // targets, which includes all apple target OSes and Redox. Per the docs:
+    //
+    // > Deprecated since 1.29.0: This function's behavior may be unexpected on
+    // > Windows. Consider using a crate from crates.io instead.
+    // >
+    // > -- https://doc.rust-lang.org/1.69.0/std/env/fn.home_dir.html
+    //
+    // Additionally, the `home` crate on crates.io, which is owned by the
+    // @rust-lang organization and used in Rustup and Cargo, uses `std::env::home_dir`
+    // to implement `home::home_dir` on `unix` and `target_os = "redox"` targets:
+    //
+    // https://docs.rs/home/0.5.5/src/home/lib.rs.html#71-75
+    #[allow(deprecated)]
+    let application_support = match application_support_bytes {
+        [] => return None,
+        [b'~'] => env::home_dir()?,
+        // Per the `sysdir` man page:
+        //
+        // > Directory paths returned in the user domain will contain "~" to
+        // > refer to the user's directory.
+        //
+        // Below we expand `~/` to `$HOME/` using APIs from `std`.
+        [b'~', b'/', tail @ ..] => {
+            let home = env::home_dir()?;
+            let mut home = home.into_os_string().into_vec();
+
+            home.try_reserve_exact(1 + tail.len()).ok()?;
+            home.push(b'/');
+            home.extend_from_slice(tail);
+
+            OsString::from_vec(home).into()
+        }
+        path => OsStr::from_bytes(path).to_owned().into(),
+    };
+    Some(application_support.join("org.artichokeruby.airb"))
+}
+
+#[must_use]
+#[cfg(all(unix, not(target_os = "macos")))]
+fn repl_history_dir() -> Option<PathBuf> {
+    use std::env;
+
+    // Use state dir from XDG Base Directory Specification/
+    //
+    // https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
+    //
+    // `$XDG_STATE_HOME` defines the base directory relative to which
+    // user-specific state files should be stored. If `$XDG_STATE_HOME` is
+    // either not set or empty, a default equal to `$HOME/.local/state` should
+    // be used.
+
+    let state_home = match env::var_os("XDG_STATE_HOME") {
+        // if `XDG_STATE_HOME` is empty, ignore it and use the default.
+        Some(path) if path.is_empty() => None,
+        Some(path) => Some(path),
+        // if `XDG_STATE_HOME` is not set, use the default.
+        None => None,
+    };
+
+    let state_dir = if let Some(state_dir) = state_dir {
+        state_dir
+    } else {
+        // `std::env::home_dir` does not have problematic behavior on `unix`
+        // targets, which includes all apple target OSes and Redox. Per the docs:
+        //
+        // > Deprecated since 1.29.0: This function's behavior may be unexpected on
+        // > Windows. Consider using a crate from crates.io instead.
+        // >
+        // > -- https://doc.rust-lang.org/1.69.0/std/env/fn.home_dir.html
+        //
+        // Additionally, the `home` crate on crates.io, which is owned by the
+        // @rust-lang organization and used in Rustup and Cargo, uses `std::env::home_dir`
+        // to implement `home::home_dir` on `unix` and `target_os = "redox"` targets:
+        //
+        // https://docs.rs/home/0.5.5/src/home/lib.rs.html#71-75
+        #[allow(deprecated)]
+        let state_dir = env::home_dir()?;
+        state_dir.extend([".local", "state"])
+    };
+
+    Some(state_dir.join("artichokeruby"))
+}
+
+#[must_use]
+#[cfg(windows)]
+fn repl_history_dir() -> Option<PathBuf> {
+    use known_folders::{get_known_folder_path, KnownFolder};
+
+    let local_app_data = get_known_folder_path(KnownFolder::LocalAppData)?;
+    Some(local_app_data.join("Artichoke Ruby").join("airb").join("data"))
+}
+
+/// Basename for history file.
+///
+/// # Platform Notes
+///
+/// - On Windows, this function returns `history.txt`.
+/// - On macOS, this function returns `history`.
+/// - On non-macOS unix targets, this function returns `airb_history`.
+#[must_use]
+fn history_file_basename() -> &'static str {
+    if cfg!(windows) {
+        return "history.txt";
+    }
+    if cfg!(target_os = "macos") {
+        return "history";
+    }
+    if cfg!(unix) {
+        return "airb_history";
+    }
+    "history"
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::OsStr;
+    use std::path;
+
+    use super::*;
+
+    // Lock for coordinating access to system env for unix target tests.
+    #[cfg(all(unix, not(target_os = "macos")))]
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    #[test]
+    fn history_file_basename_is_non_empty() {
+        assert!(!history_file_basename().is_empty());
+    }
+
+    #[test]
+    fn history_file_basename_does_not_contain_path_separators() {
+        let filename = history_file_basename();
+        for c in filename.chars() {
+            assert!(!path::is_separator(c));
+        }
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn history_dir_on_macos() {
+        let dir = repl_history_dir().unwrap();
+        let mut components = dir.components();
+
+        assert_eq!(components.next().unwrap().as_os_str(), OsStr::new("/"));
+        assert_eq!(components.next().unwrap().as_os_str(), OsStr::new("Users"));
+        let _skip_user_dir = components.next().unwrap();
+        assert_eq!(components.next().unwrap().as_os_str(), OsStr::new("Library"));
+        assert_eq!(
+            components.next().unwrap().as_os_str(),
+            OsStr::new("Application Support")
+        );
+        assert_eq!(
+            components.next().unwrap().as_os_str(),
+            OsStr::new("org.artichokeruby.airb")
+        );
+        assert!(components.next().is_none());
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn history_file_on_macos() {
+        let file = repl_history_file().unwrap();
+        let mut components = file.components();
+
+        assert_eq!(components.next().unwrap().as_os_str(), OsStr::new("/"));
+        assert_eq!(components.next().unwrap().as_os_str(), OsStr::new("Users"));
+        let _skip_user_dir = components.next().unwrap();
+        assert_eq!(components.next().unwrap().as_os_str(), OsStr::new("Library"));
+        assert_eq!(
+            components.next().unwrap().as_os_str(),
+            OsStr::new("Application Support")
+        );
+        assert_eq!(
+            components.next().unwrap().as_os_str(),
+            OsStr::new("org.artichokeruby.airb")
+        );
+        assert_eq!(components.next().unwrap().as_os_str(), OsStr::new("history"));
+        assert!(components.next().is_none());
+    }
+
+    #[test]
+    #[cfg(all(unix, not(target_os = "macos")))]
+    fn history_dir_on_unix_xdg_unset() {
+        use std::env;
+
+        let _guard = ENV_LOCK.lock();
+
+        env::remove_env("XDG_STATE_DIR");
+
+        let dir = repl_history_dir().unwrap();
+        let mut components = dir.components();
+
+        assert_eq!(components.next().unwrap().as_os_str(), OsStr::new("/"));
+        assert_eq!(components.next().unwrap().as_os_str(), OsStr::new("home"));
+        let _skip_user_dir = components.next().unwrap();
+        assert_eq!(components.next().unwrap().as_os_str(), OsStr::new(".local"));
+        assert_eq!(components.next().unwrap().as_os_str(), OsStr::new("state"));
+        assert_eq!(components.next().unwrap().as_os_str(), OsStr::new("artichokeruby"));
+        assert!(components.next().is_none());
+    }
+
+    #[test]
+    #[cfg(all(unix, not(target_os = "macos")))]
+    fn history_file_on_unix_xdg_unset() {
+        use std::env;
+
+        let _guard = ENV_LOCK.lock();
+
+        env::remove_env("XDG_STATE_DIR");
+
+        let file = repl_history_file().unwrap();
+        let mut components = file.components();
+
+        assert_eq!(components.next().unwrap().as_os_str(), OsStr::new("/"));
+        assert_eq!(components.next().unwrap().as_os_str(), OsStr::new("home"));
+        let _skip_user_dir = components.next().unwrap();
+        assert_eq!(components.next().unwrap().as_os_str(), OsStr::new(".local"));
+        assert_eq!(components.next().unwrap().as_os_str(), OsStr::new("state"));
+        assert_eq!(components.next().unwrap().as_os_str(), OsStr::new("artichokeruby"));
+        assert_eq!(components.next().unwrap().as_os_str(), OsStr::new("airb_history"));
+        assert!(components.next().is_none());
+    }
+
+    #[test]
+    #[cfg(all(unix, not(target_os = "macos")))]
+    fn history_dir_on_unix_empty_xdg_state_dir() {
+        use std::env;
+
+        let _guard = ENV_LOCK.lock();
+
+        env::remove_env("XDG_STATE_DIR");
+        env::set_var("XDG_STATE_DIR", "");
+
+        let dir = repl_history_dir().unwrap();
+        let mut components = dir.components();
+
+        assert_eq!(components.next().unwrap().as_os_str(), OsStr::new("/"));
+        assert_eq!(components.next().unwrap().as_os_str(), OsStr::new("home"));
+        let _skip_user_dir = components.next().unwrap();
+        assert_eq!(components.next().unwrap().as_os_str(), OsStr::new(".local"));
+        assert_eq!(components.next().unwrap().as_os_str(), OsStr::new("state"));
+        assert_eq!(components.next().unwrap().as_os_str(), OsStr::new("artichokeruby"));
+        assert!(components.next().is_none());
+    }
+
+    #[test]
+    #[cfg(all(unix, not(target_os = "macos")))]
+    fn history_file_on_unix_empty_xdg_state_dir() {
+        use std::env;
+
+        let _guard = ENV_LOCK.lock();
+
+        env::remove_env("XDG_STATE_DIR");
+        env::set_var("XDG_STATE_DIR", "");
+
+        let file = repl_history_file().unwrap();
+        let mut components = file.components();
+
+        assert_eq!(components.next().unwrap().as_os_str(), OsStr::new("/"));
+        assert_eq!(components.next().unwrap().as_os_str(), OsStr::new("home"));
+        let _skip_user_dir = components.next().unwrap();
+        assert_eq!(components.next().unwrap().as_os_str(), OsStr::new(".local"));
+        assert_eq!(components.next().unwrap().as_os_str(), OsStr::new("state"));
+        assert_eq!(components.next().unwrap().as_os_str(), OsStr::new("artichokeruby"));
+        assert_eq!(components.next().unwrap().as_os_str(), OsStr::new("airb_history"));
+        assert!(components.next().is_none());
+    }
+
+    #[test]
+    #[cfg(all(unix, not(target_os = "macos")))]
+    fn history_dir_on_unix_set_xdg_state_dir() {
+        use std::env;
+
+        let _guard = ENV_LOCK.lock();
+
+        env::remove_env("XDG_STATE_DIR");
+        env::set_var("XDG_STATE_DIR", "/opt/artichoke/state");
+
+        let dir = repl_history_dir().unwrap();
+        let mut components = dir.components();
+
+        assert_eq!(components.next().unwrap().as_os_str(), OsStr::new("/"));
+        assert_eq!(components.next().unwrap().as_os_str(), OsStr::new("opt"));
+        assert_eq!(components.next().unwrap().as_os_str(), OsStr::new("artichoke"));
+        assert_eq!(components.next().unwrap().as_os_str(), OsStr::new("state"));
+        assert_eq!(components.next().unwrap().as_os_str(), OsStr::new("artichokeruby"));
+        assert!(components.next().is_none());
+    }
+
+    #[test]
+    #[cfg(all(unix, not(target_os = "macos")))]
+    fn history_file_on_unix_set_xdg_state_dir() {
+        use std::env;
+
+        let _guard = ENV_LOCK.lock();
+
+        env::remove_env("XDG_STATE_DIR");
+        env::set_var("XDG_STATE_DIR", "/opt/artichoke/state");
+
+        let file = repl_history_file().unwrap();
+        let mut components = file.components();
+
+        assert_eq!(components.next().unwrap().as_os_str(), OsStr::new("/"));
+        assert_eq!(components.next().unwrap().as_os_str(), OsStr::new("opt"));
+        assert_eq!(components.next().unwrap().as_os_str(), OsStr::new("artichoke"));
+        assert_eq!(components.next().unwrap().as_os_str(), OsStr::new("state"));
+        assert_eq!(components.next().unwrap().as_os_str(), OsStr::new("artichokeruby"));
+        assert_eq!(components.next().unwrap().as_os_str(), OsStr::new("airb_history"));
+        assert!(components.next().is_none());
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn history_dir_on_windows() {
+        let dir = repl_history_dir().unwrap();
+        let mut components = dir.components();
+
+        let _skip_prefix = components.next().unwrap();
+        assert_eq!(components.next().unwrap().as_os_str(), OsStr::new("/"));
+        assert_eq!(components.next().unwrap().as_os_str(), OsStr::new("Users"));
+        let _skip_user_dir = components.next().unwrap();
+        assert_eq!(components.next().unwrap().as_os_str(), OsStr::new("AppData"));
+        assert_eq!(components.next().unwrap().as_os_str(), OsStr::new("Local"));
+        assert_eq!(components.next().unwrap().as_os_str(), OsStr::new("Artichoke Ruby"));
+        assert_eq!(components.next().unwrap().as_os_str(), OsStr::new("airb"));
+        assert_eq!(components.next().unwrap().as_os_str(), OsStr::new("data"));
+        assert!(components.next().is_none());
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn history_file_on_windows() {
+        let file = repl_history_file().unwrap();
+        let mut components = file.components();
+
+        let _skip_prefix = components.next().unwrap();
+        assert_eq!(components.next().unwrap().as_os_str(), OsStr::new("/"));
+        assert_eq!(components.next().unwrap().as_os_str(), OsStr::new("Users"));
+        let _skip_user_dir = components.next().unwrap();
+        assert_eq!(components.next().unwrap().as_os_str(), OsStr::new("AppData"));
+        assert_eq!(components.next().unwrap().as_os_str(), OsStr::new("Local"));
+        assert_eq!(components.next().unwrap().as_os_str(), OsStr::new("Artichoke Ruby"));
+        assert_eq!(components.next().unwrap().as_os_str(), OsStr::new("airb"));
+        assert_eq!(components.next().unwrap().as_os_str(), OsStr::new("data"));
+        assert_eq!(components.next().unwrap().as_os_str(), OsStr::new("history.txt"));
+        assert!(components.next().is_none());
+    }
+}

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,5 +1,4 @@
 doc-valid-idents = [
   "DoS",
-  "OpenSSL",
-  "SipHash",
+  ".."
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -21,7 +21,7 @@ default = "deny"
 confidence-threshold = 0.8
 
 [bans]
-multiple-versions = "warn" # multiple versions of syn and windows-sys as ecosystem converges
+multiple-versions = "deny"
 wildcards = "deny"
 highlight = "all"
 allow = []

--- a/src/bin/airb.rs
+++ b/src/bin/airb.rs
@@ -1,7 +1,6 @@
 #![warn(clippy::all)]
 #![warn(clippy::pedantic)]
-// duplicate syn and windows-sys deps as ecosystem converges
-// #![warn(clippy::cargo)]
+#![warn(clippy::cargo)]
 #![allow(unknown_lints)]
 #![warn(missing_docs)]
 #![warn(missing_debug_implementations)]

--- a/src/bin/artichoke.rs
+++ b/src/bin/artichoke.rs
@@ -1,7 +1,6 @@
 #![warn(clippy::all)]
 #![warn(clippy::pedantic)]
-// duplicate syn and windows-sys deps as ecosystem converges
-// #![warn(clippy::cargo)]
+#![warn(clippy::cargo)]
 #![allow(unknown_lints)]
 #![warn(missing_docs)]
 #![warn(missing_debug_implementations)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 #![warn(clippy::all)]
 #![warn(clippy::pedantic)]
-// duplicate syn and windows-sys deps as ecosystem converges
-// #![warn(clippy::cargo)]
+#![warn(clippy::cargo)]
 #![allow(unknown_lints)]
 #![allow(clippy::manual_let_else)]
 #![allow(clippy::module_name_repetitions)]

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -6,13 +6,11 @@
 
 use std::error;
 use std::fmt;
-use std::fs;
 use std::io;
-use std::path::PathBuf;
 use std::sync::PoisonError;
 
 use artichoke_readline::{get_readline_edit_mode, rl_read_init_file};
-use directories::ProjectDirs;
+use artichoke_repl_history::repl_history_file;
 use rustyline::config::Builder;
 use rustyline::error::ReadlineError;
 use rustyline::history::FileHistory;
@@ -177,37 +175,6 @@ fn preamble(interp: &mut Artichoke) -> Result<String, Error> {
     buf.push_str(compiler);
     buf.push(']');
     Ok(buf)
-}
-
-// Retrieve the path to the REPL history file.
-//
-// Readline input history is stored in this file.
-//
-// The file is stored in the data directory for the host operating system. For
-// example, on macOS, the history file is located at:
-//
-// ```text
-// /Users/username/Library/Application Support/org.artichokeruby.airb/history
-// ```
-fn repl_history_file() -> Option<PathBuf> {
-    let dirs = ProjectDirs::from("org", "artichokeruby", "airb")?;
-
-    let data_dir = dirs.data_dir();
-    // Ensure the data directory exists but ignore failures (e.g. the dir
-    // already exists) because all operations on the history file are best
-    // effort and non-blocking.
-    //
-    // On Windows, the data dir is a path like:
-    //
-    // ```
-    // C:\Users\rjl\AppData\Roaming\artichokeruby\airb\data
-    // ```
-    //
-    // When this path doesn't exist, it contains several directories that
-    // must be created, so we must use `fs::create_dir_all`.
-    let _ignored = fs::create_dir_all(data_dir);
-
-    Some(data_dir.join("history"))
 }
 
 /// Initialize an [`Artichoke`] interpreter for a REPL environment.


### PR DESCRIPTION
This crate replaces uses of `directories` on `artichoke::repl` for resolving the location of the history file.

`artichoke-repl-history` supports the following platforms:

- macOS with the history file stored in `~/Library/Application Support`. Platform support is provided by the first-party `sysdir` crate.
- Windows with the history file stored in the `LocalAppData` Known Folder. Platform support is provided by the first-party `known-folders` crate.
- Linux and other non-macOS unix with platform support provided by a local implementation of the XDG Base Directory Specification for `XDG_STATE_HOME`.

`directories` and `dirs-sys` are no longer acceptable dependencies due to licensing issues. See:

- https://github.com/artichoke/artichoke/pull/2543

The recent substitution of `directories::ProjectDirs` for `artichoke-repl-history` removed the last use of the `directories` crate. This PR removes it as an explicit dependency.

This change drops 15 deps from `Cargo.lock` including the `thiserror` proc macro, Redox support crates which are not necessary since Redox became a unix target in Rustc, and duplicate versions of `windows-sys`.

As of this PR, there are no more duplicate deps in `Cargo.lock`.

## Breaking

On Linux (and other non-macOS unix), the path to the history file has changed and the history file itself has been renamed from `history` to `airb_history`.

On Windows, the path to the history file is stored in `AppDataLocal` known folder instead of `AppDataRoaming`. `AppDataRoaming` is deprecated on Windows 11.

No migration or removal of previous state is performed.