### PR TITLE
Add more tests to `scolapasta-hex`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -673,7 +673,7 @@ version = "0.1.0"
 
 [[package]]
 name = "scolapasta-hex"
-version = "0.2.0"
+version = "0.3.0"
 
 [[package]]
 name = "scolapasta-int-parse"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -483,7 +483,7 @@ version = "0.1.0"
 
 [[package]]
 name = "scolapasta-hex"
-version = "0.2.0"
+version = "0.3.0"
 
 [[package]]
 name = "scolapasta-int-parse"

--- a/scolapasta-hex/Cargo.toml
+++ b/scolapasta-hex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scolapasta-hex"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 description = """
 no_std hexadecimal encoding utility package for Artichoke Ruby.

--- a/scolapasta-hex/README.md
+++ b/scolapasta-hex/README.md
@@ -30,7 +30,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-scolapasta-hex = "0.2.0"
+scolapasta-hex = "0.3.0"
 ```
 
 Hex encode data like:

--- a/scolapasta-hex/src/lib.rs
+++ b/scolapasta-hex/src/lib.rs
@@ -1163,6 +1163,37 @@ mod tests {
             format_into("foobar", &mut fmt).unwrap();
             assert_eq!(fmt, "666f6f626172");
         }
+
+        #[test]
+        fn test_try_encode() {
+            let data = b"Artichoke Ruby";
+            let result = try_encode(data).unwrap();
+            assert_eq!(result, "4172746963686f6b652052756279");
+        }
+
+        #[test]
+        fn test_try_encode_into() {
+            let data = b"Artichoke Ruby";
+            let mut buf = String::new();
+            try_encode_into(data, &mut buf).unwrap();
+            assert_eq!(buf, "4172746963686f6b652052756279");
+        }
+
+        #[test]
+        fn test_format_into() {
+            let data = b"Artichoke Ruby";
+            let mut buf = String::new();
+            format_into(data, &mut buf).unwrap();
+            assert_eq!(buf, "4172746963686f6b652052756279");
+        }
+
+        #[test]
+        fn test_hex_iterator() {
+            let data = "Artichoke Ruby";
+            let iter = Hex::from(data);
+            let result = iter.collect::<String>();
+            assert_eq!(result, "4172746963686f6b652052756279");
+        }
     }
 
     #[cfg(feature = "std")]
@@ -1222,6 +1253,14 @@ mod tests {
             let mut write = Vec::new();
             write_into("foobar", &mut write).unwrap();
             assert_eq!(write, b"666f6f626172".to_vec());
+        }
+
+        #[test]
+        fn test_write_into() {
+            let data = b"Artichoke Ruby";
+            let mut buf = Vec::new();
+            write_into(data, &mut buf).unwrap();
+            assert_eq!(buf, b"4172746963686f6b652052756279".to_vec());
         }
     }
 }

--- a/scolapasta-hex/src/lib.rs
+++ b/scolapasta-hex/src/lib.rs
@@ -654,6 +654,321 @@ mod tests {
         assert!(hex_iter.is_empty());
     }
 
+    #[test]
+    fn test_hex_iterator_with_single_escaped_byte() {
+        let hex_str = &[0x1B];
+        let mut hex_iter = Hex::from(hex_str);
+
+        let result = hex_iter.next().unwrap();
+        assert_eq!(result, '1');
+        let result = hex_iter.next().unwrap();
+        assert_eq!(result, 'b');
+        assert!(hex_iter.is_empty());
+    }
+
+    #[test]
+    fn test_hex_iterator_with_multiple_escaped_bytes() {
+        let hex_str = &[0x1B, 0x1B, 0x1B];
+        let mut hex_iter = Hex::from(hex_str);
+
+        let result = hex_iter.next().unwrap();
+        assert_eq!(result, '1');
+        let result = hex_iter.next().unwrap();
+        assert_eq!(result, 'b');
+
+        let result = hex_iter.next().unwrap();
+        assert_eq!(result, '1');
+        let result = hex_iter.next().unwrap();
+        assert_eq!(result, 'b');
+
+        let result = hex_iter.next().unwrap();
+        assert_eq!(result, '1');
+        let result = hex_iter.next().unwrap();
+        assert_eq!(result, 'b');
+
+        assert!(hex_iter.next().is_none());
+        assert!(hex_iter.is_empty());
+    }
+
+    #[test]
+    fn test_hex_iterator_with_invalid_escape_sequence() {
+        let hex_str = &[0x41, 0x1B, 0x42];
+        let mut hex_iter = Hex::from(hex_str);
+
+        let result = hex_iter.next().unwrap();
+        assert_eq!(result, '4');
+        let result = hex_iter.next().unwrap();
+        assert_eq!(result, '1');
+
+        let result = hex_iter.next().unwrap();
+        assert_eq!(result, '1');
+        let result = hex_iter.next().unwrap();
+        assert_eq!(result, 'b');
+
+        let result = hex_iter.next().unwrap();
+        assert_eq!(result, '4');
+        let result = hex_iter.next().unwrap();
+        assert_eq!(result, '2');
+
+        assert!(hex_iter.next().is_none());
+        assert!(hex_iter.is_empty());
+    }
+
+    #[test]
+    fn test_hex_iterator_with_no_remaining_bytes() {
+        let hex_str = &[0x41, 0x42, 0x43];
+        let mut hex_iter = Hex::from(hex_str);
+
+        let result = hex_iter.next().unwrap();
+        assert_eq!(result, '4');
+        let result = hex_iter.next().unwrap();
+        assert_eq!(result, '1');
+
+        let result = hex_iter.next().unwrap();
+        assert_eq!(result, '4');
+        let result = hex_iter.next().unwrap();
+        assert_eq!(result, '2');
+
+        let result = hex_iter.next().unwrap();
+        assert_eq!(result, '4');
+        let result = hex_iter.next().unwrap();
+        assert_eq!(result, '3');
+
+        assert!(hex_iter.next().is_none());
+        assert!(hex_iter.is_empty());
+    }
+
+    #[test]
+    fn test_hex_iterator_with_emoji_sequence() {
+        // ```
+        // >>> binascii.hexlify(bytes("Hello, 😃!", "utf-8"))
+        // b'48656c6c6f2c20f09f988321'
+        // ```
+        let hex_str = Hex::from("Hello, 😃!");
+        let mut hex_iter = hex_str.into_iter();
+
+        let result = hex_iter.next().unwrap();
+        assert_eq!(result, '4');
+
+        let result = hex_iter.next().unwrap();
+        assert_eq!(result, '8');
+
+        let result = hex_iter.next().unwrap();
+        assert_eq!(result, '6');
+
+        let result = hex_iter.next().unwrap();
+        assert_eq!(result, '5');
+
+        let result = hex_iter.next().unwrap();
+        assert_eq!(result, '6');
+
+        let result = hex_iter.next().unwrap();
+        assert_eq!(result, 'c');
+
+        let result = hex_iter.next().unwrap();
+        assert_eq!(result, '6');
+
+        let result = hex_iter.next().unwrap();
+        assert_eq!(result, 'c');
+
+        let result = hex_iter.next().unwrap();
+        assert_eq!(result, '6');
+
+        let result = hex_iter.next().unwrap();
+        assert_eq!(result, 'f');
+
+        let result = hex_iter.next().unwrap();
+        assert_eq!(result, '2');
+
+        let result = hex_iter.next().unwrap();
+        assert_eq!(result, 'c');
+
+        let result = hex_iter.next().unwrap();
+        assert_eq!(result, '2');
+
+        let result = hex_iter.next().unwrap();
+        assert_eq!(result, '0');
+
+        let result = hex_iter.next().unwrap();
+        assert_eq!(result, 'f');
+
+        let result = hex_iter.next().unwrap();
+        assert_eq!(result, '0');
+
+        let result = hex_iter.next().unwrap();
+        assert_eq!(result, '9');
+
+        let result = hex_iter.next().unwrap();
+        assert_eq!(result, 'f');
+
+        let result = hex_iter.next().unwrap();
+        assert_eq!(result, '9');
+
+        let result = hex_iter.next().unwrap();
+        assert_eq!(result, '8');
+
+        let result = hex_iter.next().unwrap();
+        assert_eq!(result, '8');
+
+        let result = hex_iter.next().unwrap();
+        assert_eq!(result, '3');
+
+        let result = hex_iter.next().unwrap();
+        assert_eq!(result, '2');
+
+        let result = hex_iter.next().unwrap();
+        assert_eq!(result, '1');
+
+        assert!(hex_iter.next().is_none());
+        assert!(hex_iter.is_empty());
+    }
+
+    #[test]
+    fn test_hex_iterator_with_chinese_hanzi_sequence() {
+        // ```
+        // >>> binascii.hexlify(bytes("你好，世界！", "utf-8"))
+        // b'e4bda0e5a5bdefbc8ce4b896e7958cefbc81'
+        // ```
+        let hex_str = Hex::from("你好，世界！");
+        let mut hex_iter = hex_str.into_iter();
+
+        let result = hex_iter.next().unwrap();
+        assert_eq!(result, 'e');
+
+        let result = hex_iter.next().unwrap();
+        assert_eq!(result, '4');
+
+        let result = hex_iter.next().unwrap();
+        assert_eq!(result, 'b');
+
+        let result = hex_iter.next().unwrap();
+        assert_eq!(result, 'd');
+
+        let result = hex_iter.next().unwrap();
+        assert_eq!(result, 'a');
+
+        let result = hex_iter.next().unwrap();
+        assert_eq!(result, '0');
+
+        let result = hex_iter.next().unwrap();
+        assert_eq!(result, 'e');
+
+        let result = hex_iter.next().unwrap();
+        assert_eq!(result, '5');
+
+        let result = hex_iter.next().unwrap();
+        assert_eq!(result, 'a');
+
+        let result = hex_iter.next().unwrap();
+        assert_eq!(result, '5');
+
+        let result = hex_iter.next().unwrap();
+        assert_eq!(result, 'b');
+
+        let result = hex_iter.next().unwrap();
+        assert_eq!(result, 'd');
+
+        let result = hex_iter.next().unwrap();
+        assert_eq!(result, 'e');
+
+        let result = hex_iter.next().unwrap();
+        assert_eq!(result, 'f');
+
+        let result = hex_iter.next().unwrap();
+        assert_eq!(result, 'b');
+
+        let result = hex_iter.next().unwrap();
+        assert_eq!(result, 'c');
+
+        let result = hex_iter.next().unwrap();
+        assert_eq!(result, '8');
+
+        let result = hex_iter.next().unwrap();
+        assert_eq!(result, 'c');
+
+        let result = hex_iter.next().unwrap();
+        assert_eq!(result, 'e');
+
+        let result = hex_iter.next().unwrap();
+        assert_eq!(result, '4');
+
+        let result = hex_iter.next().unwrap();
+        assert_eq!(result, 'b');
+
+        let result = hex_iter.next().unwrap();
+        assert_eq!(result, '8');
+
+        let result = hex_iter.next().unwrap();
+        assert_eq!(result, '9');
+
+        let result = hex_iter.next().unwrap();
+        assert_eq!(result, '6');
+
+        let result = hex_iter.next().unwrap();
+        assert_eq!(result, 'e');
+
+        let result = hex_iter.next().unwrap();
+        assert_eq!(result, '7');
+
+        let result = hex_iter.next().unwrap();
+        assert_eq!(result, '9');
+
+        let result = hex_iter.next().unwrap();
+        assert_eq!(result, '5');
+
+        let result = hex_iter.next().unwrap();
+        assert_eq!(result, '8');
+
+        let result = hex_iter.next().unwrap();
+        assert_eq!(result, 'c');
+
+        let result = hex_iter.next().unwrap();
+        assert_eq!(result, 'e');
+
+        let result = hex_iter.next().unwrap();
+        assert_eq!(result, 'f');
+
+        let result = hex_iter.next().unwrap();
+        assert_eq!(result, 'b');
+
+        let result = hex_iter.next().unwrap();
+        assert_eq!(result, 'c');
+
+        let result = hex_iter.next().unwrap();
+        assert_eq!(result, '8');
+
+        let result = hex_iter.next().unwrap();
+        assert_eq!(result, '1');
+
+        assert!(hex_iter.next().is_none());
+        assert!(hex_iter.is_empty());
+    }
+
+    #[test]
+    fn test_hex_iterator_with_byte_array_exhaustive() {
+        let mut hex_str = [0u8; 256];
+
+        for (i, byte) in hex_str.iter_mut().enumerate() {
+            *byte = i as u8;
+        }
+
+        let mut hex_iter = Hex::from(&hex_str);
+
+        for byte in &hex_str {
+            let expected_chars = [
+                char::from_digit((byte >> 4) as u32, 16).unwrap(),
+                char::from_digit((byte & 0x0F) as u32, 16).unwrap(),
+            ];
+            for expected_char in expected_chars {
+                let result = hex_iter.next().unwrap();
+                assert_eq!(result, expected_char);
+            }
+        }
+
+        assert!(hex_iter.next().is_none());
+        assert!(hex_iter.is_empty());
+    }
+
     #[cfg(feature = "alloc")]
     mod alloc {
         use alloc::string::String;

--- a/scolapasta-hex/src/lib.rs
+++ b/scolapasta-hex/src/lib.rs
@@ -744,8 +744,7 @@ mod tests {
         // >>> binascii.hexlify(bytes("Hello, 😃!", "utf-8"))
         // b'48656c6c6f2c20f09f988321'
         // ```
-        let hex_str = Hex::from("Hello, 😃!");
-        let mut hex_iter = hex_str.into_iter();
+        let mut hex_iter = Hex::from("Hello, 😃!");
 
         let result = hex_iter.next().unwrap();
         assert_eq!(result, '4');
@@ -829,8 +828,7 @@ mod tests {
         // >>> binascii.hexlify(bytes("你好，世界！", "utf-8"))
         // b'e4bda0e5a5bdefbc8ce4b896e7958cefbc81'
         // ```
-        let hex_str = Hex::from("你好，世界！");
-        let mut hex_iter = hex_str.into_iter();
+        let mut hex_iter = Hex::from("你好，世界！");
 
         let result = hex_iter.next().unwrap();
         assert_eq!(result, 'e');
@@ -949,15 +947,15 @@ mod tests {
         let mut hex_str = [0u8; 256];
 
         for (i, byte) in hex_str.iter_mut().enumerate() {
-            *byte = i as u8;
+            *byte = i.try_into().unwrap();
         }
 
         let mut hex_iter = Hex::from(&hex_str);
 
         for byte in &hex_str {
             let expected_chars = [
-                char::from_digit((byte >> 4) as u32, 16).unwrap(),
-                char::from_digit((byte & 0x0F) as u32, 16).unwrap(),
+                char::from_digit(u32::from(byte >> 4), 16).unwrap(),
+                char::from_digit(u32::from(byte & 0x0F), 16).unwrap(),
             ];
             for expected_char in expected_chars {
                 let result = hex_iter.next().unwrap();

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -728,7 +728,7 @@ version = "0.1.0"
 
 [[package]]
 name = "scolapasta-hex"
-version = "0.2.0"
+version = "0.3.0"
 
 [[package]]
 name = "scolapasta-int-parse"

--- a/spinoso-securerandom/Cargo.toml
+++ b/spinoso-securerandom/Cargo.toml
@@ -28,7 +28,7 @@ default-features = false
 features = ["getrandom"]
 
 [dependencies.scolapasta-hex]
-version = "0.2.0"
+version = "0.3.0"
 path = "../scolapasta-hex"
 default-features = false
 features = ["alloc"]


### PR DESCRIPTION
Also add `impl<'a, const N: usize> From<&'a [u8; N]> for Hex` impl.

I'll let ChatGPT describe the tests we added together.

## Test Description

The `test_try_encode` function tests the `try_encode` function by encoding a byte slice and asserting that the result matches the expected output.

The `test_try_encode_into` function tests the `try_encode_into` function by encoding a byte slice into a pre-allocated `String` and asserting that the resulting `String` matches the expected output.

The `test_format_into` function tests the `format_into` function by encoding a byte slice into a pre-allocated `String` using the `fmt::Write` trait and asserting that the resulting `String` matches the expected output.

The `test_write_into` function (enabled only with the `std` feature) tests the `write_into` function by encoding a byte slice into a vector of bytes using the `io::Write` trait and asserting that the resulting vector of bytes matches the expected output.

The `test_hex_iterator` function tests the `Hex` iterator by creating an iterator from a string, collecting the elements into a `String`, and asserting that the resulting `String` matches the expected output.

Here's a brief overview of the additional tests:

1. `literal_exhaustive`: This test iterates over all possible byte values (0 to 255) and checks that the corresponding hex digits are correctly generated.

2. `test_hex_iterator_with_remaining_escaped_byte`: This test verifies that the `Hex` iterator handles a sequence of bytes correctly, even if there is a remaining escaped byte.

3. `test_hex_iterator_empty_after_exhausted`: This test ensures that the `Hex` iterator becomes empty after consuming all the bytes.

4. `test_hex_iterator_not_empty_with_remaining_escaped_byte`: This test checks that the `Hex` iterator is not empty when there are remaining escaped bytes.

5. `test_hex_iterator_not_empty_with_remaining_byte`: Similar to the previous test, this one checks that the `Hex` iterator is not empty when there are remaining unescaped bytes.

6. `test_hex_iterator_empty`: This test verifies that the `Hex` iterator is empty when the input byte slice is empty.

7. `test_hex_iterator_with_single_escaped_byte`: This test checks that the `Hex` iterator correctly handles a sequence with a single escaped byte.

8. `test_hex_iterator_with_multiple_escaped_bytes`: This test ensures that the `Hex` iterator handles multiple escaped bytes correctly.

9. `test_hex_iterator_with_invalid_escape_sequence`: This test verifies the behavior of the `Hex` iterator when an invalid escape sequence is encountered.

10. `test_hex_iterator_with_no_remaining_bytes`: This test checks the `Hex` iterator when there are no remaining bytes after iteration.

11. `test_hex_iterator_with_emoji_sequence`: This test validates that the `Hex` iterator handles an input sequence containing emojis correctly.

12. `test_hex_iterator_with_chinese_hanzi_sequence`: Similar to the previous test, this one checks the `Hex` iterator with a sequence containing Chinese characters.

These tests cover various scenarios and edge cases to ensure the correctness of the `Hex` iterator implementation.