### PR TITLE
Fix compilation errors on latest nightly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -535,9 +535,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.59"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aeca18b86b413c660b781aa319e4e2648a3e6f9eadc9b47e9038e6fe9f3451b"
+checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
 dependencies = [
  "unicode-ident",
 ]


### PR DESCRIPTION
`proc-macro2` before 1.0.60 is incompatible with the latest nightly since an unstable feature conditionally used by `proc-macro2` was renamed.

This breakage had been triggering for a couple of weeks on the periodic fuzzer builds. This build error additionally blocks the July 2023 dependabot dep update PRs. See:
https://github.com/artichoke/artichoke/pull/2615#issuecomment-1616311684.

Fixed with a targeted `cargo update`:

```console
$ cargo update --package proc-macro2
    Updating crates.io index
    Updating proc-macro2 v1.0.59 -> v1.0.63
```

See:

- https://github.com/rust-lang/rust/issues/113152
- https://github.com/dtolnay/proc-macro2/pull/391

Error below:

```console
$ cargo +nightly check
   Compiling proc-macro2 v1.0.59
   Compiling jobserver v0.1.26
    Checking scolapasta-string-escape v0.3.0 (/Users/lopopolo/dev/artichoke/artichoke/scolapasta-string-escape)
    Checking getrandom v0.2.9
   Compiling nom v7.1.3
   Compiling clang-sys v1.6.1
    Checking errno v0.3.1
    Checking io-lifetimes v1.0.11
    Checking regex v1.8.3
    Checking tz-rs v0.6.14
    Checking nix v0.26.2
   Compiling artichoke v0.1.0-pre.0 (/Users/lopopolo/dev/artichoke/artichoke)
    Checking clap v4.3.1
error[E0635]: unknown feature `proc_macro_span_shrink`
  --> /Users/lopopolo/.cargo/registry/src/index.crates.io-6f17d22bba15001f/proc-macro2-1.0.59/src/lib.rs:92:30
   |
92 |     feature(proc_macro_span, proc_macro_span_shrink)
   |                              ^^^^^^^^^^^^^^^^^^^^^^

    Checking rustix v0.37.19
    Checking rand_core v0.6.4
    Checking spinoso-string v0.24.0 (/Users/lopopolo/dev/artichoke/artichoke/spinoso-string)
    Checking spinoso-exception v0.1.0 (/Users/lopopolo/dev/artichoke/artichoke/spinoso-exception)
    Checking spinoso-symbol v0.4.0 (/Users/lopopolo/dev/artichoke/artichoke/spinoso-symbol)
    Checking spinoso-env v0.2.0 (/Users/lopopolo/dev/artichoke/artichoke/spinoso-env)
    Checking scolapasta-int-parse v0.2.2 (/Users/lopopolo/dev/artichoke/artichoke/scolapasta-int-parse)
   Compiling cc v1.0.79
For more information about this error, try `rustc --explain E0635`.
error: could not compile `proc-macro2` (lib) due to previous error
warning: build failed, waiting for other jobs to finish...
```