### PR TITLE
Improve the readability of dependency manifests in `Cargo.toml`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,28 @@ homepage.workspace = true
 documentation.workspace = true
 
 [dependencies]
-artichoke-backend = { version = "0.24.1", path = "artichoke-backend", default-features = false }
-artichoke-readline = { version = "1.0.0", path = "artichoke-readline", optional = true }
-artichoke-repl-history = { version = "1.0.0", path = "artichoke-repl-history", optional = true }
-clap = { version = "4.3.0", optional = true, default-features = false, features = ["std", "help", "usage", "error-context", "suggestions"] }
+
+[dependencies.artichoke-backend]
+version = "0.24.1"
+path = "artichoke-backend"
+default-features = false
+
+[dependencies.artichoke-readline]
+version = "1.0.0"
+path = "artichoke-readline"
+optional = true
+
+[dependencies.artichoke-repl-history]
+version = "1.0.0"
+path = "artichoke-repl-history"
+optional = true
+
+[dependencies.clap]
+version = "4.3.0"
+optional = true
+default-features = false
+features = ["std", "help", "usage", "error-context", "suggestions"]
+
 # XXX: load-bearing unused dependency.
 #
 # `rustyline` improperly declares its minimum version on `log` as `0.4` despite
@@ -33,14 +51,37 @@ clap = { version = "4.3.0", optional = true, default-features = false, features 
 # here.
 #
 # See: https://github.com/kkawakam/rustyline/pull/583
-log = { version = "0.4.5", optional = true }
-rustyline = { version = "11.0.0", optional = true, default-features = false, features = ["with-file-history"] }
-scolapasta-path = { version = "0.5.0", path = "scolapasta-path", optional = true }
-scolapasta-string-escape = { version = "0.3.0", path = "scolapasta-string-escape", optional = true, default-features = false }
-termcolor = { version = "1.1.0", optional = true }
+[dependencies.log]
+version = "0.4.5"
+optional = true
+
+[dependencies.rustyline]
+version = "11.0.0"
+optional = true
+default-features = false
+features = ["with-file-history"]
+
+[dependencies.scolapasta-path]
+version = "0.5.0"
+path = "scolapasta-path"
+optional = true
+
+[dependencies.scolapasta-string-escape]
+version = "0.3.0"
+path = "scolapasta-string-escape"
+optional = true
+default-features = false
+
+[dependencies.termcolor]
+version = "1.1.0"
+optional = true
 
 [build-dependencies]
-tz-rs = { version = "0.6.12", default-features = false, features = ["std"] }
+
+[build-dependencies.tz-rs]
+version = "0.6.12"
+default-features = false
+features = ["std"]
 
 [[bin]]
 name = "airb"

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -14,36 +14,125 @@ homepage.workspace = true
 documentation.workspace = true
 
 [dependencies]
-artichoke-core = { version = "0.13.0", path = "../artichoke-core" }
-artichoke-load-path = { version = "0.1.0", path = "../artichoke-load-path", default-features = false }
-bstr = { version = "1.2.0", default-features = false, features = ["alloc"] }
-intaglio = { version = "1.7.0", default-features = false, features = ["bytes"] }
-mezzaluna-type-registry = { version = "1.0.1", path = "../mezzaluna-type-registry" }
-onig = { version = "6.4.0", optional = true, default-features = false }
 posix-space = "1.0.0"
 qed = "1.3.0"
 regex = "1.7.0"
-scolapasta-aref = { version = "0.1.0", path = "../scolapasta-aref" }
-scolapasta-int-parse = { version = "0.2.2", path = "../scolapasta-int-parse", default-features = false }
-scolapasta-path = { version = "0.5.0", path = "../scolapasta-path" }
-scolapasta-string-escape = { version = "0.3.0", path = "../scolapasta-string-escape", default-features = false }
-spinoso-array = { version = "0.10.0", path = "../spinoso-array", default-features = false }
-spinoso-env = { version = "0.2.0", path = "../spinoso-env", optional = true, default-features = false }
-spinoso-exception = { version = "0.1.0", path = "../spinoso-exception" }
-spinoso-math = { version = "0.3.0", path = "../spinoso-math", optional = true, default-features = false }
-spinoso-random = { version = "0.4.0", path = "../spinoso-random", optional = true }
-spinoso-regexp = { version = "0.5.0", path = "../spinoso-regexp", optional = true, default-features = false }
-spinoso-securerandom = { version = "0.2.0", path = "../spinoso-securerandom", optional = true }
-spinoso-string = { version = "0.23.0", path = "../spinoso-string", features = ["nul-terminated"] }
-spinoso-symbol = { version = "0.4.0", path = "../spinoso-symbol" }
-spinoso-time = { version = "0.7.2", path = "../spinoso-time", features = ["tzrs"], default-features = false, optional = true }
+
+[dependencies.artichoke-core]
+version = "0.13.0"
+path = "../artichoke-core"
+
+[dependencies.artichoke-load-path]
+version = "0.1.0"
+path = "../artichoke-load-path"
+default-features = false
+
+[dependencies.bstr]
+version = "1.2.0"
+default-features = false
+features = ["alloc"]
+
+[dependencies.intaglio]
+version = "1.7.0"
+default-features = false
+features = ["bytes"]
+
+[dependencies.mezzaluna-type-registry]
+version = "1.0.1"
+path = "../mezzaluna-type-registry"
+
+[dependencies.onig]
+version = "6.4.0"
+optional = true
+default-features = false
+
+[dependencies.scolapasta-aref]
+version = "0.1.0"
+path = "../scolapasta-aref"
+
+[dependencies.scolapasta-int-parse]
+version = "0.2.2"
+path = "../scolapasta-int-parse"
+default-features = false
+
+[dependencies.scolapasta-path]
+version = "0.5.0"
+path = "../scolapasta-path"
+
+[dependencies.scolapasta-string-escape]
+version = "0.3.0"
+path = "../scolapasta-string-escape"
+default-features = false
+
+[dependencies.spinoso-array]
+version = "0.10.0"
+path = "../spinoso-array"
+default-features = false
+
+[dependencies.spinoso-env]
+version = "0.2.0"
+path = "../spinoso-env"
+optional = true
+default-features = false
+
+[dependencies.spinoso-exception]
+version = "0.1.0"
+path = "../spinoso-exception"
+
+[dependencies.spinoso-math]
+version = "0.3.0"
+path = "../spinoso-math"
+optional = true
+default-features = false
+
+[dependencies.spinoso-random]
+version = "0.4.0"
+path = "../spinoso-random"
+optional = true
+
+[dependencies.spinoso-regexp]
+version = "0.5.0"
+path = "../spinoso-regexp"
+optional = true
+default-features = false
+
+[dependencies.spinoso-securerandom]
+version = "0.2.0"
+path = "../spinoso-securerandom"
+optional = true
+
+[dependencies.spinoso-string]
+version = "0.23.0"
+path = "../spinoso-string"
+features = ["nul-terminated"]
+
+[dependencies.spinoso-symbol]
+version = "0.4.0"
+path = "../spinoso-symbol"
+
+[dependencies.spinoso-time]
+version = "0.7.2"
+path = "../spinoso-time"
+optional = true
+default-features = false
+features = ["tzrs"]
 
 [dev-dependencies]
-quickcheck = { version = "1.0.3", default-features = false }
+
+[dev-dependencies.quickcheck]
+version = "1.0.3"
+default-features = false
 
 [build-dependencies]
-bindgen = { version = "0.65.1", default-features = false, features = ["runtime"] }
-cc = { version = "1.0.72", features = ["parallel"] }
+
+[build-dependencies.bindgen]
+version = "0.65.1"
+default-features = false
+features = ["runtime"]
+
+[build-dependencies.cc]
+version = "1.0.72"
+features = ["parallel"]
 
 [features]
 default = [

--- a/artichoke-load-path/Cargo.toml
+++ b/artichoke-load-path/Cargo.toml
@@ -14,7 +14,10 @@ homepage.workspace = true
 documentation.workspace = true
 
 [dependencies]
-same-file = { version = "1.0.6", optional = true }
+
+[dependencies.same-file]
+version = "1.0.6"
+optional = true
 
 [features]
 default = ["native-file-system-loader", "rubylib-native-file-system-loader"]

--- a/artichoke-readline/Cargo.toml
+++ b/artichoke-readline/Cargo.toml
@@ -14,9 +14,16 @@ homepage.workspace = true
 documentation.workspace = true
 
 [dependencies]
-bstr = { version = "1.2.0", default-features = false }
 posix-space = "1.0.3"
-rustyline = { version = "11.0.0", optional = true, default-features = false }
+
+[dependencies.bstr]
+version = "1.2.0"
+default-features = false
+
+[dependencies.rustyline]
+version = "11.0.0"
+optional = true
+default-features = false
 
 [target.'cfg(windows)'.dependencies]
 known-folders = "1.0.0"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -11,9 +11,18 @@ license = "MIT"
 cargo-fuzz = true
 
 [dependencies]
-artichoke = { version = "0.1.0-pre.0", path = "..", default-features = false, features = ["kitchen-sink"] }
 libfuzzer-sys = "0.4.6"
-scolapasta-int-parse = { version = "0.2.0", path = "../scolapasta-int-parse", default-features = false }
+
+[dependencies.artichoke]
+version = "0.1.0-pre.0"
+path = ".."
+default-features = false
+features = ["kitchen-sink"]
+
+[dependencies.scolapasta-int-parse]
+version = "0.2.0"
+path = "../scolapasta-int-parse"
+default-features = false
 
 # Prevent this from interfering with workspaces
 [workspace]

--- a/mezzaluna-loaded-features/Cargo.toml
+++ b/mezzaluna-loaded-features/Cargo.toml
@@ -14,7 +14,10 @@ homepage.workspace = true
 documentation.workspace = true
 
 [dependencies]
-same-file = { version = "1.0.6", optional = true }
+
+[dependencies.same-file]
+version = "1.0.6"
+optional = true
 
 [features]
 default = ["disk", "rubylib"]

--- a/scolapasta-int-parse/Cargo.toml
+++ b/scolapasta-int-parse/Cargo.toml
@@ -17,7 +17,11 @@ documentation.workspace = true
 
 [dependencies]
 posix-space = "1.0.0"
-scolapasta-string-escape = { version = "0.3.0", path = "../scolapasta-string-escape", default-features = false }
+
+[dependencies.scolapasta-string-escape]
+version = "0.3.0"
+path = "../scolapasta-string-escape"
+default-features = false
 
 [features]
 default = ["std"]

--- a/scolapasta-strbuf/Cargo.toml
+++ b/scolapasta-strbuf/Cargo.toml
@@ -19,7 +19,10 @@ documentation.workspace = true
 raw-parts = "2.0.0"
 
 [dev-dependencies]
-quickcheck = { version = "1.0.3", default-features = false }
+
+[dev-dependencies.quickcheck]
+version = "1.0.3"
+default-features = false
 
 [features]
 default = ["std"]

--- a/scolapasta-string-escape/Cargo.toml
+++ b/scolapasta-string-escape/Cargo.toml
@@ -16,7 +16,10 @@ homepage.workspace = true
 documentation.workspace = true
 
 [dependencies]
-bstr = { version = "1.2.0", default-features = false }
+
+[dependencies.bstr]
+version = "1.2.0"
+default-features = false
 
 [features]
 default = ["std"]

--- a/spec-runner/Cargo.toml
+++ b/spec-runner/Cargo.toml
@@ -10,16 +10,34 @@ keywords = ["artichoke", "artichoke-ruby", "ruby", "ruby-spec", "testing"]
 categories = ["development-tools::testing"]
 
 [dependencies]
-artichoke = { version = "0.1.0-pre.0", path = "..", default-features = false, features = ["backtrace", "kitchen-sink"] }
 basic-toml = "0.1.1"
-clap = { version = "4.3.0", default-features = false, features = ["std", "help", "usage", "error-context", "suggestions"] }
-dhat = { version = "0.3.0", optional = true }
 rust-embed = "6.3.0"
-serde = { version = "1.0.136", features = ["derive"] }
 termcolor = "1.1.0"
 
+[dependencies.artichoke]
+version = "0.1.0-pre.0"
+path = ".."
+default-features = false
+features = ["backtrace", "kitchen-sink"]
+
+[dependencies.clap]
+version = "4.3.0"
+default-features = false
+features = ["std", "help", "usage", "error-context", "suggestions"]
+
+[dependencies.dhat]
+version = "0.3.0"
+optional = true
+
+[dependencies.serde]
+version = "1.0.136"
+features = ["derive"]
+
 [dev-dependencies]
-bstr = { version = "1.2.0", default-features = false }
+
+[dev-dependencies.bstr]
+version = "1.2.0"
+default-features = false
 
 # `spec-runner` is a regression testing tool
 # Remove it from the main artichoke workspace.

--- a/spinoso-array/Cargo.toml
+++ b/spinoso-array/Cargo.toml
@@ -17,12 +17,20 @@ documentation.workspace = true
 
 [dependencies]
 raw-parts = "2.0.0"
+
 # 1.4.1 fixed UB when allocating zero-bytes for ZST element types.
 # https://github.com/servo/rust-smallvec/releases/tag/v1.4.1
 # 1.6.1 fixed a buffer overflow when calling `SmallVec::insert_many`.
 # https://github.com/servo/rust-smallvec/issues/252
-smallvec = { version = "1.6.1", optional = true }
-tinyvec = { version = "1.3.0", optional = true, default-features = false, features = ["alloc"] }
+[dependencies.smallvec]
+version = "1.6.1"
+optional = true
+
+[dependencies.tinyvec]
+version = "1.3.0"
+optional = true
+default-features = false
+features = ["alloc"]
 
 [features]
 default = ["small-array", "tiny-array"]

--- a/spinoso-env/Cargo.toml
+++ b/spinoso-env/Cargo.toml
@@ -16,9 +16,20 @@ homepage.workspace = true
 documentation.workspace = true
 
 [dependencies]
-bstr = { version = "1.2.0", default-features = false }
-scolapasta-path = { version = "0.5.0", path = "../scolapasta-path", optional = true }
-scolapasta-string-escape = { version = "0.3.0", path = "../scolapasta-string-escape", default-features = false }
+
+[dependencies.bstr]
+version = "1.2.0"
+default-features = false
+
+[dependencies.scolapasta-path]
+version = "0.5.0"
+path = "../scolapasta-path"
+optional = true
+
+[dependencies.scolapasta-string-escape]
+version = "0.3.0"
+path = "../scolapasta-string-escape"
+default-features = false
 
 [features]
 default = ["system-env"]

--- a/spinoso-exception/Cargo.toml
+++ b/spinoso-exception/Cargo.toml
@@ -16,7 +16,11 @@ homepage.workspace = true
 documentation.workspace = true
 
 [dependencies]
-scolapasta-string-escape = { version = "0.3.0", path = "../scolapasta-string-escape", default-features = false }
+
+[dependencies.scolapasta-string-escape]
+version = "0.3.0"
+path = "../scolapasta-string-escape"
+default-features = false
 
 [features]
 default = ["std"]

--- a/spinoso-math/Cargo.toml
+++ b/spinoso-math/Cargo.toml
@@ -16,7 +16,10 @@ homepage.workspace = true
 documentation.workspace = true
 
 [dependencies]
-libm = { version = "0.2.6", optional = true }
+
+[dependencies.libm]
+version = "0.2.6"
+optional = true
 
 [features]
 default = ["full"]

--- a/spinoso-random/Cargo.toml
+++ b/spinoso-random/Cargo.toml
@@ -16,14 +16,28 @@ homepage.workspace = true
 documentation.workspace = true
 
 [dependencies]
-getrandom = { version = "0.2.0", default-features = false }
 libm = "0.2.6"
-rand = { version = "0.8.0", optional = true, default-features = false }
+
+[dependencies.getrandom]
+version = "0.2.0"
+default-features = false
+
+[dependencies.rand]
+version = "0.8.0"
+optional = true
+default-features = false
+
 # 0.6.1 is vulnerable to underfilling a buffer.
 #
 # https://rustsec.org/advisories/RUSTSEC-2021-0023
-rand_core = { version = "0.6.2", optional = true, default-features = false }
-rand_mt = { version = "4.2.0", default-features = false }
+[dependencies.rand_core]
+version = "0.6.2"
+optional = true
+default-features = false
+
+[dependencies.rand_mt]
+version = "4.2.0"
+default-features = false
 
 [features]
 default = ["rand-method", "rand_core", "std"]

--- a/spinoso-regexp/Cargo.toml
+++ b/spinoso-regexp/Cargo.toml
@@ -17,12 +17,31 @@ documentation.workspace = true
 
 [dependencies]
 bitflags = "1.3.0"
-bstr = { version = "1.2.0", default-features = false, features = ["alloc"] }
-onig = { version = "6.4.0", optional = true, default-features = false }
 posix-space = "1.0.2"
-regex = { version = "1.7.0", default-features = false, features = ["std", "unicode-perl"] }
-scolapasta-aref = { version = "0.1.0", path = "../scolapasta-aref" }
-scolapasta-string-escape = { version = "0.3.0", path = "../scolapasta-string-escape", default-features = false }
+
+[dependencies.bstr]
+version = "1.2.0"
+default-features = false
+features = ["alloc"]
+
+[dependencies.onig]
+version = "6.4.0"
+optional = true
+default-features = false
+
+[dependencies.regex]
+version = "1.7.0"
+default-features = false
+features = ["std", "unicode-perl"]
+
+[dependencies.scolapasta-aref]
+version = "0.1.0"
+path = "../scolapasta-aref"
+
+[dependencies.scolapasta-string-escape]
+version = "0.3.0"
+path = "../scolapasta-string-escape"
+default-features = false
 
 [features]
 default = ["oniguruma", "regex-full"]

--- a/spinoso-securerandom/Cargo.toml
+++ b/spinoso-securerandom/Cargo.toml
@@ -16,9 +16,22 @@ homepage.workspace = true
 documentation.workspace = true
 
 [dependencies]
-base64 = { version = "0.21.0", default-features = false, features = ["alloc"] }
-rand = { version = "0.8.0", default-features = false, features = ["getrandom"] }
-scolapasta-hex = { version = "0.2.0", path = "../scolapasta-hex", default-features = false, features = ["alloc"] }
+
+[dependencies.base64]
+version = "0.21.0"
+default-features = false
+features = ["alloc"]
+
+[dependencies.rand]
+version = "0.8.0"
+default-features = false
+features = ["getrandom"]
+
+[dependencies.scolapasta-hex]
+version = "0.2.0"
+path = "../scolapasta-hex"
+default-features = false
+features = ["alloc"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/spinoso-string/Cargo.toml
+++ b/spinoso-string/Cargo.toml
@@ -16,15 +16,37 @@ homepage.workspace = true
 documentation.workspace = true
 
 [dependencies]
-bstr = { version = "1.2.0", default-features = false, features = ["alloc"] }
 bytecount = "0.6.2"
-focaccia = { version = "1.3.1", optional = true, default-features = false }
-scolapasta-strbuf = { version = "1.0.0", path = "../scolapasta-strbuf", default-features = false }
-scolapasta-string-escape = { version = "0.3.0", path = "../scolapasta-string-escape", default-features = false }
-simdutf8 = { version = "0.1.4", default-features = false }
+
+[dependencies.bstr]
+version = "1.2.0"
+default-features = false
+features = ["alloc"]
+
+[dependencies.focaccia]
+version = "1.3.1"
+optional = true
+default-features = false
+
+[dependencies.scolapasta-strbuf]
+version = "1.0.0"
+path = "../scolapasta-strbuf"
+default-features = false
+
+[dependencies.scolapasta-string-escape]
+version = "0.3.0"
+path = "../scolapasta-string-escape"
+default-features = false
+
+[dependencies.simdutf8]
+version = "0.1.4"
+default-features = false
 
 [dev-dependencies]
-quickcheck = { version = "1.0.3", default-features = false }
+
+[dev-dependencies.quickcheck]
+version = "1.0.3"
+default-features = false
 
 [features]
 default = ["casecmp", "std"]

--- a/spinoso-symbol/Cargo.toml
+++ b/spinoso-symbol/Cargo.toml
@@ -16,11 +16,29 @@ homepage.workspace = true
 documentation.workspace = true
 
 [dependencies]
-artichoke-core = { version = "0.13.0", path = "../artichoke-core", optional = true, default-features = false }
-bstr = { version = "1.2.0", optional = true, default-features = false }
-focaccia = { version = "1.3.1", optional = true, default-features = false }
 qed = "1.3.0"
-scolapasta-string-escape = { version = "0.3.0", path = "../scolapasta-string-escape", optional = true, default-features = false }
+
+[dependencies.artichoke-core]
+version = "0.13.0"
+path = "../artichoke-core"
+optional = true
+default-features = false
+
+[dependencies.bstr]
+version = "1.2.0"
+optional = true
+default-features = false
+
+[dependencies.focaccia]
+version = "1.3.1"
+optional = true
+default-features = false
+
+[dependencies.scolapasta-string-escape]
+version = "0.3.0"
+path = "../scolapasta-string-escape"
+optional = true
+default-features = false
 
 [features]
 default = ["artichoke", "std"]

--- a/spinoso-time/Cargo.toml
+++ b/spinoso-time/Cargo.toml
@@ -16,10 +16,29 @@ homepage.workspace = true
 documentation.workspace = true
 
 [dependencies]
-regex =  { version = "1.7.0", default-features = false, features = ["std"], optional = true }
-strftime-ruby = { version = "1.0.0", default-features = false, features = ["alloc"], optional = true }
-tz-rs = { version = "0.6.12", default-features = false, features = ["std"], optional = true }
-tzdb = { version = "0.5.6", default-features = false, optional = true }
+
+[dependencies.regex]
+version = "1.7.0"
+default-features = false
+features = ["std"]
+optional = true
+
+[dependencies.strftime-ruby]
+version = "1.0.0"
+default-features = false
+features = ["alloc"]
+optional = true
+
+[dependencies.tz-rs]
+version = "0.6.12"
+optional = true
+default-features = false
+features = ["std"]
+
+[dependencies.tzdb]
+version = "0.5.6"
+optional = true
+default-features = false
 
 [features]
 default = ["tzrs", "tzrs-local"]

--- a/ui-tests/Cargo.toml
+++ b/ui-tests/Cargo.toml
@@ -8,9 +8,16 @@ rust-version = "1.70.0"
 license = "MIT"
 
 [dependencies]
-bstr = { version = "1.2.0", default-features = false, features = ["alloc"] }
-insta = { version = "1.29.0", features = ["toml"] }
 serde = "1.0.132"
+
+[dependencies.bstr]
+version = "1.2.0"
+default-features = false
+features = ["alloc"]
+
+[dependencies.insta]
+version = "1.29.0"
+features = ["toml"]
 
 [workspace]
 members = ["."]


### PR DESCRIPTION
In the same vein of quality of life improvements from #2593, this commit fixes something that has been bothering me for a while.

Dependency declarations in the `Cargo.toml` manifests in this repository have been growing unwieldy. Especially for workspace crates which are depended on by `path` attribute, the inline table can extend far to the right of my terminal width. Some crates, like `scolapasta-string-escape` are impacted badly by this because the crate name is long and it is often used without default features.

With this change, _all_ dependencies which include an inline table (i.e. anything other than a bare version specifier string) are expanded into a dedicated table.

This turns something like this:

```toml
scolapasta-string-escape = { version = "0.3.0", path = "../scolapasta-string-escape", optional = true, default-features = false }
```

into this:

```toml
[dependencies.scolapasta-string-escape]
version = "0.3.0"
path = "../scolapasta-string-escape"
optional = true
default-features = false
```

This also gave the opportunity to clean up all of the dependency declarations for consistency. In the table, keys should appear in the following order:

- version
- path
- optional
- default-features
- features

Top-level tables such as `[dependencies]` should appear in `Cargo.toml` even if they are empty.

This change is made in all workspaces.