### PR TITLE
Fix parsing bugs and add tests to `artichoke-readline`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "artichoke-readline"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "bstr",
  "known-folders",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ path = "artichoke-backend"
 default-features = false
 
 [dependencies.artichoke-readline]
-version = "1.0.0"
+version = "1.0.1"
 path = "artichoke-readline"
 optional = true
 

--- a/artichoke-readline/Cargo.toml
+++ b/artichoke-readline/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "artichoke-readline"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 description = "Helpers for interacting with GNU Readline configuration"
 keywords = ["artichoke", "artichoke-ruby", "inputrc", "readline"]

--- a/artichoke-readline/README.md
+++ b/artichoke-readline/README.md
@@ -19,7 +19,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-artichoke-readline = "1.0.0"
+artichoke-readline = "1.0.1"
 ```
 
 And parse Readline editing mode like this:

--- a/artichoke-readline/src/lib.rs
+++ b/artichoke-readline/src/lib.rs
@@ -211,19 +211,22 @@ pub fn get_readline_edit_mode(contents: impl AsRef<[u8]>) -> Option<EditMode> {
             // Skip leading whitespace.
             let line = trim_whitespace_front(line);
 
+            // The values 'vi' and 'emacs' in the 'set' directive are case insensitive.
             match line {
                 [b'v' | b'V', b'i' | b'I'] => edit_mode = Some(EditMode::Vi),
                 [b'e' | b'E', b'm' | b'M', b'a' | b'A', b'c' | b'C', b's' | b'S'] => {
-                    // Last occurrence of editing mode directive takes effect
+                    // Last occurrence of editing mode directive takes effect.
                     edit_mode = Some(EditMode::Emacs)
                 }
                 [b'v' | b'V', b'i' | b'I', next, ..] if posix_space::is_space(*next) => edit_mode = Some(EditMode::Vi),
                 [b'e' | b'E', b'm' | b'M', b'a' | b'A', b'c' | b'C', b's' | b'S', next, ..]
                     if posix_space::is_space(*next) =>
                 {
-                    // Last occurrence of editing mode directive takes effect
+                    // Last occurrence of editing mode directive takes effect.
                     edit_mode = Some(EditMode::Emacs)
                 }
+                // Ignore unrecognized or invalid lines.
+                // Lines without a valid editing mode directive are skipped.
                 _ => {}
             }
         }

--- a/artichoke-readline/src/lib.rs
+++ b/artichoke-readline/src/lib.rs
@@ -213,17 +213,23 @@ pub fn get_readline_edit_mode(contents: impl AsRef<[u8]>) -> Option<EditMode> {
 
             // The values 'vi' and 'emacs' in the 'set' directive are case insensitive.
             match line {
-                [b'v' | b'V', b'i' | b'I'] => edit_mode = Some(EditMode::Vi),
+                [b'v' | b'V', b'i' | b'I'] => {
+                    // Last occurrence of editing mode directive takes effect.
+                    edit_mode = Some(EditMode::Vi);
+                }
                 [b'e' | b'E', b'm' | b'M', b'a' | b'A', b'c' | b'C', b's' | b'S'] => {
                     // Last occurrence of editing mode directive takes effect.
-                    edit_mode = Some(EditMode::Emacs)
+                    edit_mode = Some(EditMode::Emacs);
                 }
-                [b'v' | b'V', b'i' | b'I', next, ..] if posix_space::is_space(*next) => edit_mode = Some(EditMode::Vi),
+                [b'v' | b'V', b'i' | b'I', next, ..] if posix_space::is_space(*next) => {
+                    // Last occurrence of editing mode directive takes effect.
+                    edit_mode = Some(EditMode::Vi);
+                }
                 [b'e' | b'E', b'm' | b'M', b'a' | b'A', b'c' | b'C', b's' | b'S', next, ..]
                     if posix_space::is_space(*next) =>
                 {
                     // Last occurrence of editing mode directive takes effect.
-                    edit_mode = Some(EditMode::Emacs)
+                    edit_mode = Some(EditMode::Emacs);
                 }
                 // Ignore unrecognized or invalid lines.
                 // Lines without a valid editing mode directive are skipped.


### PR DESCRIPTION
Pair programming with ChatGPT: https://chat.openai.com/c/f1a56877-ed9a-4fa9-92a8-9b0fe4763e82

Changes:

- Disallow quotes around `vi` and `emacs` values in `set` directive.
- Permit trailing garbage after a valid `set` directive.
- treat `vi` and `emacs` directive values as case-insensitive.
- When the input config contains multiple `set` directives, the last one wins.

Many more tests are added, generated with help:

- Integration tests with full configs.
- Tests with invalid UTF-8 byte strings.
- Tests with multi-byte UTF-8 characters.
- Tests with lots of differing variations of whitespace.
- Tests with comments.
- Tests with invalid directives.
- Tests to exercise case-insensitive parsing.

Added some additional comments to the parser to clarify parse steps.