### PR TITLE
Use inline const expressions where appropriate

### DIFF
--- a/artichoke-backend/src/extn/core/integer/mod.rs
+++ b/artichoke-backend/src/extn/core/integer/mod.rs
@@ -205,9 +205,7 @@ impl Integer {
 
     #[must_use]
     pub const fn size() -> usize {
-        const SIZE_OF_INT: usize = size_of::<i64>();
-
-        SIZE_OF_INT
+        const { size_of::<i64>() }
     }
 }
 

--- a/artichoke-backend/src/extn/core/integer/trampoline.rs
+++ b/artichoke-backend/src/extn/core/integer/trampoline.rs
@@ -47,6 +47,5 @@ pub fn is_nobits(interp: &mut Artichoke, value: Value, mask: Value) -> Result<Va
 #[allow(clippy::unnecessary_wraps)]
 pub fn size(interp: &Artichoke) -> Result<Value, Error> {
     qed::const_assert!(Integer::size() < i8::MAX as usize);
-    const SIZE: i64 = Integer::size() as i64;
-    Ok(interp.convert(SIZE))
+    Ok(interp.convert(const { Integer::size() as i64 }))
 }

--- a/scolapasta-string-escape/src/literal.rs
+++ b/scolapasta-string-escape/src/literal.rs
@@ -408,8 +408,7 @@ impl ByteSequenceTooLongError {
 
 impl fmt::Display for ByteSequenceTooLongError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        const MESSAGE: &str = ByteSequenceTooLongError::new().message();
-        f.write_str(MESSAGE)
+        f.write_str(const { ByteSequenceTooLongError::new().message() })
     }
 }
 

--- a/spinoso-string/src/chars.rs
+++ b/spinoso-string/src/chars.rs
@@ -40,6 +40,7 @@ impl FusedIterator for Chars<'_> {}
 impl Chars<'_> {
     pub(crate) fn new() -> Self {
         const EMPTY: &[u8] = &[];
+
         Self(State::Binary(Bytes::from(EMPTY)))
     }
 }


### PR DESCRIPTION
This eliminates some temporary constants and cleans up some simple functions