### PR TITLE
Update remaining code to compile with Rust 2024 compat lint group

### DIFF
--- a/artichoke-backend/src/lib.rs
+++ b/artichoke-backend/src/lib.rs
@@ -1,23 +1,38 @@
-#![warn(clippy::all)]
-#![warn(clippy::pedantic)]
-#![warn(clippy::cargo)]
-#![allow(clippy::let_underscore_untyped)] // https://github.com/rust-lang/rust-clippy/pull/10442#issuecomment-1516570154
-#![allow(clippy::manual_let_else)]
-#![allow(clippy::missing_errors_doc)]
-#![allow(clippy::module_name_repetitions)]
-#![allow(clippy::multiple_crate_versions)]
-#![allow(clippy::question_mark)] // https://github.com/rust-lang/rust-clippy/issues/8281
-#![allow(clippy::unnecessary_lazy_evaluations)] // https://github.com/rust-lang/rust-clippy/issues/8109
-#![cfg_attr(test, allow(clippy::non_ascii_literal))]
+#![warn(clippy::all, clippy::pedantic)]
+#![allow(
+    clippy::let_underscore_untyped,
+    reason = "https://github.com/rust-lang/rust-clippy/pull/10442#issuecomment-1516570154"
+)]
+#![allow(
+    clippy::question_mark,
+    reason = "https://github.com/rust-lang/rust-clippy/issues/8281"
+)]
+#![allow(clippy::manual_let_else, reason = "manual_let_else was very buggy on release")]
+#![allow(clippy::missing_errors_doc, reason = "A lot of existing code fails this lint")]
+#![allow(
+    clippy::module_name_repetitions,
+    reason = "incompatible with how code is organized in private modules"
+)]
+#![allow(
+    clippy::unnecessary_lazy_evaluations,
+    reason = "https://github.com/rust-lang/rust-clippy/issues/8109"
+)]
+#![cfg_attr(
+    test,
+    allow(clippy::non_ascii_literal, reason = "tests sometimes require UTF-8 string content")
+)]
 #![allow(unknown_lints)]
-// #![warn(missing_docs)]
-#![warn(missing_debug_implementations)]
-#![warn(missing_copy_implementations)]
-#![warn(rust_2018_idioms)]
-#![warn(rust_2021_compatibility)]
-#![warn(trivial_casts, trivial_numeric_casts)]
-#![warn(unused_qualifications)]
-#![warn(variant_size_differences)]
+#![warn(
+    missing_copy_implementations,
+    missing_debug_implementations,
+    // missing_docs,
+    rust_2024_compatibility,
+    trivial_casts,
+    trivial_numeric_casts,
+    unused_qualifications,
+    variant_size_differences
+)]
+#![allow(unsafe_op_in_unsafe_fn, reason = "legacy code, many spots to fix")]
 // Enable feature callouts in generated documentation:
 // https://doc.rust-lang.org/beta/unstable-book/language-features/doc-cfg.html
 //

--- a/artichoke-backend/src/macros.rs
+++ b/artichoke-backend/src/macros.rs
@@ -38,8 +38,12 @@ macro_rules! emit_fatal_warning {
 /// [`Artichoke`]: crate::Artichoke
 /// [`sys::mrb_state`]: crate::sys::mrb_state
 #[macro_export]
+#[expect(
+    edition_2024_expr_fragment_specifier,
+    reason = "want the new 2024 edition behavior once we upgrade"
+)]
 macro_rules! unwrap_interpreter {
-    ($mrb:expr, to => $to:ident, or_else = ()) => {
+    ($mrb:ident, to => $to:ident, or_else = ()) => {
         let mrb = $mrb;
         let mut interp = if let Ok(interp) = unsafe { $crate::ffi::from_user_data(mrb) } {
             interp
@@ -56,7 +60,7 @@ macro_rules! unwrap_interpreter {
         #[allow(unused_mut)]
         let mut $to = $crate::Guard::new(arena.interp());
     };
-    ($mrb:expr, to => $to:ident, or_else = $default:expr) => {
+    ($mrb:ident, to => $to:ident, or_else = $default:expr) => {
         let mrb = $mrb;
         let mut interp = if let Ok(interp) = unsafe { $crate::ffi::from_user_data(mrb) } {
             interp
@@ -73,7 +77,7 @@ macro_rules! unwrap_interpreter {
         #[allow(unused_mut)]
         let mut $to = $crate::Guard::new(arena.interp());
     };
-    ($mrb:expr, to => $to:ident) => {
+    ($mrb:ident, to => $to:ident) => {
         unwrap_interpreter!($mrb, to => $to, or_else = unsafe { $crate::sys::mrb_sys_nil_value() })
     };
 }
@@ -111,13 +115,13 @@ pub mod argspec {
 /// [does not validate argspecs]: https://github.com/mruby/mruby/issues/4688
 #[macro_export]
 macro_rules! mrb_get_args {
-    ($mrb:expr, none) => {{
+    ($mrb:ident, none) => {{
         let mrb = $mrb;
         unsafe {
             $crate::sys::mrb_get_args(mrb, $crate::macros::argspec::NONE.as_ptr());
         }
     }};
-    ($mrb:expr, required = 1) => {{
+    ($mrb:ident, required = 1) => {{
         let mrb = $mrb;
         unsafe {
             let mut req1 = std::mem::MaybeUninit::<$crate::sys::mrb_value>::uninit();
@@ -128,7 +132,7 @@ macro_rules! mrb_get_args {
             }
         }
     }};
-    ($mrb:expr, optional = 1) => {{
+    ($mrb:ident, optional = 1) => {{
         let mrb = $mrb;
         unsafe {
             let mut opt1 = std::mem::MaybeUninit::<$crate::sys::mrb_value>::uninit();
@@ -143,7 +147,7 @@ macro_rules! mrb_get_args {
             }
         }
     }};
-    ($mrb:expr, required = 1, optional = 1) => {{
+    ($mrb:ident, required = 1, optional = 1) => {{
         let mrb = $mrb;
         unsafe {
             let mut req1 = std::mem::MaybeUninit::<$crate::sys::mrb_value>::uninit();
@@ -168,7 +172,7 @@ macro_rules! mrb_get_args {
             }
         }
     }};
-    ($mrb:expr, required = 1, optional = 2) => {{
+    ($mrb:ident, required = 1, optional = 2) => {{
         let mrb = $mrb;
         unsafe {
             let mut req1 = std::mem::MaybeUninit::<$crate::sys::mrb_value>::uninit();
@@ -201,7 +205,7 @@ macro_rules! mrb_get_args {
             }
         }
     }};
-    ($mrb:expr, required = 1, optional = 3) => {{
+    ($mrb:ident, required = 1, optional = 3) => {{
         let mrb = $mrb;
         unsafe {
             let mut req1 = std::mem::MaybeUninit::<$crate::sys::mrb_value>::uninit();
@@ -243,7 +247,7 @@ macro_rules! mrb_get_args {
             }
         }
     }};
-    ($mrb:expr, required = 1, &block) => {{
+    ($mrb:ident, required = 1, &block) => {{
         let mrb = $mrb;
         unsafe {
             let mut req1 = std::mem::MaybeUninit::<$crate::sys::mrb_value>::uninit();
@@ -264,7 +268,7 @@ macro_rules! mrb_get_args {
             }
         }
     }};
-    ($mrb:expr, required = 1, optional = 1, &block) => {{
+    ($mrb:ident, required = 1, optional = 1, &block) => {{
         let mrb = $mrb;
         unsafe {
             let mut req1 = std::mem::MaybeUninit::<$crate::sys::mrb_value>::uninit();
@@ -302,7 +306,7 @@ macro_rules! mrb_get_args {
             }
         }
     }};
-    ($mrb:expr, required = 1, optional = 2, &block) => {{
+    ($mrb:ident, required = 1, optional = 2, &block) => {{
         let mrb = $mrb;
         unsafe {
             let mut req1 = std::mem::MaybeUninit::<$crate::sys::mrb_value>::uninit();
@@ -353,7 +357,7 @@ macro_rules! mrb_get_args {
             }
         }
     }};
-    ($mrb:expr, required = 2) => {{
+    ($mrb:ident, required = 2) => {{
         let mrb = $mrb;
         unsafe {
             let mut req1 = std::mem::MaybeUninit::<$crate::sys::mrb_value>::uninit();
@@ -374,7 +378,7 @@ macro_rules! mrb_get_args {
             }
         }
     }};
-    ($mrb:expr, optional = 2) => {{
+    ($mrb:ident, optional = 2) => {{
         let mrb = $mrb;
         unsafe {
             let mut opt1 = std::mem::MaybeUninit::<$crate::sys::mrb_value>::uninit();
@@ -400,7 +404,7 @@ macro_rules! mrb_get_args {
             }
         }
     }};
-    ($mrb:expr, optional = 2, &block) => {{
+    ($mrb:ident, optional = 2, &block) => {{
         let mrb = $mrb;
         unsafe {
             let mut opt1 = std::mem::MaybeUninit::<$crate::sys::mrb_value>::uninit();
@@ -425,7 +429,7 @@ macro_rules! mrb_get_args {
             (opt1, opt2, $crate::block::Block::new(block))
         }
     }};
-    ($mrb:expr, required = 2, optional = 1) => {{
+    ($mrb:ident, required = 2, optional = 1) => {{
         let mrb = $mrb;
         unsafe {
             let mut req1 = std::mem::MaybeUninit::<$crate::sys::mrb_value>::uninit();
@@ -454,7 +458,7 @@ macro_rules! mrb_get_args {
             }
         }
     }};
-    ($mrb:expr, *args) => {{
+    ($mrb:ident, *args) => {{
         let mrb = $mrb;
         unsafe {
             let mut args = std::mem::MaybeUninit::<*const $crate::sys::mrb_value>::uninit();

--- a/artichoke-backend/src/sys/mod.rs
+++ b/artichoke-backend/src/sys/mod.rs
@@ -25,6 +25,7 @@ mod args;
     clippy::restriction,
     reason = "generated code"
 )]
+#[allow(missing_unsafe_on_extern, reason = "requires bindgen upgrade for generated code")]
 mod ffi {
     include!(concat!(env!("OUT_DIR"), "/ffi.rs"));
 }

--- a/mezzaluna-conversion-methods/src/lib.rs
+++ b/mezzaluna-conversion-methods/src/lib.rs
@@ -1,17 +1,33 @@
-#![warn(clippy::all)]
-#![warn(clippy::pedantic)]
-#![warn(clippy::cargo)]
-#![allow(clippy::manual_let_else)]
-#![allow(clippy::question_mark)] // https://github.com/rust-lang/rust-clippy/issues/8281
+#![warn(clippy::all, clippy::pedantic, clippy::undocumented_unsafe_blocks)]
+#![allow(
+    clippy::let_underscore_untyped,
+    reason = "https://github.com/rust-lang/rust-clippy/pull/10442#issuecomment-1516570154"
+)]
+#![allow(
+    clippy::question_mark,
+    reason = "https://github.com/rust-lang/rust-clippy/issues/8281"
+)]
+#![allow(clippy::manual_let_else, reason = "manual_let_else was very buggy on release")]
+#![allow(clippy::missing_errors_doc, reason = "A lot of existing code fails this lint")]
+#![allow(
+    clippy::unnecessary_lazy_evaluations,
+    reason = "https://github.com/rust-lang/rust-clippy/issues/8109"
+)]
+#![cfg_attr(
+    test,
+    allow(clippy::non_ascii_literal, reason = "tests sometimes require UTF-8 string content")
+)]
 #![allow(unknown_lints)]
-#![warn(missing_docs)]
-#![warn(missing_debug_implementations)]
-#![warn(missing_copy_implementations)]
-#![warn(rust_2018_idioms)]
-#![warn(rust_2021_compatibility)]
-#![warn(trivial_casts, trivial_numeric_casts)]
-#![warn(unused_qualifications)]
-#![warn(variant_size_differences)]
+#![warn(
+    missing_copy_implementations,
+    missing_debug_implementations,
+    missing_docs,
+    rust_2024_compatibility,
+    trivial_casts,
+    trivial_numeric_casts,
+    unused_qualifications,
+    variant_size_differences
+)]
 #![forbid(unsafe_code)]
 // Enable feature callouts in generated documentation:
 // https://doc.rust-lang.org/beta/unstable-book/language-features/doc-cfg.html

--- a/mezzaluna-load-path/src/lib.rs
+++ b/mezzaluna-load-path/src/lib.rs
@@ -1,18 +1,34 @@
-#![warn(clippy::all)]
-#![warn(clippy::pedantic)]
-#![warn(clippy::cargo)]
-#![allow(clippy::manual_let_else)]
-#![allow(clippy::question_mark)] // https://github.com/rust-lang/rust-clippy/issues/8281
+#![warn(clippy::all, clippy::pedantic, clippy::undocumented_unsafe_blocks)]
+#![allow(
+    clippy::let_underscore_untyped,
+    reason = "https://github.com/rust-lang/rust-clippy/pull/10442#issuecomment-1516570154"
+)]
+#![allow(
+    clippy::question_mark,
+    reason = "https://github.com/rust-lang/rust-clippy/issues/8281"
+)]
+#![allow(clippy::manual_let_else, reason = "manual_let_else was very buggy on release")]
+#![allow(clippy::missing_errors_doc, reason = "A lot of existing code fails this lint")]
+#![allow(
+    clippy::unnecessary_lazy_evaluations,
+    reason = "https://github.com/rust-lang/rust-clippy/issues/8109"
+)]
+#![cfg_attr(
+    test,
+    allow(clippy::non_ascii_literal, reason = "tests sometimes require UTF-8 string content")
+)]
 #![allow(unknown_lints)]
-#![warn(missing_docs)]
-#![warn(missing_debug_implementations)]
-#![warn(missing_copy_implementations)]
-#![warn(rust_2018_idioms)]
-#![warn(rust_2021_compatibility)]
-#![warn(trivial_casts, trivial_numeric_casts)]
-#![warn(unused_qualifications)]
-#![warn(variant_size_differences)]
-#![forbid(unsafe_code)]
+#![warn(
+    missing_copy_implementations,
+    missing_debug_implementations,
+    missing_docs,
+    rust_2024_compatibility,
+    trivial_casts,
+    trivial_numeric_casts,
+    unused_qualifications,
+    variant_size_differences
+)]
+#![cfg_attr(not(test), forbid(unsafe_code))]
 // Enable feature callouts in generated documentation:
 // https://doc.rust-lang.org/beta/unstable-book/language-features/doc-cfg.html
 //

--- a/mezzaluna-load-path/src/rubylib.rs
+++ b/mezzaluna-load-path/src/rubylib.rs
@@ -226,15 +226,24 @@ mod tests {
 
     #[test]
     fn with_rubylib_env_var() {
-        env::remove_var("RUBYLIB");
+        // SAFETY: This is the only test that manipulates the environment.
+        unsafe {
+            env::remove_var("RUBYLIB");
+        }
         let loader = Rubylib::new();
         assert!(loader.is_none());
 
-        env::set_var("RUBYLIB", "");
+        // SAFETY: This is the only test that manipulates the environment.
+        unsafe {
+            env::set_var("RUBYLIB", "");
+        }
         let loader = Rubylib::new();
         assert!(loader.is_none());
 
-        env::set_var("RUBYLIB", "/home/artichoke/src:/usr/share/artichoke:_lib");
+        // SAFETY: This is the only test that manipulates the environment.
+        unsafe {
+            env::set_var("RUBYLIB", "/home/artichoke/src:/usr/share/artichoke:_lib");
+        }
         let loader = Rubylib::new().unwrap();
 
         assert_eq!(loader.load_path().len(), 3);
@@ -416,15 +425,24 @@ mod tests {
 
     #[test]
     fn with_rubylib_env_var() {
-        env::remove_var("RUBYLIB");
+        // SAFETY: This is the only test that manipulates the environment.
+        unsafe {
+            env::remove_var("RUBYLIB");
+        }
         let loader = Rubylib::new();
         assert!(loader.is_none());
 
-        env::set_var("RUBYLIB", "");
+        // SAFETY: This is the only test that manipulates the environment.
+        unsafe {
+            env::set_var("RUBYLIB", "");
+        }
         let loader = Rubylib::new();
         assert!(loader.is_none());
 
-        env::set_var("RUBYLIB", "c:/home/artichoke/src;c:/usr/share/artichoke;_lib");
+        // SAFETY: This is the only test that manipulates the environment.
+        unsafe {
+            env::set_var("RUBYLIB", "c:/home/artichoke/src;c:/usr/share/artichoke;_lib");
+        }
         let loader = Rubylib::new().unwrap();
 
         assert_eq!(loader.load_path().len(), 3);

--- a/mezzaluna-loaded-features/src/lib.rs
+++ b/mezzaluna-loaded-features/src/lib.rs
@@ -1,17 +1,33 @@
-#![warn(clippy::all)]
-#![warn(clippy::pedantic)]
-#![warn(clippy::cargo)]
-#![allow(clippy::manual_let_else)]
-#![allow(clippy::question_mark)] // https://github.com/rust-lang/rust-clippy/issues/8281
+#![warn(clippy::all, clippy::pedantic, clippy::undocumented_unsafe_blocks)]
+#![allow(
+    clippy::let_underscore_untyped,
+    reason = "https://github.com/rust-lang/rust-clippy/pull/10442#issuecomment-1516570154"
+)]
+#![allow(
+    clippy::question_mark,
+    reason = "https://github.com/rust-lang/rust-clippy/issues/8281"
+)]
+#![allow(clippy::manual_let_else, reason = "manual_let_else was very buggy on release")]
+#![allow(clippy::missing_errors_doc, reason = "A lot of existing code fails this lint")]
+#![allow(
+    clippy::unnecessary_lazy_evaluations,
+    reason = "https://github.com/rust-lang/rust-clippy/issues/8109"
+)]
+#![cfg_attr(
+    test,
+    allow(clippy::non_ascii_literal, reason = "tests sometimes require UTF-8 string content")
+)]
 #![allow(unknown_lints)]
-#![warn(missing_docs)]
-#![warn(missing_debug_implementations)]
-#![warn(missing_copy_implementations)]
-#![warn(rust_2018_idioms)]
-#![warn(rust_2021_compatibility)]
-#![warn(trivial_casts, trivial_numeric_casts)]
-#![warn(unused_qualifications)]
-#![warn(variant_size_differences)]
+#![warn(
+    missing_copy_implementations,
+    missing_debug_implementations,
+    missing_docs,
+    rust_2024_compatibility,
+    trivial_casts,
+    trivial_numeric_casts,
+    unused_qualifications,
+    variant_size_differences
+)]
 #![forbid(unsafe_code)]
 // Enable feature callouts in generated documentation:
 // https://doc.rust-lang.org/beta/unstable-book/language-features/doc-cfg.html

--- a/mezzaluna-type-registry/src/lib.rs
+++ b/mezzaluna-type-registry/src/lib.rs
@@ -1,16 +1,33 @@
-#![warn(clippy::all)]
-#![warn(clippy::pedantic)]
-#![warn(clippy::cargo)]
-#![allow(clippy::manual_let_else)]
+#![warn(clippy::all, clippy::pedantic, clippy::undocumented_unsafe_blocks)]
+#![allow(
+    clippy::let_underscore_untyped,
+    reason = "https://github.com/rust-lang/rust-clippy/pull/10442#issuecomment-1516570154"
+)]
+#![allow(
+    clippy::question_mark,
+    reason = "https://github.com/rust-lang/rust-clippy/issues/8281"
+)]
+#![allow(clippy::manual_let_else, reason = "manual_let_else was very buggy on release")]
+#![allow(clippy::missing_errors_doc, reason = "A lot of existing code fails this lint")]
+#![allow(
+    clippy::unnecessary_lazy_evaluations,
+    reason = "https://github.com/rust-lang/rust-clippy/issues/8109"
+)]
+#![cfg_attr(
+    test,
+    allow(clippy::non_ascii_literal, reason = "tests sometimes require UTF-8 string content")
+)]
 #![allow(unknown_lints)]
-#![warn(missing_docs)]
-#![warn(missing_debug_implementations)]
-#![warn(missing_copy_implementations)]
-#![warn(rust_2018_idioms)]
-#![warn(rust_2021_compatibility)]
-#![warn(trivial_casts, trivial_numeric_casts)]
-#![warn(unused_qualifications)]
-#![warn(variant_size_differences)]
+#![warn(
+    missing_copy_implementations,
+    missing_debug_implementations,
+    missing_docs,
+    rust_2024_compatibility,
+    trivial_casts,
+    trivial_numeric_casts,
+    unused_qualifications,
+    variant_size_differences
+)]
 #![forbid(unsafe_code)]
 // Enable feature callouts in generated documentation:
 // https://doc.rust-lang.org/beta/unstable-book/language-features/doc-cfg.html

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,17 +1,33 @@
-#![warn(clippy::all)]
-#![warn(clippy::pedantic)]
-// #![warn(clippy::cargo)] disable for bitflags v2 churn
+#![warn(clippy::all, clippy::pedantic, clippy::undocumented_unsafe_blocks)]
+#![allow(
+    clippy::let_underscore_untyped,
+    reason = "https://github.com/rust-lang/rust-clippy/pull/10442#issuecomment-1516570154"
+)]
+#![allow(
+    clippy::question_mark,
+    reason = "https://github.com/rust-lang/rust-clippy/issues/8281"
+)]
+#![allow(clippy::manual_let_else, reason = "manual_let_else was very buggy on release")]
+#![allow(clippy::missing_errors_doc, reason = "A lot of existing code fails this lint")]
+#![allow(
+    clippy::unnecessary_lazy_evaluations,
+    reason = "https://github.com/rust-lang/rust-clippy/issues/8109"
+)]
+#![cfg_attr(
+    test,
+    allow(clippy::non_ascii_literal, reason = "tests sometimes require UTF-8 string content")
+)]
 #![allow(unknown_lints)]
-#![allow(clippy::manual_let_else)]
-#![allow(clippy::module_name_repetitions)]
-#![warn(missing_docs)]
-#![warn(missing_debug_implementations)]
-#![warn(missing_copy_implementations)]
-#![warn(rust_2018_idioms)]
-#![warn(rust_2021_compatibility)]
-#![warn(trivial_casts, trivial_numeric_casts)]
-#![warn(unused_qualifications)]
-#![warn(variant_size_differences)]
+#![warn(
+    missing_copy_implementations,
+    missing_debug_implementations,
+    missing_docs,
+    rust_2024_compatibility,
+    trivial_casts,
+    trivial_numeric_casts,
+    unused_qualifications,
+    variant_size_differences
+)]
 
 //! Artichoke Ruby
 //!


### PR DESCRIPTION
Silence the `unsafe_op_in_unsafe_fn` lint in artichoke-backend; there is too much code to migrate.

Some lints are suppressed intentionally so we take macro updates in Rust 2024, some macro patterns are made tighter to match the way code is used today.

Some lints silenced waiting for updates from bindgen.

The parser is simplified with fewer silenced lints by adopting unsigned pointer arithmetic methods. All unsafe ops have SAFETY comments.