### PR TITLE
Use `Bound::as_ref` when `impl RangeBounds<usize> for Region` in `MatchData`

### DIFF
--- a/artichoke-backend/src/extn/core/matchdata/mod.rs
+++ b/artichoke-backend/src/extn/core/matchdata/mod.rs
@@ -55,23 +55,11 @@ impl Region {
 
 impl RangeBounds<usize> for Region {
     fn start_bound(&self) -> Bound<&usize> {
-        // TODO: Use `self.start.as_ref()` when upstream `std` stabilizes:
-        // https://github.com/rust-lang/rust/issues/80996
-        match self.start {
-            Bound::Included(ref bound) => Bound::Included(bound),
-            Bound::Excluded(ref bound) => Bound::Excluded(bound),
-            Bound::Unbounded => Bound::Unbounded,
-        }
+        self.start.as_ref()
     }
 
     fn end_bound(&self) -> Bound<&usize> {
-        // TODO: Use `self.end.as_ref()` when upstream `std` stabilizes:
-        // https://github.com/rust-lang/rust/issues/80996
-        match self.end {
-            Bound::Included(ref bound) => Bound::Included(bound),
-            Bound::Excluded(ref bound) => Bound::Excluded(bound),
-            Bound::Unbounded => Bound::Unbounded,
-        }
+        self.end.as_ref()
     }
 }
 


### PR DESCRIPTION
I stabilized this API in Rust 1.65.0 in https://github.com/rust-lang/rust/pull/99736 but forgot to adopt it.