### PR TITLE
Do not create a slice of rest args when none are given

### DIFF
--- a/artichoke-backend/src/macros.rs
+++ b/artichoke-backend/src/macros.rs
@@ -422,6 +422,12 @@ macro_rules! mrb_get_args {
             args.as_mut_ptr(),
             count.as_mut_ptr(),
         );
-        std::slice::from_raw_parts(args.assume_init(), count.assume_init())
+        let args = args.assume_init();
+        let count = count.assume_init();
+        if args.is_null() || count == 0 {
+            &[]
+        } else {
+            std::slice::from_raw_parts(args, count)
+        }
     }};
 }


### PR DESCRIPTION
Artichoke provides a macro `mrb_get_args!` for native code which implements Ruby methods to retrieve arguments from the mruby VM's stack. `mrb_get_args!(mrb, *args)` instructs the macro to collect all arguments in a slice ("rest" arguments).

Detailed in #2691, recent nightly includes a new precondition check for `std::slice::from_raw_parts` which checks for the validity of the pointer and length arguments passed to it. The weekly fuzzer suite run in CI isolated the following Ruby code as triggering the assertion:

```ruby
p
```

This code is `Kernel#p` when called with no args. The assertion emitted by the Rust runtime is:

```
thread 'main' panicked at library/core/src/panicking.rs:155:5:
unsafe precondition(s) violated: slice::from_raw_parts requires the pointer to be aligned and non-null, and the total size of the slice not to exceed `isize::MAX`
stack backtrace:
... snip ...
   5: core::slice::raw::from_raw_parts
             at /rustc/6cc4843512d613f51ec81aba689180c31b0b28b6/library/core/src/slice/raw.rs:98:9
   6: artichoke_backend::extn::core::kernel::mruby::kernel_p
             at ./artichoke-backend/src/extn/core/kernel/mruby.rs:69:16
   7: mrb_vm_exec
             at ./artichoke-backend/vendor/mruby/src/vm.c:1792:18
   8: mrb_vm_run
             at ./artichoke-backend/vendor/mruby/src/vm.c:1282:12
   9: mrb_top_run
             at ./artichoke-backend/vendor/mruby/src/vm.c:3112:12
  10: mrb_load_exec
             at ./artichoke-backend/mrbgems/mruby-compiler/core/parse.y:6918:7
... snip ...
```

When no arguments are passed, the mruby function `mrb_get_args` sets the args pointer to `NULL` and length to `0`. The new Rust runtime precondition does not like the `NULL` being passed to `from_raw_parts`, so we guard against both conditions and return the constant empty slice.

I audited all other uses of `std::slice::from_raw_parts` and found them to be local to the string, symbol, and array oxidized `MRB_API` implementations, which are expected to be unsafe to call and requires the VM to ensure the various pointers are non-NULL.

This fix was validated with the following command:

```shell
RUST_BACKTRACE=1 RUSTFLAGS="-Z sanitizer=address" cargo +nightly run --bin artichoke --target x86_64-apple-darwin -- -e 'p'
```

Regressions will be caught by subsequent runs in the Fuzz CI (which uses nightly) and regular CI, once the current nightly (rustc 1.78.0-nightly (6cc484351 2024-02-10)) hits stable.

Fixes #2691.