### PR TITLE
Document unsafe op in unsafe functions in artichoke-backend

### DIFF
--- a/artichoke-backend/src/convert/boolean.rs
+++ b/artichoke-backend/src/convert/boolean.rs
@@ -34,9 +34,9 @@ impl TryConvert<Value, bool> for Artichoke {
     fn try_convert(&self, value: Value) -> Result<bool, Self::Error> {
         if let Ruby::Bool = value.ruby_type() {
             let inner = value.inner();
-            if unsafe { sys::mrb_sys_value_is_true(inner) } {
+            if sys::mrb_sys_value_is_true(inner) {
                 Ok(true)
-            } else if unsafe { sys::mrb_sys_value_is_false(inner) } {
+            } else if sys::mrb_sys_value_is_false(inner) {
                 Ok(false)
             } else {
                 // This branch is unreachable because `Ruby::Bool` typed values
@@ -102,9 +102,9 @@ mod tests {
         let value = interp.convert(true);
         let inner = value.inner();
         // When true, the inner value should be true and not false or nil.
-        assert!(!unsafe { sys::mrb_sys_value_is_false(inner) });
-        assert!(unsafe { sys::mrb_sys_value_is_true(inner) });
-        assert!(!unsafe { sys::mrb_sys_value_is_nil(inner) });
+        assert!(!sys::mrb_sys_value_is_false(inner));
+        assert!(sys::mrb_sys_value_is_true(inner));
+        assert!(!sys::mrb_sys_value_is_nil(inner));
     }
 
     #[test]
@@ -113,9 +113,9 @@ mod tests {
         let value = interp.convert(false);
         let inner = value.inner();
         // When false, the inner value should be false and not true or nil.
-        assert!(unsafe { sys::mrb_sys_value_is_false(inner) });
-        assert!(!unsafe { sys::mrb_sys_value_is_true(inner) });
-        assert!(!unsafe { sys::mrb_sys_value_is_nil(inner) });
+        assert!(sys::mrb_sys_value_is_false(inner));
+        assert!(!sys::mrb_sys_value_is_true(inner));
+        assert!(!sys::mrb_sys_value_is_nil(inner));
     }
 
     #[test]
@@ -124,9 +124,9 @@ mod tests {
         let value = interp.convert(Some(true));
         let inner = value.inner();
         // For Some(true), the inner value should be true.
-        assert!(!unsafe { sys::mrb_sys_value_is_false(inner) });
-        assert!(unsafe { sys::mrb_sys_value_is_true(inner) });
-        assert!(!unsafe { sys::mrb_sys_value_is_nil(inner) });
+        assert!(!sys::mrb_sys_value_is_false(inner));
+        assert!(sys::mrb_sys_value_is_true(inner));
+        assert!(!sys::mrb_sys_value_is_nil(inner));
     }
 
     #[test]
@@ -135,9 +135,9 @@ mod tests {
         let value = interp.convert(Some(false));
         let inner = value.inner();
         // For Some(false), the inner value should be false.
-        assert!(unsafe { sys::mrb_sys_value_is_false(inner) });
-        assert!(!unsafe { sys::mrb_sys_value_is_true(inner) });
-        assert!(!unsafe { sys::mrb_sys_value_is_nil(inner) });
+        assert!(sys::mrb_sys_value_is_false(inner));
+        assert!(!sys::mrb_sys_value_is_true(inner));
+        assert!(!sys::mrb_sys_value_is_nil(inner));
     }
 
     #[test]
@@ -146,9 +146,9 @@ mod tests {
         let value = interp.convert(None::<bool>);
         let inner = value.inner();
         // For None, the converted value should be Ruby's nil.
-        assert!(!unsafe { sys::mrb_sys_value_is_false(inner) });
-        assert!(!unsafe { sys::mrb_sys_value_is_true(inner) });
-        assert!(unsafe { sys::mrb_sys_value_is_nil(inner) });
+        assert!(!sys::mrb_sys_value_is_false(inner));
+        assert!(!sys::mrb_sys_value_is_true(inner));
+        assert!(sys::mrb_sys_value_is_nil(inner));
     }
 
     #[test]

--- a/artichoke-backend/src/debug.rs
+++ b/artichoke-backend/src/debug.rs
@@ -22,11 +22,13 @@ impl Debug for Artichoke {
     }
 
     fn class_name_for_value(&mut self, value: Self::Value) -> &str {
+        // SAFETY: `mrb_obj_classname` requires an initialized mruby interpreter
+        // which is guaranteed by the `Artichoke` type.
         let class = unsafe { self.with_ffi_boundary(|mrb| sys::mrb_obj_classname(mrb, value.inner())) };
         let class = if let Ok(class) = class {
             unsafe { CStr::from_ptr(class) }
         } else {
-            Default::default()
+            c""
         };
         class.to_str().unwrap_or_default()
     }

--- a/artichoke-backend/src/def.rs
+++ b/artichoke-backend/src/def.rs
@@ -188,11 +188,15 @@ impl EnclosingRubyScope {
         match self {
             Self::Class(scope) => {
                 let enclosing_scope = scope.enclosing_scope.clone().map(|scope| *scope);
-                class::Rclass::new(scope.name_cstr, enclosing_scope).resolve(mrb)
+                let rclass = class::Rclass::new(scope.name_cstr, enclosing_scope);
+                // SAFETY: callers must uphold that `mrb` is a valid interpreter.
+                unsafe { rclass.resolve(mrb) }
             }
             Self::Module(scope) => {
                 let enclosing_scope = scope.enclosing_scope.clone().map(|scope| *scope);
-                module::Rclass::new(scope.name_symbol, scope.name_cstr, enclosing_scope).resolve(mrb)
+                let rclass = module::Rclass::new(scope.name_symbol, scope.name_cstr, enclosing_scope);
+                // SAFETY: callers must uphold that `mrb` is a valid interpreter.
+                unsafe { rclass.resolve(mrb) }
             }
         }
     }

--- a/artichoke-backend/src/eval.rs
+++ b/artichoke-backend/src/eval.rs
@@ -20,6 +20,9 @@ impl Eval for Artichoke {
     type Error = Error;
 
     fn eval(&mut self, code: &[u8]) -> Result<Self::Value, Self::Error> {
+        // SAFETY: `protect::eval` requires an initialized mruby interpreter
+        // which is guaranteed by the `Artichoke` type. All dereferenced
+        // pointers are valid by `Artichoke` invariants.
         let result = unsafe {
             let state = self.state.as_deref_mut().ok_or_else(InterpreterExtractError::new)?;
             let parser = state.parser.as_mut().ok_or_else(InterpreterExtractError::new)?;

--- a/artichoke-backend/src/extn/core/exception/mod.rs
+++ b/artichoke-backend/src/extn/core/exception/mod.rs
@@ -120,7 +120,8 @@ mod tests {
     unsafe extern "C" fn run_run(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {
         unwrap_interpreter!(mrb, to => guard);
         let exc = RuntimeError::with_message("something went wrong");
-        error::raise(guard, exc)
+        // SAFETY: only Copy objects remain on the stack
+        unsafe { error::raise(guard, exc) }
     }
 
     impl File for Run {

--- a/artichoke-backend/src/extn/core/mod.rs
+++ b/artichoke-backend/src/extn/core/mod.rs
@@ -1,4 +1,9 @@
 #![expect(clippy::too_many_lines, reason = "lots of big init functions in this module")]
+#![expect(
+    unsafe_op_in_unsafe_fn,
+    clippy::undocumented_unsafe_blocks,
+    reason = "working through legacy code"
+)]
 
 use crate::extn::prelude::*;
 

--- a/artichoke-backend/src/lib.rs
+++ b/artichoke-backend/src/lib.rs
@@ -1,4 +1,4 @@
-#![warn(clippy::all, clippy::pedantic)]
+#![warn(clippy::all, clippy::pedantic, clippy::undocumented_unsafe_blocks)]
 #![allow(
     clippy::let_underscore_untyped,
     reason = "https://github.com/rust-lang/rust-clippy/pull/10442#issuecomment-1516570154"
@@ -25,14 +25,15 @@
 #![warn(
     missing_copy_implementations,
     missing_debug_implementations,
-    // missing_docs,
+    missing_docs,
     rust_2024_compatibility,
     trivial_casts,
     trivial_numeric_casts,
     unused_qualifications,
     variant_size_differences
 )]
-#![allow(unsafe_op_in_unsafe_fn, reason = "legacy code, many spots to fix")]
+#![expect(missing_docs, reason = "TODO: fully document crate")]
+#![expect(clippy::undocumented_unsafe_blocks, reason = "working through legacy code")]
 // Enable feature callouts in generated documentation:
 // https://doc.rust-lang.org/beta/unstable-book/language-features/doc-cfg.html
 //

--- a/artichoke-backend/src/macros.rs
+++ b/artichoke-backend/src/macros.rs
@@ -78,7 +78,7 @@ macro_rules! unwrap_interpreter {
         let mut $to = $crate::Guard::new(arena.interp());
     };
     ($mrb:ident, to => $to:ident) => {
-        unwrap_interpreter!($mrb, to => $to, or_else = unsafe { $crate::sys::mrb_sys_nil_value() })
+        unwrap_interpreter!($mrb, to => $to, or_else = $crate::sys::mrb_sys_nil_value())
     };
 }
 

--- a/artichoke-backend/src/state/parser.rs
+++ b/artichoke-backend/src/state/parser.rs
@@ -166,7 +166,8 @@ impl Context {
         T: Into<Cow<'static, [u8]>>,
     {
         let filename = filename.into();
-        let cstring = CString::from_vec_unchecked(filename.clone().into_owned());
+        // SAFETY: callers must guarantee that `filename` is a valid C string.
+        let cstring = unsafe { CString::from_vec_unchecked(filename.clone().into_owned()) };
         Self {
             filename,
             filename_cstr: cstring.into_boxed_c_str(),

--- a/artichoke-backend/src/sys/protect.rs
+++ b/artichoke-backend/src/sys/protect.rs
@@ -12,7 +12,8 @@ pub unsafe fn funcall(
     block: Option<sys::mrb_value>,
 ) -> Result<sys::mrb_value, sys::mrb_value> {
     let data = Funcall { slf, func, args, block };
-    protect(mrb, data)
+    // SAFETY: caller upholds the safety contract for `protect`.
+    unsafe { protect(mrb, data) }
 }
 
 pub unsafe fn eval(
@@ -21,7 +22,8 @@ pub unsafe fn eval(
     code: &[u8],
 ) -> Result<sys::mrb_value, sys::mrb_value> {
     let data = Eval { context, code };
-    protect(mrb, data)
+    // SAFETY: caller upholds the safety contract for `protect`.
+    unsafe { protect(mrb, data) }
 }
 
 pub unsafe fn block_yield(
@@ -30,26 +32,46 @@ pub unsafe fn block_yield(
     arg: sys::mrb_value,
 ) -> Result<sys::mrb_value, sys::mrb_value> {
     let data = BlockYield { block, arg };
-    protect(mrb, data)
+    // SAFETY: caller upholds the safety contract for `protect`.
+    unsafe { protect(mrb, data) }
 }
 
+/// # Safety
+///
+/// This function is unsafe because it dereferences `mrb` and `data` and calls
+/// into the mruby C API. Callers must ensure that `mrb` is a valid interpreter
+/// and `data` is a valid `Protect` struct.
 unsafe fn protect<T>(mrb: *mut sys::mrb_state, data: T) -> Result<sys::mrb_value, sys::mrb_value>
 where
     T: Protect,
 {
-    let data = Box::new(data);
-    let data = Box::into_raw(data);
-    let data = sys::mrb_sys_cptr_value(mrb, data.cast::<c_void>());
+    // SAFETY: `data` is a valid `Protect` struct which will be passed to the
+    // associated `Protect::run` function by type guarantee. The caller upholds
+    // that `mrb` is a valid interpreter.
+    let data = unsafe {
+        let data = Box::new(data);
+        let data = Box::into_raw(data);
+        sys::mrb_sys_cptr_value(mrb, data.cast::<c_void>())
+    };
     let mut state = false;
 
-    let value = sys::mrb_protect(mrb, Some(T::run), data, &mut state);
-    if let Some(exc) = NonNull::new((*mrb).exc) {
-        (*mrb).exc = ptr::null_mut();
-        Err(sys::mrb_sys_obj_value(exc.cast::<c_void>().as_ptr()))
-    } else if state {
-        Err(value)
-    } else {
-        Ok(value)
+    // SAFETY: The caller upholds that `mrb` is a valid interpreter. The
+    // `Protect` trait is implemented for `T` which means that `T` has a `run`
+    // function that is safe to call with the `mrb` and `data` arguments.
+    let value = unsafe { sys::mrb_protect(mrb, Some(T::run), data, &mut state) };
+
+    // SAFETY: the caller upholds that `mrb` is a valid interpreter and can be
+    // dereferenced. If non-null, `mrb->exc` is a valid `mrb_value` which can be
+    // boxed into an object with `mrb_sys_obj_value`.
+    unsafe {
+        if let Some(exc) = NonNull::new((*mrb).exc) {
+            (*mrb).exc = ptr::null_mut();
+            Err(sys::mrb_sys_obj_value(exc.cast::<c_void>().as_ptr()))
+        } else if state {
+            Err(value)
+        } else {
+            Ok(value)
+        }
     }
 }
 
@@ -69,11 +91,12 @@ struct Funcall<'a> {
 
 impl Protect for Funcall<'_> {
     unsafe extern "C" fn run(mrb: *mut sys::mrb_state, data: sys::mrb_value) -> sys::mrb_value {
-        let ptr = sys::mrb_sys_cptr_ptr(data);
-        // `protect` must be `Copy` because the call to a function in the
-        // `mrb_funcall...` family can unwind with `longjmp` which does not
-        // allow Rust to run destructors.
-        let Self { slf, func, args, block } = *Box::from_raw(ptr.cast::<Self>());
+        // SAFETY: callers will ensure `data` is a valid `Funcall` struct via
+        // the `Protect` trait.
+        let Self { slf, func, args, block } = unsafe {
+            let ptr = sys::mrb_sys_cptr_ptr(data);
+            *Box::from_raw(ptr.cast::<Self>())
+        };
 
         // This will always unwrap because we've already checked that we
         // have fewer than `MRB_FUNCALL_ARGC_MAX` args, which is less than
@@ -84,10 +107,15 @@ impl Protect for Funcall<'_> {
             return sys::mrb_sys_nil_value();
         };
 
-        if let Some(block) = block {
-            sys::mrb_funcall_with_block(mrb, slf, func, argslen, args.as_ptr(), block)
-        } else {
-            sys::mrb_funcall_argv(mrb, slf, func, argslen, args.as_ptr())
+        // SAFETY: all live stack bindings are `Copy` which ensures exceptions
+        // raised in the call to a function in the `mrb_funcall...` family can
+        // unwind with `longjmp` without running Rust drop glue.
+        unsafe {
+            if let Some(block) = block {
+                sys::mrb_funcall_with_block(mrb, slf, func, argslen, args.as_ptr(), block)
+            } else {
+                sys::mrb_funcall_argv(mrb, slf, func, argslen, args.as_ptr())
+            }
         }
     }
 }
@@ -102,16 +130,23 @@ struct Eval<'a> {
 
 impl Protect for Eval<'_> {
     unsafe extern "C" fn run(mrb: *mut sys::mrb_state, data: sys::mrb_value) -> sys::mrb_value {
-        let ptr = sys::mrb_sys_cptr_ptr(data);
-        let Self { context, code } = *Box::from_raw(ptr.cast::<Self>());
+        // SAFETY: callers will ensure `data` is a valid `Eval` struct via the
+        // `Protect` trait.
+        let Self { context, code } = unsafe {
+            let ptr = sys::mrb_sys_cptr_ptr(data);
+            *Box::from_raw(ptr.cast::<Self>())
+        };
 
-        // Execute arbitrary ruby code, which may generate objects with C APIs
+        // Execute arbitrary Ruby code, which may generate objects with C APIs
         // if backed by Rust functions.
         //
         // `mrb_load_nstring_ctx` sets the "stack keep" field on the context
         // which means the most recent value returned by eval will always be
         // considered live by the GC.
-        sys::mrb_load_nstring_cxt(mrb, code.as_ptr().cast::<c_char>(), code.len(), context)
+        //
+        // SAFETY: callers will ensure `mrb` and `context` are non-null via the
+        // `Protect` trait.
+        unsafe { sys::mrb_load_nstring_cxt(mrb, code.as_ptr().cast::<c_char>(), code.len(), context) }
     }
 }
 
@@ -125,9 +160,15 @@ struct BlockYield {
 
 impl Protect for BlockYield {
     unsafe extern "C" fn run(mrb: *mut sys::mrb_state, data: sys::mrb_value) -> sys::mrb_value {
-        let ptr = sys::mrb_sys_cptr_ptr(data);
-        let Self { block, arg } = *Box::from_raw(ptr.cast::<Self>());
-        sys::mrb_yield(mrb, block, arg)
+        // SAFETY: callers will ensure `data` is a valid `BlockYield` struct via
+        // the `Protect` trait.
+        let Self { block, arg } = unsafe {
+            let ptr = sys::mrb_sys_cptr_ptr(data);
+            *Box::from_raw(ptr.cast::<Self>())
+        };
+        // SAFETY: callers ensure `mrb` is non-null and `block` is an
+        // `mrb_value` of type `Proc`.
+        unsafe { sys::mrb_yield(mrb, block, arg) }
     }
 }
 
@@ -137,12 +178,17 @@ pub unsafe fn is_range(
     len: i64,
 ) -> Result<Option<Range>, sys::mrb_value> {
     let data = IsRange { value, len };
-    let is_range = protect(mrb, data)?;
+    // SAFETY: caller upholds the safety contract for `protect`.
+    let is_range = unsafe { protect(mrb, data)? };
     if sys::mrb_sys_value_is_nil(is_range) {
         Ok(None)
     } else {
-        let ptr = sys::mrb_sys_cptr_ptr(is_range);
-        let out = *Box::from_raw(ptr.cast::<Range>());
+        // SAFETY: `is_range` is a valid `mrb_value` of type `T_DATA` via the
+        // `Protect` trait.
+        let out = unsafe {
+            let ptr = sys::mrb_sys_cptr_ptr(is_range);
+            *Box::from_raw(ptr.cast::<Range>())
+        };
         Ok(Some(out))
     }
 }
@@ -165,24 +211,34 @@ impl Protect for IsRange {
     unsafe extern "C" fn run(mrb: *mut sys::mrb_state, data: sys::mrb_value) -> sys::mrb_value {
         use sys::mrb_range_beg_len::{MRB_RANGE_OK, MRB_RANGE_OUT, MRB_RANGE_TYPE_MISMATCH};
 
-        let ptr = sys::mrb_sys_cptr_ptr(data);
-        let Self { value, len } = *Box::from_raw(ptr.cast::<Self>());
+        // SAFETY: callers will ensure `data` is a valid `IsRange` struct via
+        // the `Protect` trait.
+        let Self { value, len } = unsafe {
+            let ptr = sys::mrb_sys_cptr_ptr(data);
+            *Box::from_raw(ptr.cast::<Self>())
+        };
         let mut start = mem::MaybeUninit::<sys::mrb_int>::uninit();
         let mut range_len = mem::MaybeUninit::<sys::mrb_int>::uninit();
-        let check_range = sys::mrb_range_beg_len(mrb, value, start.as_mut_ptr(), range_len.as_mut_ptr(), len, false);
+        // SAFETY: callers ensure `mrb` is non-null, `start` and `range_len` are
+        // valid pointers to intentionally uninitialized memory.
+        let check_range =
+            unsafe { sys::mrb_range_beg_len(mrb, value, start.as_mut_ptr(), range_len.as_mut_ptr(), len, false) };
         match check_range {
             MRB_RANGE_OK => {
-                let start = start.assume_init();
-                let range_len = range_len.assume_init();
+                // SAFETY: `mrb_range_beg_len` will have initialized `start` and
+                // `range_len` because `MRB_RANGE_OK` was returned.
+                let (start, range_len) = unsafe { (start.assume_init(), range_len.assume_init()) };
                 let out = Some(Range::Valid { start, len: range_len });
                 let out = Box::new(out);
                 let out = Box::into_raw(out);
-                sys::mrb_sys_cptr_value(mrb, out.cast::<c_void>())
+                // SAFETY: callers ensure `mrb` is non-null.
+                unsafe { sys::mrb_sys_cptr_value(mrb, out.cast::<c_void>()) }
             }
             MRB_RANGE_OUT => {
                 let out = Box::new(Range::Out);
                 let out = Box::into_raw(out);
-                sys::mrb_sys_cptr_value(mrb, out.cast::<c_void>())
+                // SAFETY: callers ensure `mrb` is non-null.
+                unsafe { sys::mrb_sys_cptr_value(mrb, out.cast::<c_void>()) }
             }
             MRB_RANGE_TYPE_MISMATCH => sys::mrb_sys_nil_value(),
         }

--- a/artichoke-backend/src/top_self.rs
+++ b/artichoke-backend/src/top_self.rs
@@ -7,6 +7,8 @@ impl TopSelf for Artichoke {
     type Value = Value;
 
     fn top_self(&mut self) -> Value {
+        // SAFETY: `mrb_top_self` requires an initialized mruby interpreter
+        // which is guaranteed by the `Artichoke` type.
         let top_self = unsafe { self.with_ffi_boundary(|mrb| sys::mrb_top_self(mrb)) };
         top_self.map(Value::from).unwrap_or_default()
     }

--- a/artichoke-backend/src/types.rs
+++ b/artichoke-backend/src/types.rs
@@ -21,7 +21,7 @@ pub fn ruby_from_mrb_value(value: sys::mrb_value) -> Ruby {
         // `nil` is implemented with the `MRB_TT_FALSE` type tag in mruby
         // (since both values are falsy). The difference is that Booleans are
         // non-zero `Fixnum`s.
-        MRB_TT_FALSE if unsafe { sys::mrb_sys_value_is_nil(value) } => Ruby::Nil,
+        MRB_TT_FALSE if sys::mrb_sys_value_is_nil(value) => Ruby::Nil,
         MRB_TT_FALSE => Ruby::Bool,
         // `MRB_TT_FREE` is a marker type tag that indicates to the mruby
         // VM that an object is unreachable and should be deallocated by the

--- a/spinoso-regexp/src/lib.rs
+++ b/spinoso-regexp/src/lib.rs
@@ -32,7 +32,7 @@
     unused_qualifications,
     variant_size_differences
 )]
-#![allow(missing_docs, reason = "TODO: fully document crate")]
+#![expect(missing_docs, reason = "TODO: fully document crate")]
 // Enable feature callouts in generated documentation:
 // https://doc.rust-lang.org/beta/unstable-book/language-features/doc-cfg.html
 //

--- a/spinoso-string/src/lib.rs
+++ b/spinoso-string/src/lib.rs
@@ -31,7 +31,7 @@
     unused_qualifications,
     variant_size_differences
 )]
-#![allow(missing_docs, reason = "TODO: fully document crate")]
+#![expect(missing_docs, reason = "TODO: fully document crate")]
 // Enable feature callouts in generated documentation:
 // https://doc.rust-lang.org/beta/unstable-book/language-features/doc-cfg.html
 //


### PR DESCRIPTION
Prepare for Rust 2024 edition without massively silencing this lint. All unsafe operations are documented with SAFETY comments with the exception of the `artichoke_backend::extn` module.

Even outside of the `extn` module, about 200 `unsafe` blocks are not documented with SAFETY comments.