### PR TITLE
Properly handle calling `#initialize` on a frozen `String`

### DIFF
--- a/artichoke-backend/src/extn/core/string/mod.rs
+++ b/artichoke-backend/src/extn/core/string/mod.rs
@@ -297,4 +297,39 @@ mod tests {
         let result = interp.eval(test.as_bytes());
         unwrap_or_panic_with_backtrace(&mut interp, SUBJECT, result);
     }
+
+    #[test]
+    fn reinitializing_a_frozen_string_with_no_args_is_permitted() {
+        let mut interp = interpreter();
+        let test = r"
+            raise 'reinitializing empty frozen string failed' unless String.new.freeze.send(:initialize) == ''
+            raise 'reinitializing non-empty frozen string failed' unless String.new('hello').freeze.send(:initialize) == 'hello'
+        ";
+        let result = interp.eval(test.as_bytes());
+        unwrap_or_panic_with_backtrace(&mut interp, SUBJECT, result);
+    }
+
+    #[test]
+    fn reinitializing_a_frozen_string_with_args_raises_frozen_error() {
+        let mut interp = interpreter();
+        let test = r"
+            begin
+                String.new.freeze.send(:initialize, 'world')
+            rescue FrozenError
+                # expected
+            else
+                raise 'reinitializing frozen empty string with args did not raise FrozenError'
+            end
+
+            begin
+                String.new('hello').freeze.send(:initialize, 'world')
+            rescue FrozenError
+                # expected
+            else
+                raise 'reinitializing frozen non-empty string with args did not raise FrozenError'
+            end
+        ";
+        let result = interp.eval(test.as_bytes());
+        unwrap_or_panic_with_backtrace(&mut interp, SUBJECT, result);
+    }
 }

--- a/artichoke-backend/src/extn/core/string/trampoline.rs
+++ b/artichoke-backend/src/extn/core/string/trampoline.rs
@@ -1205,6 +1205,17 @@ pub fn index(
 }
 
 pub fn initialize(interp: &mut Artichoke, mut value: Value, from: Option<Value>) -> Result<Value, Error> {
+    if value.is_frozen(interp) && from.is_some() {
+        return Err(FrozenError::from("can't modify frozen String").into());
+    }
+    if from.is_none() {
+        // Calling `initialize` on an already initialized `String` with no arguments
+        // is a no-op. If the string is not yet initialized, we will subsequently
+        // initialize it when unpacking the `Value` in the `String::unbox_from_value`
+        // call.
+        return Ok(value);
+    };
+
     // We must convert `from` to a byte buffer first in case `#to_str` raises.
     //
     // If we don't, the following scenario could leave `value` with a dangling


### PR DESCRIPTION
It is only permissible to call `#initialize` with no args on an already initialized `String`, in which case it is a no-op.