### PR TITLE
Clarify warning delegation with code comments

### DIFF
--- a/artichoke-backend/src/extn/core/kernel/kernel.rb
+++ b/artichoke-backend/src/extn/core/kernel/kernel.rb
@@ -154,8 +154,13 @@ module Kernel
     msg.each do |warning|
       warning = warning.to_s
       warning << "\n" unless warning[-1] == "\n"
-      # TODO: This should call `Warning.warn` but due to method visibility
-      # limitations of the mruby VM, we cannot shadow the warn method there.
+
+      # FIXME: Delegate warnings to `Warning.warn` instead of directly printing
+      # to stderr. This prevents duplicate output and aligns with MRI behavior.
+      # Currently blocked by method visibility limitations in the mruby VM,
+      # which prevent shadowing `Kernel#warn` with `Warning.warn`.
+      #
+      # See issue: https://github.com/artichoke/artichoke/issues/2844
       out = $stderr || $stdout || self
       out.print(warning)
     end

--- a/artichoke-backend/src/extn/core/warning/warning.rb
+++ b/artichoke-backend/src/extn/core/warning/warning.rb
@@ -1,8 +1,18 @@
 # frozen_string_literal: true
 
+# FIXME: Implement `Warning.warn` method to handle Ruby warnings properly.
+# Currently stubbed due to method visibility limitations in the mruby VM. Full
+# implementation will resolve duplicate warnings.
+#
+# See issue: https://github.com/artichoke/artichoke/issues/2844
 module Warning
-  # TODO: This method should be defined, but due to method visibility
-  # limitations of the mruby VM, we cannot shadow the warn method in `Kernel`.
+  # FIXME: Delegate warnings to `Warning.warn` instead of directly printing to
+  # stderr. This prevents duplicate output and aligns with MRI behavior.
+  # Currently blocked by method visibility limitations in the mruby VM, which
+  # prevent shadowing `Kernel#warn` with `Warning.warn`.
+  #
+  # See issue: https://github.com/artichoke/artichoke/issues/2844
+  #
   # def warn(message)
   #   $stderr.print(message)
   # end

--- a/artichoke-backend/src/warn.rs
+++ b/artichoke-backend/src/warn.rs
@@ -16,6 +16,13 @@ impl Warn for Artichoke {
 
     fn warn(&mut self, message: &[u8]) -> Result<(), Self::Error> {
         let state = self.state.as_deref_mut().ok_or_else(InterpreterExtractError::new)?;
+
+        // FIXME: Avoid direct printing to stderr here.
+        //
+        // Ruby warnings should be exclusively handled by `Warning.warn` in Ruby code to avoid
+        // duplicate messages.
+        //
+        // See issue: https://github.com/artichoke/artichoke/issues/2844
         if let Err(err) = state.output.write_stderr(b"rb warning: ") {
             let mut message = String::from("Failed to write warning to $stderr: ");
             write!(&mut message, "{err}").map_err(WriteError::from)?;
@@ -31,6 +38,7 @@ impl Warn for Artichoke {
             write!(&mut message, "{err}").map_err(WriteError::from)?;
             return Err(IOError::from(message).into());
         }
+
         let warning = self
             .module_of::<Warning>()?
             .ok_or_else(|| NotDefinedError::module("Warning"))?;


### PR DESCRIPTION
Add detailed comments explaining the current limitations and desired implementation for warning delegation between Rust and Ruby in Artichoke. Clarifies that warnings should exclusively use `Warning.warn` to prevent duplicates, aligning with MRI Ruby behavior.

See: https://github.com/artichoke/artichoke/issues/2844