### PR TITLE
Begin to address some warnings in preparation for Rust 2024

### DIFF
--- a/artichoke-backend/src/extn/core/array/ffi.rs
+++ b/artichoke-backend/src/extn/core/array/ffi.rs
@@ -14,7 +14,10 @@ unsafe extern "C" fn mrb_ary_new(mrb: *mut sys::mrb_state) -> sys::mrb_value {
     let result = Array::alloc_value(result, &mut guard);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -29,7 +32,10 @@ unsafe extern "C" fn mrb_ary_new_capa(mrb: *mut sys::mrb_state, capa: sys::mrb_i
     let result = Array::alloc_value(result, &mut guard);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -53,7 +59,10 @@ unsafe extern "C" fn mrb_ary_new_from_values(
             sys::mrb_write_barrier(mrb, basic);
             value.inner()
         }
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -75,7 +84,10 @@ unsafe extern "C" fn mrb_assoc_new(
             sys::mrb_write_barrier(mrb, basic);
             value.inner()
         }
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -99,7 +111,10 @@ unsafe extern "C" fn mrb_ary_splat(mrb: *mut sys::mrb_state, value: sys::mrb_val
             sys::mrb_write_barrier(mrb, basic);
             value.inner()
         }
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 

--- a/artichoke-backend/src/extn/core/array/mruby.rs
+++ b/artichoke-backend/src/extn/core/array/mruby.rs
@@ -59,7 +59,10 @@ unsafe extern "C" fn ary_cls_constructor(mrb: *mut sys::mrb_state, ary: sys::mrb
 
             value
         }
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -75,7 +78,10 @@ unsafe extern "C" fn ary_plus(mrb: *mut sys::mrb_state, ary: sys::mrb_value) -> 
             sys::mrb_write_barrier(mrb, basic);
             value.inner()
         }
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -91,7 +97,10 @@ unsafe extern "C" fn ary_mul(mrb: *mut sys::mrb_state, ary: sys::mrb_value) -> s
             sys::mrb_write_barrier(mrb, basic);
             value.inner()
         }
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -107,7 +116,10 @@ unsafe extern "C" fn ary_push_single(mrb: *mut sys::mrb_state, ary: sys::mrb_val
             sys::mrb_write_barrier(mrb, basic);
             value.inner()
         }
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -123,7 +135,10 @@ unsafe extern "C" fn ary_push(mrb: *mut sys::mrb_state, ary: sys::mrb_value) -> 
             sys::mrb_write_barrier(mrb, basic);
             value.inner()
         }
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -136,7 +151,10 @@ unsafe extern "C" fn ary_element_reference(mrb: *mut sys::mrb_state, ary: sys::m
     let result = trampoline::element_reference(&mut guard, array, elem, len);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -154,7 +172,10 @@ unsafe extern "C" fn ary_element_assignment(mrb: *mut sys::mrb_state, ary: sys::
             sys::mrb_write_barrier(mrb, basic);
             value.inner()
         }
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -169,7 +190,10 @@ unsafe extern "C" fn ary_clear(mrb: *mut sys::mrb_state, ary: sys::mrb_value) ->
             sys::mrb_write_barrier(mrb, basic);
             value.inner()
         }
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -185,7 +209,10 @@ unsafe extern "C" fn ary_concat(mrb: *mut sys::mrb_state, ary: sys::mrb_value) -
             sys::mrb_write_barrier(mrb, basic);
             value.inner()
         }
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -201,7 +228,10 @@ unsafe extern "C" fn ary_first(mrb: *mut sys::mrb_state, ary: sys::mrb_value) ->
             sys::mrb_write_barrier(mrb, basic);
             value.inner()
         }
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -218,7 +248,10 @@ unsafe extern "C" fn ary_initialize(mrb: *mut sys::mrb_state, ary: sys::mrb_valu
             sys::mrb_write_barrier(mrb, basic);
             value.inner()
         }
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -234,7 +267,10 @@ unsafe extern "C" fn ary_initialize_copy(mrb: *mut sys::mrb_state, ary: sys::mrb
             sys::mrb_write_barrier(mrb, basic);
             value.inner()
         }
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -250,7 +286,10 @@ unsafe extern "C" fn ary_last(mrb: *mut sys::mrb_state, ary: sys::mrb_value) -> 
             sys::mrb_write_barrier(mrb, basic);
             value.inner()
         }
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -270,7 +309,10 @@ unsafe extern "C" fn ary_len(mrb: *mut sys::mrb_state, ary: sys::mrb_value) -> s
             let len = guard.convert(len);
             len.inner()
         }
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -285,7 +327,10 @@ unsafe extern "C" fn ary_pop(mrb: *mut sys::mrb_state, ary: sys::mrb_value) -> s
             sys::mrb_write_barrier(mrb, basic);
             value.inner()
         }
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -300,7 +345,10 @@ unsafe extern "C" fn ary_reverse(mrb: *mut sys::mrb_state, ary: sys::mrb_value) 
             sys::mrb_write_barrier(mrb, basic);
             value.inner()
         }
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -315,7 +363,10 @@ unsafe extern "C" fn ary_reverse_bang(mrb: *mut sys::mrb_state, ary: sys::mrb_va
             sys::mrb_write_barrier(mrb, basic);
             value.inner()
         }
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -331,6 +382,9 @@ unsafe extern "C" fn ary_shift(mrb: *mut sys::mrb_state, ary: sys::mrb_value) ->
             sys::mrb_write_barrier(mrb, basic);
             value.inner()
         }
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }

--- a/artichoke-backend/src/extn/core/env/mruby.rs
+++ b/artichoke-backend/src/extn/core/env/mruby.rs
@@ -44,7 +44,10 @@ unsafe extern "C" fn env_initialize(mrb: *mut sys::mrb_state, slf: sys::mrb_valu
     let result = trampoline::initialize(&mut guard, slf);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -56,7 +59,10 @@ unsafe extern "C" fn env_element_reference(mrb: *mut sys::mrb_state, slf: sys::m
     let result = trampoline::element_reference(&mut guard, obj, name);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -69,7 +75,10 @@ unsafe extern "C" fn env_element_assignment(mrb: *mut sys::mrb_state, slf: sys::
     let result = trampoline::element_assignment(&mut guard, obj, name, value);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -80,6 +89,9 @@ unsafe extern "C" fn env_to_h(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> 
     let result = trampoline::to_h(&mut guard, obj);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }

--- a/artichoke-backend/src/extn/core/integer/mruby.rs
+++ b/artichoke-backend/src/extn/core/integer/mruby.rs
@@ -36,7 +36,10 @@ unsafe extern "C" fn integer_chr(mrb: *mut sys::mrb_state, slf: sys::mrb_value) 
     let result = trampoline::chr(&mut guard, value, encoding);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -48,7 +51,10 @@ unsafe extern "C" fn integer_element_reference(mrb: *mut sys::mrb_state, slf: sy
     let result = trampoline::element_reference(&mut guard, value, bit);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -60,7 +66,10 @@ unsafe extern "C" fn integer_div(mrb: *mut sys::mrb_state, slf: sys::mrb_value) 
     let result = trampoline::div(&mut guard, value, denominator);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -72,7 +81,10 @@ unsafe extern "C" fn integer_is_allbits(mrb: *mut sys::mrb_state, slf: sys::mrb_
     let result = trampoline::is_allbits(&mut guard, value, mask);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -84,7 +96,10 @@ unsafe extern "C" fn integer_is_anybits(mrb: *mut sys::mrb_state, slf: sys::mrb_
     let result = trampoline::is_anybits(&mut guard, value, mask);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -96,7 +111,10 @@ unsafe extern "C" fn integer_is_nobits(mrb: *mut sys::mrb_state, slf: sys::mrb_v
     let result = trampoline::is_nobits(&mut guard, value, mask);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -106,6 +124,9 @@ unsafe extern "C" fn integer_size(mrb: *mut sys::mrb_state, _slf: sys::mrb_value
     let result = trampoline::size(&guard);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }

--- a/artichoke-backend/src/extn/core/kernel/mruby.rs
+++ b/artichoke-backend/src/extn/core/kernel/mruby.rs
@@ -50,7 +50,10 @@ unsafe extern "C" fn kernel_integer(mrb: *mut sys::mrb_state, _slf: sys::mrb_val
     let result = trampoline::integer(&mut guard, arg, base);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -61,7 +64,10 @@ unsafe extern "C" fn kernel_load(mrb: *mut sys::mrb_state, _slf: sys::mrb_value)
     let result = trampoline::load(&mut guard, file);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -72,7 +78,10 @@ unsafe extern "C" fn kernel_p(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) ->
     let result = trampoline::p(&mut guard, args);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -83,7 +92,10 @@ unsafe extern "C" fn kernel_print(mrb: *mut sys::mrb_state, _slf: sys::mrb_value
     let result = trampoline::print(&mut guard, args);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -94,7 +106,10 @@ unsafe extern "C" fn kernel_puts(mrb: *mut sys::mrb_state, _slf: sys::mrb_value)
     let result = trampoline::puts(&mut guard, args);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -105,7 +120,10 @@ unsafe extern "C" fn kernel_require(mrb: *mut sys::mrb_state, _slf: sys::mrb_val
     let result = trampoline::require(&mut guard, file);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -116,6 +134,9 @@ unsafe extern "C" fn kernel_require_relative(mrb: *mut sys::mrb_state, _slf: sys
     let result = trampoline::require_relative(&mut guard, file);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }

--- a/artichoke-backend/src/extn/core/matchdata/mruby.rs
+++ b/artichoke-backend/src/extn/core/matchdata/mruby.rs
@@ -49,7 +49,10 @@ unsafe extern "C" fn matchdata_begin(mrb: *mut sys::mrb_state, slf: sys::mrb_val
     let result = trampoline::begin(&mut guard, value, begin);
     match result {
         Ok(result) => result.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -60,7 +63,10 @@ unsafe extern "C" fn matchdata_captures(mrb: *mut sys::mrb_state, slf: sys::mrb_
     let result = trampoline::captures(&mut guard, value);
     match result {
         Ok(result) => result.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -73,7 +79,10 @@ unsafe extern "C" fn matchdata_element_reference(mrb: *mut sys::mrb_state, slf: 
     let result = trampoline::element_reference(&mut guard, value, elem, len);
     match result {
         Ok(result) => result.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -85,7 +94,10 @@ unsafe extern "C" fn matchdata_end(mrb: *mut sys::mrb_state, slf: sys::mrb_value
     let result = trampoline::end(&mut guard, value, end);
     match result {
         Ok(result) => result.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -96,7 +108,10 @@ unsafe extern "C" fn matchdata_length(mrb: *mut sys::mrb_state, slf: sys::mrb_va
     let result = trampoline::length(&mut guard, value);
     match result {
         Ok(result) => result.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -107,7 +122,10 @@ unsafe extern "C" fn matchdata_named_captures(mrb: *mut sys::mrb_state, slf: sys
     let result = trampoline::named_captures(&mut guard, value);
     match result {
         Ok(result) => result.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -118,7 +136,10 @@ unsafe extern "C" fn matchdata_names(mrb: *mut sys::mrb_state, slf: sys::mrb_val
     let result = trampoline::names(&mut guard, value);
     match result {
         Ok(result) => result.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -130,7 +151,10 @@ unsafe extern "C" fn matchdata_offset(mrb: *mut sys::mrb_state, slf: sys::mrb_va
     let result = trampoline::offset(&mut guard, value, offset);
     match result {
         Ok(result) => result.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -141,7 +165,10 @@ unsafe extern "C" fn matchdata_post_match(mrb: *mut sys::mrb_state, slf: sys::mr
     let result = trampoline::post_match(&mut guard, value);
     match result {
         Ok(result) => result.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -152,7 +179,10 @@ unsafe extern "C" fn matchdata_pre_match(mrb: *mut sys::mrb_state, slf: sys::mrb
     let result = trampoline::pre_match(&mut guard, value);
     match result {
         Ok(result) => result.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -163,7 +193,10 @@ unsafe extern "C" fn matchdata_regexp(mrb: *mut sys::mrb_state, slf: sys::mrb_va
     let result = trampoline::regexp(&mut guard, value);
     match result {
         Ok(result) => result.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -174,7 +207,10 @@ unsafe extern "C" fn matchdata_string(mrb: *mut sys::mrb_state, slf: sys::mrb_va
     let result = trampoline::string(&mut guard, value);
     match result {
         Ok(result) => result.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -185,7 +221,10 @@ unsafe extern "C" fn matchdata_to_a(mrb: *mut sys::mrb_state, slf: sys::mrb_valu
     let result = trampoline::to_a(&mut guard, value);
     match result {
         Ok(result) => result.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -196,6 +235,9 @@ unsafe extern "C" fn matchdata_to_s(mrb: *mut sys::mrb_state, slf: sys::mrb_valu
     let result = trampoline::to_s(&mut guard, value);
     match result {
         Ok(result) => result.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }

--- a/artichoke-backend/src/extn/core/math/mruby.rs
+++ b/artichoke-backend/src/extn/core/math/mruby.rs
@@ -71,7 +71,10 @@ unsafe extern "C" fn math_acos(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -
     let result = trampoline::acos(&mut guard, value).map(|result| guard.convert_mut(result));
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -82,7 +85,10 @@ unsafe extern "C" fn math_acosh(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) 
     let result = trampoline::acosh(&mut guard, value).map(|result| guard.convert_mut(result));
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -93,7 +99,10 @@ unsafe extern "C" fn math_asin(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -
     let result = trampoline::asin(&mut guard, value).map(|result| guard.convert_mut(result));
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -104,7 +113,10 @@ unsafe extern "C" fn math_asinh(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) 
     let result = trampoline::asinh(&mut guard, value).map(|result| guard.convert_mut(result));
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -115,7 +127,10 @@ unsafe extern "C" fn math_atan(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -
     let result = trampoline::atan(&mut guard, value).map(|result| guard.convert_mut(result));
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -127,7 +142,10 @@ unsafe extern "C" fn math_atan2(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) 
     let result = trampoline::atan2(&mut guard, value, other).map(|result| guard.convert_mut(result));
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -138,7 +156,10 @@ unsafe extern "C" fn math_atanh(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) 
     let result = trampoline::atanh(&mut guard, value).map(|result| guard.convert_mut(result));
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -149,7 +170,10 @@ unsafe extern "C" fn math_cbrt(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -
     let result = trampoline::cbrt(&mut guard, value).map(|result| guard.convert_mut(result));
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -160,7 +184,10 @@ unsafe extern "C" fn math_cos(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) ->
     let result = trampoline::cos(&mut guard, value).map(|result| guard.convert_mut(result));
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -171,7 +198,10 @@ unsafe extern "C" fn math_cosh(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -
     let result = trampoline::cosh(&mut guard, value).map(|result| guard.convert_mut(result));
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -182,7 +212,10 @@ unsafe extern "C" fn math_erf(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) ->
     let result = trampoline::erf(&mut guard, value).map(|result| guard.convert_mut(result));
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -193,7 +226,10 @@ unsafe extern "C" fn math_erfc(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -
     let result = trampoline::erfc(&mut guard, value).map(|result| guard.convert_mut(result));
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -204,7 +240,10 @@ unsafe extern "C" fn math_exp(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) ->
     let result = trampoline::exp(&mut guard, value).map(|result| guard.convert_mut(result));
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -219,7 +258,10 @@ unsafe extern "C" fn math_frexp(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) 
     });
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -230,7 +272,10 @@ unsafe extern "C" fn math_gamma(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) 
     let result = trampoline::gamma(&mut guard, value).map(|result| guard.convert_mut(result));
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -242,7 +287,10 @@ unsafe extern "C" fn math_hypot(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) 
     let result = trampoline::hypot(&mut guard, value, other).map(|result| guard.convert_mut(result));
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -254,7 +302,10 @@ unsafe extern "C" fn math_ldexp(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) 
     let result = trampoline::ldexp(&mut guard, fraction, exponent).map(|result| guard.convert_mut(result));
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -269,7 +320,10 @@ unsafe extern "C" fn math_lgamma(mrb: *mut sys::mrb_state, _slf: sys::mrb_value)
     });
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -281,7 +335,10 @@ unsafe extern "C" fn math_log(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) ->
     let result = trampoline::log(&mut guard, value, base).map(|result| guard.convert_mut(result));
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -292,7 +349,10 @@ unsafe extern "C" fn math_log10(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) 
     let result = trampoline::log10(&mut guard, value).map(|result| guard.convert_mut(result));
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -303,7 +363,10 @@ unsafe extern "C" fn math_log2(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -
     let result = trampoline::log2(&mut guard, value).map(|result| guard.convert_mut(result));
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -314,7 +377,10 @@ unsafe extern "C" fn math_sin(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) ->
     let result = trampoline::sin(&mut guard, value).map(|result| guard.convert_mut(result));
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -325,7 +391,10 @@ unsafe extern "C" fn math_sinh(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -
     let result = trampoline::sinh(&mut guard, value).map(|result| guard.convert_mut(result));
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -336,7 +405,10 @@ unsafe extern "C" fn math_sqrt(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -
     let result = trampoline::sqrt(&mut guard, value).map(|result| guard.convert_mut(result));
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -347,7 +419,10 @@ unsafe extern "C" fn math_tan(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) ->
     let result = trampoline::tan(&mut guard, value).map(|result| guard.convert_mut(result));
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -358,6 +433,9 @@ unsafe extern "C" fn math_tanh(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -
     let result = trampoline::tanh(&mut guard, value).map(|result| guard.convert_mut(result));
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }

--- a/artichoke-backend/src/extn/core/random/mruby.rs
+++ b/artichoke-backend/src/extn/core/random/mruby.rs
@@ -43,7 +43,10 @@ unsafe extern "C" fn random_initialize(mrb: *mut sys::mrb_state, slf: sys::mrb_v
     let result = trampoline::initialize(&mut guard, seed, slf);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -55,7 +58,10 @@ unsafe extern "C" fn random_eq(mrb: *mut sys::mrb_state, slf: sys::mrb_value) ->
     let result = trampoline::equal(&mut guard, rand, other);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -67,7 +73,10 @@ unsafe extern "C" fn random_bytes(mrb: *mut sys::mrb_state, slf: sys::mrb_value)
     let result = trampoline::bytes(&mut guard, rand, size);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -79,7 +88,10 @@ unsafe extern "C" fn random_rand(mrb: *mut sys::mrb_state, slf: sys::mrb_value) 
     let result = trampoline::rand(&mut guard, rand, max);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -90,7 +102,10 @@ unsafe extern "C" fn random_seed(mrb: *mut sys::mrb_state, slf: sys::mrb_value) 
     let result = trampoline::seed(&mut guard, rand);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -100,7 +115,10 @@ unsafe extern "C" fn random_self_new_seed(mrb: *mut sys::mrb_state, _slf: sys::m
     let result = trampoline::new_seed(&mut guard);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -111,7 +129,10 @@ unsafe extern "C" fn random_self_srand(mrb: *mut sys::mrb_state, _slf: sys::mrb_
     let result = trampoline::srand(&mut guard, number);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -122,6 +143,9 @@ unsafe extern "C" fn random_self_urandom(mrb: *mut sys::mrb_state, _slf: sys::mr
     let result = trampoline::urandom(&mut guard, size);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }

--- a/artichoke-backend/src/extn/core/regexp/mruby.rs
+++ b/artichoke-backend/src/extn/core/regexp/mruby.rs
@@ -64,7 +64,10 @@ unsafe extern "C" fn initialize(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -
     let result = trampoline::initialize(&mut guard, pattern, options, encoding, slf);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -87,7 +90,10 @@ unsafe extern "C" fn escape(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> s
     let result = trampoline::escape(&mut guard, pattern);
     match result {
         Ok(result) => result.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -98,7 +104,10 @@ unsafe extern "C" fn union(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sy
     let result = trampoline::union(&mut guard, args);
     match result {
         Ok(result) => result.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -111,7 +120,10 @@ unsafe extern "C" fn match_q(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> s
     let result = trampoline::is_match(&mut guard, value, pattern, pos);
     match result {
         Ok(result) => result.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -124,7 +136,10 @@ unsafe extern "C" fn match_(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sy
     let result = trampoline::match_(&mut guard, value, pattern, pos, block);
     match result {
         Ok(result) => result.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -136,7 +151,10 @@ unsafe extern "C" fn eql(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::
     let result = trampoline::eql(&mut guard, value, other);
     match result {
         Ok(result) => result.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -148,7 +166,10 @@ unsafe extern "C" fn case_compare(mrb: *mut sys::mrb_state, slf: sys::mrb_value)
     let result = trampoline::case_compare(&mut guard, value, pattern);
     match result {
         Ok(result) => result.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -160,7 +181,10 @@ unsafe extern "C" fn match_operator(mrb: *mut sys::mrb_state, slf: sys::mrb_valu
     let result = trampoline::match_operator(&mut guard, value, pattern);
     match result {
         Ok(result) => result.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -171,7 +195,10 @@ unsafe extern "C" fn casefold(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> 
     let result = trampoline::is_casefold(&mut guard, value);
     match result {
         Ok(result) => result.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -182,7 +209,10 @@ unsafe extern "C" fn fixed_encoding(mrb: *mut sys::mrb_state, slf: sys::mrb_valu
     let result = trampoline::is_fixed_encoding(&mut guard, value);
     match result {
         Ok(result) => result.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -193,7 +223,10 @@ unsafe extern "C" fn hash(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys:
     let result = trampoline::hash(&mut guard, value);
     match result {
         Ok(result) => result.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -204,7 +237,10 @@ unsafe extern "C" fn inspect(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> s
     let result = trampoline::inspect(&mut guard, value);
     match result {
         Ok(result) => result.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -215,7 +251,10 @@ unsafe extern "C" fn named_captures(mrb: *mut sys::mrb_state, slf: sys::mrb_valu
     let result = trampoline::named_captures(&mut guard, value);
     match result {
         Ok(result) => result.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -226,7 +265,10 @@ unsafe extern "C" fn names(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys
     let result = trampoline::names(&mut guard, value);
     match result {
         Ok(result) => result.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -237,7 +279,10 @@ unsafe extern "C" fn options(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> s
     let result = trampoline::options(&mut guard, value);
     match result {
         Ok(result) => result.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -248,7 +293,10 @@ unsafe extern "C" fn source(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sy
     let result = trampoline::source(&mut guard, value);
     match result {
         Ok(result) => result.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -259,6 +307,9 @@ unsafe extern "C" fn to_s(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys:
     let result = trampoline::to_s(&mut guard, value);
     match result {
         Ok(result) => result.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }

--- a/artichoke-backend/src/extn/core/string/ffi.rs
+++ b/artichoke-backend/src/extn/core/string/ffi.rs
@@ -40,7 +40,10 @@ unsafe extern "C" fn mrb_str_new_capa(mrb: *mut sys::mrb_state, capa: sys::mrb_i
     let result = String::alloc_value(result, &mut guard);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -65,7 +68,10 @@ unsafe extern "C" fn mrb_str_new(mrb: *mut sys::mrb_state, p: *const c_char, len
     let result = String::alloc_value(s, &mut guard);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -81,7 +87,10 @@ unsafe extern "C" fn mrb_str_new_cstr(mrb: *mut sys::mrb_state, p: *const c_char
     let result = String::alloc_value(result, &mut guard);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 

--- a/artichoke-backend/src/extn/core/string/mruby.rs
+++ b/artichoke-backend/src/extn/core/string/mruby.rs
@@ -89,7 +89,10 @@ unsafe extern "C" fn string_mul(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -
     let result = trampoline::mul(&mut guard, value, other);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -101,7 +104,10 @@ unsafe extern "C" fn string_add(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -
     let result = trampoline::add(&mut guard, value, other);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -113,7 +119,10 @@ unsafe extern "C" fn string_append(mrb: *mut sys::mrb_state, slf: sys::mrb_value
     let result = trampoline::append(&mut guard, value, other);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -125,7 +134,10 @@ unsafe extern "C" fn string_cmp_rocket(mrb: *mut sys::mrb_state, slf: sys::mrb_v
     let result = trampoline::cmp_rocket(&mut guard, value, other);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -137,7 +149,10 @@ unsafe extern "C" fn string_equals_equals(mrb: *mut sys::mrb_state, slf: sys::mr
     let result = trampoline::equals_equals(&mut guard, value, other);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -150,7 +165,10 @@ unsafe extern "C" fn string_aref(mrb: *mut sys::mrb_state, slf: sys::mrb_value) 
     let result = trampoline::aref(&mut guard, value, first, second);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -161,7 +179,10 @@ unsafe extern "C" fn string_aset(mrb: *mut sys::mrb_state, slf: sys::mrb_value) 
     let result = trampoline::aset(&mut guard, value);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -172,7 +193,10 @@ unsafe extern "C" fn string_ascii_only(mrb: *mut sys::mrb_state, slf: sys::mrb_v
     let result = trampoline::is_ascii_only(&mut guard, value);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -183,7 +207,10 @@ unsafe extern "C" fn string_b(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> 
     let result = trampoline::b(&mut guard, value);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -196,7 +223,10 @@ unsafe extern "C" fn string_byteindex(mrb: *mut sys::mrb_state, slf: sys::mrb_va
     let result = trampoline::byteindex(&mut guard, value, substring, offset);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -209,7 +239,10 @@ unsafe extern "C" fn string_byterindex(mrb: *mut sys::mrb_state, slf: sys::mrb_v
     let result = trampoline::byterindex(&mut guard, value, substring, offset);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -220,7 +253,10 @@ unsafe extern "C" fn string_bytes(mrb: *mut sys::mrb_state, slf: sys::mrb_value)
     let result = trampoline::bytes(&mut guard, value);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -231,7 +267,10 @@ unsafe extern "C" fn string_bytesize(mrb: *mut sys::mrb_state, slf: sys::mrb_val
     let result = trampoline::bytesize(&mut guard, value);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -254,7 +293,10 @@ unsafe extern "C" fn string_byteslice(mrb: *mut sys::mrb_state, slf: sys::mrb_va
 
             value
         }
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -265,7 +307,10 @@ unsafe extern "C" fn string_capitalize(mrb: *mut sys::mrb_state, slf: sys::mrb_v
     let result = trampoline::capitalize(&mut guard, value);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -276,7 +321,10 @@ unsafe extern "C" fn string_capitalize_bang(mrb: *mut sys::mrb_state, slf: sys::
     let result = trampoline::capitalize_bang(&mut guard, value);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -288,7 +336,10 @@ unsafe extern "C" fn string_casecmp_ascii(mrb: *mut sys::mrb_state, slf: sys::mr
     let result = trampoline::casecmp_ascii(&mut guard, value, other);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -300,7 +351,10 @@ unsafe extern "C" fn string_casecmp_unicode(mrb: *mut sys::mrb_state, slf: sys::
     let result = trampoline::casecmp_unicode(&mut guard, value, other);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -313,7 +367,10 @@ unsafe extern "C" fn string_center(mrb: *mut sys::mrb_state, slf: sys::mrb_value
     let result = trampoline::center(&mut guard, value, width, padstr);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -324,7 +381,10 @@ unsafe extern "C" fn string_chars(mrb: *mut sys::mrb_state, slf: sys::mrb_value)
     let result = trampoline::chars(&mut guard, value);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -345,7 +405,10 @@ unsafe extern "C" fn string_chomp(mrb: *mut sys::mrb_state, slf: sys::mrb_value)
 
             value
         }
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -357,7 +420,10 @@ unsafe extern "C" fn string_chomp_bang(mrb: *mut sys::mrb_state, slf: sys::mrb_v
     let result = trampoline::chomp_bang(&mut guard, value, separator);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -377,7 +443,10 @@ unsafe extern "C" fn string_chop(mrb: *mut sys::mrb_state, slf: sys::mrb_value) 
 
             value
         }
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -388,7 +457,10 @@ unsafe extern "C" fn string_chop_bang(mrb: *mut sys::mrb_state, slf: sys::mrb_va
     let result = trampoline::chop_bang(&mut guard, value);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -399,7 +471,10 @@ unsafe extern "C" fn string_chr(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -
     let result = trampoline::chr(&mut guard, value);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -410,7 +485,10 @@ unsafe extern "C" fn string_clear(mrb: *mut sys::mrb_state, slf: sys::mrb_value)
     let result = trampoline::clear(&mut guard, value);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -421,7 +499,10 @@ unsafe extern "C" fn string_codepoints(mrb: *mut sys::mrb_state, slf: sys::mrb_v
     let result = trampoline::codepoints(&mut guard, value);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -432,7 +513,10 @@ unsafe extern "C" fn string_concat(mrb: *mut sys::mrb_state, slf: sys::mrb_value
     let result = trampoline::concat(&mut guard, value);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -443,7 +527,10 @@ unsafe extern "C" fn string_downcase(mrb: *mut sys::mrb_state, slf: sys::mrb_val
     let result = trampoline::downcase(&mut guard, value);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -454,7 +541,10 @@ unsafe extern "C" fn string_downcase_bang(mrb: *mut sys::mrb_state, slf: sys::mr
     let result = trampoline::downcase_bang(&mut guard, value);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -465,7 +555,10 @@ unsafe extern "C" fn string_empty(mrb: *mut sys::mrb_state, slf: sys::mrb_value)
     let result = trampoline::is_empty(&mut guard, value);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -477,7 +570,10 @@ unsafe extern "C" fn string_end_with(mrb: *mut sys::mrb_state, slf: sys::mrb_val
     let result = trampoline::end_with(&mut guard, value, suffixes);
     match result {
         Ok(result) => result.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -489,7 +585,10 @@ unsafe extern "C" fn string_eql(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -
     let result = trampoline::eql(&mut guard, value, other);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -501,7 +600,10 @@ unsafe extern "C" fn string_getbyte(mrb: *mut sys::mrb_state, slf: sys::mrb_valu
     let result = trampoline::getbyte(&mut guard, value, index);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -512,7 +614,10 @@ unsafe extern "C" fn string_hash(mrb: *mut sys::mrb_state, slf: sys::mrb_value) 
     let result = trampoline::hash(&mut guard, value);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -524,7 +629,10 @@ unsafe extern "C" fn string_include(mrb: *mut sys::mrb_state, slf: sys::mrb_valu
     let result = trampoline::include(&mut guard, value, other);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -537,7 +645,10 @@ unsafe extern "C" fn string_index(mrb: *mut sys::mrb_state, slf: sys::mrb_value)
     let result = trampoline::index(&mut guard, value, needle, offset);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -549,7 +660,10 @@ unsafe extern "C" fn string_initialize(mrb: *mut sys::mrb_state, slf: sys::mrb_v
     let result = trampoline::initialize(&mut guard, value, s);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -561,7 +675,10 @@ unsafe extern "C" fn string_initialize_copy(mrb: *mut sys::mrb_state, slf: sys::
     let result = trampoline::initialize_copy(&mut guard, value, other);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -572,7 +689,10 @@ unsafe extern "C" fn string_inspect(mrb: *mut sys::mrb_state, slf: sys::mrb_valu
     let result = trampoline::inspect(&mut guard, value);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -583,7 +703,10 @@ unsafe extern "C" fn string_intern(mrb: *mut sys::mrb_state, slf: sys::mrb_value
     let result = trampoline::intern(&mut guard, value);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -594,7 +717,10 @@ unsafe extern "C" fn string_length(mrb: *mut sys::mrb_state, slf: sys::mrb_value
     let result = trampoline::length(&mut guard, value);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -605,7 +731,10 @@ unsafe extern "C" fn string_ord(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -
     let result = trampoline::ord(&mut guard, value);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -617,7 +746,10 @@ unsafe extern "C" fn string_replace(mrb: *mut sys::mrb_state, slf: sys::mrb_valu
     let result = trampoline::replace(&mut guard, value, other);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -628,7 +760,10 @@ unsafe extern "C" fn string_reverse(mrb: *mut sys::mrb_state, slf: sys::mrb_valu
     let result = trampoline::reverse(&mut guard, value);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -639,7 +774,10 @@ unsafe extern "C" fn string_reverse_bang(mrb: *mut sys::mrb_state, slf: sys::mrb
     let result = trampoline::reverse_bang(&mut guard, value);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -652,7 +790,10 @@ unsafe extern "C" fn string_rindex(mrb: *mut sys::mrb_state, slf: sys::mrb_value
     let result = trampoline::rindex(&mut guard, value, needle, offset);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -664,7 +805,10 @@ unsafe extern "C" fn string_scan(mrb: *mut sys::mrb_state, slf: sys::mrb_value) 
     let result = trampoline::scan(&mut guard, value, pattern, block);
     match result {
         Ok(result) => result.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -677,7 +821,10 @@ unsafe extern "C" fn string_setbyte(mrb: *mut sys::mrb_state, slf: sys::mrb_valu
     let result = trampoline::setbyte(&mut guard, value, index, byte);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -688,7 +835,10 @@ unsafe extern "C" fn string_slice_bang(mrb: *mut sys::mrb_state, slf: sys::mrb_v
     let result = trampoline::slice_bang(&mut guard, value);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -699,7 +849,10 @@ unsafe extern "C" fn string_split(mrb: *mut sys::mrb_state, slf: sys::mrb_value)
     let result = trampoline::split(&mut guard, value);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -711,7 +864,10 @@ unsafe extern "C" fn string_start_with(mrb: *mut sys::mrb_state, slf: sys::mrb_v
     let result = trampoline::start_with(&mut guard, value, prefixes);
     match result {
         Ok(result) => result.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -722,7 +878,10 @@ unsafe extern "C" fn string_to_f(mrb: *mut sys::mrb_state, slf: sys::mrb_value) 
     let result = trampoline::to_f(&mut guard, value);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -734,7 +893,10 @@ unsafe extern "C" fn string_to_i(mrb: *mut sys::mrb_state, slf: sys::mrb_value) 
     let result = trampoline::to_i(&mut guard, value, base);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -746,7 +908,10 @@ unsafe extern "C" fn string_to_s(mrb: *mut sys::mrb_state, slf: sys::mrb_value) 
     let result = trampoline::to_s(&mut guard, value);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -757,7 +922,10 @@ unsafe extern "C" fn string_upcase(mrb: *mut sys::mrb_state, slf: sys::mrb_value
     let result = trampoline::upcase(&mut guard, value);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -768,7 +936,10 @@ unsafe extern "C" fn string_upcase_bang(mrb: *mut sys::mrb_state, slf: sys::mrb_
     let result = trampoline::upcase_bang(&mut guard, value);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -779,6 +950,9 @@ unsafe extern "C" fn string_valid_encoding(mrb: *mut sys::mrb_state, slf: sys::m
     let result = trampoline::is_valid_encoding(&mut guard, value);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }

--- a/artichoke-backend/src/extn/core/symbol/mruby.rs
+++ b/artichoke-backend/src/extn/core/symbol/mruby.rs
@@ -34,7 +34,10 @@ unsafe extern "C" fn symbol_all_symbols(mrb: *mut sys::mrb_state, _slf: sys::mrb
     let result = trampoline::all_symbols(&mut guard);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -46,7 +49,10 @@ unsafe extern "C" fn symbol_equal_equal(mrb: *mut sys::mrb_state, slf: sys::mrb_
     let result = trampoline::equal_equal(&mut guard, sym, other);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -58,7 +64,10 @@ unsafe extern "C" fn symbol_ascii_casecmp(mrb: *mut sys::mrb_state, slf: sys::mr
     let result = trampoline::ascii_casecmp(&mut guard, sym, other);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -70,7 +79,10 @@ unsafe extern "C" fn symbol_unicode_casecmp(mrb: *mut sys::mrb_state, slf: sys::
     let result = trampoline::unicode_casecmp(&mut guard, sym, other);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -81,7 +93,10 @@ unsafe extern "C" fn symbol_empty(mrb: *mut sys::mrb_state, slf: sys::mrb_value)
     let result = trampoline::is_empty(&mut guard, sym);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -92,7 +107,10 @@ unsafe extern "C" fn symbol_inspect(mrb: *mut sys::mrb_state, slf: sys::mrb_valu
     let result = trampoline::inspect(&mut guard, value);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -103,7 +121,10 @@ unsafe extern "C" fn symbol_length(mrb: *mut sys::mrb_state, slf: sys::mrb_value
     let result = trampoline::length(&mut guard, sym);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -114,6 +135,9 @@ unsafe extern "C" fn symbol_to_s(mrb: *mut sys::mrb_state, slf: sys::mrb_value) 
     let result = trampoline::bytes(&mut guard, sym);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }

--- a/artichoke-backend/src/extn/core/time/mruby.rs
+++ b/artichoke-backend/src/extn/core/time/mruby.rs
@@ -107,7 +107,10 @@ unsafe extern "C" fn time_self_now(mrb: *mut sys::mrb_state, _slf: sys::mrb_valu
     let result = trampoline::now(&mut guard);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -123,7 +126,10 @@ unsafe extern "C" fn time_self_at(mrb: *mut sys::mrb_state, _slf: sys::mrb_value
     let result = trampoline::at(&mut guard, seconds, opt1, opt2, opt3);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -134,7 +140,10 @@ unsafe extern "C" fn time_self_mkutc(mrb: *mut sys::mrb_state, _slf: sys::mrb_va
     let result = trampoline::mkutc(&mut guard, &mut args);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -145,7 +154,10 @@ unsafe extern "C" fn time_self_mktime(mrb: *mut sys::mrb_state, _slf: sys::mrb_v
     let result = trampoline::mktime(&mut guard, &mut args);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -158,7 +170,10 @@ unsafe extern "C" fn time_to_int(mrb: *mut sys::mrb_state, slf: sys::mrb_value) 
     let result = trampoline::to_int(&mut guard, time);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -169,7 +184,10 @@ unsafe extern "C" fn time_to_float(mrb: *mut sys::mrb_state, slf: sys::mrb_value
     let result = trampoline::to_float(&mut guard, time);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -180,7 +198,10 @@ unsafe extern "C" fn time_to_rational(mrb: *mut sys::mrb_state, slf: sys::mrb_va
     let result = trampoline::to_rational(&mut guard, time);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -192,7 +213,10 @@ unsafe extern "C" fn time_cmp(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> 
     let result = trampoline::cmp(&mut guard, time, other);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -204,7 +228,10 @@ unsafe extern "C" fn time_eql(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> 
     let result = trampoline::eql(&mut guard, time, other);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -215,7 +242,10 @@ unsafe extern "C" fn time_hash(mrb: *mut sys::mrb_state, slf: sys::mrb_value) ->
     let result = trampoline::hash(&mut guard, time);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -227,7 +257,10 @@ unsafe extern "C" fn time_initialize(mrb: *mut sys::mrb_state, slf: sys::mrb_val
     let result = trampoline::initialize(&mut guard, time, args);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -239,7 +272,10 @@ unsafe extern "C" fn time_initialize_copy(mrb: *mut sys::mrb_state, slf: sys::mr
     let result = trampoline::initialize_copy(&mut guard, time, other);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -253,7 +289,10 @@ unsafe extern "C" fn time_mutate_to_local(mrb: *mut sys::mrb_state, slf: sys::mr
     let result = trampoline::mutate_to_local(&mut guard, time, utc_offset);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -264,7 +303,10 @@ unsafe extern "C" fn time_mutate_to_utc(mrb: *mut sys::mrb_state, slf: sys::mrb_
     let result = trampoline::mutate_to_utc(&mut guard, time);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -276,7 +318,10 @@ unsafe extern "C" fn time_as_local(mrb: *mut sys::mrb_state, slf: sys::mrb_value
     let result = trampoline::as_local(&mut guard, time, utc_offset);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -287,7 +332,10 @@ unsafe extern "C" fn time_as_utc(mrb: *mut sys::mrb_state, slf: sys::mrb_value) 
     let result = trampoline::as_utc(&mut guard, time);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -300,7 +348,10 @@ unsafe extern "C" fn time_asctime(mrb: *mut sys::mrb_state, slf: sys::mrb_value)
     let result = trampoline::asctime(&mut guard, time);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -311,7 +362,10 @@ unsafe extern "C" fn time_to_string(mrb: *mut sys::mrb_state, slf: sys::mrb_valu
     let result = trampoline::to_string(&mut guard, time);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -322,7 +376,10 @@ unsafe extern "C" fn time_to_array(mrb: *mut sys::mrb_state, slf: sys::mrb_value
     let result = trampoline::to_array(&mut guard, time);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -336,7 +393,10 @@ unsafe extern "C" fn time_plus(mrb: *mut sys::mrb_state, slf: sys::mrb_value) ->
     let result = trampoline::plus(&mut guard, time, other);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -348,7 +408,10 @@ unsafe extern "C" fn time_minus(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -
     let result = trampoline::minus(&mut guard, time, other);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -361,7 +424,10 @@ unsafe extern "C" fn time_succ(mrb: *mut sys::mrb_state, slf: sys::mrb_value) ->
     let result = trampoline::succ(&mut guard, time);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -373,7 +439,10 @@ unsafe extern "C" fn time_round(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -
     let result = trampoline::round(&mut guard, time, num_digits);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -386,7 +455,10 @@ unsafe extern "C" fn time_second(mrb: *mut sys::mrb_state, slf: sys::mrb_value) 
     let result = trampoline::second(&mut guard, time);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -397,7 +469,10 @@ unsafe extern "C" fn time_minute(mrb: *mut sys::mrb_state, slf: sys::mrb_value) 
     let result = trampoline::minute(&mut guard, time);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -408,7 +483,10 @@ unsafe extern "C" fn time_hour(mrb: *mut sys::mrb_state, slf: sys::mrb_value) ->
     let result = trampoline::hour(&mut guard, time);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -419,7 +497,10 @@ unsafe extern "C" fn time_day(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> 
     let result = trampoline::day(&mut guard, time);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -430,7 +511,10 @@ unsafe extern "C" fn time_month(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -
     let result = trampoline::month(&mut guard, time);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -441,7 +525,10 @@ unsafe extern "C" fn time_year(mrb: *mut sys::mrb_state, slf: sys::mrb_value) ->
     let result = trampoline::year(&mut guard, time);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -452,7 +539,10 @@ unsafe extern "C" fn time_weekday(mrb: *mut sys::mrb_state, slf: sys::mrb_value)
     let result = trampoline::weekday(&mut guard, time);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -463,7 +553,10 @@ unsafe extern "C" fn time_year_day(mrb: *mut sys::mrb_state, slf: sys::mrb_value
     let result = trampoline::year_day(&mut guard, time);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -474,7 +567,10 @@ unsafe extern "C" fn time_is_dst(mrb: *mut sys::mrb_state, slf: sys::mrb_value) 
     let result = trampoline::is_dst(&mut guard, time);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -485,7 +581,10 @@ unsafe extern "C" fn time_zone(mrb: *mut sys::mrb_state, slf: sys::mrb_value) ->
     let result = trampoline::timezone(&mut guard, time);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -496,7 +595,10 @@ unsafe extern "C" fn time_utc_offset(mrb: *mut sys::mrb_state, slf: sys::mrb_val
     let result = trampoline::utc_offset(&mut guard, time);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -509,7 +611,10 @@ unsafe extern "C" fn time_is_utc(mrb: *mut sys::mrb_state, slf: sys::mrb_value) 
     let result = trampoline::is_utc(&mut guard, time);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -522,7 +627,10 @@ unsafe extern "C" fn time_is_sunday(mrb: *mut sys::mrb_state, slf: sys::mrb_valu
     let result = trampoline::is_sunday(&mut guard, time);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -533,7 +641,10 @@ unsafe extern "C" fn time_is_monday(mrb: *mut sys::mrb_state, slf: sys::mrb_valu
     let result = trampoline::is_monday(&mut guard, time);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -544,7 +655,10 @@ unsafe extern "C" fn time_is_tuesday(mrb: *mut sys::mrb_state, slf: sys::mrb_val
     let result = trampoline::is_tuesday(&mut guard, time);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -555,7 +669,10 @@ unsafe extern "C" fn time_is_wednesday(mrb: *mut sys::mrb_state, slf: sys::mrb_v
     let result = trampoline::is_wednesday(&mut guard, time);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -566,7 +683,10 @@ unsafe extern "C" fn time_is_thursday(mrb: *mut sys::mrb_state, slf: sys::mrb_va
     let result = trampoline::is_thursday(&mut guard, time);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -577,7 +697,10 @@ unsafe extern "C" fn time_is_friday(mrb: *mut sys::mrb_state, slf: sys::mrb_valu
     let result = trampoline::is_friday(&mut guard, time);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -588,7 +711,10 @@ unsafe extern "C" fn time_is_saturday(mrb: *mut sys::mrb_state, slf: sys::mrb_va
     let result = trampoline::is_saturday(&mut guard, time);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -601,7 +727,10 @@ unsafe extern "C" fn time_microsecond(mrb: *mut sys::mrb_state, slf: sys::mrb_va
     let result = trampoline::microsecond(&mut guard, time);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -612,7 +741,10 @@ unsafe extern "C" fn time_nanosecond(mrb: *mut sys::mrb_state, slf: sys::mrb_val
     let result = trampoline::nanosecond(&mut guard, time);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -623,7 +755,10 @@ unsafe extern "C" fn time_subsec(mrb: *mut sys::mrb_state, slf: sys::mrb_value) 
     let result = trampoline::subsec(&mut guard, time);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -637,6 +772,9 @@ unsafe extern "C" fn time_strftime(mrb: *mut sys::mrb_state, slf: sys::mrb_value
     let result = trampoline::strftime(&mut guard, time, format);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }

--- a/artichoke-backend/src/extn/stdlib/securerandom/mruby.rs
+++ b/artichoke-backend/src/extn/stdlib/securerandom/mruby.rs
@@ -50,7 +50,10 @@ unsafe extern "C" fn securerandom_alphanumeric(mrb: *mut sys::mrb_state, _slf: s
     let result = trampoline::alphanumeric(&mut guard, len);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -61,7 +64,10 @@ unsafe extern "C" fn securerandom_base64(mrb: *mut sys::mrb_state, _slf: sys::mr
     let result = trampoline::base64(&mut guard, len);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -73,7 +79,10 @@ unsafe extern "C" fn securerandom_urlsafe_base64(mrb: *mut sys::mrb_state, _slf:
     let result = trampoline::urlsafe_base64(&mut guard, len, padding);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -84,7 +93,10 @@ unsafe extern "C" fn securerandom_hex(mrb: *mut sys::mrb_state, _slf: sys::mrb_v
     let result = trampoline::hex(&mut guard, len);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -95,7 +107,10 @@ unsafe extern "C" fn securerandom_random_bytes(mrb: *mut sys::mrb_state, _slf: s
     let result = trampoline::random_bytes(&mut guard, len);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -106,7 +121,10 @@ unsafe extern "C" fn securerandom_random_number(mrb: *mut sys::mrb_state, _slf: 
     let result = trampoline::random_number(&mut guard, max);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 
@@ -116,6 +134,9 @@ unsafe extern "C" fn securerandom_uuid(mrb: *mut sys::mrb_state, _slf: sys::mrb_
     let result = trampoline::uuid(&mut guard);
     match result {
         Ok(value) => value.inner(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }

--- a/artichoke-backend/tests/integration/leak/boxing.rs
+++ b/artichoke-backend/tests/integration/leak/boxing.rs
@@ -31,7 +31,10 @@ unsafe extern "C" fn container_initialize(mrb: *mut sys::mrb_state, slf: sys::mr
     let result = Container::box_into_value(container, slf, &mut guard);
     match result {
         Ok(value) => value.into(),
-        Err(exception) => error::raise(guard, exception),
+        Err(exception) => {
+            // SAFETY: only Copy objects remain on the stack
+            unsafe { error::raise(guard, exception) }
+        }
     }
 }
 

--- a/ui-tests/src/lib.rs
+++ b/ui-tests/src/lib.rs
@@ -1,3 +1,34 @@
+#![warn(clippy::all, clippy::pedantic, clippy::undocumented_unsafe_blocks)]
+#![allow(
+    clippy::let_underscore_untyped,
+    reason = "https://github.com/rust-lang/rust-clippy/pull/10442#issuecomment-1516570154"
+)]
+#![allow(
+    clippy::question_mark,
+    reason = "https://github.com/rust-lang/rust-clippy/issues/8281"
+)]
+#![allow(clippy::manual_let_else, reason = "manual_let_else was very buggy on release")]
+#![allow(clippy::missing_errors_doc, reason = "A lot of existing code fails this lint")]
+#![allow(
+    clippy::unnecessary_lazy_evaluations,
+    reason = "https://github.com/rust-lang/rust-clippy/issues/8109"
+)]
+#![cfg_attr(
+    test,
+    allow(clippy::non_ascii_literal, reason = "tests sometimes require UTF-8 string content")
+)]
+#![allow(unknown_lints)]
+#![warn(
+    missing_copy_implementations,
+    missing_debug_implementations,
+    // missing_docs,
+    rust_2024_compatibility,
+    trivial_casts,
+    trivial_numeric_casts,
+    unused_qualifications,
+    variant_size_differences
+)]
+
 use std::env;
 use std::path::PathBuf;
 use std::process::{Command, Output};
@@ -5,6 +36,7 @@ use std::process::{Command, Output};
 use bstr::{BString, ByteSlice};
 use serde::ser::{Serialize, SerializeStruct, Serializer};
 
+#[derive(Debug)]
 pub struct CommandOutput {
     call_args: Vec<String>,
     status: i32,
@@ -88,12 +120,18 @@ fn binary_path(name: &str) -> Result<PathBuf, String> {
         .join("debug")
         .join(&executable);
 
-    match path.exists() {
-        true => Ok(path),
-        false => Err(format!("Can't find binary {executable} in ./target/debug/")),
+    if path.exists() {
+        Ok(path)
+    } else {
+        Err(format!("Can't find binary {executable} in ./target/debug/"))
     }
 }
 
+/// Run the given Artichoke binary with a set of command line arguments
+///
+/// # Panics
+///
+/// If the command fails to run successfully, this function will panic.
 pub fn run(binary_name: &str, call_args: &[&str]) -> Result<CommandOutput, String> {
     let binary = binary_path(binary_name)?;
 


### PR DESCRIPTION
- Use unsafe blocks in mrb C trampoline macros
- assign `$mrb` expr token to a local binding to avoid interpolating it into an unsafe block
- Add an unsafe block and SAFETY comment for calls to `error::raise` in mrb C trampolines
- Address clippy lints in `ui-tests` workspace