### PR TITLE
Fix memory leak in `Array#initialize`

### DIFF
--- a/artichoke-backend/tests/integration/leak.rs
+++ b/artichoke-backend/tests/integration/leak.rs
@@ -1,3 +1,4 @@
 mod arena_growth;
+mod array;
 mod boxing;
 mod funcall;

--- a/artichoke-backend/tests/integration/leak/array.rs
+++ b/artichoke-backend/tests/integration/leak/array.rs
@@ -1,0 +1,26 @@
+// These integration tests checks for memory leaks that stem from improper
+// handling of already initialized `Array`s when calling `Array#initialize`.
+//
+// Previously, existing buffers were not deallocated when calling `Array#initialize`
+// on an already initialized `Array` which led to a memory leak.
+
+use artichoke_backend::prelude::*;
+
+const ITERATIONS: usize = 25_000;
+
+#[test]
+fn initialize_already_initialized_array() {
+    let mut interp = artichoke_backend::interpreter().unwrap();
+
+    let code = format!(
+        "
+        a = []
+        {ITERATIONS}.times do
+          a.send(:initialize, 100_000)
+        end
+        "
+    );
+    interp.eval(code.as_bytes()).unwrap();
+
+    interp.close();
+}


### PR DESCRIPTION
Ruby allows calling `#initialize` on any object, including ones that are already initialized. Previously, the trampoline code for `Array` did not take this into account and did not try to drop an existing buffer if present. This caused a memory leak when the `Array` internals were then overwritten with an empty buffer.

This logic mirrors what already exists for `String`.