### PR TITLE
API work on mezzaluna-feature-loader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -441,7 +441,7 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "mezzaluna-feature-loader"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "same-file",
  "scolapasta-path",

--- a/mezzaluna-feature-loader/Cargo.toml
+++ b/mezzaluna-feature-loader/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mezzaluna-feature-loader"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 description = "Source and extension loaders for a managing a Ruby $LOAD_PATH"
 keywords = ["artichoke", "artichoke-ruby", "load-path", "ruby"]

--- a/mezzaluna-feature-loader/src/loaders/disk.rs
+++ b/mezzaluna-feature-loader/src/loaders/disk.rs
@@ -28,6 +28,7 @@ use scolapasta_path::is_explicit_relative;
 /// use std::path::{Path, PathBuf};
 /// use mezzaluna_feature_loader::loaders::Disk;
 ///
+/// # #[cfg(unix)]
 /// # fn example() -> Option<()> {
 /// // Search `/home/artichoke/src` first, only attempting to search
 /// // `/usr/share/artichoke` if no file is found in `/home/artichoke/src`.
@@ -44,6 +45,7 @@ use scolapasta_path::is_explicit_relative;
 /// )?;
 /// # Some(())
 /// # }
+/// # #[cfg(unix)]
 /// # example().unwrap();
 /// ```
 ///
@@ -165,6 +167,7 @@ impl Disk {
     /// use std::path::{Path, PathBuf};
     /// use mezzaluna_feature_loader::loaders::Disk;
     ///
+    /// # #[cfg(unix)]
     /// # fn example() -> Option<()> {
     /// // Search `/home/artichoke/src` first, only attempting to search
     /// // `/usr/share/artichoke` if no file is found in `/home/artichoke/src`.
@@ -181,6 +184,7 @@ impl Disk {
     /// )?;
     /// # Some(())
     /// # }
+    /// # #[cfg(unix)]
     /// # example().unwrap();
     /// ```
     /// [`load_path`]: Self::load_path
@@ -254,6 +258,7 @@ impl Disk {
     /// use std::path::{Path, PathBuf};
     /// use mezzaluna_feature_loader::loaders::Disk;
     ///
+    /// # #[cfg(unix)]
     /// # fn example() -> Option<()> {
     /// let loader = Disk::with_load_path_and_cwd(
     ///     [
@@ -273,6 +278,7 @@ impl Disk {
     /// );
     /// # Some(())
     /// # }
+    /// # #[cfg(unix)]
     /// # example().unwrap();
     /// ```
     #[inline]
@@ -291,6 +297,7 @@ impl Disk {
     /// use std::path::{Path, PathBuf};
     /// use mezzaluna_feature_loader::loaders::Disk;
     ///
+    /// # #[cfg(unix)]
     /// # fn example() -> Option<()> {
     /// let mut loader = Disk::with_load_path_and_cwd(
     ///     [
@@ -322,6 +329,7 @@ impl Disk {
     /// assert_eq!(loader.load_path(), [Path::new("/home/app/libpath")]);
     /// # Some(())
     /// # }
+    /// # #[cfg(unix)]
     /// # example().unwrap();
     /// ```
     #[inline]

--- a/mezzaluna-feature-loader/src/loaders/memory.rs
+++ b/mezzaluna-feature-loader/src/loaders/memory.rs
@@ -10,17 +10,14 @@ use std::path::{Path, PathBuf};
 /// virtual file system.
 ///
 /// The memory loader has a hard-coded load path and only supports loading paths
-/// that are relative or absolute within this loader's [load path].
+/// that are relative to or absolute within this loader's [load path].
+///
+/// # Examples
 ///
 /// ```
-/// # use std::ffi::OsStr;
-/// # use std::path::{Path, PathBuf};
-/// # use mezzaluna_feature_loader::loaders::Memory;
-/// # fn example() -> Option<()> {
-/// let loader = Memory::new();
-/// # Some(())
-/// # }
-/// # example().unwrap();
+/// use mezzaluna_feature_loader::loaders::Memory;
+///
+/// let mut loader = Memory::new();
 /// ```
 ///
 /// [load path]: Self::load_path
@@ -40,6 +37,15 @@ impl Memory {
     ///
     /// This source loader does NOT grant access to the host file system. The
     /// `Memory` loader does not support native extensions.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use mezzaluna_feature_loader::loaders::Memory;
+    ///
+    /// let mut loader = Memory::new();
+    /// assert_eq!(loader.capacity(), 0);
+    /// ```
     ///
     /// [load path]: Self::load_path
     #[inline]
@@ -62,6 +68,15 @@ impl Memory {
     /// This source loader does NOT grant access to the host file system. The
     /// `Memory` loader does not support native extensions.
     ///
+    /// # Examples
+    ///
+    /// ```
+    /// use mezzaluna_feature_loader::loaders::Memory;
+    ///
+    /// let mut loader = Memory::with_capacity(10);
+    /// assert!(loader.capacity() >= 10);
+    /// ```
+    ///
     /// [load path]: Self::load_path
     #[inline]
     #[must_use]
@@ -69,6 +84,25 @@ impl Memory {
         Self {
             sources: HashMap::with_capacity(capacity),
         }
+    }
+
+    /// Returns the number of sources the loader can hold without reallocating.
+    ///
+    /// This number is a lower bound; the memory loader might be able to hold
+    /// more, but is guaranteed to be able to hold at least this many.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use mezzaluna_feature_loader::loaders::Memory;
+    ///
+    /// let mut loader = Memory::with_capacity(10);
+    /// assert!(loader.capacity() >= 10);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn capacity(&self) -> usize {
+        self.sources.capacity()
     }
 
     /// Check whether `path` points to a file in the backing file system and
@@ -108,20 +142,16 @@ impl Memory {
     /// # Examples
     ///
     /// ```
-    /// # use std::ffi::OsStr;
-    /// # use std::path::{Path, PathBuf};
-    /// # use mezzaluna_feature_loader::loaders::Memory;
-    /// # fn example() -> Option<()> {
+    /// use std::path::{Path, PathBuf};
+    /// use mezzaluna_feature_loader::loaders::Memory;
+    ///
+    /// const STRSCAN: &[u8] = b"class StringScanner; end";
+    ///
     /// let mut loader = Memory::new();
-    /// loader.put_file_bytes(
-    ///     PathBuf::from("strscan.rb"),
-    ///     b"class StringScanner; end".to_vec(),
-    /// );
+    /// loader.put_file_bytes(PathBuf::from("strscan.rb"), STRSCAN);
+    ///
     /// let content = loader.resolve_file(Path::new("strscan.rb"));
-    /// assert_eq!(content, Some("class StringScanner; end".as_bytes()));
-    /// # Some(())
-    /// # }
-    /// # example().unwrap();
+    /// assert_eq!(content, Some(STRSCAN));
     /// ```
     ///
     /// [load path]: Self::load_path
@@ -161,17 +191,16 @@ impl Memory {
     /// # Examples
     ///
     /// ```
-    /// # use std::ffi::OsStr;
-    /// # use std::path::{Path, PathBuf};
-    /// # use mezzaluna_feature_loader::loaders::Memory;
-    /// # fn example() -> Option<()> {
+    /// use std::path::{Path, PathBuf};
+    /// use mezzaluna_feature_loader::loaders::Memory;
+    ///
+    /// const STRSCAN: &str = "class StringScanner; end";
+    ///
     /// let mut loader = Memory::new();
-    /// loader.put_file_str(PathBuf::from("strscan.rb"), "class StringScanner; end");
+    /// loader.put_file_str(PathBuf::from("strscan.rb"), STRSCAN);
+    ///
     /// let content = loader.resolve_file(Path::new("strscan.rb"));
-    /// assert_eq!(content, Some("class StringScanner; end".as_bytes()));
-    /// # Some(())
-    /// # }
-    /// # example().unwrap();
+    /// assert_eq!(content, Some(STRSCAN.as_bytes()));
     /// ```
     ///
     /// [load path]: Self::load_path
@@ -196,38 +225,32 @@ impl Memory {
     ///
     /// # Examples
     ///
+    /// On non-Windows systems, this method returns:
+    ///
     /// ```
-    /// # use std::ffi::OsStr;
-    /// # use std::path::{Path, PathBuf};
-    /// # use mezzaluna_feature_loader::loaders::Memory;
-    /// # fn example() -> Option<()> {
+    /// use std::path::Path;
+    /// use mezzaluna_feature_loader::loaders::Memory;
+    ///
     /// let loader = Memory::new();
     /// # #[cfg(not(windows))]
     /// assert_eq!(
     ///     loader.load_path(),
     ///     Path::new("/artichoke/virtual_root/src/lib")
     /// );
-    /// # Some(())
-    /// # }
-    /// # example().unwrap();
     /// ```
     ///
     /// On Windows, this method returns a different path:
     ///
     /// ```
-    /// # use std::ffi::OsStr;
-    /// # use std::path::{Path, PathBuf};
-    /// # use mezzaluna_feature_loader::loaders::Memory;
-    /// # fn example() -> Option<()> {
+    /// use std::path::Path;
+    /// use mezzaluna_feature_loader::loaders::Memory;
+    ///
     /// let loader = Memory::new();
     /// # #[cfg(windows)]
     /// assert_eq!(
     ///     loader.load_path(),
-    ///     Path::new("c://artichoke/virtual_root/src/lib")
+    ///     Path::new("c:/artichoke/virtual_root/src/lib")
     /// );
-    /// # Some(())
-    /// # }
-    /// # example().unwrap();
     /// ```
     #[inline]
     #[must_use]
@@ -237,5 +260,26 @@ impl Memory {
         } else {
             Path::new("/artichoke/virtual_root/src/lib")
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use super::*;
+
+    #[test]
+    #[cfg(windows)]
+    fn test_windows_load_path() {
+        let loader = Memory::new();
+        assert_eq!(loader.load_path(), Path::new("c:/artichoke/virtual_root/src/lib"));
+    }
+
+    #[test]
+    #[cfg(not(windows))]
+    fn test_not_windows_load_path() {
+        let loader = Memory::new();
+        assert_eq!(loader.load_path(), Path::new("/artichoke/virtual_root/src/lib"));
     }
 }

--- a/mezzaluna-feature-loader/src/loaders/rubylib.rs
+++ b/mezzaluna-feature-loader/src/loaders/rubylib.rs
@@ -196,9 +196,7 @@ impl Rubylib {
             return None;
         }
 
-        Some(Self {
-            load_path: dbg!(load_path),
-        })
+        Some(Self { load_path })
     }
 
     /// Check whether `path` points to a file in the backing file system and

--- a/mezzaluna-feature-loader/src/loaders/rubylib.rs
+++ b/mezzaluna-feature-loader/src/loaders/rubylib.rs
@@ -178,10 +178,10 @@ impl Rubylib {
     #[inline]
     #[must_use]
     pub fn with_rubylib_and_cwd(rubylib: &OsStr, cwd: &Path) -> Option<Self> {
-        if !cwd.is_absolute() {
+        if rubylib.is_empty() {
             return None;
         }
-        if rubylib.is_empty() {
+        if !cwd.is_absolute() {
             return None;
         }
 

--- a/mezzaluna-feature-loader/src/loaders/rubylib.rs
+++ b/mezzaluna-feature-loader/src/loaders/rubylib.rs
@@ -18,10 +18,6 @@ use same_file::Handle;
 /// This loader will attempt to resolve relative paths in any of the paths given
 /// in `RUBYLIB`. Absolute paths are rejected by this loader.
 ///
-/// This loader tracks the files it has loaded, which MRI refers to as "loaded
-/// features". This loader deduplicates loaded features be detecting whether the
-/// given path [resolves to the same file] as a previously loaded path.
-///
 /// The `RUBYLIB` environment variable or other sequence of paths is parsed when
 /// this loader is created and is immutable.
 ///
@@ -30,9 +26,10 @@ use same_file::Handle;
 /// have higher priority.
 ///
 /// ```no_run
-/// # use std::ffi::OsStr;
-/// # use std::path::Path;
-/// # use mezzaluna_feature_loader::loaders::Rubylib;
+/// use std::ffi::OsStr;
+/// use std::path::Path;
+/// use mezzaluna_feature_loader::loaders::Rubylib;
+///
 /// # fn example() -> Option<()> {
 /// // Grab the load paths from the `RUBYLIB` environment variable. If the
 /// // variable is empty or unset, `None` is returned.
@@ -61,7 +58,7 @@ use same_file::Handle;
 #[cfg_attr(docsrs, doc(cfg(feature = "rubylib")))]
 pub struct Rubylib {
     /// Fixed set of paths on the host file system to search for Ruby sources.
-    load_paths: Box<[PathBuf]>,
+    load_path: Box<[PathBuf]>,
 }
 
 impl Rubylib {
@@ -76,13 +73,25 @@ impl Rubylib {
     /// absolute paths, they are absolutized relative to the current process's
     /// [current working directory] at the time this method is called.
     ///
-    /// This source loader grants access to the host file system. The `Rubylib`
-    /// loader does not support native extensions.
+    /// This source loader grants access to the host file system. This loader
+    /// does not support native extensions.
     ///
     /// This method returns [`None`] if there are errors resolving the
     /// `RUBYLIB` environment variable, if the `RUBYLIB` environment variable is
     /// not set, if the current working directory cannot be retrieved, or if the
     /// `RUBYLIB` environment variable does not contain any paths.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use mezzaluna_feature_loader::loaders::Rubylib;
+    ///
+    /// # fn example() -> Option<()> {
+    /// let loader = Rubylib::new()?;
+    /// # Some(())
+    /// # }
+    /// # example().unwrap();
+    /// ```
     ///
     /// [current working directory]: env::current_dir
     #[inline]
@@ -104,11 +113,25 @@ impl Rubylib {
     /// are absolutized relative to the current process's [current working
     /// directory] at the time this method is called.
     ///
-    /// This source loader grants access to the host file system. The `Rubylib`
-    /// loader does not support native extensions.
+    /// This source loader grants access to the host file system. This loader
+    /// does not support native extensions.
     ///
     /// This method returns [`None`] if the current working directory cannot be
     /// retrieved or if the given `rubylib` does not contain any paths.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #![cfg(unix)]
+    /// use std::ffi::OsStr;
+    /// use mezzaluna_feature_loader::loaders::Rubylib;
+    ///
+    /// # fn example() -> Option<()> {
+    /// let loader = Rubylib::with_rubylib(OsStr::new("/home/artichoke/src:/usr/share/artichoke:_lib"))?;
+    /// # Some(())
+    /// # }
+    /// # example().unwrap();
+    /// ```
     ///
     /// [current working directory]: env::current_dir
     #[inline]
@@ -129,26 +152,53 @@ impl Rubylib {
     /// are absolutized relative to the given current working directory at the
     /// time this method is called.
     ///
-    /// This source loader grants access to the host file system. The `Rubylib`
-    /// loader does not support native extensions.
+    /// This source loader grants access to the host file system. This loader
+    /// does not support native extensions.
     ///
     /// This method returns [`None`] if the given `rubylib` does not contain any
-    /// paths.
+    /// paths or if the given working directory is not an absolute path.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #![cfg(unix)]
+    /// use std::ffi::OsStr;
+    /// use std::path::Path;
+    /// use mezzaluna_feature_loader::loaders::Rubylib;
+    ///
+    /// # fn example() -> Option<()> {
+    /// let loader = Rubylib::with_rubylib_and_cwd(
+    ///     OsStr::new("/home/artichoke/src:/usr/share/artichoke:_lib"),
+    ///     Path::new("/home/artichoke"),
+    /// )?;
+    /// # Some(())
+    /// # }
+    /// # example().unwrap();
+    /// ```
     #[inline]
     #[must_use]
     pub fn with_rubylib_and_cwd(rubylib: &OsStr, cwd: &Path) -> Option<Self> {
-        let load_paths = env::split_paths(rubylib)
+        if !cwd.is_absolute() {
+            return None;
+        }
+        if rubylib.is_empty() {
+            return None;
+        }
+
+        let load_path = env::split_paths(rubylib)
             .map(|load_path| cwd.join(load_path))
             .collect::<Box<[_]>>();
 
         // If the `RUBYLIB` env variable is empty or otherwise results in no
         // search paths being resolved, return `None` so the `Rubylib` loader is
         // not used.
-        if load_paths.is_empty() {
+        if load_path.is_empty() {
             return None;
         }
 
-        Some(Self { load_paths })
+        Some(Self {
+            load_path: dbg!(load_path),
+        })
     }
 
     /// Check whether `path` points to a file in the backing file system and
@@ -169,12 +219,146 @@ impl Rubylib {
         if path.is_absolute() {
             return None;
         }
-        for load_path in &*self.load_paths {
+        for load_path in &*self.load_path {
             let path = load_path.join(path);
             if let Ok(handle) = Handle::from_path(path) {
                 return Some(handle);
             }
         }
         None
+    }
+
+    /// Return a reference to the loader's current `$LOAD_PATH`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #![cfg(unix)]
+    /// use std::ffi::OsStr;
+    /// use std::path::Path;
+    /// use mezzaluna_feature_loader::loaders::Rubylib;
+    ///
+    /// # fn example() -> Option<()> {
+    /// let loader = Rubylib::with_rubylib_and_cwd(
+    ///     OsStr::new("/home/artichoke/src:/usr/share/artichoke:_lib"),
+    ///     Path::new("/home/artichoke"),
+    /// )?;
+    /// assert_eq!(
+    ///     loader.load_path(),
+    ///     &[
+    ///         Path::new("/home/artichoke/src"),
+    ///         Path::new("/usr/share/artichoke"),
+    ///         Path::new("/home/artichoke/_lib")
+    ///     ]
+    /// );
+    /// # Some(())
+    /// # }
+    /// # example().unwrap();
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn load_path(&self) -> &[PathBuf] {
+        &self.load_path
+    }
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use std::env;
+    use std::ffi::OsStr;
+    use std::path::Path;
+
+    use super::*;
+
+    #[test]
+    fn with_rubylib_env_var() {
+        env::remove_var("RUBYLIB");
+        let loader = Rubylib::new();
+        assert!(loader.is_none());
+
+        env::set_var("RUBYLIB", "");
+        let loader = Rubylib::new();
+        assert!(loader.is_none());
+
+        env::set_var("RUBYLIB", "/home/artichoke/src:/usr/share/artichoke:_lib");
+        let loader = Rubylib::new().unwrap();
+
+        assert_eq!(loader.load_path().len(), 3);
+
+        let mut iter = loader.load_path().iter();
+        assert_eq!(iter.next().unwrap(), Path::new("/home/artichoke/src"));
+        assert_eq!(iter.next().unwrap(), Path::new("/usr/share/artichoke"));
+        assert_eq!(iter.next().unwrap(), &env::current_dir().unwrap().join("_lib"));
+        assert_eq!(iter.next(), None);
+    }
+
+    #[test]
+    fn test_load_path_is_set_on_construction() {
+        let loader = Rubylib::with_rubylib(OsStr::new("/home/artichoke/src:/usr/share/artichoke:_lib")).unwrap();
+
+        assert_eq!(loader.load_path().len(), 3);
+
+        let mut iter = loader.load_path().iter();
+        assert_eq!(iter.next().unwrap(), Path::new("/home/artichoke/src"));
+        assert_eq!(iter.next().unwrap(), Path::new("/usr/share/artichoke"));
+        assert_eq!(iter.next().unwrap(), &env::current_dir().unwrap().join("_lib"));
+        assert_eq!(iter.next(), None);
+
+        let loader = Rubylib::with_rubylib_and_cwd(
+            OsStr::new("/home/artichoke/src:/usr/share/artichoke:_lib"),
+            Path::new("/test/xyz"),
+        )
+        .unwrap();
+
+        assert_eq!(loader.load_path().len(), 3);
+
+        let mut iter = loader.load_path().iter();
+        assert_eq!(iter.next().unwrap(), Path::new("/home/artichoke/src"));
+        assert_eq!(iter.next().unwrap(), Path::new("/usr/share/artichoke"));
+        assert_eq!(iter.next().unwrap(), Path::new("/test/xyz/_lib"));
+        assert_eq!(iter.next(), None);
+    }
+
+    #[test]
+    fn test_relative_cwd_is_err() {
+        let loader = Rubylib::with_rubylib_and_cwd(
+            OsStr::new("/home/artichoke/src:/usr/share/artichoke:_lib"),
+            Path::new("xyz"),
+        );
+        assert!(loader.is_none());
+    }
+
+    #[test]
+    fn test_env_var_path_is_none() {
+        let loader = Rubylib::with_rubylib_and_cwd(OsStr::new(""), Path::new("/test/xyz"));
+        assert!(loader.is_none());
+
+        let loader = Rubylib::with_rubylib(OsStr::new(""));
+        assert!(loader.is_none());
+    }
+
+    #[test]
+    fn test_resolve_file_rejects_absolute_paths() {
+        let loader = Rubylib::with_rubylib_and_cwd(
+            OsStr::new("/home/artichoke/src:/usr/share/artichoke:_lib"),
+            Path::new("/test/xyz"),
+        )
+        .unwrap();
+
+        let file = loader.resolve_file(Path::new("/absolute/path/to/source.rb"));
+        assert!(file.is_none());
+    }
+
+    #[test]
+    fn test_resolve_file_returns_none_for_nonexistent_path() {
+        let loader = Rubylib::with_rubylib_and_cwd(
+            OsStr::new("/home/artichoke/src:/usr/share/artichoke:_lib"),
+            Path::new("/test/xyz"),
+        )
+        .unwrap();
+
+        // randomly generated with `python -c 'import secrets; print(secrets.token_urlsafe())'`
+        let file = loader.resolve_file(Path::new("aSMZbEQeJbIfEJYtV-sDOxvJuvSvO4arx3nNXVzMRvg.rb"));
+        assert!(file.is_none());
     }
 }

--- a/mezzaluna-feature-loader/src/loaders/rubylib.rs
+++ b/mezzaluna-feature-loader/src/loaders/rubylib.rs
@@ -30,6 +30,7 @@ use same_file::Handle;
 /// use std::path::Path;
 /// use mezzaluna_feature_loader::loaders::Rubylib;
 ///
+/// # #[cfg(unix)]
 /// # fn example() -> Option<()> {
 /// // Grab the load paths from the `RUBYLIB` environment variable. If the
 /// // variable is empty or unset, `None` is returned.
@@ -49,6 +50,7 @@ use same_file::Handle;
 /// )?;
 /// # Some(())
 /// # }
+/// # #[cfg(unix)]
 /// # example().unwrap();
 /// ```
 ///
@@ -122,14 +124,15 @@ impl Rubylib {
     /// # Examples
     ///
     /// ```
-    /// # #![cfg(unix)]
     /// use std::ffi::OsStr;
     /// use mezzaluna_feature_loader::loaders::Rubylib;
     ///
+    /// # #[cfg(unix)]
     /// # fn example() -> Option<()> {
     /// let loader = Rubylib::with_rubylib(OsStr::new("/home/artichoke/src:/usr/share/artichoke:_lib"))?;
     /// # Some(())
     /// # }
+    /// # #[cfg(unix)]
     /// # example().unwrap();
     /// ```
     ///
@@ -161,11 +164,11 @@ impl Rubylib {
     /// # Examples
     ///
     /// ```
-    /// # #![cfg(unix)]
     /// use std::ffi::OsStr;
     /// use std::path::Path;
     /// use mezzaluna_feature_loader::loaders::Rubylib;
     ///
+    /// # #[cfg(unix)]
     /// # fn example() -> Option<()> {
     /// let loader = Rubylib::with_rubylib_and_cwd(
     ///     OsStr::new("/home/artichoke/src:/usr/share/artichoke:_lib"),
@@ -173,6 +176,7 @@ impl Rubylib {
     /// )?;
     /// # Some(())
     /// # }
+    /// # #[cfg(unix)]
     /// # example().unwrap();
     /// ```
     #[inline]
@@ -231,11 +235,11 @@ impl Rubylib {
     /// # Examples
     ///
     /// ```
-    /// # #![cfg(unix)]
     /// use std::ffi::OsStr;
     /// use std::path::Path;
     /// use mezzaluna_feature_loader::loaders::Rubylib;
     ///
+    /// # #[cfg(unix)]
     /// # fn example() -> Option<()> {
     /// let loader = Rubylib::with_rubylib_and_cwd(
     ///     OsStr::new("/home/artichoke/src:/usr/share/artichoke:_lib"),
@@ -251,6 +255,7 @@ impl Rubylib {
     /// );
     /// # Some(())
     /// # }
+    /// # #[cfg(unix)]
     /// # example().unwrap();
     /// ```
     #[inline]


### PR DESCRIPTION
Add tests, add APIs, change error behavior.

Prep for: https://github.com/artichoke/artichoke/issues/2172.

Breaking change: Disk loader is allowed to have an empty load path. This is because it must store `$LOAD_PATH` which can be modified at runtime.

Breaking change: all methods that take a `cwd` arg fail if that cwd is not an absolute path.