### PR TITLE
Do not normalize verbatim paths on Windows in `scolapasta-path`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -685,7 +685,7 @@ dependencies = [
 
 [[package]]
 name = "scolapasta-path"
-version = "0.5.0"
+version = "0.5.1"
 
 [[package]]
 name = "scolapasta-strbuf"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ default-features = false
 features = ["with-file-history"]
 
 [dependencies.scolapasta-path]
-version = "0.5.0"
+version = "0.5.1"
 path = "scolapasta-path"
 optional = true
 

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -60,7 +60,7 @@ path = "../scolapasta-int-parse"
 default-features = false
 
 [dependencies.scolapasta-path]
-version = "0.5.0"
+version = "0.5.1"
 path = "../scolapasta-path"
 
 [dependencies.scolapasta-string-escape]

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -495,7 +495,7 @@ dependencies = [
 
 [[package]]
 name = "scolapasta-path"
-version = "0.5.0"
+version = "0.5.1"
 
 [[package]]
 name = "scolapasta-strbuf"

--- a/scolapasta-path/Cargo.toml
+++ b/scolapasta-path/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scolapasta-path"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 description = """
 Path utilities for loading Ruby source code"

--- a/scolapasta-path/README.md
+++ b/scolapasta-path/README.md
@@ -20,7 +20,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-scolapasta-path = "0.5.0"
+scolapasta-path = "0.5.1"
 ```
 
 And check for explicit relative paths like:

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -740,7 +740,7 @@ dependencies = [
 
 [[package]]
 name = "scolapasta-path"
-version = "0.5.0"
+version = "0.5.1"
 
 [[package]]
 name = "scolapasta-strbuf"

--- a/spinoso-env/Cargo.toml
+++ b/spinoso-env/Cargo.toml
@@ -22,7 +22,7 @@ version = "1.2.0"
 default-features = false
 
 [dependencies.scolapasta-path]
-version = "0.5.0"
+version = "0.5.1"
 path = "../scolapasta-path"
 optional = true
 


### PR DESCRIPTION
Fixes #2567.