### PR TITLE
Prepare `spinoso-env` for Rust 2024

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-env"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bstr",
  "scolapasta-path",

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -87,7 +87,7 @@ path = "../spinoso-array"
 default-features = false
 
 [dependencies.spinoso-env]
-version = "0.2.0"
+version = "0.3.0"
 path = "../spinoso-env"
 optional = true
 default-features = false

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -606,7 +606,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-env"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bstr",
  "scolapasta-path",

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-env"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bstr",
  "scolapasta-path",

--- a/spinoso-env/Cargo.toml
+++ b/spinoso-env/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spinoso-env"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 description = """
 Access to environment variables, system or virtualized, for Artichoke Ruby

--- a/spinoso-env/README.md
+++ b/spinoso-env/README.md
@@ -43,7 +43,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-spinoso-env = "0.2.0"
+spinoso-env = "0.3.0"
 ```
 
 Using the in-memory backend allows safely manipulating an emulated environment:

--- a/spinoso-env/src/env/system.rs
+++ b/spinoso-env/src/env/system.rs
@@ -205,13 +205,19 @@ impl System {
             }
             let name = bytes_to_os_str(name)?;
             let value = bytes_to_os_str(value)?;
-            env::set_var(name, value);
+            // SAFETY: MRI Ruby permits this unsafety.
+            unsafe {
+                env::set_var(name, value);
+            }
             Ok(())
         } else if name.is_empty() || name.find_byte(b'=').is_some() {
             Ok(())
         } else {
             let name = bytes_to_os_str(name)?;
-            env::remove_var(name);
+            // SAFETY: MRI Ruby permits this unsafety.
+            unsafe {
+                env::remove_var(name);
+            }
             Ok(())
         }
     }

--- a/spinoso-env/src/lib.rs
+++ b/spinoso-env/src/lib.rs
@@ -1,17 +1,33 @@
-#![warn(clippy::all)]
-#![warn(clippy::pedantic)]
-#![warn(clippy::cargo)]
+#![warn(clippy::all, clippy::pedantic, clippy::undocumented_unsafe_blocks)]
+#![allow(
+    clippy::let_underscore_untyped,
+    reason = "https://github.com/rust-lang/rust-clippy/pull/10442#issuecomment-1516570154"
+)]
+#![allow(
+    clippy::question_mark,
+    reason = "https://github.com/rust-lang/rust-clippy/issues/8281"
+)]
+#![allow(clippy::manual_let_else, reason = "manual_let_else was very buggy on release")]
+#![allow(clippy::missing_errors_doc, reason = "A lot of existing code fails this lint")]
+#![allow(
+    clippy::unnecessary_lazy_evaluations,
+    reason = "https://github.com/rust-lang/rust-clippy/issues/8109"
+)]
+#![cfg_attr(
+    test,
+    allow(clippy::non_ascii_literal, reason = "tests sometimes require UTF-8 string content")
+)]
 #![allow(unknown_lints)]
-#![allow(clippy::manual_let_else)]
-#![warn(missing_docs)]
-#![warn(missing_debug_implementations)]
-#![warn(missing_copy_implementations)]
-#![warn(rust_2018_idioms)]
-#![warn(rust_2021_compatibility)]
-#![warn(trivial_casts, trivial_numeric_casts)]
-#![warn(unused_qualifications)]
-#![warn(variant_size_differences)]
-#![forbid(unsafe_code)]
+#![warn(
+    missing_copy_implementations,
+    missing_debug_implementations,
+    missing_docs,
+    rust_2024_compatibility,
+    trivial_casts,
+    trivial_numeric_casts,
+    unused_qualifications,
+    variant_size_differences
+)]
 // Enable feature callouts in generated documentation:
 // https://doc.rust-lang.org/beta/unstable-book/language-features/doc-cfg.html
 //


### PR DESCRIPTION
In Rust 2024, functions for reading and writing to the system environment are marked unsafe. Add the unsafe blocks, SAFETY comments, and remove the `#[forbid(unsafe_code)]` pragma in the crate preamble.

Update the crate-level pragmas to match the new set we're standardizing on.

Bump `spinoso-env` to v0.3.0.