### PR TITLE
Unify code pattern for all paths that invoke bstr::decode_utf8

### DIFF
--- a/spinoso-regexp/src/lib.rs
+++ b/spinoso-regexp/src/lib.rs
@@ -14,7 +14,6 @@
 #![warn(trivial_casts, trivial_numeric_casts)]
 #![warn(unused_qualifications)]
 #![warn(variant_size_differences)]
-#![forbid(unsafe_code)]
 // Enable feature callouts in generated documentation:
 // https://doc.rust-lang.org/beta/unstable-book/language-features/doc-cfg.html
 //

--- a/spinoso-string/src/chars.rs
+++ b/spinoso-string/src/chars.rs
@@ -191,15 +191,15 @@ impl<'a> Iterator for ConventionallyUtf8<'a> {
             return Some(slice);
         }
         let (ch, size) = bstr::decode_utf8(self.bytes);
+        // SAFETY: bstr guarantees that the size is within the bounds of the slice.
+        let (chunk, remainder) = unsafe { self.bytes.split_at_unchecked(size) };
+        self.bytes = remainder;
+
         if ch.is_some() {
-            let (ch, remainder) = self.bytes.split_at(size);
-            self.bytes = remainder;
-            Some(ch)
+            Some(chunk)
         } else {
-            let (invalid_utf8_bytes, remainder) = self.bytes.split_at(size);
             // Invalid UTF-8 bytes are yielded as byte slices one byte at a time.
-            self.invalid_bytes = InvalidBytes::with_bytes(invalid_utf8_bytes);
-            self.bytes = remainder;
+            self.invalid_bytes = InvalidBytes::with_bytes(chunk);
             self.invalid_bytes.next()
         }
     }

--- a/spinoso-string/src/enc/utf8/inspect.rs
+++ b/spinoso-string/src/enc/utf8/inspect.rs
@@ -77,6 +77,10 @@ impl<'a> Iterator for Inspect<'a> {
             return Some(ch);
         }
         let (ch, size) = bstr::decode_utf8(self.bytes);
+        // SAFETY: bstr guarantees that the size is within the bounds of the slice.
+        let (chunk, remainder) = unsafe { self.bytes.split_at_unchecked(size) };
+        self.bytes = remainder;
+
         match ch.map(|ch| {
             ascii_char_with_escape(ch)
                 .and_then(|esc| esc.as_bytes().split_first())
@@ -84,22 +88,19 @@ impl<'a> Iterator for Inspect<'a> {
         }) {
             Some(Ok((&head, tail))) => {
                 self.escaped_bytes = tail;
-                self.bytes = &self.bytes[size..];
                 return Some(head.into());
             }
             Some(Err(ch)) => {
-                self.bytes = &self.bytes[size..];
                 return Some(ch);
             }
             None if size == 0 => {}
             None => {
-                let (invalid_utf8_bytes, remainder) = self.bytes.split_at(size);
+                let invalid_utf8_bytes = chunk;
                 // This conversion is safe to unwrap due to the documented
                 // behavior of `bstr::decode_utf8` and `InvalidUtf8ByteSequence`
                 // which indicate that `size` is always in the range of 0..=3.
                 self.byte_literal = InvalidUtf8ByteSequence::try_from(invalid_utf8_bytes)
                     .expect("Invalid UTF-8 byte sequence should be at most 3 bytes long");
-                self.bytes = remainder;
                 return self.byte_literal.next();
             }
         };

--- a/spinoso-string/src/enc/utf8/owned.rs
+++ b/spinoso-string/src/enc/utf8/owned.rs
@@ -180,36 +180,34 @@ impl Utf8String {
         let mut replacement = Vec::with_capacity(self.len());
         let mut bytes = self.inner.as_slice();
 
-        match bstr::decode_utf8(bytes) {
-            (Some(ch), size) => {
-                // Converting a UTF-8 character to uppercase may yield
-                // multiple codepoints.
-                for ch in ch.to_uppercase() {
-                    replacement.push_char(ch);
-                }
-                bytes = &bytes[size..];
+        let (ch, size) = bstr::decode_utf8(bytes);
+        // SAFETY: bstr guarantees that the size is within the bounds of the slice.
+        let (chunk, remainder) = unsafe { bytes.split_at_unchecked(size) };
+        bytes = remainder;
+
+        if let Some(ch) = ch {
+            // Converting a UTF-8 character to uppercase may yield multiple codepoints.
+            for ch in ch.to_uppercase() {
+                replacement.push_char(ch);
             }
-            (None, 0) => return,
-            (None, size) => {
-                let (substring, remainder) = bytes.split_at(size);
-                replacement.extend_from_slice(substring);
-                bytes = remainder;
-            }
+        } else {
+            replacement.extend_from_slice(chunk);
         }
 
         while !bytes.is_empty() {
             let (ch, size) = bstr::decode_utf8(bytes);
+            // SAFETY: bstr guarantees that the size is within the bounds of the slice.
+            let (chunk, remainder) = unsafe { bytes.split_at_unchecked(size) };
+            bytes = remainder;
+
             if let Some(ch) = ch {
                 // Converting a UTF-8 character to lowercase may yield
                 // multiple codepoints.
                 for ch in ch.to_lowercase() {
                     replacement.push_char(ch);
                 }
-                bytes = &bytes[size..];
             } else {
-                let (substring, remainder) = bytes.split_at(size);
-                replacement.extend_from_slice(substring);
-                bytes = remainder;
+                replacement.extend_from_slice(chunk);
             }
         }
         self.inner = replacement.into();
@@ -229,17 +227,18 @@ impl Utf8String {
 
         while !bytes.is_empty() {
             let (ch, size) = bstr::decode_utf8(bytes);
+            // SAFETY: bstr guarantees that the size is within the bounds of the slice.
+            let (chunk, remainder) = unsafe { bytes.split_at_unchecked(size) };
+            bytes = remainder;
+
             if let Some(ch) = ch {
                 // Converting a UTF-8 character to lowercase may yield
                 // multiple codepoints.
                 for ch in ch.to_lowercase() {
                     replacement.push_char(ch);
                 }
-                bytes = &bytes[size..];
             } else {
-                let (substring, remainder) = bytes.split_at(size);
-                replacement.extend_from_slice(substring);
-                bytes = remainder;
+                replacement.extend_from_slice(chunk);
             }
         }
         self.inner = replacement.into();
@@ -259,17 +258,18 @@ impl Utf8String {
 
         while !bytes.is_empty() {
             let (ch, size) = bstr::decode_utf8(bytes);
+            // SAFETY: bstr guarantees that the size is within the bounds of the slice.
+            let (chunk, remainder) = unsafe { bytes.split_at_unchecked(size) };
+            bytes = remainder;
+
             if let Some(ch) = ch {
                 // Converting a UTF-8 character to lowercase may yield
                 // multiple codepoints.
                 for ch in ch.to_uppercase() {
                     replacement.push_char(ch);
                 }
-                bytes = &bytes[size..];
             } else {
-                let (substring, remainder) = bytes.split_at(size);
-                replacement.extend_from_slice(substring);
-                bytes = remainder;
+                replacement.extend_from_slice(chunk);
             }
         }
         self.inner = replacement.into();

--- a/spinoso-symbol/src/inspect.rs
+++ b/spinoso-symbol/src/inspect.rs
@@ -303,13 +303,15 @@ impl<'a> Iterator for State<'a> {
             return Some(ch);
         }
         let (ch, size) = bstr::decode_utf8(self.bytes);
+        // SAFETY: bstr guarantees that the size is within the bounds of the slice.
+        let (chunk, remainder) = unsafe { self.bytes.split_at_unchecked(size) };
+        self.bytes = remainder;
+
         match ch {
             Some('"' | '\\') if self.flags.is_ident() => {
-                self.bytes = &self.bytes[size..];
                 return ch;
             }
             Some(ch) => {
-                self.bytes = &self.bytes[size..];
                 if let Some([head, tail @ ..]) = ascii_char_with_escape(ch).map(str::as_bytes) {
                     self.escaped_bytes = tail;
                     return Some(char::from(*head));
@@ -318,12 +320,10 @@ impl<'a> Iterator for State<'a> {
             }
             None if size == 0 => {}
             None => {
-                let (invalid_utf8_bytes, remainder) = self.bytes.split_at(size);
                 // This conversion is safe to unwrap due to the documented
                 // behavior of `bstr::decode_utf8` and `InvalidUtf8ByteSequence`
                 // which indicate that `size` is always in the range of 0..=3.
-                self.forward_byte_literal = InvalidUtf8ByteSequence::try_from(invalid_utf8_bytes).unwrap();
-                self.bytes = remainder;
+                self.forward_byte_literal = InvalidUtf8ByteSequence::try_from(chunk).unwrap();
                 return self.forward_byte_literal.next();
             }
         };

--- a/spinoso-symbol/src/lib.rs
+++ b/spinoso-symbol/src/lib.rs
@@ -12,7 +12,6 @@
 #![warn(trivial_casts, trivial_numeric_casts)]
 #![warn(unused_qualifications)]
 #![warn(variant_size_differences)]
-#![forbid(unsafe_code)]
 // Enable feature callouts in generated documentation:
 // https://doc.rust-lang.org/beta/unstable-book/language-features/doc-cfg.html
 //


### PR DESCRIPTION
Make the code consistent, smaller, and more performant.