### PR TITLE
Prepare `artichoke-*` crates for Rust 2024

### DIFF
--- a/artichoke-core/src/lib.rs
+++ b/artichoke-core/src/lib.rs
@@ -1,17 +1,37 @@
-#![warn(clippy::all)]
-#![warn(clippy::pedantic)]
-#![warn(clippy::cargo)]
+#![warn(clippy::all, clippy::pedantic, clippy::undocumented_unsafe_blocks)]
+#![allow(
+    clippy::let_underscore_untyped,
+    reason = "https://github.com/rust-lang/rust-clippy/pull/10442#issuecomment-1516570154"
+)]
+#![allow(
+    clippy::question_mark,
+    reason = "https://github.com/rust-lang/rust-clippy/issues/8281"
+)]
+#![allow(clippy::manual_let_else, reason = "manual_let_else was very buggy on release")]
+#![allow(clippy::missing_errors_doc, reason = "A lot of existing code fails this lint")]
+#![allow(
+    clippy::unnecessary_lazy_evaluations,
+    reason = "https://github.com/rust-lang/rust-clippy/issues/8109"
+)]
+#![allow(
+    clippy::module_name_repetitions,
+    reason = "incompatible with how code is organized in private modules"
+)]
+#![cfg_attr(
+    test,
+    allow(clippy::non_ascii_literal, reason = "tests sometimes require UTF-8 string content")
+)]
 #![allow(unknown_lints)]
-#![allow(clippy::manual_let_else)]
-#![allow(clippy::module_name_repetitions)]
-#![warn(missing_docs)]
-#![warn(missing_debug_implementations)]
-#![warn(missing_copy_implementations)]
-#![warn(rust_2018_idioms)]
-#![warn(rust_2021_compatibility)]
-#![warn(trivial_casts, trivial_numeric_casts)]
-#![warn(unused_qualifications)]
-#![warn(variant_size_differences)]
+#![warn(
+    missing_copy_implementations,
+    missing_debug_implementations,
+    missing_docs,
+    rust_2024_compatibility,
+    trivial_casts,
+    trivial_numeric_casts,
+    unused_qualifications,
+    variant_size_differences
+)]
 #![forbid(unsafe_code)]
 // Enable feature callouts in generated documentation:
 // https://doc.rust-lang.org/beta/unstable-book/language-features/doc-cfg.html

--- a/artichoke-readline/src/lib.rs
+++ b/artichoke-readline/src/lib.rs
@@ -1,18 +1,33 @@
-#![warn(clippy::all)]
-#![warn(clippy::pedantic)]
-#![warn(clippy::cargo)]
-#![allow(clippy::manual_let_else)]
-#![allow(clippy::multiple_crate_versions)]
-#![allow(clippy::question_mark)] // https://github.com/rust-lang/rust-clippy/issues/8281
+#![warn(clippy::all, clippy::pedantic, clippy::undocumented_unsafe_blocks)]
+#![allow(
+    clippy::let_underscore_untyped,
+    reason = "https://github.com/rust-lang/rust-clippy/pull/10442#issuecomment-1516570154"
+)]
+#![allow(
+    clippy::question_mark,
+    reason = "https://github.com/rust-lang/rust-clippy/issues/8281"
+)]
+#![allow(clippy::manual_let_else, reason = "manual_let_else was very buggy on release")]
+#![allow(clippy::missing_errors_doc, reason = "A lot of existing code fails this lint")]
+#![allow(
+    clippy::unnecessary_lazy_evaluations,
+    reason = "https://github.com/rust-lang/rust-clippy/issues/8109"
+)]
+#![cfg_attr(
+    test,
+    allow(clippy::non_ascii_literal, reason = "tests sometimes require UTF-8 string content")
+)]
 #![allow(unknown_lints)]
-#![warn(missing_docs)]
-#![warn(missing_debug_implementations)]
-#![warn(missing_copy_implementations)]
-#![warn(rust_2018_idioms)]
-#![warn(rust_2021_compatibility)]
-#![warn(trivial_casts, trivial_numeric_casts)]
-#![warn(unused_qualifications)]
-#![warn(variant_size_differences)]
+#![warn(
+    missing_copy_implementations,
+    missing_debug_implementations,
+    missing_docs,
+    rust_2024_compatibility,
+    trivial_casts,
+    trivial_numeric_casts,
+    unused_qualifications,
+    variant_size_differences
+)]
 #![forbid(unsafe_code)]
 // Enable feature callouts in generated documentation:
 // https://doc.rust-lang.org/beta/unstable-book/language-features/doc-cfg.html


### PR DESCRIPTION
All except `artichoke-backend`. Add missing SAFETY comments and align crates to use new set of crate-level pragmas.