### PR TITLE
Use let-else where possible in artichoke-backend

### DIFF
--- a/artichoke-backend/src/class.rs
+++ b/artichoke-backend/src/class.rs
@@ -45,18 +45,16 @@ impl<'a> Builder<'a> {
         U: Into<Cow<'static, str>>,
     {
         let state = self.interp.state.as_deref().ok_or_else(InterpreterExtractError::new)?;
-        let rclass = if let Some(spec) = state.classes.get::<T>() {
-            spec.rclass()
-        } else {
+        let Some(spec) = state.classes.get::<T>() else {
             return Err(NotDefinedError::super_class(classname.into()).into());
         };
+        let rclass = spec.rclass();
         let rclass = unsafe { self.interp.with_ffi_boundary(|mrb| rclass.resolve(mrb))? };
-        if let Some(rclass) = rclass {
-            self.super_class = Some(rclass);
-            Ok(self)
-        } else {
-            Err(NotDefinedError::super_class(classname.into()).into())
-        }
+        let Some(rclass) = rclass else {
+            return Err(NotDefinedError::super_class(classname.into()).into());
+        };
+        self.super_class = Some(rclass);
+        Ok(self)
     }
 
     pub fn add_method<T>(mut self, name: T, method: Method, args: sys::mrb_aspec) -> Result<Self, ConstantNameError>
@@ -108,17 +106,16 @@ impl<'a> Builder<'a> {
             rclass
         } else if let Some(enclosing_scope) = self.spec.enclosing_scope() {
             let scope = unsafe { self.interp.with_ffi_boundary(|mrb| enclosing_scope.rclass(mrb)) };
-            if let Ok(Some(mut scope)) = scope {
-                let rclass = unsafe {
-                    self.interp.with_ffi_boundary(|mrb| {
-                        sys::mrb_define_class_under(mrb, scope.as_mut(), name, super_class.as_mut())
-                    })
-                };
-                let rclass = rclass.map_err(|_| NotDefinedError::class(self.spec.name()))?;
-                NonNull::new(rclass).ok_or_else(|| NotDefinedError::class(self.spec.name()))?
-            } else {
+            let Ok(Some(mut scope)) = scope else {
                 return Err(NotDefinedError::enclosing_scope(enclosing_scope.fqname().into_owned()));
-            }
+            };
+            let rclass = unsafe {
+                self.interp.with_ffi_boundary(|mrb| {
+                    sys::mrb_define_class_under(mrb, scope.as_mut(), name, super_class.as_mut())
+                })
+            };
+            let rclass = rclass.map_err(|_| NotDefinedError::class(self.spec.name()))?;
+            NonNull::new(rclass).ok_or_else(|| NotDefinedError::class(self.spec.name()))?
         } else {
             let rclass = unsafe {
                 self.interp
@@ -264,14 +261,13 @@ impl Spec {
 
     #[must_use]
     pub fn fqname(&self) -> Cow<'_, str> {
-        if let Some(scope) = self.enclosing_scope() {
-            let mut fqname = String::from(scope.fqname());
-            fqname.push_str("::");
-            fqname.push_str(self.name.as_ref());
-            fqname.into()
-        } else {
-            self.name.as_ref().into()
-        }
+        let Some(scope) = self.enclosing_scope() else {
+            return self.name();
+        };
+        let mut fqname = String::from(scope.fqname());
+        fqname.push_str("::");
+        fqname.push_str(self.name.as_ref());
+        fqname.into()
     }
 
     #[must_use]

--- a/artichoke-backend/src/class_registry.rs
+++ b/artichoke-backend/src/class_registry.rs
@@ -37,11 +37,10 @@ impl ClassRegistry for Artichoke {
     {
         let state = self.state.as_deref().ok_or_else(InterpreterExtractError::new)?;
         let spec = state.classes.get::<T>();
-        let rclass = if let Some(spec) = spec {
-            spec.rclass()
-        } else {
+        let Some(spec) = spec else {
             return Ok(None);
         };
+        let rclass = spec.rclass();
         let value_class = unsafe {
             self.with_ffi_boundary(|mrb| {
                 if let Some(mut rclass) = rclass.resolve(mrb) {
@@ -61,15 +60,12 @@ impl ClassRegistry for Artichoke {
     {
         let state = self.state.as_deref().ok_or_else(InterpreterExtractError::new)?;
         let spec = state.classes.get::<T>();
-        let rclass = if let Some(spec) = spec {
-            spec.rclass()
-        } else {
+        let Some(spec) = spec else {
             return Ok(None);
         };
+        let rclass = spec.rclass();
         let args = args.iter().map(Value::inner).collect::<Vec<_>>();
-        let arglen = if let Ok(len) = sys::mrb_int::try_from(args.len()) {
-            len
-        } else {
+        let Ok(arglen) = sys::mrb_int::try_from(args.len()) else {
             return Ok(None);
         };
         let instance = unsafe {

--- a/artichoke-backend/src/coerce_to_numeric.rs
+++ b/artichoke-backend/src/coerce_to_numeric.rs
@@ -24,36 +24,39 @@ impl CoerceToNumeric for Artichoke {
             Ruby::Nil => return Err(TypeError::with_message("can't convert nil into Float").into()),
             _ => {}
         }
+
         // TODO: This branch should use `numeric::coerce`
         let class_of_numeric = self.eval(b"Numeric")?;
         let is_a_numeric = value.funcall(self, "is_a?", &[class_of_numeric], None)?;
         let is_a_numeric = self.try_convert(is_a_numeric);
-        if let Ok(true) = is_a_numeric {
-            if !value.respond_to(self, "to_f")? {
-                let mut message = String::from("can't convert ");
-                message.push_str(self.inspect_type_name_for_value(value));
-                message.push_str(" into Float");
-                return Err(TypeError::from(message).into());
-            }
-            let coerced = value.funcall(self, "to_f", &[], None)?;
-            if let Ruby::Float = coerced.ruby_type() {
-                coerced.try_convert_into::<f64>(self)
-            } else {
-                let mut message = String::from("can't convert ");
-                let name = self.inspect_type_name_for_value(value);
-                message.push_str(name);
-                message.push_str(" into Float (");
-                message.push_str(name);
-                message.push_str("#to_f gives ");
-                message.push_str(self.inspect_type_name_for_value(coerced));
-                message.push(')');
-                Err(TypeError::from(message).into())
-            }
-        } else {
+
+        let Ok(true) = is_a_numeric else {
             let mut message = String::from("can't convert ");
             message.push_str(self.inspect_type_name_for_value(value));
             message.push_str(" into Float");
-            Err(TypeError::from(message).into())
+            return Err(TypeError::from(message).into());
+        };
+
+        if !value.respond_to(self, "to_f")? {
+            let mut message = String::from("can't convert ");
+            message.push_str(self.inspect_type_name_for_value(value));
+            message.push_str(" into Float");
+            return Err(TypeError::from(message).into());
         }
+
+        let coerced = value.funcall(self, "to_f", &[], None)?;
+        let Ruby::Float = coerced.ruby_type() else {
+            let mut message = String::from("can't convert ");
+            let name = self.inspect_type_name_for_value(value);
+            message.push_str(name);
+            message.push_str(" into Float (");
+            message.push_str(name);
+            message.push_str("#to_f gives ");
+            message.push_str(self.inspect_type_name_for_value(coerced));
+            message.push(')');
+            return Err(TypeError::from(message).into());
+        };
+
+        coerced.try_convert_into::<f64>(self)
     }
 }

--- a/artichoke-backend/src/constant.rs
+++ b/artichoke-backend/src/constant.rs
@@ -14,9 +14,7 @@ impl DefineConstant for Artichoke {
     type Error = Error;
 
     fn define_global_constant(&mut self, constant: &str, value: Self::Value) -> Result<(), Self::Error> {
-        let name = if let Ok(name) = CString::new(constant) {
-            name
-        } else {
+        let Ok(name) = CString::new(constant) else {
             return Err(ConstantNameError::from(String::from(constant)).into());
         };
         unsafe {
@@ -29,9 +27,7 @@ impl DefineConstant for Artichoke {
     where
         T: 'static,
     {
-        let name = if let Ok(name) = CString::new(constant) {
-            name
-        } else {
+        let Ok(name) = CString::new(constant) else {
             return Err(ConstantNameError::from(String::from(constant)).into());
         };
         let state = self.state.as_deref_mut().ok_or_else(InterpreterExtractError::new)?;
@@ -42,25 +38,22 @@ impl DefineConstant for Artichoke {
         let rclass = spec.rclass();
 
         let rclass = unsafe { self.with_ffi_boundary(|mrb| rclass.resolve(mrb))? };
-        if let Some(mut rclass) = rclass {
-            unsafe {
-                self.with_ffi_boundary(|mrb| {
-                    sys::mrb_define_const(mrb, rclass.as_mut(), name.as_ptr(), value.inner());
-                })?;
-            }
-            Ok(())
-        } else {
-            Err(NotDefinedError::class_constant(String::from(constant)).into())
+        let Some(mut rclass) = rclass else {
+            return Err(NotDefinedError::class_constant(String::from(constant)).into());
+        };
+        unsafe {
+            self.with_ffi_boundary(|mrb| {
+                sys::mrb_define_const(mrb, rclass.as_mut(), name.as_ptr(), value.inner());
+            })?;
         }
+        Ok(())
     }
 
     fn define_module_constant<T>(&mut self, constant: &str, value: Self::Value) -> Result<(), Self::Error>
     where
         T: 'static,
     {
-        let name = if let Ok(name) = CString::new(constant) {
-            name
-        } else {
+        let Ok(name) = CString::new(constant) else {
             return Err(ConstantNameError::from(String::from(constant)).into());
         };
         let state = self.state.as_deref_mut().ok_or_else(InterpreterExtractError::new)?;
@@ -71,15 +64,14 @@ impl DefineConstant for Artichoke {
         let rclass = spec.rclass();
 
         let rclass = unsafe { self.with_ffi_boundary(|mrb| rclass.resolve(mrb))? };
-        if let Some(mut rclass) = rclass {
-            unsafe {
-                self.with_ffi_boundary(|mrb| {
-                    sys::mrb_define_const(mrb, rclass.as_mut(), name.as_ptr(), value.inner());
-                })?;
-            }
-            Ok(())
-        } else {
-            Err(NotDefinedError::module_constant(String::from(constant)).into())
+        let Some(mut rclass) = rclass else {
+            return Err(NotDefinedError::module_constant(String::from(constant)).into());
+        };
+        unsafe {
+            self.with_ffi_boundary(|mrb| {
+                sys::mrb_define_const(mrb, rclass.as_mut(), name.as_ptr(), value.inner());
+            })?;
         }
+        Ok(())
     }
 }

--- a/artichoke-backend/src/convert/array.rs
+++ b/artichoke-backend/src/convert/array.rs
@@ -287,12 +287,11 @@ impl TryConvertMut<Value, Vec<Value>> for Artichoke {
     type Error = Error;
 
     fn try_convert_mut(&mut self, mut value: Value) -> Result<Vec<Value>, Self::Error> {
-        if let Ruby::Array = value.ruby_type() {
-            let array = unsafe { Array::unbox_from_value(&mut value, self)? };
-            Ok(array.iter().collect())
-        } else {
-            Err(UnboxRubyError::new(&value, Rust::Vec).into())
-        }
+        let Ruby::Array = value.ruby_type() else {
+            return Err(UnboxRubyError::new(&value, Rust::Vec).into());
+        };
+        let array = unsafe { Array::unbox_from_value(&mut value, self)? };
+        Ok(array.iter().collect())
     }
 }
 
@@ -300,12 +299,11 @@ impl TryConvertMut<Value, Vec<Vec<u8>>> for Artichoke {
     type Error = Error;
 
     fn try_convert_mut(&mut self, mut value: Value) -> Result<Vec<Vec<u8>>, Self::Error> {
-        if let Ruby::Array = value.ruby_type() {
-            let array = unsafe { Array::unbox_from_value(&mut value, self)? };
-            array.iter().map(|elem| self.try_convert_mut(elem)).collect()
-        } else {
-            Err(UnboxRubyError::new(&value, Rust::Vec).into())
-        }
+        let Ruby::Array = value.ruby_type() else {
+            return Err(UnboxRubyError::new(&value, Rust::Vec).into());
+        };
+        let array = unsafe { Array::unbox_from_value(&mut value, self)? };
+        array.iter().map(|elem| self.try_convert_mut(elem)).collect()
     }
 }
 
@@ -313,12 +311,11 @@ impl TryConvertMut<Value, Vec<Option<Vec<u8>>>> for Artichoke {
     type Error = Error;
 
     fn try_convert_mut(&mut self, mut value: Value) -> Result<Vec<Option<Vec<u8>>>, Self::Error> {
-        if let Ruby::Array = value.ruby_type() {
-            let array = unsafe { Array::unbox_from_value(&mut value, self)? };
-            array.iter().map(|elem| self.try_convert_mut(elem)).collect()
-        } else {
-            Err(UnboxRubyError::new(&value, Rust::Vec).into())
-        }
+        let Ruby::Array = value.ruby_type() else {
+            return Err(UnboxRubyError::new(&value, Rust::Vec).into());
+        };
+        let array = unsafe { Array::unbox_from_value(&mut value, self)? };
+        array.iter().map(|elem| self.try_convert_mut(elem)).collect()
     }
 }
 
@@ -326,12 +323,11 @@ impl<'a> TryConvertMut<Value, Vec<&'a [u8]>> for Artichoke {
     type Error = Error;
 
     fn try_convert_mut(&mut self, mut value: Value) -> Result<Vec<&'a [u8]>, Self::Error> {
-        if let Ruby::Array = value.ruby_type() {
-            let array = unsafe { Array::unbox_from_value(&mut value, self)? };
-            array.iter().map(|elem| self.try_convert_mut(elem)).collect()
-        } else {
-            Err(UnboxRubyError::new(&value, Rust::Vec).into())
-        }
+        let Ruby::Array = value.ruby_type() else {
+            return Err(UnboxRubyError::new(&value, Rust::Vec).into());
+        };
+        let array = unsafe { Array::unbox_from_value(&mut value, self)? };
+        array.iter().map(|elem| self.try_convert_mut(elem)).collect()
     }
 }
 
@@ -339,12 +335,11 @@ impl<'a> TryConvertMut<Value, Vec<Option<&'a [u8]>>> for Artichoke {
     type Error = Error;
 
     fn try_convert_mut(&mut self, mut value: Value) -> Result<Vec<Option<&'a [u8]>>, Self::Error> {
-        if let Ruby::Array = value.ruby_type() {
-            let array = unsafe { Array::unbox_from_value(&mut value, self)? };
-            array.iter().map(|elem| self.try_convert_mut(elem)).collect()
-        } else {
-            Err(UnboxRubyError::new(&value, Rust::Vec).into())
-        }
+        let Ruby::Array = value.ruby_type() else {
+            return Err(UnboxRubyError::new(&value, Rust::Vec).into());
+        };
+        let array = unsafe { Array::unbox_from_value(&mut value, self)? };
+        array.iter().map(|elem| self.try_convert_mut(elem)).collect()
     }
 }
 
@@ -352,12 +347,11 @@ impl TryConvertMut<Value, Vec<String>> for Artichoke {
     type Error = Error;
 
     fn try_convert_mut(&mut self, mut value: Value) -> Result<Vec<String>, Self::Error> {
-        if let Ruby::Array = value.ruby_type() {
-            let array = unsafe { Array::unbox_from_value(&mut value, self)? };
-            array.iter().map(|elem| self.try_convert_mut(elem)).collect()
-        } else {
-            Err(UnboxRubyError::new(&value, Rust::Vec).into())
-        }
+        let Ruby::Array = value.ruby_type() else {
+            return Err(UnboxRubyError::new(&value, Rust::Vec).into());
+        };
+        let array = unsafe { Array::unbox_from_value(&mut value, self)? };
+        array.iter().map(|elem| self.try_convert_mut(elem)).collect()
     }
 }
 
@@ -365,12 +359,11 @@ impl TryConvertMut<Value, Vec<Option<String>>> for Artichoke {
     type Error = Error;
 
     fn try_convert_mut(&mut self, mut value: Value) -> Result<Vec<Option<String>>, Self::Error> {
-        if let Ruby::Array = value.ruby_type() {
-            let array = unsafe { Array::unbox_from_value(&mut value, self)? };
-            array.iter().map(|elem| self.try_convert_mut(elem)).collect()
-        } else {
-            Err(UnboxRubyError::new(&value, Rust::Vec).into())
-        }
+        let Ruby::Array = value.ruby_type() else {
+            return Err(UnboxRubyError::new(&value, Rust::Vec).into());
+        };
+        let array = unsafe { Array::unbox_from_value(&mut value, self)? };
+        array.iter().map(|elem| self.try_convert_mut(elem)).collect()
     }
 }
 
@@ -378,12 +371,11 @@ impl<'a> TryConvertMut<Value, Vec<&'a str>> for Artichoke {
     type Error = Error;
 
     fn try_convert_mut(&mut self, mut value: Value) -> Result<Vec<&'a str>, Self::Error> {
-        if let Ruby::Array = value.ruby_type() {
-            let array = unsafe { Array::unbox_from_value(&mut value, self)? };
-            array.iter().map(|elem| self.try_convert_mut(elem)).collect()
-        } else {
-            Err(UnboxRubyError::new(&value, Rust::Vec).into())
-        }
+        let Ruby::Array = value.ruby_type() else {
+            return Err(UnboxRubyError::new(&value, Rust::Vec).into());
+        };
+        let array = unsafe { Array::unbox_from_value(&mut value, self)? };
+        array.iter().map(|elem| self.try_convert_mut(elem)).collect()
     }
 }
 
@@ -391,12 +383,11 @@ impl<'a> TryConvertMut<Value, Vec<Option<&'a str>>> for Artichoke {
     type Error = Error;
 
     fn try_convert_mut(&mut self, mut value: Value) -> Result<Vec<Option<&'a str>>, Self::Error> {
-        if let Ruby::Array = value.ruby_type() {
-            let array = unsafe { Array::unbox_from_value(&mut value, self)? };
-            array.iter().map(|elem| self.try_convert_mut(elem)).collect()
-        } else {
-            Err(UnboxRubyError::new(&value, Rust::Vec).into())
-        }
+        let Ruby::Array = value.ruby_type() else {
+            return Err(UnboxRubyError::new(&value, Rust::Vec).into());
+        };
+        let array = unsafe { Array::unbox_from_value(&mut value, self)? };
+        array.iter().map(|elem| self.try_convert_mut(elem)).collect()
     }
 }
 
@@ -404,12 +395,11 @@ impl TryConvertMut<Value, Vec<i64>> for Artichoke {
     type Error = Error;
 
     fn try_convert_mut(&mut self, mut value: Value) -> Result<Vec<i64>, Self::Error> {
-        if let Ruby::Array = value.ruby_type() {
-            let array = unsafe { Array::unbox_from_value(&mut value, self)? };
-            array.iter().map(|elem| self.try_convert(elem)).collect()
-        } else {
-            Err(UnboxRubyError::new(&value, Rust::Vec).into())
-        }
+        let Ruby::Array = value.ruby_type() else {
+            return Err(UnboxRubyError::new(&value, Rust::Vec).into());
+        };
+        let array = unsafe { Array::unbox_from_value(&mut value, self)? };
+        array.iter().map(|elem| self.try_convert(elem)).collect()
     }
 }
 

--- a/artichoke-backend/src/convert/boolean.rs
+++ b/artichoke-backend/src/convert/boolean.rs
@@ -20,11 +20,10 @@ impl Convert<bool, Value> for Artichoke {
 
 impl Convert<Option<bool>, Value> for Artichoke {
     fn convert(&self, value: Option<bool>) -> Value {
-        if let Some(value) = value {
-            self.convert(value)
-        } else {
-            Value::nil()
-        }
+        let Some(value) = value else {
+            return Value::nil();
+        };
+        self.convert(value)
     }
 }
 
@@ -32,18 +31,17 @@ impl TryConvert<Value, bool> for Artichoke {
     type Error = Error;
 
     fn try_convert(&self, value: Value) -> Result<bool, Self::Error> {
-        if let Ruby::Bool = value.ruby_type() {
-            let inner = value.inner();
-            if sys::mrb_sys_value_is_true(inner) {
-                Ok(true)
-            } else if sys::mrb_sys_value_is_false(inner) {
-                Ok(false)
-            } else {
-                // This branch is unreachable because `Ruby::Bool` typed values
-                // are guaranteed to be either true or false.
-                Err(UnboxRubyError::new(&value, Rust::Bool).into())
-            }
+        let Ruby::Bool = value.ruby_type() else {
+            return Err(UnboxRubyError::new(&value, Rust::Bool).into());
+        };
+        let inner = value.inner();
+        if sys::mrb_sys_value_is_true(inner) {
+            Ok(true)
+        } else if sys::mrb_sys_value_is_false(inner) {
+            Ok(false)
         } else {
+            // This branch is unreachable because `Ruby::Bool` typed values
+            // are guaranteed to be either true or false.
             Err(UnboxRubyError::new(&value, Rust::Bool).into())
         }
     }

--- a/artichoke-backend/src/convert/boxing.rs
+++ b/artichoke-backend/src/convert/boxing.rs
@@ -186,11 +186,11 @@ where
         interp: &mut Artichoke,
     ) -> Result<UnboxedValueGuard<'a, Self::Guarded>, Error> {
         // Make sure we have a Data otherwise extraction will fail.
-        if value.ruby_type() != Ruby::Data {
+        let Ruby::Data = value.ruby_type() else {
             let mut message = String::from("uninitialized ");
             message.push_str(Self::RUBY_TYPE);
             return Err(TypeError::from(message).into());
-        }
+        };
 
         let mut rclass = {
             let state = interp.state.as_ref().ok_or_else(InterpreterExtractError::new)?;
@@ -327,12 +327,13 @@ mod tests {
         unwrap_interpreter!(mrb, to => guard);
 
         let mut value = Value::from(slf);
-        let result = if let Ok(container) = unsafe { Container::unbox_from_value(&mut value, &mut guard) } {
-            guard.try_convert_mut(container.0.as_bytes()).unwrap_or_default()
-        } else {
-            Value::nil()
+        let Ok(container) = (unsafe { Container::unbox_from_value(&mut value, &mut guard) }) else {
+            return Value::nil().inner();
         };
-        result.inner()
+        guard
+            .try_convert_mut(container.0.as_bytes())
+            .unwrap_or_default()
+            .inner()
     }
 
     impl HeapAllocatedData for Container {

--- a/artichoke-backend/src/convert/conv.rs
+++ b/artichoke-backend/src/convert/conv.rs
@@ -282,11 +282,10 @@ pub fn check_to_int(interp: &mut Artichoke, value: Value) -> Result<Value, Error
         return Ok(value);
     }
     let value = try_to_int(interp, value, "to_int", ConvertOnError::ReturnNil)?;
-    if let Ruby::Fixnum = value.ruby_type() {
-        Ok(value)
-    } else {
-        Ok(Value::nil())
-    }
+    let Ruby::Fixnum = value.ruby_type() else {
+        return Ok(Value::nil());
+    };
+    Ok(value)
 }
 
 /// Fallible coercion of the given value to a Ruby `Integer` via `#to_i`.

--- a/artichoke-backend/src/convert/fixnum.rs
+++ b/artichoke-backend/src/convert/fixnum.rs
@@ -31,14 +31,14 @@ impl TryConvert<u64, Value> for Artichoke {
     type Error = Error;
 
     fn try_convert(&self, value: u64) -> Result<Value, Self::Error> {
+        let Ok(value) = i64::try_from(value) else {
+            return Err(BoxIntoRubyError::new(Rust::UnsignedInt, Ruby::Fixnum).into());
+        };
         // SAFETY: `i64` Ruby Values do not need to be protected because they
         // are immediates and do not live on the mruby heap.
-        if let Ok(value) = i64::try_from(value) {
-            let fixnum = unsafe { sys::mrb_sys_fixnum_value(value) };
-            Ok(Value::from(fixnum))
-        } else {
-            Err(BoxIntoRubyError::new(Rust::UnsignedInt, Ruby::Fixnum).into())
-        }
+        // `mrb_sys_fixnum_value` is a safe ffi call when given an `i64`.
+        let fixnum = unsafe { sys::mrb_sys_fixnum_value(value) };
+        Ok(Value::from(fixnum))
     }
 }
 
@@ -46,14 +46,14 @@ impl TryConvert<usize, Value> for Artichoke {
     type Error = Error;
 
     fn try_convert(&self, value: usize) -> Result<Value, Self::Error> {
+        let Ok(value) = i64::try_from(value) else {
+            return Err(BoxIntoRubyError::new(Rust::UnsignedInt, Ruby::Fixnum).into());
+        };
         // SAFETY: `i64` Ruby Values do not need to be protected because they
         // are immediates and do not live on the mruby heap.
-        if let Ok(value) = i64::try_from(value) {
-            let fixnum = unsafe { sys::mrb_sys_fixnum_value(value) };
-            Ok(Value::from(fixnum))
-        } else {
-            Err(BoxIntoRubyError::new(Rust::UnsignedInt, Ruby::Fixnum).into())
-        }
+        // `mrb_sys_fixnum_value` is a safe ffi call when given an `i64`.
+        let fixnum = unsafe { sys::mrb_sys_fixnum_value(value) };
+        Ok(Value::from(fixnum))
     }
 }
 
@@ -82,14 +82,14 @@ impl TryConvert<isize, Value> for Artichoke {
     type Error = Error;
 
     fn try_convert(&self, value: isize) -> Result<Value, Self::Error> {
+        let Ok(value) = i64::try_from(value) else {
+            return Err(BoxIntoRubyError::new(Rust::SignedInt, Ruby::Fixnum).into());
+        };
         // SAFETY: `i64` Ruby Values do not need to be protected because they
         // are immediates and do not live on the mruby heap.
-        if let Ok(value) = i64::try_from(value) {
-            let fixnum = unsafe { sys::mrb_sys_fixnum_value(value) };
-            Ok(Value::from(fixnum))
-        } else {
-            Err(BoxIntoRubyError::new(Rust::SignedInt, Ruby::Fixnum).into())
-        }
+        // `mrb_sys_fixnum_value` is a safe ffi call when given an `i64`.
+        let fixnum = unsafe { sys::mrb_sys_fixnum_value(value) };
+        Ok(Value::from(fixnum))
     }
 }
 
@@ -98,6 +98,7 @@ impl Convert<i64, Value> for Artichoke {
     fn convert(&self, value: i64) -> Value {
         // SAFETY: `i64` Ruby Values do not need to be protected because they
         // are immediates and do not live on the mruby heap.
+        // `mrb_sys_fixnum_value` is a safe ffi call when given an `i64`.
         let fixnum = unsafe { sys::mrb_sys_fixnum_value(value) };
         Value::from(fixnum)
     }
@@ -107,12 +108,12 @@ impl TryConvert<Value, i64> for Artichoke {
     type Error = Error;
 
     fn try_convert(&self, value: Value) -> Result<i64, Self::Error> {
-        if let Ruby::Fixnum = value.ruby_type() {
-            let inner = value.inner();
-            Ok(unsafe { sys::mrb_sys_fixnum_to_cint(inner) })
-        } else {
-            Err(UnboxRubyError::new(&value, Rust::SignedInt).into())
-        }
+        let Ruby::Fixnum = value.ruby_type() else {
+            return Err(UnboxRubyError::new(&value, Rust::SignedInt).into());
+        };
+        let inner = value.inner();
+        // SAFETY: value is validated to have integer type tag.
+        Ok(unsafe { sys::mrb_sys_fixnum_to_cint(inner) })
     }
 }
 
@@ -120,14 +121,13 @@ impl TryConvert<Value, u32> for Artichoke {
     type Error = Error;
 
     fn try_convert(&self, value: Value) -> Result<u32, Self::Error> {
-        if let Ruby::Fixnum = value.ruby_type() {
-            let inner = value.inner();
-            let num = unsafe { sys::mrb_sys_fixnum_to_cint(inner) };
-            let num = u32::try_from(num).map_err(|_| UnboxRubyError::new(&value, Rust::UnsignedInt))?;
-            Ok(num)
-        } else {
-            Err(UnboxRubyError::new(&value, Rust::SignedInt).into())
-        }
+        let Ruby::Fixnum = value.ruby_type() else {
+            return Err(UnboxRubyError::new(&value, Rust::SignedInt).into());
+        };
+        let inner = value.inner();
+        let num = unsafe { sys::mrb_sys_fixnum_to_cint(inner) };
+        let num = u32::try_from(num).map_err(|_| UnboxRubyError::new(&value, Rust::UnsignedInt))?;
+        Ok(num)
     }
 }
 
@@ -135,14 +135,13 @@ impl TryConvert<Value, usize> for Artichoke {
     type Error = Error;
 
     fn try_convert(&self, value: Value) -> Result<usize, Self::Error> {
-        if let Ruby::Fixnum = value.ruby_type() {
-            let inner = value.inner();
-            let num = unsafe { sys::mrb_sys_fixnum_to_cint(inner) };
-            let num = usize::try_from(num).map_err(|_| UnboxRubyError::new(&value, Rust::UnsignedInt))?;
-            Ok(num)
-        } else {
-            Err(UnboxRubyError::new(&value, Rust::SignedInt).into())
-        }
+        let Ruby::Fixnum = value.ruby_type() else {
+            return Err(UnboxRubyError::new(&value, Rust::SignedInt).into());
+        };
+        let inner = value.inner();
+        let num = unsafe { sys::mrb_sys_fixnum_to_cint(inner) };
+        let num = usize::try_from(num).map_err(|_| UnboxRubyError::new(&value, Rust::UnsignedInt))?;
+        Ok(num)
     }
 }
 

--- a/artichoke-backend/src/convert/float.rs
+++ b/artichoke-backend/src/convert/float.rs
@@ -18,12 +18,14 @@ impl TryConvert<Value, f64> for Artichoke {
     type Error = Error;
 
     fn try_convert(&self, value: Value) -> Result<f64, Self::Error> {
-        if let Ruby::Float = value.ruby_type() {
-            let value = value.inner();
-            Ok(unsafe { sys::mrb_sys_float_to_cdouble(value) })
-        } else {
-            Err(UnboxRubyError::new(&value, Rust::Float).into())
-        }
+        let Ruby::Float = value.ruby_type() else {
+            return Err(UnboxRubyError::new(&value, Rust::Float).into());
+        };
+        let value = value.inner();
+        // SAFETY: `f64` Ruby Values do not need to be protected because they
+        // are immediates and do not live on the mruby heap.
+        // `mrb_sys_float_to_cdouble` is a safe ffi call when given an `f64`.
+        Ok(unsafe { sys::mrb_sys_float_to_cdouble(value) })
     }
 }
 

--- a/artichoke-backend/src/convert/hash.rs
+++ b/artichoke-backend/src/convert/hash.rs
@@ -73,23 +73,22 @@ impl TryConvertMut<Option<HashMap<Vec<u8>, Option<Vec<u8>>>>, Value> for Articho
     type Error = Error;
 
     fn try_convert_mut(&mut self, value: Option<HashMap<Vec<u8>, Option<Vec<u8>>>>) -> Result<Value, Self::Error> {
-        if let Some(value) = value {
-            let capa = sys::mrb_int::try_from(value.len()).unwrap_or_default();
+        let Some(value) = value else {
+            return Ok(Value::nil());
+        };
+        let capa = sys::mrb_int::try_from(value.len()).unwrap_or_default();
 
-            let hash = unsafe { self.with_ffi_boundary(|mrb| sys::mrb_hash_new_capa(mrb, capa))? };
-            let hash = self.protect(Value::from(hash));
+        let hash = unsafe { self.with_ffi_boundary(|mrb| sys::mrb_hash_new_capa(mrb, capa))? };
+        let hash = self.protect(Value::from(hash));
 
-            for (key, val) in value {
-                let key = self.try_convert_mut(key)?;
-                let val = self.try_convert_mut(val)?;
-                unsafe {
-                    self.with_ffi_boundary(|mrb| sys::mrb_hash_set(mrb, hash.inner(), key.inner(), val.inner()))?;
-                }
+        for (key, val) in value {
+            let key = self.try_convert_mut(key)?;
+            let val = self.try_convert_mut(val)?;
+            unsafe {
+                self.with_ffi_boundary(|mrb| sys::mrb_hash_set(mrb, hash.inner(), key.inner(), val.inner()))?;
             }
-            Ok(hash)
-        } else {
-            Ok(Value::nil())
         }
+        Ok(hash)
     }
 }
 
@@ -97,22 +96,21 @@ impl TryConvertMut<Value, Vec<(Value, Value)>> for Artichoke {
     type Error = Error;
 
     fn try_convert_mut(&mut self, value: Value) -> Result<Vec<(Value, Value)>, Self::Error> {
-        if let Ruby::Hash = value.ruby_type() {
-            let hash = value.inner();
-            let keys = unsafe { self.with_ffi_boundary(|mrb| sys::mrb_hash_keys(mrb, hash))? };
+        let Ruby::Hash = value.ruby_type() else {
+            return Err(UnboxRubyError::new(&value, Rust::Map).into());
+        };
+        let hash = value.inner();
+        let keys = unsafe { self.with_ffi_boundary(|mrb| sys::mrb_hash_keys(mrb, hash))? };
 
-            let mut keys = self.protect(Value::from(keys));
-            let array = unsafe { Array::unbox_from_value(&mut keys, self) }?;
+        let mut keys = self.protect(Value::from(keys));
+        let array = unsafe { Array::unbox_from_value(&mut keys, self) }?;
 
-            let mut pairs = Vec::with_capacity(array.len());
-            for key in &*array {
-                let value = unsafe { self.with_ffi_boundary(|mrb| sys::mrb_hash_get(mrb, hash, key.inner()))? };
-                pairs.push((key, self.protect(Value::from(value))));
-            }
-            Ok(pairs)
-        } else {
-            Err(UnboxRubyError::new(&value, Rust::Map).into())
+        let mut pairs = Vec::with_capacity(array.len());
+        for key in &*array {
+            let value = unsafe { self.with_ffi_boundary(|mrb| sys::mrb_hash_get(mrb, hash, key.inner()))? };
+            pairs.push((key, self.protect(Value::from(value))));
         }
+        Ok(pairs)
     }
 }
 

--- a/artichoke-backend/src/convert/implicit.rs
+++ b/artichoke-backend/src/convert/implicit.rs
@@ -95,82 +95,8 @@ pub fn implicitly_convert_to_int(interp: &mut Artichoke, value: Value) -> Result
         Ok(None) => return Err(TypeError::with_message("no implicit conversion from nil to integer").into()),
         Err(_) => {}
     }
-    if let Ok(true) = value.respond_to(interp, "to_int") {
-        // Propagate exceptions raised in `#to_int`:
-        //
-        // ```console
-        // [2.6.6] > a = [1, 2, 3, 4, 5]
-        // => [1, 2, 3, 4, 5]
-        // [2.6.6] > class A; def to_int; raise ArgumentError, 'a message'; end; end
-        // => :to_int
-        // [2.6.6] > a[A.new]
-        // Traceback (most recent call last):
-        //         5: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `<main>'
-        //         4: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `load'
-        //         3: from /usr/local/var/rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
-        //         2: from (irb):3
-        //         1: from (irb):2:in `to_int'
-        // ArgumentError (a message)
-        // ```
-        let maybe = value.funcall(interp, "to_int", &[], None)?;
-        if let Ok(num) = maybe.try_convert_into::<i64>(interp) {
-            // successful conversion: `#to_int` returned an integer.
-            Ok(num)
-        } else {
-            // Non integer types returned from `#to_int`, even other numerics,
-            // result in a `TypeError`:
-            //
-            // ```console
-            // [2.6.6] > a = [1, 2, 3, 4, 5]
-            // => [1, 2, 3, 4, 5]
-            // [2.6.6] > class A; def to_int; "another string"; end; end
-            // => :to_int
-            // [2.6.6] > a[A.new]
-            // Traceback (most recent call last):
-            //         4: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `<main>'
-            //         3: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `load'
-            //         2: from /usr/local/var/rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
-            //         1: from (irb):3
-            // TypeError (can't convert A to Integer (A#to_int gives String))
-            // [2.6.6] > class B; def to_int; 3.2; end; end
-            // => :to_int
-            // [2.6.6] > a[B.new]
-            // Traceback (most recent call last):
-            //         4: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `<main>'
-            //         3: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `load'
-            //         2: from /usr/local/var/rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
-            //         1: from (irb):5
-            // TypeError (can't convert B to Integer (B#to_int gives Float))
-            // [2.6.6] > class C; def to_int; nil; end; end
-            // => :to_int
-            // [2.6.6] > a[C.new]
-            // Traceback (most recent call last):
-            //         4: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `<main>'
-            //         3: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `load'
-            //         2: from /usr/local/var/rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
-            //         1: from (irb):7
-            // TypeError (can't convert C to Integer (C#to_int gives NilClass))
-            // [2.6.6] > module X; class Y; class Z; def to_int; "oh no"; end; end; end; end
-            // => :to_int
-            // [2.6.6] > a[X::Y::Z.new]
-            // Traceback (most recent call last):
-            //         4: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `<main>'
-            //         3: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `load'
-            //         2: from /usr/local/var/rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
-            //         1: from (irb):9
-            // TypeError (can't convert X::Y::Z to Integer (X::Y::Z#to_int gives String))
-            // ```
-            let mut message = String::from("can't convert ");
-            let name = interp.inspect_type_name_for_value(value);
-            message.push_str(name);
-            message.push_str(" to Integer (");
-            message.push_str(name);
-            message.push_str("#to_int gives ");
-            message.push_str(interp.class_name_for_value(maybe));
-            message.push(')');
-            Err(TypeError::from(message).into())
-        }
-    } else {
+
+    let Ok(true) = value.respond_to(interp, "to_int") else {
         // The given value is not an integer and cannot be converted with
         // `#to_int`:
         //
@@ -198,8 +124,84 @@ pub fn implicitly_convert_to_int(interp: &mut Artichoke, value: Value) -> Result
         let mut message = String::from("no implicit conversion of ");
         message.push_str(interp.inspect_type_name_for_value(value));
         message.push_str(" into Integer");
-        Err(TypeError::from(message).into())
-    }
+        return Err(TypeError::from(message).into());
+    };
+
+    // Propagate exceptions raised in `#to_int`:
+    //
+    // ```console
+    // [2.6.6] > a = [1, 2, 3, 4, 5]
+    // => [1, 2, 3, 4, 5]
+    // [2.6.6] > class A; def to_int; raise ArgumentError, 'a message'; end; end
+    // => :to_int
+    // [2.6.6] > a[A.new]
+    // Traceback (most recent call last):
+    //         5: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `<main>'
+    //         4: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `load'
+    //         3: from /usr/local/var/rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
+    //         2: from (irb):3
+    //         1: from (irb):2:in `to_int'
+    // ArgumentError (a message)
+    // ```
+    let maybe = value.funcall(interp, "to_int", &[], None)?;
+
+    let Ok(num) = maybe.try_convert_into::<i64>(interp) else {
+        // Non integer types returned from `#to_int`, even other numerics,
+        // result in a `TypeError`:
+        //
+        // ```console
+        // [2.6.6] > a = [1, 2, 3, 4, 5]
+        // => [1, 2, 3, 4, 5]
+        // [2.6.6] > class A; def to_int; "another string"; end; end
+        // => :to_int
+        // [2.6.6] > a[A.new]
+        // Traceback (most recent call last):
+        //         4: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `<main>'
+        //         3: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `load'
+        //         2: from /usr/local/var/rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
+        //         1: from (irb):3
+        // TypeError (can't convert A to Integer (A#to_int gives String))
+        // [2.6.6] > class B; def to_int; 3.2; end; end
+        // => :to_int
+        // [2.6.6] > a[B.new]
+        // Traceback (most recent call last):
+        //         4: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `<main>'
+        //         3: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `load'
+        //         2: from /usr/local/var/rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
+        //         1: from (irb):5
+        // TypeError (can't convert B to Integer (B#to_int gives Float))
+        // [2.6.6] > class C; def to_int; nil; end; end
+        // => :to_int
+        // [2.6.6] > a[C.new]
+        // Traceback (most recent call last):
+        //         4: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `<main>'
+        //         3: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `load'
+        //         2: from /usr/local/var/rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
+        //         1: from (irb):7
+        // TypeError (can't convert C to Integer (C#to_int gives NilClass))
+        // [2.6.6] > module X; class Y; class Z; def to_int; "oh no"; end; end; end; end
+        // => :to_int
+        // [2.6.6] > a[X::Y::Z.new]
+        // Traceback (most recent call last):
+        //         4: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `<main>'
+        //         3: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `load'
+        //         2: from /usr/local/var/rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
+        //         1: from (irb):9
+        // TypeError (can't convert X::Y::Z to Integer (X::Y::Z#to_int gives String))
+        // ```
+        let mut message = String::from("can't convert ");
+        let name = interp.inspect_type_name_for_value(value);
+        message.push_str(name);
+        message.push_str(" to Integer (");
+        message.push_str(name);
+        message.push_str("#to_int gives ");
+        message.push_str(interp.class_name_for_value(maybe));
+        message.push(')');
+        return Err(TypeError::from(message).into());
+    };
+
+    // successful conversion: `#to_int` returned an integer.
+    Ok(num)
 }
 
 /// Attempt to implicitly convert a [`Value`] to a byte slice (Ruby `String`).
@@ -300,83 +302,7 @@ pub unsafe fn implicitly_convert_to_string<'a>(
     if let Ruby::Symbol = value.ruby_type() {
         return Err(TypeError::with_message("no implicit conversion of Symbol into String").into());
     }
-    if let Ok(true) = value.respond_to(interp, "to_str") {
-        // Propagate exceptions raised in `#to_str`:
-        //
-        // ```console
-        // [2.6.6] >  class A; def to_str; raise ArgumentError, 'a message'; end; end
-        // => :to_str
-        // [2.6.6] > ENV[A.new]
-        // Traceback (most recent call last):
-        //         6: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `<main>'
-        //         5: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `load'
-        //         4: from /usr/local/var/rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
-        //         3: from (irb):10
-        //         2: from (irb):10:in `[]'
-        //         1: from (irb):9:in `to_str'
-        // ArgumentError (a message)
-        // ```
-        let maybe = value.funcall(interp, "to_str", &[], None)?;
-        if let Ok(s) = maybe.try_convert_into_mut::<&[u8]>(interp) {
-            // successful conversion: `#to_str` returned a string.
-            Ok(s)
-        } else {
-            // Non `String` types returned from `#to_str` result in a
-            // `TypeError`:
-            //
-            // ```console
-            // [2.6.6] > class A; def to_str; 17; end; end
-            // => :to_str
-            // [2.6.6] > ENV[A.new]
-            // Traceback (most recent call last):
-            //         5: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `<main>'
-            //         4: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `load'
-            //         3: from /usr/local/var/rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
-            //         2: from (irb):5
-            //         1: from (irb):5:in `[]'
-            // TypeError (can't convert A to String (A#to_str gives Integer))
-            // [2.6.6] > class B; def to_str; true; end; end
-            // => :to_str
-            // [2.6.6] > ENV[B.new]
-            // Traceback (most recent call last):
-            //         5: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `<main>'
-            //         4: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `load'
-            //         3: from /usr/local/var/rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
-            //         2: from (irb):7
-            //         1: from (irb):7:in `[]'
-            // TypeError (can't convert B to String (B#to_str gives TrueClass))
-            // [2.6.6] > class C; def to_str; nil; end; end
-            // => :to_str
-            // [2.6.6] > ENV[C.new]
-            // Traceback (most recent call last):
-            //         5: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `<main>'
-            //         4: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `load'
-            //         3: from /usr/local/var/rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
-            //         2: from (irb):9
-            //         1: from (irb):9:in `[]'
-            // TypeError (can't convert C to String (C#to_str gives NilClass))
-            // [2.6.6] > module X; class Y; class Z; def to_str; 92; end; end; end; end
-            // => :to_str
-            // [2.6.6] > ENV[X::Y::Z.new]
-            // Traceback (most recent call last):
-            //         5: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `<main>'
-            //         4: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `load'
-            //         3: from /usr/local/var/rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
-            //         2: from (irb):11
-            //         1: from (irb):11:in `[]'
-            // TypeError (can't convert X::Y::Z to String (X::Y::Z#to_str gives Integer))
-            // ```
-            let mut message = String::from("can't convert ");
-            let name = interp.inspect_type_name_for_value(*value);
-            message.push_str(name);
-            message.push_str(" to String (");
-            message.push_str(name);
-            message.push_str("#to_str gives ");
-            message.push_str(interp.class_name_for_value(maybe));
-            message.push(')');
-            Err(TypeError::from(message).into())
-        }
-    } else {
+    let Ok(true) = value.respond_to(interp, "to_str") else {
         // The given value is not a string and cannot be converted with
         // `#to_str`:
         //
@@ -403,8 +329,85 @@ pub unsafe fn implicitly_convert_to_string<'a>(
         let mut message = String::from("no implicit conversion of ");
         message.push_str(interp.inspect_type_name_for_value(*value));
         message.push_str(" into String");
-        Err(TypeError::from(message).into())
-    }
+        return Err(TypeError::from(message).into());
+    };
+
+    // Propagate exceptions raised in `#to_str`:
+    //
+    // ```console
+    // [2.6.6] >  class A; def to_str; raise ArgumentError, 'a message'; end; end
+    // => :to_str
+    // [2.6.6] > ENV[A.new]
+    // Traceback (most recent call last):
+    //         6: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `<main>'
+    //         5: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `load'
+    //         4: from /usr/local/var/rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
+    //         3: from (irb):10
+    //         2: from (irb):10:in `[]'
+    //         1: from (irb):9:in `to_str'
+    // ArgumentError (a message)
+    // ```
+    let maybe = value.funcall(interp, "to_str", &[], None)?;
+
+    let Ok(s) = maybe.try_convert_into_mut::<&[u8]>(interp) else {
+        // Non `String` types returned from `#to_str` result in a
+        // `TypeError`:
+        //
+        // ```console
+        // [2.6.6] > class A; def to_str; 17; end; end
+        // => :to_str
+        // [2.6.6] > ENV[A.new]
+        // Traceback (most recent call last):
+        //         5: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `<main>'
+        //         4: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `load'
+        //         3: from /usr/local/var/rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
+        //         2: from (irb):5
+        //         1: from (irb):5:in `[]'
+        // TypeError (can't convert A to String (A#to_str gives Integer))
+        // [2.6.6] > class B; def to_str; true; end; end
+        // => :to_str
+        // [2.6.6] > ENV[B.new]
+        // Traceback (most recent call last):
+        //         5: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `<main>'
+        //         4: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `load'
+        //         3: from /usr/local/var/rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
+        //         2: from (irb):7
+        //         1: from (irb):7:in `[]'
+        // TypeError (can't convert B to String (B#to_str gives TrueClass))
+        // [2.6.6] > class C; def to_str; nil; end; end
+        // => :to_str
+        // [2.6.6] > ENV[C.new]
+        // Traceback (most recent call last):
+        //         5: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `<main>'
+        //         4: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `load'
+        //         3: from /usr/local/var/rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
+        //         2: from (irb):9
+        //         1: from (irb):9:in `[]'
+        // TypeError (can't convert C to String (C#to_str gives NilClass))
+        // [2.6.6] > module X; class Y; class Z; def to_str; 92; end; end; end; end
+        // => :to_str
+        // [2.6.6] > ENV[X::Y::Z.new]
+        // Traceback (most recent call last):
+        //         5: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `<main>'
+        //         4: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `load'
+        //         3: from /usr/local/var/rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
+        //         2: from (irb):11
+        //         1: from (irb):11:in `[]'
+        // TypeError (can't convert X::Y::Z to String (X::Y::Z#to_str gives Integer))
+        // ```
+        let mut message = String::from("can't convert ");
+        let name = interp.inspect_type_name_for_value(*value);
+        message.push_str(name);
+        message.push_str(" to String (");
+        message.push_str(name);
+        message.push_str("#to_str gives ");
+        message.push_str(interp.class_name_for_value(maybe));
+        message.push(')');
+        return Err(TypeError::from(message).into());
+    };
+
+    // successful conversion: `#to_str` returned a string.
+    Ok(s)
 }
 
 /// Attempt to implicitly convert a [`Value`] to an optional byte slice (nilable
@@ -587,102 +590,20 @@ pub unsafe fn implicitly_convert_to_spinoso_string<'a>(
         // ```
         return Err(TypeError::with_message("no implicit conversion of nil into String").into());
     }
+
     if let Ruby::Symbol = value.ruby_type() {
         return Err(TypeError::with_message("no implicit conversion of Symbol into String").into());
     }
+
     // SAFETY: caller must uphold that the value is bound to the same
     // Artichoke interpreter.
     if let Ok(s) = unsafe { spinoso_string::String::unbox_from_value(value, interp) } {
         return Ok(s);
     }
+
     let value = value_copy;
-    if let Ok(true) = value.respond_to(interp, "to_str") {
-        // Propagate exceptions raised in `#to_str`:
-        //
-        // ```console
-        // [2.6.6] >  class A; def to_str; raise ArgumentError, 'a message'; end; end
-        // => :to_str
-        // [2.6.6] > ENV[A.new]
-        // Traceback (most recent call last):
-        //         6: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `<main>'
-        //         5: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `load'
-        //         4: from /usr/local/var/rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
-        //         3: from (irb):10
-        //         2: from (irb):10:in `[]'
-        //         1: from (irb):9:in `to_str'
-        // ArgumentError (a message)
-        // ```
-        let mut maybe = value.funcall(interp, "to_str", &[], None)?;
-        // SAFETY: caller must uphold that the value is bound to the same
-        // Artichoke interpreter.
-        if let Ok(s) = unsafe { spinoso_string::String::unbox_from_value(&mut maybe, interp) } {
-            // successful conversion: `#to_str` returned a string.
-            //
-            // XXX: this transmute does a lifetime extension and is probably
-            // unsound.
-            unsafe {
-                Ok(mem::transmute::<
-                    UnboxedValueGuard<'_, spinoso_string::String>,
-                    UnboxedValueGuard<'a, spinoso_string::String>,
-                >(s))
-            }
-        } else {
-            // Non `String` types returned from `#to_str` result in a
-            // `TypeError`:
-            //
-            // ```console
-            // [2.6.6] > class A; def to_str; 17; end; end
-            // => :to_str
-            // [2.6.6] > ENV[A.new]
-            // Traceback (most recent call last):
-            //         5: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `<main>'
-            //         4: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `load'
-            //         3: from /usr/local/var/rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
-            //         2: from (irb):5
-            //         1: from (irb):5:in `[]'
-            // TypeError (can't convert A to String (A#to_str gives Integer))
-            // [2.6.6] > class B; def to_str; true; end; end
-            // => :to_str
-            // [2.6.6] > ENV[B.new]
-            // Traceback (most recent call last):
-            //         5: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `<main>'
-            //         4: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `load'
-            //         3: from /usr/local/var/rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
-            //         2: from (irb):7
-            //         1: from (irb):7:in `[]'
-            // TypeError (can't convert B to String (B#to_str gives TrueClass))
-            // [2.6.6] > class C; def to_str; nil; end; end
-            // => :to_str
-            // [2.6.6] > ENV[C.new]
-            // Traceback (most recent call last):
-            //         5: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `<main>'
-            //         4: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `load'
-            //         3: from /usr/local/var/rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
-            //         2: from (irb):9
-            //         1: from (irb):9:in `[]'
-            // TypeError (can't convert C to String (C#to_str gives NilClass))
-            // [2.6.6] > module X; class Y; class Z; def to_str; 92; end; end; end; end
-            // => :to_str
-            // [2.6.6] > ENV[X::Y::Z.new]
-            // Traceback (most recent call last):
-            //         5: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `<main>'
-            //         4: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `load'
-            //         3: from /usr/local/var/rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
-            //         2: from (irb):11
-            //         1: from (irb):11:in `[]'
-            // TypeError (can't convert X::Y::Z to String (X::Y::Z#to_str gives Integer))
-            // ```
-            let mut message = String::from("can't convert ");
-            let name = interp.inspect_type_name_for_value(value);
-            message.push_str(name);
-            message.push_str(" to String (");
-            message.push_str(name);
-            message.push_str("#to_str gives ");
-            message.push_str(interp.class_name_for_value(maybe));
-            message.push(')');
-            Err(TypeError::from(message).into())
-        }
-    } else {
+
+    let Ok(true) = value.respond_to(interp, "to_str") else {
         // The given value is not a string and cannot be converted with
         // `#to_str`:
         //
@@ -709,6 +630,92 @@ pub unsafe fn implicitly_convert_to_spinoso_string<'a>(
         let mut message = String::from("no implicit conversion of ");
         message.push_str(interp.inspect_type_name_for_value(value));
         message.push_str(" into String");
-        Err(TypeError::from(message).into())
-    }
+        return Err(TypeError::from(message).into());
+    };
+
+    // Propagate exceptions raised in `#to_str`:
+    //
+    // ```console
+    // [2.6.6] >  class A; def to_str; raise ArgumentError, 'a message'; end; end
+    // => :to_str
+    // [2.6.6] > ENV[A.new]
+    // Traceback (most recent call last):
+    //         6: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `<main>'
+    //         5: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `load'
+    //         4: from /usr/local/var/rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
+    //         3: from (irb):10
+    //         2: from (irb):10:in `[]'
+    //         1: from (irb):9:in `to_str'
+    // ArgumentError (a message)
+    // ```
+    let mut maybe = value.funcall(interp, "to_str", &[], None)?;
+
+    // SAFETY: caller must uphold that the value is bound to the same Artichoke
+    // interpreter.
+    let Ok(s) = (unsafe { spinoso_string::String::unbox_from_value(&mut maybe, interp) }) else {
+        // Non `String` types returned from `#to_str` result in a
+        // `TypeError`:
+        //
+        // ```console
+        // [2.6.6] > class A; def to_str; 17; end; end
+        // => :to_str
+        // [2.6.6] > ENV[A.new]
+        // Traceback (most recent call last):
+        //         5: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `<main>'
+        //         4: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `load'
+        //         3: from /usr/local/var/rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
+        //         2: from (irb):5
+        //         1: from (irb):5:in `[]'
+        // TypeError (can't convert A to String (A#to_str gives Integer))
+        // [2.6.6] > class B; def to_str; true; end; end
+        // => :to_str
+        // [2.6.6] > ENV[B.new]
+        // Traceback (most recent call last):
+        //         5: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `<main>'
+        //         4: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `load'
+        //         3: from /usr/local/var/rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
+        //         2: from (irb):7
+        //         1: from (irb):7:in `[]'
+        // TypeError (can't convert B to String (B#to_str gives TrueClass))
+        // [2.6.6] > class C; def to_str; nil; end; end
+        // => :to_str
+        // [2.6.6] > ENV[C.new]
+        // Traceback (most recent call last):
+        //         5: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `<main>'
+        //         4: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `load'
+        //         3: from /usr/local/var/rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
+        //         2: from (irb):9
+        //         1: from (irb):9:in `[]'
+        // TypeError (can't convert C to String (C#to_str gives NilClass))
+        // [2.6.6] > module X; class Y; class Z; def to_str; 92; end; end; end; end
+        // => :to_str
+        // [2.6.6] > ENV[X::Y::Z.new]
+        // Traceback (most recent call last):
+        //         5: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `<main>'
+        //         4: from /usr/local/var/rbenv/versions/2.6.6/bin/irb:23:in `load'
+        //         3: from /usr/local/var/rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
+        //         2: from (irb):11
+        //         1: from (irb):11:in `[]'
+        // TypeError (can't convert X::Y::Z to String (X::Y::Z#to_str gives Integer))
+        // ```
+        let mut message = String::from("can't convert ");
+        let name = interp.inspect_type_name_for_value(value);
+        message.push_str(name);
+        message.push_str(" to String (");
+        message.push_str(name);
+        message.push_str("#to_str gives ");
+        message.push_str(interp.class_name_for_value(maybe));
+        message.push(')');
+        return Err(TypeError::from(message).into());
+    };
+
+    // successful conversion: `#to_str` returned a string.
+    //
+    // XXX: this transmute does a lifetime extension and is probably unsound.
+    let s = unsafe {
+        mem::transmute::<UnboxedValueGuard<'_, spinoso_string::String>, UnboxedValueGuard<'a, spinoso_string::String>>(
+            s,
+        )
+    };
+    Ok(s)
 }

--- a/artichoke-backend/src/convert/nilable.rs
+++ b/artichoke-backend/src/convert/nilable.rs
@@ -15,11 +15,10 @@ impl Convert<Option<Value>, Value> for Artichoke {
 
 impl Convert<Option<i64>, Value> for Artichoke {
     fn convert(&self, value: Option<i64>) -> Value {
-        if let Some(value) = value {
-            self.convert(value)
-        } else {
-            Value::nil()
-        }
+        let Some(value) = value else {
+            return Value::nil();
+        };
+        self.convert(value)
     }
 }
 
@@ -27,11 +26,10 @@ impl TryConvert<Option<usize>, Value> for Artichoke {
     type Error = Error;
 
     fn try_convert(&self, value: Option<usize>) -> Result<Value, Self::Error> {
-        if let Some(value) = value {
-            self.try_convert(value)
-        } else {
-            Ok(Value::nil())
-        }
+        let Some(value) = value else {
+            return Ok(Value::nil());
+        };
+        self.try_convert(value)
     }
 }
 
@@ -47,11 +45,10 @@ impl TryConvertMut<Option<&[u8]>, Value> for Artichoke {
     type Error = Error;
 
     fn try_convert_mut(&mut self, value: Option<&[u8]>) -> Result<Value, Self::Error> {
-        if let Some(value) = value {
-            self.try_convert_mut(value)
-        } else {
-            Ok(Value::nil())
-        }
+        let Some(value) = value else {
+            return Ok(Value::nil());
+        };
+        self.try_convert_mut(value)
     }
 }
 
@@ -67,11 +64,10 @@ impl TryConvertMut<Option<&str>, Value> for Artichoke {
     type Error = Error;
 
     fn try_convert_mut(&mut self, value: Option<&str>) -> Result<Value, Self::Error> {
-        if let Some(value) = value {
-            self.try_convert_mut(value)
-        } else {
-            Ok(Value::nil())
-        }
+        let Some(value) = value else {
+            return Ok(Value::nil());
+        };
+        self.try_convert_mut(value)
     }
 }
 
@@ -86,10 +82,9 @@ impl TryConvertMut<Value, Option<Vec<u8>>> for Artichoke {
 
     fn try_convert_mut(&mut self, value: Value) -> Result<Option<Vec<u8>>, Self::Error> {
         if value.is_nil() {
-            Ok(None)
-        } else {
-            self.try_convert_mut(value).map(Some)
+            return Ok(None);
         }
+        self.try_convert_mut(value).map(Some)
     }
 }
 
@@ -98,10 +93,9 @@ impl<'a> TryConvertMut<Value, Option<&'a [u8]>> for Artichoke {
 
     fn try_convert_mut(&mut self, value: Value) -> Result<Option<&'a [u8]>, Self::Error> {
         if value.is_nil() {
-            Ok(None)
-        } else {
-            self.try_convert_mut(value).map(Some)
+            return Ok(None);
         }
+        self.try_convert_mut(value).map(Some)
     }
 }
 
@@ -110,10 +104,9 @@ impl TryConvertMut<Value, Option<String>> for Artichoke {
 
     fn try_convert_mut(&mut self, value: Value) -> Result<Option<String>, Self::Error> {
         if value.is_nil() {
-            Ok(None)
-        } else {
-            self.try_convert_mut(value).map(Some)
+            return Ok(None);
         }
+        self.try_convert_mut(value).map(Some)
     }
 }
 
@@ -122,10 +115,9 @@ impl<'a> TryConvertMut<Value, Option<&'a str>> for Artichoke {
 
     fn try_convert_mut(&mut self, value: Value) -> Result<Option<&'a str>, Self::Error> {
         if value.is_nil() {
-            Ok(None)
-        } else {
-            self.try_convert_mut(value).map(Some)
+            return Ok(None);
         }
+        self.try_convert_mut(value).map(Some)
     }
 }
 
@@ -134,9 +126,245 @@ impl TryConvert<Value, Option<i64>> for Artichoke {
 
     fn try_convert(&self, value: Value) -> Result<Option<i64>, Self::Error> {
         if value.is_nil() {
-            Ok(None)
-        } else {
-            self.try_convert(value).map(Some)
+            return Ok(None);
         }
+        self.try_convert(value).map(Some)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::core::{Convert, TryConvert, TryConvertMut};
+    use crate::test::prelude::*;
+    use crate::value::Value;
+
+    #[test]
+    fn convert_option_value_some_returns_the_inner_value() {
+        let interp = interpreter();
+        let inner = interp.convert(42_i64);
+        let value = interp.convert(Some(inner));
+        // Ensure the converted value is not nil.
+        assert!(!value.is_nil());
+        // Roundtrip: convert back to i64.
+        let num = value.try_convert_into::<i64>(&interp).unwrap();
+        assert_eq!(num, 42);
+    }
+
+    #[test]
+    fn convert_option_value_none_returns_nil() {
+        let interp = interpreter();
+        let value = interp.convert(None::<Value>);
+        assert!(value.is_nil());
+    }
+
+    #[test]
+    fn convert_value_to_option_value_non_nil_returns_some() {
+        let interp = interpreter();
+        let value = interp.convert(789_i64);
+        let opt: Option<Value> = interp.convert(value);
+        assert!(opt.is_some());
+        let num = opt.unwrap().try_convert_into::<i64>(&interp).unwrap();
+        assert_eq!(num, 789);
+    }
+
+    #[test]
+    fn convert_value_to_option_value_nil_returns_none() {
+        let interp = interpreter();
+        let nil_value = Value::nil();
+        let opt: Option<Value> = interp.convert(nil_value);
+        assert!(opt.is_none());
+    }
+
+    // --- Tests for Option<i64> -> Value ---
+
+    #[test]
+    fn convert_option_i64_some_converts_to_fixnum() {
+        let interp = interpreter();
+        let value = interp.convert(Some(123_i64));
+        let num = value.try_convert_into::<i64>(&interp).unwrap();
+        assert_eq!(num, 123);
+    }
+
+    #[test]
+    fn convert_option_i64_none_converts_to_nil() {
+        let interp = interpreter();
+        let value = interp.convert(None::<i64>);
+        assert!(value.is_nil());
+    }
+
+    // --- Tests for Option<usize> -> Value via TryConvert ---
+
+    #[test]
+    fn try_convert_option_usize_some_converts_to_fixnum() {
+        let interp = interpreter();
+        let value = interp.try_convert(Some(456_usize)).unwrap();
+        let num: usize = value.try_convert_into(&interp).unwrap();
+        assert_eq!(num, 456);
+    }
+
+    #[test]
+    fn try_convert_option_usize_none_converts_to_nil() {
+        let interp = interpreter();
+        let value = interp.try_convert(None::<usize>).unwrap();
+        assert!(value.is_nil());
+    }
+
+    // --- Tests for Option<Vec<u8>> -> Value via TryConvertMut ---
+
+    #[test]
+    fn try_convert_mut_option_vec_u8_some_converts_to_string() {
+        let mut interp = interpreter();
+        let input = b"hello".to_vec();
+        let value = interp.try_convert_mut(Some(input.clone())).unwrap();
+        // Convert the resulting Ruby value back to String.
+        let result = value.try_convert_into_mut::<Option<String>>(&mut interp).unwrap();
+        assert_eq!(result, Some(String::from("hello")));
+    }
+
+    #[test]
+    fn try_convert_mut_option_vec_u8_none_converts_to_nil() {
+        let mut interp = interpreter();
+        let value = interp.try_convert_mut(None::<Vec<u8>>).unwrap();
+        assert!(value.is_nil());
+    }
+
+    // --- Tests for Option<&[u8]> -> Value via TryConvertMut ---
+
+    #[test]
+    fn try_convert_mut_option_slice_u8_some_converts_to_string() {
+        let mut interp = interpreter();
+        let input: &[u8] = b"world";
+        let value = interp.try_convert_mut(Some(input)).unwrap();
+        let result = value.try_convert_into_mut::<Option<String>>(&mut interp).unwrap();
+        assert_eq!(result, Some(String::from("world")));
+    }
+
+    #[test]
+    fn try_convert_mut_option_slice_u8_none_converts_to_nil() {
+        let mut interp = interpreter();
+        let value = interp.try_convert_mut(None::<&[u8]>).unwrap();
+        assert!(value.is_nil());
+    }
+
+    #[test]
+    fn try_convert_mut_option_string_some_converts_to_string() {
+        let mut interp = interpreter();
+        let input = String::from("artichoke");
+        let value = interp.try_convert_mut(Some(input.clone())).unwrap();
+        let result = value.try_convert_into_mut::<Option<String>>(&mut interp).unwrap();
+        assert_eq!(result, Some(input));
+    }
+
+    #[test]
+    fn try_convert_mut_option_string_none_converts_to_nil() {
+        let mut interp = interpreter();
+        let value = interp.try_convert_mut(None::<String>).unwrap();
+        assert!(value.is_nil());
+    }
+
+    // --- Tests for Option<&str> -> Value via TryConvertMut ---
+
+    #[test]
+    fn try_convert_mut_option_str_some_converts_to_string() {
+        let mut interp = interpreter();
+        let input = "convert me";
+        let value = interp.try_convert_mut(Some(input)).unwrap();
+        let result = value.try_convert_into_mut::<Option<String>>(&mut interp).unwrap();
+        assert_eq!(result, Some(input.to_owned()));
+    }
+
+    #[test]
+    fn try_convert_mut_option_str_none_converts_to_nil() {
+        let mut interp = interpreter();
+        let value = interp.try_convert_mut(None::<&str>).unwrap();
+        assert!(value.is_nil());
+    }
+
+    // --- Tests for Value -> Option<Vec<u8>> via TryConvertMut ---
+
+    #[test]
+    fn try_convert_mut_value_to_option_vec_u8_non_nil_returns_some() {
+        let mut interp = interpreter();
+        let value = interp.try_convert_mut("hello world").unwrap();
+        let result = value.try_convert_into_mut::<Option<Vec<u8>>>(&mut interp).unwrap();
+        let s = String::from_utf8(result.unwrap()).unwrap();
+        assert_eq!(s, "hello world");
+    }
+
+    #[test]
+    fn try_convert_mut_value_to_option_vec_u8_nil_returns_none() {
+        let mut interp = interpreter();
+        let value = Value::nil();
+        let result = value.try_convert_into_mut::<Option<Vec<u8>>>(&mut interp).unwrap();
+        assert!(result.is_none());
+    }
+
+    // --- Tests for Value -> Option<&[u8]> via TryConvertMut ---
+
+    #[test]
+    fn try_convert_mut_value_to_option_slice_u8_non_nil_returns_some() {
+        let mut interp = interpreter();
+        let value = interp.try_convert_mut("slice-test").unwrap();
+        let result = value.try_convert_into_mut::<Option<&[u8]>>(&mut interp).unwrap();
+        let s = String::from_utf8(result.unwrap().to_vec()).unwrap();
+        assert_eq!(s, "slice-test");
+    }
+
+    #[test]
+    fn try_convert_mut_value_to_option_slice_u8_nil_returns_none() {
+        let mut interp = interpreter();
+        let value = Value::nil();
+        let result = value.try_convert_into_mut::<Option<&[u8]>>(&mut interp).unwrap();
+        assert!(result.is_none());
+    }
+
+    // --- Tests for Value -> Option<String> via TryConvertMut ---
+
+    #[test]
+    fn try_convert_mut_value_to_option_string_non_nil_returns_some() {
+        let mut interp = interpreter();
+        let value = interp.try_convert_mut("string-test").unwrap();
+        let result = value.try_convert_into_mut::<Option<String>>(&mut interp).unwrap();
+        assert_eq!(result, Some(String::from("string-test")));
+    }
+
+    #[test]
+    fn try_convert_mut_value_to_option_string_nil_returns_none() {
+        let mut interp = interpreter();
+        let value = Value::nil();
+        let result = value.try_convert_into_mut::<Option<String>>(&mut interp).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn try_convert_mut_value_to_option_str_non_nil_returns_some() {
+        let mut interp = interpreter();
+        let value = interp.try_convert_mut("str-test").unwrap();
+        let result = value.try_convert_into_mut::<Option<&str>>(&mut interp).unwrap();
+        assert_eq!(result, Some("str-test"));
+    }
+
+    #[test]
+    fn try_convert_mut_value_to_option_str_nil_returns_none() {
+        let mut interp = interpreter();
+        let value = Value::nil();
+        let result = value.try_convert_into_mut::<Option<&str>>(&mut interp).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn try_convert_value_to_option_i64_non_nil_returns_some() {
+        let interp = interpreter();
+        let value = interp.convert(555i64);
+        let result = value.try_convert_into::<Option<i64>>(&interp).unwrap();
+        assert_eq!(result, Some(555));
+    }
+
+    #[test]
+    fn try_convert_value_to_option_i64_nil_returns_none() {
+        let interp = interpreter();
+        let value = Value::nil();
+        let result = value.try_convert_into::<Option<i64>>(&interp).unwrap();
+        assert!(result.is_none());
     }
 }

--- a/artichoke-backend/src/debug.rs
+++ b/artichoke-backend/src/debug.rs
@@ -25,11 +25,10 @@ impl Debug for Artichoke {
         // SAFETY: `mrb_obj_classname` requires an initialized mruby interpreter
         // which is guaranteed by the `Artichoke` type.
         let class = unsafe { self.with_ffi_boundary(|mrb| sys::mrb_obj_classname(mrb, value.inner())) };
-        let class = if let Ok(class) = class {
-            unsafe { CStr::from_ptr(class) }
-        } else {
-            c""
+        let Ok(class) = class else {
+            return "";
         };
+        let class = unsafe { CStr::from_ptr(class) };
         class.to_str().unwrap_or_default()
     }
 }

--- a/artichoke-backend/src/def.rs
+++ b/artichoke-backend/src/def.rs
@@ -120,20 +120,25 @@ pub struct ModuleScope {
     enclosing_scope: Option<Box<EnclosingRubyScope>>,
 }
 
-/// Typesafe wrapper for the [`RClass *`](sys::RClass) of the enclosing scope
-/// for an mruby `Module` or `Class`.
+/// Typesafe wrapper for the [`RClass *`] of the enclosing scope for an mruby
+/// `Module` or `Class`.
 ///
-/// In Ruby, classes and modules can be defined inside another class or
-/// module. mruby only supports resolving [`RClass`](sys::RClass) pointers
-/// relative to an enclosing scope. This can be the top level with
-/// [`mrb_class_get`](sys::mrb_class_get) and
-/// [`mrb_module_get`](sys::mrb_module_get) or it can be under another class
-/// with [`mrb_class_get_under`](sys::mrb_class_get_under) or module with
-/// [`mrb_module_get_under`](sys::mrb_module_get_under).
+/// In Ruby, classes and modules can be defined inside another class or module.
+/// mruby only supports resolving [`RClass`] pointers relative to an enclosing
+/// scope. This can be the top level with [`mrb_class_get`] and
+/// [`mrb_module_get`] or it can be under another class with
+/// [`mrb_class_get_under`] or module with [`mrb_module_get_under`].
 ///
 /// Because there is no C API to resolve class and module names directly, each
 /// class-like holds a reference to its enclosing scope so it can recursively
-/// resolve its enclosing [`RClass *`](sys::RClass).
+/// resolve its enclosing [`RClass *`].
+///
+/// [`RClass *`]: sys::RClass
+/// [`RClass`]: sys::RClass
+/// [`mrb_class_get`]: sys::mrb_class_get
+/// [`mrb_module_get`]: sys::mrb_module_get
+/// [`mrb_class_get_under`]: sys::mrb_class_get_under
+/// [`mrb_module_get_under`]: sys::mrb_module_get_under
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub enum EnclosingRubyScope {
     /// Reference to a Ruby `Class` enclosing scope.
@@ -173,7 +178,7 @@ impl EnclosingRubyScope {
         })
     }
 
-    /// Resolve the [`RClass *`](sys::RClass) of the wrapped class or module.
+    /// Resolve the [`RClass *`] of the wrapped class or module.
     ///
     /// Return [`None`] if the class-like has no [`EnclosingRubyScope`].
     ///
@@ -184,7 +189,10 @@ impl EnclosingRubyScope {
     ///
     /// This function must be called within an [`Artichoke::with_ffi_boundary`]
     /// closure because the FFI APIs called in this function may require access
-    /// to the Artichoke [`State`](crate::state::State).
+    /// to the Artichoke [`State`].
+    ///
+    /// [`RClass *`]: sys::RClass
+    /// [`State`]: crate::state::State
     pub unsafe fn rclass(&self, mrb: *mut sys::mrb_state) -> Option<NonNull<sys::RClass>> {
         match self {
             Self::Class(scope) => {
@@ -225,14 +233,13 @@ impl EnclosingRubyScope {
             Self::Class(scope) => (&*scope.name, &scope.enclosing_scope),
             Self::Module(scope) => (&*scope.name, &scope.enclosing_scope),
         };
-        if let Some(scope) = enclosing_scope {
-            let mut fqname = String::from(scope.fqname());
-            fqname.push_str("::");
-            fqname.push_str(name);
-            fqname.into()
-        } else {
-            name.into()
-        }
+        let Some(scope) = enclosing_scope else {
+            return name.into();
+        };
+        let mut fqname = String::from(scope.fqname());
+        fqname.push_str("::");
+        fqname.push_str(name);
+        fqname.into()
     }
 }
 

--- a/artichoke-backend/src/error.rs
+++ b/artichoke-backend/src/error.rs
@@ -92,45 +92,45 @@ where
     // Ensure the Artichoke `State` is moved back into the `mrb_state`.
     drop(guard);
 
-    if let Some(exc) = exc {
+    let Some(exc) = exc else {
+        // Being unable to turn the given exception into an `mrb_value` is a bug, so
+        // log loudly to stderr and attempt to fallback to a runtime error.
+        emit_fatal_warning!("Unable to raise exception: {:?}", exception);
+
         // Any non-`Copy` objects that we haven't cleaned up at this point will
         // leak, so drop everything.
         drop(exception);
 
-        // `mrb_exc_raise` will call longjmp which will unwind the stack.
+        // `mrb_sys_raise` will call longjmp which will unwind the stack.
         //
         // SAFETY: all remaining live objects are `Copy` and the `mrb_state` is
         // valid.
         unsafe {
-            sys::mrb_exc_raise(mrb, exc);
+            sys::mrb_sys_raise(mrb, RUNTIME_ERROR_CSTR.as_ptr(), UNABLE_TO_RAISE_MESSAGE.as_ptr());
         }
 
-        // SAFETY: This line is unreachable because `raise` will unwind the
-        // stack with `longjmp` when calling `sys::mrb_exc_raise` in the
-        // preceding line.
+        // SAFETY: This line is unreachable because `raise` will unwind the stack
+        // with `longjmp` when calling `sys::mrb_exc_raise` in the preceding line.
         unsafe {
             hint::unreachable_unchecked();
         }
-    }
-
-    // Being unable to turn the given exception into an `mrb_value` is a bug, so
-    // log loudly to stderr and attempt to fallback to a runtime error.
-    emit_fatal_warning!("Unable to raise exception: {:?}", exception);
+    };
 
     // Any non-`Copy` objects that we haven't cleaned up at this point will
     // leak, so drop everything.
     drop(exception);
 
-    // `mrb_sys_raise` will call longjmp which will unwind the stack.
+    // `mrb_exc_raise` will call longjmp which will unwind the stack.
     //
     // SAFETY: all remaining live objects are `Copy` and the `mrb_state` is
     // valid.
     unsafe {
-        sys::mrb_sys_raise(mrb, RUNTIME_ERROR_CSTR.as_ptr(), UNABLE_TO_RAISE_MESSAGE.as_ptr());
+        sys::mrb_exc_raise(mrb, exc);
     }
 
-    // SAFETY: This line is unreachable because `raise` will unwind the stack
-    // with `longjmp` when calling `sys::mrb_exc_raise` in the preceding line.
+    // SAFETY: This line is unreachable because `raise` will unwind the
+    // stack with `longjmp` when calling `sys::mrb_exc_raise` in the
+    // preceding line.
     unsafe {
         hint::unreachable_unchecked();
     }

--- a/artichoke-backend/src/eval.rs
+++ b/artichoke-backend/src/eval.rs
@@ -127,12 +127,10 @@ mod tests {
             _slf: sys::mrb_value,
         ) -> sys::mrb_value {
             unwrap_interpreter!(mrb, to => guard);
-            let result = if let Ok(value) = guard.eval(b"__FILE__") {
-                value
-            } else {
-                Value::nil()
+            let Ok(value) = guard.eval(b"__FILE__") else {
+                return Value::nil().inner();
             };
-            result.inner()
+            value.inner()
         }
 
         impl File for NestedEval {

--- a/artichoke-backend/src/extn/core/string/ffi.rs
+++ b/artichoke-backend/src/extn/core/string/ffi.rs
@@ -126,9 +126,7 @@ unsafe extern "C-unwind" fn mrb_str_index(
 ) -> sys::mrb_int {
     unwrap_interpreter!(mrb, to => guard, or_else = -1);
     let mut value = s.into();
-    let string = if let Ok(string) = String::unbox_from_value(&mut value, &mut guard) {
-        string
-    } else {
+    let Ok(string) = String::unbox_from_value(&mut value, &mut guard) else {
         return -1;
     };
 
@@ -152,14 +150,10 @@ unsafe extern "C-unwind" fn mrb_str_index(
     if offset < 0 {
         offset += length;
     }
-    let offset = if let Ok(offset) = usize::try_from(offset) {
-        offset
-    } else {
+    let Ok(offset) = usize::try_from(offset) else {
         return -1;
     };
-    let haystack = if let Some(haystack) = string.get(offset..) {
-        haystack
-    } else {
+    let Some(haystack) = string.get(offset..) else {
         return -1;
     };
     let needle = slice::from_raw_parts(sptr.cast::<u8>(), usize::try_from(slen).unwrap_or(0));
@@ -227,14 +221,10 @@ unsafe extern "C-unwind" fn mrb_str_resize(
 
     unwrap_interpreter!(mrb, to => guard, or_else = s);
     let mut value = s.into();
-    let mut string = if let Ok(string) = String::unbox_from_value(&mut value, &mut guard) {
-        string
-    } else {
+    let Ok(mut string) = String::unbox_from_value(&mut value, &mut guard) else {
         return s;
     };
-    let len = if let Ok(len) = usize::try_from(len) {
-        len
-    } else {
+    let Ok(len) = usize::try_from(len) else {
         return s;
     };
     // SAFETY: The string is repacked before any intervening uses of `interp`
@@ -294,14 +284,10 @@ unsafe extern "C-unwind" fn mrb_str_plus(
     let mut a = Value::from(a);
     let mut b = Value::from(b);
 
-    let a = if let Ok(a) = String::unbox_from_value(&mut a, &mut guard) {
-        a
-    } else {
+    let Ok(a) = String::unbox_from_value(&mut a, &mut guard) else {
         return Value::nil().into();
     };
-    let b = if let Ok(b) = String::unbox_from_value(&mut b, &mut guard) {
-        b
-    } else {
+    let Ok(b) = String::unbox_from_value(&mut b, &mut guard) else {
         return Value::nil().into();
     };
 
@@ -327,14 +313,10 @@ unsafe extern "C-unwind" fn mrb_str_cmp(
     let mut a = Value::from(str1);
     let mut b = Value::from(str2);
 
-    let a = if let Ok(a) = String::unbox_from_value(&mut a, &mut guard) {
-        a
-    } else {
+    let Ok(a) = String::unbox_from_value(&mut a, &mut guard) else {
         return -1;
     };
-    let b = if let Ok(b) = String::unbox_from_value(&mut b, &mut guard) {
-        b
-    } else {
+    let Ok(b) = String::unbox_from_value(&mut b, &mut guard) else {
         return -1;
     };
 
@@ -354,14 +336,10 @@ unsafe extern "C-unwind" fn mrb_str_equal(
     let mut a = Value::from(str1);
     let mut b = Value::from(str2);
 
-    let a = if let Ok(a) = String::unbox_from_value(&mut a, &mut guard) {
-        a
-    } else {
+    let Ok(a) = String::unbox_from_value(&mut a, &mut guard) else {
         return false;
     };
-    let b = if let Ok(b) = String::unbox_from_value(&mut b, &mut guard) {
-        b
-    } else {
+    let Ok(b) = String::unbox_from_value(&mut b, &mut guard) else {
         return false;
     };
 
@@ -394,19 +372,20 @@ unsafe extern "C-unwind" fn mrb_str_dup(mrb: *mut sys::mrb_state, s: sys::mrb_va
     let basic = sys::mrb_sys_basic_ptr(s).cast::<sys::RString>();
     let class = (*basic).c;
 
-    if let Ok(string) = String::unbox_from_value(&mut string, &mut guard) {
-        let dup = string.clone();
-        if let Ok(value) = String::alloc_value(dup, &mut guard) {
-            let value = value.inner();
+    let Ok(string) = String::unbox_from_value(&mut string, &mut guard) else {
+        return Value::nil().into();
+    };
+    let dup = string.clone();
+    let Ok(value) = String::alloc_value(dup, &mut guard) else {
+        return Value::nil().into();
+    };
+    let value = value.inner();
 
-            // dup'd strings keep the class of the source `String`.
-            let dup_basic = sys::mrb_sys_basic_ptr(value).cast::<sys::RString>();
-            (*dup_basic).c = class;
+    // dup'd strings keep the class of the source `String`.
+    let dup_basic = sys::mrb_sys_basic_ptr(value).cast::<sys::RString>();
+    (*dup_basic).c = class;
 
-            return value;
-        }
-    }
-    Value::nil().into()
+    value
 }
 
 // ```c
@@ -425,9 +404,7 @@ unsafe extern "C-unwind" fn mrb_str_substr(
     unwrap_interpreter!(mrb, to => guard);
 
     let mut string = Value::from(s);
-    let string = if let Ok(string) = String::unbox_from_value(&mut string, &mut guard) {
-        string
-    } else {
+    let Ok(string) = String::unbox_from_value(&mut string, &mut guard) else {
         return Value::nil().into();
     };
 
@@ -438,20 +415,18 @@ unsafe extern "C-unwind" fn mrb_str_substr(
             .checked_neg()
             .and_then(|offset| usize::try_from(offset).ok())
             .and_then(|offset| offset.checked_sub(string.len()));
-        if let Some(offset) = offset {
-            offset
-        } else {
+        let Some(offset) = offset else {
             return Value::nil().into();
-        }
+        };
+        offset
     };
 
     // FIXME: mruby treats this as a character offset, not a byte offset.
-    if let Some(slice) = string.get(offset..) {
-        let substr = String::with_bytes_and_encoding(slice.to_vec(), string.encoding());
-        String::alloc_value(substr, &mut guard).unwrap_or_default().into()
-    } else {
-        Value::nil().into()
-    }
+    let Some(slice) = string.get(offset..) else {
+        return Value::nil().into();
+    };
+    let substr = String::with_bytes_and_encoding(slice.to_vec(), string.encoding());
+    String::alloc_value(substr, &mut guard).unwrap_or_default().into()
 }
 
 // ```c
@@ -483,14 +458,12 @@ unsafe extern "C-unwind" fn mrb_string_value_cstr(
 ) -> *const c_char {
     unwrap_interpreter!(mrb, to => guard, or_else = ptr::null());
     let mut s = Value::from(*ptr);
-    let mut string = if let Ok(string) = String::unbox_from_value(&mut s, &mut guard) {
-        if let Some(b'\0') = string.last() {
-            return string.as_ptr().cast();
-        }
-        string
-    } else {
+    let Ok(mut string) = String::unbox_from_value(&mut s, &mut guard) else {
         return ptr::null();
     };
+    if let Some(b'\0') = string.last() {
+        return string.as_ptr().cast();
+    }
     // SAFETY: The string is repacked before any intervening uses of `interp`
     // which means no mruby heap allocations can occur.
     let string_mut = string.as_inner_mut();
@@ -512,14 +485,12 @@ unsafe extern "C-unwind" fn mrb_string_value_cstr(
 unsafe extern "C-unwind" fn mrb_string_cstr(mrb: *mut sys::mrb_state, s: sys::mrb_value) -> *const c_char {
     unwrap_interpreter!(mrb, to => guard, or_else = ptr::null());
     let mut s = Value::from(s);
-    let mut string = if let Ok(string) = String::unbox_from_value(&mut s, &mut guard) {
-        if let Some(b'\0') = string.last() {
-            return string.as_ptr().cast();
-        }
-        string
-    } else {
+    let Ok(mut string) = String::unbox_from_value(&mut s, &mut guard) else {
         return ptr::null();
     };
+    if let Some(b'\0') = string.last() {
+        return string.as_ptr().cast();
+    }
     // SAFETY: The string is repacked before any intervening uses of `interp`
     // which means no mruby heap allocations can occur.
     let string_mut = string.as_inner_mut();
@@ -550,29 +521,28 @@ unsafe extern "C-unwind" fn mrb_str_to_integer(
 ) -> sys::mrb_value {
     unwrap_interpreter!(mrb, to => guard);
     let mut s = Value::from(s);
-    let s = if let Ok(s) = String::unbox_from_value(&mut s, &mut guard) {
-        s
-    } else if badcheck {
-        let err = ArgumentError::with_message("not a string");
-        error::raise(guard, err);
-    } else {
+    let Ok(s) = String::unbox_from_value(&mut s, &mut guard) else {
+        if badcheck {
+            let err = ArgumentError::with_message("not a string");
+            error::raise(guard, err);
+        }
         return guard.convert(0_i64).into();
     };
-    let num = if let Ok(s) = str::from_utf8(s.as_slice()) {
-        if let Ok(num) = s.parse::<i64>() {
-            num
-        } else if badcheck {
+    let Ok(s) = str::from_utf8(s.as_slice()) else {
+        if badcheck {
             let err = ArgumentError::with_message("invalid number");
             error::raise(guard, err);
-        } else {
-            return guard.convert(0_i64).into();
         }
-    } else if badcheck {
-        let err = ArgumentError::with_message("invalid number");
-        error::raise(guard, err);
-    } else {
+        return guard.convert(-1_i64).into();
+    };
+    let Ok(num) = s.parse::<i64>() else {
+        if badcheck {
+            let err = ArgumentError::with_message("invalid number");
+            error::raise(guard, err);
+        }
         return guard.convert(0_i64).into();
     };
+
     let radix = match u32::try_from(base) {
         Ok(base) if (2..=36).contains(&base) => base,
         Ok(_) | Err(_) => {
@@ -580,6 +550,7 @@ unsafe extern "C-unwind" fn mrb_str_to_integer(
             error::raise(guard, err);
         }
     };
+
     let mut result = vec![];
     let mut x = num;
 
@@ -614,29 +585,28 @@ unsafe extern "C-unwind" fn mrb_str_to_dbl(
 ) -> c_double {
     unwrap_interpreter!(mrb, to => guard, or_else = 0.0);
     let mut s = Value::from(s);
-    let s = if let Ok(s) = String::unbox_from_value(&mut s, &mut guard) {
-        s
-    } else if badcheck {
-        let err = ArgumentError::with_message("not a string");
-        error::raise(guard, err);
-    } else {
+    let Ok(s) = String::unbox_from_value(&mut s, &mut guard) else {
+        if badcheck {
+            let err = ArgumentError::with_message("not a string");
+            error::raise(guard, err);
+        }
         return 0.0;
     };
-    if let Ok(s) = str::from_utf8(s.as_slice()) {
-        if let Ok(num) = s.parse::<c_double>() {
-            num
-        } else if badcheck {
+    let Ok(s) = str::from_utf8(s.as_slice()) else {
+        if badcheck {
             let err = ArgumentError::with_message("invalid number");
             error::raise(guard, err);
-        } else {
-            0.0
         }
-    } else if badcheck {
-        let err = ArgumentError::with_message("invalid number");
-        error::raise(guard, err);
-    } else {
-        0.0
-    }
+        return 0.0;
+    };
+    let Ok(num) = s.parse::<c_double>() else {
+        if badcheck {
+            let err = ArgumentError::with_message("invalid number");
+            error::raise(guard, err);
+        }
+        return 0.0;
+    };
+    num
 }
 
 // ```c
@@ -651,20 +621,19 @@ unsafe extern "C-unwind" fn mrb_str_cat(
 ) -> sys::mrb_value {
     unwrap_interpreter!(mrb, to => guard, or_else = s);
     let mut s = Value::from(s);
-    if let Ok(mut string) = String::unbox_from_value(&mut s, &mut guard) {
-        let slice = slice::from_raw_parts(ptr.cast::<u8>(), len);
+    let Ok(mut string) = String::unbox_from_value(&mut s, &mut guard) else {
+        return s.inner();
+    };
+    let slice = slice::from_raw_parts(ptr.cast::<u8>(), len);
 
-        // SAFETY: The string is repacked before any intervening uses of
-        // `interp` which means no mruby heap allocations can occur.
-        let string_mut = string.as_inner_mut();
-        string_mut.extend_from_slice(slice);
-        let inner = string.take();
-        let value = String::box_into_value(inner, s, &mut guard).expect("String reboxing should not fail");
+    // SAFETY: The string is repacked before any intervening uses of
+    // `interp` which means no mruby heap allocations can occur.
+    let string_mut = string.as_inner_mut();
+    string_mut.extend_from_slice(slice);
+    let inner = string.take();
+    let value = String::box_into_value(inner, s, &mut guard).expect("String reboxing should not fail");
 
-        value.inner()
-    } else {
-        s.inner()
-    }
+    value.inner()
 }
 
 // ```c
@@ -688,15 +657,12 @@ unsafe extern "C-unwind" fn mrb_str_cat(
 unsafe extern "C-unwind" fn mrb_str_hash(mrb: *mut sys::mrb_state, s: sys::mrb_value) -> u32 {
     unwrap_interpreter!(mrb, to => guard, or_else = 0);
     let mut s = Value::from(s);
-    let mut hasher = if let Ok(global_build_hasher) = guard.global_build_hasher() {
-        global_build_hasher.build_hasher()
-    } else {
+    let Ok(global_build_hasher) = guard.global_build_hasher() else {
         return 0;
     };
+    let mut hasher = global_build_hasher.build_hasher();
 
-    let s = if let Ok(s) = String::unbox_from_value(&mut s, &mut guard) {
-        s
-    } else {
+    let Ok(s) = String::unbox_from_value(&mut s, &mut guard) else {
         return 0;
     };
     s.as_slice().hash(&mut hasher);

--- a/artichoke-backend/src/extn/core/string/ffi.rs
+++ b/artichoke-backend/src/extn/core/string/ffi.rs
@@ -1,6 +1,6 @@
 use core::char;
 use core::convert::TryFrom;
-use core::hash::{BuildHasher, Hash, Hasher};
+use core::hash::BuildHasher;
 use core::num::Wrapping;
 use core::ptr;
 use core::slice;
@@ -657,16 +657,20 @@ unsafe extern "C-unwind" fn mrb_str_cat(
 unsafe extern "C-unwind" fn mrb_str_hash(mrb: *mut sys::mrb_state, s: sys::mrb_value) -> u32 {
     unwrap_interpreter!(mrb, to => guard, or_else = 0);
     let mut s = Value::from(s);
-    let Ok(global_build_hasher) = guard.global_build_hasher() else {
-        return 0;
-    };
-    let mut hasher = global_build_hasher.build_hasher();
 
     let Ok(s) = String::unbox_from_value(&mut s, &mut guard) else {
         return 0;
     };
-    s.as_slice().hash(&mut hasher);
-    let hash = hasher.finish();
+
+    // NOTE: it is necessary to retrieve the interpreter `BuildHasher` second to
+    // avoid a duplicate borrow error. `Artichoke::global_build_hasher` requires
+    // a shared reference which the previous mutable borrow will coerce to, but
+    // the other ordering will not compile.
+    let Ok(global_build_hasher) = guard.global_build_hasher() else {
+        return 0;
+    };
+
+    let hash = global_build_hasher.hash_one(s.as_slice());
     // Grab some bytes from the `u64` to construct a `u32` hash.
     let [one, two, three, four, ..] = hash.to_ne_bytes();
     u32::from_ne_bytes([one, two, three, four])

--- a/artichoke-backend/src/extn/core/symbol/ffi.rs
+++ b/artichoke-backend/src/extn/core/symbol/ffi.rs
@@ -51,12 +51,11 @@ unsafe extern "C-unwind" fn mrb_intern_cstr(mrb: *mut sys::mrb_state, name: *con
 unsafe extern "C-unwind" fn mrb_intern_str(mrb: *mut sys::mrb_state, name: sys::mrb_value) -> sys::mrb_sym {
     unwrap_interpreter!(mrb, to => guard, or_else = 0);
     let name = Value::from(name);
-    if let Ok(bytes) = name.try_convert_into_mut::<Vec<u8>>(&mut guard) {
-        let sym = guard.intern_bytes(bytes);
-        sym.unwrap_or_default()
-    } else {
-        0
-    }
+    let Ok(bytes) = name.try_convert_into_mut::<Vec<u8>>(&mut guard) else {
+        return 0;
+    };
+    let sym = guard.intern_bytes(bytes);
+    sym.unwrap_or_default()
 }
 
 /* `mrb_intern_check` series functions returns 0 if the symbol is not defined */
@@ -72,11 +71,10 @@ unsafe extern "C-unwind" fn mrb_intern_check(
 ) -> sys::mrb_sym {
     let bytes = slice::from_raw_parts(name.cast::<u8>(), len);
     unwrap_interpreter!(mrb, to => guard, or_else = 0);
-    if let Ok(Some(sym)) = guard.check_interned_bytes(bytes) {
-        sym
-    } else {
-        0
-    }
+    let Ok(Some(sym)) = guard.check_interned_bytes(bytes) else {
+        return 0;
+    };
+    sym
 }
 
 // ```c
@@ -87,11 +85,10 @@ unsafe extern "C-unwind" fn mrb_intern_check_cstr(mrb: *mut sys::mrb_state, name
     let string = CStr::from_ptr(name);
     let bytes = string.to_bytes_with_nul();
     unwrap_interpreter!(mrb, to => guard, or_else = 0);
-    if let Ok(Some(sym)) = guard.check_interned_bytes_with_trailing_nul(bytes) {
-        sym
-    } else {
-        0
-    }
+    let Ok(Some(sym)) = guard.check_interned_bytes_with_trailing_nul(bytes) else {
+        return 0;
+    };
+    sym
 }
 
 // ```c
@@ -101,12 +98,13 @@ unsafe extern "C-unwind" fn mrb_intern_check_cstr(mrb: *mut sys::mrb_state, name
 unsafe extern "C-unwind" fn mrb_intern_check_str(mrb: *mut sys::mrb_state, name: sys::mrb_value) -> sys::mrb_sym {
     unwrap_interpreter!(mrb, to => guard, or_else = 0);
     let name = Value::from(name);
-    if let Ok(bytes) = name.try_convert_into_mut::<&[u8]>(&mut guard) {
-        if let Ok(Some(sym)) = guard.check_interned_bytes(bytes) {
-            return sym;
-        }
-    }
-    0
+    let Ok(bytes) = name.try_convert_into_mut::<&[u8]>(&mut guard) else {
+        return 0;
+    };
+    let Ok(Some(sym)) = guard.check_interned_bytes(bytes) else {
+        return 0;
+    };
+    sym
 }
 
 // `mrb_check_intern` series functions returns `nil` if the symbol is not
@@ -123,12 +121,10 @@ unsafe extern "C-unwind" fn mrb_check_intern(
 ) -> sys::mrb_value {
     let bytes = slice::from_raw_parts(name.cast::<u8>(), len);
     unwrap_interpreter!(mrb, to => guard);
-    let symbol = if let Ok(Some(sym)) = guard.check_interned_bytes(bytes) {
-        Symbol::alloc_value(sym.into(), &mut guard).unwrap_or_default()
-    } else {
-        Value::nil()
+    let Ok(Some(sym)) = guard.check_interned_bytes(bytes) else {
+        return Value::nil().inner();
     };
-    symbol.inner()
+    Symbol::alloc_value(sym.into(), &mut guard).unwrap_or_default().inner()
 }
 
 // ```c
@@ -139,12 +135,10 @@ unsafe extern "C-unwind" fn mrb_check_intern_cstr(mrb: *mut sys::mrb_state, name
     let string = CStr::from_ptr(name);
     let bytes = string.to_bytes_with_nul();
     unwrap_interpreter!(mrb, to => guard);
-    let symbol = if let Ok(Some(sym)) = guard.check_interned_bytes_with_trailing_nul(bytes) {
-        Symbol::alloc_value(sym.into(), &mut guard).unwrap_or_default()
-    } else {
-        Value::nil()
+    let Ok(Some(sym)) = guard.check_interned_bytes_with_trailing_nul(bytes) else {
+        return Value::nil().inner();
     };
-    symbol.inner()
+    Symbol::alloc_value(sym.into(), &mut guard).unwrap_or_default().inner()
 }
 
 // ```c
@@ -154,16 +148,13 @@ unsafe extern "C-unwind" fn mrb_check_intern_cstr(mrb: *mut sys::mrb_state, name
 unsafe extern "C-unwind" fn mrb_check_intern_str(mrb: *mut sys::mrb_state, name: sys::mrb_value) -> sys::mrb_value {
     unwrap_interpreter!(mrb, to => guard);
     let name = Value::from(name);
-    let symbol = if let Ok(bytes) = name.try_convert_into_mut::<&[u8]>(&mut guard) {
-        if let Ok(Some(sym)) = guard.check_interned_bytes(bytes) {
-            Symbol::alloc_value(sym.into(), &mut guard).unwrap_or_default()
-        } else {
-            Value::nil()
-        }
-    } else {
-        Value::nil()
+    let Ok(bytes) = name.try_convert_into_mut::<&[u8]>(&mut guard) else {
+        return Value::nil().inner();
     };
-    symbol.inner()
+    let Ok(Some(sym)) = guard.check_interned_bytes(bytes) else {
+        return Value::nil().inner();
+    };
+    Symbol::alloc_value(sym.into(), &mut guard).unwrap_or_default().inner()
 }
 
 // ```c
@@ -172,11 +163,10 @@ unsafe extern "C-unwind" fn mrb_check_intern_str(mrb: *mut sys::mrb_state, name:
 #[unsafe(no_mangle)]
 unsafe extern "C-unwind" fn mrb_sym_name(mrb: *mut sys::mrb_state, sym: sys::mrb_sym) -> *const c_char {
     unwrap_interpreter!(mrb, to => guard, or_else = ptr::null());
-    if let Ok(Some(bytes)) = guard.lookup_symbol_with_trailing_nul(sym) {
-        bytes.as_ptr().cast::<c_char>()
-    } else {
-        ptr::null()
-    }
+    let Ok(Some(bytes)) = guard.lookup_symbol_with_trailing_nul(sym) else {
+        return ptr::null();
+    };
+    bytes.as_ptr().cast::<c_char>()
 }
 
 // ```c
@@ -192,18 +182,16 @@ unsafe extern "C-unwind" fn mrb_sym_name_len(
         ptr::write(lenp, 0);
     }
     unwrap_interpreter!(mrb, to => guard, or_else = ptr::null());
-    if let Ok(Some(bytes)) = guard.lookup_symbol(sym) {
-        if !lenp.is_null() {
-            if let Ok(len) = sys::mrb_int::try_from(bytes.len()) {
-                ptr::write(lenp, len);
-            } else {
-                return ptr::null();
-            }
-        }
-        bytes.as_ptr().cast()
-    } else {
-        ptr::null()
+    let Ok(Some(bytes)) = guard.lookup_symbol(sym) else {
+        return ptr::null();
+    };
+    if !lenp.is_null() {
+        let Ok(len) = sys::mrb_int::try_from(bytes.len()) else {
+            return ptr::null();
+        };
+        ptr::write(lenp, len);
     }
+    bytes.as_ptr().cast()
 }
 
 // ```c
@@ -212,17 +200,19 @@ unsafe extern "C-unwind" fn mrb_sym_name_len(
 #[unsafe(no_mangle)]
 unsafe extern "C-unwind" fn mrb_sym_dump(mrb: *mut sys::mrb_state, sym: sys::mrb_sym) -> *const c_char {
     unwrap_interpreter!(mrb, to => guard, or_else = ptr::null());
-    if let Ok(Some(bytes)) = guard.lookup_symbol(sym) {
-        let bytes = bytes.to_vec();
-        // Allocate a buffer with the lifetime of the interpreter and return
-        // a pointer to it.
-        if let Ok(string) = guard.try_convert_mut(bytes) {
-            if let Ok(bytes) = string.try_convert_into_mut::<&[u8]>(&mut guard) {
-                return bytes.as_ptr().cast();
-            }
-        }
-    }
-    ptr::null()
+    let Ok(Some(bytes)) = guard.lookup_symbol(sym) else {
+        return ptr::null();
+    };
+    let bytes = bytes.to_vec();
+    // Allocate a buffer with the lifetime of the interpreter and return
+    // a pointer to it.
+    let Ok(string) = guard.try_convert_mut(bytes) else {
+        return ptr::null();
+    };
+    let Ok(bytes) = string.try_convert_into_mut::<&[u8]>(&mut guard) else {
+        return ptr::null();
+    };
+    bytes.as_ptr().cast()
 }
 
 // ```c

--- a/artichoke-backend/src/ffi.rs
+++ b/artichoke-backend/src/ffi.rs
@@ -28,9 +28,7 @@ use crate::sys;
 /// [`Box::into_raw`] and that the pointer is to a non-free'd
 /// [`Box`]`<`[`State`]`>`.
 pub unsafe fn from_user_data(mrb: *mut sys::mrb_state) -> Result<Artichoke, InterpreterExtractError> {
-    let mut mrb = if let Some(mrb) = NonNull::new(mrb) {
-        mrb
-    } else {
+    let Some(mut mrb) = NonNull::new(mrb) else {
         emit_fatal_warning!("ffi: Attempted to extract Artichoke from null `mrb_state`");
         return Err(InterpreterExtractError::new());
     };
@@ -42,12 +40,11 @@ pub unsafe fn from_user_data(mrb: *mut sys::mrb_state) -> Result<Artichoke, Inte
     } else {
         // SAFETY: `mrb` is valid and non-null by caller contract and non-null check.
         let alloc_ud = mem::replace(unsafe { &mut mrb.as_mut().allocf_ud }, ptr::null_mut());
-        if let Some(state) = NonNull::new(alloc_ud) {
-            state.cast::<State>()
-        } else {
+        let Some(state) = NonNull::new(alloc_ud) else {
             emit_fatal_warning!("ffi: Attempted to extract Artichoke from null `mrb_state->ud` pointer");
             return Err(InterpreterExtractError::new());
-        }
+        };
+        state.cast::<State>()
     };
 
     // SAFETY: An `Artichoke`-initialized `mrb_state` has a `State` in the user

--- a/artichoke-backend/src/intern.rs
+++ b/artichoke-backend/src/intern.rs
@@ -12,15 +12,13 @@ use crate::sys;
 impl Artichoke {
     pub fn lookup_symbol_with_trailing_nul(&self, symbol: u32) -> Result<Option<&[u8]>, Error> {
         let state = self.state.as_deref().ok_or_else(InterpreterExtractError::new)?;
-        if let Some(symbol) = symbol.checked_sub(1) {
-            if let Some(bytes) = state.symbols.get(symbol.into()) {
-                Ok(Some(bytes))
-            } else {
-                Ok(None)
-            }
-        } else {
-            Ok(None)
-        }
+        let Some(symbol) = symbol.checked_sub(1) else {
+            return Ok(None);
+        };
+        let Some(bytes) = state.symbols.get(symbol.into()) else {
+            return Ok(None);
+        };
+        Ok(Some(bytes))
     }
 
     pub fn intern_bytes_with_trailing_nul<T>(&mut self, bytes: T) -> Result<u32, Error>
@@ -41,16 +39,15 @@ impl Artichoke {
     pub fn check_interned_bytes_with_trailing_nul(&self, bytes: &[u8]) -> Result<Option<u32>, Error> {
         let state = self.state.as_deref().ok_or_else(InterpreterExtractError::new)?;
         let symbol = state.symbols.check_interned(bytes);
-        if let Some(symbol) = symbol {
-            let symbol = u32::from(symbol);
-            // mruby expects symbols to be non-zero.
-            let symbol = symbol
-                .checked_add(<Self as Intern>::SYMBOL_RANGE_START)
-                .ok_or_else(SymbolOverflowError::new)?;
-            Ok(Some(symbol))
-        } else {
-            Ok(None)
-        }
+        let Some(symbol) = symbol else {
+            return Ok(None);
+        };
+        let symbol = u32::from(symbol);
+        // mruby expects symbols to be non-zero.
+        let symbol = symbol
+            .checked_add(<Self as Intern>::SYMBOL_RANGE_START)
+            .ok_or_else(SymbolOverflowError::new)?;
+        Ok(Some(symbol))
     }
 }
 
@@ -83,41 +80,37 @@ impl Intern for Artichoke {
         let mut bytes = bytes.to_vec();
         bytes.push(b'\0');
         let symbol = state.symbols.check_interned(&bytes);
-        if let Some(symbol) = symbol {
-            let symbol = u32::from(symbol);
-            // mruby expects symbols to be non-zero.
-            let symbol = symbol
-                .checked_add(Self::SYMBOL_RANGE_START)
-                .ok_or_else(SymbolOverflowError::new)?;
-            Ok(Some(symbol))
-        } else {
-            Ok(None)
-        }
+        let Some(symbol) = symbol else {
+            return Ok(None);
+        };
+        let symbol = u32::from(symbol);
+        // mruby expects symbols to be non-zero.
+        let symbol = symbol
+            .checked_add(Self::SYMBOL_RANGE_START)
+            .ok_or_else(SymbolOverflowError::new)?;
+        Ok(Some(symbol))
     }
 
     fn lookup_symbol(&self, symbol: Self::Symbol) -> Result<Option<&[u8]>, Self::Error> {
         let state = self.state.as_deref().ok_or_else(InterpreterExtractError::new)?;
-        if let Some(symbol) = symbol.checked_sub(Self::SYMBOL_RANGE_START) {
-            if let Some(bytes) = state.symbols.get(symbol.into()) {
-                if bytes.is_empty() {
-                    Ok(Some(bytes))
-                } else {
-                    Ok(bytes.get(..bytes.len() - 1))
-                }
-            } else {
-                Ok(None)
-            }
+        let Some(symbol) = symbol.checked_sub(Self::SYMBOL_RANGE_START) else {
+            return Ok(None);
+        };
+        let Some(bytes) = state.symbols.get(symbol.into()) else {
+            return Ok(None);
+        };
+        if bytes.is_empty() {
+            Ok(Some(bytes))
         } else {
-            Ok(None)
+            Ok(bytes.get(..bytes.len() - 1))
         }
     }
 
     fn symbol_count(&self) -> usize {
-        if let Some(state) = self.state.as_deref() {
-            state.symbols.len()
-        } else {
-            0
-        }
+        let Some(state) = self.state.as_deref() else {
+            return 0;
+        };
+        state.symbols.len()
     }
 }
 

--- a/artichoke-backend/src/module.rs
+++ b/artichoke-backend/src/module.rs
@@ -76,16 +76,15 @@ impl<'a> Builder<'a> {
             rclass
         } else if let Some(enclosing_scope) = self.spec.enclosing_scope() {
             let scope = unsafe { self.interp.with_ffi_boundary(|mrb| enclosing_scope.rclass(mrb)) };
-            if let Ok(Some(mut scope)) = scope {
-                let rclass = unsafe {
-                    self.interp
-                        .with_ffi_boundary(|mrb| sys::mrb_define_module_under(mrb, scope.as_mut(), name))
-                };
-                let rclass = rclass.map_err(|_| NotDefinedError::module(self.spec.name()))?;
-                NonNull::new(rclass).ok_or_else(|| NotDefinedError::module(self.spec.name()))?
-            } else {
+            let Ok(Some(mut scope)) = scope else {
                 return Err(NotDefinedError::enclosing_scope(enclosing_scope.fqname().into_owned()));
-            }
+            };
+            let rclass = unsafe {
+                self.interp
+                    .with_ffi_boundary(|mrb| sys::mrb_define_module_under(mrb, scope.as_mut(), name))
+            };
+            let rclass = rclass.map_err(|_| NotDefinedError::module(self.spec.name()))?;
+            NonNull::new(rclass).ok_or_else(|| NotDefinedError::module(self.spec.name()))?
         } else {
             let rclass = unsafe { self.interp.with_ffi_boundary(|mrb| sys::mrb_define_module(mrb, name)) };
             let rclass = rclass.map_err(|_| NotDefinedError::module(self.spec.name()))?;
@@ -228,14 +227,13 @@ impl Spec {
 
     #[must_use]
     pub fn fqname(&self) -> Cow<'_, str> {
-        if let Some(scope) = self.enclosing_scope() {
-            let mut fqname = String::from(scope.fqname());
-            fqname.push_str("::");
-            fqname.push_str(self.name.as_ref());
-            fqname.into()
-        } else {
-            self.name.as_ref().into()
-        }
+        let Some(scope) = self.enclosing_scope() else {
+            return self.name();
+        };
+        let mut fqname = String::from(scope.fqname());
+        fqname.push_str("::");
+        fqname.push_str(self.name.as_ref());
+        fqname.into()
     }
 
     #[must_use]

--- a/artichoke-backend/src/module_registry.rs
+++ b/artichoke-backend/src/module_registry.rs
@@ -37,19 +37,16 @@ impl ModuleRegistry for Artichoke {
     {
         let state = self.state.as_deref().ok_or_else(InterpreterExtractError::new)?;
         let spec = state.modules.get::<T>();
-        let spec = if let Some(spec) = spec {
-            spec
-        } else {
+        let Some(spec) = spec else {
             return Ok(None);
         };
         let rclass = spec.rclass();
         let rclass = unsafe { self.with_ffi_boundary(|mrb| rclass.resolve(mrb))? };
-        if let Some(mut rclass) = rclass {
-            let module = unsafe { sys::mrb_sys_module_value(rclass.as_mut()) };
-            let module = Value::from(module);
-            Ok(Some(module))
-        } else {
-            Ok(None)
-        }
+        let Some(mut rclass) = rclass else {
+            return Ok(None);
+        };
+        let module = unsafe { sys::mrb_sys_module_value(rclass.as_mut()) };
+        let module = Value::from(module);
+        Ok(Some(module))
     }
 }

--- a/artichoke-backend/src/sys/mod.rs
+++ b/artichoke-backend/src/sys/mod.rs
@@ -27,7 +27,6 @@ mod args;
     clippy::restriction,
     reason = "generated code"
 )]
-#[allow(missing_unsafe_on_extern, reason = "requires bindgen upgrade for generated code")]
 mod ffi {
     include!(concat!(env!("OUT_DIR"), "/ffi.rs"));
 }

--- a/artichoke-backend/src/types.rs
+++ b/artichoke-backend/src/types.rs
@@ -5,7 +5,6 @@ use crate::sys;
 ///
 /// This function collapses some mruby types into a [`Ruby::Unreachable`] type
 /// that force an interaction with the VM to return an error.
-#[allow(non_upper_case_globals)]
 #[must_use]
 pub fn ruby_from_mrb_value(value: sys::mrb_value) -> Ruby {
     use sys::mrb_vtype::{

--- a/artichoke-backend/src/value.rs
+++ b/artichoke-backend/src/value.rs
@@ -41,11 +41,10 @@ impl From<sys::mrb_value> for Value {
 
 impl From<Option<sys::mrb_value>> for Value {
     fn from(value: Option<sys::mrb_value>) -> Self {
-        if let Some(value) = value {
-            Self::from(value)
-        } else {
-            Self::nil()
-        }
+        let Some(value) = value else {
+            return Self::nil();
+        };
+        Self::from(value)
     }
 }
 
@@ -198,11 +197,10 @@ impl ValueCore for Value {
     }
 
     fn inspect(&self, interp: &mut Self::Artichoke) -> Vec<u8> {
-        if let Ok(display) = self.funcall(interp, "inspect", &[], None) {
-            display.try_convert_into_mut(interp).unwrap_or_default()
-        } else {
-            Vec::new()
-        }
+        let Ok(display) = self.funcall(interp, "inspect", &[], None) else {
+            return vec![];
+        };
+        display.try_convert_into_mut(interp).unwrap_or_default()
     }
 
     fn is_nil(&self) -> bool {
@@ -223,11 +221,10 @@ impl ValueCore for Value {
     }
 
     fn to_s(&self, interp: &mut Self::Artichoke) -> Vec<u8> {
-        if let Ok(display) = self.funcall(interp, "to_s", &[], None) {
-            display.try_convert_into_mut(interp).unwrap_or_default()
-        } else {
-            Vec::new()
-        }
+        let Ok(display) = self.funcall(interp, "to_s", &[], None) else {
+            return vec![];
+        };
+        display.try_convert_into_mut(interp).unwrap_or_default()
     }
 
     fn ruby_type(&self) -> Ruby {
@@ -260,14 +257,7 @@ impl TryFrom<Vec<Value>> for ArgCountError {
     type Error = ();
 
     fn try_from(args: Vec<Value>) -> Result<Self, Self::Error> {
-        if args.len() > MRB_FUNCALL_ARGC_MAX {
-            Ok(Self {
-                given: args.len(),
-                max: MRB_FUNCALL_ARGC_MAX,
-            })
-        } else {
-            Err(())
-        }
+        args.as_slice().try_into()
     }
 }
 
@@ -275,14 +265,7 @@ impl TryFrom<Vec<sys::mrb_value>> for ArgCountError {
     type Error = ();
 
     fn try_from(args: Vec<sys::mrb_value>) -> Result<Self, Self::Error> {
-        if args.len() > MRB_FUNCALL_ARGC_MAX {
-            Ok(Self {
-                given: args.len(),
-                max: MRB_FUNCALL_ARGC_MAX,
-            })
-        } else {
-            Err(())
-        }
+        args.as_slice().try_into()
     }
 }
 
@@ -290,14 +273,15 @@ impl TryFrom<&[Value]> for ArgCountError {
     type Error = ();
 
     fn try_from(args: &[Value]) -> Result<Self, Self::Error> {
-        if args.len() > MRB_FUNCALL_ARGC_MAX {
-            Ok(Self {
-                given: args.len(),
-                max: MRB_FUNCALL_ARGC_MAX,
-            })
-        } else {
-            Err(())
+        // Arg count is ok, so we failed ton construct the error.
+        if args.len() <= MRB_FUNCALL_ARGC_MAX {
+            return Err(());
         }
+        let err = Self {
+            given: args.len(),
+            max: MRB_FUNCALL_ARGC_MAX,
+        };
+        Ok(err)
     }
 }
 
@@ -305,14 +289,15 @@ impl TryFrom<&[sys::mrb_value]> for ArgCountError {
     type Error = ();
 
     fn try_from(args: &[sys::mrb_value]) -> Result<Self, Self::Error> {
-        if args.len() > MRB_FUNCALL_ARGC_MAX {
-            Ok(Self {
-                given: args.len(),
-                max: MRB_FUNCALL_ARGC_MAX,
-            })
-        } else {
-            Err(())
+        // Arg count is ok, so we failed ton construct the error.
+        if args.len() <= MRB_FUNCALL_ARGC_MAX {
+            return Err(());
         }
+        let err = Self {
+            given: args.len(),
+            max: MRB_FUNCALL_ARGC_MAX,
+        };
+        Ok(err)
     }
 }
 
@@ -370,8 +355,11 @@ impl From<ArgCountError> for Error {
 
 #[cfg(test)]
 mod tests {
+    use core::panic;
+
     use bstr::ByteSlice;
 
+    use super::{ArgCountError, MRB_FUNCALL_ARGC_MAX};
     use crate::gc::MrbGarbageCollection;
     use crate::test::prelude::*;
 
@@ -650,5 +638,84 @@ mod tests {
         assert!(basic_object.respond_to(&mut interp, "__send__").unwrap());
         assert!(!basic_object.respond_to(&mut interp, "class").unwrap());
         assert!(!basic_object.respond_to(&mut interp, "zyxw_not_a_method").unwrap());
+    }
+
+    #[test]
+    fn arg_count_error_no_error_for_valid_count_values() {
+        // Construct a vector of Values with exactly the maximum allowed arguments.
+        let args = vec![Value::nil(); MRB_FUNCALL_ARGC_MAX];
+        // Expect conversion to fail, meaning no error should be constructed.
+        let err = ArgCountError::try_from(args.as_slice());
+        assert!(
+            err.is_err(),
+            "Expected no ArgCountError for {} arguments",
+            MRB_FUNCALL_ARGC_MAX
+        );
+    }
+
+    #[test]
+    fn arg_count_error_error_for_excess_count_values() {
+        let count = MRB_FUNCALL_ARGC_MAX + 1;
+        let args = vec![Value::nil(); count];
+        // Expect conversion to succeed and produce an ArgCountError.
+        let err = ArgCountError::try_from(args.as_slice());
+        assert!(err.is_ok(), "Expected an ArgCountError for {} arguments", count);
+        let arg_err = err.unwrap();
+        assert_eq!(arg_err.given, count);
+        assert_eq!(arg_err.max, MRB_FUNCALL_ARGC_MAX);
+    }
+
+    #[test]
+    fn arg_count_error_no_error_for_valid_count_sys_values() {
+        let args: Vec<sys::mrb_value> = vec![Value::nil().inner(); MRB_FUNCALL_ARGC_MAX];
+        // Expect conversion to fail for a valid sys value argument count.
+        let err = ArgCountError::try_from(args.as_slice());
+        assert!(
+            err.is_err(),
+            "Expected no ArgCountError for {} sys values",
+            MRB_FUNCALL_ARGC_MAX
+        );
+    }
+
+    #[test]
+    fn arg_count_error_error_for_excess_count_sys_values() {
+        let count = MRB_FUNCALL_ARGC_MAX + 1;
+        let args: Vec<sys::mrb_value> = vec![Value::nil().inner(); count];
+        // Expect conversion to succeed and produce an ArgCountError for sys values.
+        let arg_err = ArgCountError::try_from(args.as_slice()).unwrap_or_else(|()| {
+            panic!("Expected an ArgCountError for {count} sys values, but conversion failed");
+        });
+        assert_eq!(arg_err.given, count);
+        assert_eq!(arg_err.max, MRB_FUNCALL_ARGC_MAX);
+    }
+
+    #[test]
+    fn arg_count_error_display_format() {
+        let given = MRB_FUNCALL_ARGC_MAX + 2;
+        let error = ArgCountError {
+            given,
+            max: MRB_FUNCALL_ARGC_MAX,
+        };
+        let display = format!("{}", error);
+        let expected = format!(
+            "Too many arguments for function call: gave {given} arguments, but Artichoke only supports a maximum of {MRB_FUNCALL_ARGC_MAX} arguments",
+        );
+        assert_eq!(display, expected);
+    }
+
+    #[test]
+    fn integration_funcall_with_excess_arguments() {
+        let mut interp = interpreter();
+        let nil = Value::nil();
+        let args = vec![Value::nil(); MRB_FUNCALL_ARGC_MAX + 1];
+        let result = nil.funcall(&mut interp, "nil?", &args, None);
+        let err = result.expect_err("Expected an error due to too many arguments, but funcall succeeded");
+        // ArgCountError is converted into an Error with name "ArgumentError".
+        assert_eq!(err.name().as_ref(), "ArgumentError");
+        let message = err.message();
+        assert!(
+            message.as_bstr().contains_str("Too many arguments"),
+            "Error message does not indicate too many arguments"
+        );
     }
 }

--- a/artichoke-backend/src/value.rs
+++ b/artichoke-backend/src/value.rs
@@ -648,8 +648,7 @@ mod tests {
         let err = ArgCountError::try_from(args.as_slice());
         assert!(
             err.is_err(),
-            "Expected no ArgCountError for {} arguments",
-            MRB_FUNCALL_ARGC_MAX
+            "Expected no ArgCountError for {MRB_FUNCALL_ARGC_MAX} arguments",
         );
     }
 
@@ -659,8 +658,9 @@ mod tests {
         let args = vec![Value::nil(); count];
         // Expect conversion to succeed and produce an ArgCountError.
         let err = ArgCountError::try_from(args.as_slice());
-        assert!(err.is_ok(), "Expected an ArgCountError for {} arguments", count);
-        let arg_err = err.unwrap();
+        let arg_err = err.unwrap_or_else(|()| {
+            panic!("Expected an ArgCountError for {count} arguments, but conversion failed");
+        });
         assert_eq!(arg_err.given, count);
         assert_eq!(arg_err.max, MRB_FUNCALL_ARGC_MAX);
     }
@@ -672,8 +672,7 @@ mod tests {
         let err = ArgCountError::try_from(args.as_slice());
         assert!(
             err.is_err(),
-            "Expected no ArgCountError for {} sys values",
-            MRB_FUNCALL_ARGC_MAX
+            "Expected no ArgCountError for {MRB_FUNCALL_ARGC_MAX} sys values"
         );
     }
 
@@ -696,7 +695,7 @@ mod tests {
             given,
             max: MRB_FUNCALL_ARGC_MAX,
         };
-        let display = format!("{}", error);
+        let display = format!("{error}");
         let expected = format!(
             "Too many arguments for function call: gave {given} arguments, but Artichoke only supports a maximum of {MRB_FUNCALL_ARGC_MAX} arguments",
         );


### PR DESCRIPTION
I find this improves readability by unnesting the happy path and reducing indentation. It also keeps the error handling local to the destructuring operation.

Also fixup some docs and add a bunch of tests with the help of ChatGPT.