### PR TITLE
Upgrade to `rand` 0.9 and `getrandom` 0.3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -263,7 +263,6 @@ jobs:
       - name: Check spinoso-random with some features
         run: |
           cargo check --verbose --no-default-features --features rand_core --all-targets --profile=test
-          cargo check --verbose --no-default-features --features std --all-targets --profile=test
           cargo check --verbose --no-default-features --features rand-method --all-targets --profile=test
         working-directory: "spinoso-random"
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "artichoke-backend"
-version = "0.24.1"
+version = "0.25.0"
 dependencies = [
  "arbitrary",
  "artichoke-core",
@@ -58,7 +58,7 @@ dependencies = [
  "bindgen",
  "bstr",
  "cc",
- "getrandom 0.3.1",
+ "getrandom",
  "intaglio",
  "libc",
  "mezzaluna-conversion-methods",
@@ -172,6 +172,12 @@ name = "bytecount"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cc"
@@ -303,24 +309,13 @@ checksum = "9ee11ab04c870c105dd00e08fb7e2cd1a7375ab8ca4daab2ee1c9d71d6cbc80e"
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.13.3+wasi-0.2.2",
+ "wasi",
  "windows-targets",
 ]
 
@@ -538,6 +533,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb172572fa316ae7e019d10c827231a9be803f3562543813aad86f547f11f352"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+dependencies = [
+ "zerocopy 0.7.35",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -563,20 +567,33 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
 dependencies = [
+ "rand_chacha",
+ "rand_core",
+ "zerocopy 0.8.14",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
  "rand_core",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.6.4"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+checksum = "b08f3c9802962f7e1b25113931d94f43ed9725bebc59db9d0c3e9a23b67e15ff"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom",
+ "zerocopy 0.8.14",
 ]
 
 [[package]]
@@ -697,7 +714,7 @@ name = "scolapasta-strbuf"
 version = "1.0.0"
 dependencies = [
  "arbitrary",
- "getrandom 0.3.1",
+ "getrandom",
  "raw-parts",
 ]
 
@@ -780,9 +797,9 @@ dependencies = [
 
 [[package]]
 name = "spinoso-random"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom",
  "libm",
  "rand",
  "rand_core",
@@ -804,9 +821,10 @@ dependencies = [
 
 [[package]]
 name = "spinoso-securerandom"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "base64",
+ "getrandom",
  "rand",
  "scolapasta-hex",
 ]
@@ -819,7 +837,7 @@ dependencies = [
  "bstr",
  "bytecount",
  "focaccia",
- "getrandom 0.3.1",
+ "getrandom",
  "scolapasta-strbuf",
  "scolapasta-string-escape",
  "simdutf8",
@@ -951,12 +969,6 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
-name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasi"
@@ -1129,4 +1141,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
 dependencies = [
  "bitflags 2.6.0",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a367f292d93d4eab890745e75a778da40909cab4d6ff8173693812f79c4a2468"
+dependencies = [
+ "zerocopy-derive 0.8.14",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3931cb58c62c13adec22e38686b559c86a30565e16ad6e8510a337cedc611e1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -598,9 +598,9 @@ dependencies = [
 
 [[package]]
 name = "rand_mt"
-version = "4.2.2"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49e018c6ded60e5252609887c12eb3ca2592e9248c5894a7db3975c8a7a1e2df"
+checksum = "a9375873db1061df25ed185eb584cd8839196db7a43803daa0612c5ae53be5b5"
 
 [[package]]
 name = "raw-parts"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ documentation.workspace = true
 [dependencies]
 
 [dependencies.artichoke-backend]
-version = "0.24.1"
+version = "0.25.0"
 path = "artichoke-backend"
 default-features = false
 
@@ -91,12 +91,7 @@ path = "src/bin/artichoke.rs"
 required-features = ["cli"]
 
 [workspace]
-members = [
-  "artichoke-*",
-  "mezzaluna-*",
-  "scolapasta-*",
-  "spinoso-*",
-]
+members = ["artichoke-*", "mezzaluna-*", "scolapasta-*", "spinoso-*"]
 
 [workspace.package]
 edition = "2021"
@@ -112,11 +107,7 @@ lto = true
 strip = true
 
 [features]
-default = [
-  "backtrace",
-  "cli",
-  "kitchen-sink",
-]
+default = ["backtrace", "cli", "kitchen-sink"]
 # Enable a CLI frontend for Artichoke, including a `ruby`-equivalent CLI and
 # REPL.
 cli = [
@@ -170,7 +161,10 @@ core-regexp = ["artichoke-backend/core-regexp"]
 # feature, Regexp patterns must be parsable by oniguruma regardless of the
 # backend they execute on. The `regex` crate backend remains the default as long
 # as it can parse the given pattern.
-core-regexp-oniguruma = ["core-regexp", "artichoke-backend/core-regexp-oniguruma"]
+core-regexp-oniguruma = [
+  "core-regexp",
+  "artichoke-backend/core-regexp-oniguruma",
+]
 # Implement the `Time` core class. This feature adds dependencies on `tz-rs` and
 # `tzdb`.
 core-time = ["artichoke-backend/core-time"]
@@ -178,18 +172,26 @@ core-time = ["artichoke-backend/core-time"]
 # Extend the Artichoke virtual file system to have native/host access.
 #
 # This feature enables requiring sources from local disk.
-load-path-native-file-system-loader = ["artichoke-backend/load-path-native-file-system-loader"]
+load-path-native-file-system-loader = [
+  "artichoke-backend/load-path-native-file-system-loader",
+]
 # Extend the Artichoke virtual file system to search a path separator-delimited
 # list of paths for Ruby sources by parsing the `RUBYLIB` environment variable.
 #
 # This feature enables requiring sources from local disk.
-load-path-rubylib-native-file-system-loader = ["load-path-native-file-system-loader", "artichoke-backend/load-path-rubylib-native-file-system-loader"]
+load-path-rubylib-native-file-system-loader = [
+  "load-path-native-file-system-loader",
+  "artichoke-backend/load-path-rubylib-native-file-system-loader",
+]
 
 # Override the `stdout` and `stdin` streams to write to an in-memory buffer.
 output-strategy-capture = ["artichoke-backend/output-strategy-capture"]
 # Override the `stdout` and `stdin` streams to write to be discarded.
 # `output-strategy-null` implies the `output-strategy-capture` feature.
-output-strategy-null = ["output-strategy-capture", "artichoke-backend/output-strategy-null"]
+output-strategy-null = [
+  "output-strategy-capture",
+  "artichoke-backend/output-strategy-null",
+]
 
 # Enable every integrated standard library package.
 stdlib-full = [

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "artichoke-backend"
-version = "0.24.1"
+version = "0.25.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 description = "Embeddable VM implementation for Artichoke Ruby"
 keywords = ["artichoke", "artichoke-ruby", "mruby", "ruby"]
@@ -103,7 +103,7 @@ optional = true
 default-features = false
 
 [dependencies.spinoso-random]
-version = "0.4.0"
+version = "0.5.0"
 path = "../spinoso-random"
 optional = true
 
@@ -114,7 +114,7 @@ optional = true
 default-features = false
 
 [dependencies.spinoso-securerandom]
-version = "0.2.0"
+version = "0.3.0"
 path = "../spinoso-securerandom"
 optional = true
 

--- a/artichoke-backend/src/extn/stdlib/securerandom/mod.rs
+++ b/artichoke-backend/src/extn/stdlib/securerandom/mod.rs
@@ -32,6 +32,7 @@ impl From<SecureRandomError> for Error {
     fn from(err: SecureRandomError) -> Self {
         match err {
             SecureRandomError::Argument(err) => err.into(),
+            SecureRandomError::Domain(err) => err.into(),
             SecureRandomError::RandomBytes(err) => err.into(),
             // FIXME: this branch allocates when we might be out of memory.
             SecureRandomError::Memory(_) => NoMemoryError::with_message("out of memory").into(),

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -477,9 +477,9 @@ dependencies = [
 
 [[package]]
 name = "rand_mt"
-version = "4.2.2"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49e018c6ded60e5252609887c12eb3ca2592e9248c5894a7db3975c8a7a1e2df"
+checksum = "a9375873db1061df25ed185eb584cd8839196db7a43803daa0612c5ae53be5b5"
 
 [[package]]
 name = "raw-parts"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -36,7 +36,7 @@ dependencies = [
 
 [[package]]
 name = "artichoke-backend"
-version = "0.24.1"
+version = "0.25.0"
 dependencies = [
  "artichoke-core",
  "artichoke-load-path",
@@ -149,6 +149,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "cc"
 version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -210,13 +216,14 @@ checksum = "9ee11ab04c870c105dd00e08fb7e2cd1a7375ab8ca4daab2ee1c9d71d6cbc80e"
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
 dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+ "windows-targets",
 ]
 
 [[package]]
@@ -405,6 +412,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb172572fa316ae7e019d10c827231a9be803f3562543813aad86f547f11f352"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+dependencies = [
+ "zerocopy 0.7.35",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -430,20 +446,33 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
 dependencies = [
+ "rand_chacha",
+ "rand_core",
+ "zerocopy 0.8.14",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
  "rand_core",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.6.4"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+checksum = "b08f3c9802962f7e1b25113931d94f43ed9725bebc59db9d0c3e9a23b67e15ff"
 dependencies = [
  "getrandom",
+ "zerocopy 0.8.14",
 ]
 
 [[package]]
@@ -600,7 +629,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-random"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "getrandom",
  "libm",
@@ -624,9 +653,10 @@ dependencies = [
 
 [[package]]
 name = "spinoso-securerandom"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "base64",
+ "getrandom",
  "rand",
  "scolapasta-hex",
 ]
@@ -718,9 +748,12 @@ checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.13.3+wasi-0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -867,3 +900,53 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+dependencies = [
+ "bitflags 2.6.0",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a367f292d93d4eab890745e75a778da40909cab4d6ff8173693812f79c4a2468"
+dependencies = [
+ "zerocopy-derive 0.8.14",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3931cb58c62c13adec22e38686b559c86a30565e16ad6e8510a337cedc611e1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -663,9 +663,9 @@ dependencies = [
 
 [[package]]
 name = "rand_mt"
-version = "4.2.2"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49e018c6ded60e5252609887c12eb3ca2592e9248c5894a7db3975c8a7a1e2df"
+checksum = "a9375873db1061df25ed185eb584cd8839196db7a43803daa0612c5ae53be5b5"
 
 [[package]]
 name = "raw-parts"

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -52,7 +52,7 @@ dependencies = [
 
 [[package]]
 name = "artichoke-backend"
-version = "0.24.1"
+version = "0.25.0"
 dependencies = [
  "artichoke-core",
  "artichoke-load-path",
@@ -193,6 +193,12 @@ name = "bytecount"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cc"
@@ -337,13 +343,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
 dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+ "windows-targets",
 ]
 
 [[package]]
@@ -591,6 +598,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb172572fa316ae7e019d10c827231a9be803f3562543813aad86f547f11f352"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+dependencies = [
+ "zerocopy 0.7.35",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -616,20 +632,33 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
 dependencies = [
+ "rand_chacha",
+ "rand_core",
+ "zerocopy 0.8.14",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
  "rand_core",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.6.4"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+checksum = "b08f3c9802962f7e1b25113931d94f43ed9725bebc59db9d0c3e9a23b67e15ff"
 dependencies = [
  "getrandom",
+ "zerocopy 0.8.14",
 ]
 
 [[package]]
@@ -890,7 +919,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-random"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "getrandom",
  "libm",
@@ -914,9 +943,10 @@ dependencies = [
 
 [[package]]
 name = "spinoso-securerandom"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "base64",
+ "getrandom",
  "rand",
  "scolapasta-hex",
 ]
@@ -1051,9 +1081,12 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.13.3+wasi-0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -1200,3 +1233,53 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+dependencies = [
+ "bitflags 2.6.0",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a367f292d93d4eab890745e75a778da40909cab4d6ff8173693812f79c4a2468"
+dependencies = [
+ "zerocopy-derive 0.8.14",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3931cb58c62c13adec22e38686b559c86a30565e16ad6e8510a337cedc611e1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/spinoso-random/Cargo.toml
+++ b/spinoso-random/Cargo.toml
@@ -33,7 +33,7 @@ optional = true
 default-features = false
 
 [dependencies.rand_mt]
-version = "4.2.0"
+version = "5.0.0"
 default-features = false
 
 [features]

--- a/spinoso-random/Cargo.toml
+++ b/spinoso-random/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spinoso-random"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 description = """
 Implementation of Ruby Random Core class.
@@ -19,19 +19,16 @@ documentation.workspace = true
 libm = "0.2.6"
 
 [dependencies.getrandom]
-version = "0.2.0"
+version = "0.3.1"
 default-features = false
 
 [dependencies.rand]
-version = "0.8.0"
+version = "0.9.0"
 optional = true
 default-features = false
 
-# 0.6.1 is vulnerable to underfilling a buffer.
-#
-# https://rustsec.org/advisories/RUSTSEC-2021-0023
 [dependencies.rand_core]
-version = "0.6.2"
+version = "0.9.0"
 optional = true
 default-features = false
 
@@ -40,12 +37,11 @@ version = "4.2.0"
 default-features = false
 
 [features]
-default = ["rand-method", "rand_core", "std"]
+default = ["rand-method", "rand_core"]
 # Enables range sampling methods for the `rand()` function.
 rand-method = ["dep:rand", "rand_core"]
 # Enables implementations of `RngCore` on `Random` and `Mt` types.
 rand_core = ["dep:rand_core"]
-std = []
 
 [package.metadata.docs.rs]
 all-features = true

--- a/spinoso-random/README.md
+++ b/spinoso-random/README.md
@@ -31,7 +31,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-spinoso-random = "0.4.0"
+spinoso-random = "0.5.0"
 ```
 
 Generate integers:
@@ -71,8 +71,6 @@ All features are enabled by default.
   this feature removes the [`rand`] dependency.
 - **rand_core** - Enables implementations of [`RngCore`] on the [`Random`] type.
   Dropping this feature removes the [`rand_core`] dependency.
-- **std** - Enables a dependency on the Rust Standard Library. Activating this
-  feature enables [`std::error::Error`] impls on error types in this crate.
 
 ## License
 

--- a/spinoso-random/src/lib.rs
+++ b/spinoso-random/src/lib.rs
@@ -1,6 +1,5 @@
 #![warn(clippy::all)]
 #![warn(clippy::pedantic)]
-#![warn(clippy::cargo)]
 #![allow(unknown_lints)]
 #![allow(clippy::manual_let_else)]
 #![warn(missing_docs)]
@@ -80,14 +79,7 @@
 //!   feature. Dropping this feature removes the [`rand`] dependency.
 //! - **rand_core** - Enables implementations of [`RngCore`] on the [`Random`]
 //!   type. Dropping this feature removes the [`rand_core`] dependency.
-//! - **std** - Enables a dependency on the Rust Standard Library. Activating
-//!   this feature enables [`std::error::Error`] impls on error types in this
-//!   crate.
 //!
-#![cfg_attr(
-    not(feature = "std"),
-    doc = "[`std::error::Error`]: https://doc.rust-lang.org/std/error/trait.Error.html"
-)]
 #![cfg_attr(feature = "rand_core", doc = "[`RngCore`]: rand_core::RngCore")]
 #![cfg_attr(
     not(feature = "rand_core"),
@@ -116,12 +108,11 @@ mod readme {}
 
 extern crate alloc;
 
-#[cfg(any(feature = "std", test, doctest))]
+#[cfg(any(test, doctest))]
 extern crate std;
 
+use core::error;
 use core::fmt;
-#[cfg(feature = "std")]
-use std::error;
 
 #[cfg(feature = "rand-method")]
 mod rand;
@@ -202,7 +193,6 @@ impl fmt::Display for Error {
     }
 }
 
-#[cfg(feature = "std")]
 impl error::Error for Error {
     fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match self {
@@ -279,7 +269,6 @@ impl fmt::Display for InitializeError {
     }
 }
 
-#[cfg(feature = "std")]
 impl error::Error for InitializeError {}
 
 /// Error that indicates the system source of cryptographically secure
@@ -348,8 +337,14 @@ impl fmt::Display for UrandomError {
     }
 }
 
-#[cfg(feature = "std")]
 impl error::Error for UrandomError {}
+
+impl From<getrandom::Error> for UrandomError {
+    #[inline]
+    fn from(_err: getrandom::Error) -> Self {
+        Self::new()
+    }
+}
 
 /// Error that indicates the system source of cryptographically secure
 /// randomness failed to read sufficient bytes to create a new seed.
@@ -417,8 +412,14 @@ impl fmt::Display for NewSeedError {
     }
 }
 
-#[cfg(feature = "std")]
 impl error::Error for NewSeedError {}
+
+impl From<getrandom::Error> for NewSeedError {
+    #[inline]
+    fn from(_err: getrandom::Error) -> Self {
+        Self::new()
+    }
+}
 
 /// Error that indicates a random number could not be generated with the given
 /// bounds.
@@ -577,5 +578,4 @@ impl fmt::Display for ArgumentError {
     }
 }
 
-#[cfg(feature = "std")]
 impl error::Error for ArgumentError {}

--- a/spinoso-random/src/rand.rs
+++ b/spinoso-random/src/rand.rs
@@ -142,7 +142,7 @@ pub fn rand(rng: &mut Random, max: Max) -> Result<Rand, ArgumentError> {
             Ok(Rand::Float(number))
         }
         Max::Float(max) => {
-            let number = rng.gen_range(0.0..max);
+            let number = rng.random_range(0.0..max);
             Ok(Rand::Float(number))
         }
         Max::Integer(max) if max < 1 => {
@@ -150,7 +150,7 @@ pub fn rand(rng: &mut Random, max: Max) -> Result<Rand, ArgumentError> {
             Err(err)
         }
         Max::Integer(max) => {
-            let number = rng.gen_range(0..max);
+            let number = rng.random_range(0..max);
             Ok(Rand::Integer(number))
         }
         Max::None => {

--- a/spinoso-random/src/random/mod.rs
+++ b/spinoso-random/src/random/mod.rs
@@ -383,9 +383,7 @@ pub fn seed_to_key(seed: [u8; DEFAULT_SEED_BYTES]) -> [u32; DEFAULT_SEED_CNT] {
 #[inline]
 pub fn new_seed() -> Result<[u32; DEFAULT_SEED_CNT], NewSeedError> {
     let mut seed = [0; DEFAULT_SEED_BYTES];
-    if getrandom::getrandom(&mut seed).is_err() {
-        return Err(NewSeedError::new());
-    }
+    getrandom::fill(&mut seed)?;
     let seed = seed_to_key(seed);
     Ok(seed)
 }

--- a/spinoso-random/src/random/rand.rs
+++ b/spinoso-random/src/random/rand.rs
@@ -1,4 +1,4 @@
-use rand_core::{Error, RngCore, SeedableRng};
+use rand_core::{RngCore, SeedableRng};
 
 use super::{seed_to_key, Mt, Random, DEFAULT_SEED_BYTES};
 
@@ -95,46 +95,5 @@ impl RngCore for Random {
     #[inline]
     fn fill_bytes(&mut self, dest: &mut [u8]) {
         self.mt.fill_bytes(dest);
-    }
-
-    /// Fill a buffer with bytes generated from the RNG.
-    ///
-    /// This method generates random `u32`s (the native output unit of the RNG)
-    /// until `dest` is filled.
-    ///
-    /// This method may discard some output bits if `dest.len()` is not a
-    /// multiple of 4.
-    ///
-    /// `try_fill_bytes` is implemented with [`fill_bytes`] and is infallible.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use rand_core::{Error, RngCore};
-    /// use spinoso_random::Random;
-    ///
-    /// # fn example() -> Result<(), Error> {
-    /// let mut random = Random::with_seed(33);
-    /// let mut buf = [0; 32];
-    /// random.try_fill_bytes(&mut buf)?;
-    /// assert_ne!([0; 32], buf);
-    /// let mut buf = [0; 31];
-    /// random.try_fill_bytes(&mut buf)?;
-    /// assert_ne!([0; 31], buf);
-    /// # Ok(())
-    /// # }
-    /// # example().unwrap()
-    /// ```
-    ///
-    /// # Errors
-    ///
-    /// This method never returns an error. It is equivalent to calling the
-    /// infallible [`fill_bytes`] method.
-    ///
-    /// [`fill_bytes`]: Random::fill_bytes
-    #[inline]
-    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Error> {
-        self.mt.fill_bytes(dest);
-        Ok(())
     }
 }

--- a/spinoso-random/src/urandom.rs
+++ b/spinoso-random/src/urandom.rs
@@ -32,9 +32,7 @@ use crate::UrandomError;
 ///
 /// [Ruby `RuntimeError`]: https://ruby-doc.org/core-3.1.2/RuntimeError.html
 pub fn urandom(dest: &mut [u8]) -> Result<(), UrandomError> {
-    if getrandom::getrandom(dest).is_err() {
-        return Err(UrandomError::new());
-    }
+    getrandom::fill(dest)?;
     Ok(())
 }
 

--- a/spinoso-securerandom/Cargo.toml
+++ b/spinoso-securerandom/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spinoso-securerandom"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 description = """
 Secure PRNG backend for Artichoke Ruby, implements 'securerandom' package
@@ -22,10 +22,14 @@ version = "0.22.0"
 default-features = false
 features = ["alloc"]
 
-[dependencies.rand]
-version = "0.8.0"
+[dependencies.getrandom]
+version = "0.3.1"
 default-features = false
-features = ["getrandom"]
+
+[dependencies.rand]
+version = "0.9.0"
+default-features = false
+features = ["os_rng", "std_rng"]
 
 [dependencies.scolapasta-hex]
 version = "0.3.0"

--- a/spinoso-securerandom/README.md
+++ b/spinoso-securerandom/README.md
@@ -27,7 +27,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-spinoso-securerandom = "0.2.0"
+spinoso-securerandom = "0.3.0"
 ```
 
 ## Examples

--- a/spinoso-securerandom/README.md
+++ b/spinoso-securerandom/README.md
@@ -56,9 +56,9 @@ fn example() -> Result<(), spinoso_securerandom::Error> {
 Generate random floats and integers in a range bounded from zero to a maximum:
 
 ```rust
-use spinoso_securerandom::{DomainError, Max, Rand};
+use spinoso_securerandom::{Error, Max, Rand};
 
-fn example() -> Result<(), DomainError> {
+fn example() -> Result<(), Error> {
     let rand = spinoso_securerandom::random_number(Max::None)?;
     assert!(matches!(rand, Rand::Float(_)));
 

--- a/spinoso-securerandom/src/lib.rs
+++ b/spinoso-securerandom/src/lib.rs
@@ -56,8 +56,8 @@
 //! maximum:
 //!
 //! ```rust
-//! # use spinoso_securerandom::{DomainError, Max, Rand};
-//! # fn example() -> Result<(), DomainError> {
+//! # use spinoso_securerandom::{Error, Max, Rand};
+//! # fn example() -> Result<(), Error> {
 //! let rand = spinoso_securerandom::random_number(Max::None)?;
 //! assert!(matches!(rand, Rand::Float(_)));
 //!
@@ -525,7 +525,7 @@ pub enum Rand {
 ///
 /// ```rust
 /// # use spinoso_securerandom::{Max, Rand};
-/// # fn example() -> Result<(), spinoso_securerandom::DomainError> {
+/// # fn example() -> Result<(), spinoso_securerandom::Error> {
 /// let rand = spinoso_securerandom::random_number(Max::None)?;
 /// assert!(matches!(rand, Rand::Float(_)));
 ///

--- a/spinoso-securerandom/src/lib.rs
+++ b/spinoso-securerandom/src/lib.rs
@@ -1,6 +1,5 @@
 #![warn(clippy::all)]
 #![warn(clippy::pedantic)]
-#![warn(clippy::cargo)]
 #![allow(unknown_lints)]
 #![allow(clippy::manual_let_else)]
 #![warn(missing_docs)]
@@ -96,9 +95,9 @@ use core::fmt;
 use std::collections::TryReserveError;
 use std::error;
 
-use rand::distributions::Alphanumeric;
-use rand::rngs::OsRng;
-use rand::{CryptoRng, Rng, RngCore};
+use rand::distr::Alphanumeric;
+use rand::rngs::StdRng;
+use rand::{CryptoRng, Rng, SeedableRng};
 use scolapasta_hex as hex;
 
 mod uuid;
@@ -118,6 +117,10 @@ pub enum Error {
     ///
     /// See [`ArgumentError`].
     Argument(ArgumentError),
+    /// Error that indicates an invalid range was given.
+    ///
+    /// See [`DomainError`].
+    Domain(DomainError),
     /// Error that indicates the underlying source of randomness failed to
     /// generate the requested random bytes.
     ///
@@ -141,6 +144,13 @@ impl From<ArgumentError> for Error {
     }
 }
 
+impl From<DomainError> for Error {
+    #[inline]
+    fn from(err: DomainError) -> Self {
+        Self::Domain(err)
+    }
+}
+
 impl From<RandomBytesError> for Error {
     #[inline]
     fn from(err: RandomBytesError) -> Self {
@@ -148,16 +158,16 @@ impl From<RandomBytesError> for Error {
     }
 }
 
-impl From<rand::Error> for Error {
-    #[inline]
-    fn from(err: rand::Error) -> Self {
-        Self::from(RandomBytesError::from(err))
-    }
-}
-
 impl From<TryReserveError> for Error {
     fn from(err: TryReserveError) -> Self {
         Self::Memory(err)
+    }
+}
+
+impl From<getrandom::Error> for Error {
+    #[inline]
+    fn from(_: getrandom::Error) -> Self {
+        Self::RandomBytes(RandomBytesError::new())
     }
 }
 
@@ -173,6 +183,7 @@ impl error::Error for Error {
     fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match self {
             Self::Argument(ref err) => Some(err),
+            Self::Domain(ref err) => Some(err),
             Self::RandomBytes(ref err) => Some(err),
             Self::Memory(ref err) => Some(err),
         }
@@ -290,6 +301,13 @@ impl fmt::Display for RandomBytesError {
     }
 }
 
+impl From<getrandom::Error> for RandomBytesError {
+    #[inline]
+    fn from(_: getrandom::Error) -> Self {
+        Self::new()
+    }
+}
+
 impl error::Error for RandomBytesError {}
 
 impl RandomBytesError {
@@ -321,12 +339,6 @@ impl RandomBytesError {
     #[must_use]
     pub const fn message(self) -> &'static str {
         "OS Error: Failed to generate random bytes"
-    }
-}
-
-impl From<rand::Error> for RandomBytesError {
-    fn from(_: rand::Error) -> Self {
-        Self::new()
     }
 }
 
@@ -439,11 +451,6 @@ impl SecureRandom {
 /// If an allocation error occurs, an error is returned.
 #[inline]
 pub fn random_bytes(len: Option<i64>) -> Result<Vec<u8>, Error> {
-    fn get_random_bytes<T: RngCore + CryptoRng>(mut rng: T, slice: &mut [u8]) -> Result<(), RandomBytesError> {
-        rng.try_fill_bytes(slice)?;
-        Ok(())
-    }
-
     let len = match len.map(usize::try_from) {
         Some(Ok(0)) => return Ok(Vec::new()),
         Some(Ok(len)) => len,
@@ -457,7 +464,7 @@ pub fn random_bytes(len: Option<i64>) -> Result<Vec<u8>, Error> {
     let mut bytes = Vec::new();
     bytes.try_reserve(len)?;
     bytes.resize(len, 0);
-    get_random_bytes(OsRng, &mut bytes)?;
+    getrandom::fill(&mut bytes)?;
     Ok(bytes)
 }
 
@@ -549,37 +556,39 @@ pub enum Rand {
 /// If the float given in a [`Max::Float`] variant is [`NaN`](f64::NAN) or
 /// infinite, a [`DomainError`] is returned.
 #[inline]
-pub fn random_number(max: Max) -> Result<Rand, DomainError> {
-    fn get_random_number<T: RngCore + CryptoRng>(mut rng: T, max: Max) -> Result<Rand, DomainError> {
+pub fn random_number(max: Max) -> Result<Rand, Error> {
+    fn get_random_number<T: Rng + CryptoRng>(mut rng: T, max: Max) -> Result<Rand, DomainError> {
         match max {
             Max::Float(max) if !max.is_finite() => {
                 // NOTE: MRI returns `Errno::EDOM` exception class.
                 Err(DomainError::new())
             }
             Max::Float(max) if max <= 0.0 => {
-                let number = rng.gen_range(0.0..1.0);
+                let number = rng.random_range(0.0..1.0);
                 Ok(Rand::Float(number))
             }
             Max::Float(max) => {
-                let number = rng.gen_range(0.0..max);
+                let number = rng.random_range(0.0..max);
                 Ok(Rand::Float(number))
             }
             Max::Integer(max) if !max.is_positive() => {
-                let number = rng.gen_range(0.0..1.0);
+                let number = rng.random_range(0.0..1.0);
                 Ok(Rand::Float(number))
             }
             Max::Integer(max) => {
-                let number = rng.gen_range(0..max);
+                let number = rng.random_range(0..max);
                 Ok(Rand::Integer(number))
             }
             Max::None => {
-                let number = rng.gen_range(0.0..1.0);
+                let number = rng.random_range(0.0..1.0);
                 Ok(Rand::Float(number))
             }
         }
     }
 
-    get_random_number(OsRng, max)
+    let rng = StdRng::try_from_os_rng()?;
+    let num = get_random_number(rng, max)?;
+    Ok(num)
 }
 
 /// Generate a hex-encoded [`String`] of random bytes.
@@ -712,7 +721,7 @@ pub fn urlsafe_base64(len: Option<i64>, padding: bool) -> Result<String, Error> 
 /// If an allocation error occurs, an error is returned.
 #[inline]
 pub fn alphanumeric(len: Option<i64>) -> Result<Vec<u8>, Error> {
-    fn get_alphanumeric<T: RngCore + CryptoRng>(rng: T, len: usize) -> Result<Vec<u8>, TryReserveError> {
+    fn get_alphanumeric<T: Rng + CryptoRng>(rng: T, len: usize) -> Result<Vec<u8>, TryReserveError> {
         let mut buf = Vec::new();
         buf.try_reserve(len)?;
         for ch in rng.sample_iter(Alphanumeric).take(len) {
@@ -731,7 +740,8 @@ pub fn alphanumeric(len: Option<i64>) -> Result<Vec<u8>, Error> {
         None => DEFAULT_REQUESTED_BYTES,
     };
 
-    let string = get_alphanumeric(OsRng, len)?;
+    let rng = StdRng::try_from_os_rng()?;
+    let string = get_alphanumeric(rng, len)?;
     Ok(string)
 }
 
@@ -818,9 +828,18 @@ mod tests {
 
     #[test]
     fn random_number_domain_error() {
-        assert_eq!(random_number(Max::Float(f64::NAN)), Err(DomainError::new()));
-        assert_eq!(random_number(Max::Float(f64::INFINITY)), Err(DomainError::new()));
-        assert_eq!(random_number(Max::Float(f64::NEG_INFINITY)), Err(DomainError::new()));
+        assert_eq!(
+            random_number(Max::Float(f64::NAN)),
+            Err(Error::Domain(DomainError::new()))
+        );
+        assert_eq!(
+            random_number(Max::Float(f64::INFINITY)),
+            Err(Error::Domain(DomainError::new()))
+        );
+        assert_eq!(
+            random_number(Max::Float(f64::NEG_INFINITY)),
+            Err(Error::Domain(DomainError::new()))
+        );
     }
 
     #[test]

--- a/spinoso-securerandom/src/uuid.rs
+++ b/spinoso-securerandom/src/uuid.rs
@@ -4,11 +4,9 @@
 //!
 //! [RFC 4122]: https://tools.ietf.org/html/rfc4122#section-4.4
 
-use rand::rngs::OsRng;
-use rand::{CryptoRng, RngCore};
 use scolapasta_hex as hex;
 
-use crate::{Error, RandomBytesError};
+use crate::Error;
 
 /// The number of octets (bytes) in a UUID, as defined in [RFC4122].
 ///
@@ -31,13 +29,8 @@ const ENCODED_LENGTH: usize = 36;
 
 #[inline]
 pub fn v4() -> Result<String, Error> {
-    fn get_random_bytes<T: RngCore + CryptoRng>(mut rng: T, slice: &mut [u8]) -> Result<(), RandomBytesError> {
-        rng.try_fill_bytes(slice)?;
-        Ok(())
-    }
-
     let mut bytes = [0; OCTETS];
-    get_random_bytes(OsRng, &mut bytes)?;
+    getrandom::fill(&mut bytes)?;
 
     // Per RFC 4122, Section 4.4, set bits for version and `clock_seq_hi_and_reserved`.
     bytes[6] = (bytes[6] & 0x0f) | 0x40;


### PR DESCRIPTION
Also remove `std` feature from `spinoso-random`, implement `core::error::Error` directly, and add some additional `From<getrandom::Error>` impls to clean up the code.

Upgrade to `rand_mt` 5.0.0, this doesn't change any deps since we depend on this without default features.