### PR TITLE
Autogenerate full-coverage unit tests for `spinoso-exception`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -773,8 +773,9 @@ dependencies = [
 
 [[package]]
 name = "spinoso-exception"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
+ "bstr",
  "scolapasta-string-escape",
 ]
 

--- a/artichoke-backend/Cargo.toml
+++ b/artichoke-backend/Cargo.toml
@@ -107,7 +107,7 @@ optional = true
 default-features = false
 
 [dependencies.spinoso-exception]
-version = "0.2.0"
+version = "0.3.0"
 path = "../spinoso-exception"
 
 [dependencies.spinoso-math]

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -609,8 +609,9 @@ dependencies = [
 
 [[package]]
 name = "spinoso-exception"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
+ "bstr",
  "scolapasta-string-escape",
 ]
 

--- a/spec-runner/Cargo.lock
+++ b/spec-runner/Cargo.lock
@@ -911,8 +911,9 @@ dependencies = [
 
 [[package]]
 name = "spinoso-exception"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
+ "bstr",
  "scolapasta-string-escape",
 ]
 

--- a/spinoso-exception/Cargo.toml
+++ b/spinoso-exception/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spinoso-exception"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 description = """
 Ruby Exception error structs
@@ -16,6 +16,10 @@ homepage.workspace = true
 documentation.workspace = true
 
 [dependencies]
+
+[dependencies.bstr]
+version = "1.2.0"
+default-features = false
 
 [dependencies.scolapasta-string-escape]
 version = "0.3.0"

--- a/spinoso-exception/README.md
+++ b/spinoso-exception/README.md
@@ -26,7 +26,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-spinoso-exception = "0.2.0"
+spinoso-exception = "0.3.0"
 ```
 
 Create exceptions and return Ruby errors:

--- a/spinoso-exception/scripts/autogen.rb
+++ b/spinoso-exception/scripts/autogen.rb
@@ -13,6 +13,7 @@ def render(exc:, type:)
     use core::error;
     use core::fmt;
 
+    use bstr::ByteSlice;
     use scolapasta_string_escape::format_debug_escape_into;
 
     use crate::RubyException;
@@ -29,9 +30,17 @@ def render(exc:, type:)
     /// [`Exception`]: https://ruby-doc.org/core-3.1.2/Exception.html
     /// [`Kernel#raise`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-raise
     /// [`NameError#name`]: https://ruby-doc.org/core-3.1.2/NameError.html#method-i-name
-    #[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+    #[derive(Default, Clone, PartialEq, Eq, PartialOrd, Ord)]
     pub struct #{type} {
         message: Cow<'static, [u8]>,
+    }
+
+    impl fmt::Debug for #{type} {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.debug_struct("#{exc}")
+                .field("message", &self.message().as_bstr())
+                .finish()
+        }
     }
 
     impl #{type} {
@@ -181,6 +190,181 @@ def render(exc:, type:)
         #[inline]
         fn name(&self) -> Cow<'_, str> {
             Cow::Borrowed(Self::name(self))
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use alloc::borrow::Cow;
+        use alloc::format;
+        use alloc::string::ToString;
+        use core::cmp::Ordering;
+        use core::error;
+
+        use bstr::ByteSlice;
+
+        use super::*;
+
+        #[test]
+        fn test_new() {
+            let exception = #{type}::new();
+            assert_eq!(exception.message().as_bstr(), b"#{exc}".as_bstr());
+            assert_eq!(exception.name(), "#{exc}");
+        }
+
+        #[test]
+        fn test_with_message() {
+            let custom_message = "custom message";
+            let exception = #{type}::with_message(custom_message);
+            assert_eq!(exception.message().as_bstr(), custom_message.as_bytes().as_bstr());
+            // The exception name remains the default even when a custom message is used.
+            assert_eq!(exception.name(), "#{exc}");
+        }
+
+        #[test]
+        fn test_from_string() {
+            let message = "from String".to_string();
+            let exception: #{type} = message.into();
+            assert_eq!(exception.message().as_bstr(), b"from String".as_bstr());
+        }
+
+        #[test]
+        fn test_from_static_str() {
+            let message: &'static str = "from &'static str";
+            let exception: #{type} = message.into();
+            assert_eq!(exception.message().as_bstr(), b"from &'static str".as_bstr());
+        }
+
+        #[test]
+        fn test_from_cow_str_borrowed() {
+            let cow: Cow<'static, str> = Cow::Borrowed("from Cow borrowed");
+            let exception: #{type} = cow.into();
+            assert_eq!(exception.message().as_bstr(), b"from Cow borrowed".as_bstr());
+        }
+
+        #[test]
+        fn test_from_cow_str_owned() {
+            let cow: Cow<'static, str> = Cow::Owned("from Cow owned".to_string());
+            let exception: #{type} = cow.into();
+            assert_eq!(exception.message().as_bstr(), b"from Cow owned".as_bstr());
+        }
+
+        #[test]
+        fn test_from_vec_u8() {
+            let vec = b"from Vec<u8>".to_vec();
+            let exception: #{type} = vec.into();
+            assert_eq!(exception.message().as_bstr(), b"from Vec<u8>".as_bstr());
+        }
+
+        #[test]
+        fn test_from_static_slice() {
+            let slice: &'static [u8] = b"from &'static [u8]";
+            let exception: #{type} = slice.into();
+            assert_eq!(exception.message().as_bstr(), b"from &'static [u8]".as_bstr());
+        }
+
+        #[test]
+        fn test_from_cow_u8_borrowed() {
+            let cow: Cow<'static, [u8]> = Cow::Borrowed(b"from Cow<u8> borrowed");
+            let exception: #{type} = cow.into();
+            assert_eq!(exception.message().as_bstr(), b"from Cow<u8> borrowed".as_bstr());
+        }
+
+        #[test]
+        fn test_from_cow_u8_owned() {
+            let cow: Cow<'static, [u8]> = Cow::Owned(b"from Cow<u8> owned".to_vec());
+            let exception: #{type} = cow.into();
+            assert_eq!(exception.message().as_bstr(), b"from Cow<u8> owned".as_bstr());
+        }
+
+        #[test]
+        fn test_debug() {
+            let exception = #{type}::with_message("display test");
+            let output = format!("{exception:?}");
+            // Expected to contain the exception name and the debug-escaped message.
+            assert!(output.contains("#{exc}"));
+            assert!(output.contains("display test"));
+            // Check the surrounding formatting.
+            assert!(output.starts_with("#{exc} {"));
+            assert!(output.ends_with('}'));
+        }
+
+        #[test]
+        fn test_display() {
+            let exception = #{type}::with_message("display test");
+            let output = format!("{exception}");
+            // Expected to contain the exception name and the debug-escaped message.
+            assert!(output.contains("#{exc}"));
+            assert!(output.contains("display test"));
+            // Check the surrounding formatting.
+            assert!(output.starts_with("#{exc} ("));
+            assert!(output.ends_with(')'));
+        }
+
+        #[test]
+        fn test_error_trait() {
+            let exception = #{type}::with_message("error trait test");
+            let error_obj: &dyn error::Error = &exception;
+            // Our implementation does not provide a source.
+            assert!(error_obj.source().is_none());
+            // to_string() uses Display.
+            assert_eq!(error_obj.to_string(), format!("{exception}"));
+        }
+
+        #[test]
+        fn test_ruby_exception_trait() {
+            let exception = #{type}::with_message("ruby trait test");
+            let msg = RubyException::message(&exception);
+            let name = RubyException::name(&exception);
+            assert_eq!(msg.as_bstr(), exception.message().as_bstr());
+            assert_eq!(name, exception.name());
+        }
+
+        #[test]
+        fn test_default() {
+            let default_error = #{type}::default();
+            // By default, the message should be an empty slice since Default is auto-derived.
+            assert_eq!(default_error.message(), b"");
+            // The name method always returns the constant exception name.
+            assert_eq!(default_error.name(), "#{exc}");
+        }
+
+        #[test]
+        fn test_clone() {
+            let original = #{type}::with_message("clone test");
+            let cloned = original.clone();
+            assert_eq!(original, cloned, "Cloned error should be equal to the original");
+        }
+
+        #[test]
+        fn test_partial_eq() {
+            let error_a = #{type}::with_message("test message");
+            let error_b = #{type}::with_message("test message");
+            let error_c = #{type}::with_message("different message");
+            assert_eq!(error_a, error_b, "Errors with the same message should be equal");
+            assert_ne!(error_a, error_c, "Errors with different messages should not be equal");
+        }
+
+        #[test]
+        fn test_partial_ord() {
+            let error_a = #{type}::with_message("aaa");
+            let error_b = #{type}::with_message("bbb");
+            // Same error should compare equal.
+            assert_eq!(error_a.partial_cmp(&error_a), Some(Ordering::Equal));
+            // Lexicographic ordering of the underlying messages.
+            assert_eq!(error_a.partial_cmp(&error_b), Some(Ordering::Less));
+            assert_eq!(error_b.partial_cmp(&error_a), Some(Ordering::Greater));
+        }
+
+        #[test]
+        fn test_ord() {
+            let error_a = #{type}::with_message("aaa");
+            let error_b = #{type}::with_message("bbb");
+            // Same error should compare equal.
+            assert_eq!(error_a.cmp(&error_a), Ordering::Equal);
+            // Lexicographic ordering of the underlying messages.
+            assert_eq!(error_a.cmp(&error_b), Ordering::Less);
+            assert_eq!(error_b.cmp(&error_a), Ordering::Greater);
         }
     }
   AUTOGEN

--- a/spinoso-exception/src/core/argumenterror.rs
+++ b/spinoso-exception/src/core/argumenterror.rs
@@ -6,6 +6,7 @@ use alloc::vec::Vec;
 use core::error;
 use core::fmt;
 
+use bstr::ByteSlice;
 use scolapasta_string_escape::format_debug_escape_into;
 
 use crate::RubyException;
@@ -22,9 +23,17 @@ use crate::RubyException;
 /// [`Exception`]: https://ruby-doc.org/core-3.1.2/Exception.html
 /// [`Kernel#raise`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-raise
 /// [`NameError#name`]: https://ruby-doc.org/core-3.1.2/NameError.html#method-i-name
-#[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Default, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ArgumentError {
     message: Cow<'static, [u8]>,
+}
+
+impl fmt::Debug for ArgumentError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ArgumentError")
+            .field("message", &self.message().as_bstr())
+            .finish()
+    }
 }
 
 impl ArgumentError {
@@ -174,5 +183,180 @@ impl RubyException for ArgumentError {
     #[inline]
     fn name(&self) -> Cow<'_, str> {
         Cow::Borrowed(Self::name(self))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::borrow::Cow;
+    use alloc::format;
+    use alloc::string::ToString;
+    use core::cmp::Ordering;
+    use core::error;
+
+    use bstr::ByteSlice;
+
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        let exception = ArgumentError::new();
+        assert_eq!(exception.message().as_bstr(), b"ArgumentError".as_bstr());
+        assert_eq!(exception.name(), "ArgumentError");
+    }
+
+    #[test]
+    fn test_with_message() {
+        let custom_message = "custom message";
+        let exception = ArgumentError::with_message(custom_message);
+        assert_eq!(exception.message().as_bstr(), custom_message.as_bytes().as_bstr());
+        // The exception name remains the default even when a custom message is used.
+        assert_eq!(exception.name(), "ArgumentError");
+    }
+
+    #[test]
+    fn test_from_string() {
+        let message = "from String".to_string();
+        let exception: ArgumentError = message.into();
+        assert_eq!(exception.message().as_bstr(), b"from String".as_bstr());
+    }
+
+    #[test]
+    fn test_from_static_str() {
+        let message: &'static str = "from &'static str";
+        let exception: ArgumentError = message.into();
+        assert_eq!(exception.message().as_bstr(), b"from &'static str".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_str_borrowed() {
+        let cow: Cow<'static, str> = Cow::Borrowed("from Cow borrowed");
+        let exception: ArgumentError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow borrowed".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_str_owned() {
+        let cow: Cow<'static, str> = Cow::Owned("from Cow owned".to_string());
+        let exception: ArgumentError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow owned".as_bstr());
+    }
+
+    #[test]
+    fn test_from_vec_u8() {
+        let vec = b"from Vec<u8>".to_vec();
+        let exception: ArgumentError = vec.into();
+        assert_eq!(exception.message().as_bstr(), b"from Vec<u8>".as_bstr());
+    }
+
+    #[test]
+    fn test_from_static_slice() {
+        let slice: &'static [u8] = b"from &'static [u8]";
+        let exception: ArgumentError = slice.into();
+        assert_eq!(exception.message().as_bstr(), b"from &'static [u8]".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_u8_borrowed() {
+        let cow: Cow<'static, [u8]> = Cow::Borrowed(b"from Cow<u8> borrowed");
+        let exception: ArgumentError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow<u8> borrowed".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_u8_owned() {
+        let cow: Cow<'static, [u8]> = Cow::Owned(b"from Cow<u8> owned".to_vec());
+        let exception: ArgumentError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow<u8> owned".as_bstr());
+    }
+
+    #[test]
+    fn test_debug() {
+        let exception = ArgumentError::with_message("display test");
+        let output = format!("{exception:?}");
+        // Expected to contain the exception name and the debug-escaped message.
+        assert!(output.contains("ArgumentError"));
+        assert!(output.contains("display test"));
+        // Check the surrounding formatting.
+        assert!(output.starts_with("ArgumentError {"));
+        assert!(output.ends_with('}'));
+    }
+
+    #[test]
+    fn test_display() {
+        let exception = ArgumentError::with_message("display test");
+        let output = format!("{exception}");
+        // Expected to contain the exception name and the debug-escaped message.
+        assert!(output.contains("ArgumentError"));
+        assert!(output.contains("display test"));
+        // Check the surrounding formatting.
+        assert!(output.starts_with("ArgumentError ("));
+        assert!(output.ends_with(')'));
+    }
+
+    #[test]
+    fn test_error_trait() {
+        let exception = ArgumentError::with_message("error trait test");
+        let error_obj: &dyn error::Error = &exception;
+        // Our implementation does not provide a source.
+        assert!(error_obj.source().is_none());
+        // to_string() uses Display.
+        assert_eq!(error_obj.to_string(), format!("{exception}"));
+    }
+
+    #[test]
+    fn test_ruby_exception_trait() {
+        let exception = ArgumentError::with_message("ruby trait test");
+        let msg = RubyException::message(&exception);
+        let name = RubyException::name(&exception);
+        assert_eq!(msg.as_bstr(), exception.message().as_bstr());
+        assert_eq!(name, exception.name());
+    }
+
+    #[test]
+    fn test_default() {
+        let default_error = ArgumentError::default();
+        // By default, the message should be an empty slice since Default is auto-derived.
+        assert_eq!(default_error.message(), b"");
+        // The name method always returns the constant exception name.
+        assert_eq!(default_error.name(), "ArgumentError");
+    }
+
+    #[test]
+    fn test_clone() {
+        let original = ArgumentError::with_message("clone test");
+        let cloned = original.clone();
+        assert_eq!(original, cloned, "Cloned error should be equal to the original");
+    }
+
+    #[test]
+    fn test_partial_eq() {
+        let error_a = ArgumentError::with_message("test message");
+        let error_b = ArgumentError::with_message("test message");
+        let error_c = ArgumentError::with_message("different message");
+        assert_eq!(error_a, error_b, "Errors with the same message should be equal");
+        assert_ne!(error_a, error_c, "Errors with different messages should not be equal");
+    }
+
+    #[test]
+    fn test_partial_ord() {
+        let error_a = ArgumentError::with_message("aaa");
+        let error_b = ArgumentError::with_message("bbb");
+        // Same error should compare equal.
+        assert_eq!(error_a.partial_cmp(&error_a), Some(Ordering::Equal));
+        // Lexicographic ordering of the underlying messages.
+        assert_eq!(error_a.partial_cmp(&error_b), Some(Ordering::Less));
+        assert_eq!(error_b.partial_cmp(&error_a), Some(Ordering::Greater));
+    }
+
+    #[test]
+    fn test_ord() {
+        let error_a = ArgumentError::with_message("aaa");
+        let error_b = ArgumentError::with_message("bbb");
+        // Same error should compare equal.
+        assert_eq!(error_a.cmp(&error_a), Ordering::Equal);
+        // Lexicographic ordering of the underlying messages.
+        assert_eq!(error_a.cmp(&error_b), Ordering::Less);
+        assert_eq!(error_b.cmp(&error_a), Ordering::Greater);
     }
 }

--- a/spinoso-exception/src/core/encodingerror.rs
+++ b/spinoso-exception/src/core/encodingerror.rs
@@ -6,6 +6,7 @@ use alloc::vec::Vec;
 use core::error;
 use core::fmt;
 
+use bstr::ByteSlice;
 use scolapasta_string_escape::format_debug_escape_into;
 
 use crate::RubyException;
@@ -22,9 +23,17 @@ use crate::RubyException;
 /// [`Exception`]: https://ruby-doc.org/core-3.1.2/Exception.html
 /// [`Kernel#raise`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-raise
 /// [`NameError#name`]: https://ruby-doc.org/core-3.1.2/NameError.html#method-i-name
-#[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Default, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct EncodingError {
     message: Cow<'static, [u8]>,
+}
+
+impl fmt::Debug for EncodingError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("EncodingError")
+            .field("message", &self.message().as_bstr())
+            .finish()
+    }
 }
 
 impl EncodingError {
@@ -174,5 +183,180 @@ impl RubyException for EncodingError {
     #[inline]
     fn name(&self) -> Cow<'_, str> {
         Cow::Borrowed(Self::name(self))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::borrow::Cow;
+    use alloc::format;
+    use alloc::string::ToString;
+    use core::cmp::Ordering;
+    use core::error;
+
+    use bstr::ByteSlice;
+
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        let exception = EncodingError::new();
+        assert_eq!(exception.message().as_bstr(), b"EncodingError".as_bstr());
+        assert_eq!(exception.name(), "EncodingError");
+    }
+
+    #[test]
+    fn test_with_message() {
+        let custom_message = "custom message";
+        let exception = EncodingError::with_message(custom_message);
+        assert_eq!(exception.message().as_bstr(), custom_message.as_bytes().as_bstr());
+        // The exception name remains the default even when a custom message is used.
+        assert_eq!(exception.name(), "EncodingError");
+    }
+
+    #[test]
+    fn test_from_string() {
+        let message = "from String".to_string();
+        let exception: EncodingError = message.into();
+        assert_eq!(exception.message().as_bstr(), b"from String".as_bstr());
+    }
+
+    #[test]
+    fn test_from_static_str() {
+        let message: &'static str = "from &'static str";
+        let exception: EncodingError = message.into();
+        assert_eq!(exception.message().as_bstr(), b"from &'static str".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_str_borrowed() {
+        let cow: Cow<'static, str> = Cow::Borrowed("from Cow borrowed");
+        let exception: EncodingError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow borrowed".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_str_owned() {
+        let cow: Cow<'static, str> = Cow::Owned("from Cow owned".to_string());
+        let exception: EncodingError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow owned".as_bstr());
+    }
+
+    #[test]
+    fn test_from_vec_u8() {
+        let vec = b"from Vec<u8>".to_vec();
+        let exception: EncodingError = vec.into();
+        assert_eq!(exception.message().as_bstr(), b"from Vec<u8>".as_bstr());
+    }
+
+    #[test]
+    fn test_from_static_slice() {
+        let slice: &'static [u8] = b"from &'static [u8]";
+        let exception: EncodingError = slice.into();
+        assert_eq!(exception.message().as_bstr(), b"from &'static [u8]".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_u8_borrowed() {
+        let cow: Cow<'static, [u8]> = Cow::Borrowed(b"from Cow<u8> borrowed");
+        let exception: EncodingError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow<u8> borrowed".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_u8_owned() {
+        let cow: Cow<'static, [u8]> = Cow::Owned(b"from Cow<u8> owned".to_vec());
+        let exception: EncodingError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow<u8> owned".as_bstr());
+    }
+
+    #[test]
+    fn test_debug() {
+        let exception = EncodingError::with_message("display test");
+        let output = format!("{exception:?}");
+        // Expected to contain the exception name and the debug-escaped message.
+        assert!(output.contains("EncodingError"));
+        assert!(output.contains("display test"));
+        // Check the surrounding formatting.
+        assert!(output.starts_with("EncodingError {"));
+        assert!(output.ends_with('}'));
+    }
+
+    #[test]
+    fn test_display() {
+        let exception = EncodingError::with_message("display test");
+        let output = format!("{exception}");
+        // Expected to contain the exception name and the debug-escaped message.
+        assert!(output.contains("EncodingError"));
+        assert!(output.contains("display test"));
+        // Check the surrounding formatting.
+        assert!(output.starts_with("EncodingError ("));
+        assert!(output.ends_with(')'));
+    }
+
+    #[test]
+    fn test_error_trait() {
+        let exception = EncodingError::with_message("error trait test");
+        let error_obj: &dyn error::Error = &exception;
+        // Our implementation does not provide a source.
+        assert!(error_obj.source().is_none());
+        // to_string() uses Display.
+        assert_eq!(error_obj.to_string(), format!("{exception}"));
+    }
+
+    #[test]
+    fn test_ruby_exception_trait() {
+        let exception = EncodingError::with_message("ruby trait test");
+        let msg = RubyException::message(&exception);
+        let name = RubyException::name(&exception);
+        assert_eq!(msg.as_bstr(), exception.message().as_bstr());
+        assert_eq!(name, exception.name());
+    }
+
+    #[test]
+    fn test_default() {
+        let default_error = EncodingError::default();
+        // By default, the message should be an empty slice since Default is auto-derived.
+        assert_eq!(default_error.message(), b"");
+        // The name method always returns the constant exception name.
+        assert_eq!(default_error.name(), "EncodingError");
+    }
+
+    #[test]
+    fn test_clone() {
+        let original = EncodingError::with_message("clone test");
+        let cloned = original.clone();
+        assert_eq!(original, cloned, "Cloned error should be equal to the original");
+    }
+
+    #[test]
+    fn test_partial_eq() {
+        let error_a = EncodingError::with_message("test message");
+        let error_b = EncodingError::with_message("test message");
+        let error_c = EncodingError::with_message("different message");
+        assert_eq!(error_a, error_b, "Errors with the same message should be equal");
+        assert_ne!(error_a, error_c, "Errors with different messages should not be equal");
+    }
+
+    #[test]
+    fn test_partial_ord() {
+        let error_a = EncodingError::with_message("aaa");
+        let error_b = EncodingError::with_message("bbb");
+        // Same error should compare equal.
+        assert_eq!(error_a.partial_cmp(&error_a), Some(Ordering::Equal));
+        // Lexicographic ordering of the underlying messages.
+        assert_eq!(error_a.partial_cmp(&error_b), Some(Ordering::Less));
+        assert_eq!(error_b.partial_cmp(&error_a), Some(Ordering::Greater));
+    }
+
+    #[test]
+    fn test_ord() {
+        let error_a = EncodingError::with_message("aaa");
+        let error_b = EncodingError::with_message("bbb");
+        // Same error should compare equal.
+        assert_eq!(error_a.cmp(&error_a), Ordering::Equal);
+        // Lexicographic ordering of the underlying messages.
+        assert_eq!(error_a.cmp(&error_b), Ordering::Less);
+        assert_eq!(error_b.cmp(&error_a), Ordering::Greater);
     }
 }

--- a/spinoso-exception/src/core/eoferror.rs
+++ b/spinoso-exception/src/core/eoferror.rs
@@ -6,6 +6,7 @@ use alloc::vec::Vec;
 use core::error;
 use core::fmt;
 
+use bstr::ByteSlice;
 use scolapasta_string_escape::format_debug_escape_into;
 
 use crate::RubyException;
@@ -22,9 +23,17 @@ use crate::RubyException;
 /// [`Exception`]: https://ruby-doc.org/core-3.1.2/Exception.html
 /// [`Kernel#raise`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-raise
 /// [`NameError#name`]: https://ruby-doc.org/core-3.1.2/NameError.html#method-i-name
-#[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Default, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct EOFError {
     message: Cow<'static, [u8]>,
+}
+
+impl fmt::Debug for EOFError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("EOFError")
+            .field("message", &self.message().as_bstr())
+            .finish()
+    }
 }
 
 impl EOFError {
@@ -174,5 +183,180 @@ impl RubyException for EOFError {
     #[inline]
     fn name(&self) -> Cow<'_, str> {
         Cow::Borrowed(Self::name(self))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::borrow::Cow;
+    use alloc::format;
+    use alloc::string::ToString;
+    use core::cmp::Ordering;
+    use core::error;
+
+    use bstr::ByteSlice;
+
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        let exception = EOFError::new();
+        assert_eq!(exception.message().as_bstr(), b"EOFError".as_bstr());
+        assert_eq!(exception.name(), "EOFError");
+    }
+
+    #[test]
+    fn test_with_message() {
+        let custom_message = "custom message";
+        let exception = EOFError::with_message(custom_message);
+        assert_eq!(exception.message().as_bstr(), custom_message.as_bytes().as_bstr());
+        // The exception name remains the default even when a custom message is used.
+        assert_eq!(exception.name(), "EOFError");
+    }
+
+    #[test]
+    fn test_from_string() {
+        let message = "from String".to_string();
+        let exception: EOFError = message.into();
+        assert_eq!(exception.message().as_bstr(), b"from String".as_bstr());
+    }
+
+    #[test]
+    fn test_from_static_str() {
+        let message: &'static str = "from &'static str";
+        let exception: EOFError = message.into();
+        assert_eq!(exception.message().as_bstr(), b"from &'static str".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_str_borrowed() {
+        let cow: Cow<'static, str> = Cow::Borrowed("from Cow borrowed");
+        let exception: EOFError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow borrowed".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_str_owned() {
+        let cow: Cow<'static, str> = Cow::Owned("from Cow owned".to_string());
+        let exception: EOFError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow owned".as_bstr());
+    }
+
+    #[test]
+    fn test_from_vec_u8() {
+        let vec = b"from Vec<u8>".to_vec();
+        let exception: EOFError = vec.into();
+        assert_eq!(exception.message().as_bstr(), b"from Vec<u8>".as_bstr());
+    }
+
+    #[test]
+    fn test_from_static_slice() {
+        let slice: &'static [u8] = b"from &'static [u8]";
+        let exception: EOFError = slice.into();
+        assert_eq!(exception.message().as_bstr(), b"from &'static [u8]".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_u8_borrowed() {
+        let cow: Cow<'static, [u8]> = Cow::Borrowed(b"from Cow<u8> borrowed");
+        let exception: EOFError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow<u8> borrowed".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_u8_owned() {
+        let cow: Cow<'static, [u8]> = Cow::Owned(b"from Cow<u8> owned".to_vec());
+        let exception: EOFError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow<u8> owned".as_bstr());
+    }
+
+    #[test]
+    fn test_debug() {
+        let exception = EOFError::with_message("display test");
+        let output = format!("{exception:?}");
+        // Expected to contain the exception name and the debug-escaped message.
+        assert!(output.contains("EOFError"));
+        assert!(output.contains("display test"));
+        // Check the surrounding formatting.
+        assert!(output.starts_with("EOFError {"));
+        assert!(output.ends_with('}'));
+    }
+
+    #[test]
+    fn test_display() {
+        let exception = EOFError::with_message("display test");
+        let output = format!("{exception}");
+        // Expected to contain the exception name and the debug-escaped message.
+        assert!(output.contains("EOFError"));
+        assert!(output.contains("display test"));
+        // Check the surrounding formatting.
+        assert!(output.starts_with("EOFError ("));
+        assert!(output.ends_with(')'));
+    }
+
+    #[test]
+    fn test_error_trait() {
+        let exception = EOFError::with_message("error trait test");
+        let error_obj: &dyn error::Error = &exception;
+        // Our implementation does not provide a source.
+        assert!(error_obj.source().is_none());
+        // to_string() uses Display.
+        assert_eq!(error_obj.to_string(), format!("{exception}"));
+    }
+
+    #[test]
+    fn test_ruby_exception_trait() {
+        let exception = EOFError::with_message("ruby trait test");
+        let msg = RubyException::message(&exception);
+        let name = RubyException::name(&exception);
+        assert_eq!(msg.as_bstr(), exception.message().as_bstr());
+        assert_eq!(name, exception.name());
+    }
+
+    #[test]
+    fn test_default() {
+        let default_error = EOFError::default();
+        // By default, the message should be an empty slice since Default is auto-derived.
+        assert_eq!(default_error.message(), b"");
+        // The name method always returns the constant exception name.
+        assert_eq!(default_error.name(), "EOFError");
+    }
+
+    #[test]
+    fn test_clone() {
+        let original = EOFError::with_message("clone test");
+        let cloned = original.clone();
+        assert_eq!(original, cloned, "Cloned error should be equal to the original");
+    }
+
+    #[test]
+    fn test_partial_eq() {
+        let error_a = EOFError::with_message("test message");
+        let error_b = EOFError::with_message("test message");
+        let error_c = EOFError::with_message("different message");
+        assert_eq!(error_a, error_b, "Errors with the same message should be equal");
+        assert_ne!(error_a, error_c, "Errors with different messages should not be equal");
+    }
+
+    #[test]
+    fn test_partial_ord() {
+        let error_a = EOFError::with_message("aaa");
+        let error_b = EOFError::with_message("bbb");
+        // Same error should compare equal.
+        assert_eq!(error_a.partial_cmp(&error_a), Some(Ordering::Equal));
+        // Lexicographic ordering of the underlying messages.
+        assert_eq!(error_a.partial_cmp(&error_b), Some(Ordering::Less));
+        assert_eq!(error_b.partial_cmp(&error_a), Some(Ordering::Greater));
+    }
+
+    #[test]
+    fn test_ord() {
+        let error_a = EOFError::with_message("aaa");
+        let error_b = EOFError::with_message("bbb");
+        // Same error should compare equal.
+        assert_eq!(error_a.cmp(&error_a), Ordering::Equal);
+        // Lexicographic ordering of the underlying messages.
+        assert_eq!(error_a.cmp(&error_b), Ordering::Less);
+        assert_eq!(error_b.cmp(&error_a), Ordering::Greater);
     }
 }

--- a/spinoso-exception/src/core/exception.rs
+++ b/spinoso-exception/src/core/exception.rs
@@ -6,6 +6,7 @@ use alloc::vec::Vec;
 use core::error;
 use core::fmt;
 
+use bstr::ByteSlice;
 use scolapasta_string_escape::format_debug_escape_into;
 
 use crate::RubyException;
@@ -22,9 +23,17 @@ use crate::RubyException;
 /// [`Exception`]: https://ruby-doc.org/core-3.1.2/Exception.html
 /// [`Kernel#raise`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-raise
 /// [`NameError#name`]: https://ruby-doc.org/core-3.1.2/NameError.html#method-i-name
-#[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Default, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Exception {
     message: Cow<'static, [u8]>,
+}
+
+impl fmt::Debug for Exception {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Exception")
+            .field("message", &self.message().as_bstr())
+            .finish()
+    }
 }
 
 impl Exception {
@@ -174,5 +183,180 @@ impl RubyException for Exception {
     #[inline]
     fn name(&self) -> Cow<'_, str> {
         Cow::Borrowed(Self::name(self))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::borrow::Cow;
+    use alloc::format;
+    use alloc::string::ToString;
+    use core::cmp::Ordering;
+    use core::error;
+
+    use bstr::ByteSlice;
+
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        let exception = Exception::new();
+        assert_eq!(exception.message().as_bstr(), b"Exception".as_bstr());
+        assert_eq!(exception.name(), "Exception");
+    }
+
+    #[test]
+    fn test_with_message() {
+        let custom_message = "custom message";
+        let exception = Exception::with_message(custom_message);
+        assert_eq!(exception.message().as_bstr(), custom_message.as_bytes().as_bstr());
+        // The exception name remains the default even when a custom message is used.
+        assert_eq!(exception.name(), "Exception");
+    }
+
+    #[test]
+    fn test_from_string() {
+        let message = "from String".to_string();
+        let exception: Exception = message.into();
+        assert_eq!(exception.message().as_bstr(), b"from String".as_bstr());
+    }
+
+    #[test]
+    fn test_from_static_str() {
+        let message: &'static str = "from &'static str";
+        let exception: Exception = message.into();
+        assert_eq!(exception.message().as_bstr(), b"from &'static str".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_str_borrowed() {
+        let cow: Cow<'static, str> = Cow::Borrowed("from Cow borrowed");
+        let exception: Exception = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow borrowed".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_str_owned() {
+        let cow: Cow<'static, str> = Cow::Owned("from Cow owned".to_string());
+        let exception: Exception = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow owned".as_bstr());
+    }
+
+    #[test]
+    fn test_from_vec_u8() {
+        let vec = b"from Vec<u8>".to_vec();
+        let exception: Exception = vec.into();
+        assert_eq!(exception.message().as_bstr(), b"from Vec<u8>".as_bstr());
+    }
+
+    #[test]
+    fn test_from_static_slice() {
+        let slice: &'static [u8] = b"from &'static [u8]";
+        let exception: Exception = slice.into();
+        assert_eq!(exception.message().as_bstr(), b"from &'static [u8]".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_u8_borrowed() {
+        let cow: Cow<'static, [u8]> = Cow::Borrowed(b"from Cow<u8> borrowed");
+        let exception: Exception = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow<u8> borrowed".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_u8_owned() {
+        let cow: Cow<'static, [u8]> = Cow::Owned(b"from Cow<u8> owned".to_vec());
+        let exception: Exception = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow<u8> owned".as_bstr());
+    }
+
+    #[test]
+    fn test_debug() {
+        let exception = Exception::with_message("display test");
+        let output = format!("{exception:?}");
+        // Expected to contain the exception name and the debug-escaped message.
+        assert!(output.contains("Exception"));
+        assert!(output.contains("display test"));
+        // Check the surrounding formatting.
+        assert!(output.starts_with("Exception {"));
+        assert!(output.ends_with('}'));
+    }
+
+    #[test]
+    fn test_display() {
+        let exception = Exception::with_message("display test");
+        let output = format!("{exception}");
+        // Expected to contain the exception name and the debug-escaped message.
+        assert!(output.contains("Exception"));
+        assert!(output.contains("display test"));
+        // Check the surrounding formatting.
+        assert!(output.starts_with("Exception ("));
+        assert!(output.ends_with(')'));
+    }
+
+    #[test]
+    fn test_error_trait() {
+        let exception = Exception::with_message("error trait test");
+        let error_obj: &dyn error::Error = &exception;
+        // Our implementation does not provide a source.
+        assert!(error_obj.source().is_none());
+        // to_string() uses Display.
+        assert_eq!(error_obj.to_string(), format!("{exception}"));
+    }
+
+    #[test]
+    fn test_ruby_exception_trait() {
+        let exception = Exception::with_message("ruby trait test");
+        let msg = RubyException::message(&exception);
+        let name = RubyException::name(&exception);
+        assert_eq!(msg.as_bstr(), exception.message().as_bstr());
+        assert_eq!(name, exception.name());
+    }
+
+    #[test]
+    fn test_default() {
+        let default_error = Exception::default();
+        // By default, the message should be an empty slice since Default is auto-derived.
+        assert_eq!(default_error.message(), b"");
+        // The name method always returns the constant exception name.
+        assert_eq!(default_error.name(), "Exception");
+    }
+
+    #[test]
+    fn test_clone() {
+        let original = Exception::with_message("clone test");
+        let cloned = original.clone();
+        assert_eq!(original, cloned, "Cloned error should be equal to the original");
+    }
+
+    #[test]
+    fn test_partial_eq() {
+        let error_a = Exception::with_message("test message");
+        let error_b = Exception::with_message("test message");
+        let error_c = Exception::with_message("different message");
+        assert_eq!(error_a, error_b, "Errors with the same message should be equal");
+        assert_ne!(error_a, error_c, "Errors with different messages should not be equal");
+    }
+
+    #[test]
+    fn test_partial_ord() {
+        let error_a = Exception::with_message("aaa");
+        let error_b = Exception::with_message("bbb");
+        // Same error should compare equal.
+        assert_eq!(error_a.partial_cmp(&error_a), Some(Ordering::Equal));
+        // Lexicographic ordering of the underlying messages.
+        assert_eq!(error_a.partial_cmp(&error_b), Some(Ordering::Less));
+        assert_eq!(error_b.partial_cmp(&error_a), Some(Ordering::Greater));
+    }
+
+    #[test]
+    fn test_ord() {
+        let error_a = Exception::with_message("aaa");
+        let error_b = Exception::with_message("bbb");
+        // Same error should compare equal.
+        assert_eq!(error_a.cmp(&error_a), Ordering::Equal);
+        // Lexicographic ordering of the underlying messages.
+        assert_eq!(error_a.cmp(&error_b), Ordering::Less);
+        assert_eq!(error_b.cmp(&error_a), Ordering::Greater);
     }
 }

--- a/spinoso-exception/src/core/fatal.rs
+++ b/spinoso-exception/src/core/fatal.rs
@@ -6,6 +6,7 @@ use alloc::vec::Vec;
 use core::error;
 use core::fmt;
 
+use bstr::ByteSlice;
 use scolapasta_string_escape::format_debug_escape_into;
 
 use crate::RubyException;
@@ -22,9 +23,17 @@ use crate::RubyException;
 /// [`Exception`]: https://ruby-doc.org/core-3.1.2/Exception.html
 /// [`Kernel#raise`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-raise
 /// [`NameError#name`]: https://ruby-doc.org/core-3.1.2/NameError.html#method-i-name
-#[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Default, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Fatal {
     message: Cow<'static, [u8]>,
+}
+
+impl fmt::Debug for Fatal {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("fatal")
+            .field("message", &self.message().as_bstr())
+            .finish()
+    }
 }
 
 impl Fatal {
@@ -174,5 +183,180 @@ impl RubyException for Fatal {
     #[inline]
     fn name(&self) -> Cow<'_, str> {
         Cow::Borrowed(Self::name(self))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::borrow::Cow;
+    use alloc::format;
+    use alloc::string::ToString;
+    use core::cmp::Ordering;
+    use core::error;
+
+    use bstr::ByteSlice;
+
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        let exception = Fatal::new();
+        assert_eq!(exception.message().as_bstr(), b"fatal".as_bstr());
+        assert_eq!(exception.name(), "fatal");
+    }
+
+    #[test]
+    fn test_with_message() {
+        let custom_message = "custom message";
+        let exception = Fatal::with_message(custom_message);
+        assert_eq!(exception.message().as_bstr(), custom_message.as_bytes().as_bstr());
+        // The exception name remains the default even when a custom message is used.
+        assert_eq!(exception.name(), "fatal");
+    }
+
+    #[test]
+    fn test_from_string() {
+        let message = "from String".to_string();
+        let exception: Fatal = message.into();
+        assert_eq!(exception.message().as_bstr(), b"from String".as_bstr());
+    }
+
+    #[test]
+    fn test_from_static_str() {
+        let message: &'static str = "from &'static str";
+        let exception: Fatal = message.into();
+        assert_eq!(exception.message().as_bstr(), b"from &'static str".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_str_borrowed() {
+        let cow: Cow<'static, str> = Cow::Borrowed("from Cow borrowed");
+        let exception: Fatal = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow borrowed".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_str_owned() {
+        let cow: Cow<'static, str> = Cow::Owned("from Cow owned".to_string());
+        let exception: Fatal = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow owned".as_bstr());
+    }
+
+    #[test]
+    fn test_from_vec_u8() {
+        let vec = b"from Vec<u8>".to_vec();
+        let exception: Fatal = vec.into();
+        assert_eq!(exception.message().as_bstr(), b"from Vec<u8>".as_bstr());
+    }
+
+    #[test]
+    fn test_from_static_slice() {
+        let slice: &'static [u8] = b"from &'static [u8]";
+        let exception: Fatal = slice.into();
+        assert_eq!(exception.message().as_bstr(), b"from &'static [u8]".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_u8_borrowed() {
+        let cow: Cow<'static, [u8]> = Cow::Borrowed(b"from Cow<u8> borrowed");
+        let exception: Fatal = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow<u8> borrowed".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_u8_owned() {
+        let cow: Cow<'static, [u8]> = Cow::Owned(b"from Cow<u8> owned".to_vec());
+        let exception: Fatal = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow<u8> owned".as_bstr());
+    }
+
+    #[test]
+    fn test_debug() {
+        let exception = Fatal::with_message("display test");
+        let output = format!("{exception:?}");
+        // Expected to contain the exception name and the debug-escaped message.
+        assert!(output.contains("fatal"));
+        assert!(output.contains("display test"));
+        // Check the surrounding formatting.
+        assert!(output.starts_with("fatal {"));
+        assert!(output.ends_with('}'));
+    }
+
+    #[test]
+    fn test_display() {
+        let exception = Fatal::with_message("display test");
+        let output = format!("{exception}");
+        // Expected to contain the exception name and the debug-escaped message.
+        assert!(output.contains("fatal"));
+        assert!(output.contains("display test"));
+        // Check the surrounding formatting.
+        assert!(output.starts_with("fatal ("));
+        assert!(output.ends_with(')'));
+    }
+
+    #[test]
+    fn test_error_trait() {
+        let exception = Fatal::with_message("error trait test");
+        let error_obj: &dyn error::Error = &exception;
+        // Our implementation does not provide a source.
+        assert!(error_obj.source().is_none());
+        // to_string() uses Display.
+        assert_eq!(error_obj.to_string(), format!("{exception}"));
+    }
+
+    #[test]
+    fn test_ruby_exception_trait() {
+        let exception = Fatal::with_message("ruby trait test");
+        let msg = RubyException::message(&exception);
+        let name = RubyException::name(&exception);
+        assert_eq!(msg.as_bstr(), exception.message().as_bstr());
+        assert_eq!(name, exception.name());
+    }
+
+    #[test]
+    fn test_default() {
+        let default_error = Fatal::default();
+        // By default, the message should be an empty slice since Default is auto-derived.
+        assert_eq!(default_error.message(), b"");
+        // The name method always returns the constant exception name.
+        assert_eq!(default_error.name(), "fatal");
+    }
+
+    #[test]
+    fn test_clone() {
+        let original = Fatal::with_message("clone test");
+        let cloned = original.clone();
+        assert_eq!(original, cloned, "Cloned error should be equal to the original");
+    }
+
+    #[test]
+    fn test_partial_eq() {
+        let error_a = Fatal::with_message("test message");
+        let error_b = Fatal::with_message("test message");
+        let error_c = Fatal::with_message("different message");
+        assert_eq!(error_a, error_b, "Errors with the same message should be equal");
+        assert_ne!(error_a, error_c, "Errors with different messages should not be equal");
+    }
+
+    #[test]
+    fn test_partial_ord() {
+        let error_a = Fatal::with_message("aaa");
+        let error_b = Fatal::with_message("bbb");
+        // Same error should compare equal.
+        assert_eq!(error_a.partial_cmp(&error_a), Some(Ordering::Equal));
+        // Lexicographic ordering of the underlying messages.
+        assert_eq!(error_a.partial_cmp(&error_b), Some(Ordering::Less));
+        assert_eq!(error_b.partial_cmp(&error_a), Some(Ordering::Greater));
+    }
+
+    #[test]
+    fn test_ord() {
+        let error_a = Fatal::with_message("aaa");
+        let error_b = Fatal::with_message("bbb");
+        // Same error should compare equal.
+        assert_eq!(error_a.cmp(&error_a), Ordering::Equal);
+        // Lexicographic ordering of the underlying messages.
+        assert_eq!(error_a.cmp(&error_b), Ordering::Less);
+        assert_eq!(error_b.cmp(&error_a), Ordering::Greater);
     }
 }

--- a/spinoso-exception/src/core/fibererror.rs
+++ b/spinoso-exception/src/core/fibererror.rs
@@ -6,6 +6,7 @@ use alloc::vec::Vec;
 use core::error;
 use core::fmt;
 
+use bstr::ByteSlice;
 use scolapasta_string_escape::format_debug_escape_into;
 
 use crate::RubyException;
@@ -22,9 +23,17 @@ use crate::RubyException;
 /// [`Exception`]: https://ruby-doc.org/core-3.1.2/Exception.html
 /// [`Kernel#raise`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-raise
 /// [`NameError#name`]: https://ruby-doc.org/core-3.1.2/NameError.html#method-i-name
-#[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Default, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct FiberError {
     message: Cow<'static, [u8]>,
+}
+
+impl fmt::Debug for FiberError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("FiberError")
+            .field("message", &self.message().as_bstr())
+            .finish()
+    }
 }
 
 impl FiberError {
@@ -174,5 +183,180 @@ impl RubyException for FiberError {
     #[inline]
     fn name(&self) -> Cow<'_, str> {
         Cow::Borrowed(Self::name(self))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::borrow::Cow;
+    use alloc::format;
+    use alloc::string::ToString;
+    use core::cmp::Ordering;
+    use core::error;
+
+    use bstr::ByteSlice;
+
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        let exception = FiberError::new();
+        assert_eq!(exception.message().as_bstr(), b"FiberError".as_bstr());
+        assert_eq!(exception.name(), "FiberError");
+    }
+
+    #[test]
+    fn test_with_message() {
+        let custom_message = "custom message";
+        let exception = FiberError::with_message(custom_message);
+        assert_eq!(exception.message().as_bstr(), custom_message.as_bytes().as_bstr());
+        // The exception name remains the default even when a custom message is used.
+        assert_eq!(exception.name(), "FiberError");
+    }
+
+    #[test]
+    fn test_from_string() {
+        let message = "from String".to_string();
+        let exception: FiberError = message.into();
+        assert_eq!(exception.message().as_bstr(), b"from String".as_bstr());
+    }
+
+    #[test]
+    fn test_from_static_str() {
+        let message: &'static str = "from &'static str";
+        let exception: FiberError = message.into();
+        assert_eq!(exception.message().as_bstr(), b"from &'static str".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_str_borrowed() {
+        let cow: Cow<'static, str> = Cow::Borrowed("from Cow borrowed");
+        let exception: FiberError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow borrowed".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_str_owned() {
+        let cow: Cow<'static, str> = Cow::Owned("from Cow owned".to_string());
+        let exception: FiberError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow owned".as_bstr());
+    }
+
+    #[test]
+    fn test_from_vec_u8() {
+        let vec = b"from Vec<u8>".to_vec();
+        let exception: FiberError = vec.into();
+        assert_eq!(exception.message().as_bstr(), b"from Vec<u8>".as_bstr());
+    }
+
+    #[test]
+    fn test_from_static_slice() {
+        let slice: &'static [u8] = b"from &'static [u8]";
+        let exception: FiberError = slice.into();
+        assert_eq!(exception.message().as_bstr(), b"from &'static [u8]".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_u8_borrowed() {
+        let cow: Cow<'static, [u8]> = Cow::Borrowed(b"from Cow<u8> borrowed");
+        let exception: FiberError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow<u8> borrowed".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_u8_owned() {
+        let cow: Cow<'static, [u8]> = Cow::Owned(b"from Cow<u8> owned".to_vec());
+        let exception: FiberError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow<u8> owned".as_bstr());
+    }
+
+    #[test]
+    fn test_debug() {
+        let exception = FiberError::with_message("display test");
+        let output = format!("{exception:?}");
+        // Expected to contain the exception name and the debug-escaped message.
+        assert!(output.contains("FiberError"));
+        assert!(output.contains("display test"));
+        // Check the surrounding formatting.
+        assert!(output.starts_with("FiberError {"));
+        assert!(output.ends_with('}'));
+    }
+
+    #[test]
+    fn test_display() {
+        let exception = FiberError::with_message("display test");
+        let output = format!("{exception}");
+        // Expected to contain the exception name and the debug-escaped message.
+        assert!(output.contains("FiberError"));
+        assert!(output.contains("display test"));
+        // Check the surrounding formatting.
+        assert!(output.starts_with("FiberError ("));
+        assert!(output.ends_with(')'));
+    }
+
+    #[test]
+    fn test_error_trait() {
+        let exception = FiberError::with_message("error trait test");
+        let error_obj: &dyn error::Error = &exception;
+        // Our implementation does not provide a source.
+        assert!(error_obj.source().is_none());
+        // to_string() uses Display.
+        assert_eq!(error_obj.to_string(), format!("{exception}"));
+    }
+
+    #[test]
+    fn test_ruby_exception_trait() {
+        let exception = FiberError::with_message("ruby trait test");
+        let msg = RubyException::message(&exception);
+        let name = RubyException::name(&exception);
+        assert_eq!(msg.as_bstr(), exception.message().as_bstr());
+        assert_eq!(name, exception.name());
+    }
+
+    #[test]
+    fn test_default() {
+        let default_error = FiberError::default();
+        // By default, the message should be an empty slice since Default is auto-derived.
+        assert_eq!(default_error.message(), b"");
+        // The name method always returns the constant exception name.
+        assert_eq!(default_error.name(), "FiberError");
+    }
+
+    #[test]
+    fn test_clone() {
+        let original = FiberError::with_message("clone test");
+        let cloned = original.clone();
+        assert_eq!(original, cloned, "Cloned error should be equal to the original");
+    }
+
+    #[test]
+    fn test_partial_eq() {
+        let error_a = FiberError::with_message("test message");
+        let error_b = FiberError::with_message("test message");
+        let error_c = FiberError::with_message("different message");
+        assert_eq!(error_a, error_b, "Errors with the same message should be equal");
+        assert_ne!(error_a, error_c, "Errors with different messages should not be equal");
+    }
+
+    #[test]
+    fn test_partial_ord() {
+        let error_a = FiberError::with_message("aaa");
+        let error_b = FiberError::with_message("bbb");
+        // Same error should compare equal.
+        assert_eq!(error_a.partial_cmp(&error_a), Some(Ordering::Equal));
+        // Lexicographic ordering of the underlying messages.
+        assert_eq!(error_a.partial_cmp(&error_b), Some(Ordering::Less));
+        assert_eq!(error_b.partial_cmp(&error_a), Some(Ordering::Greater));
+    }
+
+    #[test]
+    fn test_ord() {
+        let error_a = FiberError::with_message("aaa");
+        let error_b = FiberError::with_message("bbb");
+        // Same error should compare equal.
+        assert_eq!(error_a.cmp(&error_a), Ordering::Equal);
+        // Lexicographic ordering of the underlying messages.
+        assert_eq!(error_a.cmp(&error_b), Ordering::Less);
+        assert_eq!(error_b.cmp(&error_a), Ordering::Greater);
     }
 }

--- a/spinoso-exception/src/core/floatdomainerror.rs
+++ b/spinoso-exception/src/core/floatdomainerror.rs
@@ -6,6 +6,7 @@ use alloc::vec::Vec;
 use core::error;
 use core::fmt;
 
+use bstr::ByteSlice;
 use scolapasta_string_escape::format_debug_escape_into;
 
 use crate::RubyException;
@@ -22,9 +23,17 @@ use crate::RubyException;
 /// [`Exception`]: https://ruby-doc.org/core-3.1.2/Exception.html
 /// [`Kernel#raise`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-raise
 /// [`NameError#name`]: https://ruby-doc.org/core-3.1.2/NameError.html#method-i-name
-#[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Default, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct FloatDomainError {
     message: Cow<'static, [u8]>,
+}
+
+impl fmt::Debug for FloatDomainError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("FloatDomainError")
+            .field("message", &self.message().as_bstr())
+            .finish()
+    }
 }
 
 impl FloatDomainError {
@@ -174,5 +183,180 @@ impl RubyException for FloatDomainError {
     #[inline]
     fn name(&self) -> Cow<'_, str> {
         Cow::Borrowed(Self::name(self))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::borrow::Cow;
+    use alloc::format;
+    use alloc::string::ToString;
+    use core::cmp::Ordering;
+    use core::error;
+
+    use bstr::ByteSlice;
+
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        let exception = FloatDomainError::new();
+        assert_eq!(exception.message().as_bstr(), b"FloatDomainError".as_bstr());
+        assert_eq!(exception.name(), "FloatDomainError");
+    }
+
+    #[test]
+    fn test_with_message() {
+        let custom_message = "custom message";
+        let exception = FloatDomainError::with_message(custom_message);
+        assert_eq!(exception.message().as_bstr(), custom_message.as_bytes().as_bstr());
+        // The exception name remains the default even when a custom message is used.
+        assert_eq!(exception.name(), "FloatDomainError");
+    }
+
+    #[test]
+    fn test_from_string() {
+        let message = "from String".to_string();
+        let exception: FloatDomainError = message.into();
+        assert_eq!(exception.message().as_bstr(), b"from String".as_bstr());
+    }
+
+    #[test]
+    fn test_from_static_str() {
+        let message: &'static str = "from &'static str";
+        let exception: FloatDomainError = message.into();
+        assert_eq!(exception.message().as_bstr(), b"from &'static str".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_str_borrowed() {
+        let cow: Cow<'static, str> = Cow::Borrowed("from Cow borrowed");
+        let exception: FloatDomainError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow borrowed".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_str_owned() {
+        let cow: Cow<'static, str> = Cow::Owned("from Cow owned".to_string());
+        let exception: FloatDomainError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow owned".as_bstr());
+    }
+
+    #[test]
+    fn test_from_vec_u8() {
+        let vec = b"from Vec<u8>".to_vec();
+        let exception: FloatDomainError = vec.into();
+        assert_eq!(exception.message().as_bstr(), b"from Vec<u8>".as_bstr());
+    }
+
+    #[test]
+    fn test_from_static_slice() {
+        let slice: &'static [u8] = b"from &'static [u8]";
+        let exception: FloatDomainError = slice.into();
+        assert_eq!(exception.message().as_bstr(), b"from &'static [u8]".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_u8_borrowed() {
+        let cow: Cow<'static, [u8]> = Cow::Borrowed(b"from Cow<u8> borrowed");
+        let exception: FloatDomainError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow<u8> borrowed".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_u8_owned() {
+        let cow: Cow<'static, [u8]> = Cow::Owned(b"from Cow<u8> owned".to_vec());
+        let exception: FloatDomainError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow<u8> owned".as_bstr());
+    }
+
+    #[test]
+    fn test_debug() {
+        let exception = FloatDomainError::with_message("display test");
+        let output = format!("{exception:?}");
+        // Expected to contain the exception name and the debug-escaped message.
+        assert!(output.contains("FloatDomainError"));
+        assert!(output.contains("display test"));
+        // Check the surrounding formatting.
+        assert!(output.starts_with("FloatDomainError {"));
+        assert!(output.ends_with('}'));
+    }
+
+    #[test]
+    fn test_display() {
+        let exception = FloatDomainError::with_message("display test");
+        let output = format!("{exception}");
+        // Expected to contain the exception name and the debug-escaped message.
+        assert!(output.contains("FloatDomainError"));
+        assert!(output.contains("display test"));
+        // Check the surrounding formatting.
+        assert!(output.starts_with("FloatDomainError ("));
+        assert!(output.ends_with(')'));
+    }
+
+    #[test]
+    fn test_error_trait() {
+        let exception = FloatDomainError::with_message("error trait test");
+        let error_obj: &dyn error::Error = &exception;
+        // Our implementation does not provide a source.
+        assert!(error_obj.source().is_none());
+        // to_string() uses Display.
+        assert_eq!(error_obj.to_string(), format!("{exception}"));
+    }
+
+    #[test]
+    fn test_ruby_exception_trait() {
+        let exception = FloatDomainError::with_message("ruby trait test");
+        let msg = RubyException::message(&exception);
+        let name = RubyException::name(&exception);
+        assert_eq!(msg.as_bstr(), exception.message().as_bstr());
+        assert_eq!(name, exception.name());
+    }
+
+    #[test]
+    fn test_default() {
+        let default_error = FloatDomainError::default();
+        // By default, the message should be an empty slice since Default is auto-derived.
+        assert_eq!(default_error.message(), b"");
+        // The name method always returns the constant exception name.
+        assert_eq!(default_error.name(), "FloatDomainError");
+    }
+
+    #[test]
+    fn test_clone() {
+        let original = FloatDomainError::with_message("clone test");
+        let cloned = original.clone();
+        assert_eq!(original, cloned, "Cloned error should be equal to the original");
+    }
+
+    #[test]
+    fn test_partial_eq() {
+        let error_a = FloatDomainError::with_message("test message");
+        let error_b = FloatDomainError::with_message("test message");
+        let error_c = FloatDomainError::with_message("different message");
+        assert_eq!(error_a, error_b, "Errors with the same message should be equal");
+        assert_ne!(error_a, error_c, "Errors with different messages should not be equal");
+    }
+
+    #[test]
+    fn test_partial_ord() {
+        let error_a = FloatDomainError::with_message("aaa");
+        let error_b = FloatDomainError::with_message("bbb");
+        // Same error should compare equal.
+        assert_eq!(error_a.partial_cmp(&error_a), Some(Ordering::Equal));
+        // Lexicographic ordering of the underlying messages.
+        assert_eq!(error_a.partial_cmp(&error_b), Some(Ordering::Less));
+        assert_eq!(error_b.partial_cmp(&error_a), Some(Ordering::Greater));
+    }
+
+    #[test]
+    fn test_ord() {
+        let error_a = FloatDomainError::with_message("aaa");
+        let error_b = FloatDomainError::with_message("bbb");
+        // Same error should compare equal.
+        assert_eq!(error_a.cmp(&error_a), Ordering::Equal);
+        // Lexicographic ordering of the underlying messages.
+        assert_eq!(error_a.cmp(&error_b), Ordering::Less);
+        assert_eq!(error_b.cmp(&error_a), Ordering::Greater);
     }
 }

--- a/spinoso-exception/src/core/frozenerror.rs
+++ b/spinoso-exception/src/core/frozenerror.rs
@@ -6,6 +6,7 @@ use alloc::vec::Vec;
 use core::error;
 use core::fmt;
 
+use bstr::ByteSlice;
 use scolapasta_string_escape::format_debug_escape_into;
 
 use crate::RubyException;
@@ -22,9 +23,17 @@ use crate::RubyException;
 /// [`Exception`]: https://ruby-doc.org/core-3.1.2/Exception.html
 /// [`Kernel#raise`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-raise
 /// [`NameError#name`]: https://ruby-doc.org/core-3.1.2/NameError.html#method-i-name
-#[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Default, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct FrozenError {
     message: Cow<'static, [u8]>,
+}
+
+impl fmt::Debug for FrozenError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("FrozenError")
+            .field("message", &self.message().as_bstr())
+            .finish()
+    }
 }
 
 impl FrozenError {
@@ -174,5 +183,180 @@ impl RubyException for FrozenError {
     #[inline]
     fn name(&self) -> Cow<'_, str> {
         Cow::Borrowed(Self::name(self))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::borrow::Cow;
+    use alloc::format;
+    use alloc::string::ToString;
+    use core::cmp::Ordering;
+    use core::error;
+
+    use bstr::ByteSlice;
+
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        let exception = FrozenError::new();
+        assert_eq!(exception.message().as_bstr(), b"FrozenError".as_bstr());
+        assert_eq!(exception.name(), "FrozenError");
+    }
+
+    #[test]
+    fn test_with_message() {
+        let custom_message = "custom message";
+        let exception = FrozenError::with_message(custom_message);
+        assert_eq!(exception.message().as_bstr(), custom_message.as_bytes().as_bstr());
+        // The exception name remains the default even when a custom message is used.
+        assert_eq!(exception.name(), "FrozenError");
+    }
+
+    #[test]
+    fn test_from_string() {
+        let message = "from String".to_string();
+        let exception: FrozenError = message.into();
+        assert_eq!(exception.message().as_bstr(), b"from String".as_bstr());
+    }
+
+    #[test]
+    fn test_from_static_str() {
+        let message: &'static str = "from &'static str";
+        let exception: FrozenError = message.into();
+        assert_eq!(exception.message().as_bstr(), b"from &'static str".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_str_borrowed() {
+        let cow: Cow<'static, str> = Cow::Borrowed("from Cow borrowed");
+        let exception: FrozenError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow borrowed".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_str_owned() {
+        let cow: Cow<'static, str> = Cow::Owned("from Cow owned".to_string());
+        let exception: FrozenError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow owned".as_bstr());
+    }
+
+    #[test]
+    fn test_from_vec_u8() {
+        let vec = b"from Vec<u8>".to_vec();
+        let exception: FrozenError = vec.into();
+        assert_eq!(exception.message().as_bstr(), b"from Vec<u8>".as_bstr());
+    }
+
+    #[test]
+    fn test_from_static_slice() {
+        let slice: &'static [u8] = b"from &'static [u8]";
+        let exception: FrozenError = slice.into();
+        assert_eq!(exception.message().as_bstr(), b"from &'static [u8]".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_u8_borrowed() {
+        let cow: Cow<'static, [u8]> = Cow::Borrowed(b"from Cow<u8> borrowed");
+        let exception: FrozenError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow<u8> borrowed".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_u8_owned() {
+        let cow: Cow<'static, [u8]> = Cow::Owned(b"from Cow<u8> owned".to_vec());
+        let exception: FrozenError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow<u8> owned".as_bstr());
+    }
+
+    #[test]
+    fn test_debug() {
+        let exception = FrozenError::with_message("display test");
+        let output = format!("{exception:?}");
+        // Expected to contain the exception name and the debug-escaped message.
+        assert!(output.contains("FrozenError"));
+        assert!(output.contains("display test"));
+        // Check the surrounding formatting.
+        assert!(output.starts_with("FrozenError {"));
+        assert!(output.ends_with('}'));
+    }
+
+    #[test]
+    fn test_display() {
+        let exception = FrozenError::with_message("display test");
+        let output = format!("{exception}");
+        // Expected to contain the exception name and the debug-escaped message.
+        assert!(output.contains("FrozenError"));
+        assert!(output.contains("display test"));
+        // Check the surrounding formatting.
+        assert!(output.starts_with("FrozenError ("));
+        assert!(output.ends_with(')'));
+    }
+
+    #[test]
+    fn test_error_trait() {
+        let exception = FrozenError::with_message("error trait test");
+        let error_obj: &dyn error::Error = &exception;
+        // Our implementation does not provide a source.
+        assert!(error_obj.source().is_none());
+        // to_string() uses Display.
+        assert_eq!(error_obj.to_string(), format!("{exception}"));
+    }
+
+    #[test]
+    fn test_ruby_exception_trait() {
+        let exception = FrozenError::with_message("ruby trait test");
+        let msg = RubyException::message(&exception);
+        let name = RubyException::name(&exception);
+        assert_eq!(msg.as_bstr(), exception.message().as_bstr());
+        assert_eq!(name, exception.name());
+    }
+
+    #[test]
+    fn test_default() {
+        let default_error = FrozenError::default();
+        // By default, the message should be an empty slice since Default is auto-derived.
+        assert_eq!(default_error.message(), b"");
+        // The name method always returns the constant exception name.
+        assert_eq!(default_error.name(), "FrozenError");
+    }
+
+    #[test]
+    fn test_clone() {
+        let original = FrozenError::with_message("clone test");
+        let cloned = original.clone();
+        assert_eq!(original, cloned, "Cloned error should be equal to the original");
+    }
+
+    #[test]
+    fn test_partial_eq() {
+        let error_a = FrozenError::with_message("test message");
+        let error_b = FrozenError::with_message("test message");
+        let error_c = FrozenError::with_message("different message");
+        assert_eq!(error_a, error_b, "Errors with the same message should be equal");
+        assert_ne!(error_a, error_c, "Errors with different messages should not be equal");
+    }
+
+    #[test]
+    fn test_partial_ord() {
+        let error_a = FrozenError::with_message("aaa");
+        let error_b = FrozenError::with_message("bbb");
+        // Same error should compare equal.
+        assert_eq!(error_a.partial_cmp(&error_a), Some(Ordering::Equal));
+        // Lexicographic ordering of the underlying messages.
+        assert_eq!(error_a.partial_cmp(&error_b), Some(Ordering::Less));
+        assert_eq!(error_b.partial_cmp(&error_a), Some(Ordering::Greater));
+    }
+
+    #[test]
+    fn test_ord() {
+        let error_a = FrozenError::with_message("aaa");
+        let error_b = FrozenError::with_message("bbb");
+        // Same error should compare equal.
+        assert_eq!(error_a.cmp(&error_a), Ordering::Equal);
+        // Lexicographic ordering of the underlying messages.
+        assert_eq!(error_a.cmp(&error_b), Ordering::Less);
+        assert_eq!(error_b.cmp(&error_a), Ordering::Greater);
     }
 }

--- a/spinoso-exception/src/core/indexerror.rs
+++ b/spinoso-exception/src/core/indexerror.rs
@@ -6,6 +6,7 @@ use alloc::vec::Vec;
 use core::error;
 use core::fmt;
 
+use bstr::ByteSlice;
 use scolapasta_string_escape::format_debug_escape_into;
 
 use crate::RubyException;
@@ -22,9 +23,17 @@ use crate::RubyException;
 /// [`Exception`]: https://ruby-doc.org/core-3.1.2/Exception.html
 /// [`Kernel#raise`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-raise
 /// [`NameError#name`]: https://ruby-doc.org/core-3.1.2/NameError.html#method-i-name
-#[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Default, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct IndexError {
     message: Cow<'static, [u8]>,
+}
+
+impl fmt::Debug for IndexError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("IndexError")
+            .field("message", &self.message().as_bstr())
+            .finish()
+    }
 }
 
 impl IndexError {
@@ -174,5 +183,180 @@ impl RubyException for IndexError {
     #[inline]
     fn name(&self) -> Cow<'_, str> {
         Cow::Borrowed(Self::name(self))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::borrow::Cow;
+    use alloc::format;
+    use alloc::string::ToString;
+    use core::cmp::Ordering;
+    use core::error;
+
+    use bstr::ByteSlice;
+
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        let exception = IndexError::new();
+        assert_eq!(exception.message().as_bstr(), b"IndexError".as_bstr());
+        assert_eq!(exception.name(), "IndexError");
+    }
+
+    #[test]
+    fn test_with_message() {
+        let custom_message = "custom message";
+        let exception = IndexError::with_message(custom_message);
+        assert_eq!(exception.message().as_bstr(), custom_message.as_bytes().as_bstr());
+        // The exception name remains the default even when a custom message is used.
+        assert_eq!(exception.name(), "IndexError");
+    }
+
+    #[test]
+    fn test_from_string() {
+        let message = "from String".to_string();
+        let exception: IndexError = message.into();
+        assert_eq!(exception.message().as_bstr(), b"from String".as_bstr());
+    }
+
+    #[test]
+    fn test_from_static_str() {
+        let message: &'static str = "from &'static str";
+        let exception: IndexError = message.into();
+        assert_eq!(exception.message().as_bstr(), b"from &'static str".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_str_borrowed() {
+        let cow: Cow<'static, str> = Cow::Borrowed("from Cow borrowed");
+        let exception: IndexError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow borrowed".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_str_owned() {
+        let cow: Cow<'static, str> = Cow::Owned("from Cow owned".to_string());
+        let exception: IndexError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow owned".as_bstr());
+    }
+
+    #[test]
+    fn test_from_vec_u8() {
+        let vec = b"from Vec<u8>".to_vec();
+        let exception: IndexError = vec.into();
+        assert_eq!(exception.message().as_bstr(), b"from Vec<u8>".as_bstr());
+    }
+
+    #[test]
+    fn test_from_static_slice() {
+        let slice: &'static [u8] = b"from &'static [u8]";
+        let exception: IndexError = slice.into();
+        assert_eq!(exception.message().as_bstr(), b"from &'static [u8]".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_u8_borrowed() {
+        let cow: Cow<'static, [u8]> = Cow::Borrowed(b"from Cow<u8> borrowed");
+        let exception: IndexError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow<u8> borrowed".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_u8_owned() {
+        let cow: Cow<'static, [u8]> = Cow::Owned(b"from Cow<u8> owned".to_vec());
+        let exception: IndexError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow<u8> owned".as_bstr());
+    }
+
+    #[test]
+    fn test_debug() {
+        let exception = IndexError::with_message("display test");
+        let output = format!("{exception:?}");
+        // Expected to contain the exception name and the debug-escaped message.
+        assert!(output.contains("IndexError"));
+        assert!(output.contains("display test"));
+        // Check the surrounding formatting.
+        assert!(output.starts_with("IndexError {"));
+        assert!(output.ends_with('}'));
+    }
+
+    #[test]
+    fn test_display() {
+        let exception = IndexError::with_message("display test");
+        let output = format!("{exception}");
+        // Expected to contain the exception name and the debug-escaped message.
+        assert!(output.contains("IndexError"));
+        assert!(output.contains("display test"));
+        // Check the surrounding formatting.
+        assert!(output.starts_with("IndexError ("));
+        assert!(output.ends_with(')'));
+    }
+
+    #[test]
+    fn test_error_trait() {
+        let exception = IndexError::with_message("error trait test");
+        let error_obj: &dyn error::Error = &exception;
+        // Our implementation does not provide a source.
+        assert!(error_obj.source().is_none());
+        // to_string() uses Display.
+        assert_eq!(error_obj.to_string(), format!("{exception}"));
+    }
+
+    #[test]
+    fn test_ruby_exception_trait() {
+        let exception = IndexError::with_message("ruby trait test");
+        let msg = RubyException::message(&exception);
+        let name = RubyException::name(&exception);
+        assert_eq!(msg.as_bstr(), exception.message().as_bstr());
+        assert_eq!(name, exception.name());
+    }
+
+    #[test]
+    fn test_default() {
+        let default_error = IndexError::default();
+        // By default, the message should be an empty slice since Default is auto-derived.
+        assert_eq!(default_error.message(), b"");
+        // The name method always returns the constant exception name.
+        assert_eq!(default_error.name(), "IndexError");
+    }
+
+    #[test]
+    fn test_clone() {
+        let original = IndexError::with_message("clone test");
+        let cloned = original.clone();
+        assert_eq!(original, cloned, "Cloned error should be equal to the original");
+    }
+
+    #[test]
+    fn test_partial_eq() {
+        let error_a = IndexError::with_message("test message");
+        let error_b = IndexError::with_message("test message");
+        let error_c = IndexError::with_message("different message");
+        assert_eq!(error_a, error_b, "Errors with the same message should be equal");
+        assert_ne!(error_a, error_c, "Errors with different messages should not be equal");
+    }
+
+    #[test]
+    fn test_partial_ord() {
+        let error_a = IndexError::with_message("aaa");
+        let error_b = IndexError::with_message("bbb");
+        // Same error should compare equal.
+        assert_eq!(error_a.partial_cmp(&error_a), Some(Ordering::Equal));
+        // Lexicographic ordering of the underlying messages.
+        assert_eq!(error_a.partial_cmp(&error_b), Some(Ordering::Less));
+        assert_eq!(error_b.partial_cmp(&error_a), Some(Ordering::Greater));
+    }
+
+    #[test]
+    fn test_ord() {
+        let error_a = IndexError::with_message("aaa");
+        let error_b = IndexError::with_message("bbb");
+        // Same error should compare equal.
+        assert_eq!(error_a.cmp(&error_a), Ordering::Equal);
+        // Lexicographic ordering of the underlying messages.
+        assert_eq!(error_a.cmp(&error_b), Ordering::Less);
+        assert_eq!(error_b.cmp(&error_a), Ordering::Greater);
     }
 }

--- a/spinoso-exception/src/core/interrupt.rs
+++ b/spinoso-exception/src/core/interrupt.rs
@@ -6,6 +6,7 @@ use alloc::vec::Vec;
 use core::error;
 use core::fmt;
 
+use bstr::ByteSlice;
 use scolapasta_string_escape::format_debug_escape_into;
 
 use crate::RubyException;
@@ -22,9 +23,17 @@ use crate::RubyException;
 /// [`Exception`]: https://ruby-doc.org/core-3.1.2/Exception.html
 /// [`Kernel#raise`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-raise
 /// [`NameError#name`]: https://ruby-doc.org/core-3.1.2/NameError.html#method-i-name
-#[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Default, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Interrupt {
     message: Cow<'static, [u8]>,
+}
+
+impl fmt::Debug for Interrupt {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Interrupt")
+            .field("message", &self.message().as_bstr())
+            .finish()
+    }
 }
 
 impl Interrupt {
@@ -174,5 +183,180 @@ impl RubyException for Interrupt {
     #[inline]
     fn name(&self) -> Cow<'_, str> {
         Cow::Borrowed(Self::name(self))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::borrow::Cow;
+    use alloc::format;
+    use alloc::string::ToString;
+    use core::cmp::Ordering;
+    use core::error;
+
+    use bstr::ByteSlice;
+
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        let exception = Interrupt::new();
+        assert_eq!(exception.message().as_bstr(), b"Interrupt".as_bstr());
+        assert_eq!(exception.name(), "Interrupt");
+    }
+
+    #[test]
+    fn test_with_message() {
+        let custom_message = "custom message";
+        let exception = Interrupt::with_message(custom_message);
+        assert_eq!(exception.message().as_bstr(), custom_message.as_bytes().as_bstr());
+        // The exception name remains the default even when a custom message is used.
+        assert_eq!(exception.name(), "Interrupt");
+    }
+
+    #[test]
+    fn test_from_string() {
+        let message = "from String".to_string();
+        let exception: Interrupt = message.into();
+        assert_eq!(exception.message().as_bstr(), b"from String".as_bstr());
+    }
+
+    #[test]
+    fn test_from_static_str() {
+        let message: &'static str = "from &'static str";
+        let exception: Interrupt = message.into();
+        assert_eq!(exception.message().as_bstr(), b"from &'static str".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_str_borrowed() {
+        let cow: Cow<'static, str> = Cow::Borrowed("from Cow borrowed");
+        let exception: Interrupt = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow borrowed".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_str_owned() {
+        let cow: Cow<'static, str> = Cow::Owned("from Cow owned".to_string());
+        let exception: Interrupt = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow owned".as_bstr());
+    }
+
+    #[test]
+    fn test_from_vec_u8() {
+        let vec = b"from Vec<u8>".to_vec();
+        let exception: Interrupt = vec.into();
+        assert_eq!(exception.message().as_bstr(), b"from Vec<u8>".as_bstr());
+    }
+
+    #[test]
+    fn test_from_static_slice() {
+        let slice: &'static [u8] = b"from &'static [u8]";
+        let exception: Interrupt = slice.into();
+        assert_eq!(exception.message().as_bstr(), b"from &'static [u8]".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_u8_borrowed() {
+        let cow: Cow<'static, [u8]> = Cow::Borrowed(b"from Cow<u8> borrowed");
+        let exception: Interrupt = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow<u8> borrowed".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_u8_owned() {
+        let cow: Cow<'static, [u8]> = Cow::Owned(b"from Cow<u8> owned".to_vec());
+        let exception: Interrupt = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow<u8> owned".as_bstr());
+    }
+
+    #[test]
+    fn test_debug() {
+        let exception = Interrupt::with_message("display test");
+        let output = format!("{exception:?}");
+        // Expected to contain the exception name and the debug-escaped message.
+        assert!(output.contains("Interrupt"));
+        assert!(output.contains("display test"));
+        // Check the surrounding formatting.
+        assert!(output.starts_with("Interrupt {"));
+        assert!(output.ends_with('}'));
+    }
+
+    #[test]
+    fn test_display() {
+        let exception = Interrupt::with_message("display test");
+        let output = format!("{exception}");
+        // Expected to contain the exception name and the debug-escaped message.
+        assert!(output.contains("Interrupt"));
+        assert!(output.contains("display test"));
+        // Check the surrounding formatting.
+        assert!(output.starts_with("Interrupt ("));
+        assert!(output.ends_with(')'));
+    }
+
+    #[test]
+    fn test_error_trait() {
+        let exception = Interrupt::with_message("error trait test");
+        let error_obj: &dyn error::Error = &exception;
+        // Our implementation does not provide a source.
+        assert!(error_obj.source().is_none());
+        // to_string() uses Display.
+        assert_eq!(error_obj.to_string(), format!("{exception}"));
+    }
+
+    #[test]
+    fn test_ruby_exception_trait() {
+        let exception = Interrupt::with_message("ruby trait test");
+        let msg = RubyException::message(&exception);
+        let name = RubyException::name(&exception);
+        assert_eq!(msg.as_bstr(), exception.message().as_bstr());
+        assert_eq!(name, exception.name());
+    }
+
+    #[test]
+    fn test_default() {
+        let default_error = Interrupt::default();
+        // By default, the message should be an empty slice since Default is auto-derived.
+        assert_eq!(default_error.message(), b"");
+        // The name method always returns the constant exception name.
+        assert_eq!(default_error.name(), "Interrupt");
+    }
+
+    #[test]
+    fn test_clone() {
+        let original = Interrupt::with_message("clone test");
+        let cloned = original.clone();
+        assert_eq!(original, cloned, "Cloned error should be equal to the original");
+    }
+
+    #[test]
+    fn test_partial_eq() {
+        let error_a = Interrupt::with_message("test message");
+        let error_b = Interrupt::with_message("test message");
+        let error_c = Interrupt::with_message("different message");
+        assert_eq!(error_a, error_b, "Errors with the same message should be equal");
+        assert_ne!(error_a, error_c, "Errors with different messages should not be equal");
+    }
+
+    #[test]
+    fn test_partial_ord() {
+        let error_a = Interrupt::with_message("aaa");
+        let error_b = Interrupt::with_message("bbb");
+        // Same error should compare equal.
+        assert_eq!(error_a.partial_cmp(&error_a), Some(Ordering::Equal));
+        // Lexicographic ordering of the underlying messages.
+        assert_eq!(error_a.partial_cmp(&error_b), Some(Ordering::Less));
+        assert_eq!(error_b.partial_cmp(&error_a), Some(Ordering::Greater));
+    }
+
+    #[test]
+    fn test_ord() {
+        let error_a = Interrupt::with_message("aaa");
+        let error_b = Interrupt::with_message("bbb");
+        // Same error should compare equal.
+        assert_eq!(error_a.cmp(&error_a), Ordering::Equal);
+        // Lexicographic ordering of the underlying messages.
+        assert_eq!(error_a.cmp(&error_b), Ordering::Less);
+        assert_eq!(error_b.cmp(&error_a), Ordering::Greater);
     }
 }

--- a/spinoso-exception/src/core/ioerror.rs
+++ b/spinoso-exception/src/core/ioerror.rs
@@ -6,6 +6,7 @@ use alloc::vec::Vec;
 use core::error;
 use core::fmt;
 
+use bstr::ByteSlice;
 use scolapasta_string_escape::format_debug_escape_into;
 
 use crate::RubyException;
@@ -22,9 +23,17 @@ use crate::RubyException;
 /// [`Exception`]: https://ruby-doc.org/core-3.1.2/Exception.html
 /// [`Kernel#raise`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-raise
 /// [`NameError#name`]: https://ruby-doc.org/core-3.1.2/NameError.html#method-i-name
-#[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Default, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct IOError {
     message: Cow<'static, [u8]>,
+}
+
+impl fmt::Debug for IOError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("IOError")
+            .field("message", &self.message().as_bstr())
+            .finish()
+    }
 }
 
 impl IOError {
@@ -174,5 +183,180 @@ impl RubyException for IOError {
     #[inline]
     fn name(&self) -> Cow<'_, str> {
         Cow::Borrowed(Self::name(self))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::borrow::Cow;
+    use alloc::format;
+    use alloc::string::ToString;
+    use core::cmp::Ordering;
+    use core::error;
+
+    use bstr::ByteSlice;
+
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        let exception = IOError::new();
+        assert_eq!(exception.message().as_bstr(), b"IOError".as_bstr());
+        assert_eq!(exception.name(), "IOError");
+    }
+
+    #[test]
+    fn test_with_message() {
+        let custom_message = "custom message";
+        let exception = IOError::with_message(custom_message);
+        assert_eq!(exception.message().as_bstr(), custom_message.as_bytes().as_bstr());
+        // The exception name remains the default even when a custom message is used.
+        assert_eq!(exception.name(), "IOError");
+    }
+
+    #[test]
+    fn test_from_string() {
+        let message = "from String".to_string();
+        let exception: IOError = message.into();
+        assert_eq!(exception.message().as_bstr(), b"from String".as_bstr());
+    }
+
+    #[test]
+    fn test_from_static_str() {
+        let message: &'static str = "from &'static str";
+        let exception: IOError = message.into();
+        assert_eq!(exception.message().as_bstr(), b"from &'static str".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_str_borrowed() {
+        let cow: Cow<'static, str> = Cow::Borrowed("from Cow borrowed");
+        let exception: IOError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow borrowed".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_str_owned() {
+        let cow: Cow<'static, str> = Cow::Owned("from Cow owned".to_string());
+        let exception: IOError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow owned".as_bstr());
+    }
+
+    #[test]
+    fn test_from_vec_u8() {
+        let vec = b"from Vec<u8>".to_vec();
+        let exception: IOError = vec.into();
+        assert_eq!(exception.message().as_bstr(), b"from Vec<u8>".as_bstr());
+    }
+
+    #[test]
+    fn test_from_static_slice() {
+        let slice: &'static [u8] = b"from &'static [u8]";
+        let exception: IOError = slice.into();
+        assert_eq!(exception.message().as_bstr(), b"from &'static [u8]".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_u8_borrowed() {
+        let cow: Cow<'static, [u8]> = Cow::Borrowed(b"from Cow<u8> borrowed");
+        let exception: IOError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow<u8> borrowed".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_u8_owned() {
+        let cow: Cow<'static, [u8]> = Cow::Owned(b"from Cow<u8> owned".to_vec());
+        let exception: IOError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow<u8> owned".as_bstr());
+    }
+
+    #[test]
+    fn test_debug() {
+        let exception = IOError::with_message("display test");
+        let output = format!("{exception:?}");
+        // Expected to contain the exception name and the debug-escaped message.
+        assert!(output.contains("IOError"));
+        assert!(output.contains("display test"));
+        // Check the surrounding formatting.
+        assert!(output.starts_with("IOError {"));
+        assert!(output.ends_with('}'));
+    }
+
+    #[test]
+    fn test_display() {
+        let exception = IOError::with_message("display test");
+        let output = format!("{exception}");
+        // Expected to contain the exception name and the debug-escaped message.
+        assert!(output.contains("IOError"));
+        assert!(output.contains("display test"));
+        // Check the surrounding formatting.
+        assert!(output.starts_with("IOError ("));
+        assert!(output.ends_with(')'));
+    }
+
+    #[test]
+    fn test_error_trait() {
+        let exception = IOError::with_message("error trait test");
+        let error_obj: &dyn error::Error = &exception;
+        // Our implementation does not provide a source.
+        assert!(error_obj.source().is_none());
+        // to_string() uses Display.
+        assert_eq!(error_obj.to_string(), format!("{exception}"));
+    }
+
+    #[test]
+    fn test_ruby_exception_trait() {
+        let exception = IOError::with_message("ruby trait test");
+        let msg = RubyException::message(&exception);
+        let name = RubyException::name(&exception);
+        assert_eq!(msg.as_bstr(), exception.message().as_bstr());
+        assert_eq!(name, exception.name());
+    }
+
+    #[test]
+    fn test_default() {
+        let default_error = IOError::default();
+        // By default, the message should be an empty slice since Default is auto-derived.
+        assert_eq!(default_error.message(), b"");
+        // The name method always returns the constant exception name.
+        assert_eq!(default_error.name(), "IOError");
+    }
+
+    #[test]
+    fn test_clone() {
+        let original = IOError::with_message("clone test");
+        let cloned = original.clone();
+        assert_eq!(original, cloned, "Cloned error should be equal to the original");
+    }
+
+    #[test]
+    fn test_partial_eq() {
+        let error_a = IOError::with_message("test message");
+        let error_b = IOError::with_message("test message");
+        let error_c = IOError::with_message("different message");
+        assert_eq!(error_a, error_b, "Errors with the same message should be equal");
+        assert_ne!(error_a, error_c, "Errors with different messages should not be equal");
+    }
+
+    #[test]
+    fn test_partial_ord() {
+        let error_a = IOError::with_message("aaa");
+        let error_b = IOError::with_message("bbb");
+        // Same error should compare equal.
+        assert_eq!(error_a.partial_cmp(&error_a), Some(Ordering::Equal));
+        // Lexicographic ordering of the underlying messages.
+        assert_eq!(error_a.partial_cmp(&error_b), Some(Ordering::Less));
+        assert_eq!(error_b.partial_cmp(&error_a), Some(Ordering::Greater));
+    }
+
+    #[test]
+    fn test_ord() {
+        let error_a = IOError::with_message("aaa");
+        let error_b = IOError::with_message("bbb");
+        // Same error should compare equal.
+        assert_eq!(error_a.cmp(&error_a), Ordering::Equal);
+        // Lexicographic ordering of the underlying messages.
+        assert_eq!(error_a.cmp(&error_b), Ordering::Less);
+        assert_eq!(error_b.cmp(&error_a), Ordering::Greater);
     }
 }

--- a/spinoso-exception/src/core/keyerror.rs
+++ b/spinoso-exception/src/core/keyerror.rs
@@ -6,6 +6,7 @@ use alloc::vec::Vec;
 use core::error;
 use core::fmt;
 
+use bstr::ByteSlice;
 use scolapasta_string_escape::format_debug_escape_into;
 
 use crate::RubyException;
@@ -22,9 +23,17 @@ use crate::RubyException;
 /// [`Exception`]: https://ruby-doc.org/core-3.1.2/Exception.html
 /// [`Kernel#raise`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-raise
 /// [`NameError#name`]: https://ruby-doc.org/core-3.1.2/NameError.html#method-i-name
-#[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Default, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct KeyError {
     message: Cow<'static, [u8]>,
+}
+
+impl fmt::Debug for KeyError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("KeyError")
+            .field("message", &self.message().as_bstr())
+            .finish()
+    }
 }
 
 impl KeyError {
@@ -174,5 +183,180 @@ impl RubyException for KeyError {
     #[inline]
     fn name(&self) -> Cow<'_, str> {
         Cow::Borrowed(Self::name(self))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::borrow::Cow;
+    use alloc::format;
+    use alloc::string::ToString;
+    use core::cmp::Ordering;
+    use core::error;
+
+    use bstr::ByteSlice;
+
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        let exception = KeyError::new();
+        assert_eq!(exception.message().as_bstr(), b"KeyError".as_bstr());
+        assert_eq!(exception.name(), "KeyError");
+    }
+
+    #[test]
+    fn test_with_message() {
+        let custom_message = "custom message";
+        let exception = KeyError::with_message(custom_message);
+        assert_eq!(exception.message().as_bstr(), custom_message.as_bytes().as_bstr());
+        // The exception name remains the default even when a custom message is used.
+        assert_eq!(exception.name(), "KeyError");
+    }
+
+    #[test]
+    fn test_from_string() {
+        let message = "from String".to_string();
+        let exception: KeyError = message.into();
+        assert_eq!(exception.message().as_bstr(), b"from String".as_bstr());
+    }
+
+    #[test]
+    fn test_from_static_str() {
+        let message: &'static str = "from &'static str";
+        let exception: KeyError = message.into();
+        assert_eq!(exception.message().as_bstr(), b"from &'static str".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_str_borrowed() {
+        let cow: Cow<'static, str> = Cow::Borrowed("from Cow borrowed");
+        let exception: KeyError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow borrowed".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_str_owned() {
+        let cow: Cow<'static, str> = Cow::Owned("from Cow owned".to_string());
+        let exception: KeyError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow owned".as_bstr());
+    }
+
+    #[test]
+    fn test_from_vec_u8() {
+        let vec = b"from Vec<u8>".to_vec();
+        let exception: KeyError = vec.into();
+        assert_eq!(exception.message().as_bstr(), b"from Vec<u8>".as_bstr());
+    }
+
+    #[test]
+    fn test_from_static_slice() {
+        let slice: &'static [u8] = b"from &'static [u8]";
+        let exception: KeyError = slice.into();
+        assert_eq!(exception.message().as_bstr(), b"from &'static [u8]".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_u8_borrowed() {
+        let cow: Cow<'static, [u8]> = Cow::Borrowed(b"from Cow<u8> borrowed");
+        let exception: KeyError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow<u8> borrowed".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_u8_owned() {
+        let cow: Cow<'static, [u8]> = Cow::Owned(b"from Cow<u8> owned".to_vec());
+        let exception: KeyError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow<u8> owned".as_bstr());
+    }
+
+    #[test]
+    fn test_debug() {
+        let exception = KeyError::with_message("display test");
+        let output = format!("{exception:?}");
+        // Expected to contain the exception name and the debug-escaped message.
+        assert!(output.contains("KeyError"));
+        assert!(output.contains("display test"));
+        // Check the surrounding formatting.
+        assert!(output.starts_with("KeyError {"));
+        assert!(output.ends_with('}'));
+    }
+
+    #[test]
+    fn test_display() {
+        let exception = KeyError::with_message("display test");
+        let output = format!("{exception}");
+        // Expected to contain the exception name and the debug-escaped message.
+        assert!(output.contains("KeyError"));
+        assert!(output.contains("display test"));
+        // Check the surrounding formatting.
+        assert!(output.starts_with("KeyError ("));
+        assert!(output.ends_with(')'));
+    }
+
+    #[test]
+    fn test_error_trait() {
+        let exception = KeyError::with_message("error trait test");
+        let error_obj: &dyn error::Error = &exception;
+        // Our implementation does not provide a source.
+        assert!(error_obj.source().is_none());
+        // to_string() uses Display.
+        assert_eq!(error_obj.to_string(), format!("{exception}"));
+    }
+
+    #[test]
+    fn test_ruby_exception_trait() {
+        let exception = KeyError::with_message("ruby trait test");
+        let msg = RubyException::message(&exception);
+        let name = RubyException::name(&exception);
+        assert_eq!(msg.as_bstr(), exception.message().as_bstr());
+        assert_eq!(name, exception.name());
+    }
+
+    #[test]
+    fn test_default() {
+        let default_error = KeyError::default();
+        // By default, the message should be an empty slice since Default is auto-derived.
+        assert_eq!(default_error.message(), b"");
+        // The name method always returns the constant exception name.
+        assert_eq!(default_error.name(), "KeyError");
+    }
+
+    #[test]
+    fn test_clone() {
+        let original = KeyError::with_message("clone test");
+        let cloned = original.clone();
+        assert_eq!(original, cloned, "Cloned error should be equal to the original");
+    }
+
+    #[test]
+    fn test_partial_eq() {
+        let error_a = KeyError::with_message("test message");
+        let error_b = KeyError::with_message("test message");
+        let error_c = KeyError::with_message("different message");
+        assert_eq!(error_a, error_b, "Errors with the same message should be equal");
+        assert_ne!(error_a, error_c, "Errors with different messages should not be equal");
+    }
+
+    #[test]
+    fn test_partial_ord() {
+        let error_a = KeyError::with_message("aaa");
+        let error_b = KeyError::with_message("bbb");
+        // Same error should compare equal.
+        assert_eq!(error_a.partial_cmp(&error_a), Some(Ordering::Equal));
+        // Lexicographic ordering of the underlying messages.
+        assert_eq!(error_a.partial_cmp(&error_b), Some(Ordering::Less));
+        assert_eq!(error_b.partial_cmp(&error_a), Some(Ordering::Greater));
+    }
+
+    #[test]
+    fn test_ord() {
+        let error_a = KeyError::with_message("aaa");
+        let error_b = KeyError::with_message("bbb");
+        // Same error should compare equal.
+        assert_eq!(error_a.cmp(&error_a), Ordering::Equal);
+        // Lexicographic ordering of the underlying messages.
+        assert_eq!(error_a.cmp(&error_b), Ordering::Less);
+        assert_eq!(error_b.cmp(&error_a), Ordering::Greater);
     }
 }

--- a/spinoso-exception/src/core/loaderror.rs
+++ b/spinoso-exception/src/core/loaderror.rs
@@ -6,6 +6,7 @@ use alloc::vec::Vec;
 use core::error;
 use core::fmt;
 
+use bstr::ByteSlice;
 use scolapasta_string_escape::format_debug_escape_into;
 
 use crate::RubyException;
@@ -22,9 +23,17 @@ use crate::RubyException;
 /// [`Exception`]: https://ruby-doc.org/core-3.1.2/Exception.html
 /// [`Kernel#raise`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-raise
 /// [`NameError#name`]: https://ruby-doc.org/core-3.1.2/NameError.html#method-i-name
-#[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Default, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct LoadError {
     message: Cow<'static, [u8]>,
+}
+
+impl fmt::Debug for LoadError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("LoadError")
+            .field("message", &self.message().as_bstr())
+            .finish()
+    }
 }
 
 impl LoadError {
@@ -174,5 +183,180 @@ impl RubyException for LoadError {
     #[inline]
     fn name(&self) -> Cow<'_, str> {
         Cow::Borrowed(Self::name(self))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::borrow::Cow;
+    use alloc::format;
+    use alloc::string::ToString;
+    use core::cmp::Ordering;
+    use core::error;
+
+    use bstr::ByteSlice;
+
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        let exception = LoadError::new();
+        assert_eq!(exception.message().as_bstr(), b"LoadError".as_bstr());
+        assert_eq!(exception.name(), "LoadError");
+    }
+
+    #[test]
+    fn test_with_message() {
+        let custom_message = "custom message";
+        let exception = LoadError::with_message(custom_message);
+        assert_eq!(exception.message().as_bstr(), custom_message.as_bytes().as_bstr());
+        // The exception name remains the default even when a custom message is used.
+        assert_eq!(exception.name(), "LoadError");
+    }
+
+    #[test]
+    fn test_from_string() {
+        let message = "from String".to_string();
+        let exception: LoadError = message.into();
+        assert_eq!(exception.message().as_bstr(), b"from String".as_bstr());
+    }
+
+    #[test]
+    fn test_from_static_str() {
+        let message: &'static str = "from &'static str";
+        let exception: LoadError = message.into();
+        assert_eq!(exception.message().as_bstr(), b"from &'static str".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_str_borrowed() {
+        let cow: Cow<'static, str> = Cow::Borrowed("from Cow borrowed");
+        let exception: LoadError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow borrowed".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_str_owned() {
+        let cow: Cow<'static, str> = Cow::Owned("from Cow owned".to_string());
+        let exception: LoadError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow owned".as_bstr());
+    }
+
+    #[test]
+    fn test_from_vec_u8() {
+        let vec = b"from Vec<u8>".to_vec();
+        let exception: LoadError = vec.into();
+        assert_eq!(exception.message().as_bstr(), b"from Vec<u8>".as_bstr());
+    }
+
+    #[test]
+    fn test_from_static_slice() {
+        let slice: &'static [u8] = b"from &'static [u8]";
+        let exception: LoadError = slice.into();
+        assert_eq!(exception.message().as_bstr(), b"from &'static [u8]".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_u8_borrowed() {
+        let cow: Cow<'static, [u8]> = Cow::Borrowed(b"from Cow<u8> borrowed");
+        let exception: LoadError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow<u8> borrowed".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_u8_owned() {
+        let cow: Cow<'static, [u8]> = Cow::Owned(b"from Cow<u8> owned".to_vec());
+        let exception: LoadError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow<u8> owned".as_bstr());
+    }
+
+    #[test]
+    fn test_debug() {
+        let exception = LoadError::with_message("display test");
+        let output = format!("{exception:?}");
+        // Expected to contain the exception name and the debug-escaped message.
+        assert!(output.contains("LoadError"));
+        assert!(output.contains("display test"));
+        // Check the surrounding formatting.
+        assert!(output.starts_with("LoadError {"));
+        assert!(output.ends_with('}'));
+    }
+
+    #[test]
+    fn test_display() {
+        let exception = LoadError::with_message("display test");
+        let output = format!("{exception}");
+        // Expected to contain the exception name and the debug-escaped message.
+        assert!(output.contains("LoadError"));
+        assert!(output.contains("display test"));
+        // Check the surrounding formatting.
+        assert!(output.starts_with("LoadError ("));
+        assert!(output.ends_with(')'));
+    }
+
+    #[test]
+    fn test_error_trait() {
+        let exception = LoadError::with_message("error trait test");
+        let error_obj: &dyn error::Error = &exception;
+        // Our implementation does not provide a source.
+        assert!(error_obj.source().is_none());
+        // to_string() uses Display.
+        assert_eq!(error_obj.to_string(), format!("{exception}"));
+    }
+
+    #[test]
+    fn test_ruby_exception_trait() {
+        let exception = LoadError::with_message("ruby trait test");
+        let msg = RubyException::message(&exception);
+        let name = RubyException::name(&exception);
+        assert_eq!(msg.as_bstr(), exception.message().as_bstr());
+        assert_eq!(name, exception.name());
+    }
+
+    #[test]
+    fn test_default() {
+        let default_error = LoadError::default();
+        // By default, the message should be an empty slice since Default is auto-derived.
+        assert_eq!(default_error.message(), b"");
+        // The name method always returns the constant exception name.
+        assert_eq!(default_error.name(), "LoadError");
+    }
+
+    #[test]
+    fn test_clone() {
+        let original = LoadError::with_message("clone test");
+        let cloned = original.clone();
+        assert_eq!(original, cloned, "Cloned error should be equal to the original");
+    }
+
+    #[test]
+    fn test_partial_eq() {
+        let error_a = LoadError::with_message("test message");
+        let error_b = LoadError::with_message("test message");
+        let error_c = LoadError::with_message("different message");
+        assert_eq!(error_a, error_b, "Errors with the same message should be equal");
+        assert_ne!(error_a, error_c, "Errors with different messages should not be equal");
+    }
+
+    #[test]
+    fn test_partial_ord() {
+        let error_a = LoadError::with_message("aaa");
+        let error_b = LoadError::with_message("bbb");
+        // Same error should compare equal.
+        assert_eq!(error_a.partial_cmp(&error_a), Some(Ordering::Equal));
+        // Lexicographic ordering of the underlying messages.
+        assert_eq!(error_a.partial_cmp(&error_b), Some(Ordering::Less));
+        assert_eq!(error_b.partial_cmp(&error_a), Some(Ordering::Greater));
+    }
+
+    #[test]
+    fn test_ord() {
+        let error_a = LoadError::with_message("aaa");
+        let error_b = LoadError::with_message("bbb");
+        // Same error should compare equal.
+        assert_eq!(error_a.cmp(&error_a), Ordering::Equal);
+        // Lexicographic ordering of the underlying messages.
+        assert_eq!(error_a.cmp(&error_b), Ordering::Less);
+        assert_eq!(error_b.cmp(&error_a), Ordering::Greater);
     }
 }

--- a/spinoso-exception/src/core/localjumperror.rs
+++ b/spinoso-exception/src/core/localjumperror.rs
@@ -6,6 +6,7 @@ use alloc::vec::Vec;
 use core::error;
 use core::fmt;
 
+use bstr::ByteSlice;
 use scolapasta_string_escape::format_debug_escape_into;
 
 use crate::RubyException;
@@ -22,9 +23,17 @@ use crate::RubyException;
 /// [`Exception`]: https://ruby-doc.org/core-3.1.2/Exception.html
 /// [`Kernel#raise`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-raise
 /// [`NameError#name`]: https://ruby-doc.org/core-3.1.2/NameError.html#method-i-name
-#[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Default, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct LocalJumpError {
     message: Cow<'static, [u8]>,
+}
+
+impl fmt::Debug for LocalJumpError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("LocalJumpError")
+            .field("message", &self.message().as_bstr())
+            .finish()
+    }
 }
 
 impl LocalJumpError {
@@ -174,5 +183,180 @@ impl RubyException for LocalJumpError {
     #[inline]
     fn name(&self) -> Cow<'_, str> {
         Cow::Borrowed(Self::name(self))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::borrow::Cow;
+    use alloc::format;
+    use alloc::string::ToString;
+    use core::cmp::Ordering;
+    use core::error;
+
+    use bstr::ByteSlice;
+
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        let exception = LocalJumpError::new();
+        assert_eq!(exception.message().as_bstr(), b"LocalJumpError".as_bstr());
+        assert_eq!(exception.name(), "LocalJumpError");
+    }
+
+    #[test]
+    fn test_with_message() {
+        let custom_message = "custom message";
+        let exception = LocalJumpError::with_message(custom_message);
+        assert_eq!(exception.message().as_bstr(), custom_message.as_bytes().as_bstr());
+        // The exception name remains the default even when a custom message is used.
+        assert_eq!(exception.name(), "LocalJumpError");
+    }
+
+    #[test]
+    fn test_from_string() {
+        let message = "from String".to_string();
+        let exception: LocalJumpError = message.into();
+        assert_eq!(exception.message().as_bstr(), b"from String".as_bstr());
+    }
+
+    #[test]
+    fn test_from_static_str() {
+        let message: &'static str = "from &'static str";
+        let exception: LocalJumpError = message.into();
+        assert_eq!(exception.message().as_bstr(), b"from &'static str".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_str_borrowed() {
+        let cow: Cow<'static, str> = Cow::Borrowed("from Cow borrowed");
+        let exception: LocalJumpError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow borrowed".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_str_owned() {
+        let cow: Cow<'static, str> = Cow::Owned("from Cow owned".to_string());
+        let exception: LocalJumpError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow owned".as_bstr());
+    }
+
+    #[test]
+    fn test_from_vec_u8() {
+        let vec = b"from Vec<u8>".to_vec();
+        let exception: LocalJumpError = vec.into();
+        assert_eq!(exception.message().as_bstr(), b"from Vec<u8>".as_bstr());
+    }
+
+    #[test]
+    fn test_from_static_slice() {
+        let slice: &'static [u8] = b"from &'static [u8]";
+        let exception: LocalJumpError = slice.into();
+        assert_eq!(exception.message().as_bstr(), b"from &'static [u8]".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_u8_borrowed() {
+        let cow: Cow<'static, [u8]> = Cow::Borrowed(b"from Cow<u8> borrowed");
+        let exception: LocalJumpError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow<u8> borrowed".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_u8_owned() {
+        let cow: Cow<'static, [u8]> = Cow::Owned(b"from Cow<u8> owned".to_vec());
+        let exception: LocalJumpError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow<u8> owned".as_bstr());
+    }
+
+    #[test]
+    fn test_debug() {
+        let exception = LocalJumpError::with_message("display test");
+        let output = format!("{exception:?}");
+        // Expected to contain the exception name and the debug-escaped message.
+        assert!(output.contains("LocalJumpError"));
+        assert!(output.contains("display test"));
+        // Check the surrounding formatting.
+        assert!(output.starts_with("LocalJumpError {"));
+        assert!(output.ends_with('}'));
+    }
+
+    #[test]
+    fn test_display() {
+        let exception = LocalJumpError::with_message("display test");
+        let output = format!("{exception}");
+        // Expected to contain the exception name and the debug-escaped message.
+        assert!(output.contains("LocalJumpError"));
+        assert!(output.contains("display test"));
+        // Check the surrounding formatting.
+        assert!(output.starts_with("LocalJumpError ("));
+        assert!(output.ends_with(')'));
+    }
+
+    #[test]
+    fn test_error_trait() {
+        let exception = LocalJumpError::with_message("error trait test");
+        let error_obj: &dyn error::Error = &exception;
+        // Our implementation does not provide a source.
+        assert!(error_obj.source().is_none());
+        // to_string() uses Display.
+        assert_eq!(error_obj.to_string(), format!("{exception}"));
+    }
+
+    #[test]
+    fn test_ruby_exception_trait() {
+        let exception = LocalJumpError::with_message("ruby trait test");
+        let msg = RubyException::message(&exception);
+        let name = RubyException::name(&exception);
+        assert_eq!(msg.as_bstr(), exception.message().as_bstr());
+        assert_eq!(name, exception.name());
+    }
+
+    #[test]
+    fn test_default() {
+        let default_error = LocalJumpError::default();
+        // By default, the message should be an empty slice since Default is auto-derived.
+        assert_eq!(default_error.message(), b"");
+        // The name method always returns the constant exception name.
+        assert_eq!(default_error.name(), "LocalJumpError");
+    }
+
+    #[test]
+    fn test_clone() {
+        let original = LocalJumpError::with_message("clone test");
+        let cloned = original.clone();
+        assert_eq!(original, cloned, "Cloned error should be equal to the original");
+    }
+
+    #[test]
+    fn test_partial_eq() {
+        let error_a = LocalJumpError::with_message("test message");
+        let error_b = LocalJumpError::with_message("test message");
+        let error_c = LocalJumpError::with_message("different message");
+        assert_eq!(error_a, error_b, "Errors with the same message should be equal");
+        assert_ne!(error_a, error_c, "Errors with different messages should not be equal");
+    }
+
+    #[test]
+    fn test_partial_ord() {
+        let error_a = LocalJumpError::with_message("aaa");
+        let error_b = LocalJumpError::with_message("bbb");
+        // Same error should compare equal.
+        assert_eq!(error_a.partial_cmp(&error_a), Some(Ordering::Equal));
+        // Lexicographic ordering of the underlying messages.
+        assert_eq!(error_a.partial_cmp(&error_b), Some(Ordering::Less));
+        assert_eq!(error_b.partial_cmp(&error_a), Some(Ordering::Greater));
+    }
+
+    #[test]
+    fn test_ord() {
+        let error_a = LocalJumpError::with_message("aaa");
+        let error_b = LocalJumpError::with_message("bbb");
+        // Same error should compare equal.
+        assert_eq!(error_a.cmp(&error_a), Ordering::Equal);
+        // Lexicographic ordering of the underlying messages.
+        assert_eq!(error_a.cmp(&error_b), Ordering::Less);
+        assert_eq!(error_b.cmp(&error_a), Ordering::Greater);
     }
 }

--- a/spinoso-exception/src/core/nameerror.rs
+++ b/spinoso-exception/src/core/nameerror.rs
@@ -6,6 +6,7 @@ use alloc::vec::Vec;
 use core::error;
 use core::fmt;
 
+use bstr::ByteSlice;
 use scolapasta_string_escape::format_debug_escape_into;
 
 use crate::RubyException;
@@ -22,9 +23,17 @@ use crate::RubyException;
 /// [`Exception`]: https://ruby-doc.org/core-3.1.2/Exception.html
 /// [`Kernel#raise`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-raise
 /// [`NameError#name`]: https://ruby-doc.org/core-3.1.2/NameError.html#method-i-name
-#[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Default, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct NameError {
     message: Cow<'static, [u8]>,
+}
+
+impl fmt::Debug for NameError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("NameError")
+            .field("message", &self.message().as_bstr())
+            .finish()
+    }
 }
 
 impl NameError {
@@ -174,5 +183,180 @@ impl RubyException for NameError {
     #[inline]
     fn name(&self) -> Cow<'_, str> {
         Cow::Borrowed(Self::name(self))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::borrow::Cow;
+    use alloc::format;
+    use alloc::string::ToString;
+    use core::cmp::Ordering;
+    use core::error;
+
+    use bstr::ByteSlice;
+
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        let exception = NameError::new();
+        assert_eq!(exception.message().as_bstr(), b"NameError".as_bstr());
+        assert_eq!(exception.name(), "NameError");
+    }
+
+    #[test]
+    fn test_with_message() {
+        let custom_message = "custom message";
+        let exception = NameError::with_message(custom_message);
+        assert_eq!(exception.message().as_bstr(), custom_message.as_bytes().as_bstr());
+        // The exception name remains the default even when a custom message is used.
+        assert_eq!(exception.name(), "NameError");
+    }
+
+    #[test]
+    fn test_from_string() {
+        let message = "from String".to_string();
+        let exception: NameError = message.into();
+        assert_eq!(exception.message().as_bstr(), b"from String".as_bstr());
+    }
+
+    #[test]
+    fn test_from_static_str() {
+        let message: &'static str = "from &'static str";
+        let exception: NameError = message.into();
+        assert_eq!(exception.message().as_bstr(), b"from &'static str".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_str_borrowed() {
+        let cow: Cow<'static, str> = Cow::Borrowed("from Cow borrowed");
+        let exception: NameError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow borrowed".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_str_owned() {
+        let cow: Cow<'static, str> = Cow::Owned("from Cow owned".to_string());
+        let exception: NameError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow owned".as_bstr());
+    }
+
+    #[test]
+    fn test_from_vec_u8() {
+        let vec = b"from Vec<u8>".to_vec();
+        let exception: NameError = vec.into();
+        assert_eq!(exception.message().as_bstr(), b"from Vec<u8>".as_bstr());
+    }
+
+    #[test]
+    fn test_from_static_slice() {
+        let slice: &'static [u8] = b"from &'static [u8]";
+        let exception: NameError = slice.into();
+        assert_eq!(exception.message().as_bstr(), b"from &'static [u8]".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_u8_borrowed() {
+        let cow: Cow<'static, [u8]> = Cow::Borrowed(b"from Cow<u8> borrowed");
+        let exception: NameError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow<u8> borrowed".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_u8_owned() {
+        let cow: Cow<'static, [u8]> = Cow::Owned(b"from Cow<u8> owned".to_vec());
+        let exception: NameError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow<u8> owned".as_bstr());
+    }
+
+    #[test]
+    fn test_debug() {
+        let exception = NameError::with_message("display test");
+        let output = format!("{exception:?}");
+        // Expected to contain the exception name and the debug-escaped message.
+        assert!(output.contains("NameError"));
+        assert!(output.contains("display test"));
+        // Check the surrounding formatting.
+        assert!(output.starts_with("NameError {"));
+        assert!(output.ends_with('}'));
+    }
+
+    #[test]
+    fn test_display() {
+        let exception = NameError::with_message("display test");
+        let output = format!("{exception}");
+        // Expected to contain the exception name and the debug-escaped message.
+        assert!(output.contains("NameError"));
+        assert!(output.contains("display test"));
+        // Check the surrounding formatting.
+        assert!(output.starts_with("NameError ("));
+        assert!(output.ends_with(')'));
+    }
+
+    #[test]
+    fn test_error_trait() {
+        let exception = NameError::with_message("error trait test");
+        let error_obj: &dyn error::Error = &exception;
+        // Our implementation does not provide a source.
+        assert!(error_obj.source().is_none());
+        // to_string() uses Display.
+        assert_eq!(error_obj.to_string(), format!("{exception}"));
+    }
+
+    #[test]
+    fn test_ruby_exception_trait() {
+        let exception = NameError::with_message("ruby trait test");
+        let msg = RubyException::message(&exception);
+        let name = RubyException::name(&exception);
+        assert_eq!(msg.as_bstr(), exception.message().as_bstr());
+        assert_eq!(name, exception.name());
+    }
+
+    #[test]
+    fn test_default() {
+        let default_error = NameError::default();
+        // By default, the message should be an empty slice since Default is auto-derived.
+        assert_eq!(default_error.message(), b"");
+        // The name method always returns the constant exception name.
+        assert_eq!(default_error.name(), "NameError");
+    }
+
+    #[test]
+    fn test_clone() {
+        let original = NameError::with_message("clone test");
+        let cloned = original.clone();
+        assert_eq!(original, cloned, "Cloned error should be equal to the original");
+    }
+
+    #[test]
+    fn test_partial_eq() {
+        let error_a = NameError::with_message("test message");
+        let error_b = NameError::with_message("test message");
+        let error_c = NameError::with_message("different message");
+        assert_eq!(error_a, error_b, "Errors with the same message should be equal");
+        assert_ne!(error_a, error_c, "Errors with different messages should not be equal");
+    }
+
+    #[test]
+    fn test_partial_ord() {
+        let error_a = NameError::with_message("aaa");
+        let error_b = NameError::with_message("bbb");
+        // Same error should compare equal.
+        assert_eq!(error_a.partial_cmp(&error_a), Some(Ordering::Equal));
+        // Lexicographic ordering of the underlying messages.
+        assert_eq!(error_a.partial_cmp(&error_b), Some(Ordering::Less));
+        assert_eq!(error_b.partial_cmp(&error_a), Some(Ordering::Greater));
+    }
+
+    #[test]
+    fn test_ord() {
+        let error_a = NameError::with_message("aaa");
+        let error_b = NameError::with_message("bbb");
+        // Same error should compare equal.
+        assert_eq!(error_a.cmp(&error_a), Ordering::Equal);
+        // Lexicographic ordering of the underlying messages.
+        assert_eq!(error_a.cmp(&error_b), Ordering::Less);
+        assert_eq!(error_b.cmp(&error_a), Ordering::Greater);
     }
 }

--- a/spinoso-exception/src/core/nomemoryerror.rs
+++ b/spinoso-exception/src/core/nomemoryerror.rs
@@ -6,6 +6,7 @@ use alloc::vec::Vec;
 use core::error;
 use core::fmt;
 
+use bstr::ByteSlice;
 use scolapasta_string_escape::format_debug_escape_into;
 
 use crate::RubyException;
@@ -22,9 +23,17 @@ use crate::RubyException;
 /// [`Exception`]: https://ruby-doc.org/core-3.1.2/Exception.html
 /// [`Kernel#raise`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-raise
 /// [`NameError#name`]: https://ruby-doc.org/core-3.1.2/NameError.html#method-i-name
-#[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Default, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct NoMemoryError {
     message: Cow<'static, [u8]>,
+}
+
+impl fmt::Debug for NoMemoryError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("NoMemoryError")
+            .field("message", &self.message().as_bstr())
+            .finish()
+    }
 }
 
 impl NoMemoryError {
@@ -174,5 +183,180 @@ impl RubyException for NoMemoryError {
     #[inline]
     fn name(&self) -> Cow<'_, str> {
         Cow::Borrowed(Self::name(self))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::borrow::Cow;
+    use alloc::format;
+    use alloc::string::ToString;
+    use core::cmp::Ordering;
+    use core::error;
+
+    use bstr::ByteSlice;
+
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        let exception = NoMemoryError::new();
+        assert_eq!(exception.message().as_bstr(), b"NoMemoryError".as_bstr());
+        assert_eq!(exception.name(), "NoMemoryError");
+    }
+
+    #[test]
+    fn test_with_message() {
+        let custom_message = "custom message";
+        let exception = NoMemoryError::with_message(custom_message);
+        assert_eq!(exception.message().as_bstr(), custom_message.as_bytes().as_bstr());
+        // The exception name remains the default even when a custom message is used.
+        assert_eq!(exception.name(), "NoMemoryError");
+    }
+
+    #[test]
+    fn test_from_string() {
+        let message = "from String".to_string();
+        let exception: NoMemoryError = message.into();
+        assert_eq!(exception.message().as_bstr(), b"from String".as_bstr());
+    }
+
+    #[test]
+    fn test_from_static_str() {
+        let message: &'static str = "from &'static str";
+        let exception: NoMemoryError = message.into();
+        assert_eq!(exception.message().as_bstr(), b"from &'static str".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_str_borrowed() {
+        let cow: Cow<'static, str> = Cow::Borrowed("from Cow borrowed");
+        let exception: NoMemoryError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow borrowed".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_str_owned() {
+        let cow: Cow<'static, str> = Cow::Owned("from Cow owned".to_string());
+        let exception: NoMemoryError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow owned".as_bstr());
+    }
+
+    #[test]
+    fn test_from_vec_u8() {
+        let vec = b"from Vec<u8>".to_vec();
+        let exception: NoMemoryError = vec.into();
+        assert_eq!(exception.message().as_bstr(), b"from Vec<u8>".as_bstr());
+    }
+
+    #[test]
+    fn test_from_static_slice() {
+        let slice: &'static [u8] = b"from &'static [u8]";
+        let exception: NoMemoryError = slice.into();
+        assert_eq!(exception.message().as_bstr(), b"from &'static [u8]".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_u8_borrowed() {
+        let cow: Cow<'static, [u8]> = Cow::Borrowed(b"from Cow<u8> borrowed");
+        let exception: NoMemoryError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow<u8> borrowed".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_u8_owned() {
+        let cow: Cow<'static, [u8]> = Cow::Owned(b"from Cow<u8> owned".to_vec());
+        let exception: NoMemoryError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow<u8> owned".as_bstr());
+    }
+
+    #[test]
+    fn test_debug() {
+        let exception = NoMemoryError::with_message("display test");
+        let output = format!("{exception:?}");
+        // Expected to contain the exception name and the debug-escaped message.
+        assert!(output.contains("NoMemoryError"));
+        assert!(output.contains("display test"));
+        // Check the surrounding formatting.
+        assert!(output.starts_with("NoMemoryError {"));
+        assert!(output.ends_with('}'));
+    }
+
+    #[test]
+    fn test_display() {
+        let exception = NoMemoryError::with_message("display test");
+        let output = format!("{exception}");
+        // Expected to contain the exception name and the debug-escaped message.
+        assert!(output.contains("NoMemoryError"));
+        assert!(output.contains("display test"));
+        // Check the surrounding formatting.
+        assert!(output.starts_with("NoMemoryError ("));
+        assert!(output.ends_with(')'));
+    }
+
+    #[test]
+    fn test_error_trait() {
+        let exception = NoMemoryError::with_message("error trait test");
+        let error_obj: &dyn error::Error = &exception;
+        // Our implementation does not provide a source.
+        assert!(error_obj.source().is_none());
+        // to_string() uses Display.
+        assert_eq!(error_obj.to_string(), format!("{exception}"));
+    }
+
+    #[test]
+    fn test_ruby_exception_trait() {
+        let exception = NoMemoryError::with_message("ruby trait test");
+        let msg = RubyException::message(&exception);
+        let name = RubyException::name(&exception);
+        assert_eq!(msg.as_bstr(), exception.message().as_bstr());
+        assert_eq!(name, exception.name());
+    }
+
+    #[test]
+    fn test_default() {
+        let default_error = NoMemoryError::default();
+        // By default, the message should be an empty slice since Default is auto-derived.
+        assert_eq!(default_error.message(), b"");
+        // The name method always returns the constant exception name.
+        assert_eq!(default_error.name(), "NoMemoryError");
+    }
+
+    #[test]
+    fn test_clone() {
+        let original = NoMemoryError::with_message("clone test");
+        let cloned = original.clone();
+        assert_eq!(original, cloned, "Cloned error should be equal to the original");
+    }
+
+    #[test]
+    fn test_partial_eq() {
+        let error_a = NoMemoryError::with_message("test message");
+        let error_b = NoMemoryError::with_message("test message");
+        let error_c = NoMemoryError::with_message("different message");
+        assert_eq!(error_a, error_b, "Errors with the same message should be equal");
+        assert_ne!(error_a, error_c, "Errors with different messages should not be equal");
+    }
+
+    #[test]
+    fn test_partial_ord() {
+        let error_a = NoMemoryError::with_message("aaa");
+        let error_b = NoMemoryError::with_message("bbb");
+        // Same error should compare equal.
+        assert_eq!(error_a.partial_cmp(&error_a), Some(Ordering::Equal));
+        // Lexicographic ordering of the underlying messages.
+        assert_eq!(error_a.partial_cmp(&error_b), Some(Ordering::Less));
+        assert_eq!(error_b.partial_cmp(&error_a), Some(Ordering::Greater));
+    }
+
+    #[test]
+    fn test_ord() {
+        let error_a = NoMemoryError::with_message("aaa");
+        let error_b = NoMemoryError::with_message("bbb");
+        // Same error should compare equal.
+        assert_eq!(error_a.cmp(&error_a), Ordering::Equal);
+        // Lexicographic ordering of the underlying messages.
+        assert_eq!(error_a.cmp(&error_b), Ordering::Less);
+        assert_eq!(error_b.cmp(&error_a), Ordering::Greater);
     }
 }

--- a/spinoso-exception/src/core/nomethoderror.rs
+++ b/spinoso-exception/src/core/nomethoderror.rs
@@ -6,6 +6,7 @@ use alloc::vec::Vec;
 use core::error;
 use core::fmt;
 
+use bstr::ByteSlice;
 use scolapasta_string_escape::format_debug_escape_into;
 
 use crate::RubyException;
@@ -22,9 +23,17 @@ use crate::RubyException;
 /// [`Exception`]: https://ruby-doc.org/core-3.1.2/Exception.html
 /// [`Kernel#raise`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-raise
 /// [`NameError#name`]: https://ruby-doc.org/core-3.1.2/NameError.html#method-i-name
-#[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Default, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct NoMethodError {
     message: Cow<'static, [u8]>,
+}
+
+impl fmt::Debug for NoMethodError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("NoMethodError")
+            .field("message", &self.message().as_bstr())
+            .finish()
+    }
 }
 
 impl NoMethodError {
@@ -174,5 +183,180 @@ impl RubyException for NoMethodError {
     #[inline]
     fn name(&self) -> Cow<'_, str> {
         Cow::Borrowed(Self::name(self))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::borrow::Cow;
+    use alloc::format;
+    use alloc::string::ToString;
+    use core::cmp::Ordering;
+    use core::error;
+
+    use bstr::ByteSlice;
+
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        let exception = NoMethodError::new();
+        assert_eq!(exception.message().as_bstr(), b"NoMethodError".as_bstr());
+        assert_eq!(exception.name(), "NoMethodError");
+    }
+
+    #[test]
+    fn test_with_message() {
+        let custom_message = "custom message";
+        let exception = NoMethodError::with_message(custom_message);
+        assert_eq!(exception.message().as_bstr(), custom_message.as_bytes().as_bstr());
+        // The exception name remains the default even when a custom message is used.
+        assert_eq!(exception.name(), "NoMethodError");
+    }
+
+    #[test]
+    fn test_from_string() {
+        let message = "from String".to_string();
+        let exception: NoMethodError = message.into();
+        assert_eq!(exception.message().as_bstr(), b"from String".as_bstr());
+    }
+
+    #[test]
+    fn test_from_static_str() {
+        let message: &'static str = "from &'static str";
+        let exception: NoMethodError = message.into();
+        assert_eq!(exception.message().as_bstr(), b"from &'static str".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_str_borrowed() {
+        let cow: Cow<'static, str> = Cow::Borrowed("from Cow borrowed");
+        let exception: NoMethodError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow borrowed".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_str_owned() {
+        let cow: Cow<'static, str> = Cow::Owned("from Cow owned".to_string());
+        let exception: NoMethodError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow owned".as_bstr());
+    }
+
+    #[test]
+    fn test_from_vec_u8() {
+        let vec = b"from Vec<u8>".to_vec();
+        let exception: NoMethodError = vec.into();
+        assert_eq!(exception.message().as_bstr(), b"from Vec<u8>".as_bstr());
+    }
+
+    #[test]
+    fn test_from_static_slice() {
+        let slice: &'static [u8] = b"from &'static [u8]";
+        let exception: NoMethodError = slice.into();
+        assert_eq!(exception.message().as_bstr(), b"from &'static [u8]".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_u8_borrowed() {
+        let cow: Cow<'static, [u8]> = Cow::Borrowed(b"from Cow<u8> borrowed");
+        let exception: NoMethodError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow<u8> borrowed".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_u8_owned() {
+        let cow: Cow<'static, [u8]> = Cow::Owned(b"from Cow<u8> owned".to_vec());
+        let exception: NoMethodError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow<u8> owned".as_bstr());
+    }
+
+    #[test]
+    fn test_debug() {
+        let exception = NoMethodError::with_message("display test");
+        let output = format!("{exception:?}");
+        // Expected to contain the exception name and the debug-escaped message.
+        assert!(output.contains("NoMethodError"));
+        assert!(output.contains("display test"));
+        // Check the surrounding formatting.
+        assert!(output.starts_with("NoMethodError {"));
+        assert!(output.ends_with('}'));
+    }
+
+    #[test]
+    fn test_display() {
+        let exception = NoMethodError::with_message("display test");
+        let output = format!("{exception}");
+        // Expected to contain the exception name and the debug-escaped message.
+        assert!(output.contains("NoMethodError"));
+        assert!(output.contains("display test"));
+        // Check the surrounding formatting.
+        assert!(output.starts_with("NoMethodError ("));
+        assert!(output.ends_with(')'));
+    }
+
+    #[test]
+    fn test_error_trait() {
+        let exception = NoMethodError::with_message("error trait test");
+        let error_obj: &dyn error::Error = &exception;
+        // Our implementation does not provide a source.
+        assert!(error_obj.source().is_none());
+        // to_string() uses Display.
+        assert_eq!(error_obj.to_string(), format!("{exception}"));
+    }
+
+    #[test]
+    fn test_ruby_exception_trait() {
+        let exception = NoMethodError::with_message("ruby trait test");
+        let msg = RubyException::message(&exception);
+        let name = RubyException::name(&exception);
+        assert_eq!(msg.as_bstr(), exception.message().as_bstr());
+        assert_eq!(name, exception.name());
+    }
+
+    #[test]
+    fn test_default() {
+        let default_error = NoMethodError::default();
+        // By default, the message should be an empty slice since Default is auto-derived.
+        assert_eq!(default_error.message(), b"");
+        // The name method always returns the constant exception name.
+        assert_eq!(default_error.name(), "NoMethodError");
+    }
+
+    #[test]
+    fn test_clone() {
+        let original = NoMethodError::with_message("clone test");
+        let cloned = original.clone();
+        assert_eq!(original, cloned, "Cloned error should be equal to the original");
+    }
+
+    #[test]
+    fn test_partial_eq() {
+        let error_a = NoMethodError::with_message("test message");
+        let error_b = NoMethodError::with_message("test message");
+        let error_c = NoMethodError::with_message("different message");
+        assert_eq!(error_a, error_b, "Errors with the same message should be equal");
+        assert_ne!(error_a, error_c, "Errors with different messages should not be equal");
+    }
+
+    #[test]
+    fn test_partial_ord() {
+        let error_a = NoMethodError::with_message("aaa");
+        let error_b = NoMethodError::with_message("bbb");
+        // Same error should compare equal.
+        assert_eq!(error_a.partial_cmp(&error_a), Some(Ordering::Equal));
+        // Lexicographic ordering of the underlying messages.
+        assert_eq!(error_a.partial_cmp(&error_b), Some(Ordering::Less));
+        assert_eq!(error_b.partial_cmp(&error_a), Some(Ordering::Greater));
+    }
+
+    #[test]
+    fn test_ord() {
+        let error_a = NoMethodError::with_message("aaa");
+        let error_b = NoMethodError::with_message("bbb");
+        // Same error should compare equal.
+        assert_eq!(error_a.cmp(&error_a), Ordering::Equal);
+        // Lexicographic ordering of the underlying messages.
+        assert_eq!(error_a.cmp(&error_b), Ordering::Less);
+        assert_eq!(error_b.cmp(&error_a), Ordering::Greater);
     }
 }

--- a/spinoso-exception/src/core/notimplementederror.rs
+++ b/spinoso-exception/src/core/notimplementederror.rs
@@ -6,6 +6,7 @@ use alloc::vec::Vec;
 use core::error;
 use core::fmt;
 
+use bstr::ByteSlice;
 use scolapasta_string_escape::format_debug_escape_into;
 
 use crate::RubyException;
@@ -22,9 +23,17 @@ use crate::RubyException;
 /// [`Exception`]: https://ruby-doc.org/core-3.1.2/Exception.html
 /// [`Kernel#raise`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-raise
 /// [`NameError#name`]: https://ruby-doc.org/core-3.1.2/NameError.html#method-i-name
-#[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Default, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct NotImplementedError {
     message: Cow<'static, [u8]>,
+}
+
+impl fmt::Debug for NotImplementedError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("NotImplementedError")
+            .field("message", &self.message().as_bstr())
+            .finish()
+    }
 }
 
 impl NotImplementedError {
@@ -174,5 +183,180 @@ impl RubyException for NotImplementedError {
     #[inline]
     fn name(&self) -> Cow<'_, str> {
         Cow::Borrowed(Self::name(self))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::borrow::Cow;
+    use alloc::format;
+    use alloc::string::ToString;
+    use core::cmp::Ordering;
+    use core::error;
+
+    use bstr::ByteSlice;
+
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        let exception = NotImplementedError::new();
+        assert_eq!(exception.message().as_bstr(), b"NotImplementedError".as_bstr());
+        assert_eq!(exception.name(), "NotImplementedError");
+    }
+
+    #[test]
+    fn test_with_message() {
+        let custom_message = "custom message";
+        let exception = NotImplementedError::with_message(custom_message);
+        assert_eq!(exception.message().as_bstr(), custom_message.as_bytes().as_bstr());
+        // The exception name remains the default even when a custom message is used.
+        assert_eq!(exception.name(), "NotImplementedError");
+    }
+
+    #[test]
+    fn test_from_string() {
+        let message = "from String".to_string();
+        let exception: NotImplementedError = message.into();
+        assert_eq!(exception.message().as_bstr(), b"from String".as_bstr());
+    }
+
+    #[test]
+    fn test_from_static_str() {
+        let message: &'static str = "from &'static str";
+        let exception: NotImplementedError = message.into();
+        assert_eq!(exception.message().as_bstr(), b"from &'static str".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_str_borrowed() {
+        let cow: Cow<'static, str> = Cow::Borrowed("from Cow borrowed");
+        let exception: NotImplementedError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow borrowed".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_str_owned() {
+        let cow: Cow<'static, str> = Cow::Owned("from Cow owned".to_string());
+        let exception: NotImplementedError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow owned".as_bstr());
+    }
+
+    #[test]
+    fn test_from_vec_u8() {
+        let vec = b"from Vec<u8>".to_vec();
+        let exception: NotImplementedError = vec.into();
+        assert_eq!(exception.message().as_bstr(), b"from Vec<u8>".as_bstr());
+    }
+
+    #[test]
+    fn test_from_static_slice() {
+        let slice: &'static [u8] = b"from &'static [u8]";
+        let exception: NotImplementedError = slice.into();
+        assert_eq!(exception.message().as_bstr(), b"from &'static [u8]".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_u8_borrowed() {
+        let cow: Cow<'static, [u8]> = Cow::Borrowed(b"from Cow<u8> borrowed");
+        let exception: NotImplementedError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow<u8> borrowed".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_u8_owned() {
+        let cow: Cow<'static, [u8]> = Cow::Owned(b"from Cow<u8> owned".to_vec());
+        let exception: NotImplementedError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow<u8> owned".as_bstr());
+    }
+
+    #[test]
+    fn test_debug() {
+        let exception = NotImplementedError::with_message("display test");
+        let output = format!("{exception:?}");
+        // Expected to contain the exception name and the debug-escaped message.
+        assert!(output.contains("NotImplementedError"));
+        assert!(output.contains("display test"));
+        // Check the surrounding formatting.
+        assert!(output.starts_with("NotImplementedError {"));
+        assert!(output.ends_with('}'));
+    }
+
+    #[test]
+    fn test_display() {
+        let exception = NotImplementedError::with_message("display test");
+        let output = format!("{exception}");
+        // Expected to contain the exception name and the debug-escaped message.
+        assert!(output.contains("NotImplementedError"));
+        assert!(output.contains("display test"));
+        // Check the surrounding formatting.
+        assert!(output.starts_with("NotImplementedError ("));
+        assert!(output.ends_with(')'));
+    }
+
+    #[test]
+    fn test_error_trait() {
+        let exception = NotImplementedError::with_message("error trait test");
+        let error_obj: &dyn error::Error = &exception;
+        // Our implementation does not provide a source.
+        assert!(error_obj.source().is_none());
+        // to_string() uses Display.
+        assert_eq!(error_obj.to_string(), format!("{exception}"));
+    }
+
+    #[test]
+    fn test_ruby_exception_trait() {
+        let exception = NotImplementedError::with_message("ruby trait test");
+        let msg = RubyException::message(&exception);
+        let name = RubyException::name(&exception);
+        assert_eq!(msg.as_bstr(), exception.message().as_bstr());
+        assert_eq!(name, exception.name());
+    }
+
+    #[test]
+    fn test_default() {
+        let default_error = NotImplementedError::default();
+        // By default, the message should be an empty slice since Default is auto-derived.
+        assert_eq!(default_error.message(), b"");
+        // The name method always returns the constant exception name.
+        assert_eq!(default_error.name(), "NotImplementedError");
+    }
+
+    #[test]
+    fn test_clone() {
+        let original = NotImplementedError::with_message("clone test");
+        let cloned = original.clone();
+        assert_eq!(original, cloned, "Cloned error should be equal to the original");
+    }
+
+    #[test]
+    fn test_partial_eq() {
+        let error_a = NotImplementedError::with_message("test message");
+        let error_b = NotImplementedError::with_message("test message");
+        let error_c = NotImplementedError::with_message("different message");
+        assert_eq!(error_a, error_b, "Errors with the same message should be equal");
+        assert_ne!(error_a, error_c, "Errors with different messages should not be equal");
+    }
+
+    #[test]
+    fn test_partial_ord() {
+        let error_a = NotImplementedError::with_message("aaa");
+        let error_b = NotImplementedError::with_message("bbb");
+        // Same error should compare equal.
+        assert_eq!(error_a.partial_cmp(&error_a), Some(Ordering::Equal));
+        // Lexicographic ordering of the underlying messages.
+        assert_eq!(error_a.partial_cmp(&error_b), Some(Ordering::Less));
+        assert_eq!(error_b.partial_cmp(&error_a), Some(Ordering::Greater));
+    }
+
+    #[test]
+    fn test_ord() {
+        let error_a = NotImplementedError::with_message("aaa");
+        let error_b = NotImplementedError::with_message("bbb");
+        // Same error should compare equal.
+        assert_eq!(error_a.cmp(&error_a), Ordering::Equal);
+        // Lexicographic ordering of the underlying messages.
+        assert_eq!(error_a.cmp(&error_b), Ordering::Less);
+        assert_eq!(error_b.cmp(&error_a), Ordering::Greater);
     }
 }

--- a/spinoso-exception/src/core/rangeerror.rs
+++ b/spinoso-exception/src/core/rangeerror.rs
@@ -6,6 +6,7 @@ use alloc::vec::Vec;
 use core::error;
 use core::fmt;
 
+use bstr::ByteSlice;
 use scolapasta_string_escape::format_debug_escape_into;
 
 use crate::RubyException;
@@ -22,9 +23,17 @@ use crate::RubyException;
 /// [`Exception`]: https://ruby-doc.org/core-3.1.2/Exception.html
 /// [`Kernel#raise`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-raise
 /// [`NameError#name`]: https://ruby-doc.org/core-3.1.2/NameError.html#method-i-name
-#[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Default, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct RangeError {
     message: Cow<'static, [u8]>,
+}
+
+impl fmt::Debug for RangeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RangeError")
+            .field("message", &self.message().as_bstr())
+            .finish()
+    }
 }
 
 impl RangeError {
@@ -174,5 +183,180 @@ impl RubyException for RangeError {
     #[inline]
     fn name(&self) -> Cow<'_, str> {
         Cow::Borrowed(Self::name(self))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::borrow::Cow;
+    use alloc::format;
+    use alloc::string::ToString;
+    use core::cmp::Ordering;
+    use core::error;
+
+    use bstr::ByteSlice;
+
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        let exception = RangeError::new();
+        assert_eq!(exception.message().as_bstr(), b"RangeError".as_bstr());
+        assert_eq!(exception.name(), "RangeError");
+    }
+
+    #[test]
+    fn test_with_message() {
+        let custom_message = "custom message";
+        let exception = RangeError::with_message(custom_message);
+        assert_eq!(exception.message().as_bstr(), custom_message.as_bytes().as_bstr());
+        // The exception name remains the default even when a custom message is used.
+        assert_eq!(exception.name(), "RangeError");
+    }
+
+    #[test]
+    fn test_from_string() {
+        let message = "from String".to_string();
+        let exception: RangeError = message.into();
+        assert_eq!(exception.message().as_bstr(), b"from String".as_bstr());
+    }
+
+    #[test]
+    fn test_from_static_str() {
+        let message: &'static str = "from &'static str";
+        let exception: RangeError = message.into();
+        assert_eq!(exception.message().as_bstr(), b"from &'static str".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_str_borrowed() {
+        let cow: Cow<'static, str> = Cow::Borrowed("from Cow borrowed");
+        let exception: RangeError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow borrowed".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_str_owned() {
+        let cow: Cow<'static, str> = Cow::Owned("from Cow owned".to_string());
+        let exception: RangeError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow owned".as_bstr());
+    }
+
+    #[test]
+    fn test_from_vec_u8() {
+        let vec = b"from Vec<u8>".to_vec();
+        let exception: RangeError = vec.into();
+        assert_eq!(exception.message().as_bstr(), b"from Vec<u8>".as_bstr());
+    }
+
+    #[test]
+    fn test_from_static_slice() {
+        let slice: &'static [u8] = b"from &'static [u8]";
+        let exception: RangeError = slice.into();
+        assert_eq!(exception.message().as_bstr(), b"from &'static [u8]".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_u8_borrowed() {
+        let cow: Cow<'static, [u8]> = Cow::Borrowed(b"from Cow<u8> borrowed");
+        let exception: RangeError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow<u8> borrowed".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_u8_owned() {
+        let cow: Cow<'static, [u8]> = Cow::Owned(b"from Cow<u8> owned".to_vec());
+        let exception: RangeError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow<u8> owned".as_bstr());
+    }
+
+    #[test]
+    fn test_debug() {
+        let exception = RangeError::with_message("display test");
+        let output = format!("{exception:?}");
+        // Expected to contain the exception name and the debug-escaped message.
+        assert!(output.contains("RangeError"));
+        assert!(output.contains("display test"));
+        // Check the surrounding formatting.
+        assert!(output.starts_with("RangeError {"));
+        assert!(output.ends_with('}'));
+    }
+
+    #[test]
+    fn test_display() {
+        let exception = RangeError::with_message("display test");
+        let output = format!("{exception}");
+        // Expected to contain the exception name and the debug-escaped message.
+        assert!(output.contains("RangeError"));
+        assert!(output.contains("display test"));
+        // Check the surrounding formatting.
+        assert!(output.starts_with("RangeError ("));
+        assert!(output.ends_with(')'));
+    }
+
+    #[test]
+    fn test_error_trait() {
+        let exception = RangeError::with_message("error trait test");
+        let error_obj: &dyn error::Error = &exception;
+        // Our implementation does not provide a source.
+        assert!(error_obj.source().is_none());
+        // to_string() uses Display.
+        assert_eq!(error_obj.to_string(), format!("{exception}"));
+    }
+
+    #[test]
+    fn test_ruby_exception_trait() {
+        let exception = RangeError::with_message("ruby trait test");
+        let msg = RubyException::message(&exception);
+        let name = RubyException::name(&exception);
+        assert_eq!(msg.as_bstr(), exception.message().as_bstr());
+        assert_eq!(name, exception.name());
+    }
+
+    #[test]
+    fn test_default() {
+        let default_error = RangeError::default();
+        // By default, the message should be an empty slice since Default is auto-derived.
+        assert_eq!(default_error.message(), b"");
+        // The name method always returns the constant exception name.
+        assert_eq!(default_error.name(), "RangeError");
+    }
+
+    #[test]
+    fn test_clone() {
+        let original = RangeError::with_message("clone test");
+        let cloned = original.clone();
+        assert_eq!(original, cloned, "Cloned error should be equal to the original");
+    }
+
+    #[test]
+    fn test_partial_eq() {
+        let error_a = RangeError::with_message("test message");
+        let error_b = RangeError::with_message("test message");
+        let error_c = RangeError::with_message("different message");
+        assert_eq!(error_a, error_b, "Errors with the same message should be equal");
+        assert_ne!(error_a, error_c, "Errors with different messages should not be equal");
+    }
+
+    #[test]
+    fn test_partial_ord() {
+        let error_a = RangeError::with_message("aaa");
+        let error_b = RangeError::with_message("bbb");
+        // Same error should compare equal.
+        assert_eq!(error_a.partial_cmp(&error_a), Some(Ordering::Equal));
+        // Lexicographic ordering of the underlying messages.
+        assert_eq!(error_a.partial_cmp(&error_b), Some(Ordering::Less));
+        assert_eq!(error_b.partial_cmp(&error_a), Some(Ordering::Greater));
+    }
+
+    #[test]
+    fn test_ord() {
+        let error_a = RangeError::with_message("aaa");
+        let error_b = RangeError::with_message("bbb");
+        // Same error should compare equal.
+        assert_eq!(error_a.cmp(&error_a), Ordering::Equal);
+        // Lexicographic ordering of the underlying messages.
+        assert_eq!(error_a.cmp(&error_b), Ordering::Less);
+        assert_eq!(error_b.cmp(&error_a), Ordering::Greater);
     }
 }

--- a/spinoso-exception/src/core/regexperror.rs
+++ b/spinoso-exception/src/core/regexperror.rs
@@ -6,6 +6,7 @@ use alloc::vec::Vec;
 use core::error;
 use core::fmt;
 
+use bstr::ByteSlice;
 use scolapasta_string_escape::format_debug_escape_into;
 
 use crate::RubyException;
@@ -22,9 +23,17 @@ use crate::RubyException;
 /// [`Exception`]: https://ruby-doc.org/core-3.1.2/Exception.html
 /// [`Kernel#raise`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-raise
 /// [`NameError#name`]: https://ruby-doc.org/core-3.1.2/NameError.html#method-i-name
-#[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Default, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct RegexpError {
     message: Cow<'static, [u8]>,
+}
+
+impl fmt::Debug for RegexpError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RegexpError")
+            .field("message", &self.message().as_bstr())
+            .finish()
+    }
 }
 
 impl RegexpError {
@@ -174,5 +183,180 @@ impl RubyException for RegexpError {
     #[inline]
     fn name(&self) -> Cow<'_, str> {
         Cow::Borrowed(Self::name(self))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::borrow::Cow;
+    use alloc::format;
+    use alloc::string::ToString;
+    use core::cmp::Ordering;
+    use core::error;
+
+    use bstr::ByteSlice;
+
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        let exception = RegexpError::new();
+        assert_eq!(exception.message().as_bstr(), b"RegexpError".as_bstr());
+        assert_eq!(exception.name(), "RegexpError");
+    }
+
+    #[test]
+    fn test_with_message() {
+        let custom_message = "custom message";
+        let exception = RegexpError::with_message(custom_message);
+        assert_eq!(exception.message().as_bstr(), custom_message.as_bytes().as_bstr());
+        // The exception name remains the default even when a custom message is used.
+        assert_eq!(exception.name(), "RegexpError");
+    }
+
+    #[test]
+    fn test_from_string() {
+        let message = "from String".to_string();
+        let exception: RegexpError = message.into();
+        assert_eq!(exception.message().as_bstr(), b"from String".as_bstr());
+    }
+
+    #[test]
+    fn test_from_static_str() {
+        let message: &'static str = "from &'static str";
+        let exception: RegexpError = message.into();
+        assert_eq!(exception.message().as_bstr(), b"from &'static str".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_str_borrowed() {
+        let cow: Cow<'static, str> = Cow::Borrowed("from Cow borrowed");
+        let exception: RegexpError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow borrowed".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_str_owned() {
+        let cow: Cow<'static, str> = Cow::Owned("from Cow owned".to_string());
+        let exception: RegexpError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow owned".as_bstr());
+    }
+
+    #[test]
+    fn test_from_vec_u8() {
+        let vec = b"from Vec<u8>".to_vec();
+        let exception: RegexpError = vec.into();
+        assert_eq!(exception.message().as_bstr(), b"from Vec<u8>".as_bstr());
+    }
+
+    #[test]
+    fn test_from_static_slice() {
+        let slice: &'static [u8] = b"from &'static [u8]";
+        let exception: RegexpError = slice.into();
+        assert_eq!(exception.message().as_bstr(), b"from &'static [u8]".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_u8_borrowed() {
+        let cow: Cow<'static, [u8]> = Cow::Borrowed(b"from Cow<u8> borrowed");
+        let exception: RegexpError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow<u8> borrowed".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_u8_owned() {
+        let cow: Cow<'static, [u8]> = Cow::Owned(b"from Cow<u8> owned".to_vec());
+        let exception: RegexpError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow<u8> owned".as_bstr());
+    }
+
+    #[test]
+    fn test_debug() {
+        let exception = RegexpError::with_message("display test");
+        let output = format!("{exception:?}");
+        // Expected to contain the exception name and the debug-escaped message.
+        assert!(output.contains("RegexpError"));
+        assert!(output.contains("display test"));
+        // Check the surrounding formatting.
+        assert!(output.starts_with("RegexpError {"));
+        assert!(output.ends_with('}'));
+    }
+
+    #[test]
+    fn test_display() {
+        let exception = RegexpError::with_message("display test");
+        let output = format!("{exception}");
+        // Expected to contain the exception name and the debug-escaped message.
+        assert!(output.contains("RegexpError"));
+        assert!(output.contains("display test"));
+        // Check the surrounding formatting.
+        assert!(output.starts_with("RegexpError ("));
+        assert!(output.ends_with(')'));
+    }
+
+    #[test]
+    fn test_error_trait() {
+        let exception = RegexpError::with_message("error trait test");
+        let error_obj: &dyn error::Error = &exception;
+        // Our implementation does not provide a source.
+        assert!(error_obj.source().is_none());
+        // to_string() uses Display.
+        assert_eq!(error_obj.to_string(), format!("{exception}"));
+    }
+
+    #[test]
+    fn test_ruby_exception_trait() {
+        let exception = RegexpError::with_message("ruby trait test");
+        let msg = RubyException::message(&exception);
+        let name = RubyException::name(&exception);
+        assert_eq!(msg.as_bstr(), exception.message().as_bstr());
+        assert_eq!(name, exception.name());
+    }
+
+    #[test]
+    fn test_default() {
+        let default_error = RegexpError::default();
+        // By default, the message should be an empty slice since Default is auto-derived.
+        assert_eq!(default_error.message(), b"");
+        // The name method always returns the constant exception name.
+        assert_eq!(default_error.name(), "RegexpError");
+    }
+
+    #[test]
+    fn test_clone() {
+        let original = RegexpError::with_message("clone test");
+        let cloned = original.clone();
+        assert_eq!(original, cloned, "Cloned error should be equal to the original");
+    }
+
+    #[test]
+    fn test_partial_eq() {
+        let error_a = RegexpError::with_message("test message");
+        let error_b = RegexpError::with_message("test message");
+        let error_c = RegexpError::with_message("different message");
+        assert_eq!(error_a, error_b, "Errors with the same message should be equal");
+        assert_ne!(error_a, error_c, "Errors with different messages should not be equal");
+    }
+
+    #[test]
+    fn test_partial_ord() {
+        let error_a = RegexpError::with_message("aaa");
+        let error_b = RegexpError::with_message("bbb");
+        // Same error should compare equal.
+        assert_eq!(error_a.partial_cmp(&error_a), Some(Ordering::Equal));
+        // Lexicographic ordering of the underlying messages.
+        assert_eq!(error_a.partial_cmp(&error_b), Some(Ordering::Less));
+        assert_eq!(error_b.partial_cmp(&error_a), Some(Ordering::Greater));
+    }
+
+    #[test]
+    fn test_ord() {
+        let error_a = RegexpError::with_message("aaa");
+        let error_b = RegexpError::with_message("bbb");
+        // Same error should compare equal.
+        assert_eq!(error_a.cmp(&error_a), Ordering::Equal);
+        // Lexicographic ordering of the underlying messages.
+        assert_eq!(error_a.cmp(&error_b), Ordering::Less);
+        assert_eq!(error_b.cmp(&error_a), Ordering::Greater);
     }
 }

--- a/spinoso-exception/src/core/runtimeerror.rs
+++ b/spinoso-exception/src/core/runtimeerror.rs
@@ -6,6 +6,7 @@ use alloc::vec::Vec;
 use core::error;
 use core::fmt;
 
+use bstr::ByteSlice;
 use scolapasta_string_escape::format_debug_escape_into;
 
 use crate::RubyException;
@@ -22,9 +23,17 @@ use crate::RubyException;
 /// [`Exception`]: https://ruby-doc.org/core-3.1.2/Exception.html
 /// [`Kernel#raise`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-raise
 /// [`NameError#name`]: https://ruby-doc.org/core-3.1.2/NameError.html#method-i-name
-#[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Default, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct RuntimeError {
     message: Cow<'static, [u8]>,
+}
+
+impl fmt::Debug for RuntimeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RuntimeError")
+            .field("message", &self.message().as_bstr())
+            .finish()
+    }
 }
 
 impl RuntimeError {
@@ -174,5 +183,180 @@ impl RubyException for RuntimeError {
     #[inline]
     fn name(&self) -> Cow<'_, str> {
         Cow::Borrowed(Self::name(self))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::borrow::Cow;
+    use alloc::format;
+    use alloc::string::ToString;
+    use core::cmp::Ordering;
+    use core::error;
+
+    use bstr::ByteSlice;
+
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        let exception = RuntimeError::new();
+        assert_eq!(exception.message().as_bstr(), b"RuntimeError".as_bstr());
+        assert_eq!(exception.name(), "RuntimeError");
+    }
+
+    #[test]
+    fn test_with_message() {
+        let custom_message = "custom message";
+        let exception = RuntimeError::with_message(custom_message);
+        assert_eq!(exception.message().as_bstr(), custom_message.as_bytes().as_bstr());
+        // The exception name remains the default even when a custom message is used.
+        assert_eq!(exception.name(), "RuntimeError");
+    }
+
+    #[test]
+    fn test_from_string() {
+        let message = "from String".to_string();
+        let exception: RuntimeError = message.into();
+        assert_eq!(exception.message().as_bstr(), b"from String".as_bstr());
+    }
+
+    #[test]
+    fn test_from_static_str() {
+        let message: &'static str = "from &'static str";
+        let exception: RuntimeError = message.into();
+        assert_eq!(exception.message().as_bstr(), b"from &'static str".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_str_borrowed() {
+        let cow: Cow<'static, str> = Cow::Borrowed("from Cow borrowed");
+        let exception: RuntimeError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow borrowed".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_str_owned() {
+        let cow: Cow<'static, str> = Cow::Owned("from Cow owned".to_string());
+        let exception: RuntimeError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow owned".as_bstr());
+    }
+
+    #[test]
+    fn test_from_vec_u8() {
+        let vec = b"from Vec<u8>".to_vec();
+        let exception: RuntimeError = vec.into();
+        assert_eq!(exception.message().as_bstr(), b"from Vec<u8>".as_bstr());
+    }
+
+    #[test]
+    fn test_from_static_slice() {
+        let slice: &'static [u8] = b"from &'static [u8]";
+        let exception: RuntimeError = slice.into();
+        assert_eq!(exception.message().as_bstr(), b"from &'static [u8]".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_u8_borrowed() {
+        let cow: Cow<'static, [u8]> = Cow::Borrowed(b"from Cow<u8> borrowed");
+        let exception: RuntimeError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow<u8> borrowed".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_u8_owned() {
+        let cow: Cow<'static, [u8]> = Cow::Owned(b"from Cow<u8> owned".to_vec());
+        let exception: RuntimeError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow<u8> owned".as_bstr());
+    }
+
+    #[test]
+    fn test_debug() {
+        let exception = RuntimeError::with_message("display test");
+        let output = format!("{exception:?}");
+        // Expected to contain the exception name and the debug-escaped message.
+        assert!(output.contains("RuntimeError"));
+        assert!(output.contains("display test"));
+        // Check the surrounding formatting.
+        assert!(output.starts_with("RuntimeError {"));
+        assert!(output.ends_with('}'));
+    }
+
+    #[test]
+    fn test_display() {
+        let exception = RuntimeError::with_message("display test");
+        let output = format!("{exception}");
+        // Expected to contain the exception name and the debug-escaped message.
+        assert!(output.contains("RuntimeError"));
+        assert!(output.contains("display test"));
+        // Check the surrounding formatting.
+        assert!(output.starts_with("RuntimeError ("));
+        assert!(output.ends_with(')'));
+    }
+
+    #[test]
+    fn test_error_trait() {
+        let exception = RuntimeError::with_message("error trait test");
+        let error_obj: &dyn error::Error = &exception;
+        // Our implementation does not provide a source.
+        assert!(error_obj.source().is_none());
+        // to_string() uses Display.
+        assert_eq!(error_obj.to_string(), format!("{exception}"));
+    }
+
+    #[test]
+    fn test_ruby_exception_trait() {
+        let exception = RuntimeError::with_message("ruby trait test");
+        let msg = RubyException::message(&exception);
+        let name = RubyException::name(&exception);
+        assert_eq!(msg.as_bstr(), exception.message().as_bstr());
+        assert_eq!(name, exception.name());
+    }
+
+    #[test]
+    fn test_default() {
+        let default_error = RuntimeError::default();
+        // By default, the message should be an empty slice since Default is auto-derived.
+        assert_eq!(default_error.message(), b"");
+        // The name method always returns the constant exception name.
+        assert_eq!(default_error.name(), "RuntimeError");
+    }
+
+    #[test]
+    fn test_clone() {
+        let original = RuntimeError::with_message("clone test");
+        let cloned = original.clone();
+        assert_eq!(original, cloned, "Cloned error should be equal to the original");
+    }
+
+    #[test]
+    fn test_partial_eq() {
+        let error_a = RuntimeError::with_message("test message");
+        let error_b = RuntimeError::with_message("test message");
+        let error_c = RuntimeError::with_message("different message");
+        assert_eq!(error_a, error_b, "Errors with the same message should be equal");
+        assert_ne!(error_a, error_c, "Errors with different messages should not be equal");
+    }
+
+    #[test]
+    fn test_partial_ord() {
+        let error_a = RuntimeError::with_message("aaa");
+        let error_b = RuntimeError::with_message("bbb");
+        // Same error should compare equal.
+        assert_eq!(error_a.partial_cmp(&error_a), Some(Ordering::Equal));
+        // Lexicographic ordering of the underlying messages.
+        assert_eq!(error_a.partial_cmp(&error_b), Some(Ordering::Less));
+        assert_eq!(error_b.partial_cmp(&error_a), Some(Ordering::Greater));
+    }
+
+    #[test]
+    fn test_ord() {
+        let error_a = RuntimeError::with_message("aaa");
+        let error_b = RuntimeError::with_message("bbb");
+        // Same error should compare equal.
+        assert_eq!(error_a.cmp(&error_a), Ordering::Equal);
+        // Lexicographic ordering of the underlying messages.
+        assert_eq!(error_a.cmp(&error_b), Ordering::Less);
+        assert_eq!(error_b.cmp(&error_a), Ordering::Greater);
     }
 }

--- a/spinoso-exception/src/core/scripterror.rs
+++ b/spinoso-exception/src/core/scripterror.rs
@@ -6,6 +6,7 @@ use alloc::vec::Vec;
 use core::error;
 use core::fmt;
 
+use bstr::ByteSlice;
 use scolapasta_string_escape::format_debug_escape_into;
 
 use crate::RubyException;
@@ -22,9 +23,17 @@ use crate::RubyException;
 /// [`Exception`]: https://ruby-doc.org/core-3.1.2/Exception.html
 /// [`Kernel#raise`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-raise
 /// [`NameError#name`]: https://ruby-doc.org/core-3.1.2/NameError.html#method-i-name
-#[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Default, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ScriptError {
     message: Cow<'static, [u8]>,
+}
+
+impl fmt::Debug for ScriptError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ScriptError")
+            .field("message", &self.message().as_bstr())
+            .finish()
+    }
 }
 
 impl ScriptError {
@@ -174,5 +183,180 @@ impl RubyException for ScriptError {
     #[inline]
     fn name(&self) -> Cow<'_, str> {
         Cow::Borrowed(Self::name(self))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::borrow::Cow;
+    use alloc::format;
+    use alloc::string::ToString;
+    use core::cmp::Ordering;
+    use core::error;
+
+    use bstr::ByteSlice;
+
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        let exception = ScriptError::new();
+        assert_eq!(exception.message().as_bstr(), b"ScriptError".as_bstr());
+        assert_eq!(exception.name(), "ScriptError");
+    }
+
+    #[test]
+    fn test_with_message() {
+        let custom_message = "custom message";
+        let exception = ScriptError::with_message(custom_message);
+        assert_eq!(exception.message().as_bstr(), custom_message.as_bytes().as_bstr());
+        // The exception name remains the default even when a custom message is used.
+        assert_eq!(exception.name(), "ScriptError");
+    }
+
+    #[test]
+    fn test_from_string() {
+        let message = "from String".to_string();
+        let exception: ScriptError = message.into();
+        assert_eq!(exception.message().as_bstr(), b"from String".as_bstr());
+    }
+
+    #[test]
+    fn test_from_static_str() {
+        let message: &'static str = "from &'static str";
+        let exception: ScriptError = message.into();
+        assert_eq!(exception.message().as_bstr(), b"from &'static str".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_str_borrowed() {
+        let cow: Cow<'static, str> = Cow::Borrowed("from Cow borrowed");
+        let exception: ScriptError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow borrowed".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_str_owned() {
+        let cow: Cow<'static, str> = Cow::Owned("from Cow owned".to_string());
+        let exception: ScriptError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow owned".as_bstr());
+    }
+
+    #[test]
+    fn test_from_vec_u8() {
+        let vec = b"from Vec<u8>".to_vec();
+        let exception: ScriptError = vec.into();
+        assert_eq!(exception.message().as_bstr(), b"from Vec<u8>".as_bstr());
+    }
+
+    #[test]
+    fn test_from_static_slice() {
+        let slice: &'static [u8] = b"from &'static [u8]";
+        let exception: ScriptError = slice.into();
+        assert_eq!(exception.message().as_bstr(), b"from &'static [u8]".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_u8_borrowed() {
+        let cow: Cow<'static, [u8]> = Cow::Borrowed(b"from Cow<u8> borrowed");
+        let exception: ScriptError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow<u8> borrowed".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_u8_owned() {
+        let cow: Cow<'static, [u8]> = Cow::Owned(b"from Cow<u8> owned".to_vec());
+        let exception: ScriptError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow<u8> owned".as_bstr());
+    }
+
+    #[test]
+    fn test_debug() {
+        let exception = ScriptError::with_message("display test");
+        let output = format!("{exception:?}");
+        // Expected to contain the exception name and the debug-escaped message.
+        assert!(output.contains("ScriptError"));
+        assert!(output.contains("display test"));
+        // Check the surrounding formatting.
+        assert!(output.starts_with("ScriptError {"));
+        assert!(output.ends_with('}'));
+    }
+
+    #[test]
+    fn test_display() {
+        let exception = ScriptError::with_message("display test");
+        let output = format!("{exception}");
+        // Expected to contain the exception name and the debug-escaped message.
+        assert!(output.contains("ScriptError"));
+        assert!(output.contains("display test"));
+        // Check the surrounding formatting.
+        assert!(output.starts_with("ScriptError ("));
+        assert!(output.ends_with(')'));
+    }
+
+    #[test]
+    fn test_error_trait() {
+        let exception = ScriptError::with_message("error trait test");
+        let error_obj: &dyn error::Error = &exception;
+        // Our implementation does not provide a source.
+        assert!(error_obj.source().is_none());
+        // to_string() uses Display.
+        assert_eq!(error_obj.to_string(), format!("{exception}"));
+    }
+
+    #[test]
+    fn test_ruby_exception_trait() {
+        let exception = ScriptError::with_message("ruby trait test");
+        let msg = RubyException::message(&exception);
+        let name = RubyException::name(&exception);
+        assert_eq!(msg.as_bstr(), exception.message().as_bstr());
+        assert_eq!(name, exception.name());
+    }
+
+    #[test]
+    fn test_default() {
+        let default_error = ScriptError::default();
+        // By default, the message should be an empty slice since Default is auto-derived.
+        assert_eq!(default_error.message(), b"");
+        // The name method always returns the constant exception name.
+        assert_eq!(default_error.name(), "ScriptError");
+    }
+
+    #[test]
+    fn test_clone() {
+        let original = ScriptError::with_message("clone test");
+        let cloned = original.clone();
+        assert_eq!(original, cloned, "Cloned error should be equal to the original");
+    }
+
+    #[test]
+    fn test_partial_eq() {
+        let error_a = ScriptError::with_message("test message");
+        let error_b = ScriptError::with_message("test message");
+        let error_c = ScriptError::with_message("different message");
+        assert_eq!(error_a, error_b, "Errors with the same message should be equal");
+        assert_ne!(error_a, error_c, "Errors with different messages should not be equal");
+    }
+
+    #[test]
+    fn test_partial_ord() {
+        let error_a = ScriptError::with_message("aaa");
+        let error_b = ScriptError::with_message("bbb");
+        // Same error should compare equal.
+        assert_eq!(error_a.partial_cmp(&error_a), Some(Ordering::Equal));
+        // Lexicographic ordering of the underlying messages.
+        assert_eq!(error_a.partial_cmp(&error_b), Some(Ordering::Less));
+        assert_eq!(error_b.partial_cmp(&error_a), Some(Ordering::Greater));
+    }
+
+    #[test]
+    fn test_ord() {
+        let error_a = ScriptError::with_message("aaa");
+        let error_b = ScriptError::with_message("bbb");
+        // Same error should compare equal.
+        assert_eq!(error_a.cmp(&error_a), Ordering::Equal);
+        // Lexicographic ordering of the underlying messages.
+        assert_eq!(error_a.cmp(&error_b), Ordering::Less);
+        assert_eq!(error_b.cmp(&error_a), Ordering::Greater);
     }
 }

--- a/spinoso-exception/src/core/securityerror.rs
+++ b/spinoso-exception/src/core/securityerror.rs
@@ -6,6 +6,7 @@ use alloc::vec::Vec;
 use core::error;
 use core::fmt;
 
+use bstr::ByteSlice;
 use scolapasta_string_escape::format_debug_escape_into;
 
 use crate::RubyException;
@@ -22,9 +23,17 @@ use crate::RubyException;
 /// [`Exception`]: https://ruby-doc.org/core-3.1.2/Exception.html
 /// [`Kernel#raise`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-raise
 /// [`NameError#name`]: https://ruby-doc.org/core-3.1.2/NameError.html#method-i-name
-#[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Default, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct SecurityError {
     message: Cow<'static, [u8]>,
+}
+
+impl fmt::Debug for SecurityError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SecurityError")
+            .field("message", &self.message().as_bstr())
+            .finish()
+    }
 }
 
 impl SecurityError {
@@ -174,5 +183,180 @@ impl RubyException for SecurityError {
     #[inline]
     fn name(&self) -> Cow<'_, str> {
         Cow::Borrowed(Self::name(self))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::borrow::Cow;
+    use alloc::format;
+    use alloc::string::ToString;
+    use core::cmp::Ordering;
+    use core::error;
+
+    use bstr::ByteSlice;
+
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        let exception = SecurityError::new();
+        assert_eq!(exception.message().as_bstr(), b"SecurityError".as_bstr());
+        assert_eq!(exception.name(), "SecurityError");
+    }
+
+    #[test]
+    fn test_with_message() {
+        let custom_message = "custom message";
+        let exception = SecurityError::with_message(custom_message);
+        assert_eq!(exception.message().as_bstr(), custom_message.as_bytes().as_bstr());
+        // The exception name remains the default even when a custom message is used.
+        assert_eq!(exception.name(), "SecurityError");
+    }
+
+    #[test]
+    fn test_from_string() {
+        let message = "from String".to_string();
+        let exception: SecurityError = message.into();
+        assert_eq!(exception.message().as_bstr(), b"from String".as_bstr());
+    }
+
+    #[test]
+    fn test_from_static_str() {
+        let message: &'static str = "from &'static str";
+        let exception: SecurityError = message.into();
+        assert_eq!(exception.message().as_bstr(), b"from &'static str".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_str_borrowed() {
+        let cow: Cow<'static, str> = Cow::Borrowed("from Cow borrowed");
+        let exception: SecurityError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow borrowed".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_str_owned() {
+        let cow: Cow<'static, str> = Cow::Owned("from Cow owned".to_string());
+        let exception: SecurityError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow owned".as_bstr());
+    }
+
+    #[test]
+    fn test_from_vec_u8() {
+        let vec = b"from Vec<u8>".to_vec();
+        let exception: SecurityError = vec.into();
+        assert_eq!(exception.message().as_bstr(), b"from Vec<u8>".as_bstr());
+    }
+
+    #[test]
+    fn test_from_static_slice() {
+        let slice: &'static [u8] = b"from &'static [u8]";
+        let exception: SecurityError = slice.into();
+        assert_eq!(exception.message().as_bstr(), b"from &'static [u8]".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_u8_borrowed() {
+        let cow: Cow<'static, [u8]> = Cow::Borrowed(b"from Cow<u8> borrowed");
+        let exception: SecurityError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow<u8> borrowed".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_u8_owned() {
+        let cow: Cow<'static, [u8]> = Cow::Owned(b"from Cow<u8> owned".to_vec());
+        let exception: SecurityError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow<u8> owned".as_bstr());
+    }
+
+    #[test]
+    fn test_debug() {
+        let exception = SecurityError::with_message("display test");
+        let output = format!("{exception:?}");
+        // Expected to contain the exception name and the debug-escaped message.
+        assert!(output.contains("SecurityError"));
+        assert!(output.contains("display test"));
+        // Check the surrounding formatting.
+        assert!(output.starts_with("SecurityError {"));
+        assert!(output.ends_with('}'));
+    }
+
+    #[test]
+    fn test_display() {
+        let exception = SecurityError::with_message("display test");
+        let output = format!("{exception}");
+        // Expected to contain the exception name and the debug-escaped message.
+        assert!(output.contains("SecurityError"));
+        assert!(output.contains("display test"));
+        // Check the surrounding formatting.
+        assert!(output.starts_with("SecurityError ("));
+        assert!(output.ends_with(')'));
+    }
+
+    #[test]
+    fn test_error_trait() {
+        let exception = SecurityError::with_message("error trait test");
+        let error_obj: &dyn error::Error = &exception;
+        // Our implementation does not provide a source.
+        assert!(error_obj.source().is_none());
+        // to_string() uses Display.
+        assert_eq!(error_obj.to_string(), format!("{exception}"));
+    }
+
+    #[test]
+    fn test_ruby_exception_trait() {
+        let exception = SecurityError::with_message("ruby trait test");
+        let msg = RubyException::message(&exception);
+        let name = RubyException::name(&exception);
+        assert_eq!(msg.as_bstr(), exception.message().as_bstr());
+        assert_eq!(name, exception.name());
+    }
+
+    #[test]
+    fn test_default() {
+        let default_error = SecurityError::default();
+        // By default, the message should be an empty slice since Default is auto-derived.
+        assert_eq!(default_error.message(), b"");
+        // The name method always returns the constant exception name.
+        assert_eq!(default_error.name(), "SecurityError");
+    }
+
+    #[test]
+    fn test_clone() {
+        let original = SecurityError::with_message("clone test");
+        let cloned = original.clone();
+        assert_eq!(original, cloned, "Cloned error should be equal to the original");
+    }
+
+    #[test]
+    fn test_partial_eq() {
+        let error_a = SecurityError::with_message("test message");
+        let error_b = SecurityError::with_message("test message");
+        let error_c = SecurityError::with_message("different message");
+        assert_eq!(error_a, error_b, "Errors with the same message should be equal");
+        assert_ne!(error_a, error_c, "Errors with different messages should not be equal");
+    }
+
+    #[test]
+    fn test_partial_ord() {
+        let error_a = SecurityError::with_message("aaa");
+        let error_b = SecurityError::with_message("bbb");
+        // Same error should compare equal.
+        assert_eq!(error_a.partial_cmp(&error_a), Some(Ordering::Equal));
+        // Lexicographic ordering of the underlying messages.
+        assert_eq!(error_a.partial_cmp(&error_b), Some(Ordering::Less));
+        assert_eq!(error_b.partial_cmp(&error_a), Some(Ordering::Greater));
+    }
+
+    #[test]
+    fn test_ord() {
+        let error_a = SecurityError::with_message("aaa");
+        let error_b = SecurityError::with_message("bbb");
+        // Same error should compare equal.
+        assert_eq!(error_a.cmp(&error_a), Ordering::Equal);
+        // Lexicographic ordering of the underlying messages.
+        assert_eq!(error_a.cmp(&error_b), Ordering::Less);
+        assert_eq!(error_b.cmp(&error_a), Ordering::Greater);
     }
 }

--- a/spinoso-exception/src/core/signalexception.rs
+++ b/spinoso-exception/src/core/signalexception.rs
@@ -6,6 +6,7 @@ use alloc::vec::Vec;
 use core::error;
 use core::fmt;
 
+use bstr::ByteSlice;
 use scolapasta_string_escape::format_debug_escape_into;
 
 use crate::RubyException;
@@ -22,9 +23,17 @@ use crate::RubyException;
 /// [`Exception`]: https://ruby-doc.org/core-3.1.2/Exception.html
 /// [`Kernel#raise`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-raise
 /// [`NameError#name`]: https://ruby-doc.org/core-3.1.2/NameError.html#method-i-name
-#[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Default, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct SignalException {
     message: Cow<'static, [u8]>,
+}
+
+impl fmt::Debug for SignalException {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SignalException")
+            .field("message", &self.message().as_bstr())
+            .finish()
+    }
 }
 
 impl SignalException {
@@ -174,5 +183,180 @@ impl RubyException for SignalException {
     #[inline]
     fn name(&self) -> Cow<'_, str> {
         Cow::Borrowed(Self::name(self))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::borrow::Cow;
+    use alloc::format;
+    use alloc::string::ToString;
+    use core::cmp::Ordering;
+    use core::error;
+
+    use bstr::ByteSlice;
+
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        let exception = SignalException::new();
+        assert_eq!(exception.message().as_bstr(), b"SignalException".as_bstr());
+        assert_eq!(exception.name(), "SignalException");
+    }
+
+    #[test]
+    fn test_with_message() {
+        let custom_message = "custom message";
+        let exception = SignalException::with_message(custom_message);
+        assert_eq!(exception.message().as_bstr(), custom_message.as_bytes().as_bstr());
+        // The exception name remains the default even when a custom message is used.
+        assert_eq!(exception.name(), "SignalException");
+    }
+
+    #[test]
+    fn test_from_string() {
+        let message = "from String".to_string();
+        let exception: SignalException = message.into();
+        assert_eq!(exception.message().as_bstr(), b"from String".as_bstr());
+    }
+
+    #[test]
+    fn test_from_static_str() {
+        let message: &'static str = "from &'static str";
+        let exception: SignalException = message.into();
+        assert_eq!(exception.message().as_bstr(), b"from &'static str".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_str_borrowed() {
+        let cow: Cow<'static, str> = Cow::Borrowed("from Cow borrowed");
+        let exception: SignalException = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow borrowed".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_str_owned() {
+        let cow: Cow<'static, str> = Cow::Owned("from Cow owned".to_string());
+        let exception: SignalException = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow owned".as_bstr());
+    }
+
+    #[test]
+    fn test_from_vec_u8() {
+        let vec = b"from Vec<u8>".to_vec();
+        let exception: SignalException = vec.into();
+        assert_eq!(exception.message().as_bstr(), b"from Vec<u8>".as_bstr());
+    }
+
+    #[test]
+    fn test_from_static_slice() {
+        let slice: &'static [u8] = b"from &'static [u8]";
+        let exception: SignalException = slice.into();
+        assert_eq!(exception.message().as_bstr(), b"from &'static [u8]".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_u8_borrowed() {
+        let cow: Cow<'static, [u8]> = Cow::Borrowed(b"from Cow<u8> borrowed");
+        let exception: SignalException = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow<u8> borrowed".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_u8_owned() {
+        let cow: Cow<'static, [u8]> = Cow::Owned(b"from Cow<u8> owned".to_vec());
+        let exception: SignalException = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow<u8> owned".as_bstr());
+    }
+
+    #[test]
+    fn test_debug() {
+        let exception = SignalException::with_message("display test");
+        let output = format!("{exception:?}");
+        // Expected to contain the exception name and the debug-escaped message.
+        assert!(output.contains("SignalException"));
+        assert!(output.contains("display test"));
+        // Check the surrounding formatting.
+        assert!(output.starts_with("SignalException {"));
+        assert!(output.ends_with('}'));
+    }
+
+    #[test]
+    fn test_display() {
+        let exception = SignalException::with_message("display test");
+        let output = format!("{exception}");
+        // Expected to contain the exception name and the debug-escaped message.
+        assert!(output.contains("SignalException"));
+        assert!(output.contains("display test"));
+        // Check the surrounding formatting.
+        assert!(output.starts_with("SignalException ("));
+        assert!(output.ends_with(')'));
+    }
+
+    #[test]
+    fn test_error_trait() {
+        let exception = SignalException::with_message("error trait test");
+        let error_obj: &dyn error::Error = &exception;
+        // Our implementation does not provide a source.
+        assert!(error_obj.source().is_none());
+        // to_string() uses Display.
+        assert_eq!(error_obj.to_string(), format!("{exception}"));
+    }
+
+    #[test]
+    fn test_ruby_exception_trait() {
+        let exception = SignalException::with_message("ruby trait test");
+        let msg = RubyException::message(&exception);
+        let name = RubyException::name(&exception);
+        assert_eq!(msg.as_bstr(), exception.message().as_bstr());
+        assert_eq!(name, exception.name());
+    }
+
+    #[test]
+    fn test_default() {
+        let default_error = SignalException::default();
+        // By default, the message should be an empty slice since Default is auto-derived.
+        assert_eq!(default_error.message(), b"");
+        // The name method always returns the constant exception name.
+        assert_eq!(default_error.name(), "SignalException");
+    }
+
+    #[test]
+    fn test_clone() {
+        let original = SignalException::with_message("clone test");
+        let cloned = original.clone();
+        assert_eq!(original, cloned, "Cloned error should be equal to the original");
+    }
+
+    #[test]
+    fn test_partial_eq() {
+        let error_a = SignalException::with_message("test message");
+        let error_b = SignalException::with_message("test message");
+        let error_c = SignalException::with_message("different message");
+        assert_eq!(error_a, error_b, "Errors with the same message should be equal");
+        assert_ne!(error_a, error_c, "Errors with different messages should not be equal");
+    }
+
+    #[test]
+    fn test_partial_ord() {
+        let error_a = SignalException::with_message("aaa");
+        let error_b = SignalException::with_message("bbb");
+        // Same error should compare equal.
+        assert_eq!(error_a.partial_cmp(&error_a), Some(Ordering::Equal));
+        // Lexicographic ordering of the underlying messages.
+        assert_eq!(error_a.partial_cmp(&error_b), Some(Ordering::Less));
+        assert_eq!(error_b.partial_cmp(&error_a), Some(Ordering::Greater));
+    }
+
+    #[test]
+    fn test_ord() {
+        let error_a = SignalException::with_message("aaa");
+        let error_b = SignalException::with_message("bbb");
+        // Same error should compare equal.
+        assert_eq!(error_a.cmp(&error_a), Ordering::Equal);
+        // Lexicographic ordering of the underlying messages.
+        assert_eq!(error_a.cmp(&error_b), Ordering::Less);
+        assert_eq!(error_b.cmp(&error_a), Ordering::Greater);
     }
 }

--- a/spinoso-exception/src/core/standarderror.rs
+++ b/spinoso-exception/src/core/standarderror.rs
@@ -6,6 +6,7 @@ use alloc::vec::Vec;
 use core::error;
 use core::fmt;
 
+use bstr::ByteSlice;
 use scolapasta_string_escape::format_debug_escape_into;
 
 use crate::RubyException;
@@ -22,9 +23,17 @@ use crate::RubyException;
 /// [`Exception`]: https://ruby-doc.org/core-3.1.2/Exception.html
 /// [`Kernel#raise`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-raise
 /// [`NameError#name`]: https://ruby-doc.org/core-3.1.2/NameError.html#method-i-name
-#[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Default, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct StandardError {
     message: Cow<'static, [u8]>,
+}
+
+impl fmt::Debug for StandardError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("StandardError")
+            .field("message", &self.message().as_bstr())
+            .finish()
+    }
 }
 
 impl StandardError {
@@ -174,5 +183,180 @@ impl RubyException for StandardError {
     #[inline]
     fn name(&self) -> Cow<'_, str> {
         Cow::Borrowed(Self::name(self))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::borrow::Cow;
+    use alloc::format;
+    use alloc::string::ToString;
+    use core::cmp::Ordering;
+    use core::error;
+
+    use bstr::ByteSlice;
+
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        let exception = StandardError::new();
+        assert_eq!(exception.message().as_bstr(), b"StandardError".as_bstr());
+        assert_eq!(exception.name(), "StandardError");
+    }
+
+    #[test]
+    fn test_with_message() {
+        let custom_message = "custom message";
+        let exception = StandardError::with_message(custom_message);
+        assert_eq!(exception.message().as_bstr(), custom_message.as_bytes().as_bstr());
+        // The exception name remains the default even when a custom message is used.
+        assert_eq!(exception.name(), "StandardError");
+    }
+
+    #[test]
+    fn test_from_string() {
+        let message = "from String".to_string();
+        let exception: StandardError = message.into();
+        assert_eq!(exception.message().as_bstr(), b"from String".as_bstr());
+    }
+
+    #[test]
+    fn test_from_static_str() {
+        let message: &'static str = "from &'static str";
+        let exception: StandardError = message.into();
+        assert_eq!(exception.message().as_bstr(), b"from &'static str".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_str_borrowed() {
+        let cow: Cow<'static, str> = Cow::Borrowed("from Cow borrowed");
+        let exception: StandardError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow borrowed".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_str_owned() {
+        let cow: Cow<'static, str> = Cow::Owned("from Cow owned".to_string());
+        let exception: StandardError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow owned".as_bstr());
+    }
+
+    #[test]
+    fn test_from_vec_u8() {
+        let vec = b"from Vec<u8>".to_vec();
+        let exception: StandardError = vec.into();
+        assert_eq!(exception.message().as_bstr(), b"from Vec<u8>".as_bstr());
+    }
+
+    #[test]
+    fn test_from_static_slice() {
+        let slice: &'static [u8] = b"from &'static [u8]";
+        let exception: StandardError = slice.into();
+        assert_eq!(exception.message().as_bstr(), b"from &'static [u8]".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_u8_borrowed() {
+        let cow: Cow<'static, [u8]> = Cow::Borrowed(b"from Cow<u8> borrowed");
+        let exception: StandardError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow<u8> borrowed".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_u8_owned() {
+        let cow: Cow<'static, [u8]> = Cow::Owned(b"from Cow<u8> owned".to_vec());
+        let exception: StandardError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow<u8> owned".as_bstr());
+    }
+
+    #[test]
+    fn test_debug() {
+        let exception = StandardError::with_message("display test");
+        let output = format!("{exception:?}");
+        // Expected to contain the exception name and the debug-escaped message.
+        assert!(output.contains("StandardError"));
+        assert!(output.contains("display test"));
+        // Check the surrounding formatting.
+        assert!(output.starts_with("StandardError {"));
+        assert!(output.ends_with('}'));
+    }
+
+    #[test]
+    fn test_display() {
+        let exception = StandardError::with_message("display test");
+        let output = format!("{exception}");
+        // Expected to contain the exception name and the debug-escaped message.
+        assert!(output.contains("StandardError"));
+        assert!(output.contains("display test"));
+        // Check the surrounding formatting.
+        assert!(output.starts_with("StandardError ("));
+        assert!(output.ends_with(')'));
+    }
+
+    #[test]
+    fn test_error_trait() {
+        let exception = StandardError::with_message("error trait test");
+        let error_obj: &dyn error::Error = &exception;
+        // Our implementation does not provide a source.
+        assert!(error_obj.source().is_none());
+        // to_string() uses Display.
+        assert_eq!(error_obj.to_string(), format!("{exception}"));
+    }
+
+    #[test]
+    fn test_ruby_exception_trait() {
+        let exception = StandardError::with_message("ruby trait test");
+        let msg = RubyException::message(&exception);
+        let name = RubyException::name(&exception);
+        assert_eq!(msg.as_bstr(), exception.message().as_bstr());
+        assert_eq!(name, exception.name());
+    }
+
+    #[test]
+    fn test_default() {
+        let default_error = StandardError::default();
+        // By default, the message should be an empty slice since Default is auto-derived.
+        assert_eq!(default_error.message(), b"");
+        // The name method always returns the constant exception name.
+        assert_eq!(default_error.name(), "StandardError");
+    }
+
+    #[test]
+    fn test_clone() {
+        let original = StandardError::with_message("clone test");
+        let cloned = original.clone();
+        assert_eq!(original, cloned, "Cloned error should be equal to the original");
+    }
+
+    #[test]
+    fn test_partial_eq() {
+        let error_a = StandardError::with_message("test message");
+        let error_b = StandardError::with_message("test message");
+        let error_c = StandardError::with_message("different message");
+        assert_eq!(error_a, error_b, "Errors with the same message should be equal");
+        assert_ne!(error_a, error_c, "Errors with different messages should not be equal");
+    }
+
+    #[test]
+    fn test_partial_ord() {
+        let error_a = StandardError::with_message("aaa");
+        let error_b = StandardError::with_message("bbb");
+        // Same error should compare equal.
+        assert_eq!(error_a.partial_cmp(&error_a), Some(Ordering::Equal));
+        // Lexicographic ordering of the underlying messages.
+        assert_eq!(error_a.partial_cmp(&error_b), Some(Ordering::Less));
+        assert_eq!(error_b.partial_cmp(&error_a), Some(Ordering::Greater));
+    }
+
+    #[test]
+    fn test_ord() {
+        let error_a = StandardError::with_message("aaa");
+        let error_b = StandardError::with_message("bbb");
+        // Same error should compare equal.
+        assert_eq!(error_a.cmp(&error_a), Ordering::Equal);
+        // Lexicographic ordering of the underlying messages.
+        assert_eq!(error_a.cmp(&error_b), Ordering::Less);
+        assert_eq!(error_b.cmp(&error_a), Ordering::Greater);
     }
 }

--- a/spinoso-exception/src/core/stopiteration.rs
+++ b/spinoso-exception/src/core/stopiteration.rs
@@ -6,6 +6,7 @@ use alloc::vec::Vec;
 use core::error;
 use core::fmt;
 
+use bstr::ByteSlice;
 use scolapasta_string_escape::format_debug_escape_into;
 
 use crate::RubyException;
@@ -22,9 +23,17 @@ use crate::RubyException;
 /// [`Exception`]: https://ruby-doc.org/core-3.1.2/Exception.html
 /// [`Kernel#raise`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-raise
 /// [`NameError#name`]: https://ruby-doc.org/core-3.1.2/NameError.html#method-i-name
-#[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Default, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct StopIteration {
     message: Cow<'static, [u8]>,
+}
+
+impl fmt::Debug for StopIteration {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("StopIteration")
+            .field("message", &self.message().as_bstr())
+            .finish()
+    }
 }
 
 impl StopIteration {
@@ -174,5 +183,180 @@ impl RubyException for StopIteration {
     #[inline]
     fn name(&self) -> Cow<'_, str> {
         Cow::Borrowed(Self::name(self))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::borrow::Cow;
+    use alloc::format;
+    use alloc::string::ToString;
+    use core::cmp::Ordering;
+    use core::error;
+
+    use bstr::ByteSlice;
+
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        let exception = StopIteration::new();
+        assert_eq!(exception.message().as_bstr(), b"StopIteration".as_bstr());
+        assert_eq!(exception.name(), "StopIteration");
+    }
+
+    #[test]
+    fn test_with_message() {
+        let custom_message = "custom message";
+        let exception = StopIteration::with_message(custom_message);
+        assert_eq!(exception.message().as_bstr(), custom_message.as_bytes().as_bstr());
+        // The exception name remains the default even when a custom message is used.
+        assert_eq!(exception.name(), "StopIteration");
+    }
+
+    #[test]
+    fn test_from_string() {
+        let message = "from String".to_string();
+        let exception: StopIteration = message.into();
+        assert_eq!(exception.message().as_bstr(), b"from String".as_bstr());
+    }
+
+    #[test]
+    fn test_from_static_str() {
+        let message: &'static str = "from &'static str";
+        let exception: StopIteration = message.into();
+        assert_eq!(exception.message().as_bstr(), b"from &'static str".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_str_borrowed() {
+        let cow: Cow<'static, str> = Cow::Borrowed("from Cow borrowed");
+        let exception: StopIteration = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow borrowed".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_str_owned() {
+        let cow: Cow<'static, str> = Cow::Owned("from Cow owned".to_string());
+        let exception: StopIteration = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow owned".as_bstr());
+    }
+
+    #[test]
+    fn test_from_vec_u8() {
+        let vec = b"from Vec<u8>".to_vec();
+        let exception: StopIteration = vec.into();
+        assert_eq!(exception.message().as_bstr(), b"from Vec<u8>".as_bstr());
+    }
+
+    #[test]
+    fn test_from_static_slice() {
+        let slice: &'static [u8] = b"from &'static [u8]";
+        let exception: StopIteration = slice.into();
+        assert_eq!(exception.message().as_bstr(), b"from &'static [u8]".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_u8_borrowed() {
+        let cow: Cow<'static, [u8]> = Cow::Borrowed(b"from Cow<u8> borrowed");
+        let exception: StopIteration = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow<u8> borrowed".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_u8_owned() {
+        let cow: Cow<'static, [u8]> = Cow::Owned(b"from Cow<u8> owned".to_vec());
+        let exception: StopIteration = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow<u8> owned".as_bstr());
+    }
+
+    #[test]
+    fn test_debug() {
+        let exception = StopIteration::with_message("display test");
+        let output = format!("{exception:?}");
+        // Expected to contain the exception name and the debug-escaped message.
+        assert!(output.contains("StopIteration"));
+        assert!(output.contains("display test"));
+        // Check the surrounding formatting.
+        assert!(output.starts_with("StopIteration {"));
+        assert!(output.ends_with('}'));
+    }
+
+    #[test]
+    fn test_display() {
+        let exception = StopIteration::with_message("display test");
+        let output = format!("{exception}");
+        // Expected to contain the exception name and the debug-escaped message.
+        assert!(output.contains("StopIteration"));
+        assert!(output.contains("display test"));
+        // Check the surrounding formatting.
+        assert!(output.starts_with("StopIteration ("));
+        assert!(output.ends_with(')'));
+    }
+
+    #[test]
+    fn test_error_trait() {
+        let exception = StopIteration::with_message("error trait test");
+        let error_obj: &dyn error::Error = &exception;
+        // Our implementation does not provide a source.
+        assert!(error_obj.source().is_none());
+        // to_string() uses Display.
+        assert_eq!(error_obj.to_string(), format!("{exception}"));
+    }
+
+    #[test]
+    fn test_ruby_exception_trait() {
+        let exception = StopIteration::with_message("ruby trait test");
+        let msg = RubyException::message(&exception);
+        let name = RubyException::name(&exception);
+        assert_eq!(msg.as_bstr(), exception.message().as_bstr());
+        assert_eq!(name, exception.name());
+    }
+
+    #[test]
+    fn test_default() {
+        let default_error = StopIteration::default();
+        // By default, the message should be an empty slice since Default is auto-derived.
+        assert_eq!(default_error.message(), b"");
+        // The name method always returns the constant exception name.
+        assert_eq!(default_error.name(), "StopIteration");
+    }
+
+    #[test]
+    fn test_clone() {
+        let original = StopIteration::with_message("clone test");
+        let cloned = original.clone();
+        assert_eq!(original, cloned, "Cloned error should be equal to the original");
+    }
+
+    #[test]
+    fn test_partial_eq() {
+        let error_a = StopIteration::with_message("test message");
+        let error_b = StopIteration::with_message("test message");
+        let error_c = StopIteration::with_message("different message");
+        assert_eq!(error_a, error_b, "Errors with the same message should be equal");
+        assert_ne!(error_a, error_c, "Errors with different messages should not be equal");
+    }
+
+    #[test]
+    fn test_partial_ord() {
+        let error_a = StopIteration::with_message("aaa");
+        let error_b = StopIteration::with_message("bbb");
+        // Same error should compare equal.
+        assert_eq!(error_a.partial_cmp(&error_a), Some(Ordering::Equal));
+        // Lexicographic ordering of the underlying messages.
+        assert_eq!(error_a.partial_cmp(&error_b), Some(Ordering::Less));
+        assert_eq!(error_b.partial_cmp(&error_a), Some(Ordering::Greater));
+    }
+
+    #[test]
+    fn test_ord() {
+        let error_a = StopIteration::with_message("aaa");
+        let error_b = StopIteration::with_message("bbb");
+        // Same error should compare equal.
+        assert_eq!(error_a.cmp(&error_a), Ordering::Equal);
+        // Lexicographic ordering of the underlying messages.
+        assert_eq!(error_a.cmp(&error_b), Ordering::Less);
+        assert_eq!(error_b.cmp(&error_a), Ordering::Greater);
     }
 }

--- a/spinoso-exception/src/core/syntaxerror.rs
+++ b/spinoso-exception/src/core/syntaxerror.rs
@@ -6,6 +6,7 @@ use alloc::vec::Vec;
 use core::error;
 use core::fmt;
 
+use bstr::ByteSlice;
 use scolapasta_string_escape::format_debug_escape_into;
 
 use crate::RubyException;
@@ -22,9 +23,17 @@ use crate::RubyException;
 /// [`Exception`]: https://ruby-doc.org/core-3.1.2/Exception.html
 /// [`Kernel#raise`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-raise
 /// [`NameError#name`]: https://ruby-doc.org/core-3.1.2/NameError.html#method-i-name
-#[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Default, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct SyntaxError {
     message: Cow<'static, [u8]>,
+}
+
+impl fmt::Debug for SyntaxError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SyntaxError")
+            .field("message", &self.message().as_bstr())
+            .finish()
+    }
 }
 
 impl SyntaxError {
@@ -174,5 +183,180 @@ impl RubyException for SyntaxError {
     #[inline]
     fn name(&self) -> Cow<'_, str> {
         Cow::Borrowed(Self::name(self))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::borrow::Cow;
+    use alloc::format;
+    use alloc::string::ToString;
+    use core::cmp::Ordering;
+    use core::error;
+
+    use bstr::ByteSlice;
+
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        let exception = SyntaxError::new();
+        assert_eq!(exception.message().as_bstr(), b"SyntaxError".as_bstr());
+        assert_eq!(exception.name(), "SyntaxError");
+    }
+
+    #[test]
+    fn test_with_message() {
+        let custom_message = "custom message";
+        let exception = SyntaxError::with_message(custom_message);
+        assert_eq!(exception.message().as_bstr(), custom_message.as_bytes().as_bstr());
+        // The exception name remains the default even when a custom message is used.
+        assert_eq!(exception.name(), "SyntaxError");
+    }
+
+    #[test]
+    fn test_from_string() {
+        let message = "from String".to_string();
+        let exception: SyntaxError = message.into();
+        assert_eq!(exception.message().as_bstr(), b"from String".as_bstr());
+    }
+
+    #[test]
+    fn test_from_static_str() {
+        let message: &'static str = "from &'static str";
+        let exception: SyntaxError = message.into();
+        assert_eq!(exception.message().as_bstr(), b"from &'static str".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_str_borrowed() {
+        let cow: Cow<'static, str> = Cow::Borrowed("from Cow borrowed");
+        let exception: SyntaxError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow borrowed".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_str_owned() {
+        let cow: Cow<'static, str> = Cow::Owned("from Cow owned".to_string());
+        let exception: SyntaxError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow owned".as_bstr());
+    }
+
+    #[test]
+    fn test_from_vec_u8() {
+        let vec = b"from Vec<u8>".to_vec();
+        let exception: SyntaxError = vec.into();
+        assert_eq!(exception.message().as_bstr(), b"from Vec<u8>".as_bstr());
+    }
+
+    #[test]
+    fn test_from_static_slice() {
+        let slice: &'static [u8] = b"from &'static [u8]";
+        let exception: SyntaxError = slice.into();
+        assert_eq!(exception.message().as_bstr(), b"from &'static [u8]".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_u8_borrowed() {
+        let cow: Cow<'static, [u8]> = Cow::Borrowed(b"from Cow<u8> borrowed");
+        let exception: SyntaxError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow<u8> borrowed".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_u8_owned() {
+        let cow: Cow<'static, [u8]> = Cow::Owned(b"from Cow<u8> owned".to_vec());
+        let exception: SyntaxError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow<u8> owned".as_bstr());
+    }
+
+    #[test]
+    fn test_debug() {
+        let exception = SyntaxError::with_message("display test");
+        let output = format!("{exception:?}");
+        // Expected to contain the exception name and the debug-escaped message.
+        assert!(output.contains("SyntaxError"));
+        assert!(output.contains("display test"));
+        // Check the surrounding formatting.
+        assert!(output.starts_with("SyntaxError {"));
+        assert!(output.ends_with('}'));
+    }
+
+    #[test]
+    fn test_display() {
+        let exception = SyntaxError::with_message("display test");
+        let output = format!("{exception}");
+        // Expected to contain the exception name and the debug-escaped message.
+        assert!(output.contains("SyntaxError"));
+        assert!(output.contains("display test"));
+        // Check the surrounding formatting.
+        assert!(output.starts_with("SyntaxError ("));
+        assert!(output.ends_with(')'));
+    }
+
+    #[test]
+    fn test_error_trait() {
+        let exception = SyntaxError::with_message("error trait test");
+        let error_obj: &dyn error::Error = &exception;
+        // Our implementation does not provide a source.
+        assert!(error_obj.source().is_none());
+        // to_string() uses Display.
+        assert_eq!(error_obj.to_string(), format!("{exception}"));
+    }
+
+    #[test]
+    fn test_ruby_exception_trait() {
+        let exception = SyntaxError::with_message("ruby trait test");
+        let msg = RubyException::message(&exception);
+        let name = RubyException::name(&exception);
+        assert_eq!(msg.as_bstr(), exception.message().as_bstr());
+        assert_eq!(name, exception.name());
+    }
+
+    #[test]
+    fn test_default() {
+        let default_error = SyntaxError::default();
+        // By default, the message should be an empty slice since Default is auto-derived.
+        assert_eq!(default_error.message(), b"");
+        // The name method always returns the constant exception name.
+        assert_eq!(default_error.name(), "SyntaxError");
+    }
+
+    #[test]
+    fn test_clone() {
+        let original = SyntaxError::with_message("clone test");
+        let cloned = original.clone();
+        assert_eq!(original, cloned, "Cloned error should be equal to the original");
+    }
+
+    #[test]
+    fn test_partial_eq() {
+        let error_a = SyntaxError::with_message("test message");
+        let error_b = SyntaxError::with_message("test message");
+        let error_c = SyntaxError::with_message("different message");
+        assert_eq!(error_a, error_b, "Errors with the same message should be equal");
+        assert_ne!(error_a, error_c, "Errors with different messages should not be equal");
+    }
+
+    #[test]
+    fn test_partial_ord() {
+        let error_a = SyntaxError::with_message("aaa");
+        let error_b = SyntaxError::with_message("bbb");
+        // Same error should compare equal.
+        assert_eq!(error_a.partial_cmp(&error_a), Some(Ordering::Equal));
+        // Lexicographic ordering of the underlying messages.
+        assert_eq!(error_a.partial_cmp(&error_b), Some(Ordering::Less));
+        assert_eq!(error_b.partial_cmp(&error_a), Some(Ordering::Greater));
+    }
+
+    #[test]
+    fn test_ord() {
+        let error_a = SyntaxError::with_message("aaa");
+        let error_b = SyntaxError::with_message("bbb");
+        // Same error should compare equal.
+        assert_eq!(error_a.cmp(&error_a), Ordering::Equal);
+        // Lexicographic ordering of the underlying messages.
+        assert_eq!(error_a.cmp(&error_b), Ordering::Less);
+        assert_eq!(error_b.cmp(&error_a), Ordering::Greater);
     }
 }

--- a/spinoso-exception/src/core/systemcallerror.rs
+++ b/spinoso-exception/src/core/systemcallerror.rs
@@ -6,6 +6,7 @@ use alloc::vec::Vec;
 use core::error;
 use core::fmt;
 
+use bstr::ByteSlice;
 use scolapasta_string_escape::format_debug_escape_into;
 
 use crate::RubyException;
@@ -22,9 +23,17 @@ use crate::RubyException;
 /// [`Exception`]: https://ruby-doc.org/core-3.1.2/Exception.html
 /// [`Kernel#raise`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-raise
 /// [`NameError#name`]: https://ruby-doc.org/core-3.1.2/NameError.html#method-i-name
-#[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Default, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct SystemCallError {
     message: Cow<'static, [u8]>,
+}
+
+impl fmt::Debug for SystemCallError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SystemCallError")
+            .field("message", &self.message().as_bstr())
+            .finish()
+    }
 }
 
 impl SystemCallError {
@@ -174,5 +183,180 @@ impl RubyException for SystemCallError {
     #[inline]
     fn name(&self) -> Cow<'_, str> {
         Cow::Borrowed(Self::name(self))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::borrow::Cow;
+    use alloc::format;
+    use alloc::string::ToString;
+    use core::cmp::Ordering;
+    use core::error;
+
+    use bstr::ByteSlice;
+
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        let exception = SystemCallError::new();
+        assert_eq!(exception.message().as_bstr(), b"SystemCallError".as_bstr());
+        assert_eq!(exception.name(), "SystemCallError");
+    }
+
+    #[test]
+    fn test_with_message() {
+        let custom_message = "custom message";
+        let exception = SystemCallError::with_message(custom_message);
+        assert_eq!(exception.message().as_bstr(), custom_message.as_bytes().as_bstr());
+        // The exception name remains the default even when a custom message is used.
+        assert_eq!(exception.name(), "SystemCallError");
+    }
+
+    #[test]
+    fn test_from_string() {
+        let message = "from String".to_string();
+        let exception: SystemCallError = message.into();
+        assert_eq!(exception.message().as_bstr(), b"from String".as_bstr());
+    }
+
+    #[test]
+    fn test_from_static_str() {
+        let message: &'static str = "from &'static str";
+        let exception: SystemCallError = message.into();
+        assert_eq!(exception.message().as_bstr(), b"from &'static str".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_str_borrowed() {
+        let cow: Cow<'static, str> = Cow::Borrowed("from Cow borrowed");
+        let exception: SystemCallError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow borrowed".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_str_owned() {
+        let cow: Cow<'static, str> = Cow::Owned("from Cow owned".to_string());
+        let exception: SystemCallError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow owned".as_bstr());
+    }
+
+    #[test]
+    fn test_from_vec_u8() {
+        let vec = b"from Vec<u8>".to_vec();
+        let exception: SystemCallError = vec.into();
+        assert_eq!(exception.message().as_bstr(), b"from Vec<u8>".as_bstr());
+    }
+
+    #[test]
+    fn test_from_static_slice() {
+        let slice: &'static [u8] = b"from &'static [u8]";
+        let exception: SystemCallError = slice.into();
+        assert_eq!(exception.message().as_bstr(), b"from &'static [u8]".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_u8_borrowed() {
+        let cow: Cow<'static, [u8]> = Cow::Borrowed(b"from Cow<u8> borrowed");
+        let exception: SystemCallError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow<u8> borrowed".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_u8_owned() {
+        let cow: Cow<'static, [u8]> = Cow::Owned(b"from Cow<u8> owned".to_vec());
+        let exception: SystemCallError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow<u8> owned".as_bstr());
+    }
+
+    #[test]
+    fn test_debug() {
+        let exception = SystemCallError::with_message("display test");
+        let output = format!("{exception:?}");
+        // Expected to contain the exception name and the debug-escaped message.
+        assert!(output.contains("SystemCallError"));
+        assert!(output.contains("display test"));
+        // Check the surrounding formatting.
+        assert!(output.starts_with("SystemCallError {"));
+        assert!(output.ends_with('}'));
+    }
+
+    #[test]
+    fn test_display() {
+        let exception = SystemCallError::with_message("display test");
+        let output = format!("{exception}");
+        // Expected to contain the exception name and the debug-escaped message.
+        assert!(output.contains("SystemCallError"));
+        assert!(output.contains("display test"));
+        // Check the surrounding formatting.
+        assert!(output.starts_with("SystemCallError ("));
+        assert!(output.ends_with(')'));
+    }
+
+    #[test]
+    fn test_error_trait() {
+        let exception = SystemCallError::with_message("error trait test");
+        let error_obj: &dyn error::Error = &exception;
+        // Our implementation does not provide a source.
+        assert!(error_obj.source().is_none());
+        // to_string() uses Display.
+        assert_eq!(error_obj.to_string(), format!("{exception}"));
+    }
+
+    #[test]
+    fn test_ruby_exception_trait() {
+        let exception = SystemCallError::with_message("ruby trait test");
+        let msg = RubyException::message(&exception);
+        let name = RubyException::name(&exception);
+        assert_eq!(msg.as_bstr(), exception.message().as_bstr());
+        assert_eq!(name, exception.name());
+    }
+
+    #[test]
+    fn test_default() {
+        let default_error = SystemCallError::default();
+        // By default, the message should be an empty slice since Default is auto-derived.
+        assert_eq!(default_error.message(), b"");
+        // The name method always returns the constant exception name.
+        assert_eq!(default_error.name(), "SystemCallError");
+    }
+
+    #[test]
+    fn test_clone() {
+        let original = SystemCallError::with_message("clone test");
+        let cloned = original.clone();
+        assert_eq!(original, cloned, "Cloned error should be equal to the original");
+    }
+
+    #[test]
+    fn test_partial_eq() {
+        let error_a = SystemCallError::with_message("test message");
+        let error_b = SystemCallError::with_message("test message");
+        let error_c = SystemCallError::with_message("different message");
+        assert_eq!(error_a, error_b, "Errors with the same message should be equal");
+        assert_ne!(error_a, error_c, "Errors with different messages should not be equal");
+    }
+
+    #[test]
+    fn test_partial_ord() {
+        let error_a = SystemCallError::with_message("aaa");
+        let error_b = SystemCallError::with_message("bbb");
+        // Same error should compare equal.
+        assert_eq!(error_a.partial_cmp(&error_a), Some(Ordering::Equal));
+        // Lexicographic ordering of the underlying messages.
+        assert_eq!(error_a.partial_cmp(&error_b), Some(Ordering::Less));
+        assert_eq!(error_b.partial_cmp(&error_a), Some(Ordering::Greater));
+    }
+
+    #[test]
+    fn test_ord() {
+        let error_a = SystemCallError::with_message("aaa");
+        let error_b = SystemCallError::with_message("bbb");
+        // Same error should compare equal.
+        assert_eq!(error_a.cmp(&error_a), Ordering::Equal);
+        // Lexicographic ordering of the underlying messages.
+        assert_eq!(error_a.cmp(&error_b), Ordering::Less);
+        assert_eq!(error_b.cmp(&error_a), Ordering::Greater);
     }
 }

--- a/spinoso-exception/src/core/systemexit.rs
+++ b/spinoso-exception/src/core/systemexit.rs
@@ -6,6 +6,7 @@ use alloc::vec::Vec;
 use core::error;
 use core::fmt;
 
+use bstr::ByteSlice;
 use scolapasta_string_escape::format_debug_escape_into;
 
 use crate::RubyException;
@@ -22,9 +23,17 @@ use crate::RubyException;
 /// [`Exception`]: https://ruby-doc.org/core-3.1.2/Exception.html
 /// [`Kernel#raise`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-raise
 /// [`NameError#name`]: https://ruby-doc.org/core-3.1.2/NameError.html#method-i-name
-#[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Default, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct SystemExit {
     message: Cow<'static, [u8]>,
+}
+
+impl fmt::Debug for SystemExit {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SystemExit")
+            .field("message", &self.message().as_bstr())
+            .finish()
+    }
 }
 
 impl SystemExit {
@@ -174,5 +183,180 @@ impl RubyException for SystemExit {
     #[inline]
     fn name(&self) -> Cow<'_, str> {
         Cow::Borrowed(Self::name(self))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::borrow::Cow;
+    use alloc::format;
+    use alloc::string::ToString;
+    use core::cmp::Ordering;
+    use core::error;
+
+    use bstr::ByteSlice;
+
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        let exception = SystemExit::new();
+        assert_eq!(exception.message().as_bstr(), b"SystemExit".as_bstr());
+        assert_eq!(exception.name(), "SystemExit");
+    }
+
+    #[test]
+    fn test_with_message() {
+        let custom_message = "custom message";
+        let exception = SystemExit::with_message(custom_message);
+        assert_eq!(exception.message().as_bstr(), custom_message.as_bytes().as_bstr());
+        // The exception name remains the default even when a custom message is used.
+        assert_eq!(exception.name(), "SystemExit");
+    }
+
+    #[test]
+    fn test_from_string() {
+        let message = "from String".to_string();
+        let exception: SystemExit = message.into();
+        assert_eq!(exception.message().as_bstr(), b"from String".as_bstr());
+    }
+
+    #[test]
+    fn test_from_static_str() {
+        let message: &'static str = "from &'static str";
+        let exception: SystemExit = message.into();
+        assert_eq!(exception.message().as_bstr(), b"from &'static str".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_str_borrowed() {
+        let cow: Cow<'static, str> = Cow::Borrowed("from Cow borrowed");
+        let exception: SystemExit = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow borrowed".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_str_owned() {
+        let cow: Cow<'static, str> = Cow::Owned("from Cow owned".to_string());
+        let exception: SystemExit = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow owned".as_bstr());
+    }
+
+    #[test]
+    fn test_from_vec_u8() {
+        let vec = b"from Vec<u8>".to_vec();
+        let exception: SystemExit = vec.into();
+        assert_eq!(exception.message().as_bstr(), b"from Vec<u8>".as_bstr());
+    }
+
+    #[test]
+    fn test_from_static_slice() {
+        let slice: &'static [u8] = b"from &'static [u8]";
+        let exception: SystemExit = slice.into();
+        assert_eq!(exception.message().as_bstr(), b"from &'static [u8]".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_u8_borrowed() {
+        let cow: Cow<'static, [u8]> = Cow::Borrowed(b"from Cow<u8> borrowed");
+        let exception: SystemExit = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow<u8> borrowed".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_u8_owned() {
+        let cow: Cow<'static, [u8]> = Cow::Owned(b"from Cow<u8> owned".to_vec());
+        let exception: SystemExit = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow<u8> owned".as_bstr());
+    }
+
+    #[test]
+    fn test_debug() {
+        let exception = SystemExit::with_message("display test");
+        let output = format!("{exception:?}");
+        // Expected to contain the exception name and the debug-escaped message.
+        assert!(output.contains("SystemExit"));
+        assert!(output.contains("display test"));
+        // Check the surrounding formatting.
+        assert!(output.starts_with("SystemExit {"));
+        assert!(output.ends_with('}'));
+    }
+
+    #[test]
+    fn test_display() {
+        let exception = SystemExit::with_message("display test");
+        let output = format!("{exception}");
+        // Expected to contain the exception name and the debug-escaped message.
+        assert!(output.contains("SystemExit"));
+        assert!(output.contains("display test"));
+        // Check the surrounding formatting.
+        assert!(output.starts_with("SystemExit ("));
+        assert!(output.ends_with(')'));
+    }
+
+    #[test]
+    fn test_error_trait() {
+        let exception = SystemExit::with_message("error trait test");
+        let error_obj: &dyn error::Error = &exception;
+        // Our implementation does not provide a source.
+        assert!(error_obj.source().is_none());
+        // to_string() uses Display.
+        assert_eq!(error_obj.to_string(), format!("{exception}"));
+    }
+
+    #[test]
+    fn test_ruby_exception_trait() {
+        let exception = SystemExit::with_message("ruby trait test");
+        let msg = RubyException::message(&exception);
+        let name = RubyException::name(&exception);
+        assert_eq!(msg.as_bstr(), exception.message().as_bstr());
+        assert_eq!(name, exception.name());
+    }
+
+    #[test]
+    fn test_default() {
+        let default_error = SystemExit::default();
+        // By default, the message should be an empty slice since Default is auto-derived.
+        assert_eq!(default_error.message(), b"");
+        // The name method always returns the constant exception name.
+        assert_eq!(default_error.name(), "SystemExit");
+    }
+
+    #[test]
+    fn test_clone() {
+        let original = SystemExit::with_message("clone test");
+        let cloned = original.clone();
+        assert_eq!(original, cloned, "Cloned error should be equal to the original");
+    }
+
+    #[test]
+    fn test_partial_eq() {
+        let error_a = SystemExit::with_message("test message");
+        let error_b = SystemExit::with_message("test message");
+        let error_c = SystemExit::with_message("different message");
+        assert_eq!(error_a, error_b, "Errors with the same message should be equal");
+        assert_ne!(error_a, error_c, "Errors with different messages should not be equal");
+    }
+
+    #[test]
+    fn test_partial_ord() {
+        let error_a = SystemExit::with_message("aaa");
+        let error_b = SystemExit::with_message("bbb");
+        // Same error should compare equal.
+        assert_eq!(error_a.partial_cmp(&error_a), Some(Ordering::Equal));
+        // Lexicographic ordering of the underlying messages.
+        assert_eq!(error_a.partial_cmp(&error_b), Some(Ordering::Less));
+        assert_eq!(error_b.partial_cmp(&error_a), Some(Ordering::Greater));
+    }
+
+    #[test]
+    fn test_ord() {
+        let error_a = SystemExit::with_message("aaa");
+        let error_b = SystemExit::with_message("bbb");
+        // Same error should compare equal.
+        assert_eq!(error_a.cmp(&error_a), Ordering::Equal);
+        // Lexicographic ordering of the underlying messages.
+        assert_eq!(error_a.cmp(&error_b), Ordering::Less);
+        assert_eq!(error_b.cmp(&error_a), Ordering::Greater);
     }
 }

--- a/spinoso-exception/src/core/systemstackerror.rs
+++ b/spinoso-exception/src/core/systemstackerror.rs
@@ -6,6 +6,7 @@ use alloc::vec::Vec;
 use core::error;
 use core::fmt;
 
+use bstr::ByteSlice;
 use scolapasta_string_escape::format_debug_escape_into;
 
 use crate::RubyException;
@@ -22,9 +23,17 @@ use crate::RubyException;
 /// [`Exception`]: https://ruby-doc.org/core-3.1.2/Exception.html
 /// [`Kernel#raise`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-raise
 /// [`NameError#name`]: https://ruby-doc.org/core-3.1.2/NameError.html#method-i-name
-#[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Default, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct SystemStackError {
     message: Cow<'static, [u8]>,
+}
+
+impl fmt::Debug for SystemStackError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SystemStackError")
+            .field("message", &self.message().as_bstr())
+            .finish()
+    }
 }
 
 impl SystemStackError {
@@ -174,5 +183,180 @@ impl RubyException for SystemStackError {
     #[inline]
     fn name(&self) -> Cow<'_, str> {
         Cow::Borrowed(Self::name(self))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::borrow::Cow;
+    use alloc::format;
+    use alloc::string::ToString;
+    use core::cmp::Ordering;
+    use core::error;
+
+    use bstr::ByteSlice;
+
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        let exception = SystemStackError::new();
+        assert_eq!(exception.message().as_bstr(), b"SystemStackError".as_bstr());
+        assert_eq!(exception.name(), "SystemStackError");
+    }
+
+    #[test]
+    fn test_with_message() {
+        let custom_message = "custom message";
+        let exception = SystemStackError::with_message(custom_message);
+        assert_eq!(exception.message().as_bstr(), custom_message.as_bytes().as_bstr());
+        // The exception name remains the default even when a custom message is used.
+        assert_eq!(exception.name(), "SystemStackError");
+    }
+
+    #[test]
+    fn test_from_string() {
+        let message = "from String".to_string();
+        let exception: SystemStackError = message.into();
+        assert_eq!(exception.message().as_bstr(), b"from String".as_bstr());
+    }
+
+    #[test]
+    fn test_from_static_str() {
+        let message: &'static str = "from &'static str";
+        let exception: SystemStackError = message.into();
+        assert_eq!(exception.message().as_bstr(), b"from &'static str".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_str_borrowed() {
+        let cow: Cow<'static, str> = Cow::Borrowed("from Cow borrowed");
+        let exception: SystemStackError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow borrowed".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_str_owned() {
+        let cow: Cow<'static, str> = Cow::Owned("from Cow owned".to_string());
+        let exception: SystemStackError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow owned".as_bstr());
+    }
+
+    #[test]
+    fn test_from_vec_u8() {
+        let vec = b"from Vec<u8>".to_vec();
+        let exception: SystemStackError = vec.into();
+        assert_eq!(exception.message().as_bstr(), b"from Vec<u8>".as_bstr());
+    }
+
+    #[test]
+    fn test_from_static_slice() {
+        let slice: &'static [u8] = b"from &'static [u8]";
+        let exception: SystemStackError = slice.into();
+        assert_eq!(exception.message().as_bstr(), b"from &'static [u8]".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_u8_borrowed() {
+        let cow: Cow<'static, [u8]> = Cow::Borrowed(b"from Cow<u8> borrowed");
+        let exception: SystemStackError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow<u8> borrowed".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_u8_owned() {
+        let cow: Cow<'static, [u8]> = Cow::Owned(b"from Cow<u8> owned".to_vec());
+        let exception: SystemStackError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow<u8> owned".as_bstr());
+    }
+
+    #[test]
+    fn test_debug() {
+        let exception = SystemStackError::with_message("display test");
+        let output = format!("{exception:?}");
+        // Expected to contain the exception name and the debug-escaped message.
+        assert!(output.contains("SystemStackError"));
+        assert!(output.contains("display test"));
+        // Check the surrounding formatting.
+        assert!(output.starts_with("SystemStackError {"));
+        assert!(output.ends_with('}'));
+    }
+
+    #[test]
+    fn test_display() {
+        let exception = SystemStackError::with_message("display test");
+        let output = format!("{exception}");
+        // Expected to contain the exception name and the debug-escaped message.
+        assert!(output.contains("SystemStackError"));
+        assert!(output.contains("display test"));
+        // Check the surrounding formatting.
+        assert!(output.starts_with("SystemStackError ("));
+        assert!(output.ends_with(')'));
+    }
+
+    #[test]
+    fn test_error_trait() {
+        let exception = SystemStackError::with_message("error trait test");
+        let error_obj: &dyn error::Error = &exception;
+        // Our implementation does not provide a source.
+        assert!(error_obj.source().is_none());
+        // to_string() uses Display.
+        assert_eq!(error_obj.to_string(), format!("{exception}"));
+    }
+
+    #[test]
+    fn test_ruby_exception_trait() {
+        let exception = SystemStackError::with_message("ruby trait test");
+        let msg = RubyException::message(&exception);
+        let name = RubyException::name(&exception);
+        assert_eq!(msg.as_bstr(), exception.message().as_bstr());
+        assert_eq!(name, exception.name());
+    }
+
+    #[test]
+    fn test_default() {
+        let default_error = SystemStackError::default();
+        // By default, the message should be an empty slice since Default is auto-derived.
+        assert_eq!(default_error.message(), b"");
+        // The name method always returns the constant exception name.
+        assert_eq!(default_error.name(), "SystemStackError");
+    }
+
+    #[test]
+    fn test_clone() {
+        let original = SystemStackError::with_message("clone test");
+        let cloned = original.clone();
+        assert_eq!(original, cloned, "Cloned error should be equal to the original");
+    }
+
+    #[test]
+    fn test_partial_eq() {
+        let error_a = SystemStackError::with_message("test message");
+        let error_b = SystemStackError::with_message("test message");
+        let error_c = SystemStackError::with_message("different message");
+        assert_eq!(error_a, error_b, "Errors with the same message should be equal");
+        assert_ne!(error_a, error_c, "Errors with different messages should not be equal");
+    }
+
+    #[test]
+    fn test_partial_ord() {
+        let error_a = SystemStackError::with_message("aaa");
+        let error_b = SystemStackError::with_message("bbb");
+        // Same error should compare equal.
+        assert_eq!(error_a.partial_cmp(&error_a), Some(Ordering::Equal));
+        // Lexicographic ordering of the underlying messages.
+        assert_eq!(error_a.partial_cmp(&error_b), Some(Ordering::Less));
+        assert_eq!(error_b.partial_cmp(&error_a), Some(Ordering::Greater));
+    }
+
+    #[test]
+    fn test_ord() {
+        let error_a = SystemStackError::with_message("aaa");
+        let error_b = SystemStackError::with_message("bbb");
+        // Same error should compare equal.
+        assert_eq!(error_a.cmp(&error_a), Ordering::Equal);
+        // Lexicographic ordering of the underlying messages.
+        assert_eq!(error_a.cmp(&error_b), Ordering::Less);
+        assert_eq!(error_b.cmp(&error_a), Ordering::Greater);
     }
 }

--- a/spinoso-exception/src/core/threaderror.rs
+++ b/spinoso-exception/src/core/threaderror.rs
@@ -6,6 +6,7 @@ use alloc::vec::Vec;
 use core::error;
 use core::fmt;
 
+use bstr::ByteSlice;
 use scolapasta_string_escape::format_debug_escape_into;
 
 use crate::RubyException;
@@ -22,9 +23,17 @@ use crate::RubyException;
 /// [`Exception`]: https://ruby-doc.org/core-3.1.2/Exception.html
 /// [`Kernel#raise`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-raise
 /// [`NameError#name`]: https://ruby-doc.org/core-3.1.2/NameError.html#method-i-name
-#[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Default, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ThreadError {
     message: Cow<'static, [u8]>,
+}
+
+impl fmt::Debug for ThreadError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ThreadError")
+            .field("message", &self.message().as_bstr())
+            .finish()
+    }
 }
 
 impl ThreadError {
@@ -174,5 +183,180 @@ impl RubyException for ThreadError {
     #[inline]
     fn name(&self) -> Cow<'_, str> {
         Cow::Borrowed(Self::name(self))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::borrow::Cow;
+    use alloc::format;
+    use alloc::string::ToString;
+    use core::cmp::Ordering;
+    use core::error;
+
+    use bstr::ByteSlice;
+
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        let exception = ThreadError::new();
+        assert_eq!(exception.message().as_bstr(), b"ThreadError".as_bstr());
+        assert_eq!(exception.name(), "ThreadError");
+    }
+
+    #[test]
+    fn test_with_message() {
+        let custom_message = "custom message";
+        let exception = ThreadError::with_message(custom_message);
+        assert_eq!(exception.message().as_bstr(), custom_message.as_bytes().as_bstr());
+        // The exception name remains the default even when a custom message is used.
+        assert_eq!(exception.name(), "ThreadError");
+    }
+
+    #[test]
+    fn test_from_string() {
+        let message = "from String".to_string();
+        let exception: ThreadError = message.into();
+        assert_eq!(exception.message().as_bstr(), b"from String".as_bstr());
+    }
+
+    #[test]
+    fn test_from_static_str() {
+        let message: &'static str = "from &'static str";
+        let exception: ThreadError = message.into();
+        assert_eq!(exception.message().as_bstr(), b"from &'static str".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_str_borrowed() {
+        let cow: Cow<'static, str> = Cow::Borrowed("from Cow borrowed");
+        let exception: ThreadError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow borrowed".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_str_owned() {
+        let cow: Cow<'static, str> = Cow::Owned("from Cow owned".to_string());
+        let exception: ThreadError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow owned".as_bstr());
+    }
+
+    #[test]
+    fn test_from_vec_u8() {
+        let vec = b"from Vec<u8>".to_vec();
+        let exception: ThreadError = vec.into();
+        assert_eq!(exception.message().as_bstr(), b"from Vec<u8>".as_bstr());
+    }
+
+    #[test]
+    fn test_from_static_slice() {
+        let slice: &'static [u8] = b"from &'static [u8]";
+        let exception: ThreadError = slice.into();
+        assert_eq!(exception.message().as_bstr(), b"from &'static [u8]".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_u8_borrowed() {
+        let cow: Cow<'static, [u8]> = Cow::Borrowed(b"from Cow<u8> borrowed");
+        let exception: ThreadError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow<u8> borrowed".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_u8_owned() {
+        let cow: Cow<'static, [u8]> = Cow::Owned(b"from Cow<u8> owned".to_vec());
+        let exception: ThreadError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow<u8> owned".as_bstr());
+    }
+
+    #[test]
+    fn test_debug() {
+        let exception = ThreadError::with_message("display test");
+        let output = format!("{exception:?}");
+        // Expected to contain the exception name and the debug-escaped message.
+        assert!(output.contains("ThreadError"));
+        assert!(output.contains("display test"));
+        // Check the surrounding formatting.
+        assert!(output.starts_with("ThreadError {"));
+        assert!(output.ends_with('}'));
+    }
+
+    #[test]
+    fn test_display() {
+        let exception = ThreadError::with_message("display test");
+        let output = format!("{exception}");
+        // Expected to contain the exception name and the debug-escaped message.
+        assert!(output.contains("ThreadError"));
+        assert!(output.contains("display test"));
+        // Check the surrounding formatting.
+        assert!(output.starts_with("ThreadError ("));
+        assert!(output.ends_with(')'));
+    }
+
+    #[test]
+    fn test_error_trait() {
+        let exception = ThreadError::with_message("error trait test");
+        let error_obj: &dyn error::Error = &exception;
+        // Our implementation does not provide a source.
+        assert!(error_obj.source().is_none());
+        // to_string() uses Display.
+        assert_eq!(error_obj.to_string(), format!("{exception}"));
+    }
+
+    #[test]
+    fn test_ruby_exception_trait() {
+        let exception = ThreadError::with_message("ruby trait test");
+        let msg = RubyException::message(&exception);
+        let name = RubyException::name(&exception);
+        assert_eq!(msg.as_bstr(), exception.message().as_bstr());
+        assert_eq!(name, exception.name());
+    }
+
+    #[test]
+    fn test_default() {
+        let default_error = ThreadError::default();
+        // By default, the message should be an empty slice since Default is auto-derived.
+        assert_eq!(default_error.message(), b"");
+        // The name method always returns the constant exception name.
+        assert_eq!(default_error.name(), "ThreadError");
+    }
+
+    #[test]
+    fn test_clone() {
+        let original = ThreadError::with_message("clone test");
+        let cloned = original.clone();
+        assert_eq!(original, cloned, "Cloned error should be equal to the original");
+    }
+
+    #[test]
+    fn test_partial_eq() {
+        let error_a = ThreadError::with_message("test message");
+        let error_b = ThreadError::with_message("test message");
+        let error_c = ThreadError::with_message("different message");
+        assert_eq!(error_a, error_b, "Errors with the same message should be equal");
+        assert_ne!(error_a, error_c, "Errors with different messages should not be equal");
+    }
+
+    #[test]
+    fn test_partial_ord() {
+        let error_a = ThreadError::with_message("aaa");
+        let error_b = ThreadError::with_message("bbb");
+        // Same error should compare equal.
+        assert_eq!(error_a.partial_cmp(&error_a), Some(Ordering::Equal));
+        // Lexicographic ordering of the underlying messages.
+        assert_eq!(error_a.partial_cmp(&error_b), Some(Ordering::Less));
+        assert_eq!(error_b.partial_cmp(&error_a), Some(Ordering::Greater));
+    }
+
+    #[test]
+    fn test_ord() {
+        let error_a = ThreadError::with_message("aaa");
+        let error_b = ThreadError::with_message("bbb");
+        // Same error should compare equal.
+        assert_eq!(error_a.cmp(&error_a), Ordering::Equal);
+        // Lexicographic ordering of the underlying messages.
+        assert_eq!(error_a.cmp(&error_b), Ordering::Less);
+        assert_eq!(error_b.cmp(&error_a), Ordering::Greater);
     }
 }

--- a/spinoso-exception/src/core/typeerror.rs
+++ b/spinoso-exception/src/core/typeerror.rs
@@ -6,6 +6,7 @@ use alloc::vec::Vec;
 use core::error;
 use core::fmt;
 
+use bstr::ByteSlice;
 use scolapasta_string_escape::format_debug_escape_into;
 
 use crate::RubyException;
@@ -22,9 +23,17 @@ use crate::RubyException;
 /// [`Exception`]: https://ruby-doc.org/core-3.1.2/Exception.html
 /// [`Kernel#raise`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-raise
 /// [`NameError#name`]: https://ruby-doc.org/core-3.1.2/NameError.html#method-i-name
-#[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Default, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct TypeError {
     message: Cow<'static, [u8]>,
+}
+
+impl fmt::Debug for TypeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TypeError")
+            .field("message", &self.message().as_bstr())
+            .finish()
+    }
 }
 
 impl TypeError {
@@ -174,5 +183,180 @@ impl RubyException for TypeError {
     #[inline]
     fn name(&self) -> Cow<'_, str> {
         Cow::Borrowed(Self::name(self))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::borrow::Cow;
+    use alloc::format;
+    use alloc::string::ToString;
+    use core::cmp::Ordering;
+    use core::error;
+
+    use bstr::ByteSlice;
+
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        let exception = TypeError::new();
+        assert_eq!(exception.message().as_bstr(), b"TypeError".as_bstr());
+        assert_eq!(exception.name(), "TypeError");
+    }
+
+    #[test]
+    fn test_with_message() {
+        let custom_message = "custom message";
+        let exception = TypeError::with_message(custom_message);
+        assert_eq!(exception.message().as_bstr(), custom_message.as_bytes().as_bstr());
+        // The exception name remains the default even when a custom message is used.
+        assert_eq!(exception.name(), "TypeError");
+    }
+
+    #[test]
+    fn test_from_string() {
+        let message = "from String".to_string();
+        let exception: TypeError = message.into();
+        assert_eq!(exception.message().as_bstr(), b"from String".as_bstr());
+    }
+
+    #[test]
+    fn test_from_static_str() {
+        let message: &'static str = "from &'static str";
+        let exception: TypeError = message.into();
+        assert_eq!(exception.message().as_bstr(), b"from &'static str".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_str_borrowed() {
+        let cow: Cow<'static, str> = Cow::Borrowed("from Cow borrowed");
+        let exception: TypeError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow borrowed".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_str_owned() {
+        let cow: Cow<'static, str> = Cow::Owned("from Cow owned".to_string());
+        let exception: TypeError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow owned".as_bstr());
+    }
+
+    #[test]
+    fn test_from_vec_u8() {
+        let vec = b"from Vec<u8>".to_vec();
+        let exception: TypeError = vec.into();
+        assert_eq!(exception.message().as_bstr(), b"from Vec<u8>".as_bstr());
+    }
+
+    #[test]
+    fn test_from_static_slice() {
+        let slice: &'static [u8] = b"from &'static [u8]";
+        let exception: TypeError = slice.into();
+        assert_eq!(exception.message().as_bstr(), b"from &'static [u8]".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_u8_borrowed() {
+        let cow: Cow<'static, [u8]> = Cow::Borrowed(b"from Cow<u8> borrowed");
+        let exception: TypeError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow<u8> borrowed".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_u8_owned() {
+        let cow: Cow<'static, [u8]> = Cow::Owned(b"from Cow<u8> owned".to_vec());
+        let exception: TypeError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow<u8> owned".as_bstr());
+    }
+
+    #[test]
+    fn test_debug() {
+        let exception = TypeError::with_message("display test");
+        let output = format!("{exception:?}");
+        // Expected to contain the exception name and the debug-escaped message.
+        assert!(output.contains("TypeError"));
+        assert!(output.contains("display test"));
+        // Check the surrounding formatting.
+        assert!(output.starts_with("TypeError {"));
+        assert!(output.ends_with('}'));
+    }
+
+    #[test]
+    fn test_display() {
+        let exception = TypeError::with_message("display test");
+        let output = format!("{exception}");
+        // Expected to contain the exception name and the debug-escaped message.
+        assert!(output.contains("TypeError"));
+        assert!(output.contains("display test"));
+        // Check the surrounding formatting.
+        assert!(output.starts_with("TypeError ("));
+        assert!(output.ends_with(')'));
+    }
+
+    #[test]
+    fn test_error_trait() {
+        let exception = TypeError::with_message("error trait test");
+        let error_obj: &dyn error::Error = &exception;
+        // Our implementation does not provide a source.
+        assert!(error_obj.source().is_none());
+        // to_string() uses Display.
+        assert_eq!(error_obj.to_string(), format!("{exception}"));
+    }
+
+    #[test]
+    fn test_ruby_exception_trait() {
+        let exception = TypeError::with_message("ruby trait test");
+        let msg = RubyException::message(&exception);
+        let name = RubyException::name(&exception);
+        assert_eq!(msg.as_bstr(), exception.message().as_bstr());
+        assert_eq!(name, exception.name());
+    }
+
+    #[test]
+    fn test_default() {
+        let default_error = TypeError::default();
+        // By default, the message should be an empty slice since Default is auto-derived.
+        assert_eq!(default_error.message(), b"");
+        // The name method always returns the constant exception name.
+        assert_eq!(default_error.name(), "TypeError");
+    }
+
+    #[test]
+    fn test_clone() {
+        let original = TypeError::with_message("clone test");
+        let cloned = original.clone();
+        assert_eq!(original, cloned, "Cloned error should be equal to the original");
+    }
+
+    #[test]
+    fn test_partial_eq() {
+        let error_a = TypeError::with_message("test message");
+        let error_b = TypeError::with_message("test message");
+        let error_c = TypeError::with_message("different message");
+        assert_eq!(error_a, error_b, "Errors with the same message should be equal");
+        assert_ne!(error_a, error_c, "Errors with different messages should not be equal");
+    }
+
+    #[test]
+    fn test_partial_ord() {
+        let error_a = TypeError::with_message("aaa");
+        let error_b = TypeError::with_message("bbb");
+        // Same error should compare equal.
+        assert_eq!(error_a.partial_cmp(&error_a), Some(Ordering::Equal));
+        // Lexicographic ordering of the underlying messages.
+        assert_eq!(error_a.partial_cmp(&error_b), Some(Ordering::Less));
+        assert_eq!(error_b.partial_cmp(&error_a), Some(Ordering::Greater));
+    }
+
+    #[test]
+    fn test_ord() {
+        let error_a = TypeError::with_message("aaa");
+        let error_b = TypeError::with_message("bbb");
+        // Same error should compare equal.
+        assert_eq!(error_a.cmp(&error_a), Ordering::Equal);
+        // Lexicographic ordering of the underlying messages.
+        assert_eq!(error_a.cmp(&error_b), Ordering::Less);
+        assert_eq!(error_b.cmp(&error_a), Ordering::Greater);
     }
 }

--- a/spinoso-exception/src/core/uncaughtthrowerror.rs
+++ b/spinoso-exception/src/core/uncaughtthrowerror.rs
@@ -6,6 +6,7 @@ use alloc::vec::Vec;
 use core::error;
 use core::fmt;
 
+use bstr::ByteSlice;
 use scolapasta_string_escape::format_debug_escape_into;
 
 use crate::RubyException;
@@ -22,9 +23,17 @@ use crate::RubyException;
 /// [`Exception`]: https://ruby-doc.org/core-3.1.2/Exception.html
 /// [`Kernel#raise`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-raise
 /// [`NameError#name`]: https://ruby-doc.org/core-3.1.2/NameError.html#method-i-name
-#[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Default, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct UncaughtThrowError {
     message: Cow<'static, [u8]>,
+}
+
+impl fmt::Debug for UncaughtThrowError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("UncaughtThrowError")
+            .field("message", &self.message().as_bstr())
+            .finish()
+    }
 }
 
 impl UncaughtThrowError {
@@ -174,5 +183,180 @@ impl RubyException for UncaughtThrowError {
     #[inline]
     fn name(&self) -> Cow<'_, str> {
         Cow::Borrowed(Self::name(self))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::borrow::Cow;
+    use alloc::format;
+    use alloc::string::ToString;
+    use core::cmp::Ordering;
+    use core::error;
+
+    use bstr::ByteSlice;
+
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        let exception = UncaughtThrowError::new();
+        assert_eq!(exception.message().as_bstr(), b"UncaughtThrowError".as_bstr());
+        assert_eq!(exception.name(), "UncaughtThrowError");
+    }
+
+    #[test]
+    fn test_with_message() {
+        let custom_message = "custom message";
+        let exception = UncaughtThrowError::with_message(custom_message);
+        assert_eq!(exception.message().as_bstr(), custom_message.as_bytes().as_bstr());
+        // The exception name remains the default even when a custom message is used.
+        assert_eq!(exception.name(), "UncaughtThrowError");
+    }
+
+    #[test]
+    fn test_from_string() {
+        let message = "from String".to_string();
+        let exception: UncaughtThrowError = message.into();
+        assert_eq!(exception.message().as_bstr(), b"from String".as_bstr());
+    }
+
+    #[test]
+    fn test_from_static_str() {
+        let message: &'static str = "from &'static str";
+        let exception: UncaughtThrowError = message.into();
+        assert_eq!(exception.message().as_bstr(), b"from &'static str".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_str_borrowed() {
+        let cow: Cow<'static, str> = Cow::Borrowed("from Cow borrowed");
+        let exception: UncaughtThrowError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow borrowed".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_str_owned() {
+        let cow: Cow<'static, str> = Cow::Owned("from Cow owned".to_string());
+        let exception: UncaughtThrowError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow owned".as_bstr());
+    }
+
+    #[test]
+    fn test_from_vec_u8() {
+        let vec = b"from Vec<u8>".to_vec();
+        let exception: UncaughtThrowError = vec.into();
+        assert_eq!(exception.message().as_bstr(), b"from Vec<u8>".as_bstr());
+    }
+
+    #[test]
+    fn test_from_static_slice() {
+        let slice: &'static [u8] = b"from &'static [u8]";
+        let exception: UncaughtThrowError = slice.into();
+        assert_eq!(exception.message().as_bstr(), b"from &'static [u8]".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_u8_borrowed() {
+        let cow: Cow<'static, [u8]> = Cow::Borrowed(b"from Cow<u8> borrowed");
+        let exception: UncaughtThrowError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow<u8> borrowed".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_u8_owned() {
+        let cow: Cow<'static, [u8]> = Cow::Owned(b"from Cow<u8> owned".to_vec());
+        let exception: UncaughtThrowError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow<u8> owned".as_bstr());
+    }
+
+    #[test]
+    fn test_debug() {
+        let exception = UncaughtThrowError::with_message("display test");
+        let output = format!("{exception:?}");
+        // Expected to contain the exception name and the debug-escaped message.
+        assert!(output.contains("UncaughtThrowError"));
+        assert!(output.contains("display test"));
+        // Check the surrounding formatting.
+        assert!(output.starts_with("UncaughtThrowError {"));
+        assert!(output.ends_with('}'));
+    }
+
+    #[test]
+    fn test_display() {
+        let exception = UncaughtThrowError::with_message("display test");
+        let output = format!("{exception}");
+        // Expected to contain the exception name and the debug-escaped message.
+        assert!(output.contains("UncaughtThrowError"));
+        assert!(output.contains("display test"));
+        // Check the surrounding formatting.
+        assert!(output.starts_with("UncaughtThrowError ("));
+        assert!(output.ends_with(')'));
+    }
+
+    #[test]
+    fn test_error_trait() {
+        let exception = UncaughtThrowError::with_message("error trait test");
+        let error_obj: &dyn error::Error = &exception;
+        // Our implementation does not provide a source.
+        assert!(error_obj.source().is_none());
+        // to_string() uses Display.
+        assert_eq!(error_obj.to_string(), format!("{exception}"));
+    }
+
+    #[test]
+    fn test_ruby_exception_trait() {
+        let exception = UncaughtThrowError::with_message("ruby trait test");
+        let msg = RubyException::message(&exception);
+        let name = RubyException::name(&exception);
+        assert_eq!(msg.as_bstr(), exception.message().as_bstr());
+        assert_eq!(name, exception.name());
+    }
+
+    #[test]
+    fn test_default() {
+        let default_error = UncaughtThrowError::default();
+        // By default, the message should be an empty slice since Default is auto-derived.
+        assert_eq!(default_error.message(), b"");
+        // The name method always returns the constant exception name.
+        assert_eq!(default_error.name(), "UncaughtThrowError");
+    }
+
+    #[test]
+    fn test_clone() {
+        let original = UncaughtThrowError::with_message("clone test");
+        let cloned = original.clone();
+        assert_eq!(original, cloned, "Cloned error should be equal to the original");
+    }
+
+    #[test]
+    fn test_partial_eq() {
+        let error_a = UncaughtThrowError::with_message("test message");
+        let error_b = UncaughtThrowError::with_message("test message");
+        let error_c = UncaughtThrowError::with_message("different message");
+        assert_eq!(error_a, error_b, "Errors with the same message should be equal");
+        assert_ne!(error_a, error_c, "Errors with different messages should not be equal");
+    }
+
+    #[test]
+    fn test_partial_ord() {
+        let error_a = UncaughtThrowError::with_message("aaa");
+        let error_b = UncaughtThrowError::with_message("bbb");
+        // Same error should compare equal.
+        assert_eq!(error_a.partial_cmp(&error_a), Some(Ordering::Equal));
+        // Lexicographic ordering of the underlying messages.
+        assert_eq!(error_a.partial_cmp(&error_b), Some(Ordering::Less));
+        assert_eq!(error_b.partial_cmp(&error_a), Some(Ordering::Greater));
+    }
+
+    #[test]
+    fn test_ord() {
+        let error_a = UncaughtThrowError::with_message("aaa");
+        let error_b = UncaughtThrowError::with_message("bbb");
+        // Same error should compare equal.
+        assert_eq!(error_a.cmp(&error_a), Ordering::Equal);
+        // Lexicographic ordering of the underlying messages.
+        assert_eq!(error_a.cmp(&error_b), Ordering::Less);
+        assert_eq!(error_b.cmp(&error_a), Ordering::Greater);
     }
 }

--- a/spinoso-exception/src/core/zerodivisionerror.rs
+++ b/spinoso-exception/src/core/zerodivisionerror.rs
@@ -6,6 +6,7 @@ use alloc::vec::Vec;
 use core::error;
 use core::fmt;
 
+use bstr::ByteSlice;
 use scolapasta_string_escape::format_debug_escape_into;
 
 use crate::RubyException;
@@ -22,9 +23,17 @@ use crate::RubyException;
 /// [`Exception`]: https://ruby-doc.org/core-3.1.2/Exception.html
 /// [`Kernel#raise`]: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-raise
 /// [`NameError#name`]: https://ruby-doc.org/core-3.1.2/NameError.html#method-i-name
-#[derive(Default, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Default, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ZeroDivisionError {
     message: Cow<'static, [u8]>,
+}
+
+impl fmt::Debug for ZeroDivisionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ZeroDivisionError")
+            .field("message", &self.message().as_bstr())
+            .finish()
+    }
 }
 
 impl ZeroDivisionError {
@@ -174,5 +183,180 @@ impl RubyException for ZeroDivisionError {
     #[inline]
     fn name(&self) -> Cow<'_, str> {
         Cow::Borrowed(Self::name(self))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::borrow::Cow;
+    use alloc::format;
+    use alloc::string::ToString;
+    use core::cmp::Ordering;
+    use core::error;
+
+    use bstr::ByteSlice;
+
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        let exception = ZeroDivisionError::new();
+        assert_eq!(exception.message().as_bstr(), b"ZeroDivisionError".as_bstr());
+        assert_eq!(exception.name(), "ZeroDivisionError");
+    }
+
+    #[test]
+    fn test_with_message() {
+        let custom_message = "custom message";
+        let exception = ZeroDivisionError::with_message(custom_message);
+        assert_eq!(exception.message().as_bstr(), custom_message.as_bytes().as_bstr());
+        // The exception name remains the default even when a custom message is used.
+        assert_eq!(exception.name(), "ZeroDivisionError");
+    }
+
+    #[test]
+    fn test_from_string() {
+        let message = "from String".to_string();
+        let exception: ZeroDivisionError = message.into();
+        assert_eq!(exception.message().as_bstr(), b"from String".as_bstr());
+    }
+
+    #[test]
+    fn test_from_static_str() {
+        let message: &'static str = "from &'static str";
+        let exception: ZeroDivisionError = message.into();
+        assert_eq!(exception.message().as_bstr(), b"from &'static str".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_str_borrowed() {
+        let cow: Cow<'static, str> = Cow::Borrowed("from Cow borrowed");
+        let exception: ZeroDivisionError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow borrowed".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_str_owned() {
+        let cow: Cow<'static, str> = Cow::Owned("from Cow owned".to_string());
+        let exception: ZeroDivisionError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow owned".as_bstr());
+    }
+
+    #[test]
+    fn test_from_vec_u8() {
+        let vec = b"from Vec<u8>".to_vec();
+        let exception: ZeroDivisionError = vec.into();
+        assert_eq!(exception.message().as_bstr(), b"from Vec<u8>".as_bstr());
+    }
+
+    #[test]
+    fn test_from_static_slice() {
+        let slice: &'static [u8] = b"from &'static [u8]";
+        let exception: ZeroDivisionError = slice.into();
+        assert_eq!(exception.message().as_bstr(), b"from &'static [u8]".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_u8_borrowed() {
+        let cow: Cow<'static, [u8]> = Cow::Borrowed(b"from Cow<u8> borrowed");
+        let exception: ZeroDivisionError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow<u8> borrowed".as_bstr());
+    }
+
+    #[test]
+    fn test_from_cow_u8_owned() {
+        let cow: Cow<'static, [u8]> = Cow::Owned(b"from Cow<u8> owned".to_vec());
+        let exception: ZeroDivisionError = cow.into();
+        assert_eq!(exception.message().as_bstr(), b"from Cow<u8> owned".as_bstr());
+    }
+
+    #[test]
+    fn test_debug() {
+        let exception = ZeroDivisionError::with_message("display test");
+        let output = format!("{exception:?}");
+        // Expected to contain the exception name and the debug-escaped message.
+        assert!(output.contains("ZeroDivisionError"));
+        assert!(output.contains("display test"));
+        // Check the surrounding formatting.
+        assert!(output.starts_with("ZeroDivisionError {"));
+        assert!(output.ends_with('}'));
+    }
+
+    #[test]
+    fn test_display() {
+        let exception = ZeroDivisionError::with_message("display test");
+        let output = format!("{exception}");
+        // Expected to contain the exception name and the debug-escaped message.
+        assert!(output.contains("ZeroDivisionError"));
+        assert!(output.contains("display test"));
+        // Check the surrounding formatting.
+        assert!(output.starts_with("ZeroDivisionError ("));
+        assert!(output.ends_with(')'));
+    }
+
+    #[test]
+    fn test_error_trait() {
+        let exception = ZeroDivisionError::with_message("error trait test");
+        let error_obj: &dyn error::Error = &exception;
+        // Our implementation does not provide a source.
+        assert!(error_obj.source().is_none());
+        // to_string() uses Display.
+        assert_eq!(error_obj.to_string(), format!("{exception}"));
+    }
+
+    #[test]
+    fn test_ruby_exception_trait() {
+        let exception = ZeroDivisionError::with_message("ruby trait test");
+        let msg = RubyException::message(&exception);
+        let name = RubyException::name(&exception);
+        assert_eq!(msg.as_bstr(), exception.message().as_bstr());
+        assert_eq!(name, exception.name());
+    }
+
+    #[test]
+    fn test_default() {
+        let default_error = ZeroDivisionError::default();
+        // By default, the message should be an empty slice since Default is auto-derived.
+        assert_eq!(default_error.message(), b"");
+        // The name method always returns the constant exception name.
+        assert_eq!(default_error.name(), "ZeroDivisionError");
+    }
+
+    #[test]
+    fn test_clone() {
+        let original = ZeroDivisionError::with_message("clone test");
+        let cloned = original.clone();
+        assert_eq!(original, cloned, "Cloned error should be equal to the original");
+    }
+
+    #[test]
+    fn test_partial_eq() {
+        let error_a = ZeroDivisionError::with_message("test message");
+        let error_b = ZeroDivisionError::with_message("test message");
+        let error_c = ZeroDivisionError::with_message("different message");
+        assert_eq!(error_a, error_b, "Errors with the same message should be equal");
+        assert_ne!(error_a, error_c, "Errors with different messages should not be equal");
+    }
+
+    #[test]
+    fn test_partial_ord() {
+        let error_a = ZeroDivisionError::with_message("aaa");
+        let error_b = ZeroDivisionError::with_message("bbb");
+        // Same error should compare equal.
+        assert_eq!(error_a.partial_cmp(&error_a), Some(Ordering::Equal));
+        // Lexicographic ordering of the underlying messages.
+        assert_eq!(error_a.partial_cmp(&error_b), Some(Ordering::Less));
+        assert_eq!(error_b.partial_cmp(&error_a), Some(Ordering::Greater));
+    }
+
+    #[test]
+    fn test_ord() {
+        let error_a = ZeroDivisionError::with_message("aaa");
+        let error_b = ZeroDivisionError::with_message("bbb");
+        // Same error should compare equal.
+        assert_eq!(error_a.cmp(&error_a), Ordering::Equal);
+        // Lexicographic ordering of the underlying messages.
+        assert_eq!(error_a.cmp(&error_b), Ordering::Less);
+        assert_eq!(error_b.cmp(&error_a), Ordering::Greater);
     }
 }


### PR DESCRIPTION
Add `bstr` as a dep for a better `Debug` impl and test assertion helpers. Remove `Hash` impl on exception types. Bump crate version.