### PR TITLE
Ban `dirs-sys` in `deny.toml`

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -27,6 +27,8 @@ highlight = "all"
 allow = []
 deny = [
   { name = "time", version = ">=0.2.0" },
+  # See https://github.com/artichoke/artichoke/pull/2564 for more context.
+  { name = "dirs-sys", version = ">= 0.4.1" },
 ]
 skip = []
 skip-tree = []


### PR DESCRIPTION
`dirs-sys` v0.4.1 brings in an additional dependency, `option-ext`. `option-ext` is licensed with MPL-2.0. MPL-2.0 is a vaguely copyleft license, all of which are banned in Artichoke by `cargo-deny` and `deny.toml`.

Complete the removal in `artichoke` and prevent regressions by banning this dep with `cargo-deny`.

See:

- https://github.com/dirs-dev/dirs-sys-rs/issues/21
- https://github.com/dirs-dev/dirs-sys-rs/commit/e169da7af901eb621e5d244efe960f4da8ed150d
- https://github.com/artichoke/artichoke/pull/2543
- https://github.com/artichoke/artichoke/pull/2556
- https://github.com/artichoke/artichoke/pull/2559