### PR TITLE
Split string buffer internals out from `spinoso-string` into a new `scolapasta-strbuf` crate

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -352,6 +352,18 @@ jobs:
         run: cargo check --verbose --all-features --all-targets --profile=test
         working-directory: "scolapasta-path"
 
+      - name: Compile scolapasta-strbuf with no default features
+        run: cargo check --verbose --no-default-features --all-targets --profile=test
+        working-directory: "scolapasta-strbuf"
+
+      - name: Compile scolapasta-strbuf with some features
+        run: cargo check --verbose --no-default-features --features nul-terminated --all-targets --profile=test
+        working-directory: "scolapasta-strbuf"
+
+      - name: Compile scolapasta-strbuf with all features
+        run: cargo check --verbose --all-features --all-targets --profile=test
+        working-directory: "scolapasta-strbuf"
+
       - name: Compile scolapasta-string-escape with no default features
         run: cargo check --verbose --no-default-features --all-targets --profile=test
         working-directory: "scolapasta-string-escape"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -688,7 +688,11 @@ version = "0.5.0"
 
 [[package]]
 name = "scolapasta-strbuf"
-version = "0.1.0"
+version = "1.0.0"
+dependencies = [
+ "bstr",
+ "raw-parts",
+]
 
 [[package]]
 name = "scolapasta-string-escape"
@@ -801,6 +805,7 @@ dependencies = [
  "focaccia",
  "quickcheck",
  "raw-parts",
+ "scolapasta-strbuf",
  "scolapasta-string-escape",
  "simdutf8",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -690,7 +690,6 @@ version = "0.5.0"
 name = "scolapasta-strbuf"
 version = "1.0.0"
 dependencies = [
- "bstr",
  "quickcheck",
  "raw-parts",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -804,7 +804,6 @@ dependencies = [
  "bytecount",
  "focaccia",
  "quickcheck",
- "raw-parts",
  "scolapasta-strbuf",
  "scolapasta-string-escape",
  "simdutf8",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -691,6 +691,7 @@ name = "scolapasta-strbuf"
 version = "1.0.0"
 dependencies = [
  "bstr",
+ "quickcheck",
  "raw-parts",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -798,7 +798,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-string"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "bstr",
  "bytecount",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -687,6 +687,10 @@ name = "scolapasta-path"
 version = "0.5.0"
 
 [[package]]
+name = "scolapasta-strbuf"
+version = "0.1.0"
+
+[[package]]
 name = "scolapasta-string-escape"
 version = "0.3.0"
 dependencies = [

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -34,7 +34,7 @@ spinoso-math = { version = "0.3.0", path = "../spinoso-math", optional = true, d
 spinoso-random = { version = "0.3.0", path = "../spinoso-random", optional = true }
 spinoso-regexp = { version = "0.5.0", path = "../spinoso-regexp", optional = true, default-features = false }
 spinoso-securerandom = { version = "0.2.0", path = "../spinoso-securerandom", optional = true }
-spinoso-string = { version = "0.22.0", path = "../spinoso-string", features = ["always-nul-terminated-c-string-compat"] }
+spinoso-string = { version = "0.23.0", path = "../spinoso-string", features = ["nul-terminated"] }
 spinoso-symbol = { version = "0.4.0", path = "../spinoso-symbol" }
 spinoso-time = { version = "0.7.2", path = "../spinoso-time", features = ["tzrs"], default-features = false, optional = true }
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -598,7 +598,6 @@ dependencies = [
  "bstr",
  "bytecount",
  "focaccia",
- "raw-parts",
  "scolapasta-strbuf",
  "scolapasta-string-escape",
  "simdutf8",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -497,6 +497,13 @@ name = "scolapasta-path"
 version = "0.5.0"
 
 [[package]]
+name = "scolapasta-strbuf"
+version = "1.0.0"
+dependencies = [
+ "raw-parts",
+]
+
+[[package]]
 name = "scolapasta-string-escape"
 version = "0.3.0"
 dependencies = [
@@ -592,6 +599,7 @@ dependencies = [
  "bytecount",
  "focaccia",
  "raw-parts",
+ "scolapasta-strbuf",
  "scolapasta-string-escape",
  "simdutf8",
 ]

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -593,7 +593,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-string"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "bstr",
  "bytecount",

--- a/scolapasta-strbuf/Cargo.toml
+++ b/scolapasta-strbuf/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "scolapasta-strbuf"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/scolapasta-strbuf/Cargo.toml
+++ b/scolapasta-strbuf/Cargo.toml
@@ -20,6 +20,7 @@ bstr = { version = "1.2.0", default-features = false, features = ["alloc"] }
 raw-parts = "2.0.0"
 
 [dev-dependencies]
+quickcheck = { version = "1.0.3", default-features = false }
 
 [features]
 default = ["std"]

--- a/scolapasta-strbuf/Cargo.toml
+++ b/scolapasta-strbuf/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 description = """
 A byte buffer backend for Ruby Strings.
 """
-keywords = ["bytes", "cstring", "no_std", "vec"]
+keywords = ["buffer", "bytes", "cstring", "no_std", "vec"]
 categories = ["data-structures", "no-std"]
 readme = "README.md"
 edition.workspace = true

--- a/scolapasta-strbuf/Cargo.toml
+++ b/scolapasta-strbuf/Cargo.toml
@@ -16,7 +16,6 @@ homepage.workspace = true
 documentation.workspace = true
 
 [dependencies]
-bstr = { version = "1.2.0", default-features = false, features = ["alloc"] }
 raw-parts = "2.0.0"
 
 [dev-dependencies]

--- a/scolapasta-strbuf/Cargo.toml
+++ b/scolapasta-strbuf/Cargo.toml
@@ -1,8 +1,35 @@
 [package]
 name = "scolapasta-strbuf"
-version = "0.1.0"
-edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+version = "1.0.0"
+authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
+description = """
+A byte buffer backend for Ruby Strings.
+"""
+keywords = ["bytes", "cstring", "no_std", "vec"]
+categories = ["data-structures", "no-std"]
+readme = "README.md"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+documentation.workspace = true
 
 [dependencies]
+bstr = { version = "1.2.0", default-features = false, features = ["alloc"] }
+raw-parts = "2.0.0"
+
+[dev-dependencies]
+
+[features]
+default = ["std"]
+# Add implementations of traits from `std` like `std::io::Write`.
+std = []
+# Use an alternate byte buffer backend that ensures string content is always
+# followed by a NUL byte. This feature can be used to ensure `String`s are FFI
+# compatible with C code that expects byte content to be NUL terminated.
+nul-terminated = []
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/scolapasta-strbuf/Cargo.toml
+++ b/scolapasta-strbuf/Cargo.toml
@@ -25,9 +25,10 @@ quickcheck = { version = "1.0.3", default-features = false }
 default = ["std"]
 # Add implementations of traits from `std` like `std::io::Write`.
 std = []
-# Use an alternate byte buffer backend that ensures string content is always
-# followed by a NUL byte. This feature can be used to ensure `Buf`s are FFI
-# compatible with C code that expects byte content to be NUL terminated.
+# Use an alternate byte buffer backend that ensures byte content is always
+# followed by a NUL byte in the buffer's spare capacity. This feature can be
+# used to ensure `Buf`s are FFI compatible with C code that expects byte content
+# to be NUL terminated.
 nul-terminated = []
 
 [package.metadata.docs.rs]

--- a/scolapasta-strbuf/Cargo.toml
+++ b/scolapasta-strbuf/Cargo.toml
@@ -27,7 +27,7 @@ default = ["std"]
 # Add implementations of traits from `std` like `std::io::Write`.
 std = []
 # Use an alternate byte buffer backend that ensures string content is always
-# followed by a NUL byte. This feature can be used to ensure `String`s are FFI
+# followed by a NUL byte. This feature can be used to ensure `Buf`s are FFI
 # compatible with C code that expects byte content to be NUL terminated.
 nul-terminated = []
 

--- a/scolapasta-strbuf/LICENSE
+++ b/scolapasta-strbuf/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2019 Ryan Lopopolo <rjl@hyperbo.la>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/scolapasta-strbuf/README.md
+++ b/scolapasta-strbuf/README.md
@@ -1,0 +1,67 @@
+# scolapasta-strbuf
+
+[![GitHub Actions](https://github.com/artichoke/artichoke/workflows/CI/badge.svg)](https://github.com/artichoke/artichoke/actions)
+[![Discord](https://img.shields.io/discord/607683947496734760)](https://discord.gg/QCe2tp2)
+[![Twitter](https://img.shields.io/twitter/follow/artichokeruby?label=Follow&style=social)](https://twitter.com/artichokeruby)
+<br>
+[![Crate](https://img.shields.io/crates/v/scolapasta-strbuf.svg)](https://crates.io/crates/scolapasta-strbuf)
+[![API](https://docs.rs/scolapasta-strbuf/badge.svg)](https://docs.rs/scolapasta-strbuf)
+[![API trunk](https://img.shields.io/badge/docs-trunk-blue.svg)](https://artichoke.github.io/artichoke/scolapasta_strbuf/)
+
+A contiguous growable byte string, written as `Buf`, short for 'buffer'.
+
+Buffers have _O_(1) indexing, amortized _O_(1) push (to the end) and _O_(1) pop
+(from the end).
+
+Buffers ensure they never allocate more than `isize::MAX` bytes.
+
+Buffers are transparent wrappers around `Vec<u8>` with a minimized API
+sufficient for implementing the Ruby [`String`] type.
+
+Buffers do not assume any encoding. Encoding is a higher-level concept that
+should be built on top of `Buf`.
+
+[`String`]: https://ruby-doc.org/3.2.0/String.html
+
+_Scolapasta_ refers to a specialized colander used to drain pasta. The utilities
+defined in the `scolapasta` family of crates are the kitchen tools for preparing
+Artichoke Ruby.
+
+## Usage
+
+Add this to your `Cargo.toml`:
+
+```toml
+[dependencies]
+scolapasta-strbuf = "1.0.0"
+```
+
+And manipulate byte buffers like:
+
+```rust
+use scolapasta_strbuf::Buf;
+
+let mut buf = Buf::from(b"Artichoke Ruby");
+buf.push_char('!');
+
+assert_eq!(buf, "Artichoke Ruby!");
+```
+
+## Crate Features
+
+This crate has a required dependency on [`alloc`].
+
+- **std**: Enabled by default. Implement [`std::io::Write`] for `Buf`. If this
+  feature is disabled, this crate only depends on [`alloc`].
+- **nul-terminated**: Use an alternate byte buffer backend that ensures byte
+  content is always followed by a NUL byte in the buffer's spare capacity. This
+  feature can be used to ensure `Buf`s are FFI compatible with C code that
+  expects byte content to be NUL terminated.
+
+[`alloc`]: https://doc.rust-lang.org/alloc/
+[`std::io::Write`]: https://doc.rust-lang.org/std/io/trait.Write.html
+
+## License
+
+`scolapasta-strbuf` is licensed with the [MIT License](LICENSE) (c) Ryan
+Lopopolo.

--- a/scolapasta-strbuf/src/lib.rs
+++ b/scolapasta-strbuf/src/lib.rs
@@ -1,0 +1,14 @@
+pub fn add(left: usize, right: usize) -> usize {
+    left + right
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        let result = add(2, 2);
+        assert_eq!(result, 4);
+    }
+}

--- a/scolapasta-strbuf/src/lib.rs
+++ b/scolapasta-strbuf/src/lib.rs
@@ -37,8 +37,9 @@ extern crate std;
 mod nul_terminated_vec;
 mod vec;
 
-pub use imp::Buf;
 #[cfg(feature = "nul-terminated")]
 use nul_terminated_vec as imp;
 #[cfg(not(feature = "nul-terminated"))]
 use vec as imp;
+
+pub use imp::Buf;

--- a/scolapasta-strbuf/src/lib.rs
+++ b/scolapasta-strbuf/src/lib.rs
@@ -1,14 +1,44 @@
-pub fn add(left: usize, right: usize) -> usize {
-    left + right
-}
+#![warn(clippy::all)]
+#![warn(clippy::pedantic)]
+#![warn(clippy::cargo)]
+#![allow(unknown_lints)]
+#![allow(clippy::manual_let_else)]
+#![allow(clippy::module_name_repetitions)]
+// TODO: warn on missing docs once crate is API-complete.
+// #![warn(missing_docs)]
+#![warn(missing_debug_implementations)]
+#![warn(missing_copy_implementations)]
+#![warn(rust_2018_idioms)]
+#![warn(rust_2021_compatibility)]
+#![warn(trivial_casts, trivial_numeric_casts)]
+#![warn(unused_qualifications)]
+#![warn(variant_size_differences)]
+// Enable feature callouts in generated documentation:
+// https://doc.rust-lang.org/beta/unstable-book/language-features/doc-cfg.html
+//
+// This approach is borrowed from tokio.
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_alias))]
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+//! A String object holds and manipulates an arbitrary sequence of bytes,
+//! typically representing characters.
 
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
-    }
-}
+#![no_std]
+
+// Ensure code blocks in `README.md` compile
+#[cfg(doctest)]
+#[doc = include_str!("../README.md")]
+mod readme {}
+
+extern crate alloc;
+#[cfg(feature = "std")]
+extern crate std;
+
+mod nul_terminated_vec;
+mod vec;
+
+pub use imp::Buf;
+#[cfg(feature = "nul-terminated")]
+use nul_terminated_vec as imp;
+#[cfg(not(feature = "nul-terminated"))]
+use vec as imp;

--- a/scolapasta-strbuf/src/lib.rs
+++ b/scolapasta-strbuf/src/lib.rs
@@ -138,6 +138,8 @@ macro_rules! impl_partial_eq_array {
     };
 }
 
+pub use raw_parts::RawParts;
+
 mod nul_terminated_vec;
 mod vec;
 

--- a/scolapasta-strbuf/src/lib.rs
+++ b/scolapasta-strbuf/src/lib.rs
@@ -19,8 +19,73 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(docsrs, feature(doc_alias))]
 
-//! A String object holds and manipulates an arbitrary sequence of bytes,
-//! typically representing characters.
+//! A contiguous growable byte string, written as `Buf`, short for 'buffer'.
+//!
+//! Buffers have *O*(1) indexing, amortized *O*(1) push (to the end) and *O*(1)
+//! pop (from the end).
+//!
+//! Buffers ensure they never allocate more than `isize::MAX` bytes.
+//!
+//! # Examples
+//!
+//! You can explicitly create a [`Buf`] with [`Buf::new`]:
+//!
+//! ```
+//! use scolapasta_strbuf::Buf;
+//!
+//! let buf = Buf::new();
+//! ```
+//!
+//! You can [`push_byte`] bytes into the end of a buffer (which will grow the
+//! buffer as needed):
+//!
+//! ```
+//! use scolapasta_strbuf::Buf;
+//!
+//! let mut buf = Buf::from(b"12");
+//!
+//! buf.push_byte(b'3');
+//! assert_eq!(buf, b"123");
+//! ```
+//!
+//! Popping bytes works in much the same way:
+//!
+//! ```
+//! use scolapasta_strbuf::Buf;
+//!
+//! let mut buf = Buf::from(b"12");
+//!
+//! let alpha_two = buf.pop_byte();
+//! assert_eq!(alpha_two, Some(b'2'));
+//! ```
+//!
+//! Buffers also support indexing (through the [`Index`] and [`IndexMut`]
+//! traits):
+//!
+//! ```
+//! use scolapasta_strbuf::Buf;
+//!
+//! let mut buf = Buf::from(b"123");
+//! let three = buf[2];
+//! buf[1] = b'!';
+//! ```
+//!
+//! # Crate features
+//!
+//! - **std**: Enabled by default. Implement [`std::io::Write`] for `Buf`. If
+//!   this feature is disabled, this crate only depends on [`alloc`].
+//! - **nul-terminated**: Use an alternate byte buffer backend that ensures
+//!   byte content is always followed by a NUL byte in the buffer's spare
+//!   capacity. This feature can be used to ensure `Buf`s are FFI compatible
+//!   with C code that expects byte content to be NUL terminated.
+//!
+#![cfg_attr(
+    not(feature = "std"),
+    doc = "[`std::io::Write`]: https://doc.rust-lang.org/std/io/trait.Write.html"
+)]
+//! [`push_byte`]: Buf::push_byte
+//! [`Index`]: core::ops::Index
+//! [`IndexMut`]: core::ops::IndexMut
 
 #![no_std]
 

--- a/scolapasta-strbuf/src/lib.rs
+++ b/scolapasta-strbuf/src/lib.rs
@@ -26,6 +26,12 @@
 //!
 //! Buffers ensure they never allocate more than `isize::MAX` bytes.
 //!
+//! Buffers are transparent wrappers around [`Vec<u8>`] with a minimized API
+//! sufficient for implementing the Ruby [`String`] type.
+//!
+//! Buffers do not assume any encoding. Encoding is a higher-level concept that
+//! should be built on top of `Buf`.
+//!
 //! # Examples
 //!
 //! You can explicitly create a [`Buf`] with [`Buf::new`]:
@@ -79,6 +85,8 @@
 //!   capacity. This feature can be used to ensure `Buf`s are FFI compatible
 //!   with C code that expects byte content to be NUL terminated.
 //!
+//! [`Vec<u8>`]: Vec
+//! [`String`]: https://ruby-doc.org/3.2.0/String.html
 #![cfg_attr(
     not(feature = "std"),
     doc = "[`std::io::Write`]: https://doc.rust-lang.org/std/io/trait.Write.html"

--- a/scolapasta-strbuf/src/lib.rs
+++ b/scolapasta-strbuf/src/lib.rs
@@ -4,8 +4,7 @@
 #![allow(unknown_lints)]
 #![allow(clippy::manual_let_else)]
 #![allow(clippy::module_name_repetitions)]
-// TODO: warn on missing docs once crate is API-complete.
-// #![warn(missing_docs)]
+#![warn(missing_docs)]
 #![warn(missing_debug_implementations)]
 #![warn(missing_copy_implementations)]
 #![warn(rust_2018_idioms)]

--- a/scolapasta-strbuf/src/lib.rs
+++ b/scolapasta-strbuf/src/lib.rs
@@ -152,9 +152,13 @@ pub use raw_parts::RawParts;
 mod nul_terminated_vec;
 mod vec;
 
-#[cfg(feature = "nul-terminated")]
-use nul_terminated_vec as imp;
-#[cfg(not(feature = "nul-terminated"))]
-use vec as imp;
+mod imp {
+    #[cfg(feature = "nul-terminated")]
+    pub use crate::nul_terminated_vec::Buf;
+    #[cfg(not(feature = "nul-terminated"))]
+    pub use crate::vec::Buf;
+}
 
+// Only export one `Buf` type. The presence of the `nul-terminated` feature
+// determines which `Buf` type to use.
 pub use imp::Buf;

--- a/scolapasta-strbuf/src/lib.rs
+++ b/scolapasta-strbuf/src/lib.rs
@@ -86,7 +86,7 @@
 //!   capacity. This feature can be used to ensure `Buf`s are FFI compatible
 //!   with C code that expects byte content to be NUL terminated.
 //!
-//! [`Vec<u8>`]: Vec
+//! [`Vec<u8>`]: alloc::vec::Vec
 //! [`String`]: https://ruby-doc.org/3.2.0/String.html
 #![cfg_attr(
     not(feature = "std"),

--- a/scolapasta-strbuf/src/lib.rs
+++ b/scolapasta-strbuf/src/lib.rs
@@ -34,6 +34,46 @@ extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 
+macro_rules! impl_partial_eq {
+    ($lhs:ty, $rhs:ty) => {
+        impl<'a, 'b> PartialEq<$rhs> for $lhs {
+            #[inline]
+            fn eq(&self, other: &$rhs) -> bool {
+                let other: &[u8] = other.as_ref();
+                PartialEq::eq(self.as_slice(), other)
+            }
+        }
+
+        impl<'a, 'b> PartialEq<$lhs> for $rhs {
+            #[inline]
+            fn eq(&self, other: &$lhs) -> bool {
+                let this: &[u8] = self.as_ref();
+                PartialEq::eq(this, other.as_slice())
+            }
+        }
+    };
+}
+
+macro_rules! impl_partial_eq_array {
+    ($lhs:ty, $rhs:ty) => {
+        impl<'a, 'b, const N: usize> PartialEq<$rhs> for $lhs {
+            #[inline]
+            fn eq(&self, other: &$rhs) -> bool {
+                let other: &[u8] = other.as_ref();
+                PartialEq::eq(self.as_slice(), other)
+            }
+        }
+
+        impl<'a, 'b, const N: usize> PartialEq<$lhs> for $rhs {
+            #[inline]
+            fn eq(&self, other: &$lhs) -> bool {
+                let this: &[u8] = self.as_ref();
+                PartialEq::eq(this, other.as_slice())
+            }
+        }
+    };
+}
+
 mod nul_terminated_vec;
 mod vec;
 

--- a/scolapasta-strbuf/src/lib.rs
+++ b/scolapasta-strbuf/src/lib.rs
@@ -9,6 +9,8 @@
 #![warn(rust_2018_idioms)]
 #![warn(rust_2021_compatibility)]
 #![warn(trivial_casts, trivial_numeric_casts)]
+#![warn(unsafe_op_in_unsafe_fn)]
+#![warn(clippy::undocumented_unsafe_blocks)]
 #![warn(unused_qualifications)]
 #![warn(variant_size_differences)]
 // Enable feature callouts in generated documentation:

--- a/scolapasta-strbuf/src/lib.rs
+++ b/scolapasta-strbuf/src/lib.rs
@@ -3,7 +3,6 @@
 #![warn(clippy::cargo)]
 #![allow(unknown_lints)]
 #![allow(clippy::manual_let_else)]
-#![allow(clippy::module_name_repetitions)]
 #![warn(missing_docs)]
 #![warn(missing_debug_implementations)]
 #![warn(missing_copy_implementations)]

--- a/scolapasta-strbuf/src/nul_terminated_vec.rs
+++ b/scolapasta-strbuf/src/nul_terminated_vec.rs
@@ -894,12 +894,6 @@ impl Buf {
     }
 
     #[inline]
-    pub fn push(&mut self, value: u8) {
-        self.inner.push(value);
-        ensure_nul_terminated(&mut self.inner).expect("alloc failure");
-    }
-
-    #[inline]
     pub fn pop(&mut self) -> Option<u8> {
         let popped = self.inner.pop();
         ensure_nul_terminated(&mut self.inner).expect("alloc failure");
@@ -1427,13 +1421,6 @@ mod tests {
                 idx += 1;
                 idx % 2 == 0
             });
-            let mut bytes = buf.into_inner();
-            is_nul_terminated(&mut bytes)
-        }
-
-        fn test_ensure_nul_terminated_push(bytes: Vec<u8>, pushed: u8) -> bool {
-            let mut buf = Buf::from(bytes);
-            buf.push(pushed);
             let mut bytes = buf.into_inner();
             is_nul_terminated(&mut bytes)
         }

--- a/scolapasta-strbuf/src/nul_terminated_vec.rs
+++ b/scolapasta-strbuf/src/nul_terminated_vec.rs
@@ -565,11 +565,12 @@ impl Buf {
     ///
     /// unsafe {
     ///     ptr::write(ptr, b'A');
+    ///     ptr::write(ptr.add(1), b'B');
     ///
     ///     let raw_parts = RawParts { ptr, length, capacity };
     ///     let rebuilt = Buf::from_raw_parts(raw_parts);
     ///
-    ///     assert_eq!(rebuilt, b"Abcde");
+    ///     assert_eq!(rebuilt, b"ABcde");
     /// }
     /// ```
     #[inline]
@@ -604,11 +605,12 @@ impl Buf {
     ///
     /// unsafe {
     ///     ptr::write(ptr, b'A');
+    ///     ptr::write(ptr.add(1), b'B');
     ///
     ///     let raw_parts = RawParts { ptr, length, capacity };
     ///     let rebuilt = Buf::from_raw_parts(raw_parts);
     ///
-    ///     assert_eq!(rebuilt, b"Abcde");
+    ///     assert_eq!(rebuilt, b"ABcde");
     /// }
     /// ```
     #[inline]

--- a/scolapasta-strbuf/src/nul_terminated_vec.rs
+++ b/scolapasta-strbuf/src/nul_terminated_vec.rs
@@ -383,46 +383,6 @@ impl<'a> Extend<&'a u8> for Buf {
     }
 }
 
-macro_rules! impl_partial_eq {
-    ($lhs:ty, $rhs:ty) => {
-        impl<'a, 'b> PartialEq<$rhs> for $lhs {
-            #[inline]
-            fn eq(&self, other: &$rhs) -> bool {
-                let other: &[u8] = other.as_ref();
-                PartialEq::eq(self.as_slice(), other)
-            }
-        }
-
-        impl<'a, 'b> PartialEq<$lhs> for $rhs {
-            #[inline]
-            fn eq(&self, other: &$lhs) -> bool {
-                let this: &[u8] = self.as_ref();
-                PartialEq::eq(this, other.as_slice())
-            }
-        }
-    };
-}
-
-macro_rules! impl_partial_eq_array {
-    ($lhs:ty, $rhs:ty) => {
-        impl<'a, 'b, const N: usize> PartialEq<$rhs> for $lhs {
-            #[inline]
-            fn eq(&self, other: &$rhs) -> bool {
-                let other: &[u8] = other.as_ref();
-                PartialEq::eq(self.as_slice(), other)
-            }
-        }
-
-        impl<'a, 'b, const N: usize> PartialEq<$lhs> for $rhs {
-            #[inline]
-            fn eq(&self, other: &$lhs) -> bool {
-                let this: &[u8] = self.as_ref();
-                PartialEq::eq(this, other.as_slice())
-            }
-        }
-    };
-}
-
 impl_partial_eq!(Buf, Vec<u8>);
 impl_partial_eq!(Buf, &'a Vec<u8>);
 impl_partial_eq!(Buf, [u8]);

--- a/scolapasta-strbuf/src/nul_terminated_vec.rs
+++ b/scolapasta-strbuf/src/nul_terminated_vec.rs
@@ -1409,12 +1409,14 @@ mod tests {
 
         fn test_ensure_nul_terminated_after_clone(bytes: Vec<u8>) -> bool {
             let buf = Buf::from(bytes);
+            #[allow(clippy::redundant_clone)]
             let buf = buf.clone();
             let mut bytes = buf.into_inner();
             is_nul_terminated(&mut bytes)
         }
 
         fn test_ensure_nul_terminated_from_iterator(bytes: Vec<u8>) -> bool {
+            #[allow(clippy::from_iter_instead_of_collect)]
             let buf = Buf::from_iter(bytes.into_iter());
             let mut bytes = buf.into_inner();
             is_nul_terminated(&mut bytes)
@@ -1685,7 +1687,7 @@ mod tests {
             use std::io::Write;
 
             let mut buf = Buf::from(bytes);
-            buf.write(&data).unwrap();
+            let _written = buf.write(&data).unwrap();
             let mut bytes = buf.into_inner();
             is_nul_terminated(&mut bytes)
         }
@@ -1706,7 +1708,7 @@ mod tests {
             use std::io::{IoSlice, Write};
 
             let mut buf = Buf::from(bytes);
-            buf.write_vectored(&[IoSlice::new(&data1), IoSlice::new(&data2)]).unwrap();
+            let _written = buf.write_vectored(&[IoSlice::new(&data1), IoSlice::new(&data2)]).unwrap();
             let mut bytes = buf.into_inner();
             is_nul_terminated(&mut bytes)
         }
@@ -1726,7 +1728,7 @@ mod tests {
             use std::io::Write;
 
             let mut buf = Buf::from(bytes);
-            buf.write_fmt(format_args!("{}", data)).unwrap();
+            buf.write_fmt(format_args!("{data}")).unwrap();
             let mut bytes = buf.into_inner();
             is_nul_terminated(&mut bytes)
         }

--- a/scolapasta-strbuf/src/nul_terminated_vec.rs
+++ b/scolapasta-strbuf/src/nul_terminated_vec.rs
@@ -874,13 +874,6 @@ impl Buf {
     }
 
     #[inline]
-    pub fn swap_remove(&mut self, index: usize) -> u8 {
-        let removed = self.inner.swap_remove(index);
-        ensure_nul_terminated(&mut self.inner).expect("alloc failure");
-        removed
-    }
-
-    #[inline]
     pub fn insert(&mut self, index: usize, element: u8) {
         self.inner.insert(index, element);
         ensure_nul_terminated(&mut self.inner).expect("alloc failure");
@@ -1295,36 +1288,6 @@ mod tests {
             unsafe {
                 buf.set_len(0);
             }
-            let mut bytes = buf.into_inner();
-            is_nul_terminated(&mut bytes)
-        }
-
-        fn test_ensure_nul_terminated_swap_remove_first(bytes: Vec<u8>) -> bool {
-            if bytes.is_empty() {
-                return true;
-            }
-            let mut buf = Buf::from(bytes);
-            buf.swap_remove(0);
-            let mut bytes = buf.into_inner();
-            is_nul_terminated(&mut bytes)
-        }
-
-        fn test_ensure_nul_terminated_swap_remove_last(bytes: Vec<u8>) -> bool {
-            if bytes.is_empty() {
-                return true;
-            }
-            let mut buf = Buf::from(bytes);
-            buf.swap_remove(buf.len() - 1);
-            let mut bytes = buf.into_inner();
-            is_nul_terminated(&mut bytes)
-        }
-
-        fn test_ensure_nul_terminated_swap_remove_interior(bytes: Vec<u8>) -> bool {
-            if bytes.len() < 2 {
-                return true;
-            }
-            let mut buf = Buf::from(bytes);
-            buf.swap_remove(buf.len() - 2);
             let mut bytes = buf.into_inner();
             is_nul_terminated(&mut bytes)
         }

--- a/scolapasta-strbuf/src/nul_terminated_vec.rs
+++ b/scolapasta-strbuf/src/nul_terminated_vec.rs
@@ -47,9 +47,16 @@ fn ensure_nul_terminated(vec: &mut Vec<u8>) {
 }
 
 #[repr(transparent)]
-#[derive(Default, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Buf {
     inner: Vec<u8>,
+}
+
+impl Default for Buf {
+    #[inline]
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl Clone for Buf {
@@ -485,6 +492,13 @@ mod tests {
             return false;
         }
         true
+    }
+
+    #[test]
+    fn test_ensure_nul_terminated_default() {
+        let buf = Buf::default();
+        let mut bytes = buf.into_inner();
+        assert!(is_nul_terminated(&mut bytes));
     }
 
     #[test]

--- a/scolapasta-strbuf/src/nul_terminated_vec.rs
+++ b/scolapasta-strbuf/src/nul_terminated_vec.rs
@@ -894,15 +894,6 @@ impl Buf {
     }
 
     #[inline]
-    pub fn retain_mut<F>(&mut self, f: F)
-    where
-        F: FnMut(&mut u8) -> bool,
-    {
-        self.inner.retain_mut(f);
-        ensure_nul_terminated(&mut self.inner).expect("alloc failure");
-    }
-
-    #[inline]
     pub fn push(&mut self, value: u8) {
         self.inner.push(value);
         ensure_nul_terminated(&mut self.inner).expect("alloc failure");
@@ -1433,31 +1424,6 @@ mod tests {
             let mut idx = 0_usize;
             let mut buf = Buf::from(bytes);
             buf.retain(|_| {
-                idx += 1;
-                idx % 2 == 0
-            });
-            let mut bytes = buf.into_inner();
-            is_nul_terminated(&mut bytes)
-        }
-
-        fn test_ensure_nul_terminated_retain_mut_all(bytes: Vec<u8>) -> bool {
-            let mut buf = Buf::from(bytes);
-            buf.retain_mut(|_| true);
-            let mut bytes = buf.into_inner();
-            is_nul_terminated(&mut bytes)
-        }
-
-        fn test_ensure_nul_terminated_retain_mut_none(bytes: Vec<u8>) -> bool {
-            let mut buf = Buf::from(bytes);
-            buf.retain_mut(|_| false);
-            let mut bytes = buf.into_inner();
-            is_nul_terminated(&mut bytes)
-        }
-
-        fn test_ensure_nul_terminated_retain_mut_some(bytes: Vec<u8>) -> bool {
-            let mut idx = 0_usize;
-            let mut buf = Buf::from(bytes);
-            buf.retain_mut(|_| {
                 idx += 1;
                 idx % 2 == 0
             });

--- a/scolapasta-strbuf/src/nul_terminated_vec.rs
+++ b/scolapasta-strbuf/src/nul_terminated_vec.rs
@@ -1023,13 +1023,47 @@ impl Buf {
 }
 
 /// Implementation of useful extension methods from [`bstr::ByteVec`].
+///
+/// [`bstr::ByteVec`]: https://docs.rs/bstr/latest/bstr/trait.ByteVec.html
 impl Buf {
+    /// Append the given byte to the end of this buffer.
+    ///
+    /// Note that this is equivalent to the generic [`Vec::push`] method. This
+    /// method is provided to permit callers to explicitly differentiate
+    /// between pushing bytes, codepoints and strings.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use scolapasta_strbuf::Buf;
+    ///
+    /// let mut buf = Buf::from(b"abc");
+    /// buf.push_byte(b'\xF0');
+    /// buf.push_byte(b'\x9F');
+    /// buf.push_byte(b'\xA6');
+    /// buf.push_byte(b'\x80');
+    /// assert_eq!(buf, "abc🦀");
+    /// ```
     #[inline]
     pub fn push_byte(&mut self, byte: u8) {
         self.inner.push(byte);
         ensure_nul_terminated(&mut self.inner).expect("alloc failure");
     }
 
+    /// Append the given [`char`] to the end of the buffer.
+    ///
+    /// The given `char` is encoded to its UTF-8 byte sequence which is appended
+    /// to the buffer.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use scolapasta_strbuf::Buf;
+    ///
+    /// let mut buf = Buf::from(b"abc");
+    /// buf.push_char('🦀');
+    /// assert_eq!(buf, "abc🦀");
+    /// ```
     #[inline]
     pub fn push_char(&mut self, ch: char) {
         let mut buf = [0; 4];
@@ -1037,6 +1071,24 @@ impl Buf {
         self.push_str(s);
     }
 
+    /// Append the given slice to the end of this buffer.
+    ///
+    /// This method accepts any type that be converted to a `&[u8]`. This
+    /// includes, but is not limited to, `&str`, `&Buf`, and of course, `&[u8]`
+    /// itself.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use scolapasta_strbuf::Buf;
+    ///
+    /// let mut buf = Buf::from(b"abc");
+    /// buf.push_str("🦀");
+    /// assert_eq!(buf, "abc🦀");
+    ///
+    /// buf.push_str(b"\xF0\x9F\xA6\x80");
+    /// assert_eq!(buf, "abc🦀🦀");
+    /// ```
     #[inline]
     pub fn push_str<B: AsRef<[u8]>>(&mut self, bytes: B) {
         self.extend_from_slice(bytes.as_ref());

--- a/scolapasta-strbuf/src/nul_terminated_vec.rs
+++ b/scolapasta-strbuf/src/nul_terminated_vec.rs
@@ -176,6 +176,14 @@ pub struct Buf {
     inner: Vec<u8>,
 }
 
+impl Buf {
+    #[inline]
+    #[must_use]
+    pub fn into_inner(self) -> Vec<u8> {
+        self.inner
+    }
+}
+
 impl Default for Buf {
     #[inline]
     fn default() -> Self {
@@ -453,6 +461,7 @@ impl<'a> IntoIterator for &'a mut Buf {
     }
 }
 
+/// Minimal [`Vec`] API.
 impl Buf {
     /// Constructs a new, empty `Buf`.
     ///
@@ -946,12 +955,7 @@ impl Buf {
     pub fn leak<'a>(self) -> &'a mut [u8] {
         self.inner.leak()
     }
-}
 
-impl Buf
-where
-    u8: Clone,
-{
     #[inline]
     pub fn resize(&mut self, new_len: usize, value: u8) {
         self.inner.resize(new_len, value);
@@ -974,15 +978,7 @@ where
     }
 }
 
-impl Buf {
-    #[inline]
-    #[must_use]
-    pub fn into_inner(self) -> Vec<u8> {
-        self.inner
-    }
-}
-
-// `bstr::ByteVec` impls
+/// Implementation of useful extension methods from [`bstr::ByteVec`].
 impl Buf {
     #[inline]
     pub fn push_byte(&mut self, byte: u8) {

--- a/scolapasta-strbuf/src/nul_terminated_vec.rs
+++ b/scolapasta-strbuf/src/nul_terminated_vec.rs
@@ -53,6 +53,7 @@ pub struct Buf {
 }
 
 impl Clone for Buf {
+    #[inline]
     fn clone(&self) -> Self {
         let mut vec = self.inner.clone();
         ensure_nul_terminated(&mut vec);
@@ -115,6 +116,7 @@ impl Extend<u8> for Buf {
 
 impl Buf {
     #[inline]
+    #[must_use]
     pub fn new() -> Self {
         let mut inner = Vec::with_capacity(1);
         ensure_nul_terminated(&mut inner);
@@ -122,6 +124,7 @@ impl Buf {
     }
 
     #[inline]
+    #[must_use]
     pub fn with_capacity(capacity: usize) -> Self {
         let capacity = capacity.checked_add(1).expect("capacity overflow");
         let mut inner = Vec::with_capacity(capacity);
@@ -130,6 +133,7 @@ impl Buf {
     }
 
     #[inline]
+    #[must_use]
     pub unsafe fn from_raw_parts(raw_parts: RawParts<u8>) -> Self {
         let mut inner = raw_parts.into_vec();
         // SAFETY: Callers may have written into the spare capacity of the `Vec`
@@ -139,11 +143,13 @@ impl Buf {
     }
 
     #[inline]
+    #[must_use]
     pub fn into_raw_parts(self) -> RawParts<u8> {
         RawParts::from_vec(self.inner)
     }
 
     #[inline]
+    #[must_use]
     pub fn capacity(&self) -> usize {
         self.inner.capacity()
     }
@@ -189,6 +195,7 @@ impl Buf {
     }
 
     #[inline]
+    #[must_use]
     pub fn into_boxed_slice(self) -> Box<[u8]> {
         self.inner.into_boxed_slice()
     }
@@ -200,21 +207,25 @@ impl Buf {
     }
 
     #[inline]
+    #[must_use]
     pub fn as_slice(&self) -> &[u8] {
         self.inner.as_slice()
     }
 
     #[inline]
+    #[must_use]
     pub fn as_mut_slice(&mut self) -> &mut [u8] {
         self.inner.as_mut_slice()
     }
 
     #[inline]
+    #[must_use]
     pub fn as_ptr(&self) -> *const u8 {
         self.inner.as_ptr()
     }
 
     #[inline]
+    #[must_use]
     pub fn as_mut_ptr(&mut self) -> *mut u8 {
         self.inner.as_mut_ptr()
     }
@@ -309,21 +320,22 @@ impl Buf {
     }
 
     #[inline]
+    #[must_use]
     pub fn len(&self) -> usize {
         self.inner.len()
     }
 
     #[inline]
+    #[must_use]
     pub fn is_empty(&self) -> bool {
         self.inner.is_empty()
     }
 
     #[inline]
-    pub fn split_off(&mut self, at: usize) -> Buf {
-        let mut split = self.inner.split_off(at);
+    pub fn split_off(&mut self, at: usize) -> Self {
+        let split = self.inner.split_off(at);
         ensure_nul_terminated(&mut self.inner);
-        ensure_nul_terminated(&mut split);
-        Self { inner: split }
+        Self::from(split)
     }
 
     #[inline]
@@ -336,6 +348,7 @@ impl Buf {
     }
 
     #[inline]
+    #[must_use]
     pub fn leak<'a>(self) -> &'a mut [u8] {
         self.inner.leak()
     }
@@ -380,6 +393,7 @@ where
 
 impl Buf {
     #[inline]
+    #[must_use]
     pub fn into_inner(self) -> Vec<u8> {
         self.inner
     }

--- a/scolapasta-strbuf/src/nul_terminated_vec.rs
+++ b/scolapasta-strbuf/src/nul_terminated_vec.rs
@@ -548,6 +548,10 @@ impl Buf {
     /// Refer to the safety documentation for [`Vec::from_raw_parts`] for more
     /// details.
     ///
+    /// In addition to the safety invariants of `Vec`, `Buf` has the additional
+    /// requirement that callers ensure the spare capacity of the allocation
+    /// referred to by `ptr` is NUL terminated at offset `length` and `capacity`.
+    ///
     /// # Examples
     ///
     /// ```

--- a/scolapasta-strbuf/src/nul_terminated_vec.rs
+++ b/scolapasta-strbuf/src/nul_terminated_vec.rs
@@ -5,8 +5,6 @@ use alloc::string::String;
 use alloc::vec::{IntoIter, Vec};
 use core::borrow::{Borrow, BorrowMut};
 use core::fmt;
-#[cfg(feature = "std")]
-use core::fmt::Arguments;
 use core::ops::{Deref, DerefMut};
 use core::slice::{Iter, IterMut};
 #[cfg(feature = "std")]
@@ -1261,13 +1259,6 @@ impl Write for Buf {
     }
 
     #[inline]
-    fn flush(&mut self) -> io::Result<()> {
-        let result = self.inner.flush();
-        ensure_nul_terminated(&mut self.inner).expect("alloc failure");
-        result
-    }
-
-    #[inline]
     fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         let result = self.inner.write_vectored(bufs);
         ensure_nul_terminated(&mut self.inner).expect("alloc failure");
@@ -1282,8 +1273,8 @@ impl Write for Buf {
     }
 
     #[inline]
-    fn write_fmt(&mut self, fmt: Arguments<'_>) -> io::Result<()> {
-        let result = self.inner.write_fmt(fmt);
+    fn flush(&mut self) -> io::Result<()> {
+        let result = self.inner.flush();
         ensure_nul_terminated(&mut self.inner).expect("alloc failure");
         result
     }

--- a/scolapasta-strbuf/src/nul_terminated_vec.rs
+++ b/scolapasta-strbuf/src/nul_terminated_vec.rs
@@ -551,7 +551,9 @@ impl Buf {
     #[inline]
     #[must_use]
     pub unsafe fn from_raw_parts(raw_parts: RawParts<u8>) -> Self {
-        let inner = raw_parts.into_vec();
+        // SAFETY: Callers ensure that the raw parts safety invariants are
+        // upheld.
+        let inner = unsafe { raw_parts.into_vec() };
         Self::from(inner)
     }
 
@@ -934,7 +936,11 @@ impl Buf {
     /// [`capacity()`]: Self::capacity
     #[inline]
     pub unsafe fn set_len(&mut self, new_len: usize) {
-        self.inner.set_len(new_len);
+        // SAFETY: Caller has guaranteed the safety invariants of `Vec::set_len`
+        // are upheld.
+        unsafe {
+            self.inner.set_len(new_len);
+        }
         ensure_nul_terminated(&mut self.inner).expect("alloc failure");
     }
 
@@ -1269,6 +1275,7 @@ impl Write for Buf {
 }
 
 #[cfg(test)]
+#[allow(clippy::undocumented_unsafe_blocks)]
 mod tests {
     use alloc::string::String;
     use alloc::vec::Vec;

--- a/scolapasta-strbuf/src/nul_terminated_vec.rs
+++ b/scolapasta-strbuf/src/nul_terminated_vec.rs
@@ -1,5 +1,7 @@
+use alloc::borrow::Cow;
 use alloc::boxed::Box;
 use alloc::collections::TryReserveError;
+use alloc::string::String;
 use alloc::vec::Vec;
 #[cfg(feature = "std")]
 use core::fmt::Arguments;
@@ -62,9 +64,8 @@ impl Default for Buf {
 impl Clone for Buf {
     #[inline]
     fn clone(&self) -> Self {
-        let mut vec = self.inner.clone();
-        ensure_nul_terminated(&mut vec);
-        Self { inner: vec }
+        let vec = self.inner.clone();
+        Self::from(vec)
     }
 }
 
@@ -76,10 +77,109 @@ impl From<Vec<u8>> for Buf {
     }
 }
 
+impl<'a> From<&'a [u8]> for Buf {
+    #[inline]
+    fn from(s: &'a [u8]) -> Self {
+        let vec = s.to_vec();
+        Self::from(vec)
+    }
+}
+
+impl<'a> From<&'a mut [u8]> for Buf {
+    #[inline]
+    fn from(s: &'a mut [u8]) -> Self {
+        let vec = s.to_vec();
+        Self::from(vec)
+    }
+}
+
+impl<const N: usize> From<[u8; N]> for Buf {
+    #[inline]
+    fn from(s: [u8; N]) -> Self {
+        let vec = Vec::from(s);
+        Self::from(vec)
+    }
+}
+
+impl<'a, const N: usize> From<&'a [u8; N]> for Buf {
+    #[inline]
+    fn from(s: &'a [u8; N]) -> Self {
+        let vec = s.to_vec();
+        Self::from(vec)
+    }
+}
+
+impl<'a, const N: usize> From<&'a mut [u8; N]> for Buf {
+    #[inline]
+    fn from(s: &'a mut [u8; N]) -> Self {
+        let vec = s.to_vec();
+        Self::from(vec)
+    }
+}
+
+impl<'a> From<Cow<'a, [u8]>> for Buf {
+    #[inline]
+    fn from(s: Cow<'a, [u8]>) -> Self {
+        let vec = s.into_owned();
+        Self::from(vec)
+    }
+}
+
+impl From<String> for Buf {
+    #[inline]
+    fn from(s: String) -> Self {
+        let vec = s.into_bytes();
+        Self::from(vec)
+    }
+}
+
+impl<'a> From<&'a str> for Buf {
+    #[inline]
+    fn from(s: &'a str) -> Self {
+        let vec = s.as_bytes().to_vec();
+        Self::from(vec)
+    }
+}
+
+impl<'a> From<&'a mut str> for Buf {
+    #[inline]
+    fn from(s: &'a mut str) -> Self {
+        let vec = s.as_bytes().to_vec();
+        Self::from(vec)
+    }
+}
+
+impl<'a> From<Cow<'a, str>> for Buf {
+    #[inline]
+    fn from(s: Cow<'a, str>) -> Self {
+        let vec = s.into_owned().into_bytes();
+        Self::from(vec)
+    }
+}
+
 impl From<Buf> for Vec<u8> {
     #[inline]
     fn from(buf: Buf) -> Self {
         buf.inner
+    }
+}
+
+impl<const N: usize> TryFrom<Buf> for [u8; N] {
+    type Error = Buf;
+
+    #[inline]
+    fn try_from(buf: Buf) -> Result<Self, Self::Error> {
+        match buf.into_inner().try_into() {
+            Ok(array) => Ok(array),
+            Err(vec) => Err(vec.into()),
+        }
+    }
+}
+
+impl<'a> From<Buf> for Cow<'a, [u8]> {
+    #[inline]
+    fn from(buf: Buf) -> Self {
+        Cow::Owned(buf.into())
     }
 }
 

--- a/scolapasta-strbuf/src/nul_terminated_vec.rs
+++ b/scolapasta-strbuf/src/nul_terminated_vec.rs
@@ -77,13 +77,13 @@ fn ensure_nul_terminated(vec: &mut Vec<u8>) -> Result<(), TryReserveError> {
 /// use scolapasta_strbuf::Buf;
 ///
 /// let mut buf = Buf::new();
-/// buf.push(b'a');
-/// buf.push(b'z');
+/// buf.push_byte(b'a');
+/// buf.push_byte(b'z');
 ///
 /// assert_eq!(buf.len(), 2);
 /// assert_eq!(buf[0], b'a');
 ///
-/// assert_eq!(buf.pop(), Some(b'z'));
+/// assert_eq!(buf.pop_byte(), Some(b'z'));
 /// assert_eq!(buf.len(), 1);
 ///
 /// buf[0] = b'!';
@@ -508,13 +508,13 @@ impl Buf {
     ///
     /// // These are all done without reallocating...
     /// for ch in b'a'..=b'z' {
-    ///     buf.push(ch);
+    ///     buf.push_byte(ch);
     /// }
     /// assert_eq!(buf.len(), 26);
     /// assert!(buf.capacity() >= 26);
     ///
     /// // ...but this may make the buffer reallocate
-    /// buf.push(b'!');
+    /// buf.push_byte(b'!');
     /// assert_eq!(buf.len(), 27);
     /// assert!(buf.capacity() >= 27);
     /// ```
@@ -615,7 +615,7 @@ impl Buf {
     /// use scolapasta_strbuf::Buf;
     ///
     /// let mut buf = Buf::with_capacity(10);
-    /// buf.push(b'!');
+    /// buf.push_byte(b'!');
     /// assert_eq!(buf.capacity(), 11);
     /// # }
     /// ```
@@ -894,7 +894,7 @@ impl Buf {
     }
 
     #[inline]
-    pub fn pop(&mut self) -> Option<u8> {
+    pub fn pop_byte(&mut self) -> Option<u8> {
         let popped = self.inner.pop();
         ensure_nul_terminated(&mut self.inner).expect("alloc failure");
         popped
@@ -1430,7 +1430,7 @@ mod tests {
                 return true;
             }
             let mut buf = Buf::from(bytes);
-            buf.pop();
+            buf.pop_byte();
             let mut bytes = buf.into_inner();
             is_nul_terminated(&mut bytes)
         }

--- a/scolapasta-strbuf/src/nul_terminated_vec.rs
+++ b/scolapasta-strbuf/src/nul_terminated_vec.rs
@@ -903,13 +903,6 @@ impl Buf {
     }
 
     #[inline]
-    pub fn append(&mut self, other: &mut Buf) {
-        self.inner.append(&mut other.inner);
-        ensure_nul_terminated(&mut self.inner).expect("alloc failure");
-        ensure_nul_terminated(&mut other.inner).expect("alloc failure");
-    }
-
-    #[inline]
     pub fn clear(&mut self) {
         self.inner.clear();
         ensure_nul_terminated(&mut self.inner).expect("alloc failure");
@@ -1392,15 +1385,6 @@ mod tests {
             buf.pop_byte();
             let mut bytes = buf.into_inner();
             is_nul_terminated(&mut bytes)
-        }
-
-        fn test_ensure_nul_terminated_append(bytes: Vec<u8>, other: Vec<u8>) -> bool {
-            let mut buf = Buf::from(bytes);
-            let mut other_buf = Buf::from(other);
-            buf.append(&mut other_buf);
-            let mut bytes = buf.into_inner();
-            let mut other = other_buf.into_inner();
-            is_nul_terminated(&mut bytes) && is_nul_terminated(&mut other)
         }
 
         fn test_ensure_nul_terminated_clear(bytes: Vec<u8>) -> bool {

--- a/scolapasta-strbuf/src/nul_terminated_vec.rs
+++ b/scolapasta-strbuf/src/nul_terminated_vec.rs
@@ -167,7 +167,7 @@ fn ensure_nul_terminated(vec: &mut Vec<u8>) -> Result<(), TryReserveError> {
 /// [`String`]: https://ruby-doc.org/3.2.0/String.html
 /// [`Index`]: core::ops::Index
 /// [guarantees as a `Vec`]: https://doc.rust-lang.org/std/vec/struct.Vec.html#guarantees
-/// [vec-docs]: alloc::vec
+/// [vec-docs]: mod@alloc::vec
 /// [`set_len`]: Self::set_len
 #[repr(transparent)]
 #[derive(Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]

--- a/scolapasta-strbuf/src/nul_terminated_vec.rs
+++ b/scolapasta-strbuf/src/nul_terminated_vec.rs
@@ -29,6 +29,7 @@ fn ensure_nul_terminated(vec: &mut Vec<u8>) -> Result<(), TryReserveError> {
 
     let spare_capacity = vec.spare_capacity_mut();
     // If the vec has spare capacity, set the first and last bytes to NUL.
+    //
     // See:
     //
     // - https://github.com/artichoke/artichoke/pull/1976#discussion_r932782264

--- a/scolapasta-strbuf/src/nul_terminated_vec.rs
+++ b/scolapasta-strbuf/src/nul_terminated_vec.rs
@@ -11,7 +11,6 @@ use core::slice::{Iter, IterMut};
 #[cfg(feature = "std")]
 use std::io::{self, IoSlice, Write};
 
-use bstr::ByteVec;
 use raw_parts::RawParts;
 
 /// Ensure the given `Vec` can be used safely by C code as a string buffer.
@@ -1027,20 +1026,20 @@ impl Buf {
 impl Buf {
     #[inline]
     pub fn push_byte(&mut self, byte: u8) {
-        self.inner.push_byte(byte);
+        self.inner.push(byte);
         ensure_nul_terminated(&mut self.inner).expect("alloc failure");
     }
 
     #[inline]
     pub fn push_char(&mut self, ch: char) {
-        self.inner.push_char(ch);
-        ensure_nul_terminated(&mut self.inner).expect("alloc failure");
+        let mut buf = [0; 4];
+        let s = ch.encode_utf8(&mut buf[..]);
+        self.push_str(s);
     }
 
     #[inline]
     pub fn push_str<B: AsRef<[u8]>>(&mut self, bytes: B) {
-        self.inner.push_str(bytes);
-        ensure_nul_terminated(&mut self.inner).expect("alloc failure");
+        self.extend_from_slice(bytes.as_ref());
     }
 }
 

--- a/scolapasta-strbuf/src/nul_terminated_vec.rs
+++ b/scolapasta-strbuf/src/nul_terminated_vec.rs
@@ -387,12 +387,15 @@ impl_partial_eq!(Buf, Vec<u8>);
 impl_partial_eq!(Buf, &'a Vec<u8>);
 impl_partial_eq!(Buf, [u8]);
 impl_partial_eq!(Buf, &'a [u8]);
+impl_partial_eq!(Buf, &'a mut [u8]);
 impl_partial_eq!(Buf, String);
 impl_partial_eq!(Buf, &'a String);
 impl_partial_eq!(Buf, str);
 impl_partial_eq!(Buf, &'a str);
+impl_partial_eq!(Buf, &'a mut str);
 impl_partial_eq_array!(Buf, [u8; N]);
 impl_partial_eq_array!(Buf, &'a [u8; N]);
+impl_partial_eq_array!(Buf, &'a mut [u8; N]);
 
 impl IntoIterator for Buf {
     type Item = u8;

--- a/scolapasta-strbuf/src/nul_terminated_vec.rs
+++ b/scolapasta-strbuf/src/nul_terminated_vec.rs
@@ -903,25 +903,6 @@ impl Buf {
     }
 
     #[inline]
-    pub fn dedup_by_key<F, K>(&mut self, key: F)
-    where
-        F: FnMut(&mut u8) -> K,
-        K: PartialEq<K>,
-    {
-        self.inner.dedup_by_key(key);
-        ensure_nul_terminated(&mut self.inner).expect("alloc failure");
-    }
-
-    #[inline]
-    pub fn dedup_by<F>(&mut self, same_bucket: F)
-    where
-        F: FnMut(&mut u8, &mut u8) -> bool,
-    {
-        self.inner.dedup_by(same_bucket);
-        ensure_nul_terminated(&mut self.inner).expect("alloc failure");
-    }
-
-    #[inline]
     pub fn push(&mut self, value: u8) {
         self.inner.push(value);
         ensure_nul_terminated(&mut self.inner).expect("alloc failure");
@@ -1004,17 +985,6 @@ where
         R: RangeBounds<usize>,
     {
         self.inner.extend_from_within(src);
-        ensure_nul_terminated(&mut self.inner).expect("alloc failure");
-    }
-}
-
-impl Buf
-where
-    u8: PartialEq<u8>,
-{
-    #[inline]
-    pub fn dedup(&mut self) {
-        self.inner.dedup();
         ensure_nul_terminated(&mut self.inner).expect("alloc failure");
     }
 }
@@ -1495,20 +1465,6 @@ mod tests {
             is_nul_terminated(&mut bytes)
         }
 
-        fn test_ensure_nul_terminated_dedup_by_key(bytes: Vec<u8>) -> bool {
-            let mut buf = Buf::from(bytes);
-            buf.dedup_by_key(|byte| *byte);
-            let mut bytes = buf.into_inner();
-            is_nul_terminated(&mut bytes)
-        }
-
-        fn test_ensure_nul_terminated_dedup_by(bytes: Vec<u8>) -> bool {
-            let mut buf = Buf::from(bytes);
-            buf.dedup_by(|&mut a, &mut b| a == b);
-            let mut bytes = buf.into_inner();
-            is_nul_terminated(&mut bytes)
-        }
-
         fn test_ensure_nul_terminated_push(bytes: Vec<u8>, pushed: u8) -> bool {
             let mut buf = Buf::from(bytes);
             buf.push(pushed);
@@ -1651,13 +1607,6 @@ mod tests {
             }
             let mut buf = Buf::from(bytes);
             buf.extend_from_within(1..buf.len() - 2);
-            let mut bytes = buf.into_inner();
-            is_nul_terminated(&mut bytes)
-        }
-
-        fn test_ensure_nul_terminated_dedup(bytes: Vec<u8>) -> bool {
-            let mut buf = Buf::from(bytes);
-            buf.dedup();
             let mut bytes = buf.into_inner();
             is_nul_terminated(&mut bytes)
         }

--- a/scolapasta-strbuf/src/nul_terminated_vec.rs
+++ b/scolapasta-strbuf/src/nul_terminated_vec.rs
@@ -3,6 +3,7 @@ use alloc::boxed::Box;
 use alloc::collections::TryReserveError;
 use alloc::string::String;
 use alloc::vec::Vec;
+use core::borrow::{Borrow, BorrowMut};
 #[cfg(feature = "std")]
 use core::fmt::Arguments;
 use core::ops::{Deref, DerefMut, RangeBounds};
@@ -180,6 +181,32 @@ impl<'a> From<Buf> for Cow<'a, [u8]> {
     #[inline]
     fn from(buf: Buf) -> Self {
         Cow::Owned(buf.into())
+    }
+}
+
+impl AsRef<[u8]> for Buf {
+    #[inline]
+    fn as_ref(&self) -> &[u8] {
+        self.inner.as_ref()
+    }
+}
+
+impl AsMut<[u8]> for Buf {
+    #[inline]
+    fn as_mut(&mut self) -> &mut [u8] {
+        self.inner.as_mut()
+    }
+}
+
+impl Borrow<[u8]> for Buf {
+    fn borrow(&self) -> &[u8] {
+        self
+    }
+}
+
+impl BorrowMut<[u8]> for Buf {
+    fn borrow_mut(&mut self) -> &mut [u8] {
+        self
     }
 }
 

--- a/scolapasta-strbuf/src/nul_terminated_vec.rs
+++ b/scolapasta-strbuf/src/nul_terminated_vec.rs
@@ -4,6 +4,7 @@ use alloc::collections::TryReserveError;
 use alloc::string::String;
 use alloc::vec::{IntoIter, Vec};
 use core::borrow::{Borrow, BorrowMut};
+use core::fmt;
 #[cfg(feature = "std")]
 use core::fmt::Arguments;
 use core::ops::{Deref, DerefMut};
@@ -1233,6 +1234,20 @@ impl Buf {
     #[inline]
     pub fn push_str<B: AsRef<[u8]>>(&mut self, bytes: B) {
         self.extend_from_slice(bytes.as_ref());
+    }
+}
+
+impl fmt::Write for Buf {
+    #[inline]
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        self.push_str(s);
+        Ok(())
+    }
+
+    #[inline]
+    fn write_char(&mut self, c: char) -> fmt::Result {
+        self.push_char(c);
+        Ok(())
     }
 }
 

--- a/scolapasta-strbuf/src/nul_terminated_vec.rs
+++ b/scolapasta-strbuf/src/nul_terminated_vec.rs
@@ -260,6 +260,57 @@ impl Extend<u8> for Buf {
     }
 }
 
+macro_rules! impl_partial_eq {
+    ($lhs:ty, $rhs:ty) => {
+        impl<'a, 'b> PartialEq<$rhs> for $lhs {
+            #[inline]
+            fn eq(&self, other: &$rhs) -> bool {
+                let other: &[u8] = other.as_ref();
+                PartialEq::eq(self.as_slice(), other)
+            }
+        }
+
+        impl<'a, 'b> PartialEq<$lhs> for $rhs {
+            #[inline]
+            fn eq(&self, other: &$lhs) -> bool {
+                let this: &[u8] = self.as_ref();
+                PartialEq::eq(this, other.as_slice())
+            }
+        }
+    };
+}
+
+macro_rules! impl_partial_eq_array {
+    ($lhs:ty, $rhs:ty) => {
+        impl<'a, 'b, const N: usize> PartialEq<$rhs> for $lhs {
+            #[inline]
+            fn eq(&self, other: &$rhs) -> bool {
+                let other: &[u8] = other.as_ref();
+                PartialEq::eq(self.as_slice(), other)
+            }
+        }
+
+        impl<'a, 'b, const N: usize> PartialEq<$lhs> for $rhs {
+            #[inline]
+            fn eq(&self, other: &$lhs) -> bool {
+                let this: &[u8] = self.as_ref();
+                PartialEq::eq(this, other.as_slice())
+            }
+        }
+    };
+}
+
+impl_partial_eq!(Buf, Vec<u8>);
+impl_partial_eq!(Buf, &'a Vec<u8>);
+impl_partial_eq!(Buf, [u8]);
+impl_partial_eq!(Buf, &'a [u8]);
+impl_partial_eq!(Buf, String);
+impl_partial_eq!(Buf, &'a String);
+impl_partial_eq!(Buf, str);
+impl_partial_eq!(Buf, &'a str);
+impl_partial_eq_array!(Buf, [u8; N]);
+impl_partial_eq_array!(Buf, &'a [u8; N]);
+
 impl Buf {
     #[inline]
     #[must_use]

--- a/scolapasta-strbuf/src/nul_terminated_vec.rs
+++ b/scolapasta-strbuf/src/nul_terminated_vec.rs
@@ -628,6 +628,66 @@ mod tests {
     }
 
     #[test]
+    fn default_is_new() {
+        assert_eq!(Buf::default(), Buf::new());
+    }
+
+    #[test]
+    fn extra_capa_is_not_included_in_len() {
+        let buf = Buf::new();
+        assert!(buf.is_empty());
+        assert_eq!(buf.len(), 0);
+
+        let buf = Buf::with_capacity(0);
+        assert!(buf.is_empty());
+        assert_eq!(buf.len(), 0);
+
+        let buf = Buf::with_capacity(100);
+        assert!(buf.is_empty());
+        assert_eq!(buf.len(), 0);
+    }
+
+    #[test]
+    fn clone_is_equal() {
+        let buf = Buf::from("abc");
+        assert_eq!(buf, buf.clone());
+    }
+
+    #[test]
+    fn try_reserve_overflow_is_err() {
+        let mut buf = Buf::new();
+        assert!(buf.try_reserve(usize::MAX).is_err());
+        assert!(buf.is_empty());
+        assert_eq!(buf.len(), 0);
+    }
+
+    #[test]
+    fn try_reserve_exact_overflow_is_err() {
+        let mut buf = Buf::new();
+        assert!(buf.try_reserve_exact(usize::MAX).is_err());
+        assert!(buf.is_empty());
+        assert_eq!(buf.len(), 0);
+    }
+
+    #[test]
+    fn try_reserve_zero_is_ok() {
+        let mut buf = Buf::new();
+        assert!(buf.try_reserve(0).is_ok());
+        assert_eq!(buf.capacity(), 1);
+        assert!(buf.is_empty());
+        assert_eq!(buf.len(), 0);
+    }
+
+    #[test]
+    fn try_reserve_exact_zero_is_ok() {
+        let mut buf = Buf::new();
+        assert!(buf.try_reserve_exact(0).is_ok());
+        assert_eq!(buf.capacity(), 1);
+        assert!(buf.is_empty());
+        assert_eq!(buf.len(), 0);
+    }
+
+    #[test]
     fn test_ensure_nul_terminated_default() {
         let buf = Buf::default();
         let mut bytes = buf.into_inner();

--- a/scolapasta-strbuf/src/nul_terminated_vec.rs
+++ b/scolapasta-strbuf/src/nul_terminated_vec.rs
@@ -6,7 +6,7 @@ use alloc::vec::{IntoIter, Vec};
 use core::borrow::{Borrow, BorrowMut};
 #[cfg(feature = "std")]
 use core::fmt::Arguments;
-use core::ops::{Deref, DerefMut, RangeBounds};
+use core::ops::{Deref, DerefMut};
 use core::slice::{Iter, IterMut};
 #[cfg(feature = "std")]
 use std::io::{self, IoSlice, Write};
@@ -900,15 +900,6 @@ impl Buf {
         self.inner.extend_from_slice(other);
         ensure_nul_terminated(&mut self.inner).expect("alloc failure");
     }
-
-    #[inline]
-    pub fn extend_from_within<R>(&mut self, src: R)
-    where
-        R: RangeBounds<usize>,
-    {
-        self.inner.extend_from_within(src);
-        ensure_nul_terminated(&mut self.inner).expect("alloc failure");
-    }
 }
 
 /// Implementation of useful extension methods from [`bstr::ByteVec`].
@@ -1357,37 +1348,6 @@ mod tests {
         fn test_ensure_nul_terminated_extend_from_slice(bytes: Vec<u8>, other: Vec<u8>) -> bool {
             let mut buf = Buf::from(bytes);
             buf.extend_from_slice(&other);
-            let mut bytes = buf.into_inner();
-            is_nul_terminated(&mut bytes)
-        }
-
-        fn test_ensure_nul_terminated_extend_from_within_prefix(bytes: Vec<u8>) -> bool {
-            let mut buf = Buf::from(bytes);
-            buf.extend_from_within(0..0);
-            let mut bytes = buf.into_inner();
-            is_nul_terminated(&mut bytes)
-        }
-
-        fn test_ensure_nul_terminated_extend_from_within_suffix(bytes: Vec<u8>) -> bool {
-            let mut buf = Buf::from(bytes);
-            buf.extend_from_within(buf.len()..buf.len());
-            let mut bytes = buf.into_inner();
-            is_nul_terminated(&mut bytes)
-        }
-
-        fn test_ensure_nul_terminated_extend_from_within_all(bytes: Vec<u8>) -> bool {
-            let mut buf = Buf::from(bytes);
-            buf.extend_from_within(0..buf.len());
-            let mut bytes = buf.into_inner();
-            is_nul_terminated(&mut bytes)
-        }
-
-        fn test_ensure_nul_terminated_extend_from_within_subset(bytes: Vec<u8>) -> bool {
-            if bytes.len() < 3 {
-                return true;
-            }
-            let mut buf = Buf::from(bytes);
-            buf.extend_from_within(1..buf.len() - 2);
             let mut bytes = buf.into_inner();
             is_nul_terminated(&mut bytes)
         }

--- a/scolapasta-strbuf/src/nul_terminated_vec.rs
+++ b/scolapasta-strbuf/src/nul_terminated_vec.rs
@@ -154,7 +154,7 @@ fn ensure_nul_terminated(vec: &mut Vec<u8>) -> Result<(), TryReserveError> {
 /// use scolapasta_strbuf::Buf;
 ///
 /// let buf = Buf::new();
-/// assert_ne!(buf.capacity(), 0);
+/// assert_eq!(buf.capacity(), 1);
 ///
 /// let mut inner = buf.into_inner();
 /// let spare = inner.spare_capacity_mut();
@@ -454,6 +454,18 @@ impl<'a> IntoIterator for &'a mut Buf {
 }
 
 impl Buf {
+    /// Constructs a new, empty `Buf`.
+    ///
+    /// The buffer will allocate one byte to maintain its NUL termination
+    /// invariant.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use scolapasta_strbuf::Buf;
+    ///
+    /// let mut buf = Buf::new();
+    /// ```
     #[inline]
     #[must_use]
     pub fn new() -> Self {
@@ -461,6 +473,51 @@ impl Buf {
         Self::from(inner)
     }
 
+    /// Constructs a new, empty `Buf` with at least the specified capacity.
+    ///
+    /// The buffer will be able to hold at least `capacity` bytes without
+    /// reallocating. This method is allowed to allocate for more elements than
+    /// `capacity`. If `capacity` is 0, the buffer will allocate 1 byte to
+    /// maintain its NUL termination invariant.
+    ///
+    /// It is important to note that although the returned buffer has the
+    /// minimum *capacity* specified, the vector will have a zero *length*. For
+    /// an explanation of the difference between length and capacity, see
+    /// *[Capacity and reallocation]*.
+    ///
+    /// If it is important to know the exact allocated capacity of a `Buf`,
+    /// always use the [`capacity`] method after construction.
+    ///
+    /// [Capacity and reallocation]: #capacity-and-reallocation
+    /// [`capacity`]: Self::capacity
+    ///
+    /// # Panics
+    ///
+    /// Panics if the new capacity exceeds `isize::MAX` bytes.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use scolapasta_strbuf::Buf;
+    ///
+    /// let mut buf = Buf::with_capacity(26);
+    ///
+    /// // The buffer is empty, even though it has capacity for more
+    /// assert_eq!(buf.len(), 0);
+    /// assert!(buf.capacity() >= 26);
+    ///
+    /// // These are all done without reallocating...
+    /// for ch in b'a'..=b'z' {
+    ///     buf.push(ch);
+    /// }
+    /// assert_eq!(buf.len(), 26);
+    /// assert!(buf.capacity() >= 26);
+    ///
+    /// // ...but this may make the buffer reallocate
+    /// buf.push(b'!');
+    /// assert_eq!(buf.len(), 27);
+    /// assert!(buf.capacity() >= 27);
+    /// ```
     #[inline]
     #[must_use]
     pub fn with_capacity(capacity: usize) -> Self {
@@ -469,6 +526,39 @@ impl Buf {
         Self::from(inner)
     }
 
+    /// Creates a `Buf` directly from a pointer, a capacity, and a length.
+    ///
+    /// Reconstructing the buffer may cause a reallocation to maintain the
+    /// buffer's NUL termination invariant.
+    ///
+    /// # Safety
+    ///
+    /// This is highly unsafe, due to the number of invariants that aren't
+    /// checked.
+    ///
+    /// Refer to the safety documentation for [`Vec::from_raw_parts`] for more
+    /// details.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use core::ptr;
+    ///
+    /// use raw_parts::RawParts;
+    /// use scolapasta_strbuf::Buf;
+    ///
+    /// let buf = Buf::from(b"abcde");
+    /// let RawParts { ptr, length, capacity } = buf.into_raw_parts();
+    ///
+    /// unsafe {
+    ///     ptr::write(ptr, b'A');
+    ///
+    ///     let raw_parts = RawParts { ptr, length, capacity };
+    ///     let rebuilt = Buf::from_raw_parts(raw_parts);
+    ///
+    ///     assert_eq!(rebuilt, b"Abcde");
+    /// }
+    /// ```
     #[inline]
     #[must_use]
     pub unsafe fn from_raw_parts(raw_parts: RawParts<u8>) -> Self {
@@ -476,30 +566,138 @@ impl Buf {
         Self::from(inner)
     }
 
+    /// Decomposes a `Buf` into its raw components.
+    ///
+    /// Returns the raw pointer to the underlying bytes, the length of the
+    /// buffer (in bytes), and the allocated capacity of the data (in bytes).
+    ///
+    /// After calling this function, the caller is responsible for the memory
+    /// previously managed by the `Buf`. The only way to do this is to convert
+    /// the raw pointer, length, and capacity back into a `Buf` with the
+    /// [`from_raw_parts`] function, allowing the destructor to perform the cleanup.
+    ///
+    /// [`from_raw_parts`]: Self::from_raw_parts
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use core::ptr;
+    ///
+    /// use raw_parts::RawParts;
+    /// use scolapasta_strbuf::Buf;
+    ///
+    /// let buf = Buf::from(b"abcde");
+    /// let RawParts { ptr, length, capacity } = buf.into_raw_parts();
+    ///
+    /// unsafe {
+    ///     ptr::write(ptr, b'A');
+    ///
+    ///     let raw_parts = RawParts { ptr, length, capacity };
+    ///     let rebuilt = Buf::from_raw_parts(raw_parts);
+    ///
+    ///     assert_eq!(rebuilt, b"Abcde");
+    /// }
+    /// ```
     #[inline]
     #[must_use]
     pub fn into_raw_parts(self) -> RawParts<u8> {
         RawParts::from_vec(self.inner)
     }
 
+    /// Returns the total number of bytes the buffer can hold without
+    /// reallocating.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #[cfg(feature = "nul-terminated")]
+    /// # {
+    /// use scolapasta_strbuf::Buf;
+    ///
+    /// let mut buf = Buf::with_capacity(10);
+    /// buf.push(b'!');
+    /// assert_eq!(buf.capacity(), 11);
+    /// # }
+    /// ```
     #[inline]
     #[must_use]
     pub fn capacity(&self) -> usize {
         self.inner.capacity()
     }
 
+    /// Reserves capacity for at least `additional` more bytes to be inserted in
+    /// the given `Buf`.
+    ///
+    /// The buffer may reserve more space to speculatively avoid frequent
+    /// reallocations. After calling `reserve`, capacity will be greater than or
+    /// equal to `self.len() + additional`. Does nothing if capacity is already
+    /// sufficient.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the new capacity exceeds `isize::MAX` bytes.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use scolapasta_strbuf::Buf;
+    ///
+    /// let mut buf = Buf::from(b"@");
+    /// buf.reserve(10);
+    /// assert!(buf.capacity() >= 11);
+    /// ```
     #[inline]
     pub fn reserve(&mut self, additional: usize) {
         self.inner.reserve(additional);
         ensure_nul_terminated(&mut self.inner).expect("alloc failure");
     }
 
+    /// Reserves the minimum capacity for at least `additional` more bytes to
+    /// be inserted in the given `Buf`.
+    ///
+    /// Unlike [`reserve`], this will not deliberately over-allocate to
+    /// speculatively avoid frequent allocations. After calling `reserve_exact`,
+    /// capacity will be greater than or equal to `self.len() + additional`.
+    /// Does nothing if the capacity is already sufficient.
+    ///
+    /// Note that the allocator may give the buffer more space than it requests.
+    /// Therefore, capacity can not be relied upon to be precisely minimal.
+    /// Prefer [`reserve`] if future insertions are expected.
+    ///
+    /// [`reserve`]: Self::reserve
+    ///
+    /// # Panics
+    ///
+    /// Panics if the new capacity exceeds `isize::MAX` bytes.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use scolapasta_strbuf::Buf;
+    ///
+    /// let mut buf = Buf::from(b"@");
+    /// buf.reserve_exact(10);
+    /// assert!(buf.capacity() >= 11);
+    /// ```
     #[inline]
     pub fn reserve_exact(&mut self, additional: usize) {
         self.inner.reserve_exact(additional);
         ensure_nul_terminated(&mut self.inner).expect("alloc failure");
     }
 
+    /// Tries to reserve capacity for at least `additional` more bytes to be
+    /// inserted in the given `Buf`.
+    ///
+    /// The buffer may reserve more space to speculatively avoid frequent
+    /// reallocations. After calling `try_reserve`, capacity will be greater
+    /// than or equal to `self.len() + additional` if it returns `Ok(())`. Does
+    /// nothing if capacity is already sufficient. This method preserves the
+    /// byte contents even if an error occurs.
+    ///
+    /// # Errors
+    ///
+    /// If the capacity overflows, or the allocator reports a failure, then an
+    /// error is returned.
     #[inline]
     pub fn try_reserve(&mut self, additional: usize) -> Result<(), TryReserveError> {
         let additional = additional.checked_add(1).unwrap_or(additional);
@@ -508,6 +706,25 @@ impl Buf {
         Ok(())
     }
 
+    /// Tries to reserve the minimum capacity for at least `additional`
+    /// elements to be inserted in the given `Buf`.
+    ///
+    /// Unlike [`try_reserve`], this will not deliberately over-allocate to
+    /// speculatively avoid frequent allocations. After calling
+    /// `try_reserve_exact`, capacity will be greater than or equal to
+    /// `self.len() + additional` if it returns `Ok(())`. Does nothing if the
+    /// capacity is already sufficient.
+    ///
+    /// Note that the allocator may give the buffer more space than it requests.
+    /// Therefore, capacity can not be relied upon to be precisely minimal.
+    /// Prefer [`try_reserve`] if future insertions are expected.
+    ///
+    /// [`try_reserve`]: Self::try_reserve
+    ///
+    /// # Errors
+    ///
+    /// If the capacity overflows, or the allocator reports a failure, then an
+    /// error is returned.
     #[inline]
     pub fn try_reserve_exact(&mut self, additional: usize) -> Result<(), TryReserveError> {
         let additional = additional.checked_add(1).unwrap_or(additional);
@@ -516,18 +733,95 @@ impl Buf {
         Ok(())
     }
 
+    /// Shrinks the capacity of the buffer as much as possible while maintaining
+    /// its NUL termination invariant.
+    ///
+    /// It will drop down as close as possible to the length but the allocator
+    /// may still inform the buffer that there is space for a few more bytes.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #[cfg(feature = "nul-terminated")]
+    /// # {
+    /// use scolapasta_strbuf::Buf;
+    ///
+    /// let mut buf = Buf::with_capacity(10);
+    /// buf.extend(b"123");
+    /// assert_eq!(buf.capacity(), 11);
+    /// buf.shrink_to(4);
+    /// assert!(buf.capacity() >= 4);
+    /// buf.shrink_to_fit();
+    /// assert!(buf.capacity() >= 4);
+    /// # }
+    /// ```
     #[inline]
     pub fn shrink_to_fit(&mut self) {
         self.inner.shrink_to_fit();
         ensure_nul_terminated(&mut self.inner).expect("alloc failure");
     }
 
+    /// Shrinks the capacity of the buffer with a lower bound.
+    ///
+    /// The capacity will remain at least as large as both the length and the
+    /// supplied value.
+    ///
+    /// If the current capacity is less than the lower limit, this is a no-op.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #[cfg(feature = "nul-terminated")]
+    /// # {
+    /// use scolapasta_strbuf::Buf;
+    ///
+    /// let mut buf = Buf::with_capacity(10);
+    /// buf.extend(b"123");
+    /// assert_eq!(buf.capacity(), 11);
+    /// buf.shrink_to(4);
+    /// assert!(buf.capacity() >= 4);
+    /// buf.shrink_to(0);
+    /// assert!(buf.capacity() >= 4);
+    /// # }
+    /// ```
     #[inline]
     pub fn shrink_to(&mut self, min_capacity: usize) {
         self.inner.shrink_to(min_capacity);
         ensure_nul_terminated(&mut self.inner).expect("alloc failure");
     }
 
+    /// Converts the buffer into [`Box<[u8]>`][owned slice].
+    ///
+    /// If the buffer has excess capacity, its bytes will be moved into a
+    /// newly-allocated buffer with exactly the right capacity.
+    ///
+    /// [owned slice]: Box
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use scolapasta_strbuf::Buf;
+    ///
+    /// let buf = Buf::from(b"123");
+    ///
+    /// let slice = buf.into_boxed_slice();
+    /// ```
+    ///
+    /// Any excess capacity is removed:
+    ///
+    /// ```
+    /// # #[cfg(feature = "nul-terminated")]
+    /// # {
+    /// use scolapasta_strbuf::Buf;
+    ///
+    /// let mut buf = Buf::with_capacity(10);
+    /// buf.extend(b"123");
+    ///
+    /// assert_eq!(buf.capacity(), 11);
+    /// let slice = buf.into_boxed_slice();
+    /// assert_eq!(slice.into_vec().capacity(), 3);
+    /// # }
+    /// ```
     #[inline]
     #[must_use]
     pub fn into_boxed_slice(self) -> Box<[u8]> {

--- a/scolapasta-strbuf/src/vec.rs
+++ b/scolapasta-strbuf/src/vec.rs
@@ -1,5 +1,7 @@
+use alloc::borrow::Cow;
 use alloc::boxed::Box;
 use alloc::collections::TryReserveError;
+use alloc::string::String;
 use alloc::vec::Vec;
 #[cfg(feature = "std")]
 use core::fmt::Arguments;
@@ -23,10 +25,109 @@ impl From<Vec<u8>> for Buf {
     }
 }
 
+impl<'a> From<&'a [u8]> for Buf {
+    #[inline]
+    fn from(s: &'a [u8]) -> Self {
+        let vec = s.to_vec();
+        Self::from(vec)
+    }
+}
+
+impl<'a> From<&'a mut [u8]> for Buf {
+    #[inline]
+    fn from(s: &'a mut [u8]) -> Self {
+        let vec = s.to_vec();
+        Self::from(vec)
+    }
+}
+
+impl<const N: usize> From<[u8; N]> for Buf {
+    #[inline]
+    fn from(s: [u8; N]) -> Self {
+        let vec = Vec::from(s);
+        Self::from(vec)
+    }
+}
+
+impl<'a, const N: usize> From<&'a [u8; N]> for Buf {
+    #[inline]
+    fn from(s: &'a [u8; N]) -> Self {
+        let vec = s.to_vec();
+        Self::from(vec)
+    }
+}
+
+impl<'a, const N: usize> From<&'a mut [u8; N]> for Buf {
+    #[inline]
+    fn from(s: &'a mut [u8; N]) -> Self {
+        let vec = s.to_vec();
+        Self::from(vec)
+    }
+}
+
+impl<'a> From<Cow<'a, [u8]>> for Buf {
+    #[inline]
+    fn from(s: Cow<'a, [u8]>) -> Self {
+        let vec = s.into_owned();
+        Self::from(vec)
+    }
+}
+
+impl From<String> for Buf {
+    #[inline]
+    fn from(s: String) -> Self {
+        let vec = s.into_bytes();
+        Self::from(vec)
+    }
+}
+
+impl<'a> From<&'a str> for Buf {
+    #[inline]
+    fn from(s: &'a str) -> Self {
+        let vec = s.as_bytes().to_vec();
+        Self::from(vec)
+    }
+}
+
+impl<'a> From<&'a mut str> for Buf {
+    #[inline]
+    fn from(s: &'a mut str) -> Self {
+        let vec = s.as_bytes().to_vec();
+        Self::from(vec)
+    }
+}
+
+impl<'a> From<Cow<'a, str>> for Buf {
+    #[inline]
+    fn from(s: Cow<'a, str>) -> Self {
+        let vec = s.into_owned().into_bytes();
+        Self::from(vec)
+    }
+}
+
 impl From<Buf> for Vec<u8> {
     #[inline]
     fn from(buf: Buf) -> Self {
         buf.inner
+    }
+}
+
+impl<const N: usize> TryFrom<Buf> for [u8; N] {
+    type Error = Buf;
+
+    #[inline]
+    fn try_from(buf: Buf) -> Result<Self, Self::Error> {
+        match buf.into_inner().try_into() {
+            Ok(array) => Ok(array),
+            Err(vec) => Err(vec.into()),
+        }
+    }
+}
+
+impl<'a> From<Buf> for Cow<'a, [u8]> {
+    #[inline]
+    fn from(buf: Buf) -> Self {
+        Cow::Owned(buf.into())
     }
 }
 

--- a/scolapasta-strbuf/src/vec.rs
+++ b/scolapasta-strbuf/src/vec.rs
@@ -6,7 +6,7 @@ use alloc::vec::{IntoIter, Vec};
 use core::borrow::{Borrow, BorrowMut};
 #[cfg(feature = "std")]
 use core::fmt::Arguments;
-use core::ops::{Deref, DerefMut, RangeBounds};
+use core::ops::{Deref, DerefMut};
 use core::slice::{Iter, IterMut};
 #[cfg(feature = "std")]
 use std::io::{self, IoSlice, Write};
@@ -773,14 +773,6 @@ impl Buf {
     #[inline]
     pub fn extend_from_slice(&mut self, other: &[u8]) {
         self.inner.extend_from_slice(other);
-    }
-
-    #[inline]
-    pub fn extend_from_within<R>(&mut self, src: R)
-    where
-        R: RangeBounds<usize>,
-    {
-        self.inner.extend_from_within(src);
     }
 }
 

--- a/scolapasta-strbuf/src/vec.rs
+++ b/scolapasta-strbuf/src/vec.rs
@@ -995,3 +995,68 @@ impl Write for Buf {
         self.inner.write_fmt(fmt)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::Buf;
+
+    #[test]
+    fn default_is_new() {
+        assert_eq!(Buf::default(), Buf::new());
+    }
+
+    #[test]
+    fn extra_capa_is_not_included_in_len() {
+        let buf = Buf::new();
+        assert!(buf.is_empty());
+        assert_eq!(buf.len(), 0);
+
+        let buf = Buf::with_capacity(0);
+        assert!(buf.is_empty());
+        assert_eq!(buf.len(), 0);
+
+        let buf = Buf::with_capacity(100);
+        assert!(buf.is_empty());
+        assert_eq!(buf.len(), 0);
+    }
+
+    #[test]
+    fn clone_is_equal() {
+        let buf = Buf::from("abc");
+        assert_eq!(buf, buf.clone());
+    }
+
+    #[test]
+    fn try_reserve_overflow_is_err() {
+        let mut buf = Buf::new();
+        assert!(buf.try_reserve(usize::MAX).is_err());
+        assert!(buf.is_empty());
+        assert_eq!(buf.len(), 0);
+    }
+
+    #[test]
+    fn try_reserve_exact_overflow_is_err() {
+        let mut buf = Buf::new();
+        assert!(buf.try_reserve_exact(usize::MAX).is_err());
+        assert!(buf.is_empty());
+        assert_eq!(buf.len(), 0);
+    }
+
+    #[test]
+    fn try_reserve_zero_is_ok() {
+        let mut buf = Buf::new();
+        assert!(buf.try_reserve(0).is_ok());
+        assert_eq!(buf.capacity(), 0);
+        assert!(buf.is_empty());
+        assert_eq!(buf.len(), 0);
+    }
+
+    #[test]
+    fn try_reserve_exact_zero_is_ok() {
+        let mut buf = Buf::new();
+        assert!(buf.try_reserve_exact(0).is_ok());
+        assert_eq!(buf.capacity(), 0);
+        assert!(buf.is_empty());
+        assert_eq!(buf.len(), 0);
+    }
+}

--- a/scolapasta-strbuf/src/vec.rs
+++ b/scolapasta-strbuf/src/vec.rs
@@ -4,6 +4,7 @@ use alloc::collections::TryReserveError;
 use alloc::string::String;
 use alloc::vec::{IntoIter, Vec};
 use core::borrow::{Borrow, BorrowMut};
+use core::fmt;
 #[cfg(feature = "std")]
 use core::fmt::Arguments;
 use core::ops::{Deref, DerefMut};
@@ -1100,6 +1101,20 @@ impl Buf {
     #[inline]
     pub fn push_str<B: AsRef<[u8]>>(&mut self, bytes: B) {
         self.extend_from_slice(bytes.as_ref());
+    }
+}
+
+impl fmt::Write for Buf {
+    #[inline]
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        self.push_str(s);
+        Ok(())
+    }
+
+    #[inline]
+    fn write_char(&mut self, c: char) -> fmt::Result {
+        self.push_char(c);
+        Ok(())
     }
 }
 

--- a/scolapasta-strbuf/src/vec.rs
+++ b/scolapasta-strbuf/src/vec.rs
@@ -11,7 +11,6 @@ use core::slice::{Iter, IterMut};
 #[cfg(feature = "std")]
 use std::io::{self, IoSlice, Write};
 
-use bstr::ByteVec;
 use raw_parts::RawParts;
 
 /// A contiguous growable byte string, written as `Buf`, short for 'buffer'.
@@ -901,17 +900,19 @@ impl Buf {
 impl Buf {
     #[inline]
     pub fn push_byte(&mut self, byte: u8) {
-        self.inner.push_byte(byte);
+        self.inner.push(byte);
     }
 
     #[inline]
     pub fn push_char(&mut self, ch: char) {
-        self.inner.push_char(ch);
+        let mut buf = [0; 4];
+        let s = ch.encode_utf8(&mut buf[..]);
+        self.push_str(s);
     }
 
     #[inline]
     pub fn push_str<B: AsRef<[u8]>>(&mut self, bytes: B) {
-        self.inner.push_str(bytes);
+        self.extend_from_slice(bytes.as_ref());
     }
 }
 

--- a/scolapasta-strbuf/src/vec.rs
+++ b/scolapasta-strbuf/src/vec.rs
@@ -294,12 +294,15 @@ impl_partial_eq!(Buf, Vec<u8>);
 impl_partial_eq!(Buf, &'a Vec<u8>);
 impl_partial_eq!(Buf, [u8]);
 impl_partial_eq!(Buf, &'a [u8]);
+impl_partial_eq!(Buf, &'a mut [u8]);
 impl_partial_eq!(Buf, String);
 impl_partial_eq!(Buf, &'a String);
 impl_partial_eq!(Buf, str);
 impl_partial_eq!(Buf, &'a str);
+impl_partial_eq!(Buf, &'a mut str);
 impl_partial_eq_array!(Buf, [u8; N]);
 impl_partial_eq_array!(Buf, &'a [u8; N]);
+impl_partial_eq_array!(Buf, &'a mut [u8; N]);
 
 impl IntoIterator for Buf {
     type Item = u8;

--- a/scolapasta-strbuf/src/vec.rs
+++ b/scolapasta-strbuf/src/vec.rs
@@ -897,12 +897,46 @@ impl Buf {
 }
 
 /// Implementation of useful extension methods from [`bstr::ByteVec`].
+///
+/// [`bstr::ByteVec`]: https://docs.rs/bstr/latest/bstr/trait.ByteVec.html
 impl Buf {
+    /// Append the given byte to the end of this buffer.
+    ///
+    /// Note that this is equivalent to the generic [`Vec::push`] method. This
+    /// method is provided to permit callers to explicitly differentiate
+    /// between pushing bytes, codepoints and strings.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use scolapasta_strbuf::Buf;
+    ///
+    /// let mut buf = Buf::from(b"abc");
+    /// buf.push_byte(b'\xF0');
+    /// buf.push_byte(b'\x9F');
+    /// buf.push_byte(b'\xA6');
+    /// buf.push_byte(b'\x80');
+    /// assert_eq!(buf, "abc🦀");
+    /// ```
     #[inline]
     pub fn push_byte(&mut self, byte: u8) {
         self.inner.push(byte);
     }
 
+    /// Append the given [`char`] to the end of the buffer.
+    ///
+    /// The given `char` is encoded to its UTF-8 byte sequence which is appended
+    /// to the buffer.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use scolapasta_strbuf::Buf;
+    ///
+    /// let mut buf = Buf::from(b"abc");
+    /// buf.push_char('🦀');
+    /// assert_eq!(buf, "abc🦀");
+    /// ```
     #[inline]
     pub fn push_char(&mut self, ch: char) {
         let mut buf = [0; 4];
@@ -910,6 +944,24 @@ impl Buf {
         self.push_str(s);
     }
 
+    /// Append the given slice to the end of this buffer.
+    ///
+    /// This method accepts any type that be converted to a `&[u8]`. This
+    /// includes, but is not limited to, `&str`, `&Buf`, and of course, `&[u8]`
+    /// itself.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use scolapasta_strbuf::Buf;
+    ///
+    /// let mut buf = Buf::from(b"abc");
+    /// buf.push_str("🦀");
+    /// assert_eq!(buf, "abc🦀");
+    ///
+    /// buf.push_str(b"\xF0\x9F\xA6\x80");
+    /// assert_eq!(buf, "abc🦀🦀");
+    /// ```
     #[inline]
     pub fn push_str<B: AsRef<[u8]>>(&mut self, bytes: B) {
         self.extend_from_slice(bytes.as_ref());

--- a/scolapasta-strbuf/src/vec.rs
+++ b/scolapasta-strbuf/src/vec.rs
@@ -2,17 +2,100 @@ use alloc::borrow::Cow;
 use alloc::boxed::Box;
 use alloc::collections::TryReserveError;
 use alloc::string::String;
-use alloc::vec::Vec;
+use alloc::vec::{IntoIter, Vec};
 use core::borrow::{Borrow, BorrowMut};
 #[cfg(feature = "std")]
 use core::fmt::Arguments;
 use core::ops::{Deref, DerefMut, RangeBounds};
+use core::slice::{Iter, IterMut};
 #[cfg(feature = "std")]
 use std::io::{self, IoSlice, Write};
 
 use bstr::ByteVec;
 use raw_parts::RawParts;
 
+/// A contiguous growable byte string, written as `Buf`, short for 'buffer'.
+///
+/// This buffer is a transparent wrapper around [`Vec<u8>`] with a minimized API
+/// sufficient for implementing the Ruby [`String`] type.
+///
+/// This buffer does not assume any encoding. Encoding is a higher-level concept
+/// that should be built on top of `Buf`.
+///
+/// # Examples
+///
+/// ```
+/// use scolapasta_strbuf::Buf;
+///
+/// let mut buf = Buf::new();
+/// buf.push(b'a');
+/// buf.push(b'z');
+///
+/// assert_eq!(buf.len(), 2);
+/// assert_eq!(buf[0], b'a');
+///
+/// assert_eq!(buf.pop(), Some(b'z'));
+/// assert_eq!(buf.len(), 1);
+///
+/// buf[0] = b'!';
+/// assert_eq!(buf[0], b'!');
+///
+/// buf.extend(b"excite!!!");
+///
+/// for byte in &buf {
+///     println!("{byte}");
+/// }
+/// assert_eq!(buf, b"!excite!!!");
+/// ```
+///
+/// # Indexing
+///
+/// The `Buf` type allows to access values by index, because it implements the
+/// [`Index`] trait. An example will be more explicit:
+///
+/// ```
+/// use scolapasta_strbuf::Buf;
+///
+/// let buf = Buf::from(b"scolapasta-strbuf");
+/// println!("{}", buf[1]); // it will display 'c'
+/// ```
+///
+/// However be careful: if you try to access an index which isn't in the `Buf`,
+/// your software will panic! You cannot do this:
+///
+/// ```should_panic
+/// use scolapasta_strbuf::Buf;
+///
+/// let buf = Buf::from(b"scolapasta-strbuf");
+/// println!("{}", buf[100]); // it will panic!
+/// ```
+///
+/// # Capacity and reallocation
+///
+/// The capacity of a buffer is the amount of space allocated for any future
+/// bytes that will be added onto the buffer. This is not to be confused with
+/// the _length_ of a buffer, which specifies the number of actual bytes within
+/// the buffer. If a buffer's length exceeds its capacity, its capacity will
+/// automatically be increased, but its contents will have to be reallocated.
+///
+/// For example, a buffer with capacity 10 and length 0 would be an empty buffer
+/// with space for 10 more bytes. Pushing 10 or fewer bytes into the buffer will
+/// not change its capacity or cause reallocation to occur. However, if the
+/// buffer's length is increased to 11, it will have to reallocate, which can be
+/// slow. For this reason, it is recommended to use `Buf::with_capacity`
+/// whenever possible to specify how big the buffer is expected to get.
+///
+/// # Guarantees
+///
+/// `Buf` is guaranteed to be a `repr(transparent)` wrapper around a `Vec<u8>`,
+/// which means it shares all the same [guarantees as a `Vec`]. See the upstream
+/// documentation in [`std`][vec-docs] for more details.
+///
+/// [`Vec<u8>`]: Vec
+/// [`String`]: https://ruby-doc.org/3.2.0/String.html
+/// [`Index`]: core::ops::Index
+/// [guarantees as a `Vec`]: https://doc.rust-lang.org/std/vec/struct.Vec.html#guarantees
+/// [vec-docs]: alloc::vec
 #[repr(transparent)]
 #[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Buf {

--- a/scolapasta-strbuf/src/vec.rs
+++ b/scolapasta-strbuf/src/vec.rs
@@ -66,29 +66,34 @@ impl Extend<u8> for Buf {
 
 impl Buf {
     #[inline]
+    #[must_use]
     pub fn new() -> Self {
         let inner = Vec::new();
         Self { inner }
     }
 
     #[inline]
+    #[must_use]
     pub fn with_capacity(capacity: usize) -> Self {
         let inner = Vec::with_capacity(capacity);
         Self { inner }
     }
 
     #[inline]
+    #[must_use]
     pub unsafe fn from_raw_parts(raw_parts: RawParts<u8>) -> Self {
         let inner = raw_parts.into_vec();
         Self { inner }
     }
 
     #[inline]
+    #[must_use]
     pub fn into_raw_parts(self) -> RawParts<u8> {
         RawParts::from_vec(self.inner)
     }
 
     #[inline]
+    #[must_use]
     pub fn capacity(&self) -> usize {
         self.inner.capacity()
     }
@@ -124,6 +129,7 @@ impl Buf {
     }
 
     #[inline]
+    #[must_use]
     pub fn into_boxed_slice(self) -> Box<[u8]> {
         self.inner.into_boxed_slice()
     }
@@ -134,6 +140,7 @@ impl Buf {
     }
 
     #[inline]
+    #[must_use]
     pub fn as_slice(&self) -> &[u8] {
         self.inner.as_slice()
     }
@@ -144,11 +151,13 @@ impl Buf {
     }
 
     #[inline]
+    #[must_use]
     pub fn as_ptr(&self) -> *const u8 {
         self.inner.as_ptr()
     }
 
     #[inline]
+    #[must_use]
     pub fn as_mut_ptr(&mut self) -> *mut u8 {
         self.inner.as_mut_ptr()
     }
@@ -235,19 +244,22 @@ impl Buf {
     }
 
     #[inline]
+    #[must_use]
     pub fn len(&self) -> usize {
         self.inner.len()
     }
 
     #[inline]
+    #[must_use]
     pub fn is_empty(&self) -> bool {
         self.inner.is_empty()
     }
 
     #[inline]
-    pub fn split_off(&mut self, at: usize) -> Buf {
+    #[must_use]
+    pub fn split_off(&mut self, at: usize) -> Self {
         let split = self.inner.split_off(at);
-        Self { inner: split }
+        Self::from(split)
     }
 
     #[inline]
@@ -259,6 +271,7 @@ impl Buf {
     }
 
     #[inline]
+    #[must_use]
     pub fn leak<'a>(self) -> &'a mut [u8] {
         self.inner.leak()
     }
@@ -310,6 +323,7 @@ impl Buf {
 
 impl Buf {
     #[inline]
+    #[must_use]
     pub fn into_inner(self) -> Vec<u8> {
         self.inner
     }

--- a/scolapasta-strbuf/src/vec.rs
+++ b/scolapasta-strbuf/src/vec.rs
@@ -775,11 +775,6 @@ impl Buf {
     }
 
     #[inline]
-    pub fn push(&mut self, value: u8) {
-        self.inner.push(value);
-    }
-
-    #[inline]
     pub fn pop(&mut self) -> Option<u8> {
         self.inner.pop()
     }

--- a/scolapasta-strbuf/src/vec.rs
+++ b/scolapasta-strbuf/src/vec.rs
@@ -192,6 +192,57 @@ impl Extend<u8> for Buf {
     }
 }
 
+macro_rules! impl_partial_eq {
+    ($lhs:ty, $rhs:ty) => {
+        impl<'a, 'b> PartialEq<$rhs> for $lhs {
+            #[inline]
+            fn eq(&self, other: &$rhs) -> bool {
+                let other: &[u8] = other.as_ref();
+                PartialEq::eq(self.as_slice(), other)
+            }
+        }
+
+        impl<'a, 'b> PartialEq<$lhs> for $rhs {
+            #[inline]
+            fn eq(&self, other: &$lhs) -> bool {
+                let this: &[u8] = self.as_ref();
+                PartialEq::eq(this, other.as_slice())
+            }
+        }
+    };
+}
+
+macro_rules! impl_partial_eq_array {
+    ($lhs:ty, $rhs:ty) => {
+        impl<'a, 'b, const N: usize> PartialEq<$rhs> for $lhs {
+            #[inline]
+            fn eq(&self, other: &$rhs) -> bool {
+                let other: &[u8] = other.as_ref();
+                PartialEq::eq(self.as_slice(), other)
+            }
+        }
+
+        impl<'a, 'b, const N: usize> PartialEq<$lhs> for $rhs {
+            #[inline]
+            fn eq(&self, other: &$lhs) -> bool {
+                let this: &[u8] = self.as_ref();
+                PartialEq::eq(this, other.as_slice())
+            }
+        }
+    };
+}
+
+impl_partial_eq!(Buf, Vec<u8>);
+impl_partial_eq!(Buf, &'a Vec<u8>);
+impl_partial_eq!(Buf, [u8]);
+impl_partial_eq!(Buf, &'a [u8]);
+impl_partial_eq!(Buf, String);
+impl_partial_eq!(Buf, &'a String);
+impl_partial_eq!(Buf, str);
+impl_partial_eq!(Buf, &'a str);
+impl_partial_eq_array!(Buf, [u8; N]);
+impl_partial_eq_array!(Buf, &'a [u8; N]);
+
 impl Buf {
     #[inline]
     #[must_use]

--- a/scolapasta-strbuf/src/vec.rs
+++ b/scolapasta-strbuf/src/vec.rs
@@ -462,11 +462,12 @@ impl Buf {
     ///
     /// unsafe {
     ///     ptr::write(ptr, b'A');
+    ///     ptr::write(ptr.add(1), b'B');
     ///
     ///     let raw_parts = RawParts { ptr, length, capacity };
     ///     let rebuilt = Buf::from_raw_parts(raw_parts);
     ///
-    ///     assert_eq!(rebuilt, b"Abcde");
+    ///     assert_eq!(rebuilt, b"ABcde");
     /// }
     /// ```
     #[inline]
@@ -501,11 +502,12 @@ impl Buf {
     ///
     /// unsafe {
     ///     ptr::write(ptr, b'A');
+    ///     ptr::write(ptr.add(1), b'B');
     ///
     ///     let raw_parts = RawParts { ptr, length, capacity };
     ///     let rebuilt = Buf::from_raw_parts(raw_parts);
     ///
-    ///     assert_eq!(rebuilt, b"Abcde");
+    ///     assert_eq!(rebuilt, b"ABcde");
     /// }
     /// ```
     #[inline]

--- a/scolapasta-strbuf/src/vec.rs
+++ b/scolapasta-strbuf/src/vec.rs
@@ -28,13 +28,13 @@ use raw_parts::RawParts;
 /// use scolapasta_strbuf::Buf;
 ///
 /// let mut buf = Buf::new();
-/// buf.push(b'a');
-/// buf.push(b'z');
+/// buf.push_byte(b'a');
+/// buf.push_byte(b'z');
 ///
 /// assert_eq!(buf.len(), 2);
 /// assert_eq!(buf[0], b'a');
 ///
-/// assert_eq!(buf.pop(), Some(b'z'));
+/// assert_eq!(buf.pop_byte(), Some(b'z'));
 /// assert_eq!(buf.len(), 1);
 ///
 /// buf[0] = b'!';
@@ -413,13 +413,13 @@ impl Buf {
     ///
     /// // These are all done without reallocating...
     /// for ch in b'a'..=b'z' {
-    ///     buf.push(ch);
+    ///     buf.push_byte(ch);
     /// }
     /// assert_eq!(buf.len(), 26);
     /// assert!(buf.capacity() >= 26);
     ///
     /// // ...but this may make the buffer reallocate
-    /// buf.push(b'!');
+    /// buf.push_byte(b'!');
     /// assert_eq!(buf.len(), 27);
     /// assert!(buf.capacity() >= 27);
     /// ```
@@ -516,7 +516,7 @@ impl Buf {
     /// use scolapasta_strbuf::Buf;
     ///
     /// let mut buf = Buf::with_capacity(10);
-    /// buf.push(b'!');
+    /// buf.push_byte(b'!');
     /// assert_eq!(buf.capacity(), 10);
     /// # }
     /// ```
@@ -775,7 +775,7 @@ impl Buf {
     }
 
     #[inline]
-    pub fn pop(&mut self) -> Option<u8> {
+    pub fn pop_byte(&mut self) -> Option<u8> {
         self.inner.pop()
     }
 

--- a/scolapasta-strbuf/src/vec.rs
+++ b/scolapasta-strbuf/src/vec.rs
@@ -801,27 +801,6 @@ impl Buf {
     }
 
     #[inline]
-    #[must_use]
-    pub fn split_off(&mut self, at: usize) -> Self {
-        let split = self.inner.split_off(at);
-        Self::from(split)
-    }
-
-    #[inline]
-    pub fn resize_with<F>(&mut self, new_len: usize, f: F)
-    where
-        F: FnMut() -> u8,
-    {
-        self.inner.resize_with(new_len, f);
-    }
-
-    #[inline]
-    #[must_use]
-    pub fn leak<'a>(self) -> &'a mut [u8] {
-        self.inner.leak()
-    }
-
-    #[inline]
     pub fn resize(&mut self, new_len: usize, value: u8) {
         self.inner.resize(new_len, value);
     }

--- a/scolapasta-strbuf/src/vec.rs
+++ b/scolapasta-strbuf/src/vec.rs
@@ -761,11 +761,6 @@ impl Buf {
     }
 
     #[inline]
-    pub fn swap_remove(&mut self, index: usize) -> u8 {
-        self.inner.swap_remove(index)
-    }
-
-    #[inline]
     pub fn insert(&mut self, index: usize, element: u8) {
         self.inner.insert(index, element);
     }

--- a/scolapasta-strbuf/src/vec.rs
+++ b/scolapasta-strbuf/src/vec.rs
@@ -102,6 +102,14 @@ pub struct Buf {
     inner: Vec<u8>,
 }
 
+impl Buf {
+    #[inline]
+    #[must_use]
+    pub fn into_inner(self) -> Vec<u8> {
+        self.inner
+    }
+}
+
 impl From<Vec<u8>> for Buf {
     #[inline]
     fn from(vec: Vec<u8>) -> Self {
@@ -360,6 +368,7 @@ impl<'a> IntoIterator for &'a mut Buf {
     }
 }
 
+/// Minimal [`Vec`] API.
 impl Buf {
     /// Constructs a new, empty `Buf`.
     ///
@@ -821,12 +830,7 @@ impl Buf {
     pub fn leak<'a>(self) -> &'a mut [u8] {
         self.inner.leak()
     }
-}
 
-impl Buf
-where
-    u8: Clone,
-{
     #[inline]
     pub fn resize(&mut self, new_len: usize, value: u8) {
         self.inner.resize(new_len, value);
@@ -846,15 +850,7 @@ where
     }
 }
 
-impl Buf {
-    #[inline]
-    #[must_use]
-    pub fn into_inner(self) -> Vec<u8> {
-        self.inner
-    }
-}
-
-// `bstr::ByteVec` impls
+/// Implementation of useful extension methods from [`bstr::ByteVec`].
 impl Buf {
     #[inline]
     pub fn push_byte(&mut self, byte: u8) {

--- a/scolapasta-strbuf/src/vec.rs
+++ b/scolapasta-strbuf/src/vec.rs
@@ -3,6 +3,7 @@ use alloc::boxed::Box;
 use alloc::collections::TryReserveError;
 use alloc::string::String;
 use alloc::vec::Vec;
+use core::borrow::{Borrow, BorrowMut};
 #[cfg(feature = "std")]
 use core::fmt::Arguments;
 use core::ops::{Deref, DerefMut, RangeBounds};
@@ -128,6 +129,32 @@ impl<'a> From<Buf> for Cow<'a, [u8]> {
     #[inline]
     fn from(buf: Buf) -> Self {
         Cow::Owned(buf.into())
+    }
+}
+
+impl AsRef<[u8]> for Buf {
+    #[inline]
+    fn as_ref(&self) -> &[u8] {
+        self.inner.as_ref()
+    }
+}
+
+impl AsMut<[u8]> for Buf {
+    #[inline]
+    fn as_mut(&mut self) -> &mut [u8] {
+        self.inner.as_mut()
+    }
+}
+
+impl Borrow<[u8]> for Buf {
+    fn borrow(&self) -> &[u8] {
+        self
+    }
+}
+
+impl BorrowMut<[u8]> for Buf {
+    fn borrow_mut(&mut self) -> &mut [u8] {
+        self
     }
 }
 

--- a/scolapasta-strbuf/src/vec.rs
+++ b/scolapasta-strbuf/src/vec.rs
@@ -94,7 +94,7 @@ use raw_parts::RawParts;
 /// [`String`]: https://ruby-doc.org/3.2.0/String.html
 /// [`Index`]: core::ops::Index
 /// [guarantees as a `Vec`]: https://doc.rust-lang.org/std/vec/struct.Vec.html#guarantees
-/// [vec-docs]: alloc::vec
+/// [vec-docs]: mod@alloc::vec
 #[repr(transparent)]
 #[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Buf {

--- a/scolapasta-strbuf/src/vec.rs
+++ b/scolapasta-strbuf/src/vec.rs
@@ -783,23 +783,6 @@ impl Buf {
     }
 
     #[inline]
-    pub fn dedup_by_key<F, K>(&mut self, key: F)
-    where
-        F: FnMut(&mut u8) -> K,
-        K: PartialEq<K>,
-    {
-        self.inner.dedup_by_key(key);
-    }
-
-    #[inline]
-    pub fn dedup_by<F>(&mut self, same_bucket: F)
-    where
-        F: FnMut(&mut u8, &mut u8) -> bool,
-    {
-        self.inner.dedup_by(same_bucket);
-    }
-
-    #[inline]
     pub fn push(&mut self, value: u8) {
         self.inner.push(value);
     }
@@ -873,16 +856,6 @@ where
         R: RangeBounds<usize>,
     {
         self.inner.extend_from_within(src);
-    }
-}
-
-impl Buf
-where
-    u8: PartialEq<u8>,
-{
-    #[inline]
-    pub fn dedup(&mut self) {
-        self.inner.dedup();
     }
 }
 

--- a/scolapasta-strbuf/src/vec.rs
+++ b/scolapasta-strbuf/src/vec.rs
@@ -290,46 +290,6 @@ impl<'a> Extend<&'a u8> for Buf {
     }
 }
 
-macro_rules! impl_partial_eq {
-    ($lhs:ty, $rhs:ty) => {
-        impl<'a, 'b> PartialEq<$rhs> for $lhs {
-            #[inline]
-            fn eq(&self, other: &$rhs) -> bool {
-                let other: &[u8] = other.as_ref();
-                PartialEq::eq(self.as_slice(), other)
-            }
-        }
-
-        impl<'a, 'b> PartialEq<$lhs> for $rhs {
-            #[inline]
-            fn eq(&self, other: &$lhs) -> bool {
-                let this: &[u8] = self.as_ref();
-                PartialEq::eq(this, other.as_slice())
-            }
-        }
-    };
-}
-
-macro_rules! impl_partial_eq_array {
-    ($lhs:ty, $rhs:ty) => {
-        impl<'a, 'b, const N: usize> PartialEq<$rhs> for $lhs {
-            #[inline]
-            fn eq(&self, other: &$rhs) -> bool {
-                let other: &[u8] = other.as_ref();
-                PartialEq::eq(self.as_slice(), other)
-            }
-        }
-
-        impl<'a, 'b, const N: usize> PartialEq<$lhs> for $rhs {
-            #[inline]
-            fn eq(&self, other: &$lhs) -> bool {
-                let this: &[u8] = self.as_ref();
-                PartialEq::eq(this, other.as_slice())
-            }
-        }
-    };
-}
-
 impl_partial_eq!(Buf, Vec<u8>);
 impl_partial_eq!(Buf, &'a Vec<u8>);
 impl_partial_eq!(Buf, [u8]);

--- a/scolapasta-strbuf/src/vec.rs
+++ b/scolapasta-strbuf/src/vec.rs
@@ -1,6 +1,6 @@
 use alloc::boxed::Box;
 use alloc::collections::TryReserveError;
-use alloc::vec::{Drain, Splice, Vec};
+use alloc::vec::Vec;
 #[cfg(feature = "std")]
 use core::fmt::Arguments;
 use core::ops::{Deref, DerefMut, RangeBounds};
@@ -231,14 +231,6 @@ impl Buf {
     }
 
     #[inline]
-    pub fn drain<R>(&mut self, range: R) -> Drain<'_, u8>
-    where
-        R: RangeBounds<usize>,
-    {
-        self.inner.drain(range)
-    }
-
-    #[inline]
     pub fn clear(&mut self) {
         self.inner.clear();
     }
@@ -307,17 +299,6 @@ where
     #[inline]
     pub fn dedup(&mut self) {
         self.inner.dedup();
-    }
-}
-
-impl Buf {
-    #[inline]
-    pub fn splice<R, I>(&mut self, range: R, replace_with: I) -> Splice<'_, <I as IntoIterator>::IntoIter>
-    where
-        R: RangeBounds<usize>,
-        I: IntoIterator<Item = u8>,
-    {
-        self.inner.splice(range, replace_with)
     }
 }
 

--- a/scolapasta-strbuf/src/vec.rs
+++ b/scolapasta-strbuf/src/vec.rs
@@ -448,7 +448,9 @@ impl Buf {
     #[inline]
     #[must_use]
     pub unsafe fn from_raw_parts(raw_parts: RawParts<u8>) -> Self {
-        let inner = raw_parts.into_vec();
+        // SAFETY: Callers ensure that the raw parts safety invariants are
+        // upheld.
+        let inner = unsafe { raw_parts.into_vec() };
         Self { inner }
     }
 
@@ -812,7 +814,11 @@ impl Buf {
     /// [`capacity()`]: Self::capacity
     #[inline]
     pub unsafe fn set_len(&mut self, new_len: usize) {
-        self.inner.set_len(new_len);
+        // SAFETY: Caller has guaranteed the safety invariants of `Vec::set_len`
+        // are upheld.
+        unsafe {
+            self.inner.set_len(new_len);
+        }
     }
 
     /// Insert a byte at position `index` within the buffer, shifting all

--- a/scolapasta-strbuf/src/vec.rs
+++ b/scolapasta-strbuf/src/vec.rs
@@ -775,14 +775,6 @@ impl Buf {
     }
 
     #[inline]
-    pub fn retain_mut<F>(&mut self, f: F)
-    where
-        F: FnMut(&mut u8) -> bool,
-    {
-        self.inner.retain_mut(f);
-    }
-
-    #[inline]
     pub fn push(&mut self, value: u8) {
         self.inner.push(value);
     }

--- a/scolapasta-strbuf/src/vec.rs
+++ b/scolapasta-strbuf/src/vec.rs
@@ -192,6 +192,13 @@ impl Extend<u8> for Buf {
     }
 }
 
+impl<'a> Extend<&'a u8> for Buf {
+    #[inline]
+    fn extend<I: IntoIterator<Item = &'a u8>>(&mut self, iter: I) {
+        self.inner.extend(iter.into_iter().copied());
+    }
+}
+
 macro_rules! impl_partial_eq {
     ($lhs:ty, $rhs:ty) => {
         impl<'a, 'b> PartialEq<$rhs> for $lhs {
@@ -242,6 +249,33 @@ impl_partial_eq!(Buf, str);
 impl_partial_eq!(Buf, &'a str);
 impl_partial_eq_array!(Buf, [u8; N]);
 impl_partial_eq_array!(Buf, &'a [u8; N]);
+
+impl IntoIterator for Buf {
+    type Item = u8;
+    type IntoIter = IntoIter<u8>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.into_inner().into_iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a Buf {
+    type Item = &'a u8;
+    type IntoIter = Iter<'a, u8>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a mut Buf {
+    type Item = &'a mut u8;
+    type IntoIter = IterMut<'a, u8>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter_mut()
+    }
+}
 
 impl Buf {
     #[inline]

--- a/scolapasta-strbuf/src/vec.rs
+++ b/scolapasta-strbuf/src/vec.rs
@@ -784,11 +784,6 @@ impl Buf {
     }
 
     #[inline]
-    pub fn append(&mut self, other: &mut Buf) {
-        self.inner.append(&mut other.inner);
-    }
-
-    #[inline]
     pub fn clear(&mut self) {
         self.inner.clear();
     }

--- a/scolapasta-strbuf/src/vec.rs
+++ b/scolapasta-strbuf/src/vec.rs
@@ -5,8 +5,6 @@ use alloc::string::String;
 use alloc::vec::{IntoIter, Vec};
 use core::borrow::{Borrow, BorrowMut};
 use core::fmt;
-#[cfg(feature = "std")]
-use core::fmt::Arguments;
 use core::ops::{Deref, DerefMut};
 use core::slice::{Iter, IterMut};
 #[cfg(feature = "std")]
@@ -1126,11 +1124,6 @@ impl Write for Buf {
     }
 
     #[inline]
-    fn flush(&mut self) -> io::Result<()> {
-        self.inner.flush()
-    }
-
-    #[inline]
     fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         self.inner.write_vectored(bufs)
     }
@@ -1141,8 +1134,8 @@ impl Write for Buf {
     }
 
     #[inline]
-    fn write_fmt(&mut self, fmt: Arguments<'_>) -> io::Result<()> {
-        self.inner.write_fmt(fmt)
+    fn flush(&mut self) -> io::Result<()> {
+        self.inner.flush()
     }
 }
 

--- a/scolapasta-strbuf/src/vec.rs
+++ b/scolapasta-strbuf/src/vec.rs
@@ -735,6 +735,40 @@ impl Buf {
         self.inner.remove(index)
     }
 
+    /// Retain only the bytes specified by the predicate.
+    ///
+    /// In other words, remove all bytes `b` for which `f(&b)` returns `false`.
+    /// This method operates in place, visiting each byte exactly once in the
+    /// original order, and preserves the order of the retained bytes.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use scolapasta_strbuf::Buf;
+    ///
+    /// let mut buf = Buf::from(b"abc, 123!");
+    /// buf.retain(|&b| b.is_ascii_alphanumeric());
+    /// assert_eq!(buf, b"abc123");
+    /// ```
+    ///
+    /// Because the bytes are visited exactly once in the original order,
+    /// external state may be used to decide which elements to keep.
+    ///
+    /// ```
+    /// use scolapasta_strbuf::Buf;
+    ///
+    /// let mut buf = Buf::from(b"abc, 123!");
+    /// let mut seen_space = false;
+    /// buf.retain(|&b| {
+    ///     if seen_space {
+    ///         true
+    ///     } else {
+    ///         seen_space = b.is_ascii_whitespace();
+    ///         false
+    ///     }
+    /// });
+    /// assert_eq!(buf, b"123!");
+    /// ```
     #[inline]
     pub fn retain<F>(&mut self, f: F)
     where
@@ -743,33 +777,120 @@ impl Buf {
         self.inner.retain(f);
     }
 
+    /// Remove the last byte from the buffer and return it, or [`None`] if the
+    /// buffer is empty.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use scolapasta_strbuf::Buf;
+    ///
+    /// let mut buf = Buf::from(b"abc, 123!");
+    /// assert_eq!(buf.pop_byte(), Some(b'!'));
+    /// assert_eq!(buf, "abc, 123");
+    /// ```
     #[inline]
     pub fn pop_byte(&mut self) -> Option<u8> {
         self.inner.pop()
     }
 
+    /// Clear the buffer, removing all bytes.
+    ///
+    /// This method sets the length of the buffer to zero. Note that this method
+    /// has no effect on the allocated capacity of the buffer.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use scolapasta_strbuf::Buf;
+    ///
+    /// let mut buf = Buf::from(b"abc, 123!");
+    /// let capacity = buf.capacity();
+    ///
+    /// buf.clear();
+    ///
+    /// assert!(buf.is_empty());
+    /// assert_eq!(buf.capacity(), capacity);
+    /// ```
     #[inline]
     pub fn clear(&mut self) {
         self.inner.clear();
     }
 
+    /// Return the number of bytes in the buffer, also referred to as its
+    /// 'length' or 'bytesize'.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use scolapasta_strbuf::Buf;
+    ///
+    /// let buf = Buf::from(b"abc");
+    /// assert_eq!(buf.len(), 3);
+    /// ```
     #[inline]
     #[must_use]
     pub fn len(&self) -> usize {
         self.inner.len()
     }
 
+    /// Return `true` if the buffer has empty byte content.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use scolapasta_strbuf::Buf;
+    ///
+    /// let mut buf = Buf::new();
+    /// assert!(buf.is_empty());
+    ///
+    /// buf.push_byte(b'!');
+    /// assert!(!buf.is_empty());
+    /// ```
     #[inline]
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.inner.is_empty()
     }
 
+    /// Resize the `Buf` in-place so that `len` is equal to `new_len`.
+    ///
+    /// If `new_len` is greater than `len`, the `Vec` is extended by the
+    /// difference, with each additional slot filled with `value`. If `new_len`
+    /// is less than `len`, the `Buf` is simply truncated.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use scolapasta_strbuf::Buf;
+    ///
+    /// let mut buf = Buf::from(b"hello");
+    /// buf.resize(8, b'!');
+    /// assert_eq!(buf, b"hello!!!");
+    ///
+    /// let mut buf = Buf::from("wxyz");
+    /// buf.resize(2, b'.');
+    /// assert_eq!(buf, b"wx");
+    /// ```
     #[inline]
     pub fn resize(&mut self, new_len: usize, value: u8) {
         self.inner.resize(new_len, value);
     }
 
+    /// Copy and append all bytes in the given slice to the `Buf`.
+    ///
+    /// Iterate over the slice `other`, copy each byte, and then append
+    /// it to this `Buf`. The `other` slice is traversed in-order.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use scolapasta_strbuf::Buf;
+    ///
+    /// let mut buf = Buf::from(b"h");
+    /// buf.extend_from_slice(b"ello world");
+    /// assert_eq!(buf, b"hello world");
+    /// ```
     #[inline]
     pub fn extend_from_slice(&mut self, other: &[u8]) {
         self.inner.extend_from_slice(other);

--- a/scolapasta-strbuf/src/vec.rs
+++ b/scolapasta-strbuf/src/vec.rs
@@ -102,6 +102,19 @@ pub struct Buf {
 }
 
 impl Buf {
+    /// Consume this buffer and return its inner [`Vec<u8>`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use scolapasta_strbuf::Buf;
+    ///
+    /// let buf = Buf::from(b"abc");
+    /// let vec: Vec<u8> = buf.into_inner();
+    /// assert_eq!(vec, b"abc");
+    /// ```
+    ///
+    /// [`Vec<u8>`]: Vec
     #[inline]
     #[must_use]
     pub fn into_inner(self) -> Vec<u8> {
@@ -691,45 +704,161 @@ impl Buf {
         self.inner.into_boxed_slice()
     }
 
+    /// Shorten the buffer, keeping the first `len` bytes and dropping the rest.
+    ///
+    /// If `len` is greater than the buffer's current length, this has no
+    /// effect.
+    ///
+    /// Note that this method has no effect on the allocated capacity of the
+    /// buffer.
+    ///
+    /// # Examples
+    ///
+    /// Truncating a five byte buffer to two bytes:
+    ///
+    /// ```
+    /// use scolapasta_strbuf::Buf;
+    ///
+    /// let mut buf = Buf::from(b"12345");
+    /// buf.truncate(2);
+    /// assert_eq!(buf, b"12");
+    /// ```
+    ///
+    /// No truncation occurs when `len` is greater than the buffer's current
+    /// length:
+    ///
+    /// ```
+    /// use scolapasta_strbuf::Buf;
+    ///
+    /// let mut buf = Buf::from(b"123");
+    /// buf.truncate(8);
+    /// assert_eq!(buf, b"123");
+    /// ```
+    ///
+    /// Truncating when `len == 0` is equivalent to calling the [`clear`]
+    /// method.
+    ///
+    /// ```
+    /// use scolapasta_strbuf::Buf;
+    ///
+    /// let mut buf = Buf::from(b"123");
+    /// buf.truncate(0);
+    /// assert_eq!(buf, b"");
+    /// ```
+    ///
+    /// [`clear`]: Self::clear
     #[inline]
     pub fn truncate(&mut self, len: usize) {
         self.inner.truncate(len);
     }
 
+    /// Extract a slice containing the entire buffer.
+    ///
+    /// Equivalent to `&buf[..]`.
     #[inline]
     #[must_use]
     pub fn as_slice(&self) -> &[u8] {
         self.inner.as_slice()
     }
 
+    /// Extract a mutable slice containing the entire buffer.
+    ///
+    /// Equivalent to `&mut buf[..]`.
     #[inline]
     pub fn as_mut_slice(&mut self) -> &mut [u8] {
         self.inner.as_mut_slice()
     }
 
+    /// Return a raw pointer to the buffer's inner vec, or a dangling raw
+    /// pointer valid for zero sized reads if the buffer didn't allocate.
+    ///
+    /// The caller must ensure correct use of the pointer. See [`Vec::as_ptr`]
+    /// for more details.
     #[inline]
     #[must_use]
     pub fn as_ptr(&self) -> *const u8 {
         self.inner.as_ptr()
     }
 
+    /// Return an unsafe mutable pointer to the buffer's inner vec, or a
+    /// dangling raw pointer valid for zero sized reads if the buffer didn't
+    /// allocate.
+    ///
+    /// The caller must ensure correct use of the pointer. See [`Vec::as_mut_ptr`]
+    /// for more details.
     #[inline]
     #[must_use]
     pub fn as_mut_ptr(&mut self) -> *mut u8 {
         self.inner.as_mut_ptr()
     }
 
+    /// Force the length of the buffer to `new_len`.
+    ///
+    /// This is a low-level operation that maintains none of the normal
+    /// invariants of the type. Normally changing the length of a vector is done
+    /// using one of the safe operations instead, such as [`truncate`],
+    /// [`resize`], [`extend`], or [`clear`].
+    ///
+    /// [`truncate`]: Self::truncate
+    /// [`resize`]: Self::resize
+    /// [`extend`]: Self::extend
+    /// [`clear`]: Self::clear
+    ///
+    /// # Safety
+    ///
+    /// - `new_len` must be less than or equal to [`capacity()`].
+    /// - The elements at `old_len..new_len` must be initialized.
+    ///
+    /// [`capacity()`]: Self::capacity
     #[inline]
     pub unsafe fn set_len(&mut self, new_len: usize) {
         self.inner.set_len(new_len);
     }
 
+    /// Insert a byte at position `index` within the buffer, shifting all
+    /// elements after it to the right.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index > len`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use scolapasta_strbuf::Buf;
+    ///
+    /// let mut buf = Buf::from(b"123");
+    /// buf.insert(1, b'4');
+    /// assert_eq!(buf, b"1423");
+    /// buf.insert(4, b'5');
+    /// assert_eq!(buf, b"14235");
+    /// ```
     #[inline]
     pub fn insert(&mut self, index: usize, element: u8) {
         self.inner.insert(index, element);
     }
 
+    /// Remove and return the byte at position `index` within the buffer,
+    /// shifting all bytes after it to the left.
+    ///
+    /// **Note**: Because this shifts over the remaining bytes, it has a
+    /// worst-case performance of *O*(*n*).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index` is out of bounds.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use scolapasta_strbuf::Buf;
+    ///
+    /// let mut buf = Buf::from(b"123");
+    /// assert_eq!(buf.remove(1), b'2');
+    /// assert_eq!(buf, b"13");
+    /// ```
     #[inline]
+    #[track_caller]
     pub fn remove(&mut self, index: usize) -> u8 {
         self.inner.remove(index)
     }

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -742,6 +742,13 @@ name = "scolapasta-path"
 version = "0.5.0"
 
 [[package]]
+name = "scolapasta-strbuf"
+version = "1.0.0"
+dependencies = [
+ "raw-parts",
+]
+
+[[package]]
 name = "scolapasta-string-escape"
 version = "0.3.0"
 dependencies = [
@@ -899,6 +906,7 @@ dependencies = [
  "bytecount",
  "focaccia",
  "raw-parts",
+ "scolapasta-strbuf",
  "scolapasta-string-escape",
  "simdutf8",
 ]

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -900,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-string"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "bstr",
  "bytecount",

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -905,7 +905,6 @@ dependencies = [
  "bstr",
  "bytecount",
  "focaccia",
- "raw-parts",
  "scolapasta-strbuf",
  "scolapasta-string-escape",
  "simdutf8",

--- a/spinoso-string/Cargo.toml
+++ b/spinoso-string/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spinoso-string"
-version = "0.22.0"
+version = "0.23.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 description = """
 Encoding-aware string implementation for Ruby String core type in Artichoke Ruby
@@ -33,10 +33,11 @@ casecmp = ["dep:focaccia"]
 #
 # Enable runtime SIMD dispatch in `bytecount` and `simdutf8` dependencies.
 std = ["bytecount/runtime-dispatch-simd", "scolapasta-strbuf/std", "simdutf8/std"]
-# Use an alternate byte buffer backend that ensures string content is always
-# followed by a NUL byte. This feature can be used to ensure spinoso strings are
-# FFI compatible with C code that expects byte content to be NUL terminated.
-always-nul-terminated-c-string-compat = ["scolapasta-strbuf/nul-terminated"]
+# Use an alternate byte buffer backend that ensures byte content is always
+# followed by a NUL byte in the buffer's spare capacity. This feature can be
+# used to ensure `String`s are FFI compatible with C code that expects byte
+# content to be NUL terminated.
+nul-terminated = ["scolapasta-strbuf/nul-terminated"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/spinoso-string/Cargo.toml
+++ b/spinoso-string/Cargo.toml
@@ -19,7 +19,6 @@ documentation.workspace = true
 bstr = { version = "1.2.0", default-features = false, features = ["alloc"] }
 bytecount = "0.6.2"
 focaccia = { version = "1.3.1", optional = true, default-features = false }
-raw-parts = "2.0.0"
 scolapasta-strbuf = { version = "1.0.0", path = "../scolapasta-strbuf", default-features = false }
 scolapasta-string-escape = { version = "0.3.0", path = "../scolapasta-string-escape", default-features = false }
 simdutf8 = { version = "0.1.4", default-features = false }

--- a/spinoso-string/Cargo.toml
+++ b/spinoso-string/Cargo.toml
@@ -20,6 +20,7 @@ bstr = { version = "1.2.0", default-features = false, features = ["alloc"] }
 bytecount = "0.6.2"
 focaccia = { version = "1.3.1", optional = true, default-features = false }
 raw-parts = "2.0.0"
+scolapasta-strbuf = { version = "1.0.0", path = "../scolapasta-strbuf", default-features = false }
 scolapasta-string-escape = { version = "0.3.0", path = "../scolapasta-string-escape", default-features = false }
 simdutf8 = { version = "0.1.4", default-features = false }
 
@@ -32,11 +33,11 @@ casecmp = ["dep:focaccia"]
 # Enable implementations of traits in `std` like `Error` and `io::Write`.
 #
 # Enable runtime SIMD dispatch in `bytecount` and `simdutf8` dependencies.
-std = ["bytecount/runtime-dispatch-simd", "simdutf8/std"]
+std = ["bytecount/runtime-dispatch-simd", "scolapasta-strbuf/std", "simdutf8/std"]
 # Use an alternate byte buffer backend that ensures string content is always
 # followed by a NUL byte. This feature can be used to ensure spinoso strings are
 # FFI compatible with C code that expects byte content to be NUL terminated.
-always-nul-terminated-c-string-compat = []
+always-nul-terminated-c-string-compat = ["scolapasta-strbuf/nul-terminated"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/spinoso-string/README.md
+++ b/spinoso-string/README.md
@@ -27,7 +27,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-spinoso-string = "0.22.0"
+spinoso-string = "0.23.0"
 ```
 
 ## `no_std`
@@ -44,9 +44,9 @@ All features are enabled by default unless otherwise noted.
   Activating this feature enables a dependency on [`focaccia`].
 - **std** - Enables a dependency on the Rust Standard Library. Activating this
   feature enables [`std::error::Error`] impls on error types in this crate.
-- **always-nul-terminated-c-string-compat** - NOT enabled by default. Use an
-  alternate byte buffer backend that ensures string content is always followed
-  by a NUL byte. This feature can be used to ensure spinoso strings are FFI
+- **nul-terminated** - NOT enabled by default. Use an alternate byte buffer
+  backend that ensures byte content is always followed by a NUL byte in the
+  buffer's spare capacity. This feature can be used to ensure `String`s are FFI
   compatible with C code that expects byte content to be NUL terminated.
 
 [`focaccia`]: https://docs.rs/focaccia

--- a/spinoso-string/src/buf/mod.rs
+++ b/spinoso-string/src/buf/mod.rs
@@ -1,8 +1,0 @@
-mod nul_terminated_vec;
-mod vec;
-
-pub use imp::Buf;
-#[cfg(feature = "always-nul-terminated-c-string-compat")]
-use nul_terminated_vec as imp;
-#[cfg(not(feature = "always-nul-terminated-c-string-compat"))]
-use vec as imp;

--- a/spinoso-string/src/enc/ascii/impls.rs
+++ b/spinoso-string/src/enc/ascii/impls.rs
@@ -3,8 +3,9 @@ use alloc::string::String;
 use alloc::vec::Vec;
 use core::ops::{Deref, DerefMut};
 
+use scolapasta_strbuf::Buf;
+
 use super::AsciiString;
-use crate::buf::Buf;
 
 impl Extend<u8> for AsciiString {
     #[inline]

--- a/spinoso-string/src/enc/ascii/mod.rs
+++ b/spinoso-string/src/enc/ascii/mod.rs
@@ -4,8 +4,8 @@ use core::ops::Range;
 use core::slice::SliceIndex;
 
 use bstr::ByteSlice;
+use scolapasta_strbuf::Buf;
 
-use crate::buf::Buf;
 use crate::codepoints::InvalidCodepointError;
 use crate::encoding::Encoding;
 use crate::iter::{Bytes, IntoIter, Iter, IterMut};

--- a/spinoso-string/src/enc/binary/impls.rs
+++ b/spinoso-string/src/enc/binary/impls.rs
@@ -3,8 +3,9 @@ use alloc::string::String;
 use alloc::vec::Vec;
 use core::ops::{Deref, DerefMut};
 
+use scolapasta_strbuf::Buf;
+
 use super::BinaryString;
-use crate::buf::Buf;
 
 impl Extend<u8> for BinaryString {
     #[inline]

--- a/spinoso-string/src/enc/binary/mod.rs
+++ b/spinoso-string/src/enc/binary/mod.rs
@@ -4,8 +4,8 @@ use core::ops::Range;
 use core::slice::SliceIndex;
 
 use bstr::ByteSlice;
+use scolapasta_strbuf::Buf;
 
-use crate::buf::Buf;
 use crate::codepoints::InvalidCodepointError;
 use crate::iter::{Bytes, IntoIter, Iter, IterMut};
 use crate::ord::OrdError;

--- a/spinoso-string/src/enc/mod.rs
+++ b/spinoso-string/src/enc/mod.rs
@@ -7,9 +7,9 @@ use core::slice::SliceIndex;
 
 use ascii::AsciiString;
 use binary::BinaryString;
+use scolapasta_strbuf::Buf;
 use utf8::Utf8String;
 
-use crate::buf::Buf;
 use crate::codepoints::InvalidCodepointError;
 use crate::encoding::Encoding;
 use crate::iter::{Bytes, IntoIter, Iter, IterMut};

--- a/spinoso-string/src/enc/utf8/impls.rs
+++ b/spinoso-string/src/enc/utf8/impls.rs
@@ -3,8 +3,9 @@ use alloc::string::String;
 use alloc::vec::Vec;
 use core::ops::{Deref, DerefMut};
 
+use scolapasta_strbuf::Buf;
+
 use super::Utf8String;
-use crate::buf::Buf;
 
 impl Extend<u8> for Utf8String {
     #[inline]

--- a/spinoso-string/src/enc/utf8/mod.rs
+++ b/spinoso-string/src/enc/utf8/mod.rs
@@ -5,8 +5,8 @@ use core::ops::Range;
 use core::slice::SliceIndex;
 
 use bstr::{ByteSlice, ByteVec};
+use scolapasta_strbuf::Buf;
 
-use crate::buf::Buf;
 use crate::chars::ConventionallyUtf8;
 use crate::codepoints::InvalidCodepointError;
 use crate::iter::{Bytes, IntoIter, Iter, IterMut};

--- a/spinoso-string/src/lib.rs
+++ b/spinoso-string/src/lib.rs
@@ -52,8 +52,8 @@ use bstr::ByteSlice;
 pub use focaccia::CaseFold;
 #[doc(inline)]
 pub use raw_parts::RawParts;
+use scolapasta_strbuf::Buf;
 
-mod buf;
 mod center;
 mod chars;
 mod codepoints;
@@ -65,7 +65,6 @@ mod inspect;
 mod iter;
 mod ord;
 
-use buf::Buf;
 pub use center::{Center, CenterError};
 pub use chars::Chars;
 pub use codepoints::{Codepoints, CodepointsError, InvalidCodepointError};

--- a/spinoso-string/src/lib.rs
+++ b/spinoso-string/src/lib.rs
@@ -50,9 +50,9 @@ use bstr::ByteSlice;
 #[cfg(feature = "casecmp")]
 #[cfg_attr(feature = "docsrs", doc(cfg(feature = "casecmp")))]
 pub use focaccia::CaseFold;
-#[doc(inline)]
-pub use raw_parts::RawParts;
 use scolapasta_strbuf::Buf;
+#[doc(inline)]
+pub use scolapasta_strbuf::RawParts;
 
 mod center;
 mod chars;


### PR DESCRIPTION
This PR is the first part of a yak shave to reboot https://github.com/artichoke/artichoke/pull/1909. When reviving this branch to split encoded string types into owned and ref variants (mirroring `Vec<u8>` and `&[u8]` or `BString` and `&BStr`), I ended up exploding the complexity in the source code for the UTF-8 encoded variant. To address that complexity, I thought I would split out the various encoded string variants into their own crates. Unfortunately, all encoded string variants depend on the `Buf` type to hold their byte contents, which is a private implementation detail of `spinoso-string`.

This PR splits the various `Buf` types out of `spinoso-string` into a new "Scolapasta" utility crate: `scolapasta-strbuf`.

Splitting out the internals into their own crate brings the following improvements:

- A soundness vulnerability is fixed in `Buf` when the `nul-terminated` feature is activated. `impl Default for Buf` was not properly upholding the NUL-terminated invariant on `Buf`.
- All APIs in the `nul-terminated` variant of `Buf` which take `&mut self` are fuzzed to ensure the NUL-terminated invariant is upheld using `quickcheck`.
- Both `Buf` variants have acquired tests.
- All methods on both `Buf` types are documented with examples.
- The new crate is 100% documented.
- The dependency on `bstr` is dropped.
- The `Buf` API is minimized further to remove methods that have not been required by `spinoso-string`.
- The `unsafe_op_in_unsafe_fn` and `clippy::undocumented_unsafe_block` lints are activated and their violations are addressed.
- Cargo features are renamed and simplified.
- Many more traits are implemented on `Buf` and all iterator types from the underlying `Vec` are exposed.
- Many variants of `PartialEq` are implemented on `Buf`.
- Many implementations of `From` and `TryFrom` are added.