### PR TITLE
Remove dep on `regex` from `spinoso-time`, enable local timezone

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "artichoke-backend"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "arbitrary",
  "artichoke-core",
@@ -846,10 +846,9 @@ dependencies = [
 
 [[package]]
 name = "spinoso-time"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "iana-time-zone",
- "regex",
  "strftime-ruby",
  "tz-rs",
  "tzdb",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ documentation.workspace = true
 [dependencies]
 
 [dependencies.artichoke-backend]
-version = "0.25.0"
+version = "0.26.0"
 path = "artichoke-backend"
 default-features = false
 
@@ -140,6 +140,7 @@ core-full = [
   "core-regexp",
   "core-regexp-oniguruma",
   "core-time",
+  "core-time-local",
 ]
 # Enable resolving environment variables with the `ENV` core object.
 core-env = ["artichoke-backend/core-env"]
@@ -168,6 +169,7 @@ core-regexp-oniguruma = [
 # Implement the `Time` core class. This feature adds dependencies on `tz-rs` and
 # `tzdb`.
 core-time = ["artichoke-backend/core-time"]
+core-time-local = ["artichoke-backend/core-time-local"]
 
 # Extend the Artichoke virtual file system to have native/host access.
 #

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "artichoke-backend"
-version = "0.25.0"
+version = "0.26.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 description = "Embeddable VM implementation for Artichoke Ruby"
 keywords = ["artichoke", "artichoke-ruby", "mruby", "ruby"]
@@ -142,7 +142,7 @@ version = "0.5.0"
 path = "../spinoso-symbol"
 
 [dependencies.spinoso-time]
-version = "0.9.0"
+version = "0.10.0"
 path = "../spinoso-time"
 optional = true
 default-features = false
@@ -175,6 +175,7 @@ core-full = [
   "core-regexp",
   "core-regexp-oniguruma",
   "core-time",
+  "core-time-local",
 ]
 core-env = ["dep:spinoso-env"]
 core-env-system = ["core-env", "spinoso-env?/system-env"]
@@ -184,6 +185,7 @@ core-random = ["dep:spinoso-random"]
 core-regexp = ["dep:spinoso-regexp"]
 core-regexp-oniguruma = ["core-regexp", "spinoso-regexp?/oniguruma", "dep:onig"]
 core-time = ["dep:spinoso-time"]
+core-time-local = ["core-time", "spinoso-time?/tzrs-local"]
 
 load-path-native-file-system-loader = [
   "artichoke-load-path/native-file-system-loader",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -36,7 +36,7 @@ dependencies = [
 
 [[package]]
 name = "artichoke-backend"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "artichoke-core",
  "artichoke-load-path",
@@ -680,10 +680,9 @@ dependencies = [
 
 [[package]]
 name = "spinoso-time"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "iana-time-zone",
- "regex",
  "strftime-ruby",
  "tz-rs",
  "tzdb",

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -52,7 +52,7 @@ dependencies = [
 
 [[package]]
 name = "artichoke-backend"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "artichoke-core",
  "artichoke-load-path",
@@ -982,10 +982,9 @@ dependencies = [
 
 [[package]]
 name = "spinoso-time"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "iana-time-zone",
- "regex",
  "strftime-ruby",
  "tz-rs",
  "tzdb",

--- a/spinoso-time/Cargo.toml
+++ b/spinoso-time/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spinoso-time"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 description = """
 Datetime handling for Artichoke Ruby
@@ -17,12 +17,6 @@ documentation.workspace = true
 
 [dependencies]
 iana-time-zone = "0.1.58"
-
-[dependencies.regex]
-version = "1.7.0"
-default-features = false
-features = ["std"]
-optional = true
 
 [dependencies.strftime-ruby]
 version = "1.0.0"
@@ -43,7 +37,7 @@ default-features = false
 
 [features]
 default = ["tzrs", "tzrs-local"]
-tzrs = ["dep:regex", "dep:strftime-ruby", "dep:tz-rs", "dep:tzdb"]
+tzrs = ["dep:strftime-ruby", "dep:tz-rs", "dep:tzdb"]
 tzrs-local = ["tzrs"]
 
 [package.metadata.docs.rs]

--- a/spinoso-time/README.md
+++ b/spinoso-time/README.md
@@ -37,7 +37,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-spinoso-time = { version = "0.9.0", features = ["tzrs"] }
+spinoso-time = "0.10.0"
 ```
 
 ## Examples


### PR DESCRIPTION
With the [help of o3-mini-high](https://chatgpt.com/share/67a05f20-7dfc-8002-ab24-6d1b3594182c), rewrite the parser for `[+/-]HHMM` fixed timezone offsets to be a small hand-rolled parser instead of a regex + capture groups matcher.

While in here, I noticed that the `tzrs-local` feature wasn't wired up to artichoke, which meant `Time.now` always returned a GMT datetime.

With these two changes:

```console
$ cargo tree -p spinoso-time
spinoso-time v0.10.0 (/Users/lopopolo/dev/artichoke/artichoke/spinoso-time)
├── iana-time-zone v0.1.61
│   └── core-foundation-sys v0.8.7
├── strftime-ruby v1.1.0
├── tz-rs v0.7.0
└── tzdb v0.7.2
    ├── tz-rs v0.7.0
    └── tzdb_data v0.2.1
        └── tz-rs v0.7.0
```

```console
$ cargo run --bin airb -q
artichoke 0.1.0-pre.0 (2025-02-03 revision 7370) [aarch64-apple-darwin]
[rustc 1.83.0 (90b35a623 2024-11-26) on aarch64-apple-darwin]
>>> Time.now
=> 2025-02-02 22:17:54 -0800
```

cc @b-n I think we chatted about this as a TODO a long time ago.