### PR TITLE
Remove dependency on `quickcheck`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
+
+[[package]]
 name = "artichoke"
 version = "0.1.0-pre.0"
 dependencies = [
@@ -302,7 +308,19 @@ checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.13.3+wasi-0.2.2",
+ "windows-targets",
 ]
 
 [[package]]
@@ -566,7 +584,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
 ]
 
 [[package]]
@@ -686,7 +704,8 @@ version = "0.5.1"
 name = "scolapasta-strbuf"
 version = "1.0.0"
 dependencies = [
- "quickcheck",
+ "arbitrary",
+ "getrandom 0.3.1",
  "raw-parts",
 ]
 
@@ -771,7 +790,7 @@ dependencies = [
 name = "spinoso-random"
 version = "0.4.0"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "libm",
  "rand",
  "rand_core",
@@ -947,6 +966,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasi"
+version = "0.13.3+wasi-0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1100,3 +1128,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+dependencies = [
+ "bitflags 2.6.0",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,7 +66,6 @@ dependencies = [
  "onig",
  "posix-space",
  "qed",
- "quickcheck",
  "regex",
  "rustc-hash",
  "scolapasta-aref",
@@ -554,15 +553,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf666b4ca1b0b9d8b24345b8fb64b54e7197b4b665f81bad3cc806935344eb23"
 
 [[package]]
-name = "quickcheck"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
-dependencies = [
- "rand",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -825,10 +815,11 @@ dependencies = [
 name = "spinoso-string"
 version = "0.25.0"
 dependencies = [
+ "arbitrary",
  "bstr",
  "bytecount",
  "focaccia",
- "quickcheck",
+ "getrandom 0.3.1",
  "scolapasta-strbuf",
  "scolapasta-string-escape",
  "simdutf8",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,11 +52,13 @@ dependencies = [
 name = "artichoke-backend"
 version = "0.24.1"
 dependencies = [
+ "arbitrary",
  "artichoke-core",
  "artichoke-load-path",
  "bindgen",
  "bstr",
  "cc",
+ "getrandom 0.3.1",
  "intaglio",
  "libc",
  "mezzaluna-conversion-methods",

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -138,10 +138,6 @@ features = ["tzrs"]
 arbitrary = "1.4.1"
 getrandom = "0.3.0"
 
-[dev-dependencies.quickcheck]
-version = "1.0.3"
-default-features = false
-
 [build-dependencies]
 
 [build-dependencies.bindgen]

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -135,6 +135,8 @@ default-features = false
 features = ["tzrs"]
 
 [dev-dependencies]
+arbitrary = "1.4.1"
+getrandom = "0.3.0"
 
 [dev-dependencies.quickcheck]
 version = "1.0.3"

--- a/artichoke-backend/src/convert/array.rs
+++ b/artichoke-backend/src/convert/array.rs
@@ -415,8 +415,6 @@ impl TryConvertMut<Value, Vec<i64>> for Artichoke {
 
 #[cfg(test)]
 mod tests {
-    use quickcheck::quickcheck;
-
     use crate::test::prelude::*;
 
     #[test]
@@ -428,138 +426,127 @@ mod tests {
         assert!(result.is_err());
     }
 
-    quickcheck! {
-        fn arr_int_borrowed(arr: Vec<i64>) -> bool {
-            let mut interp = interpreter();
+    #[test]
+    fn prop_arr_int_borrowed() {
+        let mut interp = interpreter();
+        run_arbitrary::<Vec<i64>>(|arr| {
             // Borrowed converter
-            let value = interp.try_convert_mut(arr.as_slice()).unwrap();
+            let value = interp.try_convert_mut(arr.clone()).unwrap();
             let len = value.funcall(&mut interp, "length", &[], None).unwrap();
             let len = len.try_convert_into::<usize>(&interp).unwrap();
-            if len != arr.len() {
-                return false;
-            }
+            assert_eq!(len, arr.len());
+
             let empty = value.funcall(&mut interp, "empty?", &[], None).unwrap();
             let empty = empty.try_convert_into::<bool>(&interp).unwrap();
-            if empty != arr.is_empty() {
-                return false;
-            }
+            assert_eq!(empty, arr.is_empty());
+
             let recovered: Vec<i64> = interp.try_convert_mut(value).unwrap();
-            if recovered != arr {
-                return false;
-            }
-            true
-        }
+            assert_eq!(recovered, arr);
+        });
+    }
 
-        fn arr_int_owned(arr: Vec<i64>) -> bool {
-            let mut interp = interpreter();
+    #[test]
+    fn prop_arr_int_owned() {
+        let mut interp = interpreter();
+        run_arbitrary::<Vec<i64>>(|arr| {
             // Owned converter
             let value = interp.try_convert_mut(arr.clone()).unwrap();
             let len = value.funcall(&mut interp, "length", &[], None).unwrap();
             let len = len.try_convert_into::<usize>(&interp).unwrap();
-            if len != arr.len() {
-                return false;
-            }
+            assert_eq!(len, arr.len());
+
             let empty = value.funcall(&mut interp, "empty?", &[], None).unwrap();
             let empty = empty.try_convert_into::<bool>(&interp).unwrap();
-            if empty != arr.is_empty() {
-                return false;
-            }
+            assert_eq!(empty, arr.is_empty());
+
             let recovered: Vec<i64> = interp.try_convert_mut(value).unwrap();
-            if recovered != arr {
-                return false;
-            }
-            true
-        }
+            assert_eq!(recovered, arr);
+        });
+    }
 
-        fn arr_utf8_borrowed(arr: Vec<String>) -> bool {
-            let mut interp = interpreter();
+    #[test]
+    fn prop_arr_utf8_borrowed() {
+        let mut interp = interpreter();
+        run_arbitrary::<Vec<String>>(|arr| {
             // Borrowed converter
             let value = interp.try_convert_mut(arr.as_slice()).unwrap();
             let len = value.funcall(&mut interp, "length", &[], None).unwrap();
             let len = len.try_convert_into::<usize>(&interp).unwrap();
-            if len != arr.len() {
-                return false;
-            }
+            assert_eq!(len, arr.len());
+
             let empty = value.funcall(&mut interp, "empty?", &[], None).unwrap();
             let empty = empty.try_convert_into::<bool>(&interp).unwrap();
-            if empty != arr.is_empty() {
-                return false;
-            }
-            let recovered: Vec<String> = interp.try_convert_mut(value).unwrap();
-            if recovered != arr {
-                return false;
-            }
-            true
-        }
+            assert_eq!(empty, arr.is_empty());
 
-        fn arr_utf8_owned(arr: Vec<String>) -> bool {
-            let mut interp = interpreter();
+            let recovered: Vec<String> = interp.try_convert_mut(value).unwrap();
+            assert_eq!(recovered, arr);
+        });
+    }
+
+    #[test]
+    fn prop_arr_utf8_owned() {
+        let mut interp = interpreter();
+        run_arbitrary::<Vec<String>>(|arr| {
             // Owned converter
             let value = interp.try_convert_mut(arr.clone()).unwrap();
             let len = value.funcall(&mut interp, "length", &[], None).unwrap();
             let len = len.try_convert_into::<usize>(&interp).unwrap();
-            if len != arr.len() {
-                return false;
-            }
+            assert_eq!(len, arr.len());
+
             let empty = value.funcall(&mut interp, "empty?", &[], None).unwrap();
             let empty = empty.try_convert_into::<bool>(&interp).unwrap();
-            if empty != arr.is_empty() {
-                return false;
-            }
-            let recovered: Vec<String> = interp.try_convert_mut(value).unwrap();
-            if recovered != arr {
-                return false;
-            }
-            true
-        }
+            assert_eq!(empty, arr.is_empty());
 
-        fn arr_nilable_bstr_borrowed(arr: Vec<Option<Vec<u8>>>) -> bool {
-            let mut interp = interpreter();
+            let recovered: Vec<String> = interp.try_convert_mut(value).unwrap();
+            assert_eq!(recovered, arr);
+        });
+    }
+
+    #[test]
+    fn prop_arr_nilable_bstr_borrowed() {
+        let mut interp = interpreter();
+        run_arbitrary::<Vec<Option<Vec<u8>>>>(|arr| {
             // Borrowed converter
             let value = interp.try_convert_mut(arr.as_slice()).unwrap();
             let len = value.funcall(&mut interp, "length", &[], None).unwrap();
             let len = len.try_convert_into::<usize>(&interp).unwrap();
-            if len != arr.len() {
-                return false;
-            }
+            assert_eq!(len, arr.len());
+
             let empty = value.funcall(&mut interp, "empty?", &[], None).unwrap();
             let empty = empty.try_convert_into::<bool>(&interp).unwrap();
-            if empty != arr.is_empty() {
-                return false;
-            }
-            let recovered: Vec<Option<Vec<u8>>> = interp.try_convert_mut(value).unwrap();
-            if recovered != arr {
-                return false;
-            }
-            true
-        }
+            assert_eq!(empty, arr.is_empty());
 
-        fn arr_nilable_bstr_owned(arr: Vec<Option<Vec<u8>>>) -> bool {
-            let mut interp = interpreter();
+            let recovered: Vec<Option<Vec<u8>>> = interp.try_convert_mut(value).unwrap();
+            assert_eq!(recovered, arr);
+        });
+    }
+
+    #[test]
+    fn prop_arr_nilable_bstr_owned() {
+        let mut interp = interpreter();
+        run_arbitrary::<Vec<Option<Vec<u8>>>>(|arr| {
             // Owned converter
             let value = interp.try_convert_mut(arr.clone()).unwrap();
             let len = value.funcall(&mut interp, "length", &[], None).unwrap();
             let len = len.try_convert_into::<usize>(&interp).unwrap();
-            if len != arr.len() {
-                return false;
-            }
+            assert_eq!(len, arr.len());
+
             let empty = value.funcall(&mut interp, "empty?", &[], None).unwrap();
             let empty = empty.try_convert_into::<bool>(&interp).unwrap();
-            if empty != arr.is_empty() {
-                return false;
-            }
-            let recovered: Vec<Option<Vec<u8>>> = interp.try_convert_mut(value).unwrap();
-            if recovered != arr {
-                return false;
-            }
-            true
-        }
+            assert_eq!(empty, arr.is_empty());
 
-        fn roundtrip_err(i: i64) -> bool {
-            let mut interp = interpreter();
+            let recovered: Vec<Option<Vec<u8>>> = interp.try_convert_mut(value).unwrap();
+            assert_eq!(recovered, arr);
+        });
+    }
+
+    #[test]
+    fn prop_roundtrip_err() {
+        let mut interp = interpreter();
+        run_arbitrary::<i64>(|i| {
             let value = interp.convert(i);
             let value = value.try_convert_into_mut::<Vec<Value>>(&mut interp);
-            value.is_err()
-        }
+            assert!(value.is_err());
+        });
     }
 }

--- a/artichoke-backend/src/convert/boolean.rs
+++ b/artichoke-backend/src/convert/boolean.rs
@@ -76,8 +76,8 @@ mod tests {
 
     #[test]
     fn prop_convert_to_bool() {
+        let interp = interpreter();
         for b in [true, false] {
-            let interp = interpreter();
             let value = interp.convert(b);
             assert_eq!(value.ruby_type(), Ruby::Bool);
         }
@@ -85,8 +85,8 @@ mod tests {
 
     #[test]
     fn prop_convert_to_nilable_bool() {
+        let interp = interpreter();
         for b in [Some(true), Some(false), None] {
-            let interp = interpreter();
             let value = interp.convert(b);
             if b.is_some() {
                 assert_eq!(value.ruby_type(), Ruby::Bool);
@@ -153,8 +153,8 @@ mod tests {
 
     #[test]
     fn prop_roundtrip() {
+        let interp = interpreter();
         for b in [true, false] {
-            let interp = interpreter();
             let value = interp.convert(b);
             let roundtrip: bool = value.try_convert_into(&interp).unwrap();
             assert_eq!(roundtrip, b);
@@ -163,8 +163,8 @@ mod tests {
 
     #[test]
     fn prop_nilable_roundtrip() {
+        let interp = interpreter();
         for b in [Some(true), Some(false), None] {
-            let interp = interpreter();
             let value = interp.convert(b);
             let roundtrip: Option<bool> = value.try_convert_into(&interp).unwrap();
             assert_eq!(roundtrip, b);
@@ -173,8 +173,8 @@ mod tests {
 
     #[test]
     fn prop_roundtrip_err() {
+        let interp = interpreter();
         run_arbitrary::<i64>(|i_val| {
-            let interp = interpreter();
             let value = interp.convert(i_val);
             let result: Result<bool, _> = value.try_convert_into(&interp);
             assert!(result.is_err());

--- a/artichoke-backend/src/convert/float.rs
+++ b/artichoke-backend/src/convert/float.rs
@@ -42,8 +42,8 @@ mod tests {
 
     #[test]
     fn prop_convert_to_float() {
+        let mut interp = interpreter();
         run_arbitrary::<f64>(|f| {
-            let mut interp = interpreter();
             let value = interp.convert_mut(f);
             assert_eq!(value.ruby_type(), Ruby::Float);
         });
@@ -51,8 +51,8 @@ mod tests {
 
     #[test]
     fn prop_float_with_value() {
+        let mut interp = interpreter();
         run_arbitrary::<f64>(|f| {
-            let mut interp = interpreter();
             let value = interp.convert_mut(f);
             let inner = value.inner();
             let cdouble = unsafe { sys::mrb_sys_float_to_cdouble(inner) };
@@ -74,8 +74,8 @@ mod tests {
 
     #[test]
     fn prop_roundtrip() {
+        let mut interp = interpreter();
         run_arbitrary::<f64>(|f| {
-            let mut interp = interpreter();
             let value = interp.convert_mut(f);
             let roundtrip_value = value.try_convert_into::<f64>(&interp).unwrap();
             if f.is_nan() {
@@ -96,8 +96,8 @@ mod tests {
 
     #[test]
     fn prop_roundtrip_err() {
+        let interp = interpreter();
         run_arbitrary::<bool>(|b| {
-            let interp = interpreter();
             let value = interp.convert(b);
             let result = value.try_convert_into::<f64>(&interp);
             assert!(result.is_err());

--- a/artichoke-backend/src/convert/float.rs
+++ b/artichoke-backend/src/convert/float.rs
@@ -29,29 +29,7 @@ impl TryConvert<Value, f64> for Artichoke {
 
 #[cfg(test)]
 mod tests {
-    use std::fmt::Debug;
-
-    use arbitrary::{Arbitrary, Unstructured};
-
     use crate::test::prelude::*;
-
-    /// Helper for property tests: repeatedly generate an arbitrary value of type `T`
-    /// from random bytes and then run the closure `f` on it.
-    fn run_arbitrary<T>(f: impl Fn(T))
-    where
-        T: for<'a> Arbitrary<'a> + Debug,
-    {
-        for _ in 0..4096 {
-            // Choose a random seed size up to 1024 bytes.
-            let size: usize = usize::try_from(getrandom::u32().unwrap() % 1024).unwrap();
-            let mut seed = vec![0; size];
-            getrandom::fill(&mut seed).unwrap();
-            let mut unstructured = Unstructured::new(&seed);
-            if let Ok(value) = T::arbitrary(&mut unstructured) {
-                f(value);
-            }
-        }
-    }
 
     #[test]
     fn fail_convert() {

--- a/artichoke-backend/src/convert/string.rs
+++ b/artichoke-backend/src/convert/string.rs
@@ -65,8 +65,6 @@ impl<'a> TryConvertMut<Value, &'a str> for Artichoke {
 
 #[cfg(test)]
 mod tests {
-    use quickcheck::quickcheck;
-
     use crate::test::prelude::*;
 
     #[test]
@@ -78,96 +76,112 @@ mod tests {
         assert!(result.is_err());
     }
 
-    quickcheck! {
-        fn convert_to_string(s: String) -> bool {
-            let mut interp = interpreter();
+    #[test]
+    fn prop_convert_to_string() {
+        let mut interp = interpreter();
+        run_arbitrary::<String>(|s| {
             let value = interp.try_convert_mut(s.clone()).unwrap();
             let string: Vec<u8> = interp.try_convert_mut(value).unwrap();
-            s.as_bytes() == string
-        }
+            assert_eq!(string, s.as_bytes());
+        });
+    }
 
-        fn string_with_value(s: String) -> bool {
-            let mut interp = interpreter();
+    #[test]
+    fn prop_string_with_value() {
+        let mut interp = interpreter();
+        run_arbitrary::<String>(|s| {
             let value = interp.try_convert_mut(s.clone()).unwrap();
-            value.to_s(&mut interp) == s.as_bytes()
-        }
+            assert_eq!(value.to_s(&mut interp), s.as_bytes());
+        });
+    }
 
-        #[cfg(feature = "core-regexp")]
-        fn utf8string_borrowed(string: String) -> bool {
-            let mut interp = interpreter();
+    #[test]
+    #[cfg(feature = "core-regexp")]
+    fn prop_utf8string_borrowed() {
+        let mut interp = interpreter();
+        run_arbitrary::<String>(|s| {
             // Borrowed converter
-            let value = interp.try_convert_mut(string.as_str()).unwrap();
+            let value = interp.try_convert_mut(s.as_str()).unwrap();
             let len = value
                 .funcall(&mut interp, "length", &[], None)
                 .and_then(|value| value.try_convert_into::<usize>(&interp))
                 .unwrap();
-            if len != string.chars().count() {
-                return false;
-            }
+            assert_eq!(len, s.chars().count());
+
             let zero = interp.convert(0);
             let first = value
                 .funcall(&mut interp, "[]", &[zero], None)
                 .and_then(|value| value.try_convert_into_mut::<Option<String>>(&mut interp))
                 .unwrap();
-            let mut iter = string.chars();
+            let mut iter = s.chars();
             if let Some(ch) = iter.next() {
-                if first != Some(ch.to_string()) {
-                    return false;
-                }
-            } else if first.is_some() {
-                return false;
+                assert_eq!(first, Some(ch.to_string()));
+            } else {
+                assert!(first.is_none());
             }
-            let recovered: String = interp.try_convert_mut(value).unwrap();
-            if recovered != string {
-                return false;
-            }
-            true
-        }
 
-        #[cfg(feature = "core-regexp")]
-        fn utf8string_owned(string: String) -> bool {
-            let mut interp = interpreter();
+            let recovered: String = interp.try_convert_mut(value).unwrap();
+            assert_eq!(recovered, s);
+        });
+    }
+
+    #[test]
+    #[cfg(feature = "core-regexp")]
+    fn prop_utf8string_owned() {
+        let mut interp = interpreter();
+        run_arbitrary::<String>(|s| {
             // Owned converter
-            let value = interp.try_convert_mut(string.clone()).unwrap();
+            let value = interp.try_convert_mut(s.clone()).unwrap();
             let len = value
                 .funcall(&mut interp, "length", &[], None)
                 .and_then(|value| value.try_convert_into::<usize>(&interp))
                 .unwrap();
-            if len != string.chars().count() {
-                return false;
-            }
+            assert_eq!(len, s.chars().count());
+
             let zero = interp.convert(0);
             let first = value
                 .funcall(&mut interp, "[]", &[zero], None)
                 .and_then(|value| value.try_convert_into_mut::<Option<String>>(&mut interp))
                 .unwrap();
-            let mut iter = string.chars();
+            let mut iter = s.chars();
             if let Some(ch) = iter.next() {
-                if first != Some(ch.to_string()) {
-                    return false;
-                }
-            } else if first.is_some() {
-                return false;
+                assert_eq!(first, Some(ch.to_string()));
+            } else {
+                assert!(first.is_none());
             }
+
             let recovered: String = interp.try_convert_mut(value).unwrap();
-            if recovered != string {
-                return false;
-            }
-            true
-        }
+            assert_eq!(recovered, s);
+        });
+    }
 
-        fn roundtrip(s: String) -> bool {
-            let mut interp = interpreter();
+    #[test]
+    fn prop_borrowed_roundtrip() {
+        let mut interp = interpreter();
+        run_arbitrary::<String>(|s| {
+            let value = interp.try_convert_mut(s.as_str()).unwrap();
+            let roundtrip = value.try_convert_into_mut::<String>(&mut interp).unwrap();
+            assert_eq!(roundtrip, s);
+        })
+    }
+
+    #[test]
+    fn prop_owned_roundtrip() {
+        let mut interp = interpreter();
+        run_arbitrary::<String>(|s| {
             let value = interp.try_convert_mut(s.clone()).unwrap();
-            let value = value.try_convert_into_mut::<String>(&mut interp).unwrap();
-            value == s
-        }
+            let roundtrip = value.try_convert_into_mut::<String>(&mut interp).unwrap();
+            assert_eq!(roundtrip, s);
+        })
+    }
 
-        fn roundtrip_err(b: bool) -> bool {
-            let mut interp = interpreter();
+    #[test]
+    fn prop_roundtrip_err() {
+        let mut interp = interpreter();
+        for b in [true, false] {
             let value = interp.convert(b);
             let result = value.try_convert_into_mut::<String>(&mut interp);
-            result.is_err()
+            assert!(result.is_err());
         }
     }
 }

--- a/artichoke-backend/src/convert/string.rs
+++ b/artichoke-backend/src/convert/string.rs
@@ -162,7 +162,7 @@ mod tests {
             let value = interp.try_convert_mut(s.as_str()).unwrap();
             let roundtrip = value.try_convert_into_mut::<String>(&mut interp).unwrap();
             assert_eq!(roundtrip, s);
-        })
+        });
     }
 
     #[test]
@@ -172,7 +172,7 @@ mod tests {
             let value = interp.try_convert_mut(s.clone()).unwrap();
             let roundtrip = value.try_convert_into_mut::<String>(&mut interp).unwrap();
             assert_eq!(roundtrip, s);
-        })
+        });
     }
 
     #[test]

--- a/artichoke-backend/src/extn/core/integer/mod.rs
+++ b/artichoke-backend/src/extn/core/integer/mod.rs
@@ -223,7 +223,10 @@ mod tests {
             }
             (x, 0) | (0, x) => {
                 let expr = format!("{x} / 0");
-                assert!(interp.eval(expr.as_bytes()).is_err(), "expected error for division by zero: {expr}");
+                assert!(
+                    interp.eval(expr.as_bytes()).is_err(),
+                    "expected error for division by zero: {expr}"
+                );
                 let expr = format!("0 / {x}");
                 let quotient = interp
                     .eval(expr.as_bytes())
@@ -254,7 +257,10 @@ mod tests {
             }
             (x, 0) | (0, x) => {
                 let expr = format!("{x}.send('/', 0)");
-                assert!(interp.eval(expr.as_bytes()).is_err(), "expected error for division by zero: {expr}");
+                assert!(
+                    interp.eval(expr.as_bytes()).is_err(),
+                    "expected error for division by zero: {expr}"
+                );
                 let expr = format!("0.send('/', {x})");
                 let quotient = interp
                     .eval(expr.as_bytes())
@@ -285,7 +291,10 @@ mod tests {
             }
             (x, 0) | (0, x) => {
                 let expr = format!("-{x} / 0");
-                assert!(interp.eval(expr.as_bytes()).is_err(), "expected error for division by zero: {expr}");
+                assert!(
+                    interp.eval(expr.as_bytes()).is_err(),
+                    "expected error for division by zero: {expr}"
+                );
                 let expr = format!("0 / -{x}");
                 let quotient = interp
                     .eval(expr.as_bytes())
@@ -321,7 +330,10 @@ mod tests {
             }
             (x, 0) | (0, x) => {
                 let expr = format!("-{x}.send('/', 0)");
-                assert!(interp.eval(expr.as_bytes()).is_err(), "expected error for division by zero: {expr}");
+                assert!(
+                    interp.eval(expr.as_bytes()).is_err(),
+                    "expected error for division by zero: {expr}"
+                );
                 let expr = format!("0.send('/', -{x})");
                 let quotient = interp
                     .eval(expr.as_bytes())

--- a/artichoke-backend/src/extn/core/integer/mod.rs
+++ b/artichoke-backend/src/extn/core/integer/mod.rs
@@ -223,7 +223,7 @@ mod tests {
             }
             (x, 0) | (0, x) => {
                 let expr = format!("{x} / 0");
-                assert!(!interp.eval(expr.as_bytes()).is_ok(), "expected error for division by zero: {expr}");
+                assert!(interp.eval(expr.as_bytes()).is_err(), "expected error for division by zero: {expr}");
                 let expr = format!("0 / {x}");
                 let quotient = interp
                     .eval(expr.as_bytes())
@@ -254,7 +254,7 @@ mod tests {
             }
             (x, 0) | (0, x) => {
                 let expr = format!("{x}.send('/', 0)");
-                assert!(!interp.eval(expr.as_bytes()).is_ok(), "expected error for division by zero: {expr}");
+                assert!(interp.eval(expr.as_bytes()).is_err(), "expected error for division by zero: {expr}");
                 let expr = format!("0.send('/', {x})");
                 let quotient = interp
                     .eval(expr.as_bytes())
@@ -285,7 +285,7 @@ mod tests {
             }
             (x, 0) | (0, x) => {
                 let expr = format!("-{x} / 0");
-                assert!(!interp.eval(expr.as_bytes()).is_ok(), "expected error for division by zero: {expr}");
+                assert!(interp.eval(expr.as_bytes()).is_err(), "expected error for division by zero: {expr}");
                 let expr = format!("0 / -{x}");
                 let quotient = interp
                     .eval(expr.as_bytes())
@@ -321,7 +321,7 @@ mod tests {
             }
             (x, 0) | (0, x) => {
                 let expr = format!("-{x}.send('/', 0)");
-                assert!(!interp.eval(expr.as_bytes()).is_ok(), "expected error for division by zero: {expr}");
+                assert!(interp.eval(expr.as_bytes()).is_err(), "expected error for division by zero: {expr}");
                 let expr = format!("0.send('/', -{x})");
                 let quotient = interp
                     .eval(expr.as_bytes())

--- a/artichoke-backend/src/extn/core/integer/mod.rs
+++ b/artichoke-backend/src/extn/core/integer/mod.rs
@@ -211,109 +211,179 @@ impl Integer {
 
 #[cfg(test)]
 mod tests {
-    use quickcheck::quickcheck;
+    use std::fmt::Debug;
 
+    use arbitrary::{Arbitrary, Unstructured};
+    use getrandom;
+
+    use crate::extn::prelude::*;
     use crate::test::prelude::*;
 
-    quickcheck! {
-        fn positive_integer_division_vm_opcode(x: u8, y: u8) -> bool {
-            let mut interp = interpreter();
-            match (x, y) {
-                (0, 0) => interp.eval(b"0 / 0").is_err(),
-                (x, 0) | (0, x) => {
-                    let expr = format!("{x} / 0").into_bytes();
-                    if interp.eval(expr.as_slice()).is_ok() {
-                        return false;
-                    }
-                    let expr = format!("0 / {x}").into_bytes();
-                    let quotient = interp.eval(expr.as_slice()).unwrap().try_convert_into::<i64>(&interp).unwrap();
-                    quotient == 0
-                }
-                (x, y) => {
-                    let expr = format!("{x} / {y}").into_bytes();
-                    let quotient = interp.eval(expr.as_slice()).unwrap().try_convert_into::<i64>(&interp).unwrap();
-                    let expected = i64::from(x) / i64::from(y);
-                    quotient == expected
-                }
+    /// Helper for property tests: repeatedly generate an arbitrary value of type `T`
+    /// from random bytes and then run the closure `f` on it.
+    fn run_arbitrary<T>(f: impl Fn(T))
+    where
+        T: for<'a> Arbitrary<'a> + Debug,
+    {
+        for _ in 0..4096 {
+            // Choose a random seed size up to 1024 bytes.
+            let size: usize = usize::try_from(getrandom::u32().unwrap() % 1024).unwrap();
+            let mut seed = vec![0; size];
+            getrandom::fill(&mut seed).unwrap();
+            let mut unstructured = Unstructured::new(&seed);
+            if let Ok(value) = T::arbitrary(&mut unstructured) {
+                f(value);
             }
         }
+    }
 
-        fn positive_integer_division_send(x: u8, y: u8) -> bool {
+    #[test]
+    fn positive_integer_division_vm_opcode() {
+        run_arbitrary::<(u8, u8)>(|(x, y)| {
             let mut interp = interpreter();
             match (x, y) {
-                (0, 0) => interp.eval(b"0.send('/', 0)").is_err(),
+                (0, 0) => {
+                    assert!(interp.eval(b"0 / 0").is_err());
+                }
                 (x, 0) | (0, x) => {
-                    let expr = format!("{x}.send('/', 0)").into_bytes();
-                    if interp.eval(expr.as_slice()).is_ok() {
-                        return false;
+                    let expr = format!("{x} / 0");
+                    if interp.eval(expr.as_bytes()).is_ok() {
+                        panic!("expected error for division by zero: {}", expr);
                     }
-                    let expr = format!("0.send('/', {x})").into_bytes();
-                    let quotient = interp.eval(expr.as_slice()).unwrap().try_convert_into::<i64>(&interp).unwrap();
-                    quotient == 0
+                    let expr = format!("0 / {x}");
+                    let quotient = interp
+                        .eval(expr.as_bytes())
+                        .unwrap()
+                        .try_convert_into::<i64>(&interp)
+                        .unwrap();
+                    assert_eq!(quotient, 0);
                 }
                 (x, y) => {
-                    let expr = format!("{x}.send('/', {y})").into_bytes();
-                    let quotient = interp.eval(expr.as_slice()).unwrap().try_convert_into::<i64>(&interp).unwrap();
+                    let expr = format!("{x} / {y}");
+                    let quotient = interp
+                        .eval(expr.as_bytes())
+                        .unwrap()
+                        .try_convert_into::<i64>(&interp)
+                        .unwrap();
                     let expected = i64::from(x) / i64::from(y);
-                    quotient == expected
+                    assert_eq!(quotient, expected);
                 }
             }
-        }
+        });
+    }
 
-        fn negative_integer_division_vm_opcode(x: u8, y: u8) -> bool {
+    #[test]
+    fn positive_integer_division_send() {
+        run_arbitrary::<(u8, u8)>(|(x, y)| {
             let mut interp = interpreter();
             match (x, y) {
-                (0, 0) => interp.eval(b"-0 / 0").is_err(),
+                (0, 0) => {
+                    assert!(interp.eval(b"0.send('/', 0)").is_err());
+                }
                 (x, 0) | (0, x) => {
-                    let expr = format!("-{x} / 0").into_bytes();
-                    if interp.eval(expr.as_slice()).is_ok() {
-                        return false;
+                    let expr = format!("{x}.send('/', 0)");
+                    if interp.eval(expr.as_bytes()).is_ok() {
+                        panic!("expected error for division by zero: {}", expr);
                     }
-                    let expr = format!("0 / -{x}").into_bytes();
-                    let quotient = interp.eval(expr.as_slice()).unwrap().try_convert_into::<i64>(&interp).unwrap();
-                    quotient == 0
+                    let expr = format!("0.send('/', {x})");
+                    let quotient = interp
+                        .eval(expr.as_bytes())
+                        .unwrap()
+                        .try_convert_into::<i64>(&interp)
+                        .unwrap();
+                    assert_eq!(quotient, 0);
                 }
                 (x, y) => {
-                    let expr = format!("-{x} / {y}").into_bytes();
-                    let quotient = interp.eval(expr.as_slice()).unwrap().try_convert_into::<i64>(&interp).unwrap();
+                    let expr = format!("{x}.send('/', {y})");
+                    let quotient = interp
+                        .eval(expr.as_bytes())
+                        .unwrap()
+                        .try_convert_into::<i64>(&interp)
+                        .unwrap();
+                    let expected = i64::from(x) / i64::from(y);
+                    assert_eq!(quotient, expected);
+                }
+            }
+        });
+    }
+
+    #[test]
+    fn negative_integer_division_vm_opcode() {
+        run_arbitrary::<(u8, u8)>(|(x, y)| {
+            let mut interp = interpreter();
+            match (x, y) {
+                (0, 0) => {
+                    assert!(interp.eval(b"-0 / 0").is_err());
+                }
+                (x, 0) | (0, x) => {
+                    let expr = format!("-{x} / 0");
+                    if interp.eval(expr.as_bytes()).is_ok() {
+                        panic!("expected error for division by zero: {}", expr);
+                    }
+                    let expr = format!("0 / -{x}");
+                    let quotient = interp
+                        .eval(expr.as_bytes())
+                        .unwrap()
+                        .try_convert_into::<i64>(&interp)
+                        .unwrap();
+                    assert_eq!(quotient, 0);
+                }
+                (x, y) => {
+                    let expr = format!("-{x} / {y}");
+                    let quotient = interp
+                        .eval(expr.as_bytes())
+                        .unwrap()
+                        .try_convert_into::<i64>(&interp)
+                        .unwrap();
                     if x % y == 0 {
                         let expected = -i64::from(x) / i64::from(y);
-                        quotient == expected
+                        assert_eq!(quotient, expected);
                     } else {
-                        // Round negative integer division toward negative infinity.
                         let expected = (-i64::from(x) / i64::from(y)) - 1;
-                        quotient == expected
+                        assert_eq!(quotient, expected);
                     }
                 }
             }
-        }
+        });
+    }
 
-        fn negative_integer_division_send(x: u8, y: u8) -> bool {
+    #[test]
+    fn negative_integer_division_send() {
+        run_arbitrary::<(u8, u8)>(|(x, y)| {
             let mut interp = interpreter();
             match (x, y) {
-                (0, 0) => interp.eval(b"-0.send('/', 0)").is_err(),
+                (0, 0) => {
+                    assert!(interp.eval(b"-0.send('/', 0)").is_err());
+                }
                 (x, 0) | (0, x) => {
-                    let expr = format!("-{x}.send('/', 0)").into_bytes();
-                    if interp.eval(expr.as_slice()).is_ok() {
-                        return false;
+                    let expr = format!("-{x}.send('/', 0)");
+                    if interp.eval(expr.as_bytes()).is_ok() {
+                        panic!("expected error for division by zero: {}", expr);
                     }
-                    let expr = format!("0.send('/', -{x})").into_bytes();
-                    let quotient = interp.eval(expr.as_slice()).unwrap().try_convert_into::<i64>(&interp).unwrap();
-                    quotient == 0
+                    let expr = format!("0.send('/', -{x})");
+                    let quotient = interp
+                        .eval(expr.as_bytes())
+                        .unwrap()
+                        .try_convert_into::<i64>(&interp)
+                        .unwrap();
+                    assert_eq!(quotient, 0);
                 }
                 (x, y) => {
-                    let expr = format!("-{x}.send('/', {y})").into_bytes();
-                    let quotient = interp.eval(expr.as_slice()).unwrap().try_convert_into::<i64>(&interp).unwrap();
+                    let expr = format!("-{x}.send('/', {y})");
+                    let quotient = interp
+                        .eval(expr.as_bytes())
+                        .unwrap()
+                        .try_convert_into::<i64>(&interp)
+                        .unwrap();
                     if x % y == 0 {
                         let expected = -i64::from(x) / i64::from(y);
-                        quotient == expected
+                        assert_eq!(quotient, expected);
                     } else {
-                        // Round negative integer division toward negative infinity.
                         let expected = (-i64::from(x) / i64::from(y)) - 1;
-                        quotient == expected
+                        assert_eq!(quotient, expected);
                     }
                 }
             }
-        }
+        });
     }
 }

--- a/artichoke-backend/src/extn/core/integer/mod.rs
+++ b/artichoke-backend/src/extn/core/integer/mod.rs
@@ -211,31 +211,8 @@ impl Integer {
 
 #[cfg(test)]
 mod tests {
-    use std::fmt::Debug;
-
-    use arbitrary::{Arbitrary, Unstructured};
-    use getrandom;
-
     use crate::extn::prelude::*;
     use crate::test::prelude::*;
-
-    /// Helper for property tests: repeatedly generate an arbitrary value of type `T`
-    /// from random bytes and then run the closure `f` on it.
-    fn run_arbitrary<T>(f: impl Fn(T))
-    where
-        T: for<'a> Arbitrary<'a> + Debug,
-    {
-        for _ in 0..4096 {
-            // Choose a random seed size up to 1024 bytes.
-            let size: usize = usize::try_from(getrandom::u32().unwrap() % 1024).unwrap();
-            let mut seed = vec![0; size];
-            getrandom::fill(&mut seed).unwrap();
-            let mut unstructured = Unstructured::new(&seed);
-            if let Ok(value) = T::arbitrary(&mut unstructured) {
-                f(value);
-            }
-        }
-    }
 
     #[test]
     fn positive_integer_division_vm_opcode() {

--- a/artichoke-backend/src/extn/core/integer/mod.rs
+++ b/artichoke-backend/src/extn/core/integer/mod.rs
@@ -223,9 +223,7 @@ mod tests {
             }
             (x, 0) | (0, x) => {
                 let expr = format!("{x} / 0");
-                if interp.eval(expr.as_bytes()).is_ok() {
-                    panic!("expected error for division by zero: {}", expr);
-                }
+                assert!(!interp.eval(expr.as_bytes()).is_ok(), "expected error for division by zero: {expr}");
                 let expr = format!("0 / {x}");
                 let quotient = interp
                     .eval(expr.as_bytes())
@@ -256,9 +254,7 @@ mod tests {
             }
             (x, 0) | (0, x) => {
                 let expr = format!("{x}.send('/', 0)");
-                if interp.eval(expr.as_bytes()).is_ok() {
-                    panic!("expected error for division by zero: {}", expr);
-                }
+                assert!(!interp.eval(expr.as_bytes()).is_ok(), "expected error for division by zero: {expr}");
                 let expr = format!("0.send('/', {x})");
                 let quotient = interp
                     .eval(expr.as_bytes())
@@ -289,9 +285,7 @@ mod tests {
             }
             (x, 0) | (0, x) => {
                 let expr = format!("-{x} / 0");
-                if interp.eval(expr.as_bytes()).is_ok() {
-                    panic!("expected error for division by zero: {}", expr);
-                }
+                assert!(!interp.eval(expr.as_bytes()).is_ok(), "expected error for division by zero: {expr}");
                 let expr = format!("0 / -{x}");
                 let quotient = interp
                     .eval(expr.as_bytes())
@@ -327,9 +321,7 @@ mod tests {
             }
             (x, 0) | (0, x) => {
                 let expr = format!("-{x}.send('/', 0)");
-                if interp.eval(expr.as_bytes()).is_ok() {
-                    panic!("expected error for division by zero: {}", expr);
-                }
+                assert!(!interp.eval(expr.as_bytes()).is_ok(), "expected error for division by zero: {expr}");
                 let expr = format!("0.send('/', -{x})");
                 let quotient = interp
                     .eval(expr.as_bytes())

--- a/artichoke-backend/src/extn/core/integer/mod.rs
+++ b/artichoke-backend/src/extn/core/integer/mod.rs
@@ -216,109 +216,103 @@ mod tests {
 
     #[test]
     fn positive_integer_division_vm_opcode() {
-        run_arbitrary::<(u8, u8)>(|(x, y)| {
-            let mut interp = interpreter();
-            match (x, y) {
-                (0, 0) => {
-                    assert!(interp.eval(b"0 / 0").is_err());
+        let mut interp = interpreter();
+        run_arbitrary::<(u8, u8)>(|(x, y)| match (x, y) {
+            (0, 0) => {
+                assert!(interp.eval(b"0 / 0").is_err());
+            }
+            (x, 0) | (0, x) => {
+                let expr = format!("{x} / 0");
+                if interp.eval(expr.as_bytes()).is_ok() {
+                    panic!("expected error for division by zero: {}", expr);
                 }
-                (x, 0) | (0, x) => {
-                    let expr = format!("{x} / 0");
-                    if interp.eval(expr.as_bytes()).is_ok() {
-                        panic!("expected error for division by zero: {}", expr);
-                    }
-                    let expr = format!("0 / {x}");
-                    let quotient = interp
-                        .eval(expr.as_bytes())
-                        .unwrap()
-                        .try_convert_into::<i64>(&interp)
-                        .unwrap();
-                    assert_eq!(quotient, 0);
-                }
-                (x, y) => {
-                    let expr = format!("{x} / {y}");
-                    let quotient = interp
-                        .eval(expr.as_bytes())
-                        .unwrap()
-                        .try_convert_into::<i64>(&interp)
-                        .unwrap();
-                    let expected = i64::from(x) / i64::from(y);
-                    assert_eq!(quotient, expected);
-                }
+                let expr = format!("0 / {x}");
+                let quotient = interp
+                    .eval(expr.as_bytes())
+                    .unwrap()
+                    .try_convert_into::<i64>(&interp)
+                    .unwrap();
+                assert_eq!(quotient, 0);
+            }
+            (x, y) => {
+                let expr = format!("{x} / {y}");
+                let quotient = interp
+                    .eval(expr.as_bytes())
+                    .unwrap()
+                    .try_convert_into::<i64>(&interp)
+                    .unwrap();
+                let expected = i64::from(x) / i64::from(y);
+                assert_eq!(quotient, expected);
             }
         });
     }
 
     #[test]
     fn positive_integer_division_send() {
-        run_arbitrary::<(u8, u8)>(|(x, y)| {
-            let mut interp = interpreter();
-            match (x, y) {
-                (0, 0) => {
-                    assert!(interp.eval(b"0.send('/', 0)").is_err());
+        let mut interp = interpreter();
+        run_arbitrary::<(u8, u8)>(|(x, y)| match (x, y) {
+            (0, 0) => {
+                assert!(interp.eval(b"0.send('/', 0)").is_err());
+            }
+            (x, 0) | (0, x) => {
+                let expr = format!("{x}.send('/', 0)");
+                if interp.eval(expr.as_bytes()).is_ok() {
+                    panic!("expected error for division by zero: {}", expr);
                 }
-                (x, 0) | (0, x) => {
-                    let expr = format!("{x}.send('/', 0)");
-                    if interp.eval(expr.as_bytes()).is_ok() {
-                        panic!("expected error for division by zero: {}", expr);
-                    }
-                    let expr = format!("0.send('/', {x})");
-                    let quotient = interp
-                        .eval(expr.as_bytes())
-                        .unwrap()
-                        .try_convert_into::<i64>(&interp)
-                        .unwrap();
-                    assert_eq!(quotient, 0);
-                }
-                (x, y) => {
-                    let expr = format!("{x}.send('/', {y})");
-                    let quotient = interp
-                        .eval(expr.as_bytes())
-                        .unwrap()
-                        .try_convert_into::<i64>(&interp)
-                        .unwrap();
-                    let expected = i64::from(x) / i64::from(y);
-                    assert_eq!(quotient, expected);
-                }
+                let expr = format!("0.send('/', {x})");
+                let quotient = interp
+                    .eval(expr.as_bytes())
+                    .unwrap()
+                    .try_convert_into::<i64>(&interp)
+                    .unwrap();
+                assert_eq!(quotient, 0);
+            }
+            (x, y) => {
+                let expr = format!("{x}.send('/', {y})");
+                let quotient = interp
+                    .eval(expr.as_bytes())
+                    .unwrap()
+                    .try_convert_into::<i64>(&interp)
+                    .unwrap();
+                let expected = i64::from(x) / i64::from(y);
+                assert_eq!(quotient, expected);
             }
         });
     }
 
     #[test]
     fn negative_integer_division_vm_opcode() {
-        run_arbitrary::<(u8, u8)>(|(x, y)| {
-            let mut interp = interpreter();
-            match (x, y) {
-                (0, 0) => {
-                    assert!(interp.eval(b"-0 / 0").is_err());
+        let mut interp = interpreter();
+        run_arbitrary::<(u8, u8)>(|(x, y)| match (x, y) {
+            (0, 0) => {
+                assert!(interp.eval(b"-0 / 0").is_err());
+            }
+            (x, 0) | (0, x) => {
+                let expr = format!("-{x} / 0");
+                if interp.eval(expr.as_bytes()).is_ok() {
+                    panic!("expected error for division by zero: {}", expr);
                 }
-                (x, 0) | (0, x) => {
-                    let expr = format!("-{x} / 0");
-                    if interp.eval(expr.as_bytes()).is_ok() {
-                        panic!("expected error for division by zero: {}", expr);
-                    }
-                    let expr = format!("0 / -{x}");
-                    let quotient = interp
-                        .eval(expr.as_bytes())
-                        .unwrap()
-                        .try_convert_into::<i64>(&interp)
-                        .unwrap();
-                    assert_eq!(quotient, 0);
-                }
-                (x, y) => {
-                    let expr = format!("-{x} / {y}");
-                    let quotient = interp
-                        .eval(expr.as_bytes())
-                        .unwrap()
-                        .try_convert_into::<i64>(&interp)
-                        .unwrap();
-                    if x % y == 0 {
-                        let expected = -i64::from(x) / i64::from(y);
-                        assert_eq!(quotient, expected);
-                    } else {
-                        let expected = (-i64::from(x) / i64::from(y)) - 1;
-                        assert_eq!(quotient, expected);
-                    }
+                let expr = format!("0 / -{x}");
+                let quotient = interp
+                    .eval(expr.as_bytes())
+                    .unwrap()
+                    .try_convert_into::<i64>(&interp)
+                    .unwrap();
+                assert_eq!(quotient, 0);
+            }
+            (x, y) => {
+                let expr = format!("-{x} / {y}");
+                let quotient = interp
+                    .eval(expr.as_bytes())
+                    .unwrap()
+                    .try_convert_into::<i64>(&interp)
+                    .unwrap();
+                if x % y == 0 {
+                    let expected = -i64::from(x) / i64::from(y);
+                    assert_eq!(quotient, expected);
+                } else {
+                    let expected = (-i64::from(x) / i64::from(y)) - 1;
+                    assert_eq!(quotient, expected);
                 }
             }
         });
@@ -326,39 +320,37 @@ mod tests {
 
     #[test]
     fn negative_integer_division_send() {
-        run_arbitrary::<(u8, u8)>(|(x, y)| {
-            let mut interp = interpreter();
-            match (x, y) {
-                (0, 0) => {
-                    assert!(interp.eval(b"-0.send('/', 0)").is_err());
+        let mut interp = interpreter();
+        run_arbitrary::<(u8, u8)>(|(x, y)| match (x, y) {
+            (0, 0) => {
+                assert!(interp.eval(b"-0.send('/', 0)").is_err());
+            }
+            (x, 0) | (0, x) => {
+                let expr = format!("-{x}.send('/', 0)");
+                if interp.eval(expr.as_bytes()).is_ok() {
+                    panic!("expected error for division by zero: {}", expr);
                 }
-                (x, 0) | (0, x) => {
-                    let expr = format!("-{x}.send('/', 0)");
-                    if interp.eval(expr.as_bytes()).is_ok() {
-                        panic!("expected error for division by zero: {}", expr);
-                    }
-                    let expr = format!("0.send('/', -{x})");
-                    let quotient = interp
-                        .eval(expr.as_bytes())
-                        .unwrap()
-                        .try_convert_into::<i64>(&interp)
-                        .unwrap();
-                    assert_eq!(quotient, 0);
-                }
-                (x, y) => {
-                    let expr = format!("-{x}.send('/', {y})");
-                    let quotient = interp
-                        .eval(expr.as_bytes())
-                        .unwrap()
-                        .try_convert_into::<i64>(&interp)
-                        .unwrap();
-                    if x % y == 0 {
-                        let expected = -i64::from(x) / i64::from(y);
-                        assert_eq!(quotient, expected);
-                    } else {
-                        let expected = (-i64::from(x) / i64::from(y)) - 1;
-                        assert_eq!(quotient, expected);
-                    }
+                let expr = format!("0.send('/', -{x})");
+                let quotient = interp
+                    .eval(expr.as_bytes())
+                    .unwrap()
+                    .try_convert_into::<i64>(&interp)
+                    .unwrap();
+                assert_eq!(quotient, 0);
+            }
+            (x, y) => {
+                let expr = format!("-{x}.send('/', {y})");
+                let quotient = interp
+                    .eval(expr.as_bytes())
+                    .unwrap()
+                    .try_convert_into::<i64>(&interp)
+                    .unwrap();
+                if x % y == 0 {
+                    let expected = -i64::from(x) / i64::from(y);
+                    assert_eq!(quotient, expected);
+                } else {
+                    let expected = (-i64::from(x) / i64::from(y)) - 1;
+                    assert_eq!(quotient, expected);
                 }
             }
         });

--- a/scolapasta-strbuf/Cargo.toml
+++ b/scolapasta-strbuf/Cargo.toml
@@ -19,10 +19,8 @@ documentation.workspace = true
 raw-parts = "2.0.0"
 
 [dev-dependencies]
-
-[dev-dependencies.quickcheck]
-version = "1.0.3"
-default-features = false
+arbitrary = "1.4.1"
+getrandom = "0.3.0"
 
 [features]
 default = ["std"]

--- a/scolapasta-strbuf/src/nul_terminated_vec.rs
+++ b/scolapasta-strbuf/src/nul_terminated_vec.rs
@@ -1283,13 +1283,13 @@ impl Write for Buf {
 }
 
 #[cfg(test)]
-#[allow(clippy::undocumented_unsafe_blocks)]
 mod tests {
     use alloc::vec::Vec;
 
     use super::Buf;
 
     #[must_use]
+    #[expect(clippy::undocumented_unsafe_blocks, reason = "Testing unsafe functions")]
     fn is_nul_terminated(bytes: &mut Vec<u8>) -> bool {
         let spare_capacity = bytes.spare_capacity_mut();
         if spare_capacity.is_empty() {
@@ -1394,6 +1394,7 @@ mod tests {
 }
 
 #[cfg(test)]
+#[expect(clippy::undocumented_unsafe_blocks, reason = "Testing unsafe functions")]
 mod proptests {
     use alloc::string::String;
     use alloc::vec;

--- a/scolapasta-strbuf/src/nul_terminated_vec.rs
+++ b/scolapasta-strbuf/src/nul_terminated_vec.rs
@@ -1398,25 +1398,31 @@ mod proptests {
     use alloc::string::String;
     use alloc::vec;
     use alloc::vec::Vec;
-    use core::fmt::Debug;
+    use core::fmt;
 
     use arbitrary::{Arbitrary, Unstructured};
     use raw_parts::RawParts;
 
     use super::{ensure_nul_terminated, Buf};
 
-    /// Helper for property tests: repeatedly generate an arbitrary value of type `T`
-    /// from random bytes and then run the closure `f` on it.
-    fn run_arbitrary<T>(f: impl Fn(T))
+    pub fn run_arbitrary<T>(mut f: impl FnMut(T))
     where
-        T: for<'a> Arbitrary<'a> + Debug,
+        T: for<'a> Arbitrary<'a> + fmt::Debug,
     {
-        for _ in 0..4096 {
-            // Choose a random seed size up to 1024 bytes.
-            let size: usize = usize::try_from(getrandom::u32().unwrap() % 1024).unwrap();
-            let mut seed = vec![0; size];
-            getrandom::fill(&mut seed).unwrap();
-            let mut unstructured = Unstructured::new(&seed);
+        fn get_unstructured(buf: &mut [u8]) -> Unstructured<'_> {
+            getrandom::fill(buf).unwrap();
+            Unstructured::new(buf)
+        }
+
+        let mut buf = vec![0; 2048];
+        let mut unstructured = get_unstructured(&mut buf);
+        for _ in 0..1024 {
+            if let Ok(value) = T::arbitrary(&mut unstructured) {
+                f(value);
+                continue;
+            }
+            // try reloading on randomness
+            unstructured = get_unstructured(&mut buf);
             if let Ok(value) = T::arbitrary(&mut unstructured) {
                 f(value);
             }

--- a/scolapasta-strbuf/src/nul_terminated_vec.rs
+++ b/scolapasta-strbuf/src/nul_terminated_vec.rs
@@ -1493,7 +1493,7 @@ mod proptests {
     #[test]
     fn prop_test_ensure_nul_terminated_from_iterator() {
         run_arbitrary::<Vec<u8>>(|bytes| {
-            let buf = Buf::from_iter(bytes.into_iter());
+            let buf = Buf::from_iter(bytes);
             let mut inner = buf.into_inner();
             assert!(is_nul_terminated(&mut inner));
         });
@@ -1512,7 +1512,7 @@ mod proptests {
     fn prop_test_ensure_nul_terminated_after_extend() {
         run_arbitrary::<(Vec<u8>, Vec<u8>)>(|(bytes, extension)| {
             let mut buf = Buf::from(bytes);
-            buf.extend(extension.into_iter());
+            buf.extend(extension);
             let mut inner = buf.into_inner();
             assert!(is_nul_terminated(&mut inner));
         });
@@ -1890,7 +1890,7 @@ mod proptests {
         run_arbitrary::<(Vec<u8>, String)>(|(bytes, data)| {
             use std::io::Write;
             let mut buf = Buf::from(bytes);
-            buf.write_fmt(format_args!("{}", data)).unwrap();
+            buf.write_fmt(format_args!("{data}")).unwrap();
             let mut inner = buf.into_inner();
             assert!(is_nul_terminated(&mut inner));
         });

--- a/scolapasta-strbuf/src/nul_terminated_vec.rs
+++ b/scolapasta-strbuf/src/nul_terminated_vec.rs
@@ -1285,13 +1285,9 @@ impl Write for Buf {
 #[cfg(test)]
 #[allow(clippy::undocumented_unsafe_blocks)]
 mod tests {
-    use alloc::string::String;
     use alloc::vec::Vec;
 
-    use quickcheck::quickcheck;
-    use raw_parts::RawParts;
-
-    use super::{ensure_nul_terminated, Buf};
+    use super::Buf;
 
     #[must_use]
     fn is_nul_terminated(bytes: &mut Vec<u8>) -> bool {
@@ -1395,357 +1391,502 @@ mod tests {
             assert!(is_nul_terminated(&mut bytes), "failed for capacity {capa}");
         }
     }
+}
 
-    quickcheck! {
-        fn test_ensure_nul_terminated(bytes: Vec<u8>) -> bool {
-            let mut bytes = bytes;
-            ensure_nul_terminated(&mut bytes).unwrap();
-            is_nul_terminated(&mut bytes)
+#[cfg(test)]
+mod proptests {
+    use alloc::string::String;
+    use alloc::vec;
+    use alloc::vec::Vec;
+    use core::fmt::Debug;
+
+    use arbitrary::{Arbitrary, Unstructured};
+    use raw_parts::RawParts;
+
+    use super::{ensure_nul_terminated, Buf};
+
+    /// Helper for property tests: repeatedly generate an arbitrary value of type `T`
+    /// from random bytes and then run the closure `f` on it.
+    fn run_arbitrary<T>(f: impl Fn(T))
+    where
+        T: for<'a> Arbitrary<'a> + Debug,
+    {
+        for _ in 0..4096 {
+            // Choose a random seed size up to 1024 bytes.
+            let size: usize = usize::try_from(getrandom::u32().unwrap() % 1024).unwrap();
+            let mut seed = vec![0; size];
+            getrandom::fill(&mut seed).unwrap();
+            let mut unstructured = Unstructured::new(&seed);
+            if let Ok(value) = T::arbitrary(&mut unstructured) {
+                f(value);
+            }
         }
+    }
 
-        fn test_ensure_nul_terminated_after_shrink(bytes: Vec<u8>) -> bool {
-            let mut bytes = bytes;
+    /// Returns whether the given vector’s spare capacity is nonempty and that both its
+    /// first and last bytes (of the spare capacity) are the NUL byte.
+    #[inline]
+    fn is_nul_terminated(vec: &mut Vec<u8>) -> bool {
+        let spare = vec.spare_capacity_mut();
+        if spare.is_empty() {
+            return false;
+        }
+        let first = unsafe { spare.first().unwrap().assume_init() };
+        if first != 0 {
+            return false;
+        }
+        let last = unsafe { spare.last().unwrap().assume_init() };
+        last == 0
+    }
+
+    #[test]
+    fn prop_test_ensure_nul_terminated() {
+        run_arbitrary::<Vec<u8>>(|mut bytes| {
+            ensure_nul_terminated(&mut bytes).unwrap();
+            assert!(is_nul_terminated(&mut bytes));
+        });
+    }
+
+    #[test]
+    fn prop_test_ensure_nul_terminated_after_shrink() {
+        run_arbitrary::<Vec<u8>>(|mut bytes| {
             bytes.shrink_to_fit();
             ensure_nul_terminated(&mut bytes).unwrap();
-            is_nul_terminated(&mut bytes)
-        }
+            assert!(is_nul_terminated(&mut bytes));
+        });
+    }
 
-        fn test_ensure_nul_terminated_from_vec(bytes: Vec<u8>) -> bool {
+    #[test]
+    fn prop_test_ensure_nul_terminated_from_vec() {
+        run_arbitrary::<Vec<u8>>(|bytes| {
             let buf = Buf::from(bytes);
-            let mut bytes = buf.into_inner();
-            is_nul_terminated(&mut bytes)
-        }
+            let mut inner = buf.into_inner();
+            assert!(is_nul_terminated(&mut inner));
+        });
+    }
 
-        fn test_ensure_nul_terminated_from_buf(bytes: Vec<u8>) -> bool {
+    #[test]
+    fn prop_test_ensure_nul_terminated_from_buf() {
+        run_arbitrary::<Vec<u8>>(|bytes| {
             let buf = Buf::from(bytes);
-            let mut bytes = Vec::from(buf);
-            is_nul_terminated(&mut bytes)
-        }
+            let mut inner: Vec<u8> = buf.into();
+            assert!(is_nul_terminated(&mut inner));
+        });
+    }
 
-        fn test_ensure_nul_terminated_after_clone(bytes: Vec<u8>) -> bool {
+    #[test]
+    fn prop_test_ensure_nul_terminated_after_clone() {
+        run_arbitrary::<Vec<u8>>(|bytes| {
             let buf = Buf::from(bytes);
-            #[allow(clippy::redundant_clone)]
-            let buf = buf.clone();
-            let mut bytes = buf.into_inner();
-            is_nul_terminated(&mut bytes)
-        }
+            let buf_clone = buf.clone();
+            let mut inner = buf_clone.into_inner();
+            assert!(is_nul_terminated(&mut inner));
+        });
+    }
 
-        fn test_ensure_nul_terminated_from_iterator(bytes: Vec<u8>) -> bool {
-            #[allow(clippy::from_iter_instead_of_collect)]
+    #[test]
+    fn prop_test_ensure_nul_terminated_from_iterator() {
+        run_arbitrary::<Vec<u8>>(|bytes| {
             let buf = Buf::from_iter(bytes.into_iter());
-            let mut bytes = buf.into_inner();
-            is_nul_terminated(&mut bytes)
-        }
+            let mut inner = buf.into_inner();
+            assert!(is_nul_terminated(&mut inner));
+        });
+    }
 
-        fn test_ensure_nul_terminated_collect(bytes: Vec<u8>) -> bool {
-            let buf = bytes.into_iter().collect::<Buf>();
-            let mut bytes = buf.into_inner();
-            is_nul_terminated(&mut bytes)
-        }
+    #[test]
+    fn prop_test_ensure_nul_terminated_collect() {
+        run_arbitrary::<Vec<u8>>(|bytes| {
+            let buf: Buf = bytes.into_iter().collect();
+            let mut inner = buf.into_inner();
+            assert!(is_nul_terminated(&mut inner));
+        });
+    }
 
-        fn test_ensure_nul_terminated_after_extend(bytes: Vec<u8>, extend: Vec<u8>) -> bool {
+    #[test]
+    fn prop_test_ensure_nul_terminated_after_extend() {
+        run_arbitrary::<(Vec<u8>, Vec<u8>)>(|(bytes, extension)| {
             let mut buf = Buf::from(bytes);
-            buf.extend(extend.into_iter());
-            let mut bytes = buf.into_inner();
-            is_nul_terminated(&mut bytes)
-        }
+            buf.extend(extension.into_iter());
+            let mut inner = buf.into_inner();
+            assert!(is_nul_terminated(&mut inner));
+        });
+    }
 
-        fn test_ensure_nul_terminated_from_raw_parts(bytes: Vec<u8>) -> bool {
+    #[test]
+    fn prop_test_ensure_nul_terminated_from_raw_parts() {
+        run_arbitrary::<Vec<u8>>(|bytes| {
             let raw_parts = RawParts::from_vec(bytes);
             let buf = unsafe { Buf::from_raw_parts(raw_parts) };
-            let mut bytes = buf.into_inner();
-            is_nul_terminated(&mut bytes)
-        }
+            let mut inner = buf.into_inner();
+            assert!(is_nul_terminated(&mut inner));
+        });
+    }
 
-        fn test_ensure_nul_terminated_raw_parts_round_trip(bytes: Vec<u8>) -> bool {
+    #[test]
+    fn prop_test_ensure_nul_terminated_raw_parts_round_trip() {
+        run_arbitrary::<Vec<u8>>(|bytes| {
             let buf = Buf::from(bytes);
             let raw_parts = buf.into_raw_parts();
             let buf = unsafe { Buf::from_raw_parts(raw_parts) };
-            let mut bytes = buf.into_inner();
-            is_nul_terminated(&mut bytes)
-        }
+            let mut inner = buf.into_inner();
+            assert!(is_nul_terminated(&mut inner));
+        });
+    }
 
-        fn test_ensure_nul_terminated_reserve(bytes: Vec<u8>) -> bool {
+    #[test]
+    fn prop_test_ensure_nul_terminated_reserve() {
+        run_arbitrary::<Vec<u8>>(|bytes| {
             let additional = [0_usize, 1, 2, 3, 4, 19, 280, 499, 1024, 4096, 4099];
             for reserve in additional {
                 let mut buf = Buf::from(bytes.clone());
                 buf.reserve(reserve);
-                let mut bytes = buf.into_inner();
-                if !is_nul_terminated(&mut bytes) {
-                    return false;
-                }
+                let mut inner = buf.into_inner();
+                assert!(is_nul_terminated(&mut inner));
             }
-            true
-        }
+        });
+    }
 
-        fn test_ensure_nul_terminated_reserve_exact(bytes: Vec<u8>) -> bool {
+    #[test]
+    fn prop_test_ensure_nul_terminated_reserve_exact() {
+        run_arbitrary::<Vec<u8>>(|bytes| {
             let additional = [0_usize, 1, 2, 3, 4, 19, 280, 499, 1024, 4096, 4099];
             for reserve in additional {
                 let mut buf = Buf::from(bytes.clone());
                 buf.reserve_exact(reserve);
-                let mut bytes = buf.into_inner();
-                if !is_nul_terminated(&mut bytes) {
-                    return false;
-                }
+                let mut inner = buf.into_inner();
+                assert!(is_nul_terminated(&mut inner));
             }
-            true
-        }
+        });
+    }
 
-        fn test_ensure_nul_terminated_try_reserve(bytes: Vec<u8>) -> bool {
+    #[test]
+    fn prop_test_ensure_nul_terminated_try_reserve() {
+        run_arbitrary::<Vec<u8>>(|bytes| {
             let additional = [0_usize, 1, 2, 3, 4, 19, 280, 499, 1024, 4096, 4099];
             for reserve in additional {
                 let mut buf = Buf::from(bytes.clone());
                 buf.try_reserve(reserve).unwrap();
-                let mut bytes = buf.into_inner();
-                if !is_nul_terminated(&mut bytes) {
-                    return false;
-                }
+                let mut inner = buf.into_inner();
+                assert!(is_nul_terminated(&mut inner));
             }
-            true
-        }
+        });
+    }
 
-        fn test_ensure_nul_terminated_try_reserve_exact(bytes: Vec<u8>) -> bool {
+    #[test]
+    fn prop_test_ensure_nul_terminated_try_reserve_exact() {
+        run_arbitrary::<Vec<u8>>(|bytes| {
             let additional = [0_usize, 1, 2, 3, 4, 19, 280, 499, 1024, 4096, 4099];
             for reserve in additional {
                 let mut buf = Buf::from(bytes.clone());
                 buf.try_reserve_exact(reserve).unwrap();
-                let mut bytes = buf.into_inner();
-                if !is_nul_terminated(&mut bytes) {
-                    return false;
-                }
+                let mut inner = buf.into_inner();
+                assert!(is_nul_terminated(&mut inner));
             }
-            true
-        }
+        });
+    }
 
-        fn test_ensure_nul_terminated_shrink_to_fit(bytes: Vec<u8>) -> bool {
+    #[test]
+    fn prop_test_ensure_nul_terminated_shrink_to_fit() {
+        run_arbitrary::<Vec<u8>>(|bytes| {
             let mut buf = Buf::from(bytes);
             buf.shrink_to_fit();
-            let mut bytes = buf.into_inner();
-            is_nul_terminated(&mut bytes)
-        }
+            let mut inner = buf.into_inner();
+            assert!(is_nul_terminated(&mut inner));
+        });
+    }
 
-        fn test_ensure_nul_terminated_shrink_to(bytes: Vec<u8>, shrink_to: usize) -> bool {
+    #[test]
+    fn prop_test_ensure_nul_terminated_shrink_to() {
+        run_arbitrary::<(Vec<u8>, usize)>(|(bytes, shrink_to)| {
             let mut buf = Buf::from(bytes);
             buf.shrink_to(shrink_to);
-            let mut bytes = buf.into_inner();
-            is_nul_terminated(&mut bytes)
-        }
+            let mut inner = buf.into_inner();
+            assert!(is_nul_terminated(&mut inner));
+        });
+    }
 
-        fn test_ensure_nul_terminated_truncate(bytes: Vec<u8>, truncate_to: usize) -> bool {
+    #[test]
+    fn prop_test_ensure_nul_terminated_truncate() {
+        run_arbitrary::<(Vec<u8>, usize)>(|(bytes, truncate_to)| {
             let mut buf = Buf::from(bytes);
             buf.truncate(truncate_to);
-            let mut bytes = buf.into_inner();
-            is_nul_terminated(&mut bytes)
-        }
+            let mut inner = buf.into_inner();
+            assert!(is_nul_terminated(&mut inner));
+        });
+    }
 
-        fn test_ensure_nul_terminated_set_len(bytes: Vec<u8>) -> bool {
+    #[test]
+    fn prop_test_ensure_nul_terminated_set_len() {
+        run_arbitrary::<Vec<u8>>(|bytes| {
             let mut buf = Buf::from(bytes);
             unsafe {
                 buf.set_len(0);
             }
-            let mut bytes = buf.into_inner();
-            is_nul_terminated(&mut bytes)
-        }
+            let mut inner = buf.into_inner();
+            assert!(is_nul_terminated(&mut inner));
+        });
+    }
 
-        fn test_ensure_nul_terminated_insert_first(bytes: Vec<u8>) -> bool {
+    #[test]
+    fn prop_test_ensure_nul_terminated_insert_first() {
+        run_arbitrary::<Vec<u8>>(|bytes| {
             if bytes.is_empty() {
-                return true;
+                return;
             }
             let mut buf = Buf::from(bytes);
             buf.insert(0, u8::MAX);
-            let mut bytes = buf.into_inner();
-            is_nul_terminated(&mut bytes)
-        }
+            let mut inner = buf.into_inner();
+            assert!(is_nul_terminated(&mut inner));
+        });
+    }
 
-        fn test_ensure_nul_terminated_insert_past_end(bytes: Vec<u8>) -> bool {
+    #[test]
+    fn prop_test_ensure_nul_terminated_insert_past_end() {
+        run_arbitrary::<Vec<u8>>(|bytes| {
             let mut buf = Buf::from(bytes);
             buf.insert(buf.len(), u8::MAX);
-            let mut bytes = buf.into_inner();
-            is_nul_terminated(&mut bytes)
-        }
+            let mut inner = buf.into_inner();
+            assert!(is_nul_terminated(&mut inner));
+        });
+    }
 
-        fn test_ensure_nul_terminated_insert_last(bytes: Vec<u8>) -> bool {
+    #[test]
+    fn prop_test_ensure_nul_terminated_insert_last() {
+        run_arbitrary::<Vec<u8>>(|bytes| {
             if bytes.is_empty() {
-                return true;
+                return;
             }
             let mut buf = Buf::from(bytes);
             buf.insert(buf.len() - 1, u8::MAX);
-            let mut bytes = buf.into_inner();
-            is_nul_terminated(&mut bytes)
-        }
+            let mut inner = buf.into_inner();
+            assert!(is_nul_terminated(&mut inner));
+        });
+    }
 
-        fn test_ensure_nul_terminated_insert_interior(bytes: Vec<u8>) -> bool {
+    #[test]
+    fn prop_test_ensure_nul_terminated_insert_interior() {
+        run_arbitrary::<Vec<u8>>(|bytes| {
             if bytes.len() < 2 {
-                return true;
+                return;
             }
             let mut buf = Buf::from(bytes);
             buf.insert(buf.len() - 2, u8::MAX);
-            let mut bytes = buf.into_inner();
-            is_nul_terminated(&mut bytes)
-        }
+            let mut inner = buf.into_inner();
+            assert!(is_nul_terminated(&mut inner));
+        });
+    }
 
-        fn test_ensure_nul_terminated_remove_first(bytes: Vec<u8>) -> bool {
+    #[test]
+    fn prop_test_ensure_nul_terminated_remove_first() {
+        run_arbitrary::<Vec<u8>>(|bytes| {
             if bytes.is_empty() {
-                return true;
+                return;
             }
             let mut buf = Buf::from(bytes);
             buf.remove(0);
-            let mut bytes = buf.into_inner();
-            is_nul_terminated(&mut bytes)
-        }
+            let mut inner = buf.into_inner();
+            assert!(is_nul_terminated(&mut inner));
+        });
+    }
 
-        fn test_ensure_nul_terminated_remove_last(bytes: Vec<u8>) -> bool {
+    #[test]
+    fn prop_test_ensure_nul_terminated_remove_last() {
+        run_arbitrary::<Vec<u8>>(|bytes| {
             if bytes.is_empty() {
-                return true;
+                return;
             }
             let mut buf = Buf::from(bytes);
             buf.remove(buf.len() - 1);
-            let mut bytes = buf.into_inner();
-            is_nul_terminated(&mut bytes)
-        }
+            let mut inner = buf.into_inner();
+            assert!(is_nul_terminated(&mut inner));
+        });
+    }
 
-        fn test_ensure_nul_terminated_remove_interior(bytes: Vec<u8>) -> bool {
+    #[test]
+    fn prop_test_ensure_nul_terminated_remove_interior() {
+        run_arbitrary::<Vec<u8>>(|bytes| {
             if bytes.len() < 2 {
-                return true;
+                return;
             }
             let mut buf = Buf::from(bytes);
             buf.remove(buf.len() - 2);
-            let mut bytes = buf.into_inner();
-            is_nul_terminated(&mut bytes)
-        }
+            let mut inner = buf.into_inner();
+            assert!(is_nul_terminated(&mut inner));
+        });
+    }
 
-        fn test_ensure_nul_terminated_retain_all(bytes: Vec<u8>) -> bool {
+    #[test]
+    fn prop_test_ensure_nul_terminated_retain_all() {
+        run_arbitrary::<Vec<u8>>(|bytes| {
             let mut buf = Buf::from(bytes);
             buf.retain(|_| true);
-            let mut bytes = buf.into_inner();
-            is_nul_terminated(&mut bytes)
-        }
+            let mut inner = buf.into_inner();
+            assert!(is_nul_terminated(&mut inner));
+        });
+    }
 
-        fn test_ensure_nul_terminated_retain_none(bytes: Vec<u8>) -> bool {
+    #[test]
+    fn prop_test_ensure_nul_terminated_retain_none() {
+        run_arbitrary::<Vec<u8>>(|bytes| {
             let mut buf = Buf::from(bytes);
             buf.retain(|_| false);
-            let mut bytes = buf.into_inner();
-            is_nul_terminated(&mut bytes)
-        }
+            let mut inner = buf.into_inner();
+            assert!(is_nul_terminated(&mut inner));
+        });
+    }
 
-        fn test_ensure_nul_terminated_retain_some(bytes: Vec<u8>) -> bool {
-            let mut idx = 0_usize;
+    #[test]
+    fn prop_test_ensure_nul_terminated_retain_some() {
+        run_arbitrary::<Vec<u8>>(|bytes| {
+            let mut idx = 0;
             let mut buf = Buf::from(bytes);
             buf.retain(|_| {
                 idx += 1;
                 idx % 2 == 0
             });
-            let mut bytes = buf.into_inner();
-            is_nul_terminated(&mut bytes)
-        }
+            let mut inner = buf.into_inner();
+            assert!(is_nul_terminated(&mut inner));
+        });
+    }
 
-        fn test_ensure_nul_terminated_pop(bytes: Vec<u8>) -> bool {
+    #[test]
+    fn prop_test_ensure_nul_terminated_pop() {
+        run_arbitrary::<Vec<u8>>(|bytes| {
             if bytes.is_empty() {
-                return true;
+                return;
             }
             let mut buf = Buf::from(bytes);
             buf.pop_byte();
-            let mut bytes = buf.into_inner();
-            is_nul_terminated(&mut bytes)
-        }
+            let mut inner = buf.into_inner();
+            assert!(is_nul_terminated(&mut inner));
+        });
+    }
 
-        fn test_ensure_nul_terminated_clear(bytes: Vec<u8>) -> bool {
+    #[test]
+    fn prop_test_ensure_nul_terminated_clear() {
+        run_arbitrary::<Vec<u8>>(|bytes| {
             let mut buf = Buf::from(bytes);
             buf.clear();
-            let mut bytes = buf.into_inner();
-            is_nul_terminated(&mut bytes)
-        }
+            let mut inner = buf.into_inner();
+            assert!(is_nul_terminated(&mut inner));
+        });
+    }
 
-        fn test_ensure_nul_terminated_resize(bytes: Vec<u8>) -> bool {
+    #[test]
+    fn prop_test_ensure_nul_terminated_resize() {
+        run_arbitrary::<Vec<u8>>(|bytes| {
             let lengths = [0_usize, 1, 2, 3, 4, 19, 280, 499, 1024, 4096, 4099];
             for len in lengths {
                 let mut buf = Buf::from(bytes.clone());
                 buf.resize(len, u8::MAX);
-                let mut bytes = buf.into_inner();
-                if !is_nul_terminated(&mut bytes) {
-                    return false;
-                }
+                let mut inner = buf.into_inner();
+                assert!(is_nul_terminated(&mut inner));
             }
-            true
-        }
+        });
+    }
 
-        fn test_ensure_nul_terminated_extend_from_slice(bytes: Vec<u8>, other: Vec<u8>) -> bool {
+    #[test]
+    fn prop_test_ensure_nul_terminated_extend_from_slice() {
+        run_arbitrary::<(Vec<u8>, Vec<u8>)>(|(bytes, other)| {
             let mut buf = Buf::from(bytes);
             buf.extend_from_slice(&other);
-            let mut bytes = buf.into_inner();
-            is_nul_terminated(&mut bytes)
-        }
+            let mut inner = buf.into_inner();
+            assert!(is_nul_terminated(&mut inner));
+        });
+    }
 
-        fn test_ensure_nul_terminated_push_byte(bytes: Vec<u8>, pushed: u8) -> bool {
+    #[test]
+    fn prop_test_ensure_nul_terminated_push_byte() {
+        run_arbitrary::<(Vec<u8>, u8)>(|(bytes, pushed)| {
             let mut buf = Buf::from(bytes);
             buf.push_byte(pushed);
-            let mut bytes = buf.into_inner();
-            is_nul_terminated(&mut bytes)
-        }
+            let mut inner = buf.into_inner();
+            assert!(is_nul_terminated(&mut inner));
+        });
+    }
 
-        fn test_ensure_nul_terminated_push_char(bytes: Vec<u8>, pushed: char) -> bool {
+    #[test]
+    fn prop_test_ensure_nul_terminated_push_char() {
+        run_arbitrary::<(Vec<u8>, char)>(|(bytes, pushed)| {
             let mut buf = Buf::from(bytes);
             buf.push_char(pushed);
-            let mut bytes = buf.into_inner();
-            is_nul_terminated(&mut bytes)
-        }
+            let mut inner = buf.into_inner();
+            assert!(is_nul_terminated(&mut inner));
+        });
+    }
 
-        fn test_ensure_nul_terminated_push_str(bytes: Vec<u8>, pushed: String) -> bool {
+    #[test]
+    fn prop_test_ensure_nul_terminated_push_str() {
+        run_arbitrary::<(Vec<u8>, String)>(|(bytes, pushed)| {
             let mut buf = Buf::from(bytes);
             buf.push_str(pushed);
-            let mut bytes = buf.into_inner();
-            is_nul_terminated(&mut bytes)
-        }
+            let mut inner = buf.into_inner();
+            assert!(is_nul_terminated(&mut inner));
+        });
+    }
 
-        #[cfg(feature = "std")]
-        fn test_ensure_nul_terminated_write(bytes: Vec<u8>, data: Vec<u8>) -> bool {
+    // std::io-related tests (enabled only with the "std" feature)
+
+    #[test]
+    #[cfg(feature = "std")]
+    fn prop_test_ensure_nul_terminated_write() {
+        run_arbitrary::<(Vec<u8>, Vec<u8>)>(|(bytes, data)| {
             use std::io::Write;
-
             let mut buf = Buf::from(bytes);
             let _written = buf.write(&data).unwrap();
-            let mut bytes = buf.into_inner();
-            is_nul_terminated(&mut bytes)
-        }
+            let mut inner = buf.into_inner();
+            assert!(is_nul_terminated(&mut inner));
+        });
+    }
 
-        #[cfg(feature = "std")]
-        fn test_ensure_nul_terminated_flush(bytes: Vec<u8>, data: Vec<u8>) -> bool {
+    #[test]
+    #[cfg(feature = "std")]
+    fn prop_test_ensure_nul_terminated_flush() {
+        run_arbitrary::<(Vec<u8>, Vec<u8>)>(|(bytes, data)| {
             use std::io::Write;
-
             let mut buf = Buf::from(bytes);
             buf.write_all(&data).unwrap();
             buf.flush().unwrap();
-            let mut bytes = buf.into_inner();
-            is_nul_terminated(&mut bytes)
-        }
+            let mut inner = buf.into_inner();
+            assert!(is_nul_terminated(&mut inner));
+        });
+    }
 
-        #[cfg(feature = "std")]
-        fn test_ensure_nul_terminated_write_vectored(bytes: Vec<u8>, data1: Vec<u8>, data2: Vec<u8>) -> bool {
+    #[test]
+    #[cfg(feature = "std")]
+    fn prop_test_ensure_nul_terminated_write_vectored() {
+        run_arbitrary::<(Vec<u8>, Vec<u8>, Vec<u8>)>(|(bytes, data1, data2)| {
             use std::io::{IoSlice, Write};
-
             let mut buf = Buf::from(bytes);
-            let _written = buf.write_vectored(&[IoSlice::new(&data1), IoSlice::new(&data2)]).unwrap();
-            let mut bytes = buf.into_inner();
-            is_nul_terminated(&mut bytes)
-        }
+            let _written = buf
+                .write_vectored(&[IoSlice::new(&data1), IoSlice::new(&data2)])
+                .unwrap();
+            let mut inner = buf.into_inner();
+            assert!(is_nul_terminated(&mut inner));
+        });
+    }
 
-        #[cfg(feature = "std")]
-        fn test_ensure_nul_terminated_write_all(bytes: Vec<u8>, data: Vec<u8>) -> bool {
+    #[test]
+    #[cfg(feature = "std")]
+    fn prop_test_ensure_nul_terminated_write_all() {
+        run_arbitrary::<(Vec<u8>, Vec<u8>)>(|(bytes, data)| {
             use std::io::Write;
-
             let mut buf = Buf::from(bytes);
             buf.write_all(&data).unwrap();
-            let mut bytes = buf.into_inner();
-            is_nul_terminated(&mut bytes)
-        }
+            let mut inner = buf.into_inner();
+            assert!(is_nul_terminated(&mut inner));
+        });
+    }
 
-        #[cfg(feature = "std")]
-        fn test_ensure_nul_terminated_write_fmt(bytes: Vec<u8>, data: String) -> bool {
+    #[test]
+    #[cfg(feature = "std")]
+    fn prop_test_ensure_nul_terminated_write_fmt() {
+        run_arbitrary::<(Vec<u8>, String)>(|(bytes, data)| {
             use std::io::Write;
-
             let mut buf = Buf::from(bytes);
-            buf.write_fmt(format_args!("{data}")).unwrap();
-            let mut bytes = buf.into_inner();
-            is_nul_terminated(&mut bytes)
-        }
+            buf.write_fmt(format_args!("{}", data)).unwrap();
+            let mut inner = buf.into_inner();
+            assert!(is_nul_terminated(&mut inner));
+        });
     }
 }

--- a/spinoso-string/Cargo.toml
+++ b/spinoso-string/Cargo.toml
@@ -43,10 +43,8 @@ version = "0.1.4"
 default-features = false
 
 [dev-dependencies]
-
-[dev-dependencies.quickcheck]
-version = "1.0.3"
-default-features = false
+arbitrary = "1.4.1"
+getrandom = "0.3.0"
 
 [features]
 default = ["casecmp", "std"]
@@ -54,7 +52,11 @@ casecmp = ["dep:focaccia"]
 # Enable implementations of traits in `std` like `Error` and `io::Write`.
 #
 # Enable runtime SIMD dispatch in `bytecount` and `simdutf8` dependencies.
-std = ["bytecount/runtime-dispatch-simd", "scolapasta-strbuf/std", "simdutf8/std"]
+std = [
+    "bytecount/runtime-dispatch-simd",
+    "scolapasta-strbuf/std",
+    "simdutf8/std",
+]
 # Use an alternate byte buffer backend that ensures byte content is always
 # followed by a NUL byte in the buffer's spare capacity. This feature can be
 # used to ensure `String`s are FFI compatible with C code that expects byte

--- a/spinoso-string/src/enc/ascii/mod.rs
+++ b/spinoso-string/src/enc/ascii/mod.rs
@@ -369,34 +369,43 @@ mod tests {
     use alloc::string::String;
     use alloc::vec::Vec;
 
-    use quickcheck::quickcheck;
-
     use super::AsciiString;
+    use crate::test::run_arbitrary;
 
-    quickcheck! {
-        fn fuzz_char_len_utf8_contents_ascii_string(contents: String) -> bool {
+    #[test]
+    fn prop_fuzz_char_len_utf8_contents_ascii_string() {
+        run_arbitrary::<String>(|contents| {
             let expected = contents.len();
             let s = AsciiString::from(contents);
-            s.char_len() == expected
-        }
+            assert_eq!(s.char_len(), expected);
+        });
+    }
 
-        fn fuzz_len_utf8_contents_ascii_string(contents: String) -> bool {
+    #[test]
+    fn prop_fuzz_len_utf8_contents_ascii_string() {
+        run_arbitrary::<String>(|contents| {
             let expected = contents.len();
             let s = AsciiString::from(contents);
-            s.len() == expected
-        }
+            assert_eq!(s.len(), expected);
+        });
+    }
 
-        fn fuzz_char_len_binary_contents_ascii_string(contents: Vec<u8>) -> bool {
+    #[test]
+    fn prop_fuzz_char_len_binary_contents_ascii_string() {
+        run_arbitrary::<Vec<u8>>(|contents| {
             let expected = contents.len();
             let s = AsciiString::from(contents);
-            s.char_len() == expected
-        }
+            assert_eq!(s.char_len(), expected);
+        });
+    }
 
-        fn fuzz_len_binary_contents_ascii_string(contents: Vec<u8>) -> bool {
+    #[test]
+    fn prop_fuzz_len_binary_contents_ascii_string() {
+        run_arbitrary::<Vec<u8>>(|contents| {
             let expected = contents.len();
             let s = AsciiString::from(contents);
-            s.len() == expected
-        }
+            assert_eq!(s.len(), expected);
+        });
     }
 
     #[test]

--- a/spinoso-string/src/enc/binary/mod.rs
+++ b/spinoso-string/src/enc/binary/mod.rs
@@ -360,34 +360,43 @@ mod tests {
     use alloc::string::String;
     use alloc::vec::Vec;
 
-    use quickcheck::quickcheck;
-
     use super::BinaryString;
+    use crate::test::run_arbitrary;
 
-    quickcheck! {
-        fn fuzz_char_len_utf8_contents_binary_string(contents: String) -> bool {
+    #[test]
+    fn prop_fuzz_char_len_utf8_contents_binary_string() {
+        run_arbitrary::<String>(|contents| {
             let expected = contents.len();
             let s = BinaryString::from(contents);
-            s.char_len() == expected
-        }
+            assert_eq!(s.char_len(), expected)
+        });
+    }
 
-        fn fuzz_len_utf8_contents_binary_string(contents: String) -> bool {
+    #[test]
+    fn prop_fuzz_len_utf8_contents_binary_string() {
+        run_arbitrary::<String>(|contents| {
             let expected = contents.len();
             let s = BinaryString::from(contents);
-            s.len() == expected
-        }
+            assert_eq!(s.len(), expected)
+        });
+    }
 
-        fn fuzz_char_len_binary_contents_binary_string(contents: Vec<u8>) -> bool {
+    #[test]
+    fn prop_fuzz_char_len_binary_contents_binary_string() {
+        run_arbitrary::<Vec<u8>>(|contents| {
             let expected = contents.len();
             let s = BinaryString::from(contents);
-            s.char_len() == expected
-        }
+            assert_eq!(s.char_len(), expected)
+        });
+    }
 
-        fn fuzz_len_binary_contents_binary_string(contents: Vec<u8>) -> bool {
+    #[test]
+    fn prop_fuzz_len_binary_contents_binary_string() {
+        run_arbitrary::<Vec<u8>>(|contents| {
             let expected = contents.len();
             let s = BinaryString::from(contents);
-            s.len() == expected
-        }
+            assert_eq!(s.len(), expected)
+        });
     }
 
     #[test]

--- a/spinoso-string/src/enc/binary/mod.rs
+++ b/spinoso-string/src/enc/binary/mod.rs
@@ -368,7 +368,7 @@ mod tests {
         run_arbitrary::<String>(|contents| {
             let expected = contents.len();
             let s = BinaryString::from(contents);
-            assert_eq!(s.char_len(), expected)
+            assert_eq!(s.char_len(), expected);
         });
     }
 
@@ -377,7 +377,7 @@ mod tests {
         run_arbitrary::<String>(|contents| {
             let expected = contents.len();
             let s = BinaryString::from(contents);
-            assert_eq!(s.len(), expected)
+            assert_eq!(s.len(), expected);
         });
     }
 
@@ -386,7 +386,7 @@ mod tests {
         run_arbitrary::<Vec<u8>>(|contents| {
             let expected = contents.len();
             let s = BinaryString::from(contents);
-            assert_eq!(s.char_len(), expected)
+            assert_eq!(s.char_len(), expected);
         });
     }
 
@@ -395,7 +395,7 @@ mod tests {
         run_arbitrary::<Vec<u8>>(|contents| {
             let expected = contents.len();
             let s = BinaryString::from(contents);
-            assert_eq!(s.len(), expected)
+            assert_eq!(s.len(), expected);
         });
     }
 

--- a/spinoso-string/src/enc/utf8/mod.rs
+++ b/spinoso-string/src/enc/utf8/mod.rs
@@ -54,42 +54,51 @@ mod tests {
     use alloc::vec::Vec;
     use core::str;
 
-    use quickcheck::quickcheck;
-
     use super::{Utf8Str, Utf8String};
+    use crate::test::run_arbitrary;
 
     const REPLACEMENT_CHARACTER_BYTES: [u8; 3] = [239, 191, 189];
 
-    quickcheck! {
-        fn fuzz_char_len_utf8_contents_utf8_string(contents: String) -> bool {
+    #[test]
+    fn prop_fuzz_char_len_utf8_contents_utf8_string() {
+        run_arbitrary::<String>(|contents| {
             let expected = contents.chars().count();
             let s = Utf8String::from(contents);
-            s.char_len() == expected
-        }
+            assert_eq!(s.char_len(), expected);
+        });
+    }
 
-        fn fuzz_len_utf8_contents_utf8_string(contents: String) -> bool {
+    #[test]
+    fn prop_fuzz_len_utf8_contents_utf8_string() {
+        run_arbitrary::<String>(|contents| {
             let expected = contents.len();
             let s = Utf8String::from(contents);
-            s.len() == expected
-        }
+            assert_eq!(s.len(), expected);
+        });
+    }
 
-        fn fuzz_char_len_binary_contents_utf8_string(contents: Vec<u8>) -> bool {
+    #[test]
+    fn prop_fuzz_char_len_binary_contents_utf8_string() {
+        run_arbitrary::<Vec<u8>>(|contents| {
             if let Ok(utf8_contents) = str::from_utf8(&contents) {
                 let expected = utf8_contents.chars().count();
                 let s = Utf8String::from(contents);
-                s.char_len() == expected
+                assert_eq!(s.char_len(), expected);
             } else {
                 let expected_at_most = contents.len();
                 let s = Utf8String::from(contents);
-                s.char_len() <= expected_at_most
+                assert!(s.char_len() <= expected_at_most);
             }
-        }
+        });
+    }
 
-        fn fuzz_len_binary_contents_utf8_string(contents: Vec<u8>) -> bool {
+    #[test]
+    fn prop_fuzz_len_binary_contents_utf8_string() {
+        run_arbitrary::<Vec<u8>>(|contents| {
             let expected = contents.len();
             let s = Utf8String::from(contents);
-            s.len() == expected
-        }
+            assert_eq!(s.len(), expected);
+        });
     }
 
     #[test]

--- a/spinoso-string/src/lib.rs
+++ b/spinoso-string/src/lib.rs
@@ -64,6 +64,8 @@ mod impls;
 mod inspect;
 mod iter;
 mod ord;
+#[cfg(test)]
+mod test;
 
 pub use center::{Center, CenterError};
 pub use chars::Chars;

--- a/spinoso-string/src/test.rs
+++ b/spinoso-string/src/test.rs
@@ -1,0 +1,27 @@
+use core::fmt;
+
+use arbitrary::{Arbitrary, Unstructured};
+
+pub fn run_arbitrary<T>(mut f: impl FnMut(T))
+where
+    T: for<'a> Arbitrary<'a> + fmt::Debug,
+{
+    fn get_unstructured(buf: &mut [u8]) -> Unstructured<'_> {
+        getrandom::fill(buf).unwrap();
+        Unstructured::new(buf)
+    }
+
+    let mut buf = [0; 1024];
+    let mut unstructured = get_unstructured(&mut buf);
+    for _ in 0..1024 {
+        if let Ok(value) = T::arbitrary(&mut unstructured) {
+            f(value);
+            continue;
+        }
+        // try reloading on randomness
+        unstructured = get_unstructured(&mut buf);
+        if let Ok(value) = T::arbitrary(&mut unstructured) {
+            f(value);
+        }
+    }
+}


### PR DESCRIPTION
Quickcheck hasn't seen a commit since October 2023 and it will block upgrading to `rand` 0.9 in this repository. Additionally, I'm not the biggest fan of how the macro makes formatting these large blocks of tests difficult.

Replace `quickcheck` with a small handrolled helper which stitches together `getrandom` and `arbitrary` to yield values to a closure.

Update all the tests in `artichoke-backend`, `scolapasta-strbuf`, and `spinoso-string`.

As part of this change, the Artichoke interpreter can be reused for all property candidates in each test, which drops the runtime of the `artichoke-backend` test suite from 5s to 0.4s. I've also replaced all the `bool` tests with manual, exhaustive loops.