### PR TITLE
Set lower bound on libc to fix wasm32-unknown-emscripten builds on Rust 1.84.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,6 +52,7 @@ dependencies = [
  "bstr",
  "cc",
  "intaglio",
+ "libc",
  "mezzaluna-conversion-methods",
  "mezzaluna-type-registry",
  "onig",
@@ -389,9 +390,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.155"
+version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "libloading"

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -14,6 +14,15 @@ homepage.workspace = true
 documentation.workspace = true
 
 [dependencies]
+# aritchoke-backend requires at least libc@0.2.162 to compile on emscripten >=
+# 3.1.68 and Rust >= 1.84.0. This dependency constraint adds a lower bound on
+# an indirect dependency in `cc`.
+#
+# See:
+# - https://github.com/emscripten-core/emscripten/issues/22742
+# - https://github.com/rust-lang/libc/pull/4002
+# - https://github.com/rust-lang/rust/pull/131736
+libc = "0.2.162"
 posix-space = "1.0.0"
 qed = "1.3.0"
 regex = "1.7.0"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -44,6 +44,7 @@ dependencies = [
  "bstr",
  "cc",
  "intaglio",
+ "libc",
  "mezzaluna-conversion-methods",
  "mezzaluna-type-registry",
  "onig",
@@ -294,9 +295,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.155"
+version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "libfuzzer-sys"

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -60,6 +60,7 @@ dependencies = [
  "bstr",
  "cc",
  "intaglio",
+ "libc",
  "mezzaluna-conversion-methods",
  "mezzaluna-type-registry",
  "onig",
@@ -433,9 +434,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.155"
+version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "libloading"


### PR DESCRIPTION
`aritchoke-backend` requires at least libc@0.2.162 to compile on emscripten >= 3.1.68 and Rust >= 1.84.0. This dependency constraint adds a lower bound on an indirect dependency in `cc`.

See:
- https://github.com/emscripten-core/emscripten/issues/22742
- https://github.com/rust-lang/libc/pull/4002
- https://github.com/rust-lang/rust/pull/131736

Without this PR and the corresponding version bump in `Cargo.lock`, compiling the playground fails with:

```
  = note: error: undefined symbol: _emscripten_memcpy_js (referenced by root reference (e.g. compiled C/C++ code))
          warning: To disable errors for undefined symbols use `-sERROR_ON_UNDEFINED_SYMBOLS=0`
          warning: __emscripten_memcpy_js may need to be added to EXPORTED_FUNCTIONS if it arrives from a system library
          Error: Aborting compilation due to previous errors
          emcc: error: '/Users/lopopolo/dev/artichoke/playground/emsdk/node/20.18.0_64bit/bin/node /Users/lopopolo/dev/artichoke/playground/emsdk/upstream/emscripten/src/compiler.mjs /var/folders/mx/5h5721mn3dgdrdrwnlmz32vm0000gn/T/tmpme0071h9.json' failed (returned 1)
```