### PR TITLE
Add tests in `array::trampoline` and `string::trampoline` to check for `FrozenErrors` in mutating APIs

### DIFF
--- a/artichoke-backend/src/extn/core/array/trampoline.rs
+++ b/artichoke-backend/src/extn/core/array/trampoline.rs
@@ -407,3 +407,56 @@ pub fn shift(interp: &mut Artichoke, mut ary: Value, count: Option<Value>) -> Re
         Ok(interp.convert(shifted))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test::prelude::*;
+
+    #[test]
+    fn mutating_methods_may_raise_frozen_error() {
+        let mut interp = interpreter();
+        let mut slf = interp.eval(b"[1,2,3]").unwrap();
+        slf.freeze(&mut interp).unwrap();
+
+        let value = interp.convert(0);
+        assert_eq!(
+            push_single(&mut interp, slf, value).unwrap_err().to_string(),
+            "FrozenError (can't modify frozen Array)",
+        );
+
+        let first = interp.convert(0);
+        let second = interp.try_convert_mut(Vec::<u8>::new()).unwrap();
+        assert_eq!(
+            element_assignment(&mut interp, slf, first, second, None)
+                .unwrap_err()
+                .to_string(),
+            "FrozenError (can't modify frozen Array)",
+        );
+
+        assert_eq!(
+            clear(&mut interp, slf).unwrap_err().to_string(),
+            "FrozenError (can't modify frozen Array)",
+        );
+
+        assert_eq!(
+            push(&mut interp, slf, None).unwrap_err().to_string(),
+            "FrozenError (can't modify frozen Array)",
+        );
+
+        assert_eq!(
+            concat(&mut interp, slf, []).unwrap_err().to_string(),
+            "FrozenError (can't modify frozen Array)",
+        );
+
+        assert_eq!(
+            reverse_bang(&mut interp, slf).unwrap_err().to_string(),
+            "FrozenError (can't modify frozen Array)",
+        );
+
+        assert_eq!(
+            shift(&mut interp, slf, None).unwrap_err().to_string(),
+            "FrozenError (can't modify frozen Array)",
+        );
+    }
+}

--- a/artichoke-backend/src/extn/core/string/trampoline.rs
+++ b/artichoke-backend/src/extn/core/string/trampoline.rs
@@ -1754,3 +1754,60 @@ pub fn is_valid_encoding(interp: &mut Artichoke, mut value: Value) -> Result<Val
     let s = unsafe { super::String::unbox_from_value(&mut value, interp)? };
     Ok(interp.convert(s.is_valid_encoding()))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test::prelude::*;
+
+    #[test]
+    fn mutating_methods_may_raise_frozen_error() {
+        let mut interp = interpreter();
+        let mut slf = interp.eval(b"'foo'").unwrap();
+
+        slf.freeze(&mut interp).unwrap();
+
+        let other = interp.try_convert_mut("bar").unwrap();
+        assert_eq!(
+            append(&mut interp, slf, other).unwrap_err().to_string(),
+            "FrozenError (can't modify frozen String: \\\"foo\\\")",
+        );
+
+        assert_eq!(
+            aset(&mut interp, slf).unwrap_err().to_string(),
+            "FrozenError (can't modify frozen String: \\\"foo\\\")",
+        );
+
+        assert_eq!(
+            capitalize_bang(&mut interp, slf).unwrap_err().to_string(),
+            "FrozenError (can't modify frozen String: \\\"foo\\\")",
+        );
+
+        assert_eq!(
+            chomp_bang(&mut interp, slf, None).unwrap_err().to_string(),
+            "FrozenError (can't modify frozen String: \\\"foo\\\")",
+        );
+
+        assert_eq!(
+            chop_bang(&mut interp, slf).unwrap_err().to_string(),
+            "FrozenError (can't modify frozen String: \\\"foo\\\")",
+        );
+
+        assert_eq!(
+            clear(&mut interp, slf).unwrap_err().to_string(),
+            "FrozenError (can't modify frozen String: \\\"foo\\\")",
+        );
+
+        assert_eq!(
+            reverse_bang(&mut interp, slf).unwrap_err().to_string(),
+            "FrozenError (can't modify frozen String: \\\"foo\\\")",
+        );
+
+        let index = interp.convert(0);
+        let byte = interp.convert(0);
+        assert_eq!(
+            setbyte(&mut interp, slf, index, byte).unwrap_err().to_string(),
+            "FrozenError (can't modify frozen String: \\\"foo\\\")",
+        );
+    }
+}


### PR DESCRIPTION
Close #2086 