### PR TITLE
Improve MRI-conformance of RUBYLIB feature loader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -441,7 +441,7 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "mezzaluna-feature-loader"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "same-file",
  "scolapasta-path",

--- a/mezzaluna-feature-loader/Cargo.toml
+++ b/mezzaluna-feature-loader/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mezzaluna-feature-loader"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 description = "Source and extension loaders for a managing a Ruby $LOAD_PATH"
 keywords = ["artichoke", "artichoke-ruby", "load-path", "ruby"]


### PR DESCRIPTION
- BREAKING: remove "with cwd" constructor.
- BREAKING: do not absolutize paths by joining with cwd.
- FIX: filter out all empty paths, e.g. "::::" yields no paths.