### PR TITLE
Push `codepoints()` implementation down into encoded variants

### DIFF
--- a/spinoso-string/src/codepoints.rs
+++ b/spinoso-string/src/codepoints.rs
@@ -190,7 +190,7 @@ impl std::error::Error for InvalidCodepointError {}
 /// [Conventionally UTF-8]: crate::Encoding::Utf8
 #[derive(Debug, Default, Clone)]
 pub struct Codepoints {
-    iter: IntoIter<char>,
+    iter: IntoIter<u32>,
 }
 
 impl TryFrom<&String> for Codepoints {
@@ -202,8 +202,8 @@ impl TryFrom<&String> for Codepoints {
     }
 }
 
-impl From<IntoIter<char>> for Codepoints {
-    fn from(iter: IntoIter<char>) -> Self {
+impl From<IntoIter<u32>> for Codepoints {
+    fn from(iter: IntoIter<u32>) -> Self {
         Self { iter }
     }
 }

--- a/spinoso-string/src/codepoints.rs
+++ b/spinoso-string/src/codepoints.rs
@@ -190,7 +190,7 @@ impl std::error::Error for InvalidCodepointError {}
 /// [Conventionally UTF-8]: crate::Encoding::Utf8
 #[derive(Debug, Default, Clone)]
 pub struct Codepoints {
-    iter: IntoIter<u32>,
+    iter: IntoIter<char>,
 }
 
 impl TryFrom<&String> for Codepoints {
@@ -202,8 +202,8 @@ impl TryFrom<&String> for Codepoints {
     }
 }
 
-impl From<IntoIter<u32>> for Codepoints {
-    fn from(iter: IntoIter<u32>) -> Self {
+impl From<IntoIter<char>> for Codepoints {
+    fn from(iter: IntoIter<char>) -> Self {
         Self { iter }
     }
 }

--- a/spinoso-string/src/codepoints.rs
+++ b/spinoso-string/src/codepoints.rs
@@ -1,11 +1,9 @@
+use alloc::vec::IntoIter;
 use core::fmt::{self, Write};
 use core::iter::FusedIterator;
 use core::mem;
-use core::str::Chars;
 
-use bstr::{ByteSlice, Bytes};
-
-use crate::{Encoding, String};
+use crate::String;
 
 /// Error returned when failing to construct a [`Codepoints`] iterator/
 ///
@@ -191,68 +189,32 @@ impl std::error::Error for InvalidCodepointError {}
 /// [encoding-aware]: crate::Encoding
 /// [Conventionally UTF-8]: crate::Encoding::Utf8
 #[derive(Debug, Default, Clone)]
-pub struct Codepoints<'a>(State<'a>);
+pub struct Codepoints {
+    iter: IntoIter<u32>,
+}
 
-impl<'a> TryFrom<&'a String> for Codepoints<'a> {
+impl TryFrom<&String> for Codepoints {
     type Error = CodepointsError;
 
     #[inline]
-    fn try_from(s: &'a String) -> Result<Self, Self::Error> {
-        let state = match s.encoding() {
-            Encoding::Utf8 => {
-                if let Ok(s) = s.inner.as_slice().to_str() {
-                    State::Utf8(s.chars())
-                } else {
-                    return Err(CodepointsError::invalid_utf8_codepoint());
-                }
-            }
-            Encoding::Ascii => {
-                let iter = s.as_slice().bytes();
-                State::Ascii(iter)
-            }
-            Encoding::Binary => {
-                let iter = s.as_slice().bytes();
-                State::Binary(iter)
-            }
-        };
-        Ok(Self(state))
+    fn try_from(s: &String) -> Result<Self, Self::Error> {
+        s.inner.codepoints()
     }
 }
 
-impl<'a> Iterator for Codepoints<'a> {
+impl From<IntoIter<u32>> for Codepoints {
+    fn from(iter: IntoIter<u32>) -> Self {
+        Self { iter }
+    }
+}
+
+impl Iterator for Codepoints {
     type Item = u32;
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
-        self.0.next()
+        self.iter.next().map(u32::from)
     }
 }
 
-impl<'a> FusedIterator for Codepoints<'a> {}
-
-#[derive(Debug, Clone)]
-enum State<'a> {
-    Utf8(Chars<'a>),
-    Ascii(Bytes<'a>),
-    Binary(Bytes<'a>),
-}
-
-impl<'a> Default for State<'a> {
-    fn default() -> Self {
-        Self::Utf8("".chars())
-    }
-}
-
-impl<'a> Iterator for State<'a> {
-    type Item = u32;
-
-    #[inline]
-    fn next(&mut self) -> Option<Self::Item> {
-        match self {
-            Self::Ascii(iter) | Self::Binary(iter) => iter.next().map(u32::from),
-            Self::Utf8(iter) => iter.next().map(u32::from),
-        }
-    }
-}
-
-impl<'a> FusedIterator for State<'a> {}
+impl FusedIterator for Codepoints {}

--- a/spinoso-string/src/enc/ascii/codepoints.rs
+++ b/spinoso-string/src/enc/ascii/codepoints.rs
@@ -26,3 +26,32 @@ impl<'a> Default for Codepoints<'a> {
         Self::new(b"")
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec::Vec;
+
+    use super::*;
+    use crate::enc::ascii::AsciiString;
+
+    #[test]
+    fn test_valid_ascii() {
+        let s = AsciiString::from("abc");
+        let codepoints = Codepoints::new(&s);
+        assert_eq!(codepoints.collect::<Vec<_>>(), &[97, 98, 99]);
+    }
+
+    #[test]
+    fn test_utf8_interpreted_as_bytes() {
+        let s = AsciiString::from("abc💎");
+        let codepoints = Codepoints::new(&s);
+        assert_eq!(codepoints.collect::<Vec<_>>(), &[97, 98, 99, 240, 159, 146, 142]);
+    }
+
+    #[test]
+    fn test_invalid_utf8_interpreted_as_bytes() {
+        let s = AsciiString::from(b"abc\xFF");
+        let codepoints = Codepoints::new(&s);
+        assert_eq!(codepoints.collect::<Vec<_>>(), &[97, 98, 99, 255]);
+    }
+}

--- a/spinoso-string/src/enc/ascii/codepoints.rs
+++ b/spinoso-string/src/enc/ascii/codepoints.rs
@@ -1,0 +1,28 @@
+use core::slice;
+
+#[derive(Debug, Clone)]
+pub struct Codepoints<'a> {
+    inner: slice::Iter<'a, u8>,
+}
+
+impl<'a> Codepoints<'a> {
+    #[inline]
+    pub fn new(bytes: &'a [u8]) -> Self {
+        Self { inner: bytes.iter() }
+    }
+}
+
+impl<'a> Iterator for Codepoints<'a> {
+    type Item = u32;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next().map(|&b| u32::from(b))
+    }
+}
+
+impl<'a> Default for Codepoints<'a> {
+    #[inline]
+    fn default() -> Self {
+        Self::new(b"")
+    }
+}

--- a/spinoso-string/src/enc/ascii/mod.rs
+++ b/spinoso-string/src/enc/ascii/mod.rs
@@ -11,6 +11,7 @@ use crate::codepoints::{Codepoints, InvalidCodepointError};
 use crate::encoding::Encoding;
 use crate::iter::{Bytes, IntoIter, Iter, IterMut};
 use crate::ord::OrdError;
+use crate::CodepointsError;
 
 mod eq;
 mod impls;
@@ -283,15 +284,15 @@ impl AsciiString {
     }
 
     #[inline]
-    pub fn codepoints(&self) -> Codepoints {
+    pub fn codepoints(&self) -> Result<Codepoints, CodepointsError> {
         let iter = self
             .inner
             .as_slice()
             .bytes()
-            .map(u32::from)
+            .map(|b| b as u32)
             .collect::<Vec<_>>()
             .into_iter();
-        Codepoints::from(iter)
+        Ok(Codepoints::from(iter))
     }
 }
 

--- a/spinoso-string/src/enc/ascii/mod.rs
+++ b/spinoso-string/src/enc/ascii/mod.rs
@@ -1,5 +1,4 @@
 use alloc::collections::TryReserveError;
-use alloc::vec::Vec;
 use core::fmt;
 use core::ops::Range;
 use core::slice::SliceIndex;
@@ -7,11 +6,10 @@ use core::slice::SliceIndex;
 use bstr::ByteSlice;
 use scolapasta_strbuf::Buf;
 
-use crate::codepoints::{Codepoints, InvalidCodepointError};
+use crate::codepoints::InvalidCodepointError;
 use crate::encoding::Encoding;
 use crate::iter::{Bytes, IntoIter, Iter, IterMut};
 use crate::ord::OrdError;
-use crate::CodepointsError;
 
 mod eq;
 mod impls;
@@ -281,18 +279,6 @@ impl AsciiString {
     #[inline]
     pub fn extend_from_slice(&mut self, other: &[u8]) {
         self.inner.extend_from_slice(other);
-    }
-
-    #[inline]
-    pub fn codepoints(&self) -> Result<Codepoints, CodepointsError> {
-        let iter = self
-            .inner
-            .as_slice()
-            .bytes()
-            .map(|b| b as u32)
-            .collect::<Vec<_>>()
-            .into_iter();
-        Ok(Codepoints::from(iter))
     }
 }
 

--- a/spinoso-string/src/enc/ascii/mod.rs
+++ b/spinoso-string/src/enc/ascii/mod.rs
@@ -288,7 +288,7 @@ impl AsciiString {
             .inner
             .as_slice()
             .bytes()
-            .map(u32::from)
+            .map(char::from)
             .collect::<Vec<_>>()
             .into_iter();
         Codepoints::from(iter)

--- a/spinoso-string/src/enc/ascii/mod.rs
+++ b/spinoso-string/src/enc/ascii/mod.rs
@@ -11,7 +11,6 @@ use crate::codepoints::{Codepoints, InvalidCodepointError};
 use crate::encoding::Encoding;
 use crate::iter::{Bytes, IntoIter, Iter, IterMut};
 use crate::ord::OrdError;
-use crate::CodepointsError;
 
 mod eq;
 mod impls;
@@ -284,15 +283,15 @@ impl AsciiString {
     }
 
     #[inline]
-    pub fn codepoints(&self) -> Result<Codepoints, CodepointsError> {
+    pub fn codepoints(&self) -> Codepoints {
         let iter = self
             .inner
             .as_slice()
             .bytes()
-            .map(|b| b as u32)
+            .map(u32::from)
             .collect::<Vec<_>>()
             .into_iter();
-        Ok(Codepoints::from(iter))
+        Codepoints::from(iter)
     }
 }
 

--- a/spinoso-string/src/enc/ascii/mod.rs
+++ b/spinoso-string/src/enc/ascii/mod.rs
@@ -288,7 +288,7 @@ impl AsciiString {
             .inner
             .as_slice()
             .bytes()
-            .map(char::from)
+            .map(u32::from)
             .collect::<Vec<_>>()
             .into_iter();
         Codepoints::from(iter)

--- a/spinoso-string/src/enc/ascii/mod.rs
+++ b/spinoso-string/src/enc/ascii/mod.rs
@@ -11,12 +11,14 @@ use crate::encoding::Encoding;
 use crate::iter::{Bytes, IntoIter, Iter, IterMut};
 use crate::ord::OrdError;
 
+mod codepoints;
 mod eq;
 mod impls;
 mod inspect;
 #[cfg(feature = "std")]
 mod io;
 
+pub use codepoints::Codepoints;
 pub use inspect::Inspect;
 
 #[repr(transparent)]

--- a/spinoso-string/src/enc/ascii/mod.rs
+++ b/spinoso-string/src/enc/ascii/mod.rs
@@ -1,4 +1,5 @@
 use alloc::collections::TryReserveError;
+use alloc::vec::Vec;
 use core::fmt;
 use core::ops::Range;
 use core::slice::SliceIndex;
@@ -6,10 +7,11 @@ use core::slice::SliceIndex;
 use bstr::ByteSlice;
 use scolapasta_strbuf::Buf;
 
-use crate::codepoints::InvalidCodepointError;
+use crate::codepoints::{Codepoints, InvalidCodepointError};
 use crate::encoding::Encoding;
 use crate::iter::{Bytes, IntoIter, Iter, IterMut};
 use crate::ord::OrdError;
+use crate::CodepointsError;
 
 mod eq;
 mod impls;
@@ -279,6 +281,18 @@ impl AsciiString {
     #[inline]
     pub fn extend_from_slice(&mut self, other: &[u8]) {
         self.inner.extend_from_slice(other);
+    }
+
+    #[inline]
+    pub fn codepoints(&self) -> Result<Codepoints, CodepointsError> {
+        let iter = self
+            .inner
+            .as_slice()
+            .bytes()
+            .map(|b| b as u32)
+            .collect::<Vec<_>>()
+            .into_iter();
+        Ok(Codepoints::from(iter))
     }
 }
 

--- a/spinoso-string/src/enc/binary/codepoints.rs
+++ b/spinoso-string/src/enc/binary/codepoints.rs
@@ -26,3 +26,32 @@ impl<'a> Default for Codepoints<'a> {
         Self::new(b"")
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec::Vec;
+
+    use super::*;
+    use crate::enc::binary::BinaryString;
+
+    #[test]
+    fn test_valid_ascii() {
+        let s = BinaryString::from("abc");
+        let codepoints = Codepoints::new(&s);
+        assert_eq!(codepoints.collect::<Vec<_>>(), &[97, 98, 99]);
+    }
+
+    #[test]
+    fn test_utf8_interpreted_as_bytes() {
+        let s = BinaryString::from("abc💎");
+        let codepoints = Codepoints::new(&s);
+        assert_eq!(codepoints.collect::<Vec<_>>(), &[97, 98, 99, 240, 159, 146, 142]);
+    }
+
+    #[test]
+    fn test_invalid_utf8_interpreted_as_bytes() {
+        let s = BinaryString::from(b"abc\xFF");
+        let codepoints = Codepoints::new(&s);
+        assert_eq!(codepoints.collect::<Vec<_>>(), &[97, 98, 99, 255]);
+    }
+}

--- a/spinoso-string/src/enc/binary/codepoints.rs
+++ b/spinoso-string/src/enc/binary/codepoints.rs
@@ -1,0 +1,28 @@
+use core::slice;
+
+#[derive(Debug, Clone)]
+pub struct Codepoints<'a> {
+    inner: slice::Iter<'a, u8>,
+}
+
+impl<'a> Codepoints<'a> {
+    #[inline]
+    pub fn new(bytes: &'a [u8]) -> Self {
+        Self { inner: bytes.iter() }
+    }
+}
+
+impl<'a> Iterator for Codepoints<'a> {
+    type Item = u32;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next().map(|&b| u32::from(b))
+    }
+}
+
+impl<'a> Default for Codepoints<'a> {
+    #[inline]
+    fn default() -> Self {
+        Self::new(b"")
+    }
+}

--- a/spinoso-string/src/enc/binary/mod.rs
+++ b/spinoso-string/src/enc/binary/mod.rs
@@ -278,7 +278,7 @@ impl BinaryString {
             .inner
             .as_slice()
             .bytes()
-            .map(char::from)
+            .map(u32::from)
             .collect::<Vec<_>>()
             .into_iter();
         Codepoints::from(iter)

--- a/spinoso-string/src/enc/binary/mod.rs
+++ b/spinoso-string/src/enc/binary/mod.rs
@@ -7,7 +7,7 @@ use core::slice::SliceIndex;
 use bstr::ByteSlice;
 use scolapasta_strbuf::Buf;
 
-use crate::codepoints::{Codepoints, InvalidCodepointError};
+use crate::codepoints::{Codepoints, CodepointsError, InvalidCodepointError};
 use crate::iter::{Bytes, IntoIter, Iter, IterMut};
 use crate::ord::OrdError;
 
@@ -273,15 +273,15 @@ impl BinaryString {
     }
 
     #[inline]
-    pub fn codepoints(&self) -> Codepoints {
+    pub fn codepoints(&self) -> Result<Codepoints, CodepointsError> {
         let iter = self
             .inner
             .as_slice()
             .bytes()
-            .map(u32::from)
+            .map(|b| b as u32)
             .collect::<Vec<_>>()
             .into_iter();
-        Codepoints::from(iter)
+        Ok(Codepoints::from(iter))
     }
 }
 

--- a/spinoso-string/src/enc/binary/mod.rs
+++ b/spinoso-string/src/enc/binary/mod.rs
@@ -1,4 +1,5 @@
 use alloc::collections::TryReserveError;
+use alloc::vec::Vec;
 use core::fmt;
 use core::ops::Range;
 use core::slice::SliceIndex;
@@ -6,7 +7,7 @@ use core::slice::SliceIndex;
 use bstr::ByteSlice;
 use scolapasta_strbuf::Buf;
 
-use crate::codepoints::InvalidCodepointError;
+use crate::codepoints::{Codepoints, CodepointsError, InvalidCodepointError};
 use crate::iter::{Bytes, IntoIter, Iter, IterMut};
 use crate::ord::OrdError;
 
@@ -269,6 +270,18 @@ impl BinaryString {
     #[inline]
     pub fn extend_from_slice(&mut self, other: &[u8]) {
         self.inner.extend_from_slice(other);
+    }
+
+    #[inline]
+    pub fn codepoints(&self) -> Result<Codepoints, CodepointsError> {
+        let iter = self
+            .inner
+            .as_slice()
+            .bytes()
+            .map(|b| b as u32)
+            .collect::<Vec<_>>()
+            .into_iter();
+        Ok(Codepoints::from(iter))
     }
 }
 

--- a/spinoso-string/src/enc/binary/mod.rs
+++ b/spinoso-string/src/enc/binary/mod.rs
@@ -278,7 +278,7 @@ impl BinaryString {
             .inner
             .as_slice()
             .bytes()
-            .map(u32::from)
+            .map(char::from)
             .collect::<Vec<_>>()
             .into_iter();
         Codepoints::from(iter)

--- a/spinoso-string/src/enc/binary/mod.rs
+++ b/spinoso-string/src/enc/binary/mod.rs
@@ -1,5 +1,4 @@
 use alloc::collections::TryReserveError;
-use alloc::vec::Vec;
 use core::fmt;
 use core::ops::Range;
 use core::slice::SliceIndex;
@@ -7,7 +6,7 @@ use core::slice::SliceIndex;
 use bstr::ByteSlice;
 use scolapasta_strbuf::Buf;
 
-use crate::codepoints::{Codepoints, CodepointsError, InvalidCodepointError};
+use crate::codepoints::InvalidCodepointError;
 use crate::iter::{Bytes, IntoIter, Iter, IterMut};
 use crate::ord::OrdError;
 
@@ -270,18 +269,6 @@ impl BinaryString {
     #[inline]
     pub fn extend_from_slice(&mut self, other: &[u8]) {
         self.inner.extend_from_slice(other);
-    }
-
-    #[inline]
-    pub fn codepoints(&self) -> Result<Codepoints, CodepointsError> {
-        let iter = self
-            .inner
-            .as_slice()
-            .bytes()
-            .map(|b| b as u32)
-            .collect::<Vec<_>>()
-            .into_iter();
-        Ok(Codepoints::from(iter))
     }
 }
 

--- a/spinoso-string/src/enc/binary/mod.rs
+++ b/spinoso-string/src/enc/binary/mod.rs
@@ -10,12 +10,14 @@ use crate::codepoints::InvalidCodepointError;
 use crate::iter::{Bytes, IntoIter, Iter, IterMut};
 use crate::ord::OrdError;
 
+mod codepoints;
 mod eq;
 mod impls;
 mod inspect;
 #[cfg(feature = "std")]
 mod io;
 
+pub use codepoints::Codepoints;
 pub use inspect::Inspect;
 
 #[repr(transparent)]

--- a/spinoso-string/src/enc/binary/mod.rs
+++ b/spinoso-string/src/enc/binary/mod.rs
@@ -7,7 +7,7 @@ use core::slice::SliceIndex;
 use bstr::ByteSlice;
 use scolapasta_strbuf::Buf;
 
-use crate::codepoints::{Codepoints, CodepointsError, InvalidCodepointError};
+use crate::codepoints::{Codepoints, InvalidCodepointError};
 use crate::iter::{Bytes, IntoIter, Iter, IterMut};
 use crate::ord::OrdError;
 
@@ -273,15 +273,15 @@ impl BinaryString {
     }
 
     #[inline]
-    pub fn codepoints(&self) -> Result<Codepoints, CodepointsError> {
+    pub fn codepoints(&self) -> Codepoints {
         let iter = self
             .inner
             .as_slice()
             .bytes()
-            .map(|b| b as u32)
+            .map(u32::from)
             .collect::<Vec<_>>()
             .into_iter();
-        Ok(Codepoints::from(iter))
+        Codepoints::from(iter)
     }
 }
 

--- a/spinoso-string/src/enc/codepoints.rs
+++ b/spinoso-string/src/enc/codepoints.rs
@@ -1,0 +1,59 @@
+use core::iter::FusedIterator;
+
+use super::{
+    ascii::{self, AsciiString},
+    binary::{self, BinaryString},
+    utf8::{self, Utf8String},
+};
+use crate::CodepointsError;
+
+#[derive(Default, Debug, Clone)]
+#[must_use = "this `Codepoint` is an `Iterator`, which should be consumed if constructed"]
+pub struct Codepoints<'a>(State<'a>);
+
+impl<'a> From<&'a AsciiString> for Codepoints<'a> {
+    fn from(value: &'a AsciiString) -> Self {
+        Self(State::Ascii(ascii::Codepoints::new(value)))
+    }
+}
+
+impl<'a> From<&'a BinaryString> for Codepoints<'a> {
+    fn from(value: &'a BinaryString) -> Self {
+        Self(State::Binary(binary::Codepoints::new(value)))
+    }
+}
+impl<'a> TryFrom<&'a Utf8String> for Codepoints<'a> {
+    type Error = CodepointsError;
+
+    fn try_from(s: &'a Utf8String) -> Result<Self, Self::Error> {
+        utf8::Codepoints::try_from(s.as_utf8_str()).map(|v| Self(State::Utf8(v)))
+    }
+}
+
+#[derive(Debug, Clone)]
+enum State<'a> {
+    Ascii(ascii::Codepoints<'a>),
+    Binary(binary::Codepoints<'a>),
+    Utf8(utf8::Codepoints<'a>),
+}
+
+impl<'a> Default for State<'a> {
+    fn default() -> Self {
+        Self::Ascii(ascii::Codepoints::default())
+    }
+}
+
+impl<'a> Iterator for Codepoints<'a> {
+    type Item = u32;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self(State::Ascii(iter)) => iter.next(),
+            Self(State::Binary(iter)) => iter.next(),
+            Self(State::Utf8(iter)) => iter.next().map(u32::from),
+        }
+    }
+}
+
+impl<'a> FusedIterator for Codepoints<'a> {}

--- a/spinoso-string/src/enc/mod.rs
+++ b/spinoso-string/src/enc/mod.rs
@@ -477,8 +477,8 @@ impl EncodedString {
     pub fn codepoints(&self) -> Result<Codepoints, CodepointsError> {
         match self {
             EncodedString::Utf8(inner) => inner.codepoints(),
-            EncodedString::Binary(inner) => inner.codepoints(),
-            EncodedString::Ascii(inner) => inner.codepoints(),
+            EncodedString::Binary(inner) => Ok(inner.codepoints()),
+            EncodedString::Ascii(inner) => Ok(inner.codepoints()),
         }
     }
 

--- a/spinoso-string/src/enc/mod.rs
+++ b/spinoso-string/src/enc/mod.rs
@@ -14,15 +14,18 @@ use crate::codepoints::InvalidCodepointError;
 use crate::encoding::Encoding;
 use crate::iter::{Bytes, IntoIter, Iter, IterMut};
 use crate::ord::OrdError;
+use crate::CodepointsError;
 
 mod ascii;
 mod binary;
+mod codepoints;
 mod impls;
 mod inspect;
 #[cfg(feature = "std")]
 mod io;
 mod utf8;
 
+pub use codepoints::Codepoints;
 pub use inspect::Inspect;
 
 #[derive(Clone)]
@@ -310,6 +313,14 @@ impl EncodedString {
             EncodedString::Ascii(inner) => inner.into(),
             EncodedString::Binary(inner) => inner.into(),
             EncodedString::Utf8(inner) => inner.into(),
+        }
+    }
+    #[inline]
+    pub fn codepoints(&self) -> Result<Codepoints<'_>, CodepointsError> {
+        match self {
+            EncodedString::Ascii(inner) => Ok(inner.into()),
+            EncodedString::Binary(inner) => Ok(inner.into()),
+            EncodedString::Utf8(inner) => inner.try_into(),
         }
     }
 

--- a/spinoso-string/src/enc/mod.rs
+++ b/spinoso-string/src/enc/mod.rs
@@ -477,8 +477,8 @@ impl EncodedString {
     pub fn codepoints(&self) -> Result<Codepoints, CodepointsError> {
         match self {
             EncodedString::Utf8(inner) => inner.codepoints(),
-            EncodedString::Binary(inner) => Ok(inner.codepoints()),
-            EncodedString::Ascii(inner) => Ok(inner.codepoints()),
+            EncodedString::Binary(inner) => inner.codepoints(),
+            EncodedString::Ascii(inner) => inner.codepoints(),
         }
     }
 

--- a/spinoso-string/src/enc/mod.rs
+++ b/spinoso-string/src/enc/mod.rs
@@ -10,7 +10,7 @@ use binary::BinaryString;
 use scolapasta_strbuf::Buf;
 use utf8::Utf8String;
 
-use crate::codepoints::InvalidCodepointError;
+use crate::codepoints::{Codepoints, CodepointsError, InvalidCodepointError};
 use crate::encoding::Encoding;
 use crate::iter::{Bytes, IntoIter, Iter, IterMut};
 use crate::ord::OrdError;
@@ -471,6 +471,15 @@ impl EncodedString {
             EncodedString::Utf8(inner) => inner.try_push_int(int)?,
         }
         Ok(())
+    }
+
+    #[inline]
+    pub fn codepoints(&self) -> Result<Codepoints, CodepointsError> {
+        match self {
+            EncodedString::Utf8(inner) => inner.codepoints(),
+            EncodedString::Binary(inner) => inner.codepoints(),
+            EncodedString::Ascii(inner) => inner.codepoints(),
+        }
     }
 
     #[inline]

--- a/spinoso-string/src/enc/mod.rs
+++ b/spinoso-string/src/enc/mod.rs
@@ -10,7 +10,7 @@ use binary::BinaryString;
 use scolapasta_strbuf::Buf;
 use utf8::Utf8String;
 
-use crate::codepoints::{Codepoints, CodepointsError, InvalidCodepointError};
+use crate::codepoints::InvalidCodepointError;
 use crate::encoding::Encoding;
 use crate::iter::{Bytes, IntoIter, Iter, IterMut};
 use crate::ord::OrdError;
@@ -471,15 +471,6 @@ impl EncodedString {
             EncodedString::Utf8(inner) => inner.try_push_int(int)?,
         }
         Ok(())
-    }
-
-    #[inline]
-    pub fn codepoints(&self) -> Result<Codepoints, CodepointsError> {
-        match self {
-            EncodedString::Utf8(inner) => inner.codepoints(),
-            EncodedString::Binary(inner) => inner.codepoints(),
-            EncodedString::Ascii(inner) => inner.codepoints(),
-        }
     }
 
     #[inline]

--- a/spinoso-string/src/enc/utf8/borrowed.rs
+++ b/spinoso-string/src/enc/utf8/borrowed.rs
@@ -7,8 +7,11 @@ use bstr::ByteSlice;
 use crate::iter::{Bytes, Iter, IterMut};
 use crate::ord::OrdError;
 
+mod codepoints;
 mod eq;
 mod impls;
+
+pub use codepoints::Codepoints;
 
 #[repr(transparent)]
 pub struct Utf8Str {

--- a/spinoso-string/src/enc/utf8/borrowed/codepoints.rs
+++ b/spinoso-string/src/enc/utf8/borrowed/codepoints.rs
@@ -15,6 +15,18 @@ impl<'a> TryFrom<&'a Utf8Str> for Codepoints<'a> {
     fn try_from(s: &'a Utf8Str) -> Result<Self, Self::Error> {
         match simdutf8::basic::from_utf8(s.as_bytes()) {
             Ok(s) => Ok(Self { inner: s.chars() }),
+            // ```
+            // [3.2.2] > s = "abc\xFFxyz"
+            // => "abc\xFFxyz"
+            // [3.2.2] > s.encoding
+            // => #<Encoding:UTF-8>
+            // [3.2.2] > s.codepoints
+            // (irb):5:in `codepoints': invalid byte sequence in UTF-8 (ArgumentError)
+            //         from (irb):5:in `<main>'
+            //         from /usr/local/var/rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/irb-1.6.2/exe/irb:11:in `<top (required)>'
+            //         from /usr/local/var/rbenv/versions/3.2.2/bin/irb:25:in `load'
+            //         from /usr/local/var/rbenv/versions/3.2.2/bin/irb:25:in `<main>'
+            // ```
             Err(_) => Err(CodepointsError::invalid_utf8_codepoint()),
         }
     }

--- a/spinoso-string/src/enc/utf8/borrowed/codepoints.rs
+++ b/spinoso-string/src/enc/utf8/borrowed/codepoints.rs
@@ -34,3 +34,24 @@ impl<'a> Default for Codepoints<'a> {
         Self { inner: "".chars() }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec::Vec;
+
+    use super::*;
+
+    #[test]
+    fn test_valid_utf8() {
+        let s = Utf8Str::new("hello💎");
+        let codepoints = Codepoints::try_from(s).unwrap();
+        assert_eq!(codepoints.collect::<Vec<_>>(), &[104, 101, 108, 108, 111, 128_142]);
+    }
+
+    #[test]
+    fn test_invalid_utf8() {
+        let s = Utf8Str::new(b"hello\xFF");
+        let err = Codepoints::try_from(s).unwrap_err();
+        assert_eq!(err, CodepointsError::invalid_utf8_codepoint());
+    }
+}

--- a/spinoso-string/src/enc/utf8/borrowed/codepoints.rs
+++ b/spinoso-string/src/enc/utf8/borrowed/codepoints.rs
@@ -1,0 +1,36 @@
+use core::str::Chars;
+
+use super::Utf8Str;
+use crate::CodepointsError;
+
+#[derive(Debug, Clone)]
+pub struct Codepoints<'a> {
+    inner: Chars<'a>,
+}
+
+impl<'a> TryFrom<&'a Utf8Str> for Codepoints<'a> {
+    type Error = CodepointsError;
+
+    #[inline]
+    fn try_from(s: &'a Utf8Str) -> Result<Self, Self::Error> {
+        match simdutf8::basic::from_utf8(s.as_bytes()) {
+            Ok(s) => Ok(Self { inner: s.chars() }),
+            Err(_) => Err(CodepointsError::invalid_utf8_codepoint()),
+        }
+    }
+}
+
+impl<'a> Iterator for Codepoints<'a> {
+    type Item = u32;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next().map(u32::from)
+    }
+}
+
+impl<'a> Default for Codepoints<'a> {
+    #[inline]
+    fn default() -> Self {
+        Self { inner: "".chars() }
+    }
+}

--- a/spinoso-string/src/enc/utf8/mod.rs
+++ b/spinoso-string/src/enc/utf8/mod.rs
@@ -42,6 +42,7 @@ mod borrowed;
 mod inspect;
 mod owned;
 
+pub use borrowed::Codepoints;
 pub use borrowed::Utf8Str;
 pub use inspect::Inspect;
 pub use owned::Utf8String;

--- a/spinoso-string/src/enc/utf8/owned.rs
+++ b/spinoso-string/src/enc/utf8/owned.rs
@@ -150,7 +150,7 @@ impl Utf8String {
     #[inline]
     pub fn codepoints(&self) -> Result<Codepoints, CodepointsError> {
         if let Ok(s) = self.inner.as_slice().to_str() {
-            let iter = s.chars().collect::<Vec<_>>().into_iter();
+            let iter = s.chars().map(u32::from).collect::<Vec<_>>().into_iter();
             return Ok(Codepoints::from(iter));
         }
 

--- a/spinoso-string/src/enc/utf8/owned.rs
+++ b/spinoso-string/src/enc/utf8/owned.rs
@@ -1,12 +1,11 @@
 use alloc::collections::TryReserveError;
 use alloc::vec::Vec;
 
-use bstr::ByteSlice;
 use scolapasta_strbuf::Buf;
 
 use super::Utf8Str;
 use crate::chars::ConventionallyUtf8;
-use crate::codepoints::{Codepoints, CodepointsError, InvalidCodepointError};
+use crate::codepoints::InvalidCodepointError;
 use crate::iter::IntoIter;
 
 mod eq;
@@ -145,16 +144,6 @@ impl Utf8String {
     #[inline]
     pub fn try_push_int(&mut self, int: i64) -> Result<(), InvalidCodepointError> {
         self.try_push_codepoint(int)
-    }
-
-    #[inline]
-    pub fn codepoints(&self) -> Result<Codepoints, CodepointsError> {
-        if let Ok(s) = self.inner.as_slice().to_str() {
-            let iter = s.chars().map(u32::from).collect::<Vec<_>>().into_iter();
-            return Ok(Codepoints::from(iter));
-        }
-
-        Err(CodepointsError::invalid_utf8_codepoint())
     }
 
     #[inline]

--- a/spinoso-string/src/enc/utf8/owned.rs
+++ b/spinoso-string/src/enc/utf8/owned.rs
@@ -1,11 +1,12 @@
 use alloc::collections::TryReserveError;
 use alloc::vec::Vec;
 
+use bstr::ByteSlice;
 use scolapasta_strbuf::Buf;
 
 use super::Utf8Str;
 use crate::chars::ConventionallyUtf8;
-use crate::codepoints::InvalidCodepointError;
+use crate::codepoints::{Codepoints, CodepointsError, InvalidCodepointError};
 use crate::iter::IntoIter;
 
 mod eq;
@@ -144,6 +145,16 @@ impl Utf8String {
     #[inline]
     pub fn try_push_int(&mut self, int: i64) -> Result<(), InvalidCodepointError> {
         self.try_push_codepoint(int)
+    }
+
+    #[inline]
+    pub fn codepoints(&self) -> Result<Codepoints, CodepointsError> {
+        if let Ok(s) = self.inner.as_slice().to_str() {
+            let iter = s.chars().map(u32::from).collect::<Vec<_>>().into_iter();
+            return Ok(Codepoints::from(iter));
+        }
+
+        Err(CodepointsError::invalid_utf8_codepoint())
     }
 
     #[inline]

--- a/spinoso-string/src/enc/utf8/owned.rs
+++ b/spinoso-string/src/enc/utf8/owned.rs
@@ -164,9 +164,9 @@ impl Utf8String {
 
 // Casing
 impl Utf8String {
-    // TODO: Use roe for case changing operations. UTF-8 case changing needs to
-    //       be parameterized on the case folding strategy to account for e.g.
-    //       Turkic or ASCII-only modes
+    // TODO: #1723 Use roe for case changing operations. UTF-8 case changing
+    //       needs to be parameterized on the case folding strategy to account
+    //       for e.g. Turkic or ASCII-only modes
     #[inline]
     pub fn make_capitalized(&mut self) {
         use bstr::ByteVec;

--- a/spinoso-string/src/enc/utf8/owned.rs
+++ b/spinoso-string/src/enc/utf8/owned.rs
@@ -150,7 +150,7 @@ impl Utf8String {
     #[inline]
     pub fn codepoints(&self) -> Result<Codepoints, CodepointsError> {
         if let Ok(s) = self.inner.as_slice().to_str() {
-            let iter = s.chars().map(u32::from).collect::<Vec<_>>().into_iter();
+            let iter = s.chars().collect::<Vec<_>>().into_iter();
             return Ok(Codepoints::from(iter));
         }
 

--- a/spinoso-string/src/lib.rs
+++ b/spinoso-string/src/lib.rs
@@ -1919,7 +1919,7 @@ impl String {
     /// [binary encoded]: crate::Encoding::Binary
     /// [`str::from_utf8`]: core::str::from_utf8
     #[inline]
-    pub fn codepoints(&self) -> Result<Codepoints<'_>, CodepointsError> {
+    pub fn codepoints(&self) -> Result<Codepoints, CodepointsError> {
         Codepoints::try_from(self)
     }
 

--- a/spinoso-string/src/lib.rs
+++ b/spinoso-string/src/lib.rs
@@ -1919,7 +1919,7 @@ impl String {
     /// [binary encoded]: crate::Encoding::Binary
     /// [`str::from_utf8`]: core::str::from_utf8
     #[inline]
-    pub fn codepoints(&self) -> Result<Codepoints, CodepointsError> {
+    pub fn codepoints(&self) -> Result<Codepoints<'_>, CodepointsError> {
         Codepoints::try_from(self)
     }
 


### PR DESCRIPTION
Fix #1728

This PR moves the encoding-specific code from `codepoints.rs` to encoded variants.

- The original version [consumes](https://github.com/artichoke/artichoke/compare/choznerol/1728-Implement-a-Codepoints-iterator-for-each-encoded-string-variant-in-spinoso-string?expand=1#diff-a2d2fa818d5b61fb277dd19f5a3a58b696944224b071fe8faee5bca3c19103d3L1923) the `String` to produce a `Codepoints` iterator, while the new version doesn't consume the `String` but allocate a `Vec` to create iterator. I'm not sure if the previous approach is preferred, if so I can try to refactor it.
- I made 589977d and 24837dd separate commits, as they may or may not be the preferred approach.