### PR TITLE
Upgrade to `tzdb` v0.6.0-pre.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -816,6 +816,7 @@ dependencies = [
 name = "spinoso-time"
 version = "0.7.2"
 dependencies = [
+ "iana-time-zone",
  "regex",
  "strftime-ruby",
  "tz-rs",
@@ -892,11 +893,10 @@ dependencies = [
 
 [[package]]
 name = "tzdb"
-version = "0.5.7"
+version = "0.6.0-pre.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec758958f2fb5069cd7fae385be95cc8eceb8cdfd270c7d14de6034f0108d99e"
+checksum = "58d8b51e1d35ca1094870b46d453ee9374345bad838b47d0478e248493d0ff84"
 dependencies = [
- "iana-time-zone",
  "tz-rs",
 ]
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -641,6 +641,7 @@ dependencies = [
 name = "spinoso-time"
 version = "0.7.2"
 dependencies = [
+ "iana-time-zone",
  "regex",
  "strftime-ruby",
  "tz-rs",
@@ -675,11 +676,10 @@ dependencies = [
 
 [[package]]
 name = "tzdb"
-version = "0.5.7"
+version = "0.6.0-pre.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec758958f2fb5069cd7fae385be95cc8eceb8cdfd270c7d14de6034f0108d99e"
+checksum = "58d8b51e1d35ca1094870b46d453ee9374345bad838b47d0478e248493d0ff84"
 dependencies = [
- "iana-time-zone",
  "tz-rs",
 ]
 

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -933,6 +933,7 @@ dependencies = [
 name = "spinoso-time"
 version = "0.7.2"
 dependencies = [
+ "iana-time-zone",
  "regex",
  "strftime-ruby",
  "tz-rs",
@@ -1004,11 +1005,10 @@ dependencies = [
 
 [[package]]
 name = "tzdb"
-version = "0.5.7"
+version = "0.6.0-pre.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec758958f2fb5069cd7fae385be95cc8eceb8cdfd270c7d14de6034f0108d99e"
+checksum = "58d8b51e1d35ca1094870b46d453ee9374345bad838b47d0478e248493d0ff84"
 dependencies = [
- "iana-time-zone",
  "tz-rs",
 ]
 

--- a/spinoso-time/Cargo.toml
+++ b/spinoso-time/Cargo.toml
@@ -16,6 +16,7 @@ homepage.workspace = true
 documentation.workspace = true
 
 [dependencies]
+iana-time-zone = "0.1.58"
 
 [dependencies.regex]
 version = "1.7.0"
@@ -36,7 +37,7 @@ default-features = false
 features = ["std"]
 
 [dependencies.tzdb]
-version = "0.5.6"
+version = "0.6.0-pre.1"
 optional = true
 default-features = false
 

--- a/spinoso-time/src/time/tzrs/offset.rs
+++ b/spinoso-time/src/time/tzrs/offset.rs
@@ -5,8 +5,6 @@ use std::sync::OnceLock;
 
 use regex::Regex;
 use tz::timezone::{LocalTimeType, TimeZoneRef};
-#[cfg(feature = "tzrs-local")]
-use tzdb::local_tz;
 use tzdb::time_zone::etc::GMT;
 
 use super::error::{TimeError, TzOutOfRangeError, TzStringError};
@@ -53,9 +51,9 @@ fn local_time_zone() -> TimeZoneRef<'static> {
     // local timezone: https://docs.rs/tzdb/latest/tzdb/fn.local_tz.html.
     static LOCAL_TZ: OnceLock<TimeZoneRef<'static>> = OnceLock::new();
 
-    *LOCAL_TZ.get_or_init(|| match local_tz() {
-        Some(tz) => tz,
-        None => GMT,
+    *LOCAL_TZ.get_or_init(|| {
+        let tz = iana_time_zone::get_timezone().ok().and_then(tzdb::tz_by_name);
+        tz.unwrap_or(GMT)
     })
 }
 


### PR DESCRIPTION
In Kijewski/tzdb#178, I asked upstream to make the dependency on `iana-time-zone` optional so I could unnest the `iana-time-zone` dependency in the cargo DAG.

This change was added in tzdb v0.6.0, which I am testing out the pre-release for.

These changes require `spinoso-time` to depend on `iana-time-zone` directly. `tzdb` is used without any features activated.

This change shaves about 1s off of builds times and moves `iana-time-zone` and `tzdb` earlier in the cargo dep DAG as measured by `cargo build --timings`.