### PR TITLE
Prepare `spinoso-string` for Rust 2024 edition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -831,7 +831,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-string"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "arbitrary",
  "bstr",

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -119,7 +119,7 @@ path = "../spinoso-securerandom"
 optional = true
 
 [dependencies.spinoso-string]
-version = "0.25.0"
+version = "0.26.0"
 path = "../spinoso-string"
 features = ["nul-terminated"]
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -663,7 +663,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-string"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "bstr",
  "bytecount",

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -953,7 +953,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-string"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "bstr",
  "bytecount",

--- a/spinoso-string/Cargo.toml
+++ b/spinoso-string/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spinoso-string"
-version = "0.25.0"
+version = "0.26.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 description = """
 Encoding-aware string implementation for Ruby String core type in Artichoke Ruby

--- a/spinoso-string/README.md
+++ b/spinoso-string/README.md
@@ -27,7 +27,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-spinoso-string = "0.25.0"
+spinoso-string = "0.26.0"
 ```
 
 ## `no_std`

--- a/spinoso-string/src/center.rs
+++ b/spinoso-string/src/center.rs
@@ -117,10 +117,10 @@ impl std::error::Error for CenterError {}
 /// [Conventionally UTF-8]: crate::Encoding::Utf8
 #[derive(Debug, Clone)]
 pub struct Center<'a, 'b> {
-    pub left: Take<Cycle<slice::Iter<'b, u8>>>,
-    pub next: Option<&'a [u8]>,
-    pub s: Chars<'a>,
-    pub right: Take<Cycle<slice::Iter<'b, u8>>>,
+    left: Take<Cycle<slice::Iter<'b, u8>>>,
+    next: Option<&'a [u8]>,
+    s: Chars<'a>,
+    right: Take<Cycle<slice::Iter<'b, u8>>>,
 }
 
 impl Default for Center<'_, '_> {

--- a/spinoso-string/src/enc/ascii/mod.rs
+++ b/spinoso-string/src/enc/ascii/mod.rs
@@ -112,7 +112,11 @@ impl AsciiString {
 
     #[inline]
     pub unsafe fn set_len(&mut self, len: usize) {
-        self.inner.set_len(len);
+        // SAFETY: The caller must uphold the documented safety contract, which
+        // is the same as the ASCII string's inner buffer.
+        unsafe {
+            self.inner.set_len(len);
+        }
     }
 
     #[inline]
@@ -225,7 +229,9 @@ impl AsciiString {
     where
         I: SliceIndex<[u8]>,
     {
-        self.inner.get_unchecked(index)
+        // SAFETY: The caller must uphold the documented safety contract, which
+        // is the same as the ASCII string's inner buffer.
+        unsafe { self.inner.get_unchecked(index) }
     }
 
     #[inline]
@@ -234,7 +240,9 @@ impl AsciiString {
     where
         I: SliceIndex<[u8]>,
     {
-        self.inner.get_unchecked_mut(index)
+        // SAFETY: The caller must uphold the documented safety contract, which
+        // is the same as the ASCII string's inner buffer.
+        unsafe { self.inner.get_unchecked_mut(index) }
     }
 }
 

--- a/spinoso-string/src/enc/binary/mod.rs
+++ b/spinoso-string/src/enc/binary/mod.rs
@@ -110,7 +110,11 @@ impl BinaryString {
 
     #[inline]
     pub unsafe fn set_len(&mut self, len: usize) {
-        self.inner.set_len(len);
+        // SAFETY: The caller must uphold the documented safety contract, which
+        // is the same as the binary string's inner buffer.
+        unsafe {
+            self.inner.set_len(len);
+        }
     }
 
     #[inline]
@@ -223,7 +227,9 @@ impl BinaryString {
     where
         I: SliceIndex<[u8]>,
     {
-        self.inner.get_unchecked(index)
+        // SAFETY: The caller must uphold the documented safety contract, which
+        // is the same as the binary string's inner buffer.
+        unsafe { self.inner.get_unchecked(index) }
     }
 
     #[inline]
@@ -232,7 +238,9 @@ impl BinaryString {
     where
         I: SliceIndex<[u8]>,
     {
-        self.inner.get_unchecked_mut(index)
+        // SAFETY: The caller must uphold the documented safety contract, which
+        // is the same as the binary string's inner buffer.
+        unsafe { self.inner.get_unchecked_mut(index) }
     }
 }
 

--- a/spinoso-string/src/enc/mod.rs
+++ b/spinoso-string/src/enc/mod.rs
@@ -222,10 +222,14 @@ impl EncodedString {
 
     #[inline]
     pub unsafe fn set_len(&mut self, len: usize) {
-        match self {
-            EncodedString::Ascii(inner) => inner.set_len(len),
-            EncodedString::Binary(inner) => inner.set_len(len),
-            EncodedString::Utf8(inner) => inner.set_len(len),
+        // SAFETY: The caller must uphold the documented safety contract, which
+        // is the same as each encoded string's inner buffer.
+        unsafe {
+            match self {
+                EncodedString::Ascii(inner) => inner.set_len(len),
+                EncodedString::Binary(inner) => inner.set_len(len),
+                EncodedString::Utf8(inner) => inner.set_len(len),
+            }
         }
     }
 
@@ -430,10 +434,14 @@ impl EncodedString {
     where
         I: SliceIndex<[u8]>,
     {
-        match self {
-            EncodedString::Ascii(inner) => inner.get_unchecked(index),
-            EncodedString::Binary(inner) => inner.get_unchecked(index),
-            EncodedString::Utf8(inner) => inner.get_unchecked(index),
+        // SAFETY: The caller must uphold the documented safety contract, which
+        // is the same as each encoded string's inner buffer.
+        unsafe {
+            match self {
+                EncodedString::Ascii(inner) => inner.get_unchecked(index),
+                EncodedString::Binary(inner) => inner.get_unchecked(index),
+                EncodedString::Utf8(inner) => inner.get_unchecked(index),
+            }
         }
     }
 
@@ -443,10 +451,14 @@ impl EncodedString {
     where
         I: SliceIndex<[u8]>,
     {
-        match self {
-            EncodedString::Ascii(inner) => inner.get_unchecked_mut(index),
-            EncodedString::Binary(inner) => inner.get_unchecked_mut(index),
-            EncodedString::Utf8(inner) => inner.get_unchecked_mut(index),
+        // SAFETY: The caller must uphold the documented safety contract, which
+        // is the same as each encoded string's inner buffer.
+        unsafe {
+            match self {
+                EncodedString::Ascii(inner) => inner.get_unchecked_mut(index),
+                EncodedString::Binary(inner) => inner.get_unchecked_mut(index),
+                EncodedString::Utf8(inner) => inner.get_unchecked_mut(index),
+            }
         }
     }
 

--- a/spinoso-string/src/enc/utf8/borrowed.rs
+++ b/spinoso-string/src/enc/utf8/borrowed.rs
@@ -628,7 +628,9 @@ impl Utf8Str {
     where
         I: SliceIndex<[u8]>,
     {
-        self.as_bytes().get_unchecked(index)
+        // SAFETY: The caller must uphold the documented safety contract, which
+        // is the same as the borrowed UTF-8 str's inner slice.
+        unsafe { self.as_bytes().get_unchecked(index) }
     }
 
     #[inline]
@@ -637,7 +639,9 @@ impl Utf8Str {
     where
         I: SliceIndex<[u8]>,
     {
-        self.as_bytes_mut().get_unchecked_mut(index)
+        // SAFETY: The caller must uphold the documented safety contract, which
+        // is the same as the borrowed UTF-8 str's inner slice.
+        unsafe { self.as_bytes_mut().get_unchecked_mut(index) }
     }
 }
 

--- a/spinoso-string/src/enc/utf8/owned.rs
+++ b/spinoso-string/src/enc/utf8/owned.rs
@@ -66,7 +66,11 @@ impl Utf8String {
 impl Utf8String {
     #[inline]
     pub unsafe fn set_len(&mut self, len: usize) {
-        self.inner.set_len(len);
+        // SAFETY: The caller must uphold the documented safety contract, which
+        // is the same as the owned UTF-8 str's inner buffer.
+        unsafe {
+            self.inner.set_len(len);
+        }
     }
 
     #[inline]


### PR DESCRIPTION
- Breaking change: remove `pub` visibility of `Center`'s internal fields.
- Warn on clippy restriction lint `clippy::undocumented_unsafe_blocks`.
- Wrap unsafe code in unsafe fn with unsafe blocks and add SAFETY comments.
- Bump crate version.
- Update crate-level pragmas to use reasons for allowing lints.