### PR TITLE
Remove stray printf debugging from MatchData#inspect

### DIFF
--- a/artichoke-backend/src/extn/core/matchdata/matchdata.rb
+++ b/artichoke-backend/src/extn/core/matchdata/matchdata.rb
@@ -17,7 +17,6 @@ class MatchData
   def inspect
     s = %(#<MatchData "#{self[0]}")
     if names.empty?
-      puts captures.inspect
       captures.each_with_index do |capture, index|
         s << %( #{index + 1}:"#{capture || nil.inspect}")
       end

--- a/artichoke-backend/src/extn/core/matchdata/matchdata_functional_test.rb
+++ b/artichoke-backend/src/extn/core/matchdata/matchdata_functional_test.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+def spec
+  setup
+
+  inspect_no_garbage
+
+  true
+end
+
+def setup
+  Kernel.alias_method :original_puts, :puts
+  Kernel.define_method(:puts) do |*args|
+    raise "puts called with #{args.inspect}"
+  end
+end
+
+def inspect_no_garbage
+  m = 'a'.match(/./)
+  raise 'MatchData#inspect does not contain garbage' unless m.inspect == '#<MatchData "a">'
+
+  m = 'a'.match(/(.)/)
+  raise 'MatchData#inspect does not contain garbage with capturing groups' unless m.inspect == '#<MatchData "a" 1:"a">'
+end
+
+spec if $PROGRAM_NAME == __FILE__

--- a/artichoke-backend/src/extn/core/matchdata/mod.rs
+++ b/artichoke-backend/src/extn/core/matchdata/mod.rs
@@ -351,3 +351,20 @@ impl MatchData {
         self.regexp.inner().capture0(haystack)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::test::prelude::*;
+
+    const SUBJECT: &str = "MatchData";
+    const FUNCTIONAL_TEST: &[u8] = include_bytes!("matchdata_functional_test.rb");
+
+    #[test]
+    fn functional() {
+        let mut interp = interpreter();
+        let result = interp.eval(FUNCTIONAL_TEST);
+        unwrap_or_panic_with_backtrace(&mut interp, SUBJECT, result);
+        let result = interp.eval(b"spec");
+        unwrap_or_panic_with_backtrace(&mut interp, SUBJECT, result);
+    }
+}


### PR DESCRIPTION
This erroneous call to `puts` has been in the code for more than five years (!) since `Regexp` was refactored to have multiple backends in PR #341 (see 19be33974dae0bd9381ee0e1a09c993f108e967e).