### PR TITLE
Convert all `#[no_mangle]` function attributes to unsafe

### DIFF
--- a/artichoke-backend/src/extn/core/array/ffi.rs
+++ b/artichoke-backend/src/extn/core/array/ffi.rs
@@ -7,7 +7,7 @@ use crate::extn::prelude::*;
 // ```c
 // MRB_API mrb_value mrb_ary_new(mrb_state *mrb);
 // ```
-#[no_mangle]
+#[unsafe(no_mangle)]
 unsafe extern "C" fn mrb_ary_new(mrb: *mut sys::mrb_state) -> sys::mrb_value {
     unwrap_interpreter!(mrb, to => guard);
     let result = Array::new();
@@ -24,7 +24,7 @@ unsafe extern "C" fn mrb_ary_new(mrb: *mut sys::mrb_state) -> sys::mrb_value {
 // ```c
 // MRB_API mrb_value mrb_ary_new_capa(mrb_state*, mrb_int);
 // ```
-#[no_mangle]
+#[unsafe(no_mangle)]
 unsafe extern "C" fn mrb_ary_new_capa(mrb: *mut sys::mrb_state, capa: sys::mrb_int) -> sys::mrb_value {
     unwrap_interpreter!(mrb, to => guard);
     let capacity = usize::try_from(capa).unwrap_or_default();
@@ -42,7 +42,7 @@ unsafe extern "C" fn mrb_ary_new_capa(mrb: *mut sys::mrb_state, capa: sys::mrb_i
 // ```c
 // MRB_API mrb_value mrb_ary_new_from_values(mrb_state *mrb, mrb_int size, const mrb_value *vals);
 // ```
-#[no_mangle]
+#[unsafe(no_mangle)]
 unsafe extern "C" fn mrb_ary_new_from_values(
     mrb: *mut sys::mrb_state,
     size: sys::mrb_int,
@@ -69,7 +69,7 @@ unsafe extern "C" fn mrb_ary_new_from_values(
 // ```c
 // MRB_API mrb_value mrb_assoc_new(mrb_state *mrb, mrb_value car, mrb_value cdr)
 // ```
-#[no_mangle]
+#[unsafe(no_mangle)]
 unsafe extern "C" fn mrb_assoc_new(
     mrb: *mut sys::mrb_state,
     one: sys::mrb_value,
@@ -94,7 +94,7 @@ unsafe extern "C" fn mrb_assoc_new(
 // ```c
 // MRB_API mrb_value mrb_ary_splat(mrb_state *mrb, mrb_value value);
 // ```
-#[no_mangle]
+#[unsafe(no_mangle)]
 unsafe extern "C" fn mrb_ary_splat(mrb: *mut sys::mrb_state, value: sys::mrb_value) -> sys::mrb_value {
     unwrap_interpreter!(mrb, to => guard);
     let mut value = Value::from(value);
@@ -123,7 +123,7 @@ unsafe extern "C" fn mrb_ary_splat(mrb: *mut sys::mrb_state, value: sys::mrb_val
 // ```
 //
 // This function corresponds to the `OP_ARYCAT` VM opcode.
-#[no_mangle]
+#[unsafe(no_mangle)]
 unsafe extern "C" fn mrb_ary_concat(mrb: *mut sys::mrb_state, ary: sys::mrb_value, other: sys::mrb_value) {
     unwrap_interpreter!(mrb, to => guard, or_else = ());
     let mut array = Value::from(ary);
@@ -153,7 +153,7 @@ unsafe extern "C" fn mrb_ary_concat(mrb: *mut sys::mrb_state, ary: sys::mrb_valu
 // ```c
 // MRB_API mrb_value mrb_ary_pop(mrb_state *mrb, mrb_value ary);
 // ```
-#[no_mangle]
+#[unsafe(no_mangle)]
 unsafe extern "C" fn mrb_ary_pop(mrb: *mut sys::mrb_state, ary: sys::mrb_value) -> sys::mrb_value {
     unwrap_interpreter!(mrb, to => guard);
     let mut array = Value::from(ary);
@@ -178,7 +178,7 @@ unsafe extern "C" fn mrb_ary_pop(mrb: *mut sys::mrb_state, ary: sys::mrb_value) 
 // ```c
 // MRB_API void mrb_ary_push(mrb_state *mrb, mrb_value array, mrb_value value);
 // ```
-#[no_mangle]
+#[unsafe(no_mangle)]
 unsafe extern "C" fn mrb_ary_push(mrb: *mut sys::mrb_state, ary: sys::mrb_value, value: sys::mrb_value) {
     unwrap_interpreter!(mrb, to => guard, or_else = ());
     let mut array = Value::from(ary);
@@ -199,7 +199,7 @@ unsafe extern "C" fn mrb_ary_push(mrb: *mut sys::mrb_state, ary: sys::mrb_value,
 // ```c
 // MRB_API mrb_value mrb_ary_ref(mrb_state *mrb, mrb_value ary, mrb_int n);
 // ```
-#[no_mangle]
+#[unsafe(no_mangle)]
 unsafe extern "C" fn mrb_ary_ref(
     mrb: *mut sys::mrb_state,
     ary: sys::mrb_value,
@@ -219,7 +219,7 @@ unsafe extern "C" fn mrb_ary_ref(
 // ```c
 // MRB_API void mrb_ary_set(mrb_state *mrb, mrb_value ary, mrb_int n, mrb_value val);
 // ```
-#[no_mangle]
+#[unsafe(no_mangle)]
 unsafe extern "C" fn mrb_ary_set(
     mrb: *mut sys::mrb_state,
     ary: sys::mrb_value,
@@ -249,7 +249,7 @@ unsafe extern "C" fn mrb_ary_set(
 // ```c
 // MRB_API mrb_value mrb_ary_shift(mrb_state *mrb, mrb_value self)
 // ```
-#[no_mangle]
+#[unsafe(no_mangle)]
 unsafe extern "C" fn mrb_ary_shift(mrb: *mut sys::mrb_state, ary: sys::mrb_value) -> sys::mrb_value {
     unwrap_interpreter!(mrb, to => guard);
     let mut array = Value::from(ary);
@@ -274,7 +274,7 @@ unsafe extern "C" fn mrb_ary_shift(mrb: *mut sys::mrb_state, ary: sys::mrb_value
 // ```c
 // MRB_API mrb_value mrb_ary_unshift(mrb_state *mrb, mrb_value self, mrb_value item)
 // ```
-#[no_mangle]
+#[unsafe(no_mangle)]
 unsafe extern "C" fn mrb_ary_unshift(
     mrb: *mut sys::mrb_state,
     ary: sys::mrb_value,
@@ -296,7 +296,7 @@ unsafe extern "C" fn mrb_ary_unshift(
     value
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[allow(clippy::cast_possible_truncation)]
 #[allow(clippy::cast_sign_loss)]
 unsafe extern "C" fn mrb_ary_artichoke_free(mrb: *mut sys::mrb_state, ary: *mut sys::RArray) {

--- a/artichoke-backend/src/extn/core/string/ffi.rs
+++ b/artichoke-backend/src/extn/core/string/ffi.rs
@@ -28,7 +28,7 @@ use crate::value::Value;
 // ```c
 // MRB_API mrb_value mrb_str_new_capa(mrb_state *mrb, size_t capa)
 // ```
-#[no_mangle]
+#[unsafe(no_mangle)]
 unsafe extern "C" fn mrb_str_new_capa(mrb: *mut sys::mrb_state, capa: sys::mrb_int) -> sys::mrb_value {
     let capa = if let Ok(capa) = usize::try_from(capa) {
         capa
@@ -50,7 +50,7 @@ unsafe extern "C" fn mrb_str_new_capa(mrb: *mut sys::mrb_state, capa: sys::mrb_i
 // ```c
 // MRB_API mrb_value mrb_str_new(mrb_state *mrb, const char *p, size_t len)
 // ```
-#[no_mangle]
+#[unsafe(no_mangle)]
 unsafe extern "C" fn mrb_str_new(mrb: *mut sys::mrb_state, p: *const c_char, len: sys::mrb_int) -> sys::mrb_value {
     let len = if let Ok(len) = usize::try_from(len) {
         len
@@ -78,7 +78,7 @@ unsafe extern "C" fn mrb_str_new(mrb: *mut sys::mrb_state, p: *const c_char, len
 // ```c
 // MRB_API mrb_value mrb_str_new_cstr(mrb_state *mrb, const char *p)
 // ```
-#[no_mangle]
+#[unsafe(no_mangle)]
 unsafe extern "C" fn mrb_str_new_cstr(mrb: *mut sys::mrb_state, p: *const c_char) -> sys::mrb_value {
     unwrap_interpreter!(mrb, to => guard);
     let cstr = CStr::from_ptr(p);
@@ -97,7 +97,7 @@ unsafe extern "C" fn mrb_str_new_cstr(mrb: *mut sys::mrb_state, p: *const c_char
 // ```c
 // MRB_API mrb_value mrb_str_new_static(mrb_state *mrb, const char *p, size_t len)
 // ```
-#[no_mangle]
+#[unsafe(no_mangle)]
 unsafe extern "C" fn mrb_str_new_static(
     mrb: *mut sys::mrb_state,
     p: *const c_char,
@@ -110,7 +110,7 @@ unsafe extern "C" fn mrb_str_new_static(
 // ```c
 // MRB_API mrb_int mrb_str_index(mrb_state *mrb, mrb_value str, const char *sptr, mrb_int slen, mrb_int offset)
 // ```
-#[no_mangle]
+#[unsafe(no_mangle)]
 unsafe extern "C" fn mrb_str_index(
     mrb: *mut sys::mrb_state,
     s: sys::mrb_value,
@@ -166,7 +166,7 @@ unsafe extern "C" fn mrb_str_index(
 // ```c
 // mrb_value mrb_str_aref(mrb_state *mrb, mrb_value str, mrb_value indx, mrb_value alen)
 // ```
-#[no_mangle]
+#[unsafe(no_mangle)]
 unsafe extern "C" fn mrb_str_aref(
     mrb: *mut sys::mrb_state,
     s: sys::mrb_value,
@@ -203,7 +203,7 @@ unsafe extern "C" fn mrb_str_aref(
 // ```c
 // MRB_API mrb_value mrb_str_resize(mrb_state *mrb, mrb_value str, mrb_int len)
 // ```
-#[no_mangle]
+#[unsafe(no_mangle)]
 unsafe extern "C" fn mrb_str_resize(mrb: *mut sys::mrb_state, s: sys::mrb_value, len: sys::mrb_int) -> sys::mrb_value {
     fn try_resize(s: &mut String, len: usize) -> Result<(), TryReserveError> {
         match len.checked_sub(s.len()) {
@@ -267,7 +267,7 @@ unsafe extern "C" fn mrb_str_resize(mrb: *mut sys::mrb_state, s: sys::mrb_value,
 // NOTE: Implemented in C in `mruby-sys/src/mruby-sys/ext.c`.
 //
 // ```
-// #[no_mangle]
+// #[unsafe(no_mangle)]
 // unsafe extern "C" mrb_str_concat(mrb: *mut sys::mrb_state, this: sys::mrb_value, other: sys::mrb_value) {
 //     unwrap_interpreter!(mrb, to => guard, or_else = ());
 // }
@@ -276,7 +276,7 @@ unsafe extern "C" fn mrb_str_resize(mrb: *mut sys::mrb_state, s: sys::mrb_value,
 // ```c
 // MRB_API mrb_value mrb_str_plus(mrb_state *mrb, mrb_value a, mrb_value b)
 // ```
-#[no_mangle]
+#[unsafe(no_mangle)]
 unsafe extern "C" fn mrb_str_plus(mrb: *mut sys::mrb_state, a: sys::mrb_value, b: sys::mrb_value) -> sys::mrb_value {
     unwrap_interpreter!(mrb, to => guard);
     let mut a = Value::from(a);
@@ -305,7 +305,7 @@ unsafe extern "C" fn mrb_str_plus(mrb: *mut sys::mrb_state, a: sys::mrb_value, b
 // ```c
 // MRB_API int mrb_str_cmp(mrb_state *mrb, mrb_value str1, mrb_value str2)
 // ```
-#[no_mangle]
+#[unsafe(no_mangle)]
 unsafe extern "C" fn mrb_str_cmp(mrb: *mut sys::mrb_state, str1: sys::mrb_value, str2: sys::mrb_value) -> c_int {
     unwrap_interpreter!(mrb, to => guard, or_else = -1);
     let mut a = Value::from(str1);
@@ -328,7 +328,7 @@ unsafe extern "C" fn mrb_str_cmp(mrb: *mut sys::mrb_state, str1: sys::mrb_value,
 // ```c
 // MRB_API mrb_bool mrb_str_equal(mrb_state *mrb, mrb_value str1, mrb_value str2)
 // ```
-#[no_mangle]
+#[unsafe(no_mangle)]
 unsafe extern "C" fn mrb_str_equal(
     mrb: *mut sys::mrb_state,
     str1: sys::mrb_value,
@@ -371,7 +371,7 @@ unsafe extern "C" fn mrb_str_equal(
 // ```c
 // MRB_API mrb_value mrb_str_dup(mrb_state *mrb, mrb_value str)
 // ```
-#[no_mangle]
+#[unsafe(no_mangle)]
 unsafe extern "C" fn mrb_str_dup(mrb: *mut sys::mrb_state, s: sys::mrb_value) -> sys::mrb_value {
     unwrap_interpreter!(mrb, to => guard);
     let mut string = Value::from(s);
@@ -396,7 +396,7 @@ unsafe extern "C" fn mrb_str_dup(mrb: *mut sys::mrb_state, s: sys::mrb_value) ->
 // ```c
 // MRB_API mrb_value mrb_str_substr(mrb_state *mrb, mrb_value str, mrb_int beg, mrb_int len)
 // ```
-#[no_mangle]
+#[unsafe(no_mangle)]
 unsafe extern "C" fn mrb_str_substr(
     mrb: *mut sys::mrb_state,
     s: sys::mrb_value,
@@ -441,7 +441,7 @@ unsafe extern "C" fn mrb_str_substr(
 // ```c
 // MRB_API mrb_value mrb_ptr_to_str(mrb_state *mrb, void *p)
 // ```
-#[no_mangle]
+#[unsafe(no_mangle)]
 unsafe extern "C" fn mrb_ptr_to_str(mrb: *mut sys::mrb_state, p: *mut c_void) -> sys::mrb_value {
     unwrap_interpreter!(mrb, to => guard);
     let mut s = String::with_capacity(16 + 2);
@@ -460,7 +460,7 @@ unsafe extern "C" fn mrb_ptr_to_str(mrb: *mut sys::mrb_state, p: *mut c_void) ->
 // ```
 //
 // obsolete: use `RSTRING_CSTR()` or `mrb_string_cstr()`
-#[no_mangle]
+#[unsafe(no_mangle)]
 unsafe extern "C" fn mrb_string_value_cstr(mrb: *mut sys::mrb_state, ptr: *mut sys::mrb_value) -> *const c_char {
     unwrap_interpreter!(mrb, to => guard, or_else = ptr::null());
     let mut s = Value::from(*ptr);
@@ -489,7 +489,7 @@ unsafe extern "C" fn mrb_string_value_cstr(mrb: *mut sys::mrb_state, ptr: *mut s
 // ```c
 // MRB_API const char* mrb_string_cstr(mrb_state *mrb, mrb_value str)
 // ```
-#[no_mangle]
+#[unsafe(no_mangle)]
 unsafe extern "C" fn mrb_string_cstr(mrb: *mut sys::mrb_state, s: sys::mrb_value) -> *const c_char {
     unwrap_interpreter!(mrb, to => guard, or_else = ptr::null());
     let mut s = Value::from(s);
@@ -522,7 +522,7 @@ unsafe extern "C" fn mrb_string_cstr(mrb: *mut sys::mrb_state, s: sys::mrb_value
 // ```
 //
 // This function converts a numeric string to numeric `mrb_value` with the given base.
-#[no_mangle]
+#[unsafe(no_mangle)]
 unsafe extern "C" fn mrb_str_to_integer(
     mrb: *mut sys::mrb_state,
     s: sys::mrb_value,
@@ -587,7 +587,7 @@ unsafe extern "C" fn mrb_str_to_integer(
 // ```c
 // MRB_API double mrb_str_to_dbl(mrb_state *mrb, mrb_value str, mrb_bool badcheck)
 // ```
-#[no_mangle]
+#[unsafe(no_mangle)]
 unsafe extern "C" fn mrb_str_to_dbl(mrb: *mut sys::mrb_state, s: sys::mrb_value, badcheck: sys::mrb_bool) -> c_double {
     unwrap_interpreter!(mrb, to => guard, or_else = 0.0);
     let mut s = Value::from(s);
@@ -619,7 +619,7 @@ unsafe extern "C" fn mrb_str_to_dbl(mrb: *mut sys::mrb_state, s: sys::mrb_value,
 // ```c
 // MRB_API mrb_value mrb_str_cat(mrb_state *mrb, mrb_value str, const char *ptr, size_t len)
 // ```
-#[no_mangle]
+#[unsafe(no_mangle)]
 unsafe extern "C" fn mrb_str_cat(
     mrb: *mut sys::mrb_state,
     s: sys::mrb_value,
@@ -661,7 +661,7 @@ unsafe extern "C" fn mrb_str_cat(
 // ```c
 // uint32_t mrb_str_hash(mrb_state *mrb, mrb_value str);
 // ```
-#[no_mangle]
+#[unsafe(no_mangle)]
 unsafe extern "C" fn mrb_str_hash(mrb: *mut sys::mrb_state, s: sys::mrb_value) -> u32 {
     unwrap_interpreter!(mrb, to => guard, or_else = 0);
     let mut s = Value::from(s);
@@ -693,12 +693,12 @@ unsafe extern "C" fn mrb_str_hash(mrb: *mut sys::mrb_state, s: sys::mrb_value) -
 const FNV_32_PRIME: Wrapping<u32> = Wrapping(0x0100_0193);
 const FNV1_32_INIT: Wrapping<u32> = Wrapping(0x811c_9dc5);
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 unsafe extern "C" fn mrb_byte_hash(s: *const u8, len: sys::mrb_int) -> u32 {
     mrb_byte_hash_step(s, len, FNV1_32_INIT)
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[allow(clippy::cast_possible_truncation)]
 #[allow(clippy::cast_sign_loss)]
 unsafe extern "C" fn mrb_byte_hash_step(s: *const u8, len: sys::mrb_int, mut hval: Wrapping<u32>) -> u32 {
@@ -714,7 +714,7 @@ unsafe extern "C" fn mrb_byte_hash_step(s: *const u8, len: sys::mrb_int, mut hva
     hval.0
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[allow(clippy::cast_possible_truncation)]
 #[allow(clippy::cast_sign_loss)]
 unsafe extern "C" fn mrb_gc_free_str(mrb: *mut sys::mrb_state, string: *mut sys::RString) {

--- a/artichoke-backend/src/extn/core/symbol/ffi.rs
+++ b/artichoke-backend/src/extn/core/symbol/ffi.rs
@@ -8,7 +8,7 @@ use crate::extn::prelude::*;
 // ```c
 // MRB_API mrb_sym mrb_intern(mrb_state*,const char*,size_t);
 // ```
-#[no_mangle]
+#[unsafe(no_mangle)]
 unsafe extern "C" fn mrb_intern(mrb: *mut sys::mrb_state, name: *const c_char, len: usize) -> sys::mrb_sym {
     let bytes = slice::from_raw_parts(name.cast::<u8>(), len);
     let bytes = bytes.to_vec();
@@ -21,7 +21,7 @@ unsafe extern "C" fn mrb_intern(mrb: *mut sys::mrb_state, name: *const c_char, l
 // ```c
 // MRB_API mrb_sym mrb_intern_static(mrb_state*,const char*,size_t);
 // ```
-#[no_mangle]
+#[unsafe(no_mangle)]
 unsafe extern "C" fn mrb_intern_static(mrb: *mut sys::mrb_state, name: *const c_char, len: usize) -> sys::mrb_sym {
     let bytes = slice::from_raw_parts::<'static, _>(name.cast::<u8>(), len);
     unwrap_interpreter!(mrb, to => guard, or_else = 0);
@@ -33,7 +33,7 @@ unsafe extern "C" fn mrb_intern_static(mrb: *mut sys::mrb_state, name: *const c_
 // ```c
 // MRB_API mrb_sym mrb_intern_cstr(mrb_state *mrb, const char* str);
 // ```
-#[no_mangle]
+#[unsafe(no_mangle)]
 unsafe extern "C" fn mrb_intern_cstr(mrb: *mut sys::mrb_state, name: *const c_char) -> sys::mrb_sym {
     let string = CStr::from_ptr(name);
     let bytes = string.to_bytes_with_nul().to_vec();
@@ -46,7 +46,7 @@ unsafe extern "C" fn mrb_intern_cstr(mrb: *mut sys::mrb_state, name: *const c_ch
 // ```c
 // MRB_API mrb_sym mrb_intern_str(mrb_state*,mrb_value);
 // ```
-#[no_mangle]
+#[unsafe(no_mangle)]
 unsafe extern "C" fn mrb_intern_str(mrb: *mut sys::mrb_state, name: sys::mrb_value) -> sys::mrb_sym {
     unwrap_interpreter!(mrb, to => guard, or_else = 0);
     let name = Value::from(name);
@@ -64,7 +64,7 @@ unsafe extern "C" fn mrb_intern_str(mrb: *mut sys::mrb_state, name: sys::mrb_val
 // ```c
 // MRB_API mrb_sym mrb_intern_check(mrb_state*,const char*,size_t);
 // ```
-#[no_mangle]
+#[unsafe(no_mangle)]
 unsafe extern "C" fn mrb_intern_check(mrb: *mut sys::mrb_state, name: *const c_char, len: usize) -> sys::mrb_sym {
     let bytes = slice::from_raw_parts(name.cast::<u8>(), len);
     unwrap_interpreter!(mrb, to => guard, or_else = 0);
@@ -78,7 +78,7 @@ unsafe extern "C" fn mrb_intern_check(mrb: *mut sys::mrb_state, name: *const c_c
 // ```c
 // MRB_API mrb_sym mrb_intern_check_cstr(mrb_state*,const char*);
 // ```
-#[no_mangle]
+#[unsafe(no_mangle)]
 unsafe extern "C" fn mrb_intern_check_cstr(mrb: *mut sys::mrb_state, name: *const c_char) -> sys::mrb_sym {
     let string = CStr::from_ptr(name);
     let bytes = string.to_bytes_with_nul();
@@ -93,7 +93,7 @@ unsafe extern "C" fn mrb_intern_check_cstr(mrb: *mut sys::mrb_state, name: *cons
 // ```c
 // MRB_API mrb_sym mrb_intern_check_str(mrb_state*,mrb_value);
 // ```
-#[no_mangle]
+#[unsafe(no_mangle)]
 unsafe extern "C" fn mrb_intern_check_str(mrb: *mut sys::mrb_state, name: sys::mrb_value) -> sys::mrb_sym {
     unwrap_interpreter!(mrb, to => guard, or_else = 0);
     let name = Value::from(name);
@@ -111,7 +111,7 @@ unsafe extern "C" fn mrb_intern_check_str(mrb: *mut sys::mrb_state, name: sys::m
 // ```c
 // MRB_API mrb_value mrb_check_intern(mrb_state*,const char*,size_t);
 // ```
-#[no_mangle]
+#[unsafe(no_mangle)]
 unsafe extern "C" fn mrb_check_intern(mrb: *mut sys::mrb_state, name: *const c_char, len: usize) -> sys::mrb_value {
     let bytes = slice::from_raw_parts(name.cast::<u8>(), len);
     unwrap_interpreter!(mrb, to => guard);
@@ -126,7 +126,7 @@ unsafe extern "C" fn mrb_check_intern(mrb: *mut sys::mrb_state, name: *const c_c
 // ```c
 // MRB_API mrb_value mrb_check_intern_cstr(mrb_state*,const char*);
 // ```
-#[no_mangle]
+#[unsafe(no_mangle)]
 unsafe extern "C" fn mrb_check_intern_cstr(mrb: *mut sys::mrb_state, name: *const c_char) -> sys::mrb_value {
     let string = CStr::from_ptr(name);
     let bytes = string.to_bytes_with_nul();
@@ -142,7 +142,7 @@ unsafe extern "C" fn mrb_check_intern_cstr(mrb: *mut sys::mrb_state, name: *cons
 // ```c
 // MRB_API mrb_value mrb_check_intern_str(mrb_state*,mrb_value);
 // ```
-#[no_mangle]
+#[unsafe(no_mangle)]
 unsafe extern "C" fn mrb_check_intern_str(mrb: *mut sys::mrb_state, name: sys::mrb_value) -> sys::mrb_value {
     unwrap_interpreter!(mrb, to => guard);
     let name = Value::from(name);
@@ -161,7 +161,7 @@ unsafe extern "C" fn mrb_check_intern_str(mrb: *mut sys::mrb_state, name: sys::m
 // ```c
 // MRB_API const char *mrb_sym_name(mrb_state*,mrb_sym);
 // ```
-#[no_mangle]
+#[unsafe(no_mangle)]
 unsafe extern "C" fn mrb_sym_name(mrb: *mut sys::mrb_state, sym: sys::mrb_sym) -> *const c_char {
     unwrap_interpreter!(mrb, to => guard, or_else = ptr::null());
     if let Ok(Some(bytes)) = guard.lookup_symbol_with_trailing_nul(sym) {
@@ -174,7 +174,7 @@ unsafe extern "C" fn mrb_sym_name(mrb: *mut sys::mrb_state, sym: sys::mrb_sym) -
 // ```c
 // MRB_API const char *mrb_sym_name_len(mrb_state*,mrb_sym,mrb_int*);
 // ```
-#[no_mangle]
+#[unsafe(no_mangle)]
 unsafe extern "C" fn mrb_sym_name_len(
     mrb: *mut sys::mrb_state,
     sym: sys::mrb_sym,
@@ -201,7 +201,7 @@ unsafe extern "C" fn mrb_sym_name_len(
 // ```c
 // MRB_API const char *mrb_sym_dump(mrb_state*,mrb_sym);
 // ```
-#[no_mangle]
+#[unsafe(no_mangle)]
 unsafe extern "C" fn mrb_sym_dump(mrb: *mut sys::mrb_state, sym: sys::mrb_sym) -> *const c_char {
     unwrap_interpreter!(mrb, to => guard, or_else = ptr::null());
     if let Ok(Some(bytes)) = guard.lookup_symbol(sym) {
@@ -220,7 +220,7 @@ unsafe extern "C" fn mrb_sym_dump(mrb: *mut sys::mrb_state, sym: sys::mrb_sym) -
 // ```c
 // MRB_API mrb_value mrb_sym_str(mrb_state*,mrb_sym);
 // ```
-#[no_mangle]
+#[unsafe(no_mangle)]
 unsafe extern "C" fn mrb_sym_str(mrb: *mut sys::mrb_state, sym: sys::mrb_sym) -> sys::mrb_value {
     unwrap_interpreter!(mrb, to => guard);
 
@@ -236,7 +236,7 @@ unsafe extern "C" fn mrb_sym_str(mrb: *mut sys::mrb_state, sym: sys::mrb_sym) ->
 // ```c
 // void mrb_init_symtbl(mrb_state*);
 // ```
-#[no_mangle]
+#[unsafe(no_mangle)]
 unsafe extern "C" fn mrb_init_symtbl(mrb: *mut sys::mrb_state) {
     // The symbol table is initialized before the call to `mrb_open_allocf` in
     // `crate::interpreter::interpreter`. This function is intended to be called
@@ -247,7 +247,7 @@ unsafe extern "C" fn mrb_init_symtbl(mrb: *mut sys::mrb_state) {
 // ```c
 // void mrb_free_symtbl(mrb_state *mrb);
 // ```
-#[no_mangle]
+#[unsafe(no_mangle)]
 unsafe extern "C" fn mrb_free_symtbl(mrb: *mut sys::mrb_state) {
     // The symbol table is freed when the Rust `State` is freed.
     let _ = mrb;


### PR DESCRIPTION
https://rust-lang.github.io/rfcs/3325-unsafe-attributes.html

These changes will be required in Rust 2024 edition.

The correctness of these attributes depends on `#ifdef`'ing out parts of the murby build process when building to link with Artichoke.