### PR TITLE
Rework `spinoso-random` cargo features

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -254,9 +254,9 @@ jobs:
 
       - name: Check spinoso-random with some features
         run: |
-          cargo check --verbose --no-default-features --features rand-traits --all-targets --profile=test
+          cargo check --verbose --no-default-features --features rand_core --all-targets --profile=test
           cargo check --verbose --no-default-features --features std --all-targets --profile=test
-          cargo check --verbose --no-default-features --features random-rand --all-targets --profile=test
+          cargo check --verbose --no-default-features --features rand-method --all-targets --profile=test
         working-directory: "spinoso-random"
 
       - name: Check spinoso-regexp with no default features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -765,7 +765,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-random"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "getrandom",
  "libm",

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -31,7 +31,7 @@ spinoso-array = { version = "0.10.0", path = "../spinoso-array", default-feature
 spinoso-env = { version = "0.2.0", path = "../spinoso-env", optional = true, default-features = false }
 spinoso-exception = { version = "0.1.0", path = "../spinoso-exception" }
 spinoso-math = { version = "0.3.0", path = "../spinoso-math", optional = true, default-features = false }
-spinoso-random = { version = "0.3.0", path = "../spinoso-random", optional = true }
+spinoso-random = { version = "0.4.0", path = "../spinoso-random", optional = true }
 spinoso-regexp = { version = "0.5.0", path = "../spinoso-regexp", optional = true, default-features = false }
 spinoso-securerandom = { version = "0.2.0", path = "../spinoso-securerandom", optional = true }
 spinoso-string = { version = "0.23.0", path = "../spinoso-string", features = ["nul-terminated"] }

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -560,7 +560,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-random"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "getrandom",
  "libm",

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-random"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "getrandom",
  "libm",

--- a/spinoso-random/Cargo.toml
+++ b/spinoso-random/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spinoso-random"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 description = """
 Implementation of Ruby Random Core class.
@@ -26,11 +26,11 @@ rand_core = { version = "0.6.2", optional = true, default-features = false }
 rand_mt = { version = "4.2.0", default-features = false }
 
 [features]
-default = ["random-rand", "rand-traits", "std"]
+default = ["rand-method", "rand_core", "std"]
 # Enables range sampling methods for the `rand()` function.
-random-rand = ["dep:rand", "rand-traits"]
+rand-method = ["dep:rand", "rand_core"]
 # Enables implementations of `RngCore` on `Random` and `Mt` types.
-rand-traits = ["dep:rand_core"]
+rand_core = ["dep:rand_core"]
 std = []
 
 [package.metadata.docs.rs]

--- a/spinoso-random/README.md
+++ b/spinoso-random/README.md
@@ -31,7 +31,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-spinoso-random = "0.3.0"
+spinoso-random = "0.4.0"
 ```
 
 Generate integers:
@@ -66,11 +66,11 @@ crate depends on [`alloc`].
 
 All features are enabled by default.
 
-- **random-rand** - Enables range sampling methods for the `rand()` function.
+- **rand-method** - Enables range sampling methods for the `rand()` function.
   Activating this feature also activates the **rand_core** feature. Dropping
   this feature removes the [`rand`] dependency.
-- **rand-traits** - Enables implementations of [`RngCore`] on `Random` and `Mt`
-  types. Dropping this feature removes the [`rand_core`] dependency.
+- **rand_core** - Enables implementations of [`RngCore`] on the [`Random`] type.
+  Dropping this feature removes the [`rand_core`] dependency.
 - **std** - Enables a dependency on the Rust Standard Library. Activating this
   feature enables [`std::error::Error`] impls on error types in this crate.
 

--- a/spinoso-random/src/lib.rs
+++ b/spinoso-random/src/lib.rs
@@ -42,7 +42,8 @@
 //! Generate integers:
 //!
 //! ```
-//! # use spinoso_random::Random;
+//! use spinoso_random::Random;
+//!
 //! let seed = [627457_u32, 697550, 16438, 41926];
 //! let mut random = Random::with_array_seed(seed);
 //! let rand = random.next_int32();
@@ -51,17 +52,17 @@
 //! Generate random numbers in a range:
 //!
 //! ```
-//! # #[cfg(feature = "random-rand")]
-//! # use spinoso_random::{rand, Error, Max, Rand, Random};
-//! # #[cfg(feature = "random-rand")]
-//! # fn example() -> Result<(), Error> {
+//! # #[cfg(feature = "rand-method")]
+//! # fn example() -> Result<(), spinoso_random::Error> {
+//! use spinoso_random::{rand, Max, Rand, Random};
+//!
 //! let mut random = Random::new()?;
 //! let max = Max::Integer(10);
 //! let mut rand = rand(&mut random, max)?;
 //! assert!(matches!(rand, Rand::Integer(x) if x < 10));
 //! # Ok(())
 //! # }
-//! # #[cfg(feature = "random-rand")]
+//! # #[cfg(feature = "rand-method")]
 //! # example().unwrap();
 //! ```
 //!
@@ -74,10 +75,10 @@
 //!
 //! All features are enabled by default.
 //!
-//! - **random-rand** - Enables range sampling methods for the [`rand()`]
-//!   function.  Activating this feature also activates the **rand-traits**
+//! - **rand-method** - Enables range sampling methods for the [`rand()`]
+//!   function. Activating this feature also activates the **rand_core**
 //!   feature. Dropping this feature removes the [`rand`] dependency.
-//! - **rand-traits** - Enables implementations of [`RngCore`] on the [`Random`]
+//! - **rand_core** - Enables implementations of [`RngCore`] on the [`Random`]
 //!   type. Dropping this feature removes the [`rand_core`] dependency.
 //! - **std** - Enables a dependency on the Rust Standard Library. Activating
 //!   this feature enables [`std::error::Error`] impls on error types in this
@@ -87,20 +88,20 @@
     not(feature = "std"),
     doc = "[`std::error::Error`]: https://doc.rust-lang.org/std/error/trait.Error.html"
 )]
-#![cfg_attr(feature = "rand-traits", doc = "[`RngCore`]: rand_core::RngCore")]
+#![cfg_attr(feature = "rand_core", doc = "[`RngCore`]: rand_core::RngCore")]
 #![cfg_attr(
-    not(feature = "rand-traits"),
+    not(feature = "rand_core"),
     doc = "[`RngCore`]: https://docs.rs/rand_core/latest/rand_core/trait.RngCore.html"
 )]
-#![cfg_attr(feature = "rand-traits", doc = "[`rand_core`]: ::rand_core")]
+#![cfg_attr(feature = "rand_core", doc = "[`rand_core`]: ::rand_core")]
 #![cfg_attr(
-    not(feature = "rand-traits"),
+    not(feature = "rand_core"),
     doc = "[`rand_core`]: https://docs.rs/rand_core/latest/rand_core/"
 )]
-#![cfg_attr(feature = "random-rand", doc = "[`rand`]: ::rand")]
-#![cfg_attr(not(feature = "random-rand"), doc = "[`rand`]: https://docs.rs/rand/latest/rand/")]
+#![cfg_attr(feature = "rand-method", doc = "[`rand`]: ::rand")]
+#![cfg_attr(not(feature = "rand-method"), doc = "[`rand`]: https://docs.rs/rand/latest/rand/")]
 #![cfg_attr(
-    not(feature = "random-rand"),
+    not(feature = "rand-method"),
     doc = "[`rand()`]: https://artichoke.github.io/artichoke/spinoso_random/fn.rand.html"
 )]
 //! [ruby-random]: https://ruby-doc.org/core-3.1.2/Random.html
@@ -109,7 +110,7 @@
 #![no_std]
 
 // Ensure code blocks in `README.md` compile
-#[cfg(doctest)]
+#[cfg(all(feature = "rand-method", doctest))]
 #[doc = include_str!("../README.md")]
 mod readme {}
 
@@ -122,7 +123,7 @@ use core::fmt;
 #[cfg(feature = "std")]
 use std::error;
 
-#[cfg(feature = "random-rand")]
+#[cfg(feature = "rand-method")]
 mod rand;
 mod random;
 mod urandom;
@@ -130,7 +131,7 @@ mod urandom;
 pub use random::{new_seed, seed_to_key, Random};
 pub use urandom::urandom;
 
-#[cfg(feature = "random-rand")]
+#[cfg(feature = "rand-method")]
 pub use self::rand::{rand, Max, Rand};
 
 /// Sum type of all errors possibly returned from `Random` functions.
@@ -145,7 +146,7 @@ pub use self::rand::{rand, Max, Rand};
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
 pub enum Error {
     #[cfg_attr(
-        feature = "random-rand",
+        feature = "rand-method",
         doc = "Error that indicates [`rand()`] was passed an invalid constraint."
     )]
     ///
@@ -224,7 +225,8 @@ impl error::Error for Error {
 /// # Examples
 ///
 /// ```
-/// # use spinoso_random::InitializeError;
+/// use spinoso_random::InitializeError;
+///
 /// let err = InitializeError::new();
 /// assert_eq!(err.message(), "failed to get urandom");
 /// ```
@@ -241,7 +243,8 @@ impl InitializeError {
     /// # Examples
     ///
     /// ```
-    /// # use spinoso_random::InitializeError;
+    /// use spinoso_random::InitializeError;
+    ///
     /// const ERR: InitializeError = InitializeError::new();
     /// assert_eq!(ERR.message(), "failed to get urandom");
     /// ```
@@ -257,7 +260,8 @@ impl InitializeError {
     /// # Examples
     ///
     /// ```
-    /// # use spinoso_random::InitializeError;
+    /// use spinoso_random::InitializeError;
+    ///
     /// let err = InitializeError::new();
     /// assert_eq!(err.message(), "failed to get urandom");
     /// ```
@@ -291,7 +295,8 @@ impl error::Error for InitializeError {}
 /// # Examples
 ///
 /// ```
-/// # use spinoso_random::UrandomError;
+/// use spinoso_random::UrandomError;
+///
 /// let err = UrandomError::new();
 /// assert_eq!(err.message(), "failed to get urandom");
 /// ```
@@ -308,7 +313,8 @@ impl UrandomError {
     /// # Examples
     ///
     /// ```
-    /// # use spinoso_random::UrandomError;
+    /// use spinoso_random::UrandomError;
+    ///
     /// const ERR: UrandomError = UrandomError::new();
     /// assert_eq!(ERR.message(), "failed to get urandom");
     /// ```
@@ -323,7 +329,8 @@ impl UrandomError {
     /// # Examples
     ///
     /// ```
-    /// # use spinoso_random::UrandomError;
+    /// use spinoso_random::UrandomError;
+    ///
     /// let err = UrandomError::new();
     /// assert_eq!(err.message(), "failed to get urandom");
     /// ```
@@ -357,7 +364,8 @@ impl error::Error for UrandomError {}
 /// # Examples
 ///
 /// ```
-/// # use spinoso_random::NewSeedError;
+/// use spinoso_random::NewSeedError;
+///
 /// let err = NewSeedError::new();
 /// assert_eq!(err.message(), "failed to get urandom");
 /// ```
@@ -374,7 +382,8 @@ impl NewSeedError {
     /// # Examples
     ///
     /// ```
-    /// # use spinoso_random::NewSeedError;
+    /// use spinoso_random::NewSeedError;
+    ///
     /// const ERR: NewSeedError = NewSeedError::new();
     /// assert_eq!(ERR.message(), "failed to get urandom");
     /// ```
@@ -389,7 +398,8 @@ impl NewSeedError {
     /// # Examples
     ///
     /// ```
-    /// # use spinoso_random::NewSeedError;
+    /// use spinoso_random::NewSeedError;
+    ///
     /// let err = NewSeedError::new();
     /// assert_eq!(err.message(), "failed to get urandom");
     /// ```
@@ -414,7 +424,7 @@ impl error::Error for NewSeedError {}
 /// bounds.
 ///
 #[cfg_attr(
-    feature = "random-rand",
+    feature = "rand-method",
     doc = "This error is returned by [`rand()`]. See its documentation for more details."
 )]
 ///
@@ -423,7 +433,8 @@ impl error::Error for NewSeedError {}
 /// # Examples
 ///
 /// ```
-/// # use spinoso_random::ArgumentError;
+/// use spinoso_random::ArgumentError;
+///
 /// let err = ArgumentError::new();
 /// assert_eq!(err.message(), "ArgumentError");
 /// ```
@@ -436,8 +447,8 @@ pub struct ArgumentError(ArgumentErrorInner);
 enum ArgumentErrorInner {
     Default,
     DomainError,
-    #[cfg(feature = "random-rand")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "random-rand")))]
+    #[cfg(feature = "rand-method")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "rand-method")))]
     Rand(Max),
 }
 
@@ -447,7 +458,8 @@ impl ArgumentError {
     /// # Examples
     ///
     /// ```
-    /// # use spinoso_random::ArgumentError;
+    /// use spinoso_random::ArgumentError;
+    ///
     /// const ERR: ArgumentError = ArgumentError::new();
     /// assert_eq!(ERR.message(), "ArgumentError");
     /// ```
@@ -462,7 +474,8 @@ impl ArgumentError {
     /// # Examples
     ///
     /// ```
-    /// # use spinoso_random::ArgumentError;
+    /// use spinoso_random::ArgumentError;
+    ///
     /// const ERR: ArgumentError = ArgumentError::domain_error();
     /// assert_eq!(ERR.message(), "Numerical argument out of domain");
     /// ```
@@ -477,35 +490,37 @@ impl ArgumentError {
     /// # Examples
     ///
     /// ```
-    /// # use spinoso_random::{ArgumentError, Max};
+    /// use spinoso_random::{ArgumentError, Max};
+    ///
     /// const ERR: ArgumentError = ArgumentError::with_rand_max(Max::Integer(-1));
     /// assert_eq!(ERR.message(), "invalid argument");
     /// ```
     #[inline]
     #[must_use]
-    #[cfg(feature = "random-rand")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "random-rand")))]
+    #[cfg(feature = "rand-method")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "rand-method")))]
     pub const fn with_rand_max(max: Max) -> Self {
         Self(ArgumentErrorInner::Rand(max))
     }
 
     /// Retrieve the exception message associated with this new seed error.
     ///
-    #[cfg_attr(feature = "random-rand", doc = "# Implementation notes")]
+    #[cfg_attr(feature = "rand-method", doc = "# Implementation notes")]
     #[cfg_attr(
-        feature = "random-rand",
+        feature = "rand-method",
         doc = "Argument errors constructed with [`ArgumentError::with_rand_max`] return"
     )]
     #[cfg_attr(
-        feature = "random-rand",
+        feature = "rand-method",
         doc = "an incomplete error message. Prefer to use the [`Display`] impl to"
     )]
-    #[cfg_attr(feature = "random-rand", doc = "retrieve error messages from [`ArgumentError`].")]
+    #[cfg_attr(feature = "rand-method", doc = "retrieve error messages from [`ArgumentError`].")]
     ///
     /// # Examples
     ///
     /// ```
-    /// # use spinoso_random::ArgumentError;
+    /// use spinoso_random::ArgumentError;
+    ///
     /// let err = ArgumentError::new();
     /// assert_eq!(err.message(), "ArgumentError");
     /// let err = ArgumentError::domain_error();
@@ -519,7 +534,7 @@ impl ArgumentError {
         match self.0 {
             ArgumentErrorInner::Default => "ArgumentError",
             ArgumentErrorInner::DomainError => "Numerical argument out of domain",
-            #[cfg(feature = "random-rand")]
+            #[cfg(feature = "rand-method")]
             ArgumentErrorInner::Rand(_) => "invalid argument",
         }
     }
@@ -531,7 +546,8 @@ impl ArgumentError {
     /// # Examples
     ///
     /// ```
-    /// # use spinoso_random::ArgumentError;
+    /// use spinoso_random::ArgumentError;
+    ///
     /// let err = ArgumentError::domain_error();
     /// assert!(err.is_domain_error());
     /// let err = ArgumentError::new();
@@ -549,7 +565,7 @@ impl fmt::Display for ArgumentError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.0 {
             ArgumentErrorInner::Default | ArgumentErrorInner::DomainError => f.write_str(self.message()),
-            #[cfg(feature = "random-rand")]
+            #[cfg(feature = "rand-method")]
             ArgumentErrorInner::Rand(max) => write!(f, "invalid argument - {max}"),
         }
     }

--- a/spinoso-random/src/rand.rs
+++ b/spinoso-random/src/rand.rs
@@ -10,7 +10,7 @@ use crate::{ArgumentError, Random};
 /// more details.
 // TODO: Add range variants
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-#[cfg_attr(docsrs, doc(cfg(feature = "random-rand")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "rand-method")))]
 pub enum Max {
     /// A maximum float bound.
     ///
@@ -47,7 +47,7 @@ impl fmt::Display for Max {
 /// This enum is returned by the [`rand()`] function. See its documentation for
 /// more details.
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-#[cfg_attr(docsrs, doc(cfg(feature = "random-rand")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "rand-method")))]
 pub enum Rand {
     /// A random float.
     ///
@@ -80,7 +80,8 @@ pub enum Rand {
 /// Generate floats from `(0.0..1.0)`:
 ///
 /// ```
-/// # use spinoso_random::{rand, ArgumentError, InitializeError, Max, Rand, Random};
+/// use spinoso_random::{rand, ArgumentError, InitializeError, Max, Rand, Random};
+///
 /// # #[derive(Debug)]
 /// # enum ExampleError { Argument(ArgumentError), Initialize(InitializeError) }
 /// # impl From<ArgumentError> for ExampleError { fn from(err: ArgumentError) -> Self { Self::Argument(err) } }
@@ -98,7 +99,8 @@ pub enum Rand {
 /// Generate random integers:
 ///
 /// ```
-/// # use spinoso_random::{rand, ArgumentError, InitializeError, Max, Rand, Random};
+/// use spinoso_random::{rand, ArgumentError, InitializeError, Max, Rand, Random};
+///
 /// # #[derive(Debug)]
 /// # enum ExampleError { Argument(ArgumentError), Initialize(InitializeError) }
 /// # impl From<ArgumentError> for ExampleError { fn from(err: ArgumentError) -> Self { Self::Argument(err) } }
@@ -122,8 +124,8 @@ pub enum Rand {
 ///
 /// When `max` is a non-finite `f64`, `rand` returns a domain error
 /// [`ArgumentError`].
-#[cfg(feature = "random-rand")]
-#[cfg_attr(docsrs, doc(cfg(feature = "random-rand")))]
+#[cfg(feature = "rand-method")]
+#[cfg_attr(docsrs, doc(cfg(feature = "rand-method")))]
 pub fn rand(rng: &mut Random, max: Max) -> Result<Rand, ArgumentError> {
     let constraint = max;
     match constraint {

--- a/spinoso-random/src/random/mod.rs
+++ b/spinoso-random/src/random/mod.rs
@@ -6,7 +6,7 @@ use rand_mt::Mt;
 
 use crate::{InitializeError, NewSeedError};
 
-#[cfg(feature = "rand-traits")]
+#[cfg(feature = "rand_core")]
 mod rand;
 
 const DEFAULT_SEED_CNT: usize = 4;
@@ -35,7 +35,8 @@ const DEFAULT_SEED: u32 = 5489_u32;
 /// Create an RNG with a random seed:
 ///
 /// ```
-/// # use spinoso_random::{Error, Random};
+/// use spinoso_random::{Error, Random};
+///
 /// # fn example() -> Result<(), Error> {
 /// let mut random = Random::new()?;
 /// let next = random.next_int32();
@@ -47,7 +48,8 @@ const DEFAULT_SEED: u32 = 5489_u32;
 /// Create a RNG with a fixed seed:
 ///
 /// ```
-/// # use spinoso_random::Random;
+/// use spinoso_random::Random;
+///
 /// let seed = 5489_u32;
 /// let mut random = Random::with_seed(seed);
 /// let rand = random.next_int32();
@@ -118,7 +120,8 @@ impl Random {
     /// # Examples
     ///
     /// ```
-    /// # use spinoso_random::{Error, Random};
+    /// use spinoso_random::{Error, Random};
+    ///
     /// # fn example() -> Result<(), Error> {
     /// let mut random = Random::new()?;
     /// let next = random.next_int32();
@@ -152,7 +155,8 @@ impl Random {
     /// # Examples
     ///
     /// ```
-    /// # use spinoso_random::Random;
+    /// use spinoso_random::Random;
+    ///
     /// let seed = 33;
     /// let mut random = Random::with_seed(seed);
     /// let rand = random.next_int32();
@@ -174,7 +178,8 @@ impl Random {
     /// # Examples
     ///
     /// ```
-    /// # use spinoso_random::Random;
+    /// use spinoso_random::Random;
+    ///
     /// let seed = [1_u32, 2, 3, 4];
     /// let mut random = Random::with_array_seed(seed);
     /// let rand = random.next_int32();
@@ -199,7 +204,8 @@ impl Random {
     /// # Examples
     ///
     /// ```
-    /// # use spinoso_random::Random;
+    /// use spinoso_random::Random;
+    ///
     /// let seed = [1_u32, 2, 3, 4];
     /// let mut random = Random::with_array_seed(seed);
     /// let rand = random.next_int32();
@@ -225,7 +231,8 @@ impl Random {
     /// # Examples
     ///
     /// ```
-    /// # use spinoso_random::{Error, Random};
+    /// use spinoso_random::{Error, Random};
+    ///
     /// # fn example() -> Result<(), Error> {
     /// let mut random = Random::new()?;
     /// assert_ne!(random.next_int32(), random.next_int32());
@@ -246,7 +253,8 @@ impl Random {
     /// # Examples
     ///
     /// ```
-    /// # use spinoso_random::{Error, Random};
+    /// use spinoso_random::{Error, Random};
+    ///
     /// # fn example() -> Result<(), Error> {
     /// let mut random = Random::new()?;
     /// assert_ne!(random.next_real(), random.next_real());
@@ -273,7 +281,8 @@ impl Random {
     /// # Examples
     ///
     /// ```
-    /// # use spinoso_random::{Error, Random};
+    /// use spinoso_random::{Error, Random};
+    ///
     /// # fn example() -> Result<(), Error> {
     /// let mut random = Random::new()?;
     /// let mut buf = [0; 32];
@@ -299,7 +308,8 @@ impl Random {
     /// # Examples
     ///
     /// ```
-    /// # use spinoso_random::Random;
+    /// use spinoso_random::Random;
+    ///
     /// let seed = [1_u32, 2, 3, 4];
     /// let random = Random::with_array_seed(seed);
     /// assert_eq!(random.seed(), seed);
@@ -354,7 +364,8 @@ pub fn seed_to_key(seed: [u8; DEFAULT_SEED_BYTES]) -> [u32; DEFAULT_SEED_CNT] {
 /// # Examples
 ///
 /// ```
-/// # use spinoso_random::{Error, Random};
+/// use spinoso_random::{Error, Random};
+///
 /// # fn example() -> Result<(), Error> {
 /// let seed = spinoso_random::new_seed()?;
 /// # Ok(())

--- a/spinoso-random/src/random/rand.rs
+++ b/spinoso-random/src/random/rand.rs
@@ -10,8 +10,9 @@ impl SeedableRng for Random {
     /// # Examples
     ///
     /// ```
-    /// # use rand_core::{RngCore, SeedableRng};
-    /// # use spinoso_random::Random;
+    /// use rand_core::{RngCore, SeedableRng};
+    /// use spinoso_random::Random;
+    ///
     /// // Default MT seed
     /// let seed = 5489_u128.to_le_bytes();
     /// let mut mt = Random::from_seed(seed);
@@ -37,8 +38,9 @@ impl RngCore for Random {
     /// # Examples
     ///
     /// ```
-    /// # use rand_core::RngCore;
-    /// # use spinoso_random::Random;
+    /// use rand_core::RngCore;
+    /// use spinoso_random::Random;
+    ///
     /// let mut random = Random::with_seed(33);
     /// assert_ne!(random.next_u64(), random.next_u64());
     /// ```
@@ -56,8 +58,9 @@ impl RngCore for Random {
     /// # Examples
     ///
     /// ```
-    /// # use rand_core::RngCore;
-    /// # use spinoso_random::Random;
+    /// use rand_core::RngCore;
+    /// use spinoso_random::Random;
+    ///
     /// let mut random = Random::with_seed(33);
     /// assert_ne!(random.next_u32(), random.next_u32());
     /// ```
@@ -78,8 +81,9 @@ impl RngCore for Random {
     /// # Examples
     ///
     /// ```
-    /// # use rand_core::RngCore;
-    /// # use spinoso_random::Random;
+    /// use rand_core::RngCore;
+    /// use spinoso_random::Random;
+    ///
     /// let mut random = Random::with_seed(33);
     /// let mut buf = [0; 32];
     /// random.fill_bytes(&mut buf);
@@ -106,8 +110,9 @@ impl RngCore for Random {
     /// # Examples
     ///
     /// ```
-    /// # use rand_core::{Error, RngCore};
-    /// # use spinoso_random::Random;
+    /// use rand_core::{Error, RngCore};
+    /// use spinoso_random::Random;
+    ///
     /// # fn example() -> Result<(), Error> {
     /// let mut random = Random::with_seed(33);
     /// let mut buf = [0; 32];

--- a/spinoso-random/src/urandom.rs
+++ b/spinoso-random/src/urandom.rs
@@ -13,7 +13,8 @@ use crate::UrandomError;
 /// # Examples
 ///
 /// ```
-/// # use spinoso_random::Error;
+/// use spinoso_random::Error;
+///
 /// # fn example() -> Result<(), Error> {
 /// let mut bytes = [0_u8; 32];
 /// spinoso_random::urandom(&mut bytes)?;


### PR DESCRIPTION
I have long disliked how cumbersome the feature names are in `spinoso-random`. This commit renames `random-rand`, which enables the machinery for the `Random#rand` and `Kernel#rand` methods, to `rand-method`. It also removes the indirection from `rand-traits` to `rand_core`, preferring instead to simply name the feature `rand_core`.

This commit also tweaks all the doc examples to not hide the required `use` statements.

The README doctests now declare which features they require so the crate passes tests on all conditional compilation combinations.

Due to feature renames being a breaking change, bump spinoso-random to v0.4.0.