### PR TITLE
Upgrade rustyline to new v13.0.0 major version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -228,13 +228,11 @@ checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 
 [[package]]
 name = "clipboard-win"
-version = "4.5.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7191c27c2357d9b7ef96baac1773290d4ca63b24205b82a3fd8a0637afcf0362"
+checksum = "c57002a5d9be777c1ef967e33674dac9ebd310d8893e4e3437b14d5f0f6372cc"
 dependencies = [
  "error-code",
- "str-buf",
- "winapi",
 ]
 
 [[package]]
@@ -256,28 +254,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
 name = "error-code"
-version = "2.3.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64f18991e7bf11e7ffee451b5318b5c1a73c52d0d0ada6e5a3017c8c1ced6a21"
-dependencies = [
- "libc",
- "str-buf",
-]
+checksum = "281e452d3bad4005426416cdba5ccfd4f5c1280e10099e21db27f7c1c28347fc"
 
 [[package]]
 name = "fd-lock"
-version = "3.0.13"
+version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef033ed5e9bad94e55838ca0ca906db0e043f517adda0c8b79c7a8c66c93c1b5"
+checksum = "7e5768da2206272c81ef0b5e951a41862938a6070da63bcea197899942d3b947"
 dependencies = [
  "cfg-if",
  "rustix",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -356,7 +350,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4397c789f2709d23cfcb703b316e0766a8d4b17db2d47b0ab096ef6047cae1d8"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -434,11 +428,11 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "nix"
-version = "0.26.4"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.1",
  "cfg-if",
  "libc",
 ]
@@ -607,14 +601,14 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
 name = "rustyline"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "994eca4bca05c87e86e15d90fc7a91d1be64b4482b38cb2d27474568fe7c9db9"
+checksum = "02a2d683a4ac90aeef5b1013933f6d977bd37d51ff3f4dad829d4931a7e6be86"
 dependencies = [
  "bitflags 2.4.1",
  "cfg-if",
@@ -624,7 +618,6 @@ dependencies = [
  "log",
  "memchr",
  "nix",
- "scopeguard",
  "unicode-segmentation",
  "unicode-width",
  "utf8parse",
@@ -678,12 +671,6 @@ version = "0.3.0"
 dependencies = [
  "bstr",
 ]
-
-[[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
@@ -822,12 +809,6 @@ dependencies = [
  "tz-rs",
  "tzdb",
 ]
-
-[[package]]
-name = "str-buf"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e08d8363704e6c71fc928674353e6b7c23dcea9d82d7012c8faf2a3a025f8d0"
 
 [[package]]
 name = "strftime-ruby"
@@ -1020,15 +1001,6 @@ name = "windows-core"
 version = "0.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1f8cf84f35d2db49a46868f947758c7a1138116f7fac3bc844f43ade1292e64"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
  "windows-targets 0.48.5",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "artichoke-readline"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "bstr",
  "known-folders",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ version = "0.4.19"
 optional = true
 
 [dependencies.rustyline]
-version = "12.0.0"
+version = "13.0.0"
 optional = true
 default-features = false
 features = ["with-file-history"]

--- a/artichoke-readline/Cargo.toml
+++ b/artichoke-readline/Cargo.toml
@@ -21,7 +21,7 @@ version = "1.2.0"
 default-features = false
 
 [dependencies.rustyline]
-version = "12.0.0"
+version = "13.0.0"
 optional = true
 default-features = false
 

--- a/artichoke-readline/Cargo.toml
+++ b/artichoke-readline/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "artichoke-readline"
-version = "1.0.1"
+version = "1.1.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 description = "Helpers for interacting with GNU Readline configuration"
 keywords = ["artichoke", "artichoke-ruby", "inputrc", "readline"]

--- a/artichoke-readline/README.md
+++ b/artichoke-readline/README.md
@@ -19,7 +19,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-artichoke-readline = "1.0.1"
+artichoke-readline = "1.1.0"
 ```
 
 And parse Readline editing mode like this:
@@ -39,6 +39,8 @@ if let Some(config) = rl_read_init_file() {
 The **rustyline** feature (enabled by default) adds trait implementations to
 allow `EditMode` to interoperate with the corresponding enum in the `rustyline`
 crate.
+
+`rustyline` major version upgrades can be made in minor version bumps.
 
 ## License
 


### PR DESCRIPTION
Down to only 2 direct deps pulling in old duplicate deps:

- `onig` pulls in `bitflags` v1
- `iana-time-zone` pulls in `windows-targets` v0.48 – https://github.com/strawlab/iana-time-zone/pull/125