### PR TITLE
Add additional windows platform to Gemfile

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,6 +40,7 @@ GEM
 
 PLATFORMS
   ruby
+  x64-mingw-ucrt
   x64-mingw32
 
 DEPENDENCIES


### PR DESCRIPTION
VSCode created this diff for me automatically when I installed the Ruby LSP extension