### PR TITLE
Use `FxHasher` for symbol table

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,6 +58,7 @@ dependencies = [
  "qed",
  "quickcheck",
  "regex",
+ "rustc-hash",
  "scolapasta-aref",
  "scolapasta-int-parse",
  "scolapasta-path",

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -17,7 +17,6 @@ documentation.workspace = true
 posix-space = "1.0.0"
 qed = "1.3.0"
 regex = "1.7.0"
-rustc-hash = { version = "1.1.0", default-features = false }
 
 [dependencies.artichoke-core]
 version = "0.13.0"
@@ -45,6 +44,10 @@ path = "../mezzaluna-type-registry"
 [dependencies.onig]
 version = "6.4.0"
 optional = true
+default-features = false
+
+[dependencies.rustc-hash]
+version = "1.1.0"
 default-features = false
 
 [dependencies.scolapasta-aref]

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -17,6 +17,7 @@ documentation.workspace = true
 posix-space = "1.0.0"
 qed = "1.3.0"
 regex = "1.7.0"
+rustc-hash = { version = "1.1.0", default-features = false }
 
 [dependencies.artichoke-core]
 version = "0.13.0"

--- a/artichoke-backend/src/state/mod.rs
+++ b/artichoke-backend/src/state/mod.rs
@@ -1,7 +1,9 @@
+use core::hash::BuildHasherDefault;
 use std::collections::hash_map::RandomState;
 
 use intaglio::bytes::SymbolTable;
 use mezzaluna_type_registry::Registry;
+use rustc_hash::FxHasher;
 
 use crate::class;
 #[cfg(feature = "core-random")]
@@ -13,6 +15,8 @@ use crate::sys;
 
 pub mod output;
 pub mod parser;
+
+type SymbolTableHasher = BuildHasherDefault<FxHasher>;
 
 /// Container for interpreter global state.
 ///
@@ -31,7 +35,7 @@ pub struct State {
     pub load_path_vfs: load_path::Adapter,
     #[cfg(feature = "core-regexp")]
     pub regexp: spinoso_regexp::State,
-    pub symbols: SymbolTable,
+    pub symbols: SymbolTable<SymbolTableHasher>,
     pub output: output::Strategy,
     pub hash_builder: RandomState,
     #[cfg(feature = "core-random")]
@@ -71,7 +75,7 @@ impl State {
             load_path_vfs: load_path::Adapter::new(),
             #[cfg(feature = "core-regexp")]
             regexp: spinoso_regexp::State::new(),
-            symbols: SymbolTable::new(),
+            symbols: SymbolTable::with_hasher(SymbolTableHasher::default()),
             output: output::Strategy::new(),
             hash_builder: RandomState::new(),
             #[cfg(feature = "core-random")]

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -49,6 +49,7 @@ dependencies = [
  "posix-space",
  "qed",
  "regex",
+ "rustc-hash",
  "scolapasta-aref",
  "scolapasta-int-parse",
  "scolapasta-path",

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -65,6 +65,7 @@ dependencies = [
  "posix-space",
  "qed",
  "regex",
+ "rustc-hash",
  "scolapasta-aref",
  "scolapasta-int-parse",
  "scolapasta-path",


### PR DESCRIPTION
The symbol table is filled with ints which are not user-controlled. `FxHasher` is used for a similar purpose within `rustc` and is much more performant than the default `RandomState` hasher.

This change results in a 1% speedup for the entire interpreter when running the `all-core-specs.toml` suite with the `spec-runner`.

This approach is recommended in the Rust perf book: https://nnethercote.github.io/perf-book/hashing.html

## Benchmarks

### Methodology

Compile two binaries using the following:

```console
$ git show --no-patch
commit a2ededa3d41e8195de47109ee398c684a6c6bb57 (HEAD -> lopopolo/fxhash-symbol-table, origin/lopopolo/fxhash-symbol-table)
Author: Ryan Lopopolo <rjl@hyperbo.la>
Date:   Sun Jun 4 22:30:21 2023 -0700

    Use `FxHasher` for symbol table

    The symbol table is filled with ints which are not user-controlled.
    `FxHasher` is used for a similar purpose within `rustc` and is much more
    performant than the default `RandomState` hasher.
$ cargo build --release -q
$ cp target/release/spec-runner ./spec-runner-branch-`git rev-parse HEAD`
$ git show --no-patch
commit e4b92ab064829169b5f28391c0b5f03b963068fc (HEAD -> trunk, origin/trunk, origin/HEAD)
Merge: 5f3a013847 8ca47adf53
Author: Ryan Lopopolo <rjl@hyperbo.la>
Date:   Sun Jun 4 15:10:29 2023 -0700

    Merge pull request #2594 from artichoke/lopopolo/cargo.toml-dependency-tables

    Improve the readability of dependency manifests in `Cargo.toml`
$ cargo build --release -q
$ cp target/release/spec-runner ./spec-runner-trunk-`git rev-parse HEAD`
```

### Results

```console
$ hyperfine --warmup 1 './spec-runner-trunk-e4b92ab064829169b5f28391c0b5f03b963068fc -q all-core-specs.toml' './spec-runner-branch-a2ededa3d41e8195de47109ee398c684a6c6bb57 -q all-core-specs.toml'
Benchmark 1: ./spec-runner-trunk-e4b92ab064829169b5f28391c0b5f03b963068fc -q all-core-specs.toml
  Time (mean ± σ):      4.167 s ±  0.017 s    [User: 3.926 s, System: 0.237 s]
  Range (min … max):    4.137 s …  4.187 s    10 runs

Benchmark 2: ./spec-runner-branch-a2ededa3d41e8195de47109ee398c684a6c6bb57 -q all-core-specs.toml
  Time (mean ± σ):      4.126 s ±  0.031 s    [User: 3.884 s, System: 0.236 s]
  Range (min … max):    4.074 s …  4.168 s    10 runs

Summary
  './spec-runner-branch-a2ededa3d41e8195de47109ee398c684a6c6bb57 -q all-core-specs.toml' ran
    1.01 ± 0.01 times faster than './spec-runner-trunk-e4b92ab064829169b5f28391c0b5f03b963068fc -q all-core-specs.toml'
$ hyperfine --warmup 1 './spec-runner-trunk-e4b92ab064829169b5f28391c0b5f03b963068fc -q all-core-specs.toml' './spec-runner-branch-a2ededa3d41e8195de47109ee398c684a6c6bb57 -q all-core-specs.toml'
Benchmark 1: ./spec-runner-trunk-e4b92ab064829169b5f28391c0b5f03b963068fc -q all-core-specs.toml
  Time (mean ± σ):      4.183 s ±  0.032 s    [User: 3.937 s, System: 0.242 s]
  Range (min … max):    4.143 s …  4.242 s    10 runs

Benchmark 2: ./spec-runner-branch-a2ededa3d41e8195de47109ee398c684a6c6bb57 -q all-core-specs.toml
  Time (mean ± σ):      4.133 s ±  0.024 s    [User: 3.887 s, System: 0.242 s]
  Range (min … max):    4.107 s …  4.185 s    10 runs

Summary
  './spec-runner-branch-a2ededa3d41e8195de47109ee398c684a6c6bb57 -q all-core-specs.toml' ran
    1.01 ± 0.01 times faster than './spec-runner-trunk-e4b92ab064829169b5f28391c0b5f03b963068fc -q all-core-specs.toml'
```