### PR TITLE
Ensure frozen arrays cannot be initialized

### DIFF
--- a/artichoke-backend/src/extn/core/array/trampoline.rs
+++ b/artichoke-backend/src/extn/core/array/trampoline.rs
@@ -253,6 +253,9 @@ pub fn initialize(
     second: Option<Value>,
     block: Option<Block>,
 ) -> Result<Value, Error> {
+    if value.is_frozen(interp) {
+        return Err(FrozenError::with_message("can't modify frozen Array").into());
+    }
     // If we are calling `initialize` on an already initialized `Array`,
     // pluck out the inner buffer and drop it so we don't leak memory.
     if let Ok(a) = unsafe { Array::unbox_from_value(&mut value, interp) } {


### PR DESCRIPTION
An array can be frozen and have `#initialize` called on it in one of several ways:

- An allocated, but uninitialized `Array` is frozen and then initialized.
- An existing `Array` is frozen and then sent the `:initialize` message.

In both of these cases, we should fail with a `FrozenError`.