### PR TITLE
Remove cargo ecosystem from dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,23 +13,6 @@ updates:
       - lopopolo
     labels:
       - A-deps
-  - package-ecosystem: cargo
-    directories:
-      - "/"
-      - "/artichoke-*"
-      - "/mezzaluna-*"
-      - "/scolapasta-*"
-      - "/spinoso-*"
-    schedule:
-      interval: monthly
-    groups:
-      cargo-deps:
-        patterns:
-          - "*"
-    assignees:
-      - lopopolo
-    labels:
-      - A-deps
   - package-ecosystem: bundler
     directory: "/"
     schedule:


### PR DESCRIPTION
this repo is too complicated for dependabot and I get zero value from dependabot's PRs.