### PR TITLE
Fix undefined behavior when manipulating allocated but uninitialized `Array`s and `String`s

### DIFF
--- a/artichoke-backend/src/extn/core/array/mod.rs
+++ b/artichoke-backend/src/extn/core/array/mod.rs
@@ -333,4 +333,17 @@ mod tests {
         let result = interp.eval(b"spec");
         unwrap_or_panic_with_backtrace(&mut interp, SUBJECT, result);
     }
+
+    #[test]
+    fn allocated_but_uninitialized_array_can_be_garbage_collected() {
+        let mut interp = interpreter();
+        let test = r"
+            1_000_000.times do
+              Array.allocate
+            end
+        ";
+        let result = interp.eval(test.as_bytes());
+        unwrap_or_panic_with_backtrace(&mut interp, SUBJECT, result);
+        interp.full_gc().unwrap();
+    }
 }

--- a/artichoke-backend/src/extn/core/array/mod.rs
+++ b/artichoke-backend/src/extn/core/array/mod.rs
@@ -316,6 +316,7 @@ impl BoxUnboxVmValue for Array {
         //
         // Array should not have a destructor registered in the class registry.
         let _ = data;
+        unreachable!("<Array as BoxUnboxVmValue>::free is never called");
     }
 }
 

--- a/artichoke-backend/src/extn/core/string/ffi.rs
+++ b/artichoke-backend/src/extn/core/string/ffi.rs
@@ -8,9 +8,8 @@ use core::ptr;
 use core::slice;
 use core::str;
 use std::collections::TryReserveError;
-use std::ffi::{c_void, CStr};
+use std::ffi::{c_char, c_double, c_int, c_void, CStr};
 use std::io::Write as _;
-use std::os::raw::{c_char, c_double, c_int};
 use std::ptr::NonNull;
 
 use artichoke_core::convert::Convert;

--- a/artichoke-backend/src/extn/core/string/mod.rs
+++ b/artichoke-backend/src/extn/core/string/mod.rs
@@ -70,9 +70,7 @@ impl BoxUnboxVmValue for String {
             },
             encoding,
         );
-        let s = UnboxedValueGuard::new(s);
-
-        Ok(s)
+        Ok(UnboxedValueGuard::new(s))
     }
 
     fn alloc_value(value: Self::Unboxed, interp: &mut Artichoke) -> Result<Value, Error> {

--- a/artichoke-backend/src/extn/core/string/mod.rs
+++ b/artichoke-backend/src/extn/core/string/mod.rs
@@ -142,6 +142,7 @@ impl BoxUnboxVmValue for String {
         // `String` should not have a destructor registered in the class
         // registry.
         let _ = data;
+        unreachable!("<String as BoxUnboxVmValue>::free is never called");
     }
 }
 

--- a/artichoke-backend/src/extn/core/string/mod.rs
+++ b/artichoke-backend/src/extn/core/string/mod.rs
@@ -1,8 +1,7 @@
 #![allow(clippy::cast_possible_wrap)]
 
 use core::ops::Deref;
-use std::ffi::c_void;
-use std::os::raw::c_char;
+use std::ffi::{c_char, c_void};
 use std::ptr::NonNull;
 
 use artichoke_core::value::Value as _;

--- a/artichoke-backend/src/extn/core/string/mod.rs
+++ b/artichoke-backend/src/extn/core/string/mod.rs
@@ -194,4 +194,17 @@ mod tests {
         let result = interp.eval(test.as_bytes());
         unwrap_or_panic_with_backtrace(&mut interp, SUBJECT, result);
     }
+
+    #[test]
+    fn allocated_but_uninitialized_string_can_be_garbage_collected() {
+        let mut interp = interpreter();
+        let test = r"
+            1_000_000.times do
+              String.allocate
+            end
+        ";
+        let result = interp.eval(test.as_bytes());
+        unwrap_or_panic_with_backtrace(&mut interp, SUBJECT, result);
+        interp.full_gc().unwrap();
+    }
 }

--- a/artichoke-backend/src/extn/core/string/mod.rs
+++ b/artichoke-backend/src/extn/core/string/mod.rs
@@ -267,4 +267,36 @@ mod tests {
         let result = interp.eval(test.as_bytes());
         unwrap_or_panic_with_backtrace(&mut interp, SUBJECT, result);
     }
+
+    #[test]
+    #[should_panic = "String.allocate.encoding is not binary"]
+    fn freshly_allocated_string_has_binary_encoding() {
+        let mut interp = interpreter();
+        // ```console
+        // $ irb
+        // [3.3.6] > s = String.new
+        // => ""
+        // [3.3.6] > s.encoding == Encoding::BINARY
+        // => true
+        // [3.3.6] > s << "abc"
+        // => "abc"
+        // [3.3.6] > s.encoding == Encoding::UTF_8
+        // => false
+        // [3.3.6] > s.encoding
+        // => #<Encoding:ASCII-8BIT>
+        // [3.3.6] > s << "❤️"
+        // => "abc❤️"
+        // [3.3.6] > s.encoding == Encoding::UTF_8
+        // ```
+        let test = r#"
+            s = String.new
+            raise 'String.allocate.encoding is not binary' unless s.encoding == Encoding::BINARY
+            s << "abc"
+            raise 'String.allocate.encoding is not binary after appending ASCII' unless s.encoding == Encoding::BINARY
+            s << "❤️"
+            raise 'String.allocate.encoding is not UTF-8 after appending UTF-8' unless s.encoding == Encoding::UTF_8
+        "#;
+        let result = interp.eval(test.as_bytes());
+        unwrap_or_panic_with_backtrace(&mut interp, SUBJECT, result);
+    }
 }

--- a/artichoke-backend/src/extn/core/symbol/ffi.rs
+++ b/artichoke-backend/src/extn/core/symbol/ffi.rs
@@ -1,5 +1,4 @@
-use std::ffi::CStr;
-use std::os::raw::c_char;
+use std::ffi::{c_char, CStr};
 use std::ptr;
 use std::slice;
 

--- a/artichoke-backend/src/sys/protect.rs
+++ b/artichoke-backend/src/sys/protect.rs
@@ -1,6 +1,5 @@
-use std::ffi::c_void;
+use std::ffi::{c_char, c_void};
 use std::mem;
-use std::os::raw::c_char;
 use std::ptr::{self, NonNull};
 
 use crate::sys;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3,8 +3,7 @@
 //! The REPL needs to check if code is valid to determine whether it should
 //! enter multiline editing mode.
 
-use std::ffi::CStr;
-use std::os::raw::c_char;
+use std::ffi::{c_char, CStr};
 use std::ptr::NonNull;
 
 use crate::backend::sys;


### PR DESCRIPTION
In Ruby, objects are normally created by calling `<Class>.new`, but under the covers this does a Smalltalk-style sequence of calling:

```
instance = <Class>.allocate
instance.initialize
```

`Object::allocate` is directly callable by application code, and there are Ruby Specs which exercise this behavior. This permits a state where a `RArray*` and `RString*` objects are created and live on the GC heap but does not contain an underlying Rust `Vec` buffer.

This means, prior to this PR, the following defects existed:

- Null pointer dereference when freeing an allocated but uninitialized array
- Null pointer dereference when freeing an allocated but uninitialized string
- Null pointer dereference and invalid read when performing read-only operations on an allocated but uninitialized array
- Null pointer dereference and invalid read when performing read-only operations on an allocated but uninitialized string
- Null pointer dereference and invalid write when performing mutating operations on an allocated but uninitialized array
- Null pointer dereference and invalid write when performing mutating operations on an allocated but uninitialized array

These defects were discovered when upgrading to Rust 1.83.0 in #2767 which introduces pointer well-formedness debug assertions in debug builds.