### PR TITLE
Use new APIs stabilized in Rust 1.70.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -820,7 +820,6 @@ dependencies = [
 name = "spinoso-time"
 version = "0.7.1"
 dependencies = [
- "once_cell",
  "regex",
  "strftime-ruby",
  "tz-rs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,7 +53,6 @@ dependencies = [
  "cc",
  "intaglio",
  "mezzaluna-type-registry",
- "once_cell",
  "onig",
  "posix-space",
  "qed",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-time"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "regex",
  "strftime-ruby",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,7 +44,7 @@ dependencies = [
 
 [[package]]
 name = "artichoke-backend"
-version = "0.24.0"
+version = "0.24.1"
 dependencies = [
  "artichoke-core",
  "artichoke-load-path",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ homepage.workspace = true
 documentation.workspace = true
 
 [dependencies]
-artichoke-backend = { version = "0.24.0", path = "artichoke-backend", default-features = false }
+artichoke-backend = { version = "0.24.1", path = "artichoke-backend", default-features = false }
 artichoke-readline = { version = "1.0.0", path = "artichoke-readline", optional = true }
 artichoke-repl-history = { version = "1.0.0", path = "artichoke-repl-history", optional = true }
 clap = { version = "4.3.0", optional = true, default-features = false, features = ["std", "help", "usage", "error-context", "suggestions"] }

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -19,7 +19,6 @@ artichoke-load-path = { version = "0.1.0", path = "../artichoke-load-path", defa
 bstr = { version = "1.2.0", default-features = false, features = ["alloc"] }
 intaglio = { version = "1.7.0", default-features = false, features = ["bytes"] }
 mezzaluna-type-registry = { version = "1.0.1", path = "../mezzaluna-type-registry" }
-once_cell = "1.12.0"
 onig = { version = "6.4.0", optional = true, default-features = false }
 posix-space = "1.0.0"
 qed = "1.3.0"

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -37,7 +37,7 @@ spinoso-regexp = { version = "0.5.0", path = "../spinoso-regexp", optional = tru
 spinoso-securerandom = { version = "0.2.0", path = "../spinoso-securerandom", optional = true }
 spinoso-string = { version = "0.22.0", path = "../spinoso-string", features = ["always-nul-terminated-c-string-compat"] }
 spinoso-symbol = { version = "0.4.0", path = "../spinoso-symbol" }
-spinoso-time = { version = "0.7.1", path = "../spinoso-time", features = ["tzrs"], default-features = false, optional = true }
+spinoso-time = { version = "0.7.2", path = "../spinoso-time", features = ["tzrs"], default-features = false, optional = true }
 
 [dev-dependencies]
 quickcheck = { version = "1.0.3", default-features = false }

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "artichoke-backend"
-version = "0.24.0"
+version = "0.24.1"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 description = "Embeddable VM implementation for Artichoke Ruby"
 keywords = ["artichoke", "artichoke-ruby", "mruby", "ruby"]

--- a/artichoke-backend/src/convert/conv.rs
+++ b/artichoke-backend/src/convert/conv.rs
@@ -3,10 +3,10 @@
 //! See: <https://github.com/ruby/ruby/blob/v3_1_2/object.c#L2908-L3018>.
 
 use std::ffi::CStr;
+use std::sync::OnceLock;
 
 use artichoke_core::debug::Debug as _;
 use artichoke_core::value::Value as _;
-use once_cell::sync::OnceCell;
 use qed::const_cstr_from_str as cstr;
 use spinoso_exception::TypeError;
 
@@ -49,7 +49,7 @@ fn conv_method_table(interp: &mut Artichoke) -> &'static [ConvMethod; 12] {
         ("to_r",    cstr!("to_r\0"),    false),
     ];
 
-    static CONV_METHOD_TABLE: OnceCell<[ConvMethod; 12]> = OnceCell::new();
+    static CONV_METHOD_TABLE: OnceLock<[ConvMethod; 12]> = OnceLock::new();
 
     CONV_METHOD_TABLE.get_or_init(|| {
         METHODS.map(|(method, method_cstr, is_implicit_conversion)| {

--- a/artichoke-backend/src/extn/core/regexp/backend/onig.rs
+++ b/artichoke-backend/src/extn/core/regexp/backend/onig.rs
@@ -171,7 +171,7 @@ impl RegexpType for Onig {
 
             for group in 0..captures.len() {
                 let value = interp.try_convert_mut(captures.at(group))?;
-                let group = unsafe { NonZeroUsize::new_unchecked(1 + group) };
+                let group = NonZeroUsize::MIN.saturating_add(group);
                 interp.set_global_variable(regexp::nth_match_group(group), &value)?;
             }
 
@@ -244,7 +244,7 @@ impl RegexpType for Onig {
             interp.set_global_variable(regexp::LAST_MATCHED_STRING, &value)?;
             for group in 0..captures.len() {
                 let value = interp.try_convert_mut(captures.at(group))?;
-                let group = unsafe { NonZeroUsize::new_unchecked(1 + group) };
+                let group = NonZeroUsize::MIN.saturating_add(group);
                 interp.set_global_variable(regexp::nth_match_group(group), &value)?;
             }
 
@@ -283,7 +283,7 @@ impl RegexpType for Onig {
             interp.set_global_variable(regexp::LAST_MATCHED_STRING, &value)?;
             for group in 0..captures.len() {
                 let value = interp.try_convert_mut(captures.at(group))?;
-                let group = unsafe { NonZeroUsize::new_unchecked(1 + group) };
+                let group = NonZeroUsize::MIN.saturating_add(group);
                 interp.set_global_variable(regexp::nth_match_group(group), &value)?;
             }
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -36,7 +36,7 @@ dependencies = [
 
 [[package]]
 name = "artichoke-backend"
-version = "0.24.0"
+version = "0.24.1"
 dependencies = [
  "artichoke-core",
  "artichoke-load-path",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -613,7 +613,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-time"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "regex",
  "strftime-ruby",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -615,7 +615,6 @@ dependencies = [
 name = "spinoso-time"
 version = "0.7.1"
 dependencies = [
- "once_cell",
  "regex",
  "strftime-ruby",
  "tz-rs",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -45,7 +45,6 @@ dependencies = [
  "cc",
  "intaglio",
  "mezzaluna-type-registry",
- "once_cell",
  "onig",
  "posix-space",
  "qed",

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -61,7 +61,6 @@ dependencies = [
  "cc",
  "intaglio",
  "mezzaluna-type-registry",
- "once_cell",
  "onig",
  "posix-space",
  "qed",

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -922,7 +922,6 @@ dependencies = [
 name = "spinoso-time"
 version = "0.7.1"
 dependencies = [
- "once_cell",
  "regex",
  "strftime-ruby",
  "tz-rs",

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -52,7 +52,7 @@ dependencies = [
 
 [[package]]
 name = "artichoke-backend"
-version = "0.24.0"
+version = "0.24.1"
 dependencies = [
  "artichoke-core",
  "artichoke-load-path",

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-time"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "regex",
  "strftime-ruby",

--- a/spinoso-time/Cargo.toml
+++ b/spinoso-time/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spinoso-time"
-version = "0.7.1"
+version = "0.7.2"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 description = """
 Datetime handling for Artichoke Ruby

--- a/spinoso-time/Cargo.toml
+++ b/spinoso-time/Cargo.toml
@@ -16,7 +16,6 @@ homepage.workspace = true
 documentation.workspace = true
 
 [dependencies]
-once_cell = { version = "1.12.0", optional = true }
 regex =  { version = "1.7.0", default-features = false, features = ["std"], optional = true }
 strftime-ruby = { version = "1.0.0", default-features = false, features = ["alloc"], optional = true }
 tz-rs = { version = "0.6.12", default-features = false, features = ["std"], optional = true }
@@ -24,7 +23,7 @@ tzdb = { version = "0.5.6", default-features = false, optional = true }
 
 [features]
 default = ["tzrs", "tzrs-local"]
-tzrs = ["dep:once_cell", "dep:regex", "dep:strftime-ruby", "dep:tz-rs", "dep:tzdb"]
+tzrs = ["dep:regex", "dep:strftime-ruby", "dep:tz-rs", "dep:tzdb"]
 tzrs-local = ["tzrs"]
 
 [package.metadata.docs.rs]

--- a/spinoso-time/src/time/tzrs/offset.rs
+++ b/spinoso-time/src/time/tzrs/offset.rs
@@ -1,8 +1,8 @@
 use std::io::{self, Write as _};
 use std::slice;
 use std::str;
+use std::sync::OnceLock;
 
-use once_cell::sync::Lazy;
 use regex::Regex;
 use tz::timezone::{LocalTimeType, TimeZoneRef};
 #[cfg(feature = "tzrs-local")]
@@ -147,10 +147,12 @@ impl Offset {
     pub fn local() -> Self {
         // Per the docs, it is suggested to cache the result of fetching the
         // local timezone: https://docs.rs/tzdb/latest/tzdb/fn.local_tz.html.
-        static LOCAL_TZ: Lazy<TimeZoneRef<'static>> = Lazy::new(local_time_zone);
+        static LOCAL_TZ: OnceLock<TimeZoneRef<'static>> = OnceLock::new();
+
+        let local_tz = *LOCAL_TZ.get_or_init(local_time_zone);
 
         Self {
-            inner: OffsetType::Tz(*LOCAL_TZ),
+            inner: OffsetType::Tz(local_tz),
         }
     }
 
@@ -308,23 +310,26 @@ impl TryFrom<&str> for Offset {
             // ```
             "Z" | "UTC" => Ok(Self::utc()),
             _ => {
-                // With `Regex`, `\d` is a "Unicode friendly" Perl character
-                // class which matches Unicode property `Nd`. The `Nd` property
-                // includes all sorts of numerals, including Devanagari and
-                // Kannada, which don't parse into an `i32` using `FromStr`.
-                //
-                // `[[:digit:]]` is documented to be an ASCII character class
-                // for only digits 0-9.
-                //
-                // See:
-                // - https://docs.rs/regex/latest/regex/#perl-character-classes-unicode-friendly
-                // - https://docs.rs/regex/latest/regex/#ascii-character-classes
-                static HH_MM_MATCHER: Lazy<Regex> = Lazy::new(|| {
-                    // regex must compile
+                static HH_MM_MATCHER: OnceLock<Regex> = OnceLock::new();
+
+                let hh_mm_matcher = HH_MM_MATCHER.get_or_init(|| {
+                    // With `Regex`, `\d` is a "Unicode friendly" Perl character
+                    // class which matches Unicode property `Nd`. The `Nd` property
+                    // includes all sorts of numerals, including Devanagari and
+                    // Kannada, which don't parse into an `i32` using `FromStr`.
+                    //
+                    // `[[:digit:]]` is documented to be an ASCII character class
+                    // for only digits 0-9.
+                    //
+                    // See:
+                    // - https://docs.rs/regex/latest/regex/#perl-character-classes-unicode-friendly
+                    // - https://docs.rs/regex/latest/regex/#ascii-character-classes
+                    //
+                    // Use `unwrap()` here because the regex must compile.
                     Regex::new(r"^([\-\+]{1})([[:digit:]]{2}):?([[:digit:]]{2})$").unwrap()
                 });
 
-                let caps = HH_MM_MATCHER.captures(input).ok_or_else(TzStringError::new)?;
+                let caps = hh_mm_matcher.captures(input).ok_or_else(TzStringError::new)?;
 
                 // Special handling of the +/- sign is required because `-00:30`
                 // must parse to a negative offset and `i32::from_str_radix`
@@ -391,7 +396,8 @@ impl TryFrom<i32> for Offset {
 
 #[cfg(test)]
 mod tests {
-    use once_cell::sync::Lazy;
+    use std::sync::OnceLock;
+
     use tz::timezone::Transition;
     use tz::{LocalTimeType, TimeZone};
 
@@ -603,7 +609,9 @@ mod tests {
     // https://github.com/x-hgg-x/tz-rs/issues/34#issuecomment-1206140198
     #[test]
     fn tzrs_gh_34_handle_missing_transition_tzif_v1() {
-        static TZ: Lazy<TimeZone> = Lazy::new(|| {
+        static TZ: OnceLock<TimeZone> = OnceLock::new();
+
+        let tz = TZ.get_or_init(|| {
             let local_time_types = vec![
                 LocalTimeType::new(0, false, None).unwrap(),
                 LocalTimeType::new(3600, false, None).unwrap(),
@@ -617,8 +625,9 @@ mod tests {
             )
             .unwrap()
         });
+
         let offset = Offset {
-            inner: OffsetType::Tz(TZ.as_ref()),
+            inner: OffsetType::Tz(tz.as_ref()),
         };
         assert!(matches!(
             Time::new(1970, 1, 2, 12, 0, 0, 0, offset).unwrap_err(),


### PR DESCRIPTION
https://blog.rust-lang.org/2023/06/01/Rust-1.70.0.html#stabilized-apis

These changes drop direct workspace dependencies on `once_cell`.

Followup to #2586.