### PR TITLE
Propagate rust-version to cargo-deny action

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -62,3 +62,4 @@ jobs:
           arguments: --locked --all-features
           command: check ${{ matrix.checks }}
           command-arguments: --show-stats
+          rust-version: "1.83.0"

--- a/Rakefile
+++ b/Rakefile
@@ -211,7 +211,7 @@ namespace :toolchain do
 
       workflow_files.each do |file|
         contents = File.read(file)
-        contents = contents.gsub(/(toolchain: "?)\d+\.\d+\.\d+("?)/, "\\1#{toolchain_version}\\2")
+        contents = contents.gsub(/((toolchain|rust-version): "?)\d+\.\d+\.\d+("?)/, "\\1#{toolchain_version}\\3")
 
         File.write(file, contents)
       end


### PR DESCRIPTION
Fix failing audit build on trunk.