### PR TITLE
Remove invalid `Borrow` impl on spinoso-string

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -795,7 +795,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-string"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "bstr",
  "bytecount",

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -35,7 +35,7 @@ spinoso-math = { version = "0.3.0", path = "../spinoso-math", optional = true, d
 spinoso-random = { version = "0.3.0", path = "../spinoso-random", optional = true }
 spinoso-regexp = { version = "0.5.0", path = "../spinoso-regexp", optional = true, default-features = false }
 spinoso-securerandom = { version = "0.2.0", path = "../spinoso-securerandom", optional = true }
-spinoso-string = { version = "0.21.0", path = "../spinoso-string", features = ["always-nul-terminated-c-string-compat"] }
+spinoso-string = { version = "0.22.0", path = "../spinoso-string", features = ["always-nul-terminated-c-string-compat"] }
 spinoso-symbol = { version = "0.3.0", path = "../spinoso-symbol" }
 spinoso-time = { version = "0.7.1", path = "../spinoso-time", features = ["tzrs"], default-features = false, optional = true }
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -590,7 +590,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-string"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "bstr",
  "bytecount",

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -897,7 +897,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-string"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "bstr",
  "bytecount",

--- a/spinoso-string/Cargo.toml
+++ b/spinoso-string/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spinoso-string"
-version = "0.21.0"
+version = "0.22.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 description = """
 Encoding-aware string implementation for Ruby String core type in Artichoke Ruby

--- a/spinoso-string/README.md
+++ b/spinoso-string/README.md
@@ -27,7 +27,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-spinoso-string = "0.21.0"
+spinoso-string = "0.22.0"
 ```
 
 ## `no_std`

--- a/spinoso-string/src/buf/nul_terminated_vec.rs
+++ b/spinoso-string/src/buf/nul_terminated_vec.rs
@@ -1,7 +1,6 @@
 use alloc::boxed::Box;
 use alloc::collections::TryReserveError;
 use alloc::vec::Vec;
-use core::borrow::Borrow;
 #[cfg(feature = "std")]
 use core::fmt::Arguments;
 use core::ops::{Deref, DerefMut, RangeBounds};
@@ -91,13 +90,6 @@ impl DerefMut for Buf {
         // SAFETY: the mutable reference given out is a slice, NOT the
         // underlying `Vec`, so the allocation cannot change size.
         &mut self.inner
-    }
-}
-
-impl Borrow<[u8]> for Buf {
-    #[inline]
-    fn borrow(&self) -> &[u8] {
-        &self.inner
     }
 }
 

--- a/spinoso-string/src/buf/vec.rs
+++ b/spinoso-string/src/buf/vec.rs
@@ -1,7 +1,6 @@
 use alloc::boxed::Box;
 use alloc::collections::TryReserveError;
 use alloc::vec::{Drain, Splice, Vec};
-use core::borrow::Borrow;
 #[cfg(feature = "std")]
 use core::fmt::Arguments;
 use core::ops::{Deref, DerefMut, RangeBounds};
@@ -44,13 +43,6 @@ impl DerefMut for Buf {
     #[inline]
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
-    }
-}
-
-impl Borrow<[u8]> for Buf {
-    #[inline]
-    fn borrow(&self) -> &[u8] {
-        &self.inner
     }
 }
 

--- a/spinoso-string/src/enc/mod.rs
+++ b/spinoso-string/src/enc/mod.rs
@@ -1,5 +1,4 @@
 use alloc::collections::TryReserveError;
-use core::borrow::Borrow;
 use core::cmp::Ordering;
 use core::hash::{Hash, Hasher};
 use core::mem;
@@ -90,26 +89,6 @@ impl PartialOrd for EncodedString {
 impl Ord for EncodedString {
     fn cmp(&self, other: &Self) -> Ordering {
         self.as_slice().cmp(other.as_slice())
-    }
-}
-
-// This impl of `Borrow<[u8]>` is permissible due to the manual implementations
-// of `PartialEq`, `Hash`, and `Ord` above which only rely on the byte slice
-// contents in the underlying typed strings.
-//
-// Per the docs in `std`:
-//
-// > In particular `Eq`, `Ord` and `Hash` must be equivalent for borrowed and
-// > owned values: `x.borrow() == y.borrow()` should give the same result as
-// > `x == y`.
-impl Borrow<[u8]> for EncodedString {
-    #[inline]
-    fn borrow(&self) -> &[u8] {
-        match self {
-            EncodedString::Ascii(inner) => inner.borrow(),
-            EncodedString::Binary(inner) => inner.borrow(),
-            EncodedString::Utf8(inner) => inner.borrow(),
-        }
     }
 }
 

--- a/spinoso-string/src/impls.rs
+++ b/spinoso-string/src/impls.rs
@@ -1,6 +1,5 @@
 use alloc::borrow::Cow;
 use alloc::vec::Vec;
-use core::borrow::Borrow;
 use core::fmt;
 use core::ops::{Deref, DerefMut, Index, IndexMut};
 use core::slice::SliceIndex;
@@ -203,22 +202,6 @@ impl DerefMut for String {
     #[inline]
     fn deref_mut(&mut self) -> &mut [u8] {
         &mut self.inner
-    }
-}
-
-// This impl of `Borrow<[u8]>` is permissible due to the behavior of
-// `PartialEq`, `Hash`, and `Ord` impls on `String` which only rely on the byte
-// slice contents in the underlying encoded string.
-//
-// Per the docs in `std`:
-//
-// > In particular `Eq`, `Ord` and `Hash` must be equivalent for borrowed and
-// > owned values: `x.borrow() == y.borrow()` should give the same result as
-// > `x == y`.
-impl Borrow<[u8]> for String {
-    #[inline]
-    fn borrow(&self) -> &[u8] {
-        self.inner.borrow()
     }
 }
 


### PR DESCRIPTION
Since #2308 has been merged, `impl PartialEq for String` has not been equivalent to `impl PartialEq for [u8]`, which means the documented guarantees around all of the `Borrow` impls in this crate no longer hold.

Remove the impls and do a semver incompatible bump for spinoso-string. These `Borrow` impls are unused, so de facto no soundness implications.