### PR TITLE
Use const generics for `PartialEq` impls on `spinoso-array` vectors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -765,7 +765,7 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "spinoso-array"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "raw-parts",
  "smallvec",

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -82,7 +82,7 @@ path = "../scolapasta-string-escape"
 default-features = false
 
 [dependencies.spinoso-array]
-version = "0.10.0"
+version = "0.11.0"
 path = "../spinoso-array"
 default-features = false
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -599,7 +599,7 @@ checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
 
 [[package]]
 name = "spinoso-array"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "raw-parts",
 ]

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -889,7 +889,7 @@ dependencies = [
 
 [[package]]
 name = "spinoso-array"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "raw-parts",
 ]

--- a/spinoso-array/Cargo.toml
+++ b/spinoso-array/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spinoso-array"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 description = """
 Growable vector backends for the Ruby Array core type in Artichoke Ruby

--- a/spinoso-array/README.md
+++ b/spinoso-array/README.md
@@ -30,7 +30,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-spinoso-array = "0.10.0"
+spinoso-array = "0.11.0"
 ```
 
 Then construct and manipulate an `Array` like this:

--- a/spinoso-array/src/array/smallvec/eq.rs
+++ b/spinoso-array/src/array/smallvec/eq.rs
@@ -107,80 +107,42 @@ where
     }
 }
 
-macro_rules! __smallarray_T_eq_primitive_array {
-    ($len:literal) => {
-        impl<T, U> PartialEq<[U; $len]> for SmallArray<T>
-        where
-            T: PartialEq<U>,
-        {
-            #[inline]
-            fn eq(&self, other: &[U; $len]) -> bool {
-                self[..] == other[..]
-            }
-        }
-
-        impl<T, U> PartialEq<SmallArray<U>> for [T; $len]
-        where
-            T: PartialEq<U>,
-        {
-            #[inline]
-            fn eq(&self, other: &SmallArray<U>) -> bool {
-                self[..] == other[..]
-            }
-        }
-
-        impl<T, U> PartialEq<&[U; $len]> for SmallArray<T>
-        where
-            T: PartialEq<U>,
-        {
-            #[inline]
-            fn eq(&self, other: &&[U; $len]) -> bool {
-                self[..] == other[..]
-            }
-        }
-
-        impl<T, U> PartialEq<SmallArray<U>> for &[T; $len]
-        where
-            T: PartialEq<U>,
-        {
-            #[inline]
-            fn eq(&self, other: &SmallArray<U>) -> bool {
-                self[..] == other[..]
-            }
-        }
-    };
+impl<T, U, const N: usize> PartialEq<[U; N]> for SmallArray<T>
+where
+    T: PartialEq<U>,
+{
+    #[inline]
+    fn eq(&self, other: &[U; N]) -> bool {
+        self[..] == other[..]
+    }
 }
 
-__smallarray_T_eq_primitive_array!(0);
-__smallarray_T_eq_primitive_array!(1);
-__smallarray_T_eq_primitive_array!(2);
-__smallarray_T_eq_primitive_array!(3);
-__smallarray_T_eq_primitive_array!(4);
-__smallarray_T_eq_primitive_array!(5);
-__smallarray_T_eq_primitive_array!(6);
-__smallarray_T_eq_primitive_array!(7);
-__smallarray_T_eq_primitive_array!(8);
-__smallarray_T_eq_primitive_array!(9);
-__smallarray_T_eq_primitive_array!(10);
-__smallarray_T_eq_primitive_array!(11);
-__smallarray_T_eq_primitive_array!(12);
-__smallarray_T_eq_primitive_array!(13);
-__smallarray_T_eq_primitive_array!(14);
-__smallarray_T_eq_primitive_array!(15);
-__smallarray_T_eq_primitive_array!(16);
-__smallarray_T_eq_primitive_array!(17);
-__smallarray_T_eq_primitive_array!(18);
-__smallarray_T_eq_primitive_array!(19);
-__smallarray_T_eq_primitive_array!(20);
-__smallarray_T_eq_primitive_array!(21);
-__smallarray_T_eq_primitive_array!(22);
-__smallarray_T_eq_primitive_array!(23);
-__smallarray_T_eq_primitive_array!(24);
-__smallarray_T_eq_primitive_array!(25);
-__smallarray_T_eq_primitive_array!(26);
-__smallarray_T_eq_primitive_array!(27);
-__smallarray_T_eq_primitive_array!(28);
-__smallarray_T_eq_primitive_array!(29);
-__smallarray_T_eq_primitive_array!(30);
-__smallarray_T_eq_primitive_array!(31);
-__smallarray_T_eq_primitive_array!(32);
+impl<T, U, const N: usize> PartialEq<SmallArray<U>> for [T; N]
+where
+    T: PartialEq<U>,
+{
+    #[inline]
+    fn eq(&self, other: &SmallArray<U>) -> bool {
+        self[..] == other[..]
+    }
+}
+
+impl<T, U, const N: usize> PartialEq<&[U; N]> for SmallArray<T>
+where
+    T: PartialEq<U>,
+{
+    #[inline]
+    fn eq(&self, other: &&[U; N]) -> bool {
+        self[..] == other[..]
+    }
+}
+
+impl<T, U, const N: usize> PartialEq<SmallArray<U>> for &[T; N]
+where
+    T: PartialEq<U>,
+{
+    #[inline]
+    fn eq(&self, other: &SmallArray<U>) -> bool {
+        self[..] == other[..]
+    }
+}

--- a/spinoso-array/src/array/tinyvec/eq.rs
+++ b/spinoso-array/src/array/tinyvec/eq.rs
@@ -113,82 +113,44 @@ where
     }
 }
 
-macro_rules! __tinyarray_T_eq_primitive_array {
-    ($len:literal) => {
-        impl<T, U> PartialEq<[U; $len]> for TinyArray<T>
-        where
-            T: PartialEq<U> + Default,
-        {
-            #[inline]
-            fn eq(&self, other: &[U; $len]) -> bool {
-                self[..] == other[..]
-            }
-        }
-
-        impl<T, U> PartialEq<TinyArray<U>> for [T; $len]
-        where
-            T: PartialEq<U>,
-            U: Default,
-        {
-            #[inline]
-            fn eq(&self, other: &TinyArray<U>) -> bool {
-                self[..] == other[..]
-            }
-        }
-
-        impl<T, U> PartialEq<&[U; $len]> for TinyArray<T>
-        where
-            T: PartialEq<U> + Default,
-        {
-            #[inline]
-            fn eq(&self, other: &&[U; $len]) -> bool {
-                self[..] == other[..]
-            }
-        }
-
-        impl<T, U> PartialEq<TinyArray<U>> for &[T; $len]
-        where
-            T: PartialEq<U>,
-            U: Default,
-        {
-            #[inline]
-            fn eq(&self, other: &TinyArray<U>) -> bool {
-                self[..] == other[..]
-            }
-        }
-    };
+impl<T, U, const N: usize> PartialEq<[U; N]> for TinyArray<T>
+where
+    T: PartialEq<U> + Default,
+{
+    #[inline]
+    fn eq(&self, other: &[U; N]) -> bool {
+        self[..] == other[..]
+    }
 }
 
-__tinyarray_T_eq_primitive_array!(0);
-__tinyarray_T_eq_primitive_array!(1);
-__tinyarray_T_eq_primitive_array!(2);
-__tinyarray_T_eq_primitive_array!(3);
-__tinyarray_T_eq_primitive_array!(4);
-__tinyarray_T_eq_primitive_array!(5);
-__tinyarray_T_eq_primitive_array!(6);
-__tinyarray_T_eq_primitive_array!(7);
-__tinyarray_T_eq_primitive_array!(8);
-__tinyarray_T_eq_primitive_array!(9);
-__tinyarray_T_eq_primitive_array!(10);
-__tinyarray_T_eq_primitive_array!(11);
-__tinyarray_T_eq_primitive_array!(12);
-__tinyarray_T_eq_primitive_array!(13);
-__tinyarray_T_eq_primitive_array!(14);
-__tinyarray_T_eq_primitive_array!(15);
-__tinyarray_T_eq_primitive_array!(16);
-__tinyarray_T_eq_primitive_array!(17);
-__tinyarray_T_eq_primitive_array!(18);
-__tinyarray_T_eq_primitive_array!(19);
-__tinyarray_T_eq_primitive_array!(20);
-__tinyarray_T_eq_primitive_array!(21);
-__tinyarray_T_eq_primitive_array!(22);
-__tinyarray_T_eq_primitive_array!(23);
-__tinyarray_T_eq_primitive_array!(24);
-__tinyarray_T_eq_primitive_array!(25);
-__tinyarray_T_eq_primitive_array!(26);
-__tinyarray_T_eq_primitive_array!(27);
-__tinyarray_T_eq_primitive_array!(28);
-__tinyarray_T_eq_primitive_array!(29);
-__tinyarray_T_eq_primitive_array!(30);
-__tinyarray_T_eq_primitive_array!(31);
-__tinyarray_T_eq_primitive_array!(32);
+impl<T, U, const N: usize> PartialEq<TinyArray<U>> for [T; N]
+where
+    T: PartialEq<U>,
+    U: Default,
+{
+    #[inline]
+    fn eq(&self, other: &TinyArray<U>) -> bool {
+        self[..] == other[..]
+    }
+}
+
+impl<T, U, const N: usize> PartialEq<&[U; N]> for TinyArray<T>
+where
+    T: PartialEq<U> + Default,
+{
+    #[inline]
+    fn eq(&self, other: &&[U; N]) -> bool {
+        self[..] == other[..]
+    }
+}
+
+impl<T, U, const N: usize> PartialEq<TinyArray<U>> for &[T; N]
+where
+    T: PartialEq<U>,
+    U: Default,
+{
+    #[inline]
+    fn eq(&self, other: &TinyArray<U>) -> bool {
+        self[..] == other[..]
+    }
+}

--- a/spinoso-array/src/array/vec/eq.rs
+++ b/spinoso-array/src/array/vec/eq.rs
@@ -63,80 +63,42 @@ where
     }
 }
 
-macro_rules! __array_T_eq_primitive_array {
-    ($len:literal) => {
-        impl<T, U> PartialEq<[U; $len]> for Array<T>
-        where
-            T: PartialEq<U>,
-        {
-            #[inline]
-            fn eq(&self, other: &[U; $len]) -> bool {
-                self[..] == other[..]
-            }
-        }
-
-        impl<T, U> PartialEq<Array<U>> for [T; $len]
-        where
-            T: PartialEq<U>,
-        {
-            #[inline]
-            fn eq(&self, other: &Array<U>) -> bool {
-                self[..] == other[..]
-            }
-        }
-
-        impl<T, U> PartialEq<&[U; $len]> for Array<T>
-        where
-            T: PartialEq<U>,
-        {
-            #[inline]
-            fn eq(&self, other: &&[U; $len]) -> bool {
-                self[..] == other[..]
-            }
-        }
-
-        impl<T, U> PartialEq<Array<U>> for &[T; $len]
-        where
-            T: PartialEq<U>,
-        {
-            #[inline]
-            fn eq(&self, other: &Array<U>) -> bool {
-                self[..] == other[..]
-            }
-        }
-    };
+impl<T, U, const N: usize> PartialEq<[U; N]> for Array<T>
+where
+    T: PartialEq<U>,
+{
+    #[inline]
+    fn eq(&self, other: &[U; N]) -> bool {
+        self[..] == other[..]
+    }
 }
 
-__array_T_eq_primitive_array!(0);
-__array_T_eq_primitive_array!(1);
-__array_T_eq_primitive_array!(2);
-__array_T_eq_primitive_array!(3);
-__array_T_eq_primitive_array!(4);
-__array_T_eq_primitive_array!(5);
-__array_T_eq_primitive_array!(6);
-__array_T_eq_primitive_array!(7);
-__array_T_eq_primitive_array!(8);
-__array_T_eq_primitive_array!(9);
-__array_T_eq_primitive_array!(10);
-__array_T_eq_primitive_array!(11);
-__array_T_eq_primitive_array!(12);
-__array_T_eq_primitive_array!(13);
-__array_T_eq_primitive_array!(14);
-__array_T_eq_primitive_array!(15);
-__array_T_eq_primitive_array!(16);
-__array_T_eq_primitive_array!(17);
-__array_T_eq_primitive_array!(18);
-__array_T_eq_primitive_array!(19);
-__array_T_eq_primitive_array!(20);
-__array_T_eq_primitive_array!(21);
-__array_T_eq_primitive_array!(22);
-__array_T_eq_primitive_array!(23);
-__array_T_eq_primitive_array!(24);
-__array_T_eq_primitive_array!(25);
-__array_T_eq_primitive_array!(26);
-__array_T_eq_primitive_array!(27);
-__array_T_eq_primitive_array!(28);
-__array_T_eq_primitive_array!(29);
-__array_T_eq_primitive_array!(30);
-__array_T_eq_primitive_array!(31);
-__array_T_eq_primitive_array!(32);
+impl<T, U, const N: usize> PartialEq<Array<U>> for [T; N]
+where
+    T: PartialEq<U>,
+{
+    #[inline]
+    fn eq(&self, other: &Array<U>) -> bool {
+        self[..] == other[..]
+    }
+}
+
+impl<T, U, const N: usize> PartialEq<&[U; N]> for Array<T>
+where
+    T: PartialEq<U>,
+{
+    #[inline]
+    fn eq(&self, other: &&[U; N]) -> bool {
+        self[..] == other[..]
+    }
+}
+
+impl<T, U, const N: usize> PartialEq<Array<U>> for &[T; N]
+where
+    T: PartialEq<U>,
+{
+    #[inline]
+    fn eq(&self, other: &Array<U>) -> bool {
+        self[..] == other[..]
+    }
+}


### PR DESCRIPTION
Bump crate version.

Found this when working on #2807.