### PR TITLE
Remove an orphaned rustdoc link anchor

### DIFF
--- a/artichoke-core/src/lib.rs
+++ b/artichoke-core/src/lib.rs
@@ -78,8 +78,7 @@
 //!   current filename.
 //! - [`Prng`][core-prng]: An interpreter-level pseudorandom number generator
 //!   that is the backend for [`Random::DEFAULT`].
-//! - [`Regexp`][core-regexp]: Manipulate [`Regexp`][regexp-globals] global
-//!   state.
+//! - [`Regexp`][core-regexp]: Manipulate interpreter-global `Regexp` state.
 //! - [`ReleaseMetadata`][core-releasemetadata]: Enable interpreters to describe
 //!   themselves.
 //! - [`TopSelf`][core-topself]: Access to the root execution context.


### PR DESCRIPTION
address a new build failure on nightly