### PR TITLE
Deactivate clap's 'color' feature

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,6 +95,8 @@ rake build                         # Build Rust workspace
 rake build:all                     # Build Rust workspace and sub-workspaces
 rake bundle:audit:check            # Checks the Gemfile.lock for insecure dependencies
 rake bundle:audit:update           # Updates the bundler-audit vulnerability database
+rake deps:firstparty               # List first-party crate dependencies
+rake deps:thirdparty               # List third-party crate dependencies
 rake doc                           # Generate Rust API documentation
 rake doc:open                      # Generate Rust API documentation and open it in a web browser
 rake fmt                           # Format sources

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,53 +21,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "anstream"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
-dependencies = [
- "anstyle",
- "anstyle-parse",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is-terminal",
- "utf8parse",
-]
-
-[[package]]
 name = "anstyle"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41ed9a86bf92ae6580e0a31281f65a1b1d867c0cc68d5346e2ae128dddfa6a7d"
-
-[[package]]
-name = "anstyle-parse"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e765fd216e48e067936442276d1d57399e37bce53c264d6fefbe298080cb57ee"
-dependencies = [
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle-query"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
-dependencies = [
- "windows-sys",
-]
-
-[[package]]
-name = "anstyle-wincon"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
-dependencies = [
- "anstyle",
- "windows-sys",
-]
 
 [[package]]
 name = "artichoke"
@@ -241,20 +198,19 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.2.7"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34d21f9bf1b425d2968943631ec91202fe5e837264063503708b83013f8fc938"
+checksum = "93aae7a4192245f70fe75dd9157fc7b4a5bf53e88d30bd4396f7d8f9284d5acc"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.2.7"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "914c8c79fb560f238ef6429439a30023c862f7a28e688c58f7203f12b29970bd"
+checksum = "4f423e341edefb78c9caba2d9c7f7687d0e72e89df3ce3394554754393ac3990"
 dependencies = [
- "anstream",
  "anstyle",
  "bitflags",
  "clap_lex",
@@ -263,9 +219,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a2dd5a6fe8c6e3502f568a6353e5273bbb15193ad9a89e457b9970798efbea1"
+checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 
 [[package]]
 name = "clipboard-win"
@@ -277,12 +233,6 @@ dependencies = [
  "str-buf",
  "winapi",
 ]
-
-[[package]]
-name = "colorchoice"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "const_fn"
@@ -404,18 +354,6 @@ checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys",
-]
-
-[[package]]
-name = "is-terminal"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
-dependencies = [
- "hermit-abi",
- "io-lifetimes",
- "rustix",
  "windows-sys",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ artichoke-backend = { version = "0.23.0", path = "artichoke-backend", default-fe
 artichoke-readline = { version = "1.0.0", path = "artichoke-readline", optional = true }
 artichoke-repl-history = { version = "1.0.0", path = "artichoke-repl-history", optional = true }
 bstr = { version = "1.2.0", optional = true, default-features = false }
-clap = { version = "4.2.4", optional = true }
+clap = { version = "4.3.0", optional = true, default-features = false, features = ["std", "help", "usage", "error-context", "suggestions"] }
 # XXX: load-bearing unused dependency.
 #
 # `rustyline` improperly declares its minimum version on `log` as `0.4` despite

--- a/Rakefile
+++ b/Rakefile
@@ -235,3 +235,45 @@ namespace :toolchain do
     end
   end
 end
+
+namespace :deps do
+  KNOWN_WORKSPACE_PREFIXES = %w[
+    artichoke
+    mezzaluna
+    scolapasta
+    spinoso
+  ]
+  KNOWN_FIRST_PARTY = %w[
+    focaccia
+    intaglio
+    known-folders
+    posix-space
+    qed
+    rand_mt
+    raw-parts
+    roe
+    strftime-ruby
+    sysdir
+  ]
+
+  desc 'List first-party crate dependencies'
+  task :firstparty do
+    deps = File.readlines("Cargo.lock", chomp: true)
+      .select { |line| line.start_with?("name = ") }
+      .map { |line| line.delete_prefix('name = "') }
+      .map { |line| line.delete_suffix('"') }
+      .select { |dep| KNOWN_FIRST_PARTY.include?(dep) || KNOWN_WORKSPACE_PREFIXES.any? { |prefix| dep.include?(prefix) } }
+    puts deps
+  end
+
+  desc 'List third-party crate dependencies'
+  task :thirdparty do
+    deps = File.readlines("Cargo.lock", chomp: true)
+      .select { |line| line.start_with?("name = ") }
+      .map { |line| line.delete_prefix('name = "') }
+      .map { |line| line.delete_suffix('"') }
+      .reject { |dep| KNOWN_FIRST_PARTY.include?(dep) }
+      .reject { |dep| KNOWN_WORKSPACE_PREFIXES.any? { |prefix| dep.include?(prefix) } }
+    puts deps
+  end
+end

--- a/Rakefile
+++ b/Rakefile
@@ -236,30 +236,31 @@ namespace :toolchain do
   end
 end
 
-namespace :deps do
-  KNOWN_WORKSPACE_PREFIXES = %w[
-    artichoke
-    mezzaluna
-    scolapasta
-    spinoso
-  ]
-  KNOWN_FIRST_PARTY = %w[
-    focaccia
-    intaglio
-    known-folders
-    posix-space
-    qed
-    rand_mt
-    raw-parts
-    roe
-    strftime-ruby
-    sysdir
-  ]
+KNOWN_WORKSPACE_PREFIXES = %w[
+  artichoke
+  mezzaluna
+  scolapasta
+  spinoso
+].freeze
 
+KNOWN_FIRST_PARTY = %w[
+  focaccia
+  intaglio
+  known-folders
+  posix-space
+  qed
+  rand_mt
+  raw-parts
+  roe
+  strftime-ruby
+  sysdir
+].freeze
+
+namespace :deps do
   desc 'List first-party crate dependencies'
   task :firstparty do
-    deps = File.readlines("Cargo.lock", chomp: true)
-      .select { |line| line.start_with?("name = ") }
+    deps = File.readlines('Cargo.lock', chomp: true)
+      .select { |line| line.start_with?('name = ') }
       .map { |line| line.delete_prefix('name = "') }
       .map { |line| line.delete_suffix('"') }
       .select { |dep| KNOWN_FIRST_PARTY.include?(dep) || KNOWN_WORKSPACE_PREFIXES.any? { |prefix| dep.include?(prefix) } }
@@ -268,8 +269,8 @@ namespace :deps do
 
   desc 'List third-party crate dependencies'
   task :thirdparty do
-    deps = File.readlines("Cargo.lock", chomp: true)
-      .select { |line| line.start_with?("name = ") }
+    deps = File.readlines('Cargo.lock', chomp: true)
+      .select { |line| line.start_with?('name = ') }
       .map { |line| line.delete_prefix('name = "') }
       .map { |line| line.delete_suffix('"') }
       .reject { |dep| KNOWN_FIRST_PARTY.include?(dep) }

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -36,53 +36,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "anstream"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
-dependencies = [
- "anstyle",
- "anstyle-parse",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is-terminal",
- "utf8parse",
-]
-
-[[package]]
 name = "anstyle"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41ed9a86bf92ae6580e0a31281f65a1b1d867c0cc68d5346e2ae128dddfa6a7d"
-
-[[package]]
-name = "anstyle-parse"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e765fd216e48e067936442276d1d57399e37bce53c264d6fefbe298080cb57ee"
-dependencies = [
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle-query"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
-dependencies = [
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "anstyle-wincon"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
-dependencies = [
- "anstyle",
- "windows-sys 0.48.0",
-]
 
 [[package]]
 name = "artichoke"
@@ -269,20 +226,19 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.2.7"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34d21f9bf1b425d2968943631ec91202fe5e837264063503708b83013f8fc938"
+checksum = "93aae7a4192245f70fe75dd9157fc7b4a5bf53e88d30bd4396f7d8f9284d5acc"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.2.7"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "914c8c79fb560f238ef6429439a30023c862f7a28e688c58f7203f12b29970bd"
+checksum = "4f423e341edefb78c9caba2d9c7f7687d0e72e89df3ce3394554754393ac3990"
 dependencies = [
- "anstream",
  "anstyle",
  "bitflags",
  "clap_lex",
@@ -291,15 +247,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a2dd5a6fe8c6e3502f568a6353e5273bbb15193ad9a89e457b9970798efbea1"
-
-[[package]]
-name = "colorchoice"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 
 [[package]]
 name = "const_fn"
@@ -359,27 +309,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "errno"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
-dependencies = [
- "errno-dragonfly",
- "libc",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
 name = "focaccia"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -419,12 +348,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
-name = "hermit-abi"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
-
-[[package]]
 name = "iana-time-zone"
 version = "0.1.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -452,29 +375,6 @@ name = "intaglio"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b4f756a47a2dac507018af2d4e47988e93829f34a665da3655b23cc1d21ee47"
-
-[[package]]
-name = "io-lifetimes"
-version = "1.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "is-terminal"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
-dependencies = [
- "hermit-abi",
- "io-lifetimes",
- "rustix",
- "windows-sys 0.48.0",
-]
 
 [[package]]
 name = "itoa"
@@ -533,12 +433,6 @@ name = "libm"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ece97ea872ece730aed82664c424eb4c8291e1ff2480247ccf7409044bc6479f"
 
 [[package]]
 name = "lock_api"
@@ -661,7 +555,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys 0.45.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -817,20 +711,6 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
-name = "rustix"
-version = "0.37.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acf8729d8542766f1b2cf77eb034d52f40d375bb8b615d0b147089946e16613d"
-dependencies = [
- "bitflags",
- "errno",
- "io-lifetimes",
- "libc",
- "linux-raw-sys",
- "windows-sys 0.48.0",
-]
 
 [[package]]
 name = "ryu"
@@ -1142,12 +1022,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
 
 [[package]]
-name = "utf8parse"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
-
-[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1270,15 +1144,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.0",
 ]
 
 [[package]]

--- a/spec-runner/Cargo.toml
+++ b/spec-runner/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["development-tools::testing"]
 [dependencies]
 artichoke = { version = "0.1.0-pre.0", path = "..", default-features = false, features = ["backtrace", "kitchen-sink"] }
 basic-toml = "0.1.1"
-clap = "4.2.4"
+clap = { version = "4.3.0", default-features = false, features = ["std", "help", "usage", "error-context", "suggestions"] }
 dhat = { version = "0.3.0", optional = true }
 rust-embed = "6.3.0"
 serde = { version = "1.0.136", features = ["derive"] }


### PR DESCRIPTION
This removes 6 deps in the root workspace and 14 in the spec-runner.

Upgrade clap to v4.3.0.

Add new Rake tasks that can enumerate first party and third party dependencies by inspecting `Cargo.lock`.

```console
$ bundle exec rake deps:thirdparty | wc -l # main
     103
$ bundle exec rake deps:thirdparty | wc -l # this PR
      97
```