### PR TITLE
Remove all `Borrow` trait impls in Artichoke workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -730,7 +730,7 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "spinoso-array"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "raw-parts",
  "smallvec",
@@ -808,7 +808,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-symbol"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "artichoke-core",
  "bstr",

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -28,7 +28,7 @@ scolapasta-aref = { version = "0.1.0", path = "../scolapasta-aref" }
 scolapasta-int-parse = { version = "0.2.2", path = "../scolapasta-int-parse", default-features = false }
 scolapasta-path = { version = "0.5.0", path = "../scolapasta-path" }
 scolapasta-string-escape = { version = "0.3.0", path = "../scolapasta-string-escape", default-features = false }
-spinoso-array = { version = "0.9.0", path = "../spinoso-array", default-features = false }
+spinoso-array = { version = "0.10.0", path = "../spinoso-array", default-features = false }
 spinoso-env = { version = "0.2.0", path = "../spinoso-env", optional = true, default-features = false }
 spinoso-exception = { version = "0.1.0", path = "../spinoso-exception" }
 spinoso-math = { version = "0.3.0", path = "../spinoso-math", optional = true, default-features = false }
@@ -36,7 +36,7 @@ spinoso-random = { version = "0.3.0", path = "../spinoso-random", optional = tru
 spinoso-regexp = { version = "0.5.0", path = "../spinoso-regexp", optional = true, default-features = false }
 spinoso-securerandom = { version = "0.2.0", path = "../spinoso-securerandom", optional = true }
 spinoso-string = { version = "0.22.0", path = "../spinoso-string", features = ["always-nul-terminated-c-string-compat"] }
-spinoso-symbol = { version = "0.3.0", path = "../spinoso-symbol" }
+spinoso-symbol = { version = "0.4.0", path = "../spinoso-symbol" }
 spinoso-time = { version = "0.7.1", path = "../spinoso-time", features = ["tzrs"], default-features = false, optional = true }
 
 [dev-dependencies]

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -527,7 +527,7 @@ checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
 
 [[package]]
 name = "spinoso-array"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "raw-parts",
 ]
@@ -602,7 +602,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-symbol"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "artichoke-core",
  "bstr",

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-array"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "raw-parts",
 ]
@@ -909,7 +909,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-symbol"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "artichoke-core",
  "bstr",

--- a/spinoso-array/Cargo.toml
+++ b/spinoso-array/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spinoso-array"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 description = """
 Growable vector backends for the Ruby Array core type in Artichoke Ruby

--- a/spinoso-array/README.md
+++ b/spinoso-array/README.md
@@ -30,7 +30,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-spinoso-array = "0.9.0"
+spinoso-array = "0.10.0"
 ```
 
 Then construct and manipulate an `Array` like this:

--- a/spinoso-array/src/array/smallvec/impls.rs
+++ b/spinoso-array/src/array/smallvec/impls.rs
@@ -1,4 +1,3 @@
-use core::borrow::{Borrow, BorrowMut};
 use core::ops::{Deref, DerefMut, Index, IndexMut};
 use core::slice::SliceIndex;
 
@@ -15,20 +14,6 @@ impl<T> AsMut<[T]> for SmallArray<T> {
     #[inline]
     fn as_mut(&mut self) -> &mut [T] {
         self.0.as_mut()
-    }
-}
-
-impl<T> Borrow<[T]> for SmallArray<T> {
-    #[inline]
-    fn borrow(&self) -> &[T] {
-        self.0.borrow()
-    }
-}
-
-impl<T> BorrowMut<[T]> for SmallArray<T> {
-    #[inline]
-    fn borrow_mut(&mut self) -> &mut [T] {
-        self.0.borrow_mut()
     }
 }
 

--- a/spinoso-array/src/array/tinyvec/impls.rs
+++ b/spinoso-array/src/array/tinyvec/impls.rs
@@ -1,4 +1,3 @@
-use core::borrow::{Borrow, BorrowMut};
 use core::ops::{Deref, DerefMut, Index, IndexMut};
 use core::slice::SliceIndex;
 
@@ -21,26 +20,6 @@ where
     #[inline]
     fn as_mut(&mut self) -> &mut [T] {
         self.0.as_mut()
-    }
-}
-
-impl<T> Borrow<[T]> for TinyArray<T>
-where
-    T: Default,
-{
-    #[inline]
-    fn borrow(&self) -> &[T] {
-        self.0.borrow()
-    }
-}
-
-impl<T> BorrowMut<[T]> for TinyArray<T>
-where
-    T: Default,
-{
-    #[inline]
-    fn borrow_mut(&mut self) -> &mut [T] {
-        self.0.borrow_mut()
     }
 }
 

--- a/spinoso-array/src/array/vec/impls.rs
+++ b/spinoso-array/src/array/vec/impls.rs
@@ -1,4 +1,3 @@
-use core::borrow::{Borrow, BorrowMut};
 use core::ops::{Deref, DerefMut, Index, IndexMut};
 use core::slice::SliceIndex;
 
@@ -15,20 +14,6 @@ impl<T> AsMut<[T]> for Array<T> {
     #[inline]
     fn as_mut(&mut self) -> &mut [T] {
         self.0.as_mut()
-    }
-}
-
-impl<T> Borrow<[T]> for Array<T> {
-    #[inline]
-    fn borrow(&self) -> &[T] {
-        self.0.borrow()
-    }
-}
-
-impl<T> BorrowMut<[T]> for Array<T> {
-    #[inline]
-    fn borrow_mut(&mut self) -> &mut [T] {
-        self.0.borrow_mut()
     }
 }
 

--- a/spinoso-symbol/Cargo.toml
+++ b/spinoso-symbol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spinoso-symbol"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 description = """
 Symbol implementation for Ruby Symbol core type in Artichoke Ruby

--- a/spinoso-symbol/README.md
+++ b/spinoso-symbol/README.md
@@ -30,7 +30,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-spinoso-symbol = "0.3.0"
+spinoso-symbol = "0.4.0"
 ```
 
 Most of the functionality in this crate depends on a Ruby interpreter that

--- a/spinoso-symbol/src/lib.rs
+++ b/spinoso-symbol/src/lib.rs
@@ -83,7 +83,6 @@ mod readme {}
 #[cfg(any(feature = "std", test, doctest))]
 extern crate std;
 
-use core::borrow::Borrow;
 use core::fmt;
 use core::num::TryFromIntError;
 
@@ -166,12 +165,6 @@ impl std::error::Error for SymbolOverflowError {}
 /// `Symbol`s are not constrained to the interner which created them.
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Symbol(u32);
-
-impl Borrow<u32> for Symbol {
-    fn borrow(&self) -> &u32 {
-        &self.0
-    }
-}
 
 impl Symbol {
     /// Construct a new `Symbol` from the given `u32`.


### PR DESCRIPTION
Followup to #2572.

Rust `std` is very sparing with its `Borrow` impls. All of these are unused, dead code which is prone to drift and invariant breakage as these types evolve.

Remove the unused impls and bump versions.