### PR TITLE
Add tests for `MatchData#inspect` happy path and fix bugs

### DIFF
--- a/artichoke-backend/src/extn/core/matchdata/matchdata.rb
+++ b/artichoke-backend/src/extn/core/matchdata/matchdata.rb
@@ -15,14 +15,29 @@ class MatchData
   end
 
   def inspect
-    s = %(#<MatchData "#{self[0]}")
+    # All interpolations below must call `#inspect` on the captures to ensure
+    # that the captures are formatted correctly if they contain binary content,
+    # control characters, such as a null byte, or legacy escape sequences.
+    #
+    # ```console
+    # [3.3.6] > m = "\0".match /(.)/
+    # => #<MatchData "\u0000" 1:"\u0000">
+    # => #<MatchData "\t" 1:"\t">
+    # [3.3.6] > m = "\e".match /(.)/
+    # => #<MatchData "\e" 1:"\e">
+    # [3.3.6] > m = "\xFF".b.match /(.)/
+    # => #<MatchData "\xFF" 1:"\xFF">
+    # ```
+    s = %(#<MatchData #{self[0].inspect})
+
     if names.empty?
       captures.each_with_index do |capture, index|
-        s << %( #{index + 1}:"#{capture || nil.inspect}")
+        s << %( #{index + 1}:#{capture.inspect})
       end
     else
       names.each do |name|
-        s << %( #{name}:#{self[name].inspect})
+        capture = self[name]
+        s << %( #{name}:#{capture.inspect})
       end
     end
     s << '>'

--- a/artichoke-backend/src/extn/core/matchdata/matchdata_functional_test.rb
+++ b/artichoke-backend/src/extn/core/matchdata/matchdata_functional_test.rb
@@ -4,6 +4,9 @@ def spec
   setup
 
   inspect_no_garbage
+  inspect_with_numbered_captures
+  inspect_with_named_captures
+  inspect_capture_control_character
 
   true
 end
@@ -15,12 +18,57 @@ def setup
   end
 end
 
+def expected_failure_due_to_implementation_gaps(expected_message)
+  yield
+rescue StandardError => e
+  raise e unless e.message == expected_message
+else
+  raise "Expected failure due to implementation gaps but did not get #{expected_message}"
+end
+
 def inspect_no_garbage
   m = 'a'.match(/./)
   raise 'MatchData#inspect does not contain garbage' unless m.inspect == '#<MatchData "a">'
 
   m = 'a'.match(/(.)/)
   raise 'MatchData#inspect does not contain garbage with capturing groups' unless m.inspect == '#<MatchData "a" 1:"a">'
+end
+
+def inspect_with_numbered_captures
+  m = 'a'.match(/(.)/)
+  raise 'MatchData#inspect with numbered captures' unless m.inspect == '#<MatchData "a" 1:"a">'
+
+  m = 'a'.match(/(.)(.)?/)
+  raise 'MatchData#inspect with numbered captures' unless m.inspect == '#<MatchData "a" 1:"a" 2:nil>'
+end
+
+def inspect_with_named_captures
+  m = 'a'.match(/(?<dot>.)/)
+  raise 'MatchData#inspect with named captures' unless m.inspect == '#<MatchData "a" dot:"a">'
+
+  m = 'a'.match(/(?<dot>.)(?<nope>.)?/)
+  raise 'MatchData#inspect with missing named captures' unless m.inspect == '#<MatchData "a" dot:"a" nope:nil>'
+end
+
+def inspect_capture_control_character
+  # FIXME: Artichoke does not properly format control characters in UTF-8 strings.
+  # Artichoke currently yields this string: #<MatchData "\x00" 1:"\x00">
+  expected_failure_due_to_implementation_gaps('MatchData#inspect with NUL character') do
+    m = "\0".match(/(.)/)
+    raise 'MatchData#inspect with NUL character' unless m.inspect == '#<MatchData "\u0000" 1:"\u0000">'
+  end
+
+  m = "\t".match(/(.)/)
+  raise 'MatchData#inspect with control character' unless m.inspect == '#<MatchData "\t" 1:"\t">'
+
+  m = "\e".match(/(.)/)
+  raise 'MatchData#inspect with control character' unless m.inspect == '#<MatchData "\e" 1:"\e">'
+
+  # FIXME: Artichoke does not yet use binary regexps on binary strings.
+  expected_failure_due_to_implementation_gaps('regex crate utf8 backend for Regexp only supports UTF-8 haystacks') do
+    m = "\xFF".b.match(/(.)/)
+    raise 'MatchData#inspect with invalid UTF-8' unless m.inspect == '#<MatchData "\xFF" 1:"\xFF">'
+  end
 end
 
 spec if $PROGRAM_NAME == __FILE__


### PR DESCRIPTION
The existing implementation was not calling `#inspect` on the matched string and captured groups, which led to improper rendering for strings with binary content, control characters, and legacy escape sequences.